### PR TITLE
fix(memory): personal recall dedup + curated-memory tasks.md (audit riders)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`PersonalMemory.query()` returned every hit twice when the process
+  cwd was the home directory.** The project-root default
+  (`cwd/.attune/memory`) resolved to the global root itself, so both
+  scans surfaced the same files (scores exactly 0.001 apart — the
+  project boost). The constructor now collapses an identical project
+  root, and `query()` dedups hits by path keeping the best score.
+
 ## [9.4.0] — 2026-07-02
 
 Memory repair release: the headline fix restores `attune memory recall`

--- a/docs/specs/curated-memory-productionization/decisions.md
+++ b/docs/specs/curated-memory-productionization/decisions.md
@@ -125,6 +125,29 @@ regenerated from receipts and re-verified as
 "presented" != "persisted" — audit artifacts must land in a git tree
 or the curated graph at creation time.
 
+### D8 — Memory-suite audit folded in as tasks.md riders
+(recorded 2026-07-02)
+
+Patrick asked for a suite-level audit ("is the memory suite strongly
+serving users by empowering the agent?"). Verdict: **barbell** — the
+hook-driven layers (lessons recall, jit recall, session stash/recall,
+R1 hydration) demonstrably empower in-session; the structured layers
+(MemoryGraph, personal memory, Redis-via-MCP, Memory-tool bridge) are
+mature but unoccupied — empty stores, and failures go unnoticed
+(9.3.0 shipped recall broken; the plugin MCP server couldn't reach
+Redis in the same session whose hook hydrated it). Removal test:
+losing the hooks would hurt immediately; losing the structured half
+would go nearly unnoticed today.
+
+The audit's ranked opportunities were mapped into
+[tasks.md](tasks.md): #1 (execute this spec) = T1–T3 as already
+ordered by D3; hygiene pass = T4; dedup bug = T5; drift self-report
+= T6; release-gate eval = T7; consolidation review = deferred-note.
+Live receipts from the audit session: `personal_memory_topics` → 1
+topic; `memory_search` → 0 results; `redis_health_check` failed →
+fixed by `uv sync --extra dev --extra developer --extra redis` in the
+worktree; recall works post-9.4.0 but duplicates results (T5).
+
 ### D3 — Requirements approved as written; R-ordering left to
 execution (decided 2026-07-02)
 

--- a/docs/specs/curated-memory-productionization/tasks.md
+++ b/docs/specs/curated-memory-productionization/tasks.md
@@ -49,6 +49,7 @@ T1's digest pull is the first; add procedures as consumers appear.
 ## Audit riders (2026-07-02 memory-suite audit — see D8)
 
 ## T4 — Harness-corpus hygiene pass + `memory_lint.py` default fix
+   — **DONE 2026-07-02** (personal infra, same session as the audit)
 
 The per-project corpus (`~/.claude/projects/-Users-patrickroebuck-attune-ai/memory/`,
 78 files) carries **134 violations** (31× R1 name/stem drift, 76× R2
@@ -63,17 +64,29 @@ so any future promotion/unification inherits the mess.
   nesting, drop `originSessionId`, repair link slugs.
 - **Receipt:** `memory_lint.py --check-all <project dir>` → 0
   violations, run explicitly against the per-project path.
+- **Done receipt (2026-07-02):** bare `--check-all` now sweeps the
+  global dir + all `~/.claude/projects/*/memory` dirs; the attune-ai
+  corpus was already clean (a parallel task fixed the 134), but the
+  multi-dir sweep surfaced 153 MORE hidden violations across six
+  other project corpora — `--fix-all` migrated 74 files; R3 relaxed
+  to accept table-form indexes; all 10 corpora now lint 0. Backup:
+  `~/.attune/memory-corpus-backup-20260702-210218.tgz`.
 
 ## T5 — `personal_memory_recall` dedup fix
+   — **DONE 2026-07-02** (commit `b38c2ed08` on this branch)
 
 Live observation (2026-07-02): recall for a store containing ONE
 topic returned the same file twice (`dispatch_test/decision.md`,
-scores 7.501 / 7.5). Find the double-indexing (summary vs excerpt, or
-duplicate ingestion) in `src/attune/memory/personal.py` / the MCP
-handler and dedup by path.
+scores 7.501 / 7.5). Root cause (controlled repro, not the guessed
+double-indexing): with cwd = home, the project-root default
+(`cwd/.attune/memory`) IS the global root — the corpus was scanned
+twice, project boost accounting for the exact 0.001 score gap.
 
-- **Receipt:** regression test naming the pre-fix failure (two
-  results, one file) + live MCP recall returning one.
+- Fix: constructor collapses an identical project root; `query()`
+  dedups by path (best score wins).
+- **Receipt:** two non-mocked regression tests against real
+  attune_rag (54/54 green); live MCP re-verify needs the plugin
+  server restarted (it holds the pre-fix module).
 
 ## T6 — "Registered ≠ working" drift self-report for the MCP surface
 

--- a/docs/specs/curated-memory-productionization/tasks.md
+++ b/docs/specs/curated-memory-productionization/tasks.md
@@ -1,0 +1,115 @@
+# Tasks: Curated-Memory Productionization
+
+**Status:** drafted 2026-07-02 (from the memory-suite audit session)
+**Requirements:** [requirements.md](requirements.md)
+**Decisions:** [decisions.md](decisions.md) — D8 records the audit
+that produced the rider tasks (T4–T7).
+
+Execution order per D3: R1 ✓ shipped → **T1 (R3)** → T2 (R4) →
+T3 (R2, on demand). T4–T7 are audit riders — small, independent,
+can interleave. R5 (non-mocked receipt) applies to every task.
+
+---
+
+## T1 — R3: recall-digest render (NEXT)
+
+Build the "here is what memory carries" surface, replacing the
+`progress`-construct misrender (memory facts strike through as done
+tasks).
+
+- **Composition check FIRST**: try a display variant of `progress`
+  before minting grammar member #6 (extension recipe: compose before
+  new `QuestionType`).
+- Build as **Redis's first real consumer**: the render pulls from
+  `FCALL recall_digest` (86us warm), not the JSON file — proving R2's
+  foundation en route.
+- **Receipt:** a live widget render + submit round-trip in a real
+  session, sourced from the Redis function call.
+
+## T2 — R4: stash → curated promotion path
+
+A deliberate, reviewable step proposing auto-stashed findings for
+promotion into the curated graph (agent proposes, Patrick verdicts).
+Bulk import is explicitly wrong (the 2026-07-02 supersession
+contradiction is the evidence).
+
+- Promotion writes provenance metadata (source stash entry, review
+  verdict, date) onto the resulting node.
+- **Receipt:** one real stashed finding promoted with provenance
+  visible on the node.
+
+## T3 — R2: targeted recall procedures (on demand)
+
+Topic/tag-filtered search + single-node fetch as Redis Functions or
+parameterized `FT.SEARCH`. Ship only with a demonstrated consumer —
+T1's digest pull is the first; add procedures as consumers appear.
+
+---
+
+## Audit riders (2026-07-02 memory-suite audit — see D8)
+
+## T4 — Harness-corpus hygiene pass + `memory_lint.py` default fix
+
+The per-project corpus (`~/.claude/projects/-Users-patrickroebuck-attune-ai/memory/`,
+78 files) carries **134 violations** (31× R1 name/stem drift, 76× R2
+schema drift, 27× R4 dangling links, 2 files with no frontmatter) —
+unenforced because `memory_lint.py --check-all`'s bare default scans
+only the GLOBAL dir. Graph ingestion silently drops dangling links,
+so any future promotion/unification inherits the mess.
+
+- Fix the lint default (scan global + per-project dirs, or require an
+  explicit path) — personal infra, `~/.claude/hooks/memory_lint.py`.
+- Mechanical corpus normalization: underscore stems, `metadata.type`
+  nesting, drop `originSessionId`, repair link slugs.
+- **Receipt:** `memory_lint.py --check-all <project dir>` → 0
+  violations, run explicitly against the per-project path.
+
+## T5 — `personal_memory_recall` dedup fix
+
+Live observation (2026-07-02): recall for a store containing ONE
+topic returned the same file twice (`dispatch_test/decision.md`,
+scores 7.501 / 7.5). Find the double-indexing (summary vs excerpt, or
+duplicate ingestion) in `src/attune/memory/personal.py` / the MCP
+handler and dedup by path.
+
+- **Receipt:** regression test naming the pre-fix failure (two
+  results, one file) + live MCP recall returning one.
+
+## T6 — "Registered ≠ working" drift self-report for the MCP surface
+
+Same-session split-brain observed 2026-07-02: the SessionStart
+hydration hook reached Redis while the plugin MCP server's venv
+lacked `[redis]` — `redis_health_check` failed until a manual
+`uv sync --extra redis`. The suite should surface this itself.
+
+- Extend the hydration hook (or a SessionStart sibling) to also probe
+  the MCP-tool env's Redis reachability and print a loud
+  `[memory-drift]` line on mismatch (pattern: D5's loud no-op).
+- Durable half: decide where `[redis]` belongs for worktree syncs
+  (dev extra vs documented sync flags) so the gap stops recurring
+  per worktree.
+- **Receipt:** a deliberately-broken env produces the drift line in
+  fresh-session context.
+
+## T7 — Recall-eval as a release gate
+
+9.3.0 shipped with `PersonalMemory.query()` 100% broken (hit@1 0/18)
+and no gate caught it — all local testing ran main, not the artifact.
+Golden queries already exist (`docs/specs/lessons-corpus-rag/golden_queries.json`;
+the memory-recall-eval spec has the harness).
+
+- Wire a recall smoke-eval against the BUILT artifact (clean venv,
+  isolated `$HOME`) into release-prep — pass/fail on hit@3 above a
+  floor, not a benchmark.
+- **Receipt:** the gate run visible in the next release's prep log.
+
+---
+
+## Deferred (noted, not tasked)
+
+- **Subsystem consolidation review** — `attune.memory` is 42 modules
+  / ~11.5k LOC with overlapping stores (`simple_storage`,
+  `file_stash`, `file_session`, `summary_index`, …) while live value
+  concentrates in a few hooks. Run the subsystem-value-gate review
+  only AFTER T1–T2 settle occupancy — consolidating before the
+  occupant moves in repeats the build-ahead-of-use pattern.

--- a/src/attune/memory/personal.py
+++ b/src/attune/memory/personal.py
@@ -133,6 +133,13 @@ class PersonalMemory:
         self._project_root: Path | None = project_root or (
             _project_default if _project_default.is_dir() else None
         )
+        # When cwd is the home directory, the project default resolves to
+        # the global root itself — scanning it twice duplicates every hit.
+        if (
+            self._project_root is not None
+            and self._project_root.resolve() == self._global_root.resolve()
+        ):
+            self._project_root = None
 
     # ------------------------------------------------------------------
     # Public API
@@ -243,8 +250,16 @@ class PersonalMemory:
             except Exception:  # noqa: BLE001
                 logger.warning("personal_memory_query_failed root=%s", root)
 
-        hits.sort(key=lambda h: h["score"], reverse=True)
-        return hits[:k]
+        # Dedup by path (keep best score) — two roots can surface the same
+        # relative path, and returning it twice is useless to the caller.
+        best: dict[str, dict[str, Any]] = {}
+        for hit in hits:
+            prior = best.get(hit["path"])
+            if prior is None or hit["score"] > prior["score"]:
+                best[hit["path"]] = hit
+
+        deduped = sorted(best.values(), key=lambda h: h["score"], reverse=True)
+        return deduped[:k]
 
     def list_topics(self) -> list[str]:
         """Return sorted list of topic slugs across global and project memory."""

--- a/tests/unit/memory/test_personal_memory.py
+++ b/tests/unit/memory/test_personal_memory.py
@@ -406,6 +406,43 @@ class TestQuery:
         assert result[0]["path"] == "redis-timeout-config/decision.md"
         assert result[0]["score"] > 0
 
+    def test_query_same_root_twice_returns_each_file_once(self, tmp_path):
+        """Regression guard (2026-07-02 live observation): when the
+        process cwd is the home directory, the project-root default
+        (`cwd/.attune/memory`) resolves to the global root itself, so
+        every file was scanned twice and recall returned the same path
+        twice with scores exactly 0.001 apart (the project boost).
+        Real attune_rag, no mocking."""
+        (tmp_path / "dispatch-test").mkdir(parents=True)
+        (tmp_path / "dispatch-test" / "decision.md").write_text(
+            "# dispatch-test\n\nverifying dispatch works\n", encoding="utf-8"
+        )
+
+        pm = PersonalMemory(global_root=tmp_path, project_root=tmp_path)
+
+        assert pm._project_root is None  # identity guard collapsed it
+        result = pm.query("verifying dispatch", k=3)
+        paths = [r["path"] for r in result]
+        assert len(paths) == len(set(paths)), f"duplicate paths: {paths}"
+        assert paths == ["dispatch-test/decision.md"]
+
+    def test_query_dedups_identical_relative_path_across_roots(self, tmp_path):
+        """Two DISTINCT roots holding the same relative path must yield
+        one result (best score wins — the project-boosted hit)."""
+        global_root = tmp_path / "global"
+        project_root = tmp_path / "project"
+        for root in (global_root, project_root):
+            (root / "shared-topic").mkdir(parents=True)
+            (root / "shared-topic" / "decision.md").write_text(
+                "# shared-topic\n\nshared decision content\n", encoding="utf-8"
+            )
+
+        pm = PersonalMemory(global_root=global_root, project_root=project_root)
+        result = pm.query("shared decision", k=3)
+
+        paths = [r["path"] for r in result]
+        assert paths == ["shared-topic/decision.md"]
+
 
 # ---------------------------------------------------------------------------
 # list_topics / forget_topic


### PR DESCRIPTION
## Summary

Memory-suite audit follow-through (spec D8):

- **fix(memory) — T5:** `PersonalMemory.query()` returned every hit twice when the process cwd was the home directory: the project-root default (`cwd/.attune/memory`) resolves to the global root itself, so the corpus was scanned twice (scores exactly 0.001 apart — the project boost). Constructor now collapses an identical project root; `query()` dedups by path, best score wins. Two non-mocked regression tests against real attune_rag. CHANGELOG entry under Unreleased.
- **docs(spec):** new `tasks.md` for curated-memory-productionization — T1–T3 = R3/R4/R2 per D3's order, plus audit riders T4–T7; D8 decision entry records the audit verdict and receipts. T4 (corpus hygiene + `memory_lint.py` multi-dir default) done as personal infra, receipted in tasks.md; T5 done in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)