### PR TITLE
feat(deps): mirror [redis] deps into [dev] extra (memory spec T6 durable half)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   project boost). The constructor now collapses an identical project
   root, and `query()` dedups hits by path keeping the best score.
 
+### Changed
+
+- `[dev]` extra now mirrors the `[redis]` deps (`redis`,
+  `agent-memory-client`), so worktree/dev syncs carry what the
+  plugin MCP server's `redis_memory_*` tools need — closes the
+  hook-hydrates-Redis / MCP-tools-can't drift class (curated-memory
+  spec T6).
+
 ## [9.4.0] — 2026-07-02
 
 Memory repair release: the headline fix restores `attune memory recall`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -238,6 +238,15 @@ dev = [
     "uvicorn[standard]>=0.27.0,<1.0",
     "jinja2>=3.1.0,<4.0",
     "requests>=2.28.0,<3.0.0",  # For notification tests
+    # Redis/AMS runtime ([redis] extra) — mirrored into [dev] so
+    # worktree/dev syncs carry the deps the plugin MCP server's
+    # redis_memory_* tools and the attune_redis backend need, without
+    # a separate `--extra redis`. Found 2026-07-02: a worktree session
+    # whose SessionStart hook hydrated Redis had MCP tools failing
+    # "Redis support not installed" (curated-memory spec, T6). Keep
+    # pins in lock-step with the [redis] extra above.
+    "agent-memory-client>=0.14.0",
+    "redis>=5.0.0,<9.0.0",
     # RAG integration test coverage — attune-rag is an
     # optional runtime dep but required for the rag_code_gen
     # and rag_knowledge_query test paths to exercise their

--- a/uv.lock
+++ b/uv.lock
@@ -342,6 +342,7 @@ backend = [
     { name = "uvicorn" },
 ]
 dev = [
+    { name = "agent-memory-client" },
     { name = "attune-rag" },
     { name = "bandit" },
     { name = "black" },
@@ -448,6 +449,7 @@ windows = [
 
 [package.metadata]
 requires-dist = [
+    { name = "agent-memory-client", marker = "extra == 'dev'", specifier = ">=0.14.0" },
     { name = "agent-memory-client", marker = "extra == 'redis'", specifier = ">=0.14.0" },
     { name = "aiohttp", marker = "extra == 'all'", specifier = ">=3.14.1,<4.0.0" },
     { name = "anthropic", specifier = ">=0.40.0,<1.0.0" },


### PR DESCRIPTION
## Summary

Completes T6 of `docs/specs/curated-memory-productionization/tasks.md` (the durable half; the hook-side drift probe already shipped in the memory repo).

Worktree/dev venvs are synced with `dev`+`developer` only, so the plugin MCP server running from them failed `redis_memory_*` tools with "Redis support not installed" while the SessionStart hydration hook (own pinned venv) reached Redis fine — live split-brain observed 2026-07-02. This mirrors the two `[redis]` deps (`redis`, `agent-memory-client`) into `[dev]`, the same pattern as the `[ops]` mirror directly above it.

**Receipt:** `uv sync --extra dev` → `import redis, agent_memory_client` OK.

Note: may need a trivial CHANGELOG rebase after #1223 (both add under Unreleased).

🤖 Generated with [Claude Code](https://claude.com/claude-code)