### PR TITLE
feat(release): artifact-level recall gate + which-memory-is-which doc (memory spec T7)

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -18,7 +18,7 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
@@ -29,10 +29,19 @@ jobs:
           cache: 'pip'
 
       - name: Install build dependencies
-        run: pip install build
+        run: pip install build uv
 
       - name: Build package
         run: python -m build
+
+      # Artifact-level recall gate (curated-memory spec T7): installs the
+      # just-built wheel into a clean venv with an isolated $HOME and
+      # proves the user-facing `attune memory capture` -> `recall`
+      # round-trip. Exists because 9.3.0 shipped with recall 100% broken
+      # while the full mocked test matrix was green — the checkout was
+      # tested, the artifact never was. A failure here means DO NOT SHIP.
+      - name: Recall gate (built artifact)
+        run: python scripts/release_recall_gate.py --wheel 'dist/attune_ai-*.whl'
 
       - name: Upload artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Release recall gate** (`scripts/release_recall_gate.py`): every
+  publish now installs the built wheel into a clean venv with an
+  isolated `$HOME` and proves the `attune memory capture` → `recall`
+  round-trip (hit@3 + no duplicate paths) before artifacts upload —
+  the gate that would have caught 9.3.0's broken recall. Enforced in
+  `publish-pypi.yml`.
+- **"Which memory is which" orientation doc**
+  (`docs/how-to/which-memory-is-which.md`): maps the memory rings —
+  personal memory, memory graph, Redis/AMS session memory, host-agent
+  memory — to what they store and which command reaches each.
+
 ### Fixed
 
 - **`PersonalMemory.query()` returned every hit twice when the process

--- a/docs/how-to/which-memory-is-which.md
+++ b/docs/how-to/which-memory-is-which.md
@@ -1,0 +1,75 @@
+# Which memory is which
+
+Attune ships several memory surfaces, and sessions often run beside a
+host agent (Claude Code) that has its own. This page is the
+orientation map: what each ring stores, where it lives, and which
+command reaches it.
+
+## The rings at a glance
+
+| Ring | What it holds | Where it lives | Reach it via |
+|------|---------------|----------------|--------------|
+| Personal memory | Curated topics you capture (decisions, patterns, troubleshooting, reference) | `~/.attune/memory/<topic>/<kind>.md` | `attune memory capture` / `recall`, `personal_memory_*` MCP tools |
+| Memory graph | Structured findings from workflows (patterns, bugs, context nodes + edges) | JSON graph on disk, per project | `memory_store` / `memory_search` MCP tools |
+| Session memory (Redis/AMS) | Per-session working keys plus semantic long-term records | Redis Agent Memory Server, `attune` namespace | `redis_memory_*` MCP tools (needs the `[redis]` extra) |
+| Host agent memory | Whatever your host agent (e.g. Claude Code) persists for itself | The host's own files (e.g. `~/.claude/.../memory/`) | The host reads it; attune does not |
+
+## Which one do I want?
+
+- **"Remember this decision for future sessions"** — personal memory.
+  It is plain markdown you can read and edit; recall is keyword
+  retrieval over the polished files.
+
+  ```bash
+  attune memory capture auth-architecture \
+      "JWT over sessions - stateless scaling" --kind decision
+  attune memory recall "why did we pick JWT"
+  ```
+
+- **"Store a structured finding a workflow produced"** — the memory
+  graph. Workflows write typed nodes (bug, pattern, context) and link
+  them; search is graph-aware.
+
+- **"Share state across agents in this session, or search past
+  sessions semantically"** — Redis/AMS session memory. Working-memory
+  keys are session-scoped; long-term records are vector-searchable
+  across sessions. Requires Redis and
+  `pip install 'attune-ai[redis]'`.
+
+- **"Why does my host agent already know X?"** — that is the host's
+  own memory, not attune's. The two do not share storage. If a fact
+  should be durable *inside attune*, capture it explicitly.
+
+## Common confusions
+
+**Personal memory vs. host memory.** Both persist across sessions and
+both are markdown, so they blur together. The test: did you (or the
+agent) run `attune memory capture`? Then it is attune's, portable to
+any host. Did the host save it on its own? Then attune cannot recall
+it.
+
+**Session memory is two tiers.** `redis_memory_store` /
+`redis_memory_retrieve` are exact key lookups in the current
+session's working memory. `redis_memory_search` is semantic search
+over long-term records, including other sessions'. Storing a key does
+not make it semantically searchable — promotion to long-term is a
+separate step (`redis_memory_promote`).
+
+**Recall is keyword, not magic.** Personal-memory recall ranks by
+word overlap with the polished files. Query with the words the memory
+would contain ("redis connection timeout"), not vague references
+("that fix from Tuesday").
+
+## Health checks
+
+```bash
+attune memory topics        # personal memory reachable + populated?
+```
+
+Use the `redis_health_check` MCP tool for the Redis/AMS ring. If it
+reports Redis support missing, install the extra:
+`pip install 'attune-ai[redis]'`.
+
+Every release is gated by `scripts/release_recall_gate.py`, which
+installs the built wheel into a clean environment and proves the
+capture-to-recall round-trip before publishing.

--- a/docs/specs/curated-memory-productionization/tasks.md
+++ b/docs/specs/curated-memory-productionization/tasks.md
@@ -105,16 +105,22 @@ lacked `[redis]` — `redis_health_check` failed until a manual
   fresh-session context.
 
 ## T7 — Recall-eval as a release gate
+   — **DONE 2026-07-02** (this branch; chosen over a broad
+   docs+testing pass via a live pushback form, Patrick's pick)
 
 9.3.0 shipped with `PersonalMemory.query()` 100% broken (hit@1 0/18)
 and no gate caught it — all local testing ran main, not the artifact.
-Golden queries already exist (`docs/specs/lessons-corpus-rag/golden_queries.json`;
-the memory-recall-eval spec has the harness).
 
-- Wire a recall smoke-eval against the BUILT artifact (clean venv,
-  isolated `$HOME`) into release-prep — pass/fail on hit@3 above a
-  floor, not a benchmark.
-- **Receipt:** the gate run visible in the next release's prep log.
+- `scripts/release_recall_gate.py`: builds/accepts the wheel,
+  installs into a clean venv with isolated `$HOME` and
+  `ANTHROPIC_API_KEY=""`, runs 3 capture→recall round-trips through
+  the user-facing CLI, asserts hit@3 = 3/3 and no duplicate paths
+  (the 9.4.x dedup class). Exit 1 = do not publish.
+- Enforced in `publish-pypi.yml` (build job, before artifact upload)
+  AND advisory in the release-execute skill (pre-tag, so failures
+  surface before tagging).
+- **Receipt:** maiden run against the 9.4.0 wheel passed 3/3
+  (2026-07-02); next release exercises the CI enforcement.
 
 ---
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -207,6 +207,7 @@ nav:
   - How-to:
       - how-to/index.md
       - Memory System:
+          - Which Memory Is Which: how-to/which-memory-is-which.md
           - Unified Memory: how-to/unified-memory-system.md
           - Memory Graph: how-to/memory-graph.md
           - Lessons Workflow: how-to/lessons-workflow.md

--- a/scripts/release_recall_gate.py
+++ b/scripts/release_recall_gate.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""Release gate: prove memory recall works in the BUILT artifact.
+
+Why this exists: 9.3.0 shipped with ``attune memory recall`` 100%
+broken (capture succeeded, recall returned nothing) while every mocked
+unit test was green — all local testing ran the checkout, never the
+wheel. This gate installs the actual artifact into a clean venv with an
+ISOLATED ``$HOME`` and exercises the user-facing CLI round-trip:
+capture N memories, recall each, assert hits land and no duplicate
+paths come back (the 9.4.x dedup class).
+
+Usage::
+
+    python scripts/release_recall_gate.py                # builds the wheel
+    python scripts/release_recall_gate.py --wheel dist/attune_ai-X.Y.Z-*.whl
+
+Exit 0 = gate passed; exit 1 = gate FAILED (do not publish).
+Spec: docs/specs/curated-memory-productionization/tasks.md (T7).
+"""
+
+from __future__ import annotations
+
+import argparse
+import glob
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+
+#: (topic, kind, content, recall query) — three kinds, distinct wording
+#: so keyword recall has real signal to rank on.
+CASES = [
+    (
+        "release-gate-decision",
+        "decision",
+        "We gate every release on an artifact-level recall round-trip "
+        "after 9.3.0 shipped with recall completely broken.",
+        "why do we gate releases on recall",
+    ),
+    (
+        "redis-timeout-tuning",
+        "troubleshooting",
+        "Intermittent Redis connection failures under load were fixed "
+        "by raising the connection timeout to thirty seconds.",
+        "intermittent redis connection failures under load",
+    ),
+    (
+        "keyword-corpus-pattern",
+        "reference",
+        "The personal memory corpus is retrieved with the attune-rag "
+        "keyword pipeline over polished markdown files.",
+        "how is the personal memory corpus retrieved",
+    ),
+]
+
+
+def run(cmd: list[str], env: dict[str, str], timeout: int = 300) -> subprocess.CompletedProcess:
+    """Run a command, echoing it, never raising on nonzero exit."""
+    print(f"  $ {' '.join(cmd)}")
+    return subprocess.run(cmd, env=env, capture_output=True, text=True, timeout=timeout)
+
+
+def fail(msg: str) -> int:
+    print(f"\nRECALL GATE FAILED: {msg}")
+    return 1
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--wheel", help="Path/glob of the wheel to test (default: build one)")
+    args = parser.parse_args()
+
+    base_env = os.environ.copy()
+
+    if args.wheel:
+        wheels = sorted(glob.glob(args.wheel))
+        if not wheels:
+            return fail(f"no wheel matches {args.wheel!r}")
+        wheel = wheels[-1]
+    else:
+        print("building wheel (uv build) ...")
+        built = run(["uv", "build", "--wheel"], base_env, timeout=600)
+        if built.returncode != 0:
+            return fail(f"uv build failed:\n{built.stderr[-800:]}")
+        wheels = sorted(glob.glob(str(REPO / "dist" / "attune_ai-*.whl")), key=os.path.getmtime)
+        if not wheels:
+            return fail("uv build produced no wheel in dist/")
+        wheel = wheels[-1]
+    print(f"wheel: {wheel}")
+
+    with tempfile.TemporaryDirectory(prefix="recall-gate-") as tmp:
+        tmpdir = Path(tmp)
+        venv = tmpdir / "venv"
+        fake_home = tmpdir / "home"
+        fake_home.mkdir()
+
+        print("creating clean venv ...")
+        made = run(["uv", "venv", "-q", str(venv)], base_env)
+        if made.returncode != 0:
+            return fail(f"uv venv failed:\n{made.stderr[-400:]}")
+
+        print("installing the artifact ...")
+        installed = run(
+            ["uv", "pip", "install", "-q", "--python", str(venv / "bin" / "python"), wheel],
+            base_env,
+            timeout=600,
+        )
+        if installed.returncode != 0:
+            return fail(f"wheel install failed:\n{installed.stderr[-800:]}")
+
+        # Isolated HOME: the artifact's memory writes/reads must land in
+        # a fresh corpus, and no key/env from the developer machine may
+        # leak in (keyless like CI — empty string, not unset).
+        env = {
+            "HOME": str(fake_home),
+            "PATH": os.environ.get("PATH", ""),
+            "ANTHROPIC_API_KEY": "",
+        }
+        attune = str(venv / "bin" / "attune")
+
+        print("capture -> recall round-trips ...")
+        for topic, kind, content, _query in CASES:
+            cap = run([attune, "memory", "capture", topic, content, "--kind", kind], env)
+            if cap.returncode != 0:
+                return fail(f"capture {topic!r} exited {cap.returncode}:\n{cap.stderr[-400:]}")
+
+        hits = 0
+        for topic, kind, _content, query in CASES:
+            rec = run([attune, "memory", "recall", query, "--k", "3", "--json"], env)
+            if rec.returncode != 0:
+                return fail(f"recall {query!r} exited {rec.returncode}:\n{rec.stderr[-400:]}")
+            try:
+                results = json.loads(rec.stdout)
+            except json.JSONDecodeError:
+                return fail(f"recall {query!r} emitted non-JSON:\n{rec.stdout[-400:]}")
+            paths = [r.get("path", "") for r in results]
+            if len(paths) != len(set(paths)):
+                return fail(f"recall {query!r} returned duplicate paths: {paths}")
+            if any(p == f"{topic}/{kind}.md" for p in paths):
+                hits += 1
+            else:
+                print(f"  MISS: {query!r} -> {paths}")
+
+        print(f"\nhit@3: {hits}/{len(CASES)}")
+        if hits < len(CASES):
+            return fail(
+                f"only {hits}/{len(CASES)} queries recalled their capture "
+                "from the built artifact"
+            )
+
+    print("RECALL GATE PASSED — artifact-level capture->recall verified")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Closes T7 of `docs/specs/curated-memory-productionization/tasks.md` plus the one orientation doc chosen (over a broad docs+testing pass) via a live pushback form.

- **`scripts/release_recall_gate.py`** — installs the built wheel into a clean venv with isolated `$HOME` and `ANTHROPIC_API_KEY=""`, runs 3 `attune memory capture` → `recall` round-trips through the user-facing CLI, asserts hit@3 = 3/3 and no duplicate paths (the 9.4.x dedup class). Exit 1 = do not publish. **Maiden run against the 9.4.0 wheel: 3/3 PASSED.**
- **`publish-pypi.yml`** — gate enforced in the build job before artifacts upload; build timeout 10→20 min (guard test range is 1–75, suite green). This is the gate that would have caught 9.3.0 shipping with recall 100% broken while all mocked tests were green.
- **`docs/how-to/which-memory-is-which.md`** (+ mkdocs nav) — orientation map for the memory rings (personal / graph / Redis-AMS / host-agent). `mkdocs build --strict` green; doc-import audit clean.

Broad memory docs deferred until T1/T2 stabilize the user-facing surfaces (doc-fiction discipline).

Note: trivial CHANGELOG Unreleased-section conflict expected with #1224 — whichever merges second rebases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)