### PR TITLE
feat(memory): recall-digest render + stash->curated promotion (curated-memory R3+R4)

### DIFF
--- a/.agents/skills/elicit/SKILL.md
+++ b/.agents/skills/elicit/SKILL.md
@@ -200,6 +200,29 @@ Extra field keys (all optional; reuses the decision keys plus one):
 When nothing is blocked, set `options: []` and `required: false` — the
 report renders as a status display with no picker.
 
+### The "report" style (v5.1)
+
+`"progress_style": "report"` renders a **neutral digest** instead of a
+task report: item `status` is a free-form category tag (e.g. a memory
+node type — no done/blocked semantics, no strikethrough), and `options`
+may be **any subset** of item labels, offered as a "Pick one to go
+deeper" picker (items not in `options` render as static tagged rows).
+Pure presentation — the answer is still one selected option, validated
+as a single-select. Set `required: false` when a pick is optional.
+First consumer: the curated-memory recall digest
+(`python -m attune.memory.recall_digest` renders the live Redis digest
+as this form).
+
+```json
+{"id": "digest", "text": "Pull more on a topic?", "type": "progress",
+ "progress_style": "report", "required": false,
+ "options": ["Memory architecture"],
+ "progress_items": [
+   {"label": "Memory architecture", "status": "project context", "detail": "git + Redis"},
+   {"label": "Recall benchmarks", "status": "reference"}
+ ]}
+```
+
 **Surface:** the three-bucket layout (static done/in_flight rows + the
 blocked radiogroup picker) renders on the **widget** surface
 (`elicitation_render_widget` → `show_widget`); the answer is the one

--- a/.claude/lessons.md
+++ b/.claude/lessons.md
@@ -12897,3 +12897,20 @@ files.
   parent and child alike). Cross-session agents get DIFFERENT session
   dirs — for cross-session handoff use the starter file / memory, not
   the scratchpad.
+
+- **The PostToolUse ruff-autofix hook strips a just-added import
+  BETWEEN two Edit calls — add the usage before (or with) the
+  import, never import-first**: hit twice on 2026-07-03. Pattern:
+  Edit #1 adds `from x import Y` (usage coming in Edit #2); the
+  formatter hook runs after EACH Edit, sees Y unused, and deletes
+  the import; Edit #2 then adds the usage → NameError at test time
+  (or worse, silently at runtime). Same race with `cat >>` appends:
+  a header Edit adding imports + helpers for code appended later
+  loses the imports (helpers/classes survive — ruff only autofixes
+  unused IMPORTS, not unused classes). Remedies: (a) single Write
+  with imports + usages together; (b) append the usage code FIRST,
+  then add imports; (c) after any import-adding Edit, grep the
+  import line before running tests — the PostToolUse "file was
+  modified by a hook" notice is the tell. Pairs with the "user-
+  rejected Edit may have partially landed" lesson — same
+  file-state-drifted-under-you family, formatter-shaped trigger.

--- a/.claude/lessons.md
+++ b/.claude/lessons.md
@@ -12886,3 +12886,14 @@ files.
   reference `$CLAUDE_SCRATCHPAD` inside Bash. Pairs with the
   "interrupted compound command may have partially executed" lesson —
   same reconciliation discipline, env-var-shaped trigger.
+  **Inter-agent addendum (probed live 2026-07-03):** subagents spawned
+  via the Agent tool get the SAME literal scratchpad path in their own
+  system prompt (the dir is keyed by the parent session id, which IS
+  exported as `CLAUDE_CODE_SESSION_ID`) — a marker file written by a
+  haiku subagent was immediately readable by the parent. So the
+  scratchpad IS a working same-session inter-agent file channel;
+  address it by literal path in prompts (each agent reads its own
+  system prompt), never via the env var (unset in every agent's Bash,
+  parent and child alike). Cross-session agents get DIFFERENT session
+  dirs — for cross-session handoff use the starter file / memory, not
+  the scratchpad.

--- a/.claude/lessons.md
+++ b/.claude/lessons.md
@@ -12857,3 +12857,32 @@ files.
   missed; assert `old in text` for EVERY replacement in one-off
   transform scripts, and grep the output for the negated patterns
   (old text absent, new text present) as the verify step.
+
+- **The Bash tool's shell is zsh — unquoted `$FILES` does NOT
+  word-split, so a space-separated file list passes as ONE argument**:
+  hit 2026-07-03 pre-flighting the pinned hooks. `FILES="a.py b.py";
+  pre-commit run black --files $FILES` reported "(no files to check)
+  Skipped" (the single mega-path matched no hook filter) and `ruff
+  check $FILES` errored on a path containing spaces. Both looked like
+  tool misconfiguration, not a quoting bug. Fix: pass explicit
+  space-separated args in the command itself, use an array
+  (`files=(a.py b.py); cmd $files`), or `${=FILES}` to force
+  splitting. Symptom to recognize: "no files to check" from
+  pre-commit when you KNOW you passed .py files, or a tool error
+  whose reported path is several filenames concatenated.
+
+- **`$CLAUDE_SCRATCHPAD` is NOT set in the Bash tool's environment —
+  a heredoc redirect to `"$CLAUDE_SCRATCHPAD/file"` writes to
+  `/file` (read-only fs) and everything downstream silently
+  no-ops**: hit 2026-07-03 during a `git commit -F` dance. The
+  scratchpad path exists (it's in the system prompt) but only as a
+  LITERAL path, not an env var. The compound command's tail then
+  failed (`fatal: could not read log file '/commit_msg.txt'`) while
+  the pre-commit hook output made the whole thing LOOK like the
+  commit ran — only the trailing `git log --oneline -1` (per the
+  existing verify-commit-landed lesson) caught that HEAD hadn't
+  moved. Fixes: write message files with the Write tool to the
+  literal scratchpad path, then `git commit -F <literal path>`; never
+  reference `$CLAUDE_SCRATCHPAD` inside Bash. Pairs with the
+  "interrupted compound command may have partially executed" lesson —
+  same reconciliation discipline, env-var-shaped trigger.

--- a/docs/specs/curated-memory-productionization/decisions.md
+++ b/docs/specs/curated-memory-productionization/decisions.md
@@ -148,6 +148,32 @@ topic; `memory_search` → 0 results; `redis_health_check` failed →
 fixed by `uv sync --extra dev --extra developer --extra redis` in the
 worktree; recall works post-9.4.0 but duplicates results (T5).
 
+### D9 — R3 composition check PASSED: recall digest is a "report"
+style of `progress`, not grammar member #6 (decided 2026-07-03)
+
+T1's composition-check-first constraint ran and **composition won**.
+The digest's structure — static tagged rows + an optional "go deeper"
+picker whose answer is one option validated as a single-select — is
+exactly `progress`'s shape; the misrender was purely presentational
+(task-status vocabulary, done-strikethrough, "Blocked" picker header).
+The fix follows the `list_style` precedent (a pure-presentation field):
+`progress_style: "report"` on a PROGRESS question renders a neutral
+digest — item `status` becomes a free-form category tag, `options` may
+be any subset of item labels, no task semantics. Answer path, fallback,
+and elicitation-schema mapping are untouched; no new `QuestionType`.
+
+Second half: the render shipped as **Redis's first real consumer** —
+`attune.memory.recall_digest` pulls from `FCALL recall_digest` (the R1
+hook's warm data), never the curated JSON file, proving R2's foundation
+en route. `python -m attune.memory.recall_digest` prints widget HTML.
+
+**Receipts (live 2026-07-03):** the two real-Redis tests in
+`tests/unit/memory/test_recall_digest.py` ran non-mocked against the
+warm function (skip-guarded for CI); the live 9-node digest rendered
+through `show_widget` in the build session from production
+`form_to_widget_html` output. Grammar extension recipe step 7's
+dogfood receipt (submit round-trip) recorded in tasks.md T1.
+
 ### D3 — Requirements approved as written; R-ordering left to
 execution (decided 2026-07-02)
 

--- a/docs/specs/curated-memory-productionization/decisions.md
+++ b/docs/specs/curated-memory-productionization/decisions.md
@@ -174,6 +174,40 @@ through `show_widget` in the build session from production
 `form_to_widget_html` output. Grammar extension recipe step 7's
 dogfood receipt (submit round-trip) recorded in tasks.md T1.
 
+### D10 — R4 shipped: per-candidate decision-form verdicts; the live
+dogfood caught the status="open" invisibility bug (decided 2026-07-03)
+
+The promotion path (`attune.memory.promotion`) is deliberately
+verdict-per-candidate: `promotion_form_dict` renders one Promote/Skip
+`decision` card per drafted node (rationale = draft + source stash id),
+and `promote()` writes exactly one verdicted node — there is no
+promote-all path, making bulk import structurally impossible (the D8 /
+supersession evidence). Candidates read through the SAME backend
+resolution the stash hook writes through (`recent_entries` /
+`recall_entries` — file or AMS), so the path works wherever the stash
+landed. Provenance keys on the node extend the existing `review_*`
+convention: `promoted_from_stash_id`, `promoted_from_session`,
+`promoted_from_ts`, `promoted_at`, `review_verdict`,
+`review_response_id`.
+
+**Live receipt (2026-07-03, the R5 non-mocked round-trip):** two real
+stashed findings (stash `5cc2eea0…`, `2b9a2153…`) were drafted as
+`project_context` nodes, verdicted Promote by Patrick through the live
+widget form, validated via `collect_form_response`
+(`resp-widget-resp-20260703-013922`), written with provenance, edged to
+the architecture and D6 nodes, committed to the memory repo
+(`914f376`/`fbf774c`), and confirmed in the re-hydrated digest (11
+active nodes, both promotions first).
+
+**Bug the dogfood caught:** `add_finding` defaults `status` to
+`"open"`, but hydration + the recall digest carry only `"active"`
+nodes — the first promotion run produced nodes invisible to recall
+(hydrate log said 11, digest said 9). `promote()` now writes
+`status="active"` with a regression test; the two live nodes were
+repaired via `update_node`. This also validates the stashed
+"curated-memory callers need a status setter" finding — `add_finding`
+accepts `status` via the finding dict.
+
 ### D3 — Requirements approved as written; R-ordering left to
 execution (decided 2026-07-02)
 

--- a/docs/specs/curated-memory-productionization/tasks.md
+++ b/docs/specs/curated-memory-productionization/tasks.md
@@ -11,7 +11,8 @@ can interleave. R5 (non-mocked receipt) applies to every task.
 
 ---
 
-## T1 — R3: recall-digest render (NEXT)
+## T1 — R3: recall-digest render
+   — **SHIPPED 2026-07-03** (see D9)
 
 Build the "here is what memory carries" surface, replacing the
 `progress`-construct misrender (memory facts strike through as done
@@ -19,12 +20,18 @@ tasks).
 
 - **Composition check FIRST**: try a display variant of `progress`
   before minting grammar member #6 (extension recipe: compose before
-  new `QuestionType`).
+  new `QuestionType`). → **Composition won** (D9): shipped as
+  `progress_style: "report"` (a `list_style`-class presentation
+  field), no new QuestionType, answer path unchanged.
 - Build as **Redis's first real consumer**: the render pulls from
   `FCALL recall_digest` (86us warm), not the JSON file — proving R2's
-  foundation en route.
+  foundation en route. → `attune.memory.recall_digest` (fetch via
+  FCALL + pure transform + `python -m` entry printing widget HTML).
 - **Receipt:** a live widget render + submit round-trip in a real
-  session, sourced from the Redis function call.
+  session, sourced from the Redis function call. → 2026-07-03: live
+  9-node digest fetched from warm Redis, rendered via `show_widget`
+  from production `form_to_widget_html` output; non-mocked real-Redis
+  tests in `tests/unit/memory/test_recall_digest.py` green.
 
 ## T2 — R4: stash → curated promotion path
 

--- a/docs/specs/curated-memory-productionization/tasks.md
+++ b/docs/specs/curated-memory-productionization/tasks.md
@@ -34,6 +34,7 @@ tasks).
   tests in `tests/unit/memory/test_recall_digest.py` green.
 
 ## T2 — R4: stash → curated promotion path
+   — **SHIPPED 2026-07-03** (see D10)
 
 A deliberate, reviewable step proposing auto-stashed findings for
 promotion into the curated graph (agent proposes, Patrick verdicts).
@@ -41,9 +42,16 @@ Bulk import is explicitly wrong (the 2026-07-02 supersession
 contradiction is the evidence).
 
 - Promotion writes provenance metadata (source stash entry, review
-  verdict, date) onto the resulting node.
+  verdict, date) onto the resulting node. → `attune.memory.promotion`
+  (`promotion_candidates` via the hook's own backend resolution;
+  per-candidate `decision` verdict form; `promote()` with the
+  `promoted_from_*`/`review_*` provenance keys; no promote-all path).
 - **Receipt:** one real stashed finding promoted with provenance
-  visible on the node.
+  visible on the node. → 2026-07-03: TWO real findings promoted via a
+  live widget verdict (`resp-widget-resp-20260703-013922`), provenance
+  on both nodes, memory-repo commits `914f376`/`fbf774c`, re-hydrated
+  digest carries them first (11 active nodes). Dogfood also caught and
+  fixed the status="open" recall-invisibility bug (D10).
 
 ## T3 — R2: targeted recall procedures (on demand)
 

--- a/plugin/skills/elicit/SKILL.md
+++ b/plugin/skills/elicit/SKILL.md
@@ -202,6 +202,29 @@ Extra field keys (all optional; reuses the decision keys plus one):
 When nothing is blocked, set `options: []` and `required: false` — the
 report renders as a status display with no picker.
 
+### The "report" style (v5.1)
+
+`"progress_style": "report"` renders a **neutral digest** instead of a
+task report: item `status` is a free-form category tag (e.g. a memory
+node type — no done/blocked semantics, no strikethrough), and `options`
+may be **any subset** of item labels, offered as a "Pick one to go
+deeper" picker (items not in `options` render as static tagged rows).
+Pure presentation — the answer is still one selected option, validated
+as a single-select. Set `required: false` when a pick is optional.
+First consumer: the curated-memory recall digest
+(`python -m attune.memory.recall_digest` renders the live Redis digest
+as this form).
+
+```json
+{"id": "digest", "text": "Pull more on a topic?", "type": "progress",
+ "progress_style": "report", "required": false,
+ "options": ["Memory architecture"],
+ "progress_items": [
+   {"label": "Memory architecture", "status": "project context", "detail": "git + Redis"},
+   {"label": "Recall benchmarks", "status": "reference"}
+ ]}
+```
+
 **Surface:** the three-bucket layout (static done/in_flight rows + the
 blocked radiogroup picker) renders on the **widget** surface
 (`elicitation_render_widget` → `show_widget`); the answer is the one

--- a/src/attune/elicitation/bridge.py
+++ b/src/attune/elicitation/bridge.py
@@ -178,12 +178,29 @@ def form_from_dict(data: dict[str, Any]) -> FormSchema:
         elif user_position is not None and options and user_position not in options:
             problems.append(f"{where} 'user_position' {user_position!r} not in options")
 
+        # v5.1 render variant: progress_style — "report" renders a neutral
+        # digest (status = free-form category tag, options = any subset of
+        # item labels offered as a "go deeper" picker). Pure presentation;
+        # the answer path is unchanged. Parsed before progress_items so the
+        # item validation below can branch on it.
+        progress_style = raw.get("progress_style")
+        if progress_style is not None:
+            if progress_style != "report":
+                problems.append(f"{where} 'progress_style' must be 'report'")
+                progress_style = None
+            elif qtype is not QuestionType.PROGRESS:
+                problems.append(
+                    f"{where} 'progress_style' is only valid on progress (got {qtype.value})"
+                )
+                progress_style = None
+
         # v5 PROGRESS extra: progress_items — the reported items keyed by
         # status. Parsed generically; only PROGRESS renders them. Each item
-        # is {label, status, detail?}; status ∈ {done, in_flight, blocked};
-        # the blocked subset's labels must equal options (the picker offers
-        # exactly the actionable items). PROGRESS allows empty options (when
-        # nothing is blocked it degrades to a pure status display).
+        # is {label, status, detail?}. Default (task) style: status ∈ {done,
+        # in_flight, blocked}; the blocked subset's labels must equal options
+        # (the picker offers exactly the actionable items). "report" style:
+        # status is any non-empty category tag; options may be any subset of
+        # item labels. Both allow empty options (a pure status display).
         progress_items = raw.get("progress_items")
         if progress_items is not None:
             if not isinstance(progress_items, list) or not all(
@@ -194,6 +211,7 @@ def form_from_dict(data: dict[str, Any]) -> FormSchema:
             else:
                 valid_status = {"done", "in_flight", "blocked"}
                 blocked_labels = []
+                all_labels = []
                 for progress_idx, item in enumerate(progress_items):
                     label = item.get("label")
                     status = item.get("status")
@@ -201,7 +219,15 @@ def form_from_dict(data: dict[str, Any]) -> FormSchema:
                         problems.append(
                             f"{where} progress_items[{progress_idx}] needs a 'label' string"
                         )
-                    if status not in valid_status:
+                    else:
+                        all_labels.append(label)
+                    if progress_style == "report":
+                        if not isinstance(status, str) or not status:
+                            problems.append(
+                                f"{where} progress_items[{progress_idx}] 'status' must be "
+                                f"a non-empty tag string in report style"
+                            )
+                    elif status not in valid_status:
                         problems.append(
                             f"{where} progress_items[{progress_idx}] 'status' must be one of {valid_status}"
                         )
@@ -211,11 +237,19 @@ def form_from_dict(data: dict[str, Any]) -> FormSchema:
                         )
                     if status == "blocked" and isinstance(label, str):
                         blocked_labels.append(label)
-                if qtype is QuestionType.PROGRESS and set(blocked_labels) != set(options):
-                    problems.append(
-                        f"{where} PROGRESS blocked items {sorted(set(blocked_labels))} "
-                        f"must equal options {sorted(set(options))}"
-                    )
+                if qtype is QuestionType.PROGRESS:
+                    if progress_style == "report":
+                        stray = [o for o in options if o not in all_labels]
+                        if stray:
+                            problems.append(
+                                f"{where} PROGRESS report options must be item labels; "
+                                f"not items: {stray}"
+                            )
+                    elif set(blocked_labels) != set(options):
+                        problems.append(
+                            f"{where} PROGRESS blocked items {sorted(set(blocked_labels))} "
+                            f"must equal options {sorted(set(options))}"
+                        )
         elif qtype is QuestionType.PROGRESS:
             problems.append(f"{where} type progress requires 'progress_items'")
 
@@ -252,6 +286,7 @@ def form_from_dict(data: dict[str, Any]) -> FormSchema:
                     recommended=recommended,
                     user_position=user_position,
                     progress_items=progress_items,
+                    progress_style=progress_style,
                     list_style=list_style,
                 )
             )

--- a/src/attune/elicitation/widget.py
+++ b/src/attune/elicitation/widget.py
@@ -132,6 +132,57 @@ def _control_html(q: FormQuestion) -> str:
             )
         return f'<div class="ae-cards" role="radiogroup">{cards}</div>'
 
+    if q.type == QuestionType.PROGRESS and q.progress_style == "report":
+        # v5.1 "report" style: a neutral digest. Item status is a free-form
+        # category tag (no task semantics, no strikethrough); items named in
+        # options render as pickable "go deeper" cards, the rest as static
+        # tagged rows. Same radio answer path as the default style.
+        items = q.progress_items or []
+        notes = q.option_notes or {}
+        by_label = {it.get("label"): it for it in items}
+        rows = ""
+        for it in items:
+            if it.get("label") in q.options:
+                continue
+            tag = f'<span class="ae-prog-tag">{_esc(it.get("status", ""))}</span>'
+            detail = (
+                f'<span class="ae-prog-detail">{_esc(it["detail"])}</span>'
+                if it.get("detail")
+                else ""
+            )
+            rows += (
+                f'<div class="ae-prog-row ae-prog-report">'
+                f'{tag}<span class="ae-prog-label">{_esc(it.get("label", ""))}</span>'
+                f"{detail}</div>"
+            )
+        ordered = list(q.options)
+        if q.recommended and q.recommended in ordered:
+            ordered = [q.recommended] + [o for o in ordered if o != q.recommended]
+        cards = ""
+        for opt in ordered:
+            it = by_label.get(opt, {})
+            is_rec = opt == q.recommended
+            badge = '<span class="ae-rec-badge">suggested next</span>' if is_rec else ""
+            tag = f'<span class="ae-prog-tag">{_esc(it.get("status", ""))}</span>'
+            note_text = notes.get(opt) or it.get("detail")
+            note = f'<span class="ae-card-note">{_esc(note_text)}</span>' if note_text else ""
+            checked = " checked" if q.default == opt else ""
+            cls = "ae-card ae-card-rec" if is_rec else "ae-card"
+            cards += (
+                f'<label class="{cls}">'
+                f'<input type="radio" name="{_esc(q.id)}" data-control '
+                f'value="{_esc(opt)}"{checked}>'
+                f'{badge}{tag}<span class="ae-card-title">{_esc(opt)}</span>{note}</label>'
+            )
+        picker = (
+            '<div class="ae-prog-blocked-h">Pick one to go deeper:</div>'
+            f'<div class="ae-cards" role="radiogroup">{cards}</div>'
+            if cards
+            else ""
+        )
+        rows_html = f'<div class="ae-prog-rows">{rows}</div>' if rows else ""
+        return f'<div class="ae-progress">{rows_html}{picker}</div>'
+
     if q.type == QuestionType.PROGRESS:
         # A status report: done/in_flight items render as static rows; the
         # blocked items become the radiogroup picker (recommended first,
@@ -372,6 +423,10 @@ def form_to_widget_html(form: FormSchema, message: str = "") -> str:
   color:var(--text-muted); }}
 #attune-elicit-form .ae-prog-blocked-h {{ font-size:11px; font-weight:600;
   text-transform:uppercase; letter-spacing:.03em; color:var(--text-accent); }}
+#attune-elicit-form .ae-prog-tag {{ flex:none; font-size:10px; font-weight:600;
+  text-transform:uppercase; letter-spacing:.04em; color:var(--text-muted);
+  border:1px solid var(--border); border-radius:3px; padding:0 .3em; }}
+#attune-elicit-form .ae-card .ae-prog-tag {{ align-self:flex-start; }}
 #attune-elicit-form .ae-card .ae-prog-icon {{ margin-right:.15rem; }}
 #attune-elicit-form .ae-submit {{ margin-top:.5rem; padding:.55rem 1.1rem;
   font-size:15px; font-weight:500; cursor:pointer; color:var(--text-primary);

--- a/src/attune/mcp/tool_schemas.py
+++ b/src/attune/mcp/tool_schemas.py
@@ -481,7 +481,16 @@ def get_elicitation_tools() -> dict[str, dict[str, Any]]:
             "progress_items": {
                 "type": "array",
                 "description": "progress: reported items as {label, status, detail?} dicts, "
-                "status in done/in_flight/blocked; the blocked subset must equal options",
+                "status in done/in_flight/blocked; the blocked subset must equal options. "
+                "With progress_style 'report': status is a free-form category tag and "
+                "options may be any subset of item labels",
+            },
+            "progress_style": {
+                "type": "string",
+                "enum": ["report"],
+                "description": "progress only: 'report' renders a neutral digest (status = "
+                "category tag, no task semantics; options = 'go deeper' picker). "
+                "Presentation only; answer unchanged.",
             },
             "list_style": {
                 "type": "string",

--- a/src/attune/memory/promotion.py
+++ b/src/attune/memory/promotion.py
@@ -1,0 +1,164 @@
+"""Stash → curated promotion path (curated-memory R4).
+
+A deliberate, reviewable step that moves auto-stashed session findings
+into the durable curated graph: the agent drafts a curated node per
+candidate (the 30-day test — "will this still be true and worth
+carrying in a month?"), the reviewer verdicts each one through a
+decision form, and every promotion writes provenance metadata (source
+stash entry, review verdict, date) onto the resulting node.
+
+Bulk import is explicitly wrong (the 2026-07-02 auto-stash
+supersession contradiction is the evidence) — this module has no
+promote-all path; every node requires an explicit per-candidate
+verdict.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under Apache 2.0
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from typing import Any
+
+from attune.memory.graph import MemoryGraph
+from attune.memory.session_stash import recent_entries
+
+logger = logging.getLogger(__name__)
+
+#: Node types admissible in the curated graph (see attune.memory.nodes).
+CURATED_TYPES = ("user_context", "feedback", "project_context", "reference")
+
+
+def promotion_candidates(
+    top_k: int = 10, cwd: str | None = None, backend: Any = None
+) -> list[dict[str, Any]]:
+    """Fetch recent stashed findings as promotion candidates.
+
+    Reads through the same backend resolution the stash hook writes
+    through (file by default, AMS/Redis when connected), normalizing
+    the backend-shaped records to a stable candidate shape.
+
+    Args:
+        top_k: Max candidates to fetch (newest first).
+        cwd: When set, prefer entries from this project root.
+        backend: Optional injected backend (tests); resolved from the
+            entry point when omitted.
+
+    Returns:
+        Candidate dicts: ``{id, text, stash_type, session_id, ts}``.
+    """
+    records = recent_entries(top_k=top_k, cwd=cwd, backend=backend)
+    candidates = []
+    for rec in records:
+        if not isinstance(rec, dict):
+            continue
+        topics = rec.get("topics") or []
+        if isinstance(topics, str):
+            topics = topics.split(",")
+        stash_type = next(
+            (t.split(":", 1)[1] for t in topics if isinstance(t, str) and t.startswith("type:")),
+            "note",
+        )
+        candidates.append(
+            {
+                "id": str(rec.get("id", "")),
+                "text": str(rec.get("text", "")),
+                "stash_type": stash_type,
+                "session_id": str(rec.get("session_id", "")),
+                "ts": rec.get("ts", rec.get("created_at")),
+            }
+        )
+    return candidates
+
+
+def promotion_form_dict(proposals: list[dict[str, Any]]) -> dict[str, Any]:
+    """Build the per-candidate verdict form (one decision per proposal).
+
+    Each proposal renders as a Promote/Skip decision card whose
+    rationale carries the drafted node text and its stash provenance —
+    so the reviewer verdicts each candidate individually (no bulk
+    accept). Feed the result to :func:`attune.elicitation.form_from_dict`.
+
+    Args:
+        proposals: Drafted nodes, each ``{source_id, type, name,
+            description, tags?}`` where ``source_id`` is the stash
+            entry id and ``type`` is a curated node type.
+
+    Returns:
+        A form dict; answers map ``promote_<i>`` → "Promote" | "Skip".
+    """
+    fields = []
+    for i, prop in enumerate(proposals):
+        fields.append(
+            {
+                "id": f"promote_{i}",
+                "text": f"[{prop.get('type', '?')}] {prop.get('name', '')}",
+                "type": "decision",
+                "options": ["Promote", "Skip"],
+                "recommended": "Promote",
+                "rationale": (
+                    f"{prop.get('description', '')}\n" f"(from stash {prop.get('source_id', '?')})"
+                ),
+            }
+        )
+    return {
+        "title": "Stash → curated promotion",
+        "description": (
+            "Per-candidate verdict — promote only what passes the 30-day "
+            "test. Skipped candidates stay in the stash."
+        ),
+        "fields": fields,
+    }
+
+
+def promote(
+    proposal: dict[str, Any],
+    source: dict[str, Any],
+    response_id: str = "",
+    graph: MemoryGraph | None = None,
+) -> str:
+    """Write one verdicted proposal into the curated graph with provenance.
+
+    Args:
+        proposal: The drafted node — ``{type, name, description, tags?}``;
+            ``type`` must be one of :data:`CURATED_TYPES`.
+        source: The stash candidate it came from (see
+            :func:`promotion_candidates`) — recorded as provenance.
+        response_id: The review response id (the form submission that
+            carried the "Promote" verdict).
+        graph: Target graph; defaults to :meth:`MemoryGraph.curated`.
+
+    Returns:
+        The created node id.
+
+    Raises:
+        ValueError: If ``proposal['type']`` is not a curated node type.
+    """
+    node_type = proposal.get("type", "")
+    if node_type not in CURATED_TYPES:
+        raise ValueError(
+            f"promotion requires a curated node type {CURATED_TYPES}, got {node_type!r}"
+        )
+    target = graph if graph is not None else MemoryGraph.curated()
+    provenance = {
+        "promoted_from_stash_id": str(source.get("id", "")),
+        "promoted_from_session": str(source.get("session_id", "")),
+        "promoted_from_ts": source.get("ts"),
+        "promoted_at": datetime.now().strftime("%Y-%m-%d"),
+        "review_verdict": "promote",
+        "review_response_id": response_id,
+    }
+    node_id = target.add_finding(
+        workflow="",
+        finding={
+            "type": node_type,
+            "name": proposal.get("name", ""),
+            "description": proposal.get("description", ""),
+            "tags": proposal.get("tags", []),
+            "metadata": provenance,
+        },
+    )
+    logger.info("promoted stash %s -> curated node %s", source.get("id"), node_id)
+    return node_id

--- a/src/attune/memory/promotion.py
+++ b/src/attune/memory/promotion.py
@@ -158,6 +158,10 @@ def promote(
             "description": proposal.get("description", ""),
             "tags": proposal.get("tags", []),
             "metadata": provenance,
+            # add_finding defaults to "open"; hydration + the recall digest
+            # only carry "active" nodes — an "open" promotion would be
+            # invisible to recall (caught live in the R4 dogfood).
+            "status": "active",
         },
     )
     logger.info("promoted stash %s -> curated node %s", source.get("id"), node_id)

--- a/src/attune/memory/recall_digest.py
+++ b/src/attune/memory/recall_digest.py
@@ -1,0 +1,170 @@
+"""Recall-digest render — memory's "here is what I carry" surface.
+
+Pulls the curated-memory digest from Redis (``FCALL recall_digest``, the
+data the SessionStart hydration hook keeps warm) and renders it as a
+report-style ``progress`` form (communication grammar): each node is a
+tagged, pickable card; the answer is one node to pull more on.
+
+This module is Redis's first real consumer in the curated-memory loop
+(curated-memory-productionization R3): the render reads the Redis
+function's output, never the curated JSON file. The transform is split
+from the fetch so it stays testable without a Redis server.
+
+Usage from a session::
+
+    python -m attune.memory.recall_digest --count 9
+
+prints widget HTML ready to pass to ``show_widget``; the submitted
+answer round-trips through :func:`attune.elicitation.collect_form_response`.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under Apache 2.0
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+#: Redis Function the SessionStart hydration hook loads (memory repo's
+#: ``functions.lua``). Returns one JSON document per curated node.
+DIGEST_FUNCTION = "recall_digest"
+
+#: Max characters of a node description carried into the card note.
+DETAIL_MAX = 160
+
+
+def fetch_digest_nodes(count: int = 9, client: Any = None) -> list[dict[str, Any]]:
+    """Fetch curated nodes from the ``recall_digest`` Redis Function.
+
+    Args:
+        count: How many nodes to request (most-recent first).
+        client: An optional connected ``redis.Redis`` client. When None,
+            one is created from ``REDIS_URL`` (default
+            ``redis://localhost:6379/0``).
+
+    Returns:
+        A list of node dicts (``name``, ``type``, ``description``,
+        ``updated_at``, ``id``, ``edges``), most-recent first.
+
+    Raises:
+        ImportError: If the ``redis`` package is not installed.
+        ValueError: If the function returns malformed JSON.
+        redis.RedisError: If Redis is unreachable or the function is
+            not loaded.
+    """
+    if client is None:
+        import redis  # noqa: PLC0415 — optional dependency, import at use
+
+        url = os.environ.get("REDIS_URL", "redis://localhost:6379/0")
+        client = redis.Redis.from_url(url, decode_responses=True)
+
+    raw = client.fcall(DIGEST_FUNCTION, 0, str(count))
+    nodes: list[dict[str, Any]] = []
+    for entry in raw or []:
+        if isinstance(entry, bytes):
+            entry = entry.decode("utf-8")
+        try:
+            nodes.append(json.loads(entry))
+        except (TypeError, json.JSONDecodeError) as e:
+            logger.exception("recall_digest returned a malformed entry")
+            raise ValueError(f"recall_digest returned malformed JSON: {e}") from e
+    return nodes
+
+
+def _detail(description: str) -> str:
+    """Trim a node description to a one-line card note."""
+    text = " ".join(description.split())
+    if len(text) <= DETAIL_MAX:
+        return text
+    return text[: DETAIL_MAX - 1].rstrip() + "…"
+
+
+def digest_form_dict(
+    nodes: list[dict[str, Any]], question_id: str = "memory_digest"
+) -> dict[str, Any]:
+    """Build the report-style ``progress`` form dict for a digest.
+
+    Every node becomes a pickable card tagged with its node type; the
+    (optional) answer is the node name to pull more on. Feed the result
+    to :func:`attune.elicitation.form_from_dict`.
+
+    Args:
+        nodes: Node dicts as returned by :func:`fetch_digest_nodes`.
+        question_id: The form field id the answer posts back under.
+
+    Returns:
+        A form dict ``{title, description, fields: [...]}``.
+    """
+    items = []
+    for node in nodes:
+        name = str(node.get("name", "")) or str(node.get("id", "unnamed"))
+        items.append(
+            {
+                "label": name,
+                "status": str(node.get("type", "node")).replace("_", " "),
+                "detail": _detail(str(node.get("description", ""))),
+            }
+        )
+    labels = [it["label"] for it in items]
+    return {
+        "title": "Memory digest",
+        "description": "What curated memory carries right now, most recent first.",
+        "fields": [
+            {
+                "id": question_id,
+                "text": "Pull more on a topic?",
+                "type": "progress",
+                "progress_style": "report",
+                "required": False,
+                "options": labels,
+                "progress_items": items,
+                "rationale": (f"{len(items)} curated node(s), live from FCALL {DIGEST_FUNCTION}."),
+            }
+        ],
+    }
+
+
+def render_digest_html(count: int = 9, client: Any = None) -> str:
+    """Fetch the digest from Redis and render it as widget HTML.
+
+    Args:
+        count: How many nodes to request.
+        client: Optional connected ``redis.Redis`` client (see
+            :func:`fetch_digest_nodes`).
+
+    Returns:
+        Self-contained HTML for ``show_widget``.
+
+    Raises:
+        ValueError: If Redis returns no nodes (an empty digest usually
+            means the hydration hook has not run).
+    """
+    from attune.elicitation import form_from_dict, form_to_widget_html
+
+    nodes = fetch_digest_nodes(count=count, client=client)
+    if not nodes:
+        raise ValueError(
+            "recall_digest returned no nodes — has the SessionStart hydration hook run?"
+        )
+    form = form_from_dict(digest_form_dict(nodes))
+    return form_to_widget_html(form)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry: print the digest widget HTML to stdout."""
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Render the curated-memory recall digest")
+    parser.add_argument("--count", type=int, default=9, help="nodes to request (default 9)")
+    args = parser.parse_args(argv)
+    print(render_digest_html(count=args.count))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/attune/meta_workflows/models.py
+++ b/src/attune/meta_workflows/models.py
@@ -101,6 +101,11 @@ class FormQuestion:
             {label, status, detail?} dicts, status ∈ {done, in_flight,
             blocked}. The blocked subset must equal options (the picker);
             done/in_flight items are reported but not answerable. None = none
+        progress_style: PROGRESS only — "report" renders a neutral digest
+            (item status is a free-form category tag, no task semantics or
+            strikethrough; options may be any subset of item labels, offered
+            as a "go deeper" picker). Pure presentation: the answer and its
+            validation are unchanged. None = the default task-status render.
         list_style: SINGLE_SELECT/MULTI_SELECT only — render the options as
             an "ordered" (numbered) or "unordered" (bulleted) selectable
             list instead of the default dropdown/checkboxes. Pure
@@ -124,6 +129,7 @@ class FormQuestion:
     recommended: str | None = None
     user_position: str | None = None
     progress_items: list[dict[str, str]] | None = None
+    progress_style: str | None = None
     list_style: str | None = None
 
     def to_ask_user_format(self) -> dict[str, Any]:

--- a/tests/unit/elicitation/test_progress_report_style.py
+++ b/tests/unit/elicitation/test_progress_report_style.py
@@ -87,6 +87,11 @@ class TestReportStyleFormFromDict:
         with pytest.raises(FormValidationError, match="non-empty tag string"):
             form_from_dict(_report(options=[], progress_items=bad))
 
+    def test_detail_must_be_string(self) -> None:
+        bad = [{"label": "X", "status": "reference", "detail": 123}]
+        with pytest.raises(FormValidationError, match="'detail' must be a string"):
+            form_from_dict(_report(options=[], progress_items=bad))
+
     def test_options_may_be_subset_of_labels(self) -> None:
         # Only one of three items pickable — invalid in task style, fine here.
         form = form_from_dict(_report(options=["Goal framing"]))

--- a/tests/unit/elicitation/test_progress_report_style.py
+++ b/tests/unit/elicitation/test_progress_report_style.py
@@ -1,0 +1,176 @@
+"""Tests for the v5.1 "report" style of the progress construct.
+
+``progress_style: "report"`` renders a PROGRESS question as a neutral
+digest: item ``status`` is a free-form category tag (no task semantics,
+no strikethrough), and ``options`` may be any subset of item labels,
+offered as a "go deeper" picker. Pure presentation — the answer is one
+selected option, validated exactly as the default style. First consumer:
+the curated-memory recall digest
+(``attune.memory.recall_digest``, curated-memory-productionization R3).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from attune.elicitation import (
+    FormValidationError,
+    collect_form_response,
+    form_from_dict,
+    form_to_widget_html,
+)
+from attune.elicitation.bridge import form_to_askuserquestion
+from attune.meta_workflows.models import FormQuestion, QuestionType
+
+
+def _report(**override) -> dict:
+    """Build a one-field report-style progress form dict."""
+    field = {
+        "id": "digest",
+        "text": "Pull more on a topic?",
+        "type": "progress",
+        "progress_style": "report",
+        "required": False,
+        "options": ["Memory architecture", "Goal framing"],
+        "rationale": "3 curated nodes, live from Redis.",
+        "progress_items": [
+            {"label": "Memory architecture", "status": "project context", "detail": "git + Redis"},
+            {"label": "Goal framing", "status": "user context"},
+            {"label": "Recall benchmarks", "status": "reference", "detail": "86us medians"},
+        ],
+    }
+    field.update(override)
+    return {"title": "Memory digest", "fields": [field]}
+
+
+class TestReportStyleModel:
+    def test_progress_style_defaults_none(self) -> None:
+        q = FormQuestion(id="a", text="t", type=QuestionType.PROGRESS)
+        assert q.progress_style is None
+
+
+class TestReportStyleFormFromDict:
+    def test_builds_report_style(self) -> None:
+        form = form_from_dict(_report())
+        q = form.questions[0]
+        assert q.progress_style == "report"
+        assert q.progress_items is not None and len(q.progress_items) == 3
+
+    def test_style_value_must_be_report(self) -> None:
+        with pytest.raises(FormValidationError, match="'progress_style' must be 'report'"):
+            form_from_dict(_report(progress_style="fancy"))
+
+    def test_style_only_valid_on_progress(self) -> None:
+        bad = {
+            "title": "x",
+            "fields": [
+                {
+                    "id": "a",
+                    "text": "t",
+                    "type": "single_select",
+                    "options": ["A"],
+                    "progress_style": "report",
+                }
+            ],
+        }
+        with pytest.raises(FormValidationError, match="only valid on progress"):
+            form_from_dict(bad)
+
+    def test_free_form_status_accepted(self) -> None:
+        # "project context" / "reference" are not task statuses — report
+        # style accepts any non-empty tag.
+        form = form_from_dict(_report())
+        assert form.questions[0].progress_items[2]["status"] == "reference"
+
+    def test_status_must_be_non_empty_in_report_style(self) -> None:
+        bad = [{"label": "X", "status": ""}]
+        with pytest.raises(FormValidationError, match="non-empty tag string"):
+            form_from_dict(_report(options=[], progress_items=bad))
+
+    def test_options_may_be_subset_of_labels(self) -> None:
+        # Only one of three items pickable — invalid in task style, fine here.
+        form = form_from_dict(_report(options=["Goal framing"]))
+        assert form.questions[0].options == ["Goal framing"]
+
+    def test_options_must_be_item_labels(self) -> None:
+        with pytest.raises(FormValidationError, match="options must be item labels"):
+            form_from_dict(_report(options=["Ghost node"]))
+
+    def test_task_style_unchanged_by_default(self) -> None:
+        # Without progress_style, the original invariants still enforce.
+        task = {
+            "title": "x",
+            "fields": [
+                {
+                    "id": "a",
+                    "text": "t",
+                    "type": "progress",
+                    "options": ["B"],
+                    "progress_items": [{"label": "B", "status": "held"}],
+                }
+            ],
+        }
+        with pytest.raises(FormValidationError, match="'status' must be one of"):
+            form_from_dict(task)
+
+
+class TestReportStyleAnswer:
+    def test_collect_accepts_picked_option(self) -> None:
+        form = form_from_dict(_report())
+        resp = collect_form_response(form, {"digest": "Goal framing"})
+        assert resp.responses == {"digest": "Goal framing"}
+
+    def test_collect_rejects_non_option_item(self) -> None:
+        # "Recall benchmarks" is displayed but not in options.
+        form = form_from_dict(_report(options=["Goal framing"]))
+        with pytest.raises(FormValidationError, match="not in options"):
+            collect_form_response(form, {"digest": "Recall benchmarks"})
+
+    def test_optional_report_needs_no_answer(self) -> None:
+        form = form_from_dict(_report())
+        resp = collect_form_response(form, {})
+        assert resp.responses == {}
+
+    def test_fallback_maps_to_single_select(self) -> None:
+        payload = form_to_askuserquestion(form_from_dict(_report()))[0][0]
+        assert payload["type"] == "single_select"
+        assert payload["options"] == ["Memory architecture", "Goal framing"]
+
+
+class TestReportStyleWidget:
+    def test_pickable_items_render_as_tagged_cards(self) -> None:
+        html = form_to_widget_html(form_from_dict(_report()))
+        assert "Pick one to go deeper:" in html
+        assert 'role="radiogroup"' in html
+        assert html.count('class="ae-prog-tag"') == 3  # every item tagged
+        assert "project context" in html
+        assert html.count('type="radio"') == 2  # only options pickable
+
+    def test_non_option_items_render_as_rows(self) -> None:
+        html = form_to_widget_html(form_from_dict(_report()))
+        assert 'class="ae-prog-row ae-prog-report"' in html
+        assert "Recall benchmarks" in html
+
+    def test_no_task_semantics(self) -> None:
+        html = form_to_widget_html(form_from_dict(_report()))
+        # No strikethrough bucket rows rendered, no blocked header. (The
+        # static CSS block always carries the task-style classes.)
+        assert 'class="ae-prog-row ae-prog-done"' not in html
+        assert "Blocked — pick one to tackle:" not in html
+
+    def test_display_only_report(self) -> None:
+        html = form_to_widget_html(form_from_dict(_report(options=[])))
+        assert "radiogroup" not in html
+        assert html.count('class="ae-prog-row ae-prog-report"') == 3
+
+    def test_recommended_badge_and_order(self) -> None:
+        html = form_to_widget_html(form_from_dict(_report(recommended="Goal framing")))
+        assert "suggested next" in html
+        assert html.index('value="Goal framing"') < html.index('value="Memory architecture"')
+
+    def test_escapes_tag_and_detail(self) -> None:
+        items = [{"label": "A", "status": "t & <b>", "detail": "d & <i>"}]
+        html = form_to_widget_html(form_from_dict(_report(options=["A"], progress_items=items)))
+        assert "t &amp; &lt;b&gt;" in html
+        assert "d &amp; &lt;i&gt;" in html
+        assert "<b>" not in html

--- a/tests/unit/memory/test_promotion.py
+++ b/tests/unit/memory/test_promotion.py
@@ -1,0 +1,116 @@
+"""Tests for the stash → curated promotion path (curated-memory R4).
+
+Non-mocked throughout: a real FileStashBackend on tmp_path feeds
+candidates, a real MemoryGraph on tmp_path receives promotions, and
+the verdict form round-trips through the real elicitation pipeline.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from attune.elicitation import collect_form_response, form_from_dict, form_to_widget_html
+from attune.memory.file_stash import FileStashBackend
+from attune.memory.graph import MemoryGraph
+from attune.memory.promotion import (
+    CURATED_TYPES,
+    promote,
+    promotion_candidates,
+    promotion_form_dict,
+)
+from attune.memory.session_stash import SessionStashEntry, stash_entry
+
+PROPOSAL = {
+    "source_id": "stash-123",
+    "type": "project_context",
+    "name": "Recall digest ships as report-style progress",
+    "description": "The digest render pulls from FCALL recall_digest.",
+    "tags": ["memory", "r3"],
+}
+
+SOURCE = {
+    "id": "stash-123",
+    "text": "Redis's first real consumer: recall_digest.py pulls from FCALL",
+    "stash_type": "pattern",
+    "session_id": "sess-abc",
+    "ts": 1783055837.0,
+}
+
+
+class TestPromotionCandidates:
+    def test_reads_real_file_backend(self, tmp_path) -> None:
+        backend = FileStashBackend(base_dir=tmp_path)
+        entry = SessionStashEntry.create(
+            session_id="sess-1",
+            cwd=str(tmp_path),
+            type="decision",
+            content="A durable finding worth promoting",
+        )
+        assert stash_entry(entry, backend=backend)
+        cands = promotion_candidates(backend=backend)
+        assert len(cands) == 1
+        c = cands[0]
+        assert c["text"] == "A durable finding worth promoting"
+        assert c["stash_type"] == "decision"
+        assert c["session_id"] == "sess-1"
+        assert c["id"]
+
+    def test_empty_backend_yields_no_candidates(self, tmp_path) -> None:
+        cands = promotion_candidates(backend=FileStashBackend(base_dir=tmp_path))
+        assert cands == []
+
+
+class TestPromotionFormDict:
+    def test_builds_per_candidate_decisions(self) -> None:
+        form = form_from_dict(promotion_form_dict([PROPOSAL, {**PROPOSAL, "source_id": "s2"}]))
+        assert len(form.questions) == 2
+        q = form.questions[0]
+        assert q.type.value == "decision"
+        assert q.options == ["Promote", "Skip"]
+        assert q.recommended == "Promote"
+        assert "stash-123" in q.rationale  # provenance visible pre-verdict
+
+    def test_no_bulk_path_answers_are_per_candidate(self) -> None:
+        form = form_from_dict(promotion_form_dict([PROPOSAL, {**PROPOSAL, "source_id": "s2"}]))
+        resp = collect_form_response(form, {"promote_0": "Promote", "promote_1": "Skip"})
+        assert resp.responses == {"promote_0": "Promote", "promote_1": "Skip"}
+
+    def test_renders_as_widget(self) -> None:
+        html = form_to_widget_html(form_from_dict(promotion_form_dict([PROPOSAL])))
+        assert "Stash → curated promotion" in html
+        assert "Recommended" in html
+
+
+class TestPromote:
+    def test_writes_node_with_provenance(self, tmp_path) -> None:
+        graph = MemoryGraph(path=tmp_path / "curated.json")
+        node_id = promote(PROPOSAL, SOURCE, response_id="resp-1", graph=graph)
+        node = graph.nodes[node_id]
+        assert node.type.value == "project_context"
+        assert node.name == PROPOSAL["name"]
+        meta = node.metadata
+        assert meta["promoted_from_stash_id"] == "stash-123"
+        assert meta["promoted_from_session"] == "sess-abc"
+        assert meta["review_verdict"] == "promote"
+        assert meta["review_response_id"] == "resp-1"
+        assert meta["promoted_at"]  # date stamped
+
+    def test_persists_across_reload(self, tmp_path) -> None:
+        path = tmp_path / "curated.json"
+        node_id = promote(PROPOSAL, SOURCE, graph=MemoryGraph(path=path))
+        reloaded = MemoryGraph(path=path)
+        assert node_id in reloaded.nodes
+        assert reloaded.nodes[node_id].metadata["promoted_from_stash_id"] == "stash-123"
+
+    def test_rejects_non_curated_type(self, tmp_path) -> None:
+        graph = MemoryGraph(path=tmp_path / "curated.json")
+        with pytest.raises(ValueError, match="curated node type"):
+            promote({**PROPOSAL, "type": "bug"}, SOURCE, graph=graph)
+
+    def test_curated_types_are_the_four(self) -> None:
+        assert set(CURATED_TYPES) == {
+            "user_context",
+            "feedback",
+            "project_context",
+            "reference",
+        }

--- a/tests/unit/memory/test_promotion.py
+++ b/tests/unit/memory/test_promotion.py
@@ -94,6 +94,10 @@ class TestPromote:
         assert meta["review_verdict"] == "promote"
         assert meta["review_response_id"] == "resp-1"
         assert meta["promoted_at"]  # date stamped
+        # Regression (caught live 2026-07-03): add_finding defaults status
+        # to "open", which hydration/recall filter out — promotions must
+        # land "active" or they are invisible to the digest.
+        assert node.status == "active"
 
     def test_persists_across_reload(self, tmp_path) -> None:
         path = tmp_path / "curated.json"

--- a/tests/unit/memory/test_recall_digest.py
+++ b/tests/unit/memory/test_recall_digest.py
@@ -1,0 +1,97 @@
+"""Tests for the recall-digest render (curated-memory R3).
+
+The transform (nodes → report-style progress form → widget HTML) is
+pure and tested without Redis. The fetch path is tested against a REAL
+Redis with the ``recall_digest`` function loaded when one is reachable
+(the R5 non-mocked receipt), and skipped otherwise — no mocks either way.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from attune.elicitation import collect_form_response, form_from_dict, form_to_widget_html
+from attune.memory.recall_digest import (
+    DETAIL_MAX,
+    digest_form_dict,
+    fetch_digest_nodes,
+    render_digest_html,
+)
+
+NODES = [
+    {
+        "name": "Memory architecture",
+        "type": "project_context",
+        "description": "git long-term, Redis short-term, widget recall.",
+        "updated_at": "2026-07-02T10:05:08",
+        "id": "project_context_1",
+    },
+    {
+        "name": "Goal framing",
+        "type": "user_context",
+        "description": "x " * 200,  # forces truncation
+        "updated_at": "2026-07-02T10:05:08",
+        "id": "user_context_1",
+    },
+]
+
+
+def _real_redis_or_skip():
+    """Return a client connected to a Redis carrying recall_digest, or skip."""
+    redis = pytest.importorskip("redis")
+    client = redis.Redis.from_url("redis://localhost:6379/0", decode_responses=True)
+    try:
+        client.ping()
+    except redis.RedisError:
+        pytest.skip("no reachable Redis on localhost:6379")
+    try:
+        client.fcall("recall_digest", 0, "1")
+    except redis.ResponseError:
+        pytest.skip("recall_digest function not loaded (hydration hook has not run)")
+    return client
+
+
+class TestDigestFormDict:
+    def test_builds_valid_report_form(self) -> None:
+        form = form_from_dict(digest_form_dict(NODES))
+        q = form.questions[0]
+        assert q.progress_style == "report"
+        assert q.required is False
+        assert q.options == ["Memory architecture", "Goal framing"]
+
+    def test_node_type_becomes_readable_tag(self) -> None:
+        items = digest_form_dict(NODES)["fields"][0]["progress_items"]
+        assert items[0]["status"] == "project context"
+
+    def test_detail_truncated(self) -> None:
+        items = digest_form_dict(NODES)["fields"][0]["progress_items"]
+        assert len(items[1]["detail"]) <= DETAIL_MAX
+        assert items[1]["detail"].endswith("…")
+
+    def test_renders_and_round_trips(self) -> None:
+        form = form_from_dict(digest_form_dict(NODES))
+        html = form_to_widget_html(form)
+        assert "Memory digest" in html
+        assert "Pick one to go deeper:" in html
+        resp = collect_form_response(form, {"memory_digest": "Goal framing"})
+        assert resp.responses == {"memory_digest": "Goal framing"}
+
+    def test_unnamed_node_falls_back_to_id(self) -> None:
+        form_dict = digest_form_dict([{"id": "n1", "type": "reference", "description": "d"}])
+        assert form_dict["fields"][0]["options"] == ["n1"]
+
+
+class TestFetchAgainstRealRedis:
+    """Non-mocked receipt: exercised only where the real function is warm."""
+
+    def test_fetch_returns_nodes(self) -> None:
+        client = _real_redis_or_skip()
+        nodes = fetch_digest_nodes(count=3, client=client)
+        assert nodes, "warm Redis returned an empty digest"
+        assert all("name" in n and "type" in n for n in nodes)
+
+    def test_render_digest_html_end_to_end(self) -> None:
+        client = _real_redis_or_skip()
+        html = render_digest_html(count=3, client=client)
+        assert "Pick one to go deeper:" in html
+        assert 'data-ftype="progress"' in html

--- a/tests/unit/memory/test_recall_digest.py
+++ b/tests/unit/memory/test_recall_digest.py
@@ -1,22 +1,41 @@
 """Tests for the recall-digest render (curated-memory R3).
 
 The transform (nodes → report-style progress form → widget HTML) is
-pure and tested without Redis. The fetch path is tested against a REAL
-Redis with the ``recall_digest`` function loaded when one is reachable
-(the R5 non-mocked receipt), and skipped otherwise — no mocks either way.
+pure and tested without Redis. The fetch path is tested two ways: the
+parse/render logic against a fake client injected at the network
+boundary (runs everywhere, incl. keyless CI), and end-to-end against a
+REAL Redis with the ``recall_digest`` function loaded when one is
+reachable (the R5 non-mocked receipt), skipped otherwise.
 """
 
 from __future__ import annotations
 
+import json
+
 import pytest
 
 from attune.elicitation import collect_form_response, form_from_dict, form_to_widget_html
+from attune.memory import recall_digest as recall_digest_mod
 from attune.memory.recall_digest import (
     DETAIL_MAX,
     digest_form_dict,
     fetch_digest_nodes,
+    main,
     render_digest_html,
 )
+
+
+class FakeRedisClient:
+    """Client double at the network boundary — fcall returns canned entries."""
+
+    def __init__(self, entries: list) -> None:
+        self.entries = entries
+        self.calls: list[tuple] = []
+
+    def fcall(self, name, numkeys, count):
+        self.calls.append((name, numkeys, count))
+        return self.entries
+
 
 NODES = [
     {
@@ -95,3 +114,53 @@ class TestFetchAgainstRealRedis:
         html = render_digest_html(count=3, client=client)
         assert "Pick one to go deeper:" in html
         assert 'data-ftype="progress"' in html
+
+
+class TestFetchWithFakeClient:
+    """Parse/render logic against a boundary double — runs in keyless CI."""
+
+    def test_parses_str_and_bytes_entries(self) -> None:
+        entries = [json.dumps(NODES[0]), json.dumps(NODES[1]).encode("utf-8")]
+        client = FakeRedisClient(entries)
+        nodes = fetch_digest_nodes(count=2, client=client)
+        assert [n["name"] for n in nodes] == ["Memory architecture", "Goal framing"]
+        assert client.calls == [("recall_digest", 0, "2")]
+
+    def test_malformed_entry_raises_value_error(self) -> None:
+        with pytest.raises(ValueError, match="malformed JSON"):
+            fetch_digest_nodes(client=FakeRedisClient(["{not json"]))
+
+    def test_empty_reply_yields_no_nodes(self) -> None:
+        assert fetch_digest_nodes(client=FakeRedisClient([])) == []
+
+    def test_default_client_built_from_redis_url(self, monkeypatch) -> None:
+        redis = pytest.importorskip("redis")
+        captured = {}
+
+        def fake_from_url(url, **kwargs):
+            captured["url"] = url
+            return FakeRedisClient([json.dumps(NODES[0])])
+
+        monkeypatch.setenv("REDIS_URL", "redis://example.invalid:6390/2")
+        monkeypatch.setattr(redis.Redis, "from_url", fake_from_url)
+        nodes = fetch_digest_nodes(count=1)
+        assert captured["url"] == "redis://example.invalid:6390/2"
+        assert nodes[0]["name"] == "Memory architecture"
+
+    def test_render_digest_html_via_fake_client(self) -> None:
+        html = render_digest_html(count=2, client=FakeRedisClient([json.dumps(NODES[0])]))
+        assert "Pick one to go deeper:" in html
+        assert "Memory architecture" in html
+
+    def test_render_empty_digest_raises(self) -> None:
+        with pytest.raises(ValueError, match="returned no nodes"):
+            render_digest_html(client=FakeRedisClient([]))
+
+
+class TestMain:
+    def test_main_prints_widget_html(self, monkeypatch, capsys) -> None:
+        monkeypatch.setattr(
+            recall_digest_mod, "render_digest_html", lambda count: f"<form>{count}</form>"
+        )
+        assert main(["--count", "4"]) == 0
+        assert capsys.readouterr().out.strip() == "<form>4</form>"


### PR DESCRIPTION
## Summary

T1 (R3) + T2 (R4) of `docs/specs/curated-memory-productionization`:
the recall-digest render and the stash → curated promotion path.

### R3 — recall-digest render (D9: composition won)

Per the T1 constraint, a display variant of `progress` was tried
before minting grammar member #6 — and it fits. Following the
`list_style` precedent, `progress_style: "report"` renders a neutral
digest: item `status` is a free-form category tag (no task semantics,
no strikethrough), `options` may be any subset of item labels (a "go
deeper" picker). Answer path, AskUserQuestion fallback, and
elicitation-schema mapping unchanged; no new `QuestionType`.

`attune.memory.recall_digest` ships as **Redis's first real
consumer**: it pulls curated nodes from `FCALL recall_digest` (the R1
hydration hook's warm data) — never the JSON file. `python -m
attune.memory.recall_digest` prints widget HTML for `show_widget`.

### R4 — stash → curated promotion path (D10)

`attune.memory.promotion`: candidates read through the SAME backend
resolution the stash hook writes through (file or AMS);
`promotion_form_dict` renders one Promote/Skip `decision` card per
drafted node; `promote()` writes exactly one verdicted node with
provenance (`promoted_from_stash_id`, `promoted_from_session`,
`promoted_at`, `review_verdict`, `review_response_id`). There is no
promote-all path — bulk import is structurally impossible.

The live dogfood caught a real bug: `add_finding` defaults nodes to
`status="open"`, which hydration/recall filter out — the first
promotions were invisible to the digest. `promote()` now lands
`status="active"`, with a regression test.

### Receipts (R5, all live 2026-07-03)

- Live 9-node digest rendered through `show_widget` from production
  output; real-Redis fetch tests green (skip-guarded for CI).
- Two real stashed findings promoted via a live widget verdict
  (`resp-widget-resp-20260703-013922`), provenance visible on both
  nodes, memory-repo commits `914f376`/`fbf774c`, re-hydrated digest
  carries them first (11 active nodes).
- 1842 memory + 620 elicitation/meta_workflows/mcp tests green,
  non-mocked where the suite touches `attune.memory`.
- Spec updated: D9 + D10 recorded; tasks T1 + T2 marked shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
