### PR TITLE
chore(release): 9.5.0 — recall-digest render + stash->curated promotion

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "Developer workflow tool for building AI-powered products. Security audits, code review, test generation, release prep — skills-first, auto-triggering from natural language.",
-    "version": "9.4.1"
+    "version": "9.5.0"
   },
   "plugins": [
     {
       "name": "attune-ai",
       "description": "23 auto-triggering skills for the developer workflows behind building AI products: security audits, code reviews, test generation, bug prediction, and release preparation. For help content tools, also install attune-help and attune-author from this marketplace.",
       "source": "./plugin",
-      "version": "9.4.1",
+      "version": "9.5.0",
       "author": {
         "name": "Smart AI Memory",
         "email": "patrick.roebuck@smartaimemory.com"

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,4 +1,4 @@
-# Attune AI Framework v9.4.1
+# Attune AI Framework v9.5.0
 
 AI-powered developer workflows with cost optimization and multi-agent orchestration.
 
@@ -148,7 +148,7 @@ attune_redis/          # attune-redis plugin (pip install attune-redis)
 
 ---
 
-**Version:** 9.4.1 | **License:** Apache 2.0 | **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)
+**Version:** 9.5.0 | **License:** Apache 2.0 | **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)
 
 ## Lessons — core
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [9.5.0] — 2026-07-03
+
+The curated-memory loop closes: recall renders live from Redis as a
+purpose-built widget, and stashed session findings can be promoted
+into the durable curated graph through a reviewed, provenance-stamped
+path (curated-memory-productionization R3 + R4).
+
+### Added
+
+- **Recall-digest render** (`attune.memory.recall_digest`): renders
+  the curated-memory digest as a report-style progress form, pulling
+  nodes live from the `recall_digest` Redis Function (never the JSON
+  file). `python -m attune.memory.recall_digest` prints widget HTML.
+  Infrastructure for the curated-memory loop — requires a Redis
+  instance with the curated-memory function loaded and hydrated (see
+  `docs/specs/curated-memory-productionization/`), not a turnkey
+  feature on a bare install.
+- **`progress_style: "report"`** on the `progress` construct: a
+  pure-presentation digest variant — item `status` becomes a
+  free-form category tag (no task semantics, no strikethrough) and
+  `options` may be any subset of item labels, offered as a "go
+  deeper" picker. Answer path, `AskUserQuestion` fallback, and
+  elicitation-schema mapping unchanged.
+- **Stash → curated promotion path** (`attune.memory.promotion`):
+  proposes recent auto-stashed findings for promotion into the
+  curated graph via per-candidate Promote/Skip decision cards —
+  there is no bulk-import path by design. Each promotion writes
+  provenance metadata onto the node (`promoted_from_stash_id`,
+  source session, `promoted_at`, `review_verdict`,
+  `review_response_id`) and lands `status="active"` so it is
+  immediately visible to hydration and recall.
+
 ## [9.4.1] — 2026-07-02
 
 Memory-suite hardening release, from the 2026-07-02 suite audit: fixes

--- a/docs/reference/API_REFERENCE.md
+++ b/docs/reference/API_REFERENCE.md
@@ -1,6 +1,6 @@
 # Attune AI API Reference
 
-**Version:** 9.4.1
+**Version:** 9.5.0
 **License:** Apache License 2.0
 **Copyright:** 2025-2026 Smart AI Memory, LLC
 
@@ -1152,5 +1152,5 @@ msg = format_error(
 
 ---
 
-**Version:** 9.4.1 | **License:** Apache 2.0
+**Version:** 9.5.0 | **License:** Apache 2.0
 **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)

--- a/plugin/.claude-plugin/marketplace.json
+++ b/plugin/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "Developer workflow tools for Claude Code — run security audits, code reviews, and test generation from /attune",
-    "version": "9.4.1"
+    "version": "9.5.0"
   },
   "plugins": [
     {
       "name": "attune-ai",
       "description": "Run security audits, code reviews, test generation, and release preparation through a single /attune command with cost-optimized model routing",
       "source": "./",
-      "version": "9.4.1",
+      "version": "9.5.0",
       "author": {
         "name": "Smart AI Memory",
         "email": "patrick.roebuck@smartaimemory.com"

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "attune-ai",
-  "version": "9.4.1",
+  "version": "9.5.0",
   "description": "Developer workflow tools for Claude Code — run security audits, code reviews, test generation, and release preparation from /attune",
   "author": {
     "name": "Smart AI Memory",

--- a/plugin/core/__init__.py
+++ b/plugin/core/__init__.py
@@ -5,4 +5,4 @@ This module provides the core workflow functionality when the full
 attune-ai package is not installed via pip.
 """
 
-__version__ = "9.4.1"
+__version__ = "9.5.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "attune-ai"
-version = "9.4.1"
+version = "9.5.0"
 description = "AI-powered developer workflows for Claude with cost optimization, multi-agent orchestration, and workflow automation."
 readme = {file = "README.md", content-type = "text/markdown"}
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -253,7 +253,7 @@ wheels = [
 
 [[package]]
 name = "attune-ai"
-version = "9.4.1"
+version = "9.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },

--- a/website/app/page.tsx
+++ b/website/app/page.tsx
@@ -58,7 +58,7 @@ export default function Home() {
             <div className="grid lg:grid-cols-2 gap-16 items-center">
               <div className="z-10">
                 <div className="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-[var(--surface-container-high)] text-[var(--primary)] text-xs font-bold tracking-widest mb-6 uppercase">
-                  <span>v9.4.1</span>
+                  <span>v9.5.0</span>
                   <span className="w-1 h-1 rounded-full bg-[var(--primary)]"></span>
                   <span className="opacity-80">Spec-driven development platform</span>
                 </div>

--- a/website/lib/features.ts
+++ b/website/lib/features.ts
@@ -32,7 +32,7 @@ export const PRODUCTS: Product[] = [
     id: "attune-ai",
     name: "Attune AI",
     pypiName: "attune-ai",
-    version: "9.4.1",
+    version: "9.5.0",
     tagline: "Generate, maintain, and serve help from your code",
     installCommand: "pip install attune-ai",
     marketplaceInstall:
@@ -101,7 +101,7 @@ export const PRODUCTS: Product[] = [
     id: "claude-code-plugin",
     name: "Claude Code Plugin",
     pypiName: "attune-ai",
-    version: "9.4.1",
+    version: "9.5.0",
     tagline: "Progressive help right in your terminal",
     installCommand:
       "claude plugin marketplace add Smart-AI-Memory/attune-ai",


### PR DESCRIPTION
## Summary

Release prep for **9.5.0** — the curated-memory loop closes
([#1229](https://github.com/Smart-AI-Memory/attune-ai/pull/1229)):
recall-digest render (report-style `progress`, Redis-fed) + the
stash → curated promotion path with provenance.

- Version bumps: all sites via `scripts/bump_version.py 9.5.0`
  (incl. both marketplace.json files + website features)
- CHANGELOG: `[9.5.0] — 2026-07-03` section (recall_digest framed as
  curated-memory-loop infrastructure, not turnkey)
- `uv lock`: version-line-only diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)
