### PR TITLE
fix(agent-factory): repoint dead docs_url to live framework-docs reference

### DIFF
--- a/src/attune/agent_factory/framework.py
+++ b/src/attune/agent_factory/framework.py
@@ -132,7 +132,7 @@ def get_framework_info(framework: Framework) -> dict[str, object]:
             "description": "Built-in agent system with EmpathyLLM integration",
             "best_for": ["Simple agents", "Cost optimization", "Pattern learning"],
             "install_command": None,
-            "docs_url": "https://smartaimemory.com/docs/agents",
+            "docs_url": "https://smartaimemory.com/framework-docs/reference/multi-agent/",
         },
         Framework.LANGCHAIN: {
             "name": "LangChain",


### PR DESCRIPTION
## Summary

Full sweep of all **209 unique hard-coded documentation URLs** across README, docs/, content/, website/, plugin/, .help/, and src/ (triggered by this morning's plugin-directory submission prep). Exactly one was broken:

- `smartaimemory.com/docs/agents` → **404** — the `docs_url` for the Native framework in `agent_factory/framework.py`. Repointed to the live `framework-docs/reference/multi-agent/` (verified 200).

Everything else checked out:
- All 3 plugin manifests' homepage links: live
- Both sites' nav links (attune-ai.dev + smartaimemory.com): all 200
- All framework-docs deep links (tutorials/, reference/): all 200
- External framework docs (LangChain/LangGraph/AutoGen/Haystack): all 200
- The `/api/usage` 405s are the POST-only telemetry endpoint (correct); `/blog/tag/` was a grep artifact of the `${tag}` template literal (not a real link)

## Test plan

- `tests/agent_factory/test_framework.py` — 62 passed (asserts docs_url shape; no exact-URL assertion)

🤖 Generated with [Claude Code](https://claude.com/claude-code)