### PR TITLE
docs(marketplace): lead with spec-driven development in directory-facing manifests

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,13 +6,13 @@
     "email": "patrick.roebuck@smartaimemory.com"
   },
   "metadata": {
-    "description": "Developer workflow tool for building AI-powered products. Security audits, code review, test generation, release prep — skills-first, auto-triggering from natural language.",
+    "description": "Spec-driven development for Claude Code — take an idea through requirements, design, tasks, and gated execution with an approval loop. Plus 23 auto-triggering skills: security audits, code review, test generation, release prep.",
     "version": "9.5.0"
   },
   "plugins": [
     {
       "name": "attune-ai",
-      "description": "23 auto-triggering skills for the developer workflows behind building AI products: security audits, code reviews, test generation, bug prediction, and release preparation. For help content tools, also install attune-help and attune-author from this marketplace.",
+      "description": "Spec-driven development is the core workflow: /spec carries an idea through brainstorm, requirements, design, and task execution with quality gates and your approval at each stage. Backed by 23 auto-triggering skills — security audits, code reviews, test generation, bug prediction, and release preparation. For help content tools, also install attune-help and attune-author from this marketplace.",
       "source": "./plugin",
       "version": "9.5.0",
       "author": {
@@ -24,6 +24,7 @@
       "license": "Apache-2.0",
       "category": "developer-tools",
       "tags": [
+        "spec-driven-development",
         "workflows",
         "security",
         "code-review",

--- a/plugin/.claude-plugin/marketplace.json
+++ b/plugin/.claude-plugin/marketplace.json
@@ -6,13 +6,13 @@
     "email": "patrick.roebuck@smartaimemory.com"
   },
   "metadata": {
-    "description": "Developer workflow tools for Claude Code — run security audits, code reviews, and test generation from /attune",
+    "description": "Spec-driven development for Claude Code — /spec plans, reviews, and executes with quality gates; plus security audits, code reviews, test generation, and release prep from /attune.",
     "version": "9.5.0"
   },
   "plugins": [
     {
       "name": "attune-ai",
-      "description": "Run security audits, code reviews, test generation, and release preparation through a single /attune command with cost-optimized model routing",
+      "description": "Spec-driven development for Claude Code — /spec plans, reviews, and executes with quality gates; plus security audits, code reviews, test generation, and release prep from /attune.",
       "source": "./",
       "version": "9.5.0",
       "author": {
@@ -24,6 +24,7 @@
       "license": "Apache-2.0",
       "category": "developer-tools",
       "tags": [
+        "spec-driven-development",
         "workflows",
         "security",
         "code-review",

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "attune-ai",
   "version": "9.5.0",
-  "description": "Developer workflow tools for Claude Code — run security audits, code reviews, test generation, and release preparation from /attune",
+  "description": "Spec-driven development for Claude Code — /spec plans, reviews, and executes with quality gates; plus security audits, code reviews, test generation, and release prep from /attune.",
   "author": {
     "name": "Smart AI Memory",
     "email": "patrick.roebuck@smartaimemory.com"


### PR DESCRIPTION
## Summary

Emphasizes spec-driven development as THE core feature in all directory-facing manifest copy, ahead of the Anthropic community plugin-directory submission (Patrick-locked draft, 2026-07-03 session).

- Root `.claude-plugin/marketplace.json`: `metadata.description` + attune-ai plugin `description` lead with /spec (brainstorm → requirements → design → tasks → gated execution with approval loop); 23 auto-triggering skills become the supporting cast.
- `plugin/.claude-plugin/marketplace.json` + `plugin/.claude-plugin/plugin.json`: same one-liner applied to `metadata.description`, plugin `description`, and `plugin.json` `description`. (Applying the one-liner to the inner `metadata.description` is a consistency extension of the locked draft — flagged for review.)
- Adds `spec-driven-development` as the first tag on both marketplace manifests (existing tags kept).

No version changes; copy-only.

## Test plan

- [x] All three files parse as JSON
- [x] Pre-commit check-json green
- [ ] CI matrix green

🤖 Generated with [Claude Code](https://claude.com/claude-code)