### PR TITLE
fix(memory): recent() must survive >1-page AMS namespaces and carry ts

### DIFF
--- a/.claude/lessons.md
+++ b/.claude/lessons.md
@@ -13051,3 +13051,34 @@ files.
   the token. Beats re-drafting (which risks drifting from what the
   user actually approved). The transcript is the authoritative record
   of presented-but-not-yet-committed artifacts.
+
+- **AMS 0.14.0 long-term LISTING is broken past one page — offset
+  pagination re-serves earlier records instead of the missing ones,
+  page-1 `total` lies, and the only reliable enumeration primitive is
+  the `created_at` range filter passed as a `CreatedAt(gte=<datetime>)`
+  MODEL**: found fixing the 2026-07-04 R4 promotion failure (5 fresh
+  stash findings invisible to `promotion_candidates`; namespace held
+  1k+ records). Live-verified on a 120-record namespace: (a)
+  `search_long_term_memory(text="", limit=100, offset=100)` returned
+  records 0-19 AGAIN — records 100-119 were unreachable at ANY offset,
+  so offset pagination (and the client's `search_all_long_term_memories`
+  helper, which is just offset under the hood) cannot enumerate a
+  namespace; (b) the page-1 response reports `total == len(page)` (100
+  for a 120-record namespace) — terminating on `offset >= total` stops
+  one page in; (c) a single unfiltered page OMITS the newest records
+  (server selection is relevance/arbitrary), which was the R4 root
+  cause; (d) `created_at={"gte": iso_string}` (dict-of-string) silently
+  drops matches — build `agent_memory_client.filters.CreatedAt` from
+  datetime objects; then a window matching <=100 records returns ALL of
+  them. Working recency recipe (now in `AMSMemoryBackend.recent()`):
+  walk disjoint created_at windows backward from now (exponentially
+  widening + unbounded tail), bisect any window that fills a whole page
+  (full page ⇒ arbitrary truncation ⇒ split until complete), dedupe by
+  id across shared boundaries, stop once `limit` collected (unvisited
+  windows are strictly older), request-capped with a WARNING (only the
+  oldest tail is sacrificed). Companion fix: `recent()` must carry
+  `ts`/`created_at` in its record shape — both backends dropped it, so
+  candidates surfaced with `ts: None` and no consumer could order by
+  recency. Extends the "AMS ordering is relevance-based, sort
+  client-side by created_at" lesson — sorting is NOT enough when the
+  fetch window itself can exclude the newest records.

--- a/attune_redis/memory.py
+++ b/attune_redis/memory.py
@@ -35,6 +35,13 @@ _DEFAULT_TTL_DAYS = 30
 #: clamp. Every search/recency call must bound its limit by this.
 _AMS_MAX_SEARCH_LIMIT = 100
 
+#: Max search requests one ``recent()`` call may issue while walking
+#: created_at windows backward. Typical calls need 1-3 (the newest window
+#: usually holds enough); a 1k-record namespace with a lagging prune needs
+#: ~10-25. Hitting the cap logs a warning — older records may then be
+#: missed, which is exactly the failure this bound guards from being silent.
+_RECENT_MAX_REQUESTS = 40
+
 
 class _PersistentLoop:
     """A single event loop running in a daemon thread.
@@ -464,42 +471,115 @@ class AMSMemoryBackend:
             logger.error("search_failed: query=%s error=%s", query, e)
             return []
 
+    def _fetch_created_between(self, lo: Any, hi: Any) -> list[Any]:
+        """One empty-text search bounded to ``created_at`` in [lo, hi].
+
+        The ``created_at`` bound MUST be a ``CreatedAt`` model built from
+        datetime objects — a ``{"gte": <iso-string>}`` dict serializes
+        incorrectly and silently drops matches (verified live on AMS 0.14.0).
+        """
+        from agent_memory_client.filters import CreatedAt
+
+        results = _run_sync(
+            self._client.search_long_term_memory(
+                text="",
+                namespace={"eq": self._namespace},
+                created_at=CreatedAt(gte=lo, lte=hi),
+                limit=_AMS_MAX_SEARCH_LIMIT,
+            )
+        )
+        return list(results.memories)
+
     def recent(self, limit: int = 5, **filters: Any) -> list[dict]:
         """Most-recent long-term findings (no query) — powers SessionStart recall.
 
         Mirrors the file backend's ``recent``: newest-first, with same-project
         findings surfaced ahead of others when ``cwd`` is given (soft priority).
-        Returns the same record shape as ``search`` (minus ``score``).
+        Returns the same record shape as ``search`` plus ``ts`` (epoch float,
+        the recency key promotion consumers order by).
 
-        AMS has no query-less recency *list* primitive, but an empty-text
-        ``search_long_term_memory`` returns the namespace's memories, and the
-        server's ordering is relevance-based (verified not reliably recency-
-        sorted even with ``server_side_recency``), so the recency ordering is
-        applied client-side by ``created_at``. We over-fetch a bounded window
-        (the server can't sort by recency for us) and truncate after sorting.
-        Best-effort; returns ``[]`` on any AMS error, never raises.
+        AMS has no query-less recency *list* primitive, and (verified live on
+        0.14.0) every listing affordance breaks on a namespace larger than one
+        100-record page: the server's ordering is relevance-based (not recency,
+        even with ``server_side_recency``), a single page can simply omit the
+        newest records (the 2026-07-04 R4 failure: 1000+ records, 5 fresh
+        findings absent), and ``offset`` pagination re-serves earlier records
+        instead of the missing ones. The one primitive that behaves is the
+        ``created_at`` range filter: a window matching <=100 records returns
+        ALL of them. So recency is reconstructed client-side by walking
+        disjoint time windows backward from now (exponentially widening, then
+        an unbounded tail), bisecting any window that fills a whole page
+        (truncation ⇒ arbitrary selection ⇒ split until complete), and
+        stopping once ``limit`` records are collected — every window still
+        unvisited is strictly older, so the collected set IS the newest.
+        Request-capped by :data:`_RECENT_MAX_REQUESTS`. Best-effort; returns
+        ``[]`` on any AMS error, never raises.
         """
+        from collections import deque
+        from datetime import datetime, timedelta, timezone
+
         cwd = filters.get("cwd")
-        # Over-fetch: server ordering isn't recency, so pull a window wide
-        # enough that the true most-recent ``limit`` are within it, then sort
-        # client-side. 30-day pruning keeps per-namespace counts bounded.
-        # Server can't recency-sort for us, so the window must hold the true
-        # most-recent ``limit`` while staying under AMS's search-limit cap.
-        overscan = min(max(limit * 10, 50), _AMS_MAX_SEARCH_LIMIT)
+        now = datetime.now(timezone.utc)
+        epoch = datetime(1970, 1, 1, tzinfo=timezone.utc)
+        min_slice = timedelta(seconds=1)
+
+        # Disjoint windows, newest first: 6h, then x4 wider each step until
+        # past the 30d TTL (+grace), then one unbounded tail for anything a
+        # lagging prune left behind. Shared boundaries are deduped by id.
+        bands: list[tuple[Any, Any]] = []
+        hi = now + timedelta(minutes=5)  # tolerate small clock skew
+        span = timedelta(hours=6)
+        while (now - hi) < timedelta(days=45):
+            lo = hi - span
+            bands.append((lo, hi))
+            hi = lo
+            span *= 4
+        bands.append((epoch, hi))
+
+        collected: dict[str, Any] = {}
+        requests = 0
         try:
-            results = _run_sync(
-                self._client.search_long_term_memory(
-                    text="",
-                    namespace={"eq": self._namespace},
-                    limit=overscan,
+            for band in bands:
+                # LIFO stack, newer half pushed last so it is fetched first.
+                stack = deque([band])
+                while stack:
+                    if requests >= _RECENT_MAX_REQUESTS:
+                        logger.warning(
+                            "recent: request cap (%d) hit scanning %s; " "older records skipped",
+                            _RECENT_MAX_REQUESTS,
+                            self._namespace,
+                        )
+                        break
+                    lo, hi = stack.pop()
+                    page = self._fetch_created_between(lo, hi)
+                    requests += 1
+                    if len(page) >= _AMS_MAX_SEARCH_LIMIT and (hi - lo) > min_slice:
+                        mid = lo + (hi - lo) / 2
+                        stack.append((lo, mid))
+                        stack.append((mid, hi))
+                        continue
+                    for m in page:
+                        collected.setdefault(m.id, m)
+                if len(collected) >= limit or requests >= _RECENT_MAX_REQUESTS:
+                    break
+            if len(collected) < limit and requests < _RECENT_MAX_REQUESTS:
+                # Catch records the created_at filter can't see (created_at
+                # unset) via one unfiltered page; they sort last anyway.
+                results = _run_sync(
+                    self._client.search_long_term_memory(
+                        text="",
+                        namespace={"eq": self._namespace},
+                        limit=_AMS_MAX_SEARCH_LIMIT,
+                    )
                 )
-            )
+                for m in results.memories:
+                    collected.setdefault(m.id, m)
         except Exception as e:  # noqa: BLE001
             # INTENTIONAL: Graceful degradation for AMS HTTP errors
             logger.error("recent_failed: limit=%s error=%s", limit, e)
             return []
 
-        memories = list(results.memories)
+        memories = list(collected.values())
         # Newest-first by created_at (None sorts last via epoch-0 fallback).
         memories.sort(
             key=lambda m: (m.created_at.timestamp() if m.created_at else 0.0),
@@ -515,6 +595,8 @@ class AMSMemoryBackend:
                 "topics": m.topics,
                 "cwd": _cwd_from_topics(m.topics),
                 "session_id": m.session_id,
+                "ts": (m.created_at.timestamp() if m.created_at else None),
+                "created_at": (m.created_at.isoformat() if m.created_at else None),
             }
             for m in memories[:limit]
         ]

--- a/attune_redis/tests/test_integration.py
+++ b/attune_redis/tests/test_integration.py
@@ -269,8 +269,7 @@ class TestRecentLongTerm:
             ams_base_url=os.environ.get("AMS_BASE_URL", "http://localhost:8000"),
             ams_namespace=ns,
         )
-        b = AMSMemoryBackend(config=config)
-        try:
+        with AMSMemoryBackend(config=config) as b:
             backdated = datetime.now(timezone.utc) - timedelta(days=20)
             seeds = [
                 ClientMemoryRecord(
@@ -310,8 +309,6 @@ class TestRecentLongTerm:
             # finding's project surfaces it even among 110 other-cwd records.
             scoped = b.recent(limit=5, cwd="/proj/fresh")
             assert scoped and scoped[0]["cwd"] == "/proj/fresh"
-        finally:
-            b.close()
 
 
 class TestRememberDedup:

--- a/attune_redis/tests/test_integration.py
+++ b/attune_redis/tests/test_integration.py
@@ -229,11 +229,87 @@ class TestRecentLongTerm:
             assert out_alpha[0]["cwd"] == "/proj/alpha"
             assert out_alpha[1]["cwd"] == "/proj/alpha"
 
-            # File-backend record shape (no score).
-            assert set(out[0].keys()) == {"id", "text", "topics", "cwd", "session_id"}
+            # File-backend record shape (no score) plus the recency keys.
+            assert set(out[0].keys()) == {
+                "id",
+                "text",
+                "topics",
+                "cwd",
+                "session_id",
+                "ts",
+                "created_at",
+            }
+            assert isinstance(out[0]["ts"], float), "ts must carry the created_at epoch"
 
             # Limit honored.
             assert len(b.recent(limit=2)) == 2
+        finally:
+            b.close()
+
+    def test_recent_surfaces_fresh_finding_in_large_namespace(self):
+        """Regression for the 2026-07-04 R4 promotion failure: a namespace
+        holding more records than one AMS search page (100) must still
+        surface a just-written finding, newest-first with populated ``ts``.
+
+        The old single-page recent() asked the server for one relevance-
+        ordered page; fresh findings outside that page were unrecoverable.
+        This seeds 110 backdated records through the raw client (one batched
+        write), then stashes one fresh finding via remember() and requires it
+        to lead recent().
+        """
+        import time
+        from datetime import datetime, timedelta, timezone
+
+        from agent_memory_client.models import ClientMemoryRecord
+
+        from attune_redis.memory import AMSMemoryBackend, _run_sync
+
+        ns = f"recent-page-itest-{uuid.uuid4().hex[:8]}"
+        config = RedisPluginConfig(
+            ams_base_url=os.environ.get("AMS_BASE_URL", "http://localhost:8000"),
+            ams_namespace=ns,
+        )
+        b = AMSMemoryBackend(config=config)
+        try:
+            backdated = datetime.now(timezone.utc) - timedelta(days=20)
+            seeds = [
+                ClientMemoryRecord(
+                    id=f"seed-{i:03d}",
+                    text=f"aged seed finding number {i} with distinct token tk{i}",
+                    namespace=ns,
+                    created_at=backdated + timedelta(seconds=i),
+                    topics=["cwd:/proj/seeded"],
+                )
+                for i in range(110)
+            ]
+            _run_sync(b._client.create_long_term_memory(seeds, deduplicate=False))
+
+            # Wait for the seeds to index before writing the fresh finding.
+            for _ in range(30):
+                time.sleep(1.0)
+                if len(b.recent(limit=100)) >= 100:
+                    break
+
+            assert b.remember(
+                "the freshly stashed finding that must win recency",
+                topics=["cwd:/proj/fresh"],
+            )
+
+            out: list = []
+            for _ in range(20):
+                time.sleep(1.0)
+                out = b.recent(limit=10)
+                if out and out[0]["text"].startswith("the freshly stashed"):
+                    break
+            assert out, "recent() returned nothing"
+            assert out[0]["text"].startswith(
+                "the freshly stashed"
+            ), f"fresh finding lost to aged seeds; got {out[0]['text']!r}"
+            assert isinstance(out[0]["ts"], float)
+            # cwd scoping must not go stale either: scoping to the fresh
+            # finding's project surfaces it even among 110 other-cwd records.
+            scoped = b.recent(limit=5, cwd="/proj/fresh")
+            assert scoped and scoped[0]["cwd"] == "/proj/fresh"
         finally:
             b.close()
 

--- a/attune_redis/tests/test_memory.py
+++ b/attune_redis/tests/test_memory.py
@@ -418,14 +418,104 @@ class TestRecent:
         assert len(backend.recent(limit=2)) == 2
 
     def test_recent_maps_record_shape(self, backend, mock_ams_client):
-        """recent() returns the file-backend record shape (no score)."""
+        """recent() returns the file-backend record shape (no score) plus the
+        recency keys (``ts`` epoch float, ``created_at`` ISO) that promotion
+        consumers order by — their absence was half of the 2026-07-04 R4 bug
+        (every candidate surfaced with ``ts: None``)."""
         mock_ams_client.search_long_term_memory.return_value = FakeMemoryRecordResults(
             memories=[_rec("m1", "a finding", 5, topics=["cwd:/p", "tag"])]
         )
         out = backend.recent(limit=1)
-        assert set(out[0].keys()) == {"id", "text", "topics", "cwd", "session_id"}
+        assert set(out[0].keys()) == {
+            "id",
+            "text",
+            "topics",
+            "cwd",
+            "session_id",
+            "ts",
+            "created_at",
+        }
         assert out[0]["cwd"] == "/p"
         assert out[0]["topics"] == ["cwd:/p", "tag"]
+        assert isinstance(out[0]["ts"], float)
+        assert out[0]["created_at"].startswith("2026-01-01")
+
+    def test_recent_finds_fresh_records_in_large_namespace(self, backend, mock_ams_client):
+        """Regression for the 2026-07-04 R4 failure: on a namespace larger
+        than one 100-record page, the newest findings must still surface.
+
+        The fake emulates the live AMS 0.14.0 behaviors that broke every
+        naive listing (verified live): ``created_at`` range filters are
+        honored, but any query matching >100 records is truncated to an
+        ARBITRARY 100 — adversarially the oldest here, the selection that
+        actually hid the fresh findings. Only a window-walk that bisects
+        truncated windows recovers the true newest records."""
+        from datetime import datetime, timedelta, timezone
+
+        now = datetime.now(timezone.utc)
+        old_cluster = [
+            FakeMemoryRecord(
+                record_id=f"old-{i:03d}",
+                text=f"aged finding {i}",
+                created_at=now - timedelta(days=20) + timedelta(seconds=i * 144),
+            )
+            for i in range(150)  # spread over 6h, 20 days ago
+        ]
+        fresh = [
+            FakeMemoryRecord(
+                record_id=f"fresh-{i}",
+                text=f"fresh finding {i}",
+                created_at=now - timedelta(minutes=10 - i),
+            )
+            for i in range(5)
+        ]
+        corpus = old_cluster + fresh
+
+        def _serve(**kwargs):
+            matches = list(corpus)
+            ca = kwargs.get("created_at")
+            if ca is not None:
+                matches = [
+                    m
+                    for m in matches
+                    if (ca.gte is None or m.created_at >= ca.gte)
+                    and (ca.lte is None or m.created_at <= ca.lte)
+                ]
+            # Adversarial truncation: oldest-first, as observed live.
+            matches.sort(key=lambda m: m.created_at)
+            return FakeMemoryRecordResults(memories=matches[: kwargs.get("limit", 10)])
+
+        mock_ams_client.search_long_term_memory.side_effect = _serve
+        out = backend.recent(limit=10)
+        assert [d["id"] for d in out[:5]] == [
+            "fresh-4",
+            "fresh-3",
+            "fresh-2",
+            "fresh-1",
+            "fresh-0",
+        ], "the 5 fresh findings must lead, newest first"
+        assert [d["id"] for d in out[5:]] == [
+            "old-149",
+            "old-148",
+            "old-147",
+            "old-146",
+            "old-145",
+        ], "then the newest of the aged cluster (lost to truncation pre-fix)"
+        assert all(isinstance(d["ts"], float) for d in out), "ts populated on every record"
+
+    def test_recent_request_cap_bounds_pathological_server(self, backend, mock_ams_client):
+        """A server that returns a full page for EVERY window (ignoring the
+        created_at filter) must not loop: the request cap terminates the walk
+        and recent() still returns ``limit`` records."""
+        full_page = FakeMemoryRecordResults(
+            memories=[_rec(f"m-{i}", f"finding {i}", i) for i in range(100)]
+        )
+        mock_ams_client.search_long_term_memory.return_value = full_page
+        out = backend.recent(limit=5)
+        from attune_redis.memory import _RECENT_MAX_REQUESTS
+
+        assert mock_ams_client.search_long_term_memory.call_count <= _RECENT_MAX_REQUESTS + 1
+        assert len(out) == 5
 
     def test_recent_handles_missing_created_at(self, backend, mock_ams_client):
         """recent() tolerates records with created_at=None (sorts them last)."""

--- a/src/attune/memory/file_stash.py
+++ b/src/attune/memory/file_stash.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import json
 import os
 import time
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -60,6 +61,14 @@ def _cwd_from_topics(topics: list[str]) -> str | None:
         if t.startswith("cwd:"):
             return t[len("cwd:") :]
     return None
+
+
+def _iso_from_ts(ts: Any) -> str | None:
+    """ISO-8601 UTC string for an epoch-seconds value, or ``None``."""
+    try:
+        return datetime.fromtimestamp(float(ts), tz=timezone.utc).isoformat()
+    except (TypeError, ValueError, OSError, OverflowError):
+        return None
 
 
 class FileStashBackend:
@@ -206,7 +215,9 @@ class FileStashBackend:
 
         Sorted newest-first; when ``cwd`` is given, same-project findings
         are surfaced ahead of others (soft priority, mirroring ``search``).
-        Returns the same record shape as ``search`` (minus ``score``).
+        Returns the ``search`` record shape (minus ``score``) plus ``ts``
+        (epoch float) and ``created_at`` (ISO-8601) — the recency keys
+        promotion consumers order and display by.
         """
         cwd = filters.get("cwd")
         records = self._load_records()  # already TTL-pruned
@@ -221,6 +232,8 @@ class FileStashBackend:
                 "topics": r.get("topics", []),
                 "cwd": r.get("cwd"),
                 "session_id": r.get("session_id"),
+                "ts": r.get("ts"),
+                "created_at": _iso_from_ts(r.get("ts")),
             }
             for r in records[:limit]
         ]

--- a/tests/unit/memory/test_file_stash.py
+++ b/tests/unit/memory/test_file_stash.py
@@ -368,6 +368,10 @@ def test_recent_empty_when_no_records(backend):
 
 
 def test_recent_returns_search_shape(backend):
+    """Search shape (no score) plus the recency keys promotion orders by —
+    ``ts`` was absent from the record shape in the 2026-07-04 R4 failure."""
     backend.remember("a finding", memory_id="m1", topics=["cwd:/p"])
     hit = backend.recent()[0]
-    assert set(hit) == {"id", "text", "topics", "cwd", "session_id"}
+    assert set(hit) == {"id", "text", "topics", "cwd", "session_id", "ts", "created_at"}
+    assert isinstance(hit["ts"], float)
+    assert isinstance(hit["created_at"], str)

--- a/tests/unit/memory/test_promotion.py
+++ b/tests/unit/memory/test_promotion.py
@@ -7,6 +7,8 @@ the verdict form round-trips through the real elicitation pipeline.
 
 from __future__ import annotations
 
+import time
+
 import pytest
 
 from attune.elicitation import collect_form_response, form_from_dict, form_to_widget_html
@@ -58,6 +60,36 @@ class TestPromotionCandidates:
     def test_empty_backend_yields_no_candidates(self, tmp_path) -> None:
         cands = promotion_candidates(backend=FileStashBackend(base_dir=tmp_path))
         assert cands == []
+
+    def test_candidates_carry_ts_newest_first(self, tmp_path) -> None:
+        """Regression for the 2026-07-04 R4 failure: every candidate came
+        back with ``ts: None`` (the backends dropped the timestamp from the
+        ``recent()`` record shape), so the docstring's "newest first" could
+        not be working. Non-mocked round-trip: real backend writes, then
+        promotion_candidates must return populated ``ts`` in strictly
+        newest-first order."""
+        backend = FileStashBackend(base_dir=tmp_path)
+        for i, text in enumerate(
+            ["an older stashed finding", "a middle stashed finding", "the newest finding"]
+        ):
+            entry = SessionStashEntry.create(
+                session_id=f"sess-{i}",
+                cwd=str(tmp_path),
+                type="note",
+                content=text,
+            )
+            assert stash_entry(entry, backend=backend)
+            time.sleep(0.01)  # distinct write timestamps
+
+        cands = promotion_candidates(top_k=10, backend=backend)
+        assert [c["text"] for c in cands] == [
+            "the newest finding",
+            "a middle stashed finding",
+            "an older stashed finding",
+        ]
+        ts_values = [c["ts"] for c in cands]
+        assert all(isinstance(t, float) for t in ts_values), f"ts missing: {ts_values}"
+        assert ts_values == sorted(ts_values, reverse=True)
 
 
 class TestPromotionFormDict:


### PR DESCRIPTION
## Summary

The 2026-07-04 R4 promotion run returned 100 candidates with **none** of the 5 same-day stash findings present, and every candidate had `ts: None`. Two defects in the `recent()` path that `promotion_candidates()` reads through:

**1. One-page fetch on a >100-record namespace loses the newest records.** `AMSMemoryBackend.recent()` asked the server for a single 100-record page; selection is relevance-based, so on the live namespace (1k+ records) the fresh findings were simply never fetched. Live probing against AMS 0.14.0 showed there is no working listing affordance:

- `offset=100` **re-serves records 0-19**; records 100-119 are unreachable at any offset (so the client's `search_all_long_term_memories` helper is equally broken)
- page-1 `total` lies (reports the page size, not the namespace size)
- `created_at={"gte": "<iso-string>"}` (dict form) silently drops matches

The one primitive that behaves: a `created_at` range filter built as a `CreatedAt` **model from datetime objects** returns ALL matches when <=100 match. `recent()` now walks disjoint `created_at` windows backward from now (exponentially widening + unbounded tail for prune-lagged records), **bisects** any window that fills a whole page (full page = arbitrary truncation), dedupes across boundaries, and stops once `limit` records are collected — every unvisited window is strictly older. Request-capped (40) with a warning; the walk is newest-first, so a cap hit only sacrifices the oldest tail, never the fresh records.

**2. Both backends dropped the timestamp from the record shape**, so `ts` could never populate and "newest first" was unverifiable. AMS and file backends now return `ts` (epoch float) + `created_at` (ISO).

**cwd scoping**: same staleness, same fix — its soft-priority sort ran over the mis-fetched window; it now runs over the correctly collected newest set (asserted in the live test).

## Receipts (non-mocked round-trips)

- **Live AMS integration test**: seeds 110 backdated records + 1 fresh via the real client (reproduces the >1-page failure); the fresh finding must lead `recent()` with populated `ts`, and cwd scoping must surface it. Passes against local AMS.
- **Real file-backend promotion test**: 3 staggered writes → `promotion_candidates` returns populated `ts`, strictly newest-first.
- **Production-namespace dogfood**: `promotion_candidates(top_k=100)` on the failing namespace now surfaces **all 5 same-day findings** (0 × `ts: None`, newest-first), including the exact `25f829ff` record from the failure report.
- Mocked regressions emulate the live-verified server behaviors (honored range filters, adversarial oldest-first truncation at 100; pathological filter-ignoring server terminates under the request cap).

`tests/unit/memory` + `attune_redis/tests`: 1967 passed, 48 skipped, 3 xfailed.

Lesson appended to `.claude/lessons.md` (AMS 0.14.0 listing traps).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
