### PR TITLE
chore(specs): advance status headers (stranded from Jun 19-20)

### DIFF
--- a/docs/specs/archive/windows-xdist-flakes/requirements.md
+++ b/docs/specs/archive/windows-xdist-flakes/requirements.md
@@ -7,8 +7,7 @@
 > appeared in three distinct test files. Time to identify the shared
 > polluter and decide on a structural fix rather than continuing to
 > add xfails one test at a time.
-
-**Status:** draft
+**Status:** approved
 **Created:** 2026-06-02
 **Owner:** —
 **Related:**

--- a/docs/specs/lessons-corpus-rag/decisions.md
+++ b/docs/specs/lessons-corpus-rag/decisions.md
@@ -1,5 +1,8 @@
 # Lessons Corpus via RAG — Decisions
 
+**Status:** approved
+
+
 ## D1 — Phase 0 go/no-go matrix (PRE-COMMITTED 2026-06-11)
 
 Committed BEFORE the benchmark runs, per the "pre-committed decision

--- a/docs/specs/lessons-corpus-rag/design.md
+++ b/docs/specs/lessons-corpus-rag/design.md
@@ -1,6 +1,5 @@
 # Lessons Corpus via RAG — Design
-
-**Status:** draft (2026-06-11) — authored after Phase 0 GO (D2).
+**Status:** approved (2026-06-11) — authored after Phase 0 GO (D2).
 Grounded in the measured numbers: 375 lessons / ~116k tokens / 58%
 of window; keyword P@3 84%, high-severity 7/7.
 

--- a/docs/specs/lessons-corpus-rag/tasks.md
+++ b/docs/specs/lessons-corpus-rag/tasks.md
@@ -1,5 +1,4 @@
 # Lessons Corpus via RAG — Tasks
-
 **Status:** complete (2026-06-12) — T1–T6 done; D6 fresh-session
 receipt captured post-cutover (decisions.md).
 Bounded PRs; each task names its receipt.

--- a/docs/specs/test-discipline-controls/requirements.md
+++ b/docs/specs/test-discipline-controls/requirements.md
@@ -2,8 +2,7 @@
 
 > Four mechanical controls that close the test-coverage discipline
 > gap surfaced by PR #485 — without adopting strict TDD.
-
-**Status:** draft
+**Status:** in-review
 **Created:** 2026-05-27
 **Owner:** TBD
 **Related:**


### PR DESCRIPTION
Rescues Patrick's stranded local commit from the main checkout (authored 2026-06-26, classified WANTED via mtime+reflog): status-header advances for lessons-corpus-rag, test-discipline-controls, windows-xdist-flakes. The ops-path-picker and README portions were dropped during rebase — both already superseded on main (archived spec header richer; README content landed via another path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)