### PR TITLE
feat(memory): unification — curated corpus is .md files, no graph middle layer (spec + T1-T5)

### DIFF
--- a/docs/specs/memory-nodetype-friction-log/decisions.md
+++ b/docs/specs/memory-nodetype-friction-log/decisions.md
@@ -277,3 +277,19 @@ Consequence for THIS log: R1's "real usage" bar now has a sharper
 admission filter — a candidate curated node that fails the 30-day
 test is routed to the handoff layer, and that routing decision is
 itself loggable evidence here.
+
+---
+
+## 2026-07-04 — AMS namespace stays SHARED across projects (Patrick, form-locked)
+
+Surfaced by the memory retest: `recent()` on the default namespace
+returns stash findings from other projects (memdocs) alongside
+attune-ai ones. Options were partition-per-project, scope-default-
+views, or keep-shared. **Patrick locked keep-shared**: cross-project
+carry-over IS the continuity goal (the memdocs "Smart AI Memory
+thesis" finding surfacing in an attune-ai session is signal, not
+noise); partitioning would break that and re-multiply the >100-record
+pagination surface PR #1234 just tamed. Consumers wanting
+project-local views use the existing `cwd` scoping (`recent(cwd=...)`
+/ topic filter). The mixing is deliberate, not drift — do not
+re-open without new evidence of harm.

--- a/docs/specs/memory-unification/decisions.md
+++ b/docs/specs/memory-unification/decisions.md
@@ -29,14 +29,32 @@ exercise behind the removing-dead-code / subsystem-value gate
 (usage evidence, PersonalMemory dependency check, breaking-change
 versioning) — tracked as T6, not bundled here.
 
-## OQ1 — Curated files live in the harness memory dirs (LOCKED)
+## OQ1 — Curated files live in `~/.attune/memory/curated/` (RE-LOCKED 2026-07-04)
 
-The 13 nodes migrate into the existing global/per-project memory
-dirs as normal lint-conforming files with `curated: true`. ONE
-corpus: harness recall, MEMORY.md, lint, and the Redis digest all
-read the same files. (Rejected: a dedicated `~/.attune/memory/
-curated/` dir — keeps the two-place split this spec exists to
-kill.)
+**Correction, same day:** the first lock (harness memory dirs, on
+the agent's "one corpus" recommendation) was reversed by Patrick on
+review — recorded here in place, not rewritten. Four reasons, the
+first decisive:
+
+1. **Git source of truth.** `~/.attune/memory` is a pushed git
+   repo; the harness memory dirs are un-versioned. The first lock
+   would have retired the git-tracked graph JSON and moved the most
+   durable memories OUTSIDE version control.
+2. **Cross-project nature.** Curated nodes are machine-wide (cf.
+   the same-day shared-namespace decision); per-project harness
+   dirs force arbitrary project assignment.
+3. **Context cost.** Every file in the harness dirs adds a
+   MEMORY.md pointer line loaded into context each session —
+   eroding the rules-corpus-jit savings for zero recall benefit.
+4. **Write-layer ownership.** `promote()` stays inside attune's own
+   store; no cross-system writes into harness-owned paths.
+
+The real unification is the SERVING layer (one Redis index over
+all corpora, already live) — physical co-location bought
+aesthetics, not capability. Residuals accepted: curated facts are
+not in MEMORY.md's browse index (digest + FT.SEARCH are the
+curated read paths; one static MEMORY.md line points at the dir),
+and `memory_lint` adds the curated dir to its sweep list (T1).
 
 ## OQ2 — `curated_graph.json` retired (LOCKED, "go")
 

--- a/docs/specs/memory-unification/decisions.md
+++ b/docs/specs/memory-unification/decisions.md
@@ -1,22 +1,48 @@
 # Memory Unification — Decisions
 
-## D1 — Files-canonical, graph-derived (PROPOSED — needs Patrick's lock)
+## D1 — Files + Redis, NO graph middle layer (LOCKED, Patrick 2026-07-04)
 
-Three architectures were on the table:
+Patrick pushed past the original files-canonical/graph-derived
+recommendation to the cleaner endpoint: **no MemoryGraph object and
+no `curated_graph.json` in the curated pipeline at all**. Files are
+the store; Redis is the serving layer; nothing in between.
 
 | Option | Shape | Verdict |
 |---|---|---|
-| **(a) Files-canonical** | `.md` files are the single store; graph + Redis derived | **Recommended** |
-| (b) Graph-canonical | graph is the store; files are generated views | Rejected — fights every existing tool (lint, MEMORY.md, harness recall, Patrick's authoring habit) and inverts the ratified git-source-of-truth doctrine |
-| (c) Two stores, one protocol | keep both; promotion is the only bridge | Rejected as the end-state — it is the status quo whose double-authoring cost motivated this spec (fine as the transitional state during migration) |
+| **(a2) Files + Redis, no graph** | `.md` files canon; hydrate derives digest/edges directly from files | **LOCKED** |
+| (a1) Files-canonical, graph-derived | original recommendation — graph/JSON as derived middle layer | Superseded — the middle layer buys nothing (see audit below) |
+| (b) Graph-canonical | graph store, files projected | Rejected — fights every existing tool |
+| (c) Two stores, one protocol | status quo | Rejected as end-state |
 
-Why (a): the eval already proved faithful file→graph derivation;
-hydrate.py already rebuilds Redis from files each session (the
-derivation pipeline 80% exists); the lint/hygiene enforcement all
-targets files; `metadata.type` ↔ NodeType is a 1:1 map. The only
-genuinely new machinery is (i) a `curated` frontmatter marker,
-(ii) `promote()` writing files, (iii) the one-time 13-node
-migration.
+Capability audit that justified the cut: edges already derive from
+`[[links]]` at hydrate (Redis IS the graph at recall time,
+`recall_related` walks it); NodeTypes ≡ `metadata.type`;
+`find_similar` is outclassed by FT.SEARCH+synonyms (all eval
+numbers are from the Redis path); with files canon and Redis
+rebuilt per-session, JSON round-trip fidelity has nothing left to
+protect.
+
+**Scope guard (the accepted pushback):** this decision covers
+Patrick's curated-memory ARCHITECTURE. Deleting
+`attune.memory.MemoryGraph` from the shipped package is a SEPARATE
+exercise behind the removing-dead-code / subsystem-value gate
+(usage evidence, PersonalMemory dependency check, breaking-change
+versioning) — tracked as T6, not bundled here.
+
+## OQ1 — Curated files live in the harness memory dirs (LOCKED)
+
+The 13 nodes migrate into the existing global/per-project memory
+dirs as normal lint-conforming files with `curated: true`. ONE
+corpus: harness recall, MEMORY.md, lint, and the Redis digest all
+read the same files. (Rejected: a dedicated `~/.attune/memory/
+curated/` dir — keeps the two-place split this spec exists to
+kill.)
+
+## OQ2 — `curated_graph.json` retired (LOCKED, "go")
+
+Hydrate derives the digest set from curated-marked files each run;
+no committed graph artifact. Git history preserves the old JSON if
+archaeology is ever needed.
 
 ## D2 — Curated marker schema (additive)
 
@@ -24,19 +50,27 @@ migration.
 metadata:
   type: user | feedback | project | reference
   curated: true            # optional; absent = un-promoted file layer
+  status: active           # optional; digest-visible lifecycle state
   node_id: <original id>   # provenance for migrated/promoted nodes
   promoted_from: <memory_idx uuid>   # stash provenance, when applicable
 ```
 
 Additive-only so every existing file stays valid; `memory_lint.py`
-gains validation for the new keys (unknown-key rule updated).
-Curated-marked files hydrate into BOTH `@layer:{file}` (pointer
-recall) and the curated digest set — one file, two serving roles.
+gains validation for the new keys. Curated-marked files hydrate
+into BOTH `@layer:{file}` (pointer recall) and the curated digest
+set — one file, two serving roles.
 
-## D3 — Sequencing gate
+## D3 — Sequencing gate (RESOLVED 2026-07-04)
 
-Phase 4 (code) does not start until Patrick locks D1/OQ1/OQ2 —
-the overruled pushback (miss-log empty; evidence-first) is noted
-for the record, and the R5 no-regression eval gate is the
-compensating control: if unification degrades recall numbers, that
-IS the miss-evidence, caught before ship.
+D1/OQ1/OQ2 are locked; Phase 4 is un-gated. The overruled
+evidence-first pushback stays on record with the R5 no-regression
+eval gate (`eval_pointer_index.py` re-run) as the compensating
+control: if unification degrades recall numbers, that IS the
+miss-evidence, caught before ship.
+
+## D4 — The typed digest is the one consumer that must not silently degrade
+
+`recall_digest` today renders typed/statused nodes hydrated from
+the graph JSON. Under D1 it must render identically from
+curated-marked files — explicit task (T3), verified by comparing
+digest output before/after migration on the same 13 nodes.

--- a/docs/specs/memory-unification/decisions.md
+++ b/docs/specs/memory-unification/decisions.md
@@ -1,0 +1,42 @@
+# Memory Unification — Decisions
+
+## D1 — Files-canonical, graph-derived (PROPOSED — needs Patrick's lock)
+
+Three architectures were on the table:
+
+| Option | Shape | Verdict |
+|---|---|---|
+| **(a) Files-canonical** | `.md` files are the single store; graph + Redis derived | **Recommended** |
+| (b) Graph-canonical | graph is the store; files are generated views | Rejected — fights every existing tool (lint, MEMORY.md, harness recall, Patrick's authoring habit) and inverts the ratified git-source-of-truth doctrine |
+| (c) Two stores, one protocol | keep both; promotion is the only bridge | Rejected as the end-state — it is the status quo whose double-authoring cost motivated this spec (fine as the transitional state during migration) |
+
+Why (a): the eval already proved faithful file→graph derivation;
+hydrate.py already rebuilds Redis from files each session (the
+derivation pipeline 80% exists); the lint/hygiene enforcement all
+targets files; `metadata.type` ↔ NodeType is a 1:1 map. The only
+genuinely new machinery is (i) a `curated` frontmatter marker,
+(ii) `promote()` writing files, (iii) the one-time 13-node
+migration.
+
+## D2 — Curated marker schema (additive)
+
+```yaml
+metadata:
+  type: user | feedback | project | reference
+  curated: true            # optional; absent = un-promoted file layer
+  node_id: <original id>   # provenance for migrated/promoted nodes
+  promoted_from: <memory_idx uuid>   # stash provenance, when applicable
+```
+
+Additive-only so every existing file stays valid; `memory_lint.py`
+gains validation for the new keys (unknown-key rule updated).
+Curated-marked files hydrate into BOTH `@layer:{file}` (pointer
+recall) and the curated digest set — one file, two serving roles.
+
+## D3 — Sequencing gate
+
+Phase 4 (code) does not start until Patrick locks D1/OQ1/OQ2 —
+the overruled pushback (miss-log empty; evidence-first) is noted
+for the record, and the R5 no-regression eval gate is the
+compensating control: if unification degrades recall numbers, that
+IS the miss-evidence, caught before ship.

--- a/docs/specs/memory-unification/migration-receipt.md
+++ b/docs/specs/memory-unification/migration-receipt.md
@@ -1,0 +1,28 @@
+# Memory Unification — T2 Migration Receipt (2026-07-04)
+
+13 nodes migrated from `curated_graph.json` to
+`~/.attune/memory/curated/*.md` (memory repo commit `7f55a40`).
+State parity after hydrate cutover: **EXACT — 22/22 Redis keys
+identical** (node hashes, edge lists, status set) vs the
+pre-cutover snapshot. Eval gate (R5): class A ft 3/5·3/5, B 5/7,
+C no crowding — matches the 2026-07-04 baseline.
+
+| node_id | file | node_type |
+|---|---|---|
+| `project_context_20260701193125_070be411b98c` | `personalmemory_recall_is_file_backed_and_survives_process.md` | project_context |
+| `reference_20260701193125_3c077c622099` | `canonical_recall_benchmark_numbers_and_methodology.md` | reference |
+| `feedback_20260701193125_ffa455c1db15` | `prefer_real_round_trip_tests_over_mocks_when.md` | feedback |
+| `user_context_20260701193125_9968105aa3dc` | `patrick_s_active_priority_make_attune_s_memory.md` | user_context |
+| `user_context_20260702001507_facd3d69e6f6` | `goal_framing_attune_memory_is_the_product_harness.md` | user_context |
+| `project_context_20260702001507_148bbbbb2a80` | `frictions_a_and_c_fixed_pr_1212_b.md` | project_context |
+| `project_context_20260702004314_a6fb3022f1c6` | `memory_architecture_git_long_term_redis_short_term.md` | project_context |
+| `user_context_20260702105705_3adbdf8d0ab2` | `two_layer_memory_protocol_ratified_curated_durable_only.md` | user_context |
+| `feedback_20260702115027_05962918a6ef` | `patrick_reinforced_collaboration_patterns_caught_doing_good_2026.md` | feedback |
+| `project_context_20260703013922_5da5d6cd7625` | `recall_loop_closed_the_digest_renders_live_from.md` | project_context |
+| `project_context_20260703013922_37c45d962977` | `starter_reconciler_is_the_short_term_layer_s.md` | project_context |
+| `feedback_20260704074647_741036a34853` | `query_first_recall_discipline.md` | feedback |
+| `project_context_20260704075056_f8e3c2b19d62` | `redis_recall_decision_both_sequenced_2026_07_04.md` | project_context |
+
+Edges: 9/9 carried as `edges_json` frontmatter on their source
+node's file. `curated_graph.json` remains write-only legacy until
+T4 (promote() writes files) lands.

--- a/docs/specs/memory-unification/requirements.md
+++ b/docs/specs/memory-unification/requirements.md
@@ -1,8 +1,9 @@
 # Memory Unification — Requirements
 
 **Status:** approved (2026-07-04) — Patrick locked D1 (files +
-Redis, NO graph middle layer), OQ1 (harness memory dirs), OQ2
-(retire curated_graph.json) same day. Phase 4 un-gated.
+Redis, NO graph middle layer), OQ1 (dedicated curated dir —
+RE-LOCKED same day after reversing the first call, see
+decisions.md), OQ2 (retire curated_graph.json). Phase 4 un-gated.
 **Owner:** patrick + agent
 
 ---
@@ -53,8 +54,8 @@ layers); the WRITE side is not.
   object, no `curated_graph.json` (retired per OQ2 lock).
 - **R4 — Promotion lands as a file.** The stash→curated promotion
   path (`promote()`) writes/updates a `.md` file (with provenance
-  frontmatter) in the harness memory dirs instead of writing graph
-  JSON, then re-derives.
+  frontmatter) in `~/.attune/memory/curated/` instead of writing
+  graph JSON, then re-derives.
   Receipts unchanged (status=active, R4 receipts per
   curated-memory-productionization D10).
 - **R5 — Serving contract unchanged.** `recall_digest`,
@@ -82,7 +83,7 @@ layers); the WRITE side is not.
 
 ## Open questions — RESOLVED 2026-07-04
 
-- OQ1: **harness memory dirs** — one corpus, `curated: true`
-  marker (decisions.md).
+- OQ1: **`~/.attune/memory/curated/`** — re-locked same day
+  (first call reversed; rationale in decisions.md).
 - OQ2: **retired** — hydrate derives from files; git history keeps
   the old JSON.

--- a/docs/specs/memory-unification/requirements.md
+++ b/docs/specs/memory-unification/requirements.md
@@ -1,8 +1,8 @@
 # Memory Unification — Requirements
 
-**Status:** draft (2026-07-04) — Patrick form-locked "start
-unification now," overruling the defer-to-evidence pushback; D1
-below still needs his architectural lock before Phase 4 code.
+**Status:** approved (2026-07-04) — Patrick locked D1 (files +
+Redis, NO graph middle layer), OQ1 (harness memory dirs), OQ2
+(retire curated_graph.json) same day. Phase 4 un-gated.
 **Owner:** patrick + agent
 
 ---
@@ -47,13 +47,14 @@ layers); the WRITE side is not.
   declared in file frontmatter (opt-in field), not by duplicating
   content into `curated_graph.json`. The 30-day admission test
   applies to setting the marker.
-- **R3 — Graph is derived.** Node identity, NodeType, and edges
-  (from `[[links]]`) are DERIVED from files at hydration/promotion
-  time. `curated_graph.json` becomes a build artifact or is
-  retired; it is never hand-authored after migration.
+- **R3 — Serving is derived, no middle store.** Node identity,
+  type, status, and edges (from `[[links]]`) are derived from
+  files at hydration time, straight into Redis. No MemoryGraph
+  object, no `curated_graph.json` (retired per OQ2 lock).
 - **R4 — Promotion lands as a file.** The stash→curated promotion
   path (`promote()`) writes/updates a `.md` file (with provenance
-  frontmatter) instead of writing graph JSON, then re-derives.
+  frontmatter) in the harness memory dirs instead of writing graph
+  JSON, then re-derives.
   Receipts unchanged (status=active, R4 receipts per
   curated-memory-productionization D10).
 - **R5 — Serving contract unchanged.** `recall_digest`,
@@ -79,13 +80,9 @@ layers); the WRITE side is not.
   untouched.
 - New recall surfaces or Lua procedures — serving stays as-is (R5).
 
-## Open questions (for Patrick at D1 lock)
+## Open questions — RESOLVED 2026-07-04
 
-- OQ1: Do migrated curated files live in the per-project memory
-  dirs (visible to the harness) or a dedicated
-  `~/.attune/memory/curated/` dir (visible only to attune)? The
-  former makes them recallable by BOTH systems natively; the
-  latter keeps the harness index lean.
-- OQ2: Retire `curated_graph.json` entirely (derive in-memory at
-  hydrate) or keep it as a committed build artifact for
-  inspection/versioning?
+- OQ1: **harness memory dirs** — one corpus, `curated: true`
+  marker (decisions.md).
+- OQ2: **retired** — hydrate derives from files; git history keeps
+  the old JSON.

--- a/docs/specs/memory-unification/requirements.md
+++ b/docs/specs/memory-unification/requirements.md
@@ -1,0 +1,91 @@
+# Memory Unification — Requirements
+
+**Status:** draft (2026-07-04) — Patrick form-locked "start
+unification now," overruling the defer-to-evidence pushback; D1
+below still needs his architectural lock before Phase 4 code.
+**Owner:** patrick + agent
+
+---
+
+## Problem
+
+Two memory systems author independently and only meet at the Redis
+serving layer:
+
+1. **Harness auto-memory** — 146 lint-clean `.md` files
+   (global + per-project), `[[link]]` graph, MEMORY.md index.
+   Richly populated; the surface Patrick and the agent actually
+   write to.
+2. **Attune curated graph** — `~/.attune/memory/curated_graph.json`
+   (13 nodes, 9 edges, NodeTypes `USER_CONTEXT`/`FEEDBACK`/
+   `PROJECT_CONTEXT`/`REFERENCE`), fed by the stash→promotion path
+   (9.5.0), served by `recall_digest`.
+
+Same concepts, two schemas, two authoring paths, double curation
+cost. The read side is already unified (`idx:attune_memory`, 4
+layers); the WRITE side is not.
+
+## Evidence base (why this is buildable)
+
+- `project_curated_memory_eval` (2026-07-02): MemoryGraph ingested
+  the full file corpus faithfully — 76 nodes / 66 edges survive a
+  fresh-instance reload; recall 6/6 vs grep 5/6.
+- The file schema's `metadata.type` values map 1:1 onto the four
+  curated NodeTypes.
+- Corpus hygiene now enforced end-to-end (0 violations; bare
+  `memory_lint --check-all` sweeps every dir).
+- Ratified doctrine (friction-log 2026-07-02): curated =
+  durable-only (30-day test); operational handoff = short-term
+  layer; git = source of truth, Redis = serving layer.
+
+## Requirements
+
+- **R1 — One authoring surface.** A durable memory is written
+  exactly once, as a lint-conforming `.md` file. No fact should
+  require both a file write and a separate graph write.
+- **R2 — Curated is a marker, not a copy.** Curated status is
+  declared in file frontmatter (opt-in field), not by duplicating
+  content into `curated_graph.json`. The 30-day admission test
+  applies to setting the marker.
+- **R3 — Graph is derived.** Node identity, NodeType, and edges
+  (from `[[links]]`) are DERIVED from files at hydration/promotion
+  time. `curated_graph.json` becomes a build artifact or is
+  retired; it is never hand-authored after migration.
+- **R4 — Promotion lands as a file.** The stash→curated promotion
+  path (`promote()`) writes/updates a `.md` file (with provenance
+  frontmatter) instead of writing graph JSON, then re-derives.
+  Receipts unchanged (status=active, R4 receipts per
+  curated-memory-productionization D10).
+- **R5 — Serving contract unchanged.** `recall_digest`,
+  `recall_related`, layer tags, and the pointer-recall discipline
+  (`feedback_query_first_recall`) keep working identically —
+  consumers must not notice the cutover. Golden-query eval numbers
+  must not regress (re-run `eval_pointer_index.py` as the gate).
+- **R6 — Migration with receipts.** The 13 existing curated nodes
+  are migrated to files once, mechanically, with a diff-able
+  receipt (node id ↔ file stem map). No content is dropped; edges
+  survive as `[[links]]`.
+- **R7 — Round-trip guard.** A non-mocked test proves file →
+  derived graph → Redis → digest end-to-end ("registered ≠
+  working"), running in CI where feasible and as a local check
+  otherwise.
+
+## Non-goals
+
+- AMS stash layer (short-term) — unchanged; promotion remains the
+  only bridge (and stays namespace-shared per the 2026-07-04
+  friction-log decision).
+- Lessons corpus and rules-tail layers — already file-canonical,
+  untouched.
+- New recall surfaces or Lua procedures — serving stays as-is (R5).
+
+## Open questions (for Patrick at D1 lock)
+
+- OQ1: Do migrated curated files live in the per-project memory
+  dirs (visible to the harness) or a dedicated
+  `~/.attune/memory/curated/` dir (visible only to attune)? The
+  former makes them recallable by BOTH systems natively; the
+  latter keeps the harness index lean.
+- OQ2: Retire `curated_graph.json` entirely (derive in-memory at
+  hydrate) or keep it as a committed build artifact for
+  inspection/versioning?

--- a/docs/specs/memory-unification/tasks.md
+++ b/docs/specs/memory-unification/tasks.md
@@ -2,30 +2,35 @@
 
 Gate resolved 2026-07-04 (D1/OQ1/OQ2 locked — see decisions.md).
 Architecture: files + Redis, no graph middle layer.
+**T1–T5 executed same day; receipts inline and in
+migration-receipt.md.**
 
-- [ ] **T1 — Schema + lint.** Add `curated`/`status`/`node_id`/
+- [x] **T1 — Schema + lint.** Add `curated`/`status`/`node_id`/
   `promoted_from` to the memory frontmatter schema;
   `memory_lint.py` validates them (and still rejects other unknown
   keys) and adds `~/.attune/memory/curated/` to its bare
   `--check-all` sweep list.
-- [ ] **T2 — Migration (one-time, receipted).** The 13 curated
+- [x] **T2 — Migration (one-time, receipted).** The 13 curated
   nodes → lint-conforming `.md` files in `~/.attune/memory/curated/`
   (OQ1 re-lock) with `curated: true` + provenance `node_id`; edges
   become `[[links]]`; one static MEMORY.md line points at the dir.
   Receipt (node-id ↔ file-stem map) lands in this spec dir;
   committed + pushed in the memory repo.
-- [ ] **T3 — Hydrate cutover + typed digest (D4).**
+- [x] **T3 — Hydrate cutover + typed digest (D4).**
   hydrate.py derives the curated layer (nodes, status sets, edges)
   from curated-marked files; `curated_graph.json` read path
   removed (OQ2). Verify `recall_digest` output matches the
   pre-migration render on the same 13 nodes.
-- [ ] **T4 — Promotion writes files.** `promote()` in
+- [x] **T4 — Promotion writes files.** `promote()` in
   `src/attune/memory/` lands a `.md` file in the curated dir with
   provenance frontmatter instead of writing graph JSON; R4
   receipts preserved (status=active). attune-ai PR + tests.
-- [ ] **T5 — Round-trip guard + R5 gate.** Non-mocked file →
-  hydrate → digest test; re-run `eval_pointer_index.py` — class
-  A/B/C numbers must not regress vs the 2026-07-04 baseline.
+- [x] **T5 — Round-trip guard + R5 gate.** DONE: state parity
+  EXACT (22/22 Redis keys) vs pre-cutover snapshot; eval re-run
+  matches baseline (A ft 3/5·3/5, B 5/7, C no crowding); LIVE
+  dogfood — promote() → file → hydrate → active curated node
+  served, probe removed clean. Non-mocked promote() suite: 11
+  passed (tests/unit/memory/test_promotion.py).
 - [ ] **T6 — MemoryGraph value-gate (separate exercise).** With
   the curated pipeline off the graph, run the removing-dead-code /
   subsystem-value gate on `attune.memory.MemoryGraph` in the

--- a/docs/specs/memory-unification/tasks.md
+++ b/docs/specs/memory-unification/tasks.md
@@ -1,0 +1,25 @@
+# Memory Unification — Tasks
+
+Gated on D1/OQ1/OQ2 lock (see decisions.md D3).
+
+- [ ] **T1 — Schema + lint.** Add `curated`/`node_id`/
+  `promoted_from` to the memory frontmatter schema;
+  `memory_lint.py` validates them (and still rejects other unknown
+  keys).
+- [ ] **T2 — Migration (one-time, receipted).** Script the 13
+  curated nodes → `.md` files per OQ1's location; emit the
+  node-id ↔ file-stem receipt into this spec dir; edges become
+  `[[links]]`.
+- [ ] **T3 — Derivation.** hydrate.py (memory repo) builds the
+  curated layer from curated-marked files; `curated_graph.json`
+  per OQ2 (retire or build-artifact).
+- [ ] **T4 — Promotion writes files.** `promote()` in
+  `src/attune/memory/` lands a `.md` file + MEMORY.md pointer with
+  provenance frontmatter, then triggers re-derivation; R4 receipts
+  preserved.
+- [ ] **T5 — Round-trip guard (R7).** Non-mocked file → graph →
+  Redis → digest test; plus the R5 gate: re-run
+  `eval_pointer_index.py`, numbers must not regress.
+- [ ] **T6 — Retire dual authoring.** Remove/deprecate the direct
+  graph-write path; docs + memory updates
+  (`project_memory_subsystem_motivation` closes its loop).

--- a/docs/specs/memory-unification/tasks.md
+++ b/docs/specs/memory-unification/tasks.md
@@ -6,19 +6,21 @@ Architecture: files + Redis, no graph middle layer.
 - [ ] **T1 — Schema + lint.** Add `curated`/`status`/`node_id`/
   `promoted_from` to the memory frontmatter schema;
   `memory_lint.py` validates them (and still rejects other unknown
-  keys).
+  keys) and adds `~/.attune/memory/curated/` to its bare
+  `--check-all` sweep list.
 - [ ] **T2 — Migration (one-time, receipted).** The 13 curated
-  nodes → lint-conforming `.md` files in the harness memory dirs
-  (OQ1) with `curated: true` + provenance `node_id`; edges become
-  `[[links]]`; MEMORY.md pointers added. Receipt (node-id ↔
-  file-stem map) lands in this spec dir.
+  nodes → lint-conforming `.md` files in `~/.attune/memory/curated/`
+  (OQ1 re-lock) with `curated: true` + provenance `node_id`; edges
+  become `[[links]]`; one static MEMORY.md line points at the dir.
+  Receipt (node-id ↔ file-stem map) lands in this spec dir;
+  committed + pushed in the memory repo.
 - [ ] **T3 — Hydrate cutover + typed digest (D4).**
   hydrate.py derives the curated layer (nodes, status sets, edges)
   from curated-marked files; `curated_graph.json` read path
   removed (OQ2). Verify `recall_digest` output matches the
   pre-migration render on the same 13 nodes.
 - [ ] **T4 — Promotion writes files.** `promote()` in
-  `src/attune/memory/` lands a `.md` file + MEMORY.md pointer with
+  `src/attune/memory/` lands a `.md` file in the curated dir with
   provenance frontmatter instead of writing graph JSON; R4
   receipts preserved (status=active). attune-ai PR + tests.
 - [ ] **T5 — Round-trip guard + R5 gate.** Non-mocked file →

--- a/docs/specs/memory-unification/tasks.md
+++ b/docs/specs/memory-unification/tasks.md
@@ -1,25 +1,32 @@
 # Memory Unification — Tasks
 
-Gated on D1/OQ1/OQ2 lock (see decisions.md D3).
+Gate resolved 2026-07-04 (D1/OQ1/OQ2 locked — see decisions.md).
+Architecture: files + Redis, no graph middle layer.
 
-- [ ] **T1 — Schema + lint.** Add `curated`/`node_id`/
+- [ ] **T1 — Schema + lint.** Add `curated`/`status`/`node_id`/
   `promoted_from` to the memory frontmatter schema;
   `memory_lint.py` validates them (and still rejects other unknown
   keys).
-- [ ] **T2 — Migration (one-time, receipted).** Script the 13
-  curated nodes → `.md` files per OQ1's location; emit the
-  node-id ↔ file-stem receipt into this spec dir; edges become
-  `[[links]]`.
-- [ ] **T3 — Derivation.** hydrate.py (memory repo) builds the
-  curated layer from curated-marked files; `curated_graph.json`
-  per OQ2 (retire or build-artifact).
+- [ ] **T2 — Migration (one-time, receipted).** The 13 curated
+  nodes → lint-conforming `.md` files in the harness memory dirs
+  (OQ1) with `curated: true` + provenance `node_id`; edges become
+  `[[links]]`; MEMORY.md pointers added. Receipt (node-id ↔
+  file-stem map) lands in this spec dir.
+- [ ] **T3 — Hydrate cutover + typed digest (D4).**
+  hydrate.py derives the curated layer (nodes, status sets, edges)
+  from curated-marked files; `curated_graph.json` read path
+  removed (OQ2). Verify `recall_digest` output matches the
+  pre-migration render on the same 13 nodes.
 - [ ] **T4 — Promotion writes files.** `promote()` in
   `src/attune/memory/` lands a `.md` file + MEMORY.md pointer with
-  provenance frontmatter, then triggers re-derivation; R4 receipts
-  preserved.
-- [ ] **T5 — Round-trip guard (R7).** Non-mocked file → graph →
-  Redis → digest test; plus the R5 gate: re-run
-  `eval_pointer_index.py`, numbers must not regress.
-- [ ] **T6 — Retire dual authoring.** Remove/deprecate the direct
-  graph-write path; docs + memory updates
-  (`project_memory_subsystem_motivation` closes its loop).
+  provenance frontmatter instead of writing graph JSON; R4
+  receipts preserved (status=active). attune-ai PR + tests.
+- [ ] **T5 — Round-trip guard + R5 gate.** Non-mocked file →
+  hydrate → digest test; re-run `eval_pointer_index.py` — class
+  A/B/C numbers must not regress vs the 2026-07-04 baseline.
+- [ ] **T6 — MemoryGraph value-gate (separate exercise).** With
+  the curated pipeline off the graph, run the removing-dead-code /
+  subsystem-value gate on `attune.memory.MemoryGraph` in the
+  shipped package: usage evidence, PersonalMemory dependency
+  check, breaking-change versioning. Own spec/PR if removal is
+  warranted — NOT bundled into T1–T5.

--- a/src/attune/memory/promotion.py
+++ b/src/attune/memory/promotion.py
@@ -1,11 +1,15 @@
 """Stash → curated promotion path (curated-memory R4).
 
 A deliberate, reviewable step that moves auto-stashed session findings
-into the durable curated graph: the agent drafts a curated node per
+into the durable curated corpus: the agent drafts a curated node per
 candidate (the 30-day test — "will this still be true and worth
 carrying in a month?"), the reviewer verdicts each one through a
 decision form, and every promotion writes provenance metadata (source
 stash entry, review verdict, date) onto the resulting node.
+
+Promotions land as one ``.md`` file per node in the curated directory
+(memory-unification D1/OQ1, 2026-07-04 — files are the store, Redis is
+the derived serving layer; the graph JSON middle layer is retired).
 
 Bulk import is explicitly wrong (the 2026-07-02 auto-stash
 supersession contradiction is the evidence) — this module has no
@@ -19,15 +23,18 @@ Licensed under Apache 2.0
 from __future__ import annotations
 
 import logging
+import re
+import uuid
 from datetime import datetime
+from pathlib import Path
 from typing import Any
 
-from attune.memory.graph import MemoryGraph
 from attune.memory.session_stash import recent_entries
+from attune.security.path_validation import _validate_file_path
 
 logger = logging.getLogger(__name__)
 
-#: Node types admissible in the curated graph (see attune.memory.nodes).
+#: Node types admissible in the curated corpus (see attune.memory.nodes).
 CURATED_TYPES = ("user_context", "feedback", "project_context", "reference")
 
 
@@ -113,13 +120,32 @@ def promotion_form_dict(proposals: list[dict[str, Any]]) -> dict[str, Any]:
     }
 
 
+#: metadata.type value (harness 4-way schema) per curated node type.
+TYPE_TO_META = {
+    "user_context": "user",
+    "feedback": "feedback",
+    "project_context": "project",
+    "reference": "reference",
+}
+
+
+def default_curated_dir() -> Path:
+    """The curated corpus directory (memory-unification OQ1 re-lock)."""
+    return Path.home() / ".attune" / "memory" / "curated"
+
+
+def _slug(name: str, max_words: int = 8) -> str:
+    words = re.findall(r"[a-z0-9]+", name.lower())
+    return "_".join(words[:max_words]) or "curated_node"
+
+
 def promote(
     proposal: dict[str, Any],
     source: dict[str, Any],
     response_id: str = "",
-    graph: MemoryGraph | None = None,
+    curated_dir: Path | str | None = None,
 ) -> str:
-    """Write one verdicted proposal into the curated graph with provenance.
+    """Write one verdicted proposal as a curated ``.md`` file with provenance.
 
     Args:
         proposal: The drafted node — ``{type, name, description, tags?}``;
@@ -128,41 +154,71 @@ def promote(
             :func:`promotion_candidates`) — recorded as provenance.
         response_id: The review response id (the form submission that
             carried the "Promote" verdict).
-        graph: Target graph; defaults to :meth:`MemoryGraph.curated`.
+        curated_dir: Target directory; defaults to
+            :func:`default_curated_dir`.
 
     Returns:
-        The created node id.
+        The created node id (the file records it as ``metadata.node_id``;
+        hydration serves the node under that id).
 
     Raises:
-        ValueError: If ``proposal['type']`` is not a curated node type.
+        ValueError: If ``proposal['type']`` is not a curated node type,
+            or the target path fails validation.
     """
     node_type = proposal.get("type", "")
     if node_type not in CURATED_TYPES:
         raise ValueError(
             f"promotion requires a curated node type {CURATED_TYPES}, got {node_type!r}"
         )
-    target = graph if graph is not None else MemoryGraph.curated()
-    provenance = {
-        "promoted_from_stash_id": str(source.get("id", "")),
-        "promoted_from_session": str(source.get("session_id", "")),
-        "promoted_from_ts": source.get("ts"),
-        "promoted_at": datetime.now().strftime("%Y-%m-%d"),
-        "review_verdict": "promote",
-        "review_response_id": response_id,
-    }
-    node_id = target.add_finding(
-        workflow="",
-        finding={
-            "type": node_type,
-            "name": proposal.get("name", ""),
-            "description": proposal.get("description", ""),
-            "tags": proposal.get("tags", []),
-            "metadata": provenance,
-            # add_finding defaults to "open"; hydration + the recall digest
-            # only carry "active" nodes — an "open" promotion would be
-            # invisible to recall (caught live in the R4 dogfood).
-            "status": "active",
-        },
+    base = Path(curated_dir) if curated_dir is not None else default_curated_dir()
+    base.mkdir(parents=True, exist_ok=True)
+
+    now = datetime.now()
+    node_id = f"{node_type}_{now:%Y%m%d%H%M%S}_{uuid.uuid4().hex[:12]}"
+    stem = _slug(str(proposal.get("name", "")))
+    while (base / f"{stem}.md").exists():
+        stem += "_x"
+    path = _validate_file_path(str(base / f"{stem}.md"))
+
+    # One-line frontmatter values must stay one line.
+    one_line_name = " ".join(str(proposal.get("name", "")).split())
+    iso = now.isoformat()
+    lines = [
+        "---",
+        f"name: {stem}",
+        f"description: {one_line_name}",
+        "metadata:",
+        f"  type: {TYPE_TO_META[node_type]}",
+        "  curated: true",
+        f"  node_type: {node_type}",
+        f"  node_id: {node_id}",
+        # hydration + the recall digest only carry "active" nodes — a
+        # non-active promotion would be invisible to recall (caught live
+        # in the R4 dogfood).
+        "  status: active",
+        f"  created_at: {iso}",
+        f"  updated_at: {iso}",
+    ]
+    tags = proposal.get("tags") or []
+    if tags:
+        lines.append(f"  tags: {', '.join(tags)}")
+    lines += [
+        f"  promoted_from_stash_id: {source.get('id', '')}",
+        f"  promoted_from_session: {source.get('session_id', '')}",
+        f"  promoted_from_ts: {source.get('ts', '')}",
+        f"  promoted_at: {now:%Y-%m-%d}",
+        "  review_verdict: promote",
+        f"  review_response_id: {response_id}",
+        "---",
+        "",
+        str(proposal.get("description", "")).strip(),
+        "",
+    ]
+    path.write_text("\n".join(lines), encoding="utf-8")
+    logger.info(
+        "promoted stash %s -> curated file %s (node %s)",
+        source.get("id"),
+        path.name,
+        node_id,
     )
-    logger.info("promoted stash %s -> curated node %s", source.get("id"), node_id)
     return node_id

--- a/tests/unit/memory/test_promotion.py
+++ b/tests/unit/memory/test_promotion.py
@@ -1,8 +1,9 @@
 """Tests for the stash → curated promotion path (curated-memory R4).
 
 Non-mocked throughout: a real FileStashBackend on tmp_path feeds
-candidates, a real MemoryGraph on tmp_path receives promotions, and
-the verdict form round-trips through the real elicitation pipeline.
+candidates, promotions land as real curated ``.md`` files on tmp_path
+(memory-unification D1 — files are the store), and the verdict form
+round-trips through the real elicitation pipeline.
 """
 
 from __future__ import annotations
@@ -13,14 +14,27 @@ import pytest
 
 from attune.elicitation import collect_form_response, form_from_dict, form_to_widget_html
 from attune.memory.file_stash import FileStashBackend
-from attune.memory.graph import MemoryGraph
 from attune.memory.promotion import (
     CURATED_TYPES,
+    TYPE_TO_META,
     promote,
     promotion_candidates,
     promotion_form_dict,
 )
 from attune.memory.session_stash import SessionStashEntry, stash_entry
+
+
+def _frontmatter(path) -> dict[str, str]:
+    """Flat first-wins parse of `k: v` frontmatter lines (matches hydrate)."""
+    raw = path.read_text(encoding="utf-8")
+    inner = raw[3 : raw.find("\n---", 3)]
+    meta: dict[str, str] = {}
+    for line in inner.splitlines():
+        if ":" in line:
+            k, v = line.strip().split(":", 1)
+            meta.setdefault(k.strip(), v.strip())
+    return meta
+
 
 PROPOSAL = {
     "source_id": "stash-123",
@@ -114,34 +128,55 @@ class TestPromotionFormDict:
 
 
 class TestPromote:
-    def test_writes_node_with_provenance(self, tmp_path) -> None:
-        graph = MemoryGraph(path=tmp_path / "curated.json")
-        node_id = promote(PROPOSAL, SOURCE, response_id="resp-1", graph=graph)
-        node = graph.nodes[node_id]
-        assert node.type.value == "project_context"
-        assert node.name == PROPOSAL["name"]
-        meta = node.metadata
+    def test_writes_curated_file_with_provenance(self, tmp_path) -> None:
+        node_id = promote(PROPOSAL, SOURCE, response_id="resp-1", curated_dir=tmp_path)
+        files = list(tmp_path.glob("*.md"))
+        assert len(files) == 1
+        f = files[0]
+        meta = _frontmatter(f)
+        # Hydration contract (load_curated in the memory repo reads these).
+        assert meta["node_id"] == node_id
+        assert meta["node_type"] == "project_context"
+        assert meta["type"] == TYPE_TO_META["project_context"]
+        assert meta["curated"] == "true"
+        assert meta["description"] == PROPOSAL["name"]
+        assert meta["name"] == f.stem  # lint R1: name ≡ filename stem
+        assert meta["updated_at"]
+        # Provenance.
         assert meta["promoted_from_stash_id"] == "stash-123"
         assert meta["promoted_from_session"] == "sess-abc"
         assert meta["review_verdict"] == "promote"
         assert meta["review_response_id"] == "resp-1"
         assert meta["promoted_at"]  # date stamped
-        # Regression (caught live 2026-07-03): add_finding defaults status
-        # to "open", which hydration/recall filter out — promotions must
-        # land "active" or they are invisible to the digest.
-        assert node.status == "active"
+        # Regression (caught live 2026-07-03): non-active promotions are
+        # invisible to hydration/recall — must land "active".
+        assert meta["status"] == "active"
+        # Body carries the drafted description.
+        body = f.read_text().split("---", 2)[2]
+        assert PROPOSAL["description"] in body
 
-    def test_persists_across_reload(self, tmp_path) -> None:
-        path = tmp_path / "curated.json"
-        node_id = promote(PROPOSAL, SOURCE, graph=MemoryGraph(path=path))
-        reloaded = MemoryGraph(path=path)
-        assert node_id in reloaded.nodes
-        assert reloaded.nodes[node_id].metadata["promoted_from_stash_id"] == "stash-123"
+    def test_persists_and_reparses(self, tmp_path) -> None:
+        node_id = promote(PROPOSAL, SOURCE, curated_dir=tmp_path)
+        f = next(iter(tmp_path.glob("*.md")))
+        meta = _frontmatter(f)  # fresh parse from disk — no warm state
+        assert meta["node_id"] == node_id
+        assert meta["promoted_from_stash_id"] == "stash-123"
+
+    def test_stem_collision_gets_suffix(self, tmp_path) -> None:
+        first = promote(PROPOSAL, SOURCE, curated_dir=tmp_path)
+        second = promote(PROPOSAL, SOURCE, curated_dir=tmp_path)
+        assert first != second
+        stems = sorted(p.stem for p in tmp_path.glob("*.md"))
+        assert len(stems) == 2
+        assert stems[1] == stems[0] + "_x"
+        # R1 holds for both: name ≡ stem.
+        for p in tmp_path.glob("*.md"):
+            assert _frontmatter(p)["name"] == p.stem
 
     def test_rejects_non_curated_type(self, tmp_path) -> None:
-        graph = MemoryGraph(path=tmp_path / "curated.json")
         with pytest.raises(ValueError, match="curated node type"):
-            promote({**PROPOSAL, "type": "bug"}, SOURCE, graph=graph)
+            promote({**PROPOSAL, "type": "bug"}, SOURCE, curated_dir=tmp_path)
+        assert list(tmp_path.glob("*.md")) == []
 
     def test_curated_types_are_the_four(self) -> None:
         assert set(CURATED_TYPES) == {


### PR DESCRIPTION
## What

The memory-unification thread, spec'd and implemented same-day (all decisions Patrick-locked 2026-07-04, including the OQ1 same-day reversal recorded in place).

**Architecture (D1):** files + Redis, NO graph middle layer. `.md` files in `~/.attune/memory/curated/` are the store; hydration derives node hashes, status sets, and edges straight into Redis; `curated_graph.json` retired (OQ2).

## In this PR (attune-ai side)

- **promote() rewrite (T4)**: lands a lint-conforming curated `.md` file (frontmatter: `curated: true`, node_type/node_id, `status: active`, full stash provenance) instead of writing graph JSON. `curated_dir` kwarg replaces `graph`; no src callers existed beyond tests.
- **Tests**: TestPromote rewritten against the file artifact — hydration-contract fields, R1 name≡stem, collision suffixing, provenance. 11 passed; full memory suite 1,851 passed.
- **Spec** (requirements/decisions/tasks + migration receipt): R1–R7, D1–D4, T1–T5 receipted.

## Companion changes (memory repo + local)

- `7f55a40`: 13 nodes migrated to `curated/*.md`; hydrate.py `load_curated()`; **state parity EXACT (22/22 Redis keys)** vs pre-cutover snapshot.
- `781f686`: `curated_graph.json` removed (git history preserves it).
- Eval gate: golden-query numbers match the 2026-07-04 baseline (A ft 3/5·3/5, B 5/7, C no crowding).
- **Live round-trip receipt**: promote() → file → hydrate → active curated node served in digest → probe removed clean.

T6 (MemoryGraph package value-gate) deliberately NOT bundled — separate exercise per the scope guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)