### PR TITLE
feat(packaging): Redis memory deps become core dependencies (facade D6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **packaging:** Redis memory client deps (`redis`,
+  `agent-memory-client>=0.14.0,<0.15`) are now **core
+  dependencies** — the standard `pip install attune-ai` supports
+  the cross-session memory features (hydration, recall digest,
+  `redis_memory_*` MCP tools, `AMSMemoryBackend`) whenever a Redis
+  Stack server is reachable. Packaging catch-up with the
+  facade-direction D1 ratification ("Redis stays — align on Redis +
+  Anthropic Claude"); memory unification (9.6.0) made memory the
+  flagship story, so its deps no longer hide behind an extra. The
+  `[redis]` extra remains as an empty backward-compat alias (same
+  pattern as `[memory]`/`[rag]`), and the `[dev]` mirror entries are
+  gone — worktree venvs stop drifting out of redis support. Features
+  degrade with a clean guidance message when no server is reachable.
+
 ## [9.6.0] — 2026-07-04
 
 The memory-unification release: the curated corpus becomes plain

--- a/README.md
+++ b/README.md
@@ -186,8 +186,8 @@ durable findings, and every new session can pull them back:
 - **Stash on stop** — a `Stop` hook extracts decisions, bugs, and
   references from the session (local LLM when available, heuristic
   fallback) and writes them to the memory store: a local file by
-  default, Redis Agent Memory Server with
-  `pip install 'attune-ai[redis]'`.
+  default, Redis Agent Memory Server when one is reachable — the
+  client ships with the standard install.
 - **Recall at the door** — a `SessionStart` hook surfaces the most
   recent findings for your project, and warns when the memory
   backend is unreachable instead of degrading silently.
@@ -397,19 +397,22 @@ from retrieval. Full methodology:
 ## Installation Options
 
 `pip install attune-ai` works out of the box — the CLI, all
-workflows, the MCP server, RAG, and the Agent SDK are core
-dependencies. Add extras only for the surfaces you use:
+workflows, the MCP server, RAG, cross-session memory (the Redis /
+Agent Memory Server client is a core dependency as of 9.7.0), and
+the Agent SDK. Memory features activate when a Redis Stack server
+is reachable and degrade with guidance when not. Add extras only
+for the surfaces you use:
 
 | You want | Install |
 | -------- | ------- |
-| Everything most users need | `pip install attune-ai` |
+| Everything most users need, incl. Redis memory | `pip install attune-ai` |
 | Claude API mode + optional LangChain/LangGraph interop adapters | `pip install 'attune-ai[developer]'` |
 | The ops dashboard (`attune ops`) | `pip install 'attune-ai[ops]'` |
-| Redis / Agent Memory Server memory backend | `pip install 'attune-ai[redis]'` |
 | Help authoring (generate / maintain `.help/` templates) | `pip install 'attune-ai[author]'` |
 
-Extras combine — for example
-`pip install 'attune-ai[developer,ops,redis]'`. Keep the quotes:
+(`[redis]` remains as an empty backward-compat alias.) Extras
+combine — for example
+`pip install 'attune-ai[developer,ops]'`. Keep the quotes:
 zsh and bash treat square brackets as glob characters.
 
 Contributing? Clone and install the dev toolchain instead:

--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -36,12 +36,18 @@ These features work without any additional dependencies beyond the base install 
 
 ---
 
-## Optional Features (Require Redis)
+## Optional Features (Require a Redis Server)
 
-These features require Redis server and the `redis` extra:
+The Redis client libraries ship with the standard install (core
+dependencies as of 9.7.0 — the `[redis]` extra remains as an empty
+backward-compat alias). These features activate when a Redis Stack
+server is reachable:
 
 ```bash
-pip install 'attune-ai[redis]'
+# macOS
+brew tap redis-stack/redis-stack && brew install redis-stack-server
+# Linux
+sudo apt install redis-stack-server
 ```
 
 ### Memory - Redis-Enhanced

--- a/docs/specs/redis-facade-direction/decisions.md
+++ b/docs/specs/redis-facade-direction/decisions.md
@@ -111,6 +111,31 @@ the highest-integrity leverage move.
 superseded by "relabel-not-remove; leverage path is the work." 9.0.0
 is **not** a facade-removal release.
 
+## D6 — Redis memory deps become CORE dependencies (packaging catch-up with D1). EXECUTED 2026-07-04.
+
+**Decision:** `redis>=5.0.0,<9.0.0` and
+`agent-memory-client>=0.14.0,<0.15` move from the `[redis]` extra
+into core `dependencies`. The `[redis]` extra stays as an empty
+backward-compat alias (the `[memory]`/`[rag]` pattern); the `[dev]`
+mirror entries are removed. Install docs (README, docs/features,
+website homepage) now present memory as part of the standard
+install, activating when a Redis Stack server is reachable.
+
+**Why:** D1 ratified "Redis stays — align on Redis + Anthropic
+Claude," and memory unification (9.6.0) made cross-session memory
+the flagship story — yet the standard install couldn't run it
+(`redis_memory_*` MCP tools failed in every venv that missed the
+extra; the 2026-07-02 worktree-drift class). This REVERSES the
+packaging half of the archived redis-decoupling spec ("vanilla
+attune-ai is Redis-free") — deliberate, Patrick-directed 2026-07-04.
+
+**Conditions shipped with the flip:** (1) tight cap on
+agent-memory-client (`<0.15`) since it now sits on every user's
+resolution path; (2) a no-server degradation gate — the memory
+surface with deps installed but no reachable server must produce a
+clean guidance message, not a traceback (the 9.3.0 "boot-only smoke
+passes broken features" lesson).
+
 ---
 
 ## What this does NOT decide (open for the meeting)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,10 +78,21 @@ dependencies = [
     "attune-rag>=0.1.5,<0.8",  # RAG grounding for rag-code-gen workflow + rag_knowledge_query MCP tool. Core dep (not optional) — required for acceptable retrieval accuracy. Cap is <0.8: re-validated against attune-rag 0.7.0 (lock bumped 0.6.0->0.7.0; purely additive — subscription-first FaithfulnessJudge auth + new attune_rag.auth module; only removal is the internal Phase-4 freeze CI gate, "no library change"; all 0.6.x public symbols unchanged per its POLICY §2, confirmed by importing every attune-ai-consumed symbol); next minor (0.8.0) still requires explicit re-validation before lifting the cap.
     "attune-verify>=0.1.0,<0.3",  # Generation fact-checker backing the /verify skill (deterministic entity checks: imports/flags/links/counts). Core dep — stdlib-only (zero transitive deps), so promoting to core is cheap and lets /verify work out of the box without an extra. Semantic layer is opt-in (the skill acts as the ambient judge). Cap raised to <0.3 to admit 0.2.0 (full dotted-path import resolution — catches private-submodule hallucinations the 0.1.0 top-level-only checker missed; purely additive, no API break).
     "tomli>=2.0.0; python_version < '3.11'",  # tomllib fallback for Python 3.10. Used by attune.utils.coverage (loaded transitively from release-prep + orchestrated-health-check workflows). Without this, those workflows fail to load on 3.10.
+    # Redis memory runtime — CORE as of the 2026-07-04 packaging
+    # catch-up with the facade-direction D1 ratification ("Redis
+    # stays — align on Redis + Anthropic Claude"): cross-session
+    # memory (hydration, recall digest, redis_memory_* MCP tools,
+    # AMSMemoryBackend) is the flagship story, so the standard
+    # install carries its deps. Features still need a reachable
+    # Redis Stack server and degrade with a clean guidance message
+    # without one (see tests/unit/memory/test_no_server_degradation.py).
+    # agent-memory-client is capped tightly — it moves fast and now
+    # sits on every user's resolution path; raise the cap only after
+    # re-validating. The [redis] extra remains as an empty alias.
+    "agent-memory-client>=0.14.0,<0.15",
+    "redis>=5.0.0,<9.0.0",
     # NOTE: attune-author is a workspace-only dev dep for authoring/
     # refactoring help content — NOT a runtime requirement.
-    # NOTE: redis is opt-in via the [redis] extra (bundled attune_redis
-    # plugin). Vanilla `pip install attune-ai` is Redis-free.
 ]
 # NOTE: CrewAI dependency removed in v3.1.3 (deprecated since v4.4.0)
 # The "Crew" workflows use EmpathyLLMExecutor (Anthropic SDK) directly.
@@ -117,12 +128,10 @@ author = [
 # bundled attune_redis plugin).
 memory = []
 
-# Redis Agent Memory Server runtime deps for the bundled `attune_redis`
-# plugin. Opt-in only — vanilla `pip install attune-ai` is Redis-free.
-redis = [
-    "agent-memory-client>=0.14.0",
-    "redis>=5.0.0,<9.0.0",
-]
+# Redis/AMS deps promoted to CORE 2026-07-04 (see the core
+# dependencies comment). Empty no-op kept for backward compat with
+# `pip install 'attune-ai[redis]'` — same pattern as [memory]/[rag].
+redis = []
 
 # LLM provider (Claude-native architecture)
 anthropic = ["anthropic>=0.40.0"]
@@ -238,15 +247,9 @@ dev = [
     "uvicorn[standard]>=0.27.0,<1.0",
     "jinja2>=3.1.0,<4.0",
     "requests>=2.28.0,<3.0.0",  # For notification tests
-    # Redis/AMS runtime ([redis] extra) — mirrored into [dev] so
-    # worktree/dev syncs carry the deps the plugin MCP server's
-    # redis_memory_* tools and the attune_redis backend need, without
-    # a separate `--extra redis`. Found 2026-07-02: a worktree session
-    # whose SessionStart hook hydrated Redis had MCP tools failing
-    # "Redis support not installed" (curated-memory spec, T6). Keep
-    # pins in lock-step with the [redis] extra above.
-    "agent-memory-client>=0.14.0",
-    "redis>=5.0.0,<9.0.0",
+    # Redis/AMS mirror removed 2026-07-04 — redis + agent-memory-client
+    # are CORE deps now (see the core dependencies comment), so every
+    # sync carries them; the 2026-07-02 worktree drift class is gone.
     # RAG integration test coverage — attune-rag is an
     # optional runtime dep but required for the rag_code_gen
     # and rag_knowledge_query test paths to exercise their
@@ -258,12 +261,11 @@ dev = [
     # unconditionally. Without these, the unit suite fails at
     # collection on a fresh `pip install -e .[dev]`. See
     # docs/specs/ci-debt/ Phase A for the contract:
-    #   - redis: tests/unit/memory/test_pubsub_direct.py
     #   - langchain-anthropic: tests/unit/agent_factory/test_langgraph_adapter.py
     #   - tiktoken: tests/unit/models/test_token_estimator.py
     #     (tiktoken stays optional in production; tests cover
     #      both TIKTOKEN_AVAILABLE paths)
-    "redis>=5.0.0,<9.0.0",
+    # (redis entry removed 2026-07-04 — core dep now)
     "langchain-anthropic>=0.3.0,<2.0.0",
     "tiktoken>=0.7.0,<1.0.0",
 ]

--- a/tests/unit/memory/test_no_server_degradation.py
+++ b/tests/unit/memory/test_no_server_degradation.py
@@ -1,0 +1,93 @@
+"""No-server degradation gate for the Redis memory surface.
+
+Redis + agent-memory-client became CORE dependencies on 2026-07-04
+(redis-facade-direction D6): the standard ``pip install attune-ai``
+carries the client libraries, and the memory features are expected to
+degrade with clean guidance — never a traceback — when no Redis Stack
+server is reachable.
+
+This is the gate D6 shipped with (the 9.3.0 lesson: boot-only smoke
+checks pass broken features). It locks three contracts:
+
+1. The client deps are importable in a standard environment.
+2. Availability checks report "server not running" guidance instead
+   of raising when nothing listens.
+3. The ``redis_memory_*`` MCP handlers return a clean error dict when
+   the backend cannot reach a server.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from attune.memory.features import FeatureStatus, MemoryFeatures
+
+
+class TestCoreDepsPresent:
+    """The packaging half of D6: deps ship with the standard install."""
+
+    def test_redis_client_is_importable(self):
+        import redis  # noqa: F401
+
+    def test_agent_memory_client_is_importable(self):
+        import agent_memory_client  # noqa: F401
+
+
+class TestNoServerAvailabilityChecks:
+    """Availability checks must return False / guidance, not raise."""
+
+    def test_is_redis_running_unreachable_port_returns_false(self):
+        # Port 1 is never a Redis server; must come back False within
+        # the 1s connect timeout without raising.
+        assert MemoryFeatures.is_redis_running(host="127.0.0.1", port=1) is False
+
+    def test_redis_feature_reports_server_guidance_when_down(self):
+        with (
+            patch.object(MemoryFeatures, "is_redis_available", return_value=True),
+            patch.object(MemoryFeatures, "is_redis_running", return_value=False),
+        ):
+            info = MemoryFeatures.get_feature_status("short_term")
+        assert info.status == FeatureStatus.NOT_CONFIGURED
+        assert "server" in info.message.lower()
+        # Guidance points at installing/starting a server, not pip.
+        assert info.install_command and "redis" in info.install_command.lower()
+
+
+class TestMcpToolsDegradeCleanly:
+    """redis_memory_* handlers return an error dict, never raise."""
+
+    async def test_store_returns_clean_error_when_backend_unreachable(self):
+        import redis as redis_lib
+
+        from attune_redis.mcp_tools import handle_redis_memory_store
+
+        class _DeadBackend:
+            def stash(self, *args, **kwargs):
+                raise redis_lib.ConnectionError("Connection refused")
+
+        class _Server:
+            _redis_backend = _DeadBackend()
+
+        result = await handle_redis_memory_store(_Server(), {"key": "k", "value": "v"})
+        assert result["success"] is False
+        assert isinstance(result.get("error"), str) and result["error"]
+
+    async def test_retrieve_returns_clean_error_when_backend_unreachable(self):
+        import redis as redis_lib
+
+        from attune_redis.mcp_tools import handle_redis_memory_retrieve
+
+        class _DeadBackend:
+            def retrieve(self, *args, **kwargs):
+                raise redis_lib.ConnectionError("Connection refused")
+
+        class _Server:
+            _redis_backend = _DeadBackend()
+
+        result = await handle_redis_memory_retrieve(_Server(), {"key": "k"})
+        assert result["success"] is False
+        assert isinstance(result.get("error"), str) and result["error"]
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/uv.lock
+++ b/uv.lock
@@ -256,6 +256,7 @@ name = "attune-ai"
 version = "9.6.0"
 source = { editable = "." }
 dependencies = [
+    { name = "agent-memory-client" },
     { name = "anthropic" },
     { name = "attune-rag" },
     { name = "attune-verify" },
@@ -270,6 +271,7 @@ dependencies = [
     { name = "python-frontmatter" },
     { name = "python-multipart" },
     { name = "pyyaml" },
+    { name = "redis" },
     { name = "rich" },
     { name = "structlog" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
@@ -342,7 +344,6 @@ backend = [
     { name = "uvicorn" },
 ]
 dev = [
-    { name = "agent-memory-client" },
     { name = "attune-rag" },
     { name = "bandit" },
     { name = "black" },
@@ -361,7 +362,6 @@ dev = [
     { name = "pytest-testmon" },
     { name = "pytest-timeout" },
     { name = "pytest-xdist" },
-    { name = "redis" },
     { name = "requests" },
     { name = "ruff" },
     { name = "tiktoken" },
@@ -439,18 +439,13 @@ otel = [
     { name = "opentelemetry-exporter-otlp-proto-grpc" },
     { name = "opentelemetry-sdk" },
 ]
-redis = [
-    { name = "agent-memory-client" },
-    { name = "redis" },
-]
 windows = [
     { name = "colorama" },
 ]
 
 [package.metadata]
 requires-dist = [
-    { name = "agent-memory-client", marker = "extra == 'dev'", specifier = ">=0.14.0" },
-    { name = "agent-memory-client", marker = "extra == 'redis'", specifier = ">=0.14.0" },
+    { name = "agent-memory-client", specifier = ">=0.14.0,<0.15" },
     { name = "aiohttp", marker = "extra == 'all'", specifier = ">=3.14.1,<4.0.0" },
     { name = "anthropic", specifier = ">=0.40.0,<1.0.0" },
     { name = "anthropic", marker = "extra == 'all'", specifier = ">=0.40.0" },
@@ -581,8 +576,7 @@ requires-dist = [
     { name = "pyyaml", marker = "extra == 'developer'", specifier = ">=6.0,<7.0" },
     { name = "pyyaml", marker = "extra == 'enterprise'", specifier = ">=6.0,<7.0" },
     { name = "pyyaml", marker = "extra == 'full'", specifier = ">=6.0,<7.0" },
-    { name = "redis", marker = "extra == 'dev'", specifier = ">=5.0.0,<9.0.0" },
-    { name = "redis", marker = "extra == 'redis'", specifier = ">=5.0.0,<9.0.0" },
+    { name = "redis", specifier = ">=5.0.0,<9.0.0" },
     { name = "requests", marker = "extra == 'dev'", specifier = ">=2.28.0,<3.0.0" },
     { name = "rich", specifier = ">=13.0.0,<16.0.0" },
     { name = "ruff", marker = "extra == 'all'", specifier = ">=0.1,<1.0" },

--- a/website/app/page.tsx
+++ b/website/app/page.tsx
@@ -323,19 +323,20 @@ export default function Home() {
             <div className="grid md:grid-cols-2 gap-12 items-center">
               <div>
                 <span className="text-xs font-bold text-[var(--secondary)] tracking-[0.2em] uppercase mb-4 block">Semantic memory</span>
-                <h2 className="text-3xl md:text-4xl font-extrabold mb-4">Powered by Redis when you want it</h2>
+                <h2 className="text-3xl md:text-4xl font-extrabold mb-4">Powered by Redis, ready out of the box</h2>
                 <p className="text-[var(--text-secondary)] leading-relaxed mb-6">
                   Memory is local-first by default &mdash; nothing leaves your
-                  machine. Plug in Redis Agent Memory Server for semantic search
-                  over your project memory: local Ollama embeddings, int8 vector
-                  quantization, no cloud required.
+                  machine. The Redis Agent Memory Server client ships with the
+                  standard install: point it at a Redis Stack server for
+                  semantic search over your project memory &mdash; local Ollama
+                  embeddings, int8 vector quantization, no cloud required.
                 </p>
-                <code className="inline-block bg-[var(--surface-container-high)] px-4 py-2 rounded-lg text-sm font-mono">pip install &apos;attune-ai[redis]&apos;</code>
+                <code className="inline-block bg-[var(--surface-container-high)] px-4 py-2 rounded-lg text-sm font-mono">pip install attune-ai</code>
               </div>
               <div className="grid sm:grid-cols-2 gap-3">
                 {[
                   ['Local-first', 'Default backend is on-disk — no service required'],
-                  ['Redis AMS tier', 'Opt in for semantic recall across sessions'],
+                  ['Redis AMS tier', 'Client included — semantic recall across sessions'],
                   ['Ollama embeddings', 'Runs locally — no API key, no cloud'],
                   ['int8 quantization', 'Compact vectors, shipped in attune-ai 7.4'],
                 ].map(([title, desc]) => (

--- a/website/lib/features.ts
+++ b/website/lib/features.ts
@@ -384,7 +384,7 @@ export const PILLARS: Pillar[] = [
       "at the moment a prompt needs it.",
     points: [
       "Local-first by default — no cloud required",
-      "Optional Redis semantic tier (local Ollama embeddings)",
+      "Redis semantic tier, client included (local Ollama embeddings)",
       "Automatic recall, or on demand with /recall",
     ],
     icon: "🧠",

--- a/website/lib/features.ts
+++ b/website/lib/features.ts
@@ -76,7 +76,7 @@ export const PRODUCTS: Product[] = [
     id: "attune-author",
     name: "Attune Author",
     pypiName: "attune-author",
-    version: "0.22.0",
+    version: "0.23.0",
     tagline: "Author and polish help content with AI",
     installCommand: "pip install 'attune-author[plugin]'",
     marketplaceInstall:


### PR DESCRIPTION
**What:** `redis>=5.0.0,<9.0.0` and `agent-memory-client>=0.14.0,<0.15` move from the `[redis]` extra into core dependencies — the standard `pip install attune-ai` now supports the cross-session memory features (hydration, recall digest, `redis_memory_*` MCP tools, `AMSMemoryBackend`) whenever a Redis Stack server is reachable.

**Why:** Packaging catch-up with the facade-direction **D1** ratification ("Redis stays — align on Redis + Anthropic Claude"). Memory unification (9.6.0) made cross-session memory the flagship story, yet the standard install couldn't run it — every venv that missed the extra hit `redis_memory_*` failures (the 2026-07-02 worktree-drift class). Deliberately reverses the packaging half of the archived redis-decoupling spec; recorded as **D6** in [redis-facade-direction/decisions.md](docs/specs/redis-facade-direction/decisions.md). Patrick-directed 2026-07-04.

**Conditions shipped with the flip:**
- `agent-memory-client` capped `<0.15` — it now sits on every user's resolution path; raise deliberately
- No-server degradation gate ([test_no_server_degradation.py](tests/unit/memory/test_no_server_degradation.py), 6 tests green): deps importable, availability checks return False-not-raise, `get_feature_status` gives server guidance, `redis_memory_*` handlers return clean error dicts
- `[redis]` extra stays as an empty backward-compat alias (`[memory]`/`[rag]` pattern); `[dev]` mirrors removed

**Docs/website:** README memory bullet + Installation Options table, docs/features/index.md (server-not-extra framing), website homepage (`pip install attune-ai`, verified rendering in preview — no console errors) + features.ts bullet.

**Lock:** same 187 packages — deps moved tiers, nothing new resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)