### PR TITLE
chore(usage-signals): 2026-07-05 reach snapshot (v9.7.0 tag baseline)

### DIFF
--- a/docs/specs/usage-signals/snapshots/2026-07-05.json
+++ b/docs/specs/usage-signals/snapshots/2026-07-05.json
@@ -1,0 +1,37 @@
+{
+  "date": "2026-07-05",
+  "github": {
+    "clones_14d": 57928,
+    "forks": 0,
+    "stars": 6,
+    "views_14d": 940
+  },
+  "pypi_recent": {
+    "attune-ai": {
+      "last_day": 132,
+      "last_month": 4090,
+      "last_week": 1445
+    },
+    "attune-author": {
+      "last_day": 107,
+      "last_month": 2576,
+      "last_week": 298
+    },
+    "attune-help": {
+      "last_day": 4,
+      "last_month": 314,
+      "last_week": 63
+    },
+    "attune-rag": {
+      "last_day": 599,
+      "last_month": 31316,
+      "last_week": 4565
+    },
+    "attune-verify": {
+      "last_day": 1355,
+      "last_month": 39047,
+      "last_week": 10315
+    }
+  },
+  "taken_at": "2026-07-05T02:34:44.859738+00:00"
+}


### PR DESCRIPTION
Cooldown rerun of `scripts/reach_snapshot.py` after pypistats rate limits at both of today's tag times (9.6.0 morning, 9.7.0 evening). 5/5 packages captured; the UTC date rolled so the file is `2026-07-05.json` — this is the v9.7.0 tag baseline.

Snapshot-only diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)