### PR TITLE
docs(blog): measured memory-suite LinkedIn article

### DIFF
--- a/docs/blog/social/linkedin_memory_suite.md
+++ b/docs/blog/social/linkedin_memory_suite.md
@@ -1,0 +1,85 @@
+---
+description: "LinkedIn Article — Attune AI Memory Suite (measured): we put hard numbers on what persistent AI memory saves, by running the benchmark against our own live memory store. 67x fewer tokens, sub-millisecond recall, with a nod to the MemDocs work it grew from."
+---
+
+# LinkedIn Article — Attune AI Memory Suite (measured)
+
+*Format: LinkedIn Article (long-form, supports headers). ~450 words.
+ASCII markers only — LinkedIn mangles Unicode arrows on paste.*
+
+---
+
+**We stopped claiming our AI remembers. This week we measured it.**
+
+Every AI coding assistant starts from zero. Ours doesn't — and I
+finally put hard numbers on what that's worth by running the benchmark
+against our own live memory store, on our own codebase.
+
+Here's what persistent memory actually bought us:
+
+-> 302,949 tokens of durable memory — 751 findings, lessons, and rules
+   distilled from our own sessions
+-> A session recalls only the relevant slice: lessons injected at the
+   trap moment are capped at 3,000 tokens = **67x fewer tokens** than
+   loading the full corpus into context
+-> Recall is one warm Redis call: **0.6 ms**, versus 4.4 ms to read the
+   files from disk — roughly **7x faster**
+-> Retrieval quality: **P@3 96%** (100% on the high-severity subset) on
+   a frozen trap-moment benchmark
+
+And both wins widen as the corpus grows — the budget cap stays constant,
+the recall call stays flat.
+
+**The point isn't the store. It's what you DON'T load.**
+
+Naively, "give the AI memory" means dumping 300K tokens of history into
+context. That's slow and expensive. The memory suite does the opposite:
+it keeps everything in git-tracked files, serves them from Redis, and
+pulls back a few thousand exactly-relevant tokens on demand.
+
+The loop:
+
+- Stash on stop — a hook extracts decisions, bugs, and references at
+  session end
+- Recall at the door — the next session surfaces what's relevant to
+  your project
+- Promote what endures — a reviewed path (the 30-day test) lands durable
+  knowledge as a git-tracked file
+- Lessons at the trap moment — the right lesson shows up exactly when a
+  prompt hits a known trap
+
+As of the latest release it ships with a plain `pip install attune-ai` —
+no infrastructure required. Without Redis it degrades to files with
+clear guidance instead of failing silently.
+
+**A nod to where this started.**
+
+None of this appeared overnight. It grew out of MemDocs — our project on
+persistent memory for AI, built on one conviction: an AI's memory should
+live in git, scoped per change, and reviewed like code. The attune-ai
+memory suite is that idea, shipped and now measured.
+
+Everything above is reproducible — the numbers come straight out of
+`benchmarks/memory_savings.py`, run against the live store. No
+hand-picked figures.
+
+What would your AI do differently if it remembered last month?
+
+#AIDevelopment #DeveloperTools #Python #OpenSource #Claude
+
+---
+
+## Alternative hooks
+
+**Version B (data lead):**
+67x fewer tokens. 0.6 ms recall. We measured what persistent AI memory
+actually saves — on our own codebase, with a benchmark you can re-run.
+
+**Version C (contrarian lead):**
+"Give your AI memory" usually means stuffing 300K tokens of history into
+context. That's the expensive way. Here's the 67x-cheaper one, measured.
+
+**Version D (story lead):**
+Sarah fixed the bug in September. In December, Mike's AI hit the same
+pattern — and this time it already knew. Here's the memory loop that made
+that happen, and what it costs (almost nothing).


### PR DESCRIPTION
New long-form LinkedIn Article draft for the memory suite, built on the hard data from `benchmarks/memory_savings.py` (merged in #1254):

- 302,949-token store / 751 docs
- 67x fewer tokens (3,000-tok lessons budget cap vs 202K-tok corpus)
- ~0.6 ms recall vs ~4.4 ms disk (~7x faster)
- P@3 96% retrieval

Includes a "nod to where this started" section acknowledging the **MemDocs** project the memory suite grew from, ASCII arrows (LinkedIn mangles Unicode `→` on paste), and 3 alternative hooks for A/B.

Draft only — content, not site-published. For publishing to LinkedIn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)