### PR TITLE
release: attune-ai 10.0.0 — MemoryGraph removal ships (breaking)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "Spec-driven development for Claude Code — take an idea through requirements, design, tasks, and gated execution with an approval loop. Plus 23 auto-triggering skills: security audits, code review, test generation, release prep.",
-    "version": "9.7.1"
+    "version": "10.0.0"
   },
   "plugins": [
     {
       "name": "attune-ai",
       "description": "Spec-driven development is the core workflow: /spec carries an idea through brainstorm, requirements, design, and task execution with quality gates and your approval at each stage. Backed by 23 auto-triggering skills — security audits, code reviews, test generation, bug prediction, and release preparation. For help content tools, also install attune-help and attune-author from this marketplace.",
       "source": "./plugin",
-      "version": "9.7.1",
+      "version": "10.0.0",
       "author": {
         "name": "Smart AI Memory",
         "email": "patrick.roebuck@smartaimemory.com"

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,4 +1,4 @@
-# Attune AI Framework v9.7.1
+# Attune AI Framework v10.0.0
 
 AI-powered developer workflows with cost optimization and multi-agent orchestration.
 
@@ -148,7 +148,7 @@ attune_redis/          # attune-redis plugin (pip install attune-redis)
 
 ---
 
-**Version:** 9.7.1 | **License:** Apache 2.0 | **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)
+**Version:** 10.0.0 | **License:** Apache 2.0 | **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)
 
 ## Lessons — core
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [10.0.0] — 2026-07-05
+
+Breaking release: the legacy memory-graph API is removed. Curated
+memory has been plain `.md` files with Redis-derived serving since
+9.6.0 (memory-unification); this release deletes the orphaned
+graph layer that nothing living called — the subsystem value-gate
+verdict, receipts in `docs/specs/memorygraph-value-gate/`. No data
+migration: the graph store was already retired. If you imported
+`MemoryGraph` (telemetry says nobody did), the curated-file
+pipeline is the successor.
+
 ### Removed
 
 - **BREAKING — memory:** the graph API is gone —
@@ -21,7 +32,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   graph with zero live consumers — see
   `docs/specs/memorygraph-value-gate/` for the evidence.
   Accessing a removed name raises a pointed error naming the
-  successor. Ships in the next major (10.0.0).
+  successor (note: Python's `from`-import form surfaces a generic
+  `ImportError`; attribute access shows the full guidance).
 
 ## [9.7.1] — 2026-07-04
 

--- a/README.md
+++ b/README.md
@@ -75,14 +75,27 @@ developer workflow hub; `attune-gui` is the docs hub.
      a permanent section below (see "Dynamic forms" for the pattern).
      Don't stack a second "New in" section here. -->
 
-## New in 9.7.0 — the memory suite, out of the box
+## New in 10.0.0 — one memory architecture, no legacy layer
 
-**Your agent stops starting from zero — and now it works with a plain
-`pip install attune-ai`.** The memory suite matured across the last
-several releases (curated promotion in 9.5, files-canonical
-unification in 9.6); 9.7.0 removes the last install friction by
-shipping the Redis / Agent Memory Server client as a core dependency.
-The loop:
+Major version, one breaking change: the legacy memory-graph API
+(`attune.memory.MemoryGraph` and its node/edge types) is removed.
+Curated memory has been plain `.md` files served from Redis since
+9.6.0 — the graph was the layer nothing living called, confirmed by
+a usage audit before deletion (receipts in
+`docs/specs/memorygraph-value-gate/`). If you never imported
+`MemoryGraph` — telemetry says that's everyone — nothing changes:
+same install, same memory loop, same measured economics below.
+Accessing a removed name raises an error naming the successor, and
+there is no data migration because the graph store was already
+retired.
+
+## The memory suite — out of the box, measured
+
+**Your agent stops starting from zero — with a plain
+`pip install attune-ai`.** The memory suite matured across recent
+releases (curated promotion in 9.5, files-canonical unification in
+9.6, Redis / Agent Memory Server client as a core dependency in
+9.7). The loop:
 
 - **Stash on stop** — a `Stop` hook extracts decisions, bugs, and
   references from the session (local LLM when available, heuristic
@@ -113,13 +126,13 @@ guidance. Your memory, your corpus: we dogfood the loop on our own
 380+ engineering lessons, retrieved via attune-rag at **P@3 96%**
 (100% on the high-severity subset) on a frozen trap-moment benchmark.
 
-**The economics, measured.** Durable memory here is 302,949 tokens
-across 751 docs; a session recalls only the relevant slice:
+**The economics, measured.** Durable memory here is 303,205 tokens
+across 752 docs; a session recalls only the relevant slice:
 
 | Memory-suite recall | Instead of loading | You load | Win |
 |---|--:|--:|--:|
 | Trap-moment lessons | 202,042 tok (583 lessons) | ≤3,000 tok | **67× fewer tokens** |
-| SessionStart digest | 16 corpus files (4.4 ms) | one Redis call (0.6 ms) | **~7× faster** |
+| SessionStart digest | 16 corpus files (4.6 ms) | one Redis call (0.6 ms) | **~7× faster** |
 
 The lessons injection stays budget-capped no matter how large the
 corpus grows, and recall is a single warm Redis call — so both wins
@@ -214,7 +227,7 @@ Most AI coding sessions start from zero. Attune ships a
 cross-session memory loop — stash on stop, recall at the door,
 reviewed promotion into a git-tracked curated corpus, and lessons
 retrieved at the exact trap moment they guard against. Covered in
-depth in the "New in 9.7.0" section at the top of this README; the
+depth in "The memory suite" section at the top of this README; the
 hook-by-hook mechanics and tunables live in the
 "Session continuity & cross-session memory" section below.
 

--- a/docs/reference/API_REFERENCE.md
+++ b/docs/reference/API_REFERENCE.md
@@ -1,6 +1,6 @@
 # Attune AI API Reference
 
-**Version:** 9.7.1
+**Version:** 10.0.0
 **License:** Apache License 2.0
 **Copyright:** 2025-2026 Smart AI Memory, LLC
 
@@ -1152,5 +1152,5 @@ msg = format_error(
 
 ---
 
-**Version:** 9.7.1 | **License:** Apache 2.0
+**Version:** 10.0.0 | **License:** Apache 2.0
 **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)

--- a/plugin/.claude-plugin/marketplace.json
+++ b/plugin/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "Spec-driven development for Claude Code — /spec plans, reviews, and executes with quality gates; plus security audits, code reviews, test generation, and release prep from /attune.",
-    "version": "9.7.1"
+    "version": "10.0.0"
   },
   "plugins": [
     {
       "name": "attune-ai",
       "description": "Spec-driven development for Claude Code — /spec plans, reviews, and executes with quality gates; plus security audits, code reviews, test generation, and release prep from /attune.",
       "source": "./",
-      "version": "9.7.1",
+      "version": "10.0.0",
       "author": {
         "name": "Smart AI Memory",
         "email": "patrick.roebuck@smartaimemory.com"

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "attune-ai",
-  "version": "9.7.1",
+  "version": "10.0.0",
   "description": "Spec-driven development for Claude Code — /spec plans, reviews, and executes with quality gates; plus security audits, code reviews, test generation, and release prep from /attune.",
   "author": {
     "name": "Smart AI Memory",

--- a/plugin/core/__init__.py
+++ b/plugin/core/__init__.py
@@ -5,4 +5,4 @@ This module provides the core workflow functionality when the full
 attune-ai package is not installed via pip.
 """
 
-__version__ = "9.7.1"
+__version__ = "10.0.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "attune-ai"
-version = "9.7.1"
+version = "10.0.0"
 description = "AI-powered developer workflows for Claude with cost optimization, multi-agent orchestration, and workflow automation."
 readme = {file = "README.md", content-type = "text/markdown"}
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -253,7 +253,7 @@ wheels = [
 
 [[package]]
 name = "attune-ai"
-version = "9.7.1"
+version = "10.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "agent-memory-client" },

--- a/website/app/page.tsx
+++ b/website/app/page.tsx
@@ -58,7 +58,7 @@ export default function Home() {
             <div className="grid lg:grid-cols-2 gap-16 items-center">
               <div className="z-10">
                 <div className="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-[var(--surface-container-high)] text-[var(--primary)] text-xs font-bold tracking-widest mb-6 uppercase">
-                  <span>v9.7.1</span>
+                  <span>v10.0.0</span>
                   <span className="w-1 h-1 rounded-full bg-[var(--primary)]"></span>
                   <span className="opacity-80">Spec-driven development platform</span>
                 </div>

--- a/website/lib/features.ts
+++ b/website/lib/features.ts
@@ -32,7 +32,7 @@ export const PRODUCTS: Product[] = [
     id: "attune-ai",
     name: "Attune AI",
     pypiName: "attune-ai",
-    version: "9.7.1",
+    version: "10.0.0",
     tagline: "Generate, maintain, and serve help from your code",
     installCommand: "pip install attune-ai",
     marketplaceInstall:
@@ -101,7 +101,7 @@ export const PRODUCTS: Product[] = [
     id: "claude-code-plugin",
     name: "Claude Code Plugin",
     pypiName: "attune-ai",
-    version: "9.7.1",
+    version: "10.0.0",
     tagline: "Progressive help right in your terminal",
     installCommand:
       "claude plugin marketplace add Smart-AI-Memory/attune-ai",


### PR DESCRIPTION
## Summary

Release prep for **10.0.0** — the major carrying the #1256 `feat!:` MemoryGraph removal (no other unreleased changes).

- `bump_version.py 10.0.0` — 9 version sites, zero residuals
- Changelog: `[Unreleased]` → `[10.0.0] — 2026-07-05` with breaking-release intro (no data migration; successor = curated files)
- **README** (PyPI long_description): rotating slot → "New in 10.0.0 — one memory architecture, no legacy layer"; the 9.7.0 memory-suite section demoted to permanent per the slot convention; measured table refreshed to the 2026-07-05 benchmark re-run (303,205 tok / 752 docs / 4.6 ms); tests badge unchanged (20,000+ floor rule, suite at 20,562)
- `uv lock`: version line only
- Help regen skipped: zero help-corpus references to the removed API

Tag will target this PR's **merge SHA** (main HEAD is a `[skip ci]` rebuild — known publish-skip trap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)