### PR TITLE
docs(blog): v10 deletion-release LinkedIn article

### DIFF
--- a/docs/blog/social/linkedin_v10_release.md
+++ b/docs/blog/social/linkedin_v10_release.md
@@ -1,0 +1,89 @@
+---
+description: "LinkedIn Article — Attune AI 10.0.0: a major version whose headline feature is a deletion. The MemoryGraph value-gate story: 7,440 lines removed on telemetry evidence of zero usage, with receipts committed to the repo."
+---
+
+# LinkedIn Article — Attune AI 10.0.0 (the deletion release)
+
+*Format: LinkedIn Article (long-form, supports headers). ~450 words.
+ASCII markers only — LinkedIn mangles Unicode arrows on paste.*
+
+---
+
+**We just shipped a major version. The headline feature is 7,000 lines we deleted.**
+
+Attune AI 10.0.0 is out today. It adds nothing. It removes an entire
+subsystem — and that's exactly why it deserved the major version number.
+
+Here's the story.
+
+**The subsystem that sounded right.**
+
+Early on, we built a memory graph for our AI developer platform: typed
+nodes (bugs, patterns, vulnerabilities), typed edges, a wrapper that
+made any agent "memory-aware." A knowledge graph for AI memory — it
+sounds like the obviously correct architecture.
+
+Then the memory suite grew up around it. By 9.6.0, curated memory had
+become plain markdown files, tracked in git, served through Redis —
+reviewed like code, recalled in under a millisecond (I posted those
+benchmark numbers earlier this week). The graph was still there. It had
+just quietly become a middle layer that nothing called.
+
+**The value gate.**
+
+We don't delete on vibes. Before removing it, we ran an evidence pass:
+
+-> Telemetry: **0 invocations** of the graph API. Ever.
+-> Live consumers in the codebase: **zero** — the curated-file pipeline
+   had replaced every path.
+-> User-facing story: none. No doc page sent anyone there.
+-> The receipts are committed to the repo, in the same spec format we
+   use to ship features.
+
+Four removal signals fired. The verdict wrote itself.
+
+**No deprecation window — on purpose.**
+
+Zero measured usage means a deprecation window protects nobody; it just
+carries dead code longer. So 10.0.0 removes the graph outright. But
+breakage is informative, not silent: touching a removed name raises a
+pointed error that names the successor and tells you where to go.
+
+The diff: 41 files, **7,440 deletions**, 395 insertions. Net -7,045
+lines — most of it tests and docs that existed only to keep dead code
+looking alive.
+
+**The lesson.**
+
+Dead code isn't neutral. It costs test time, doc maintenance, and — the
+expensive part — every future reader who has to figure out whether it
+matters. The discipline that fixed it wasn't a refactoring sprint. It
+was a standing question we now ask of every subsystem: *what's the
+evidence anyone gets value from this?*
+
+When the answer is a measured zero, you don't deprecate. You delete,
+with receipts, and you give the deletion the version number it earned.
+
+What's the biggest thing you've ever deleted from a codebase — and what
+did keeping it that long cost you?
+
+#AIDevelopment #DeveloperTools #Python #OpenSource #SoftwareEngineering
+
+---
+
+## Alternative hooks
+
+**Version B (data lead):**
+41 files. 7,440 lines deleted. 0 users affected — and we can prove the
+zero. Why our new major release removes more than it adds.
+
+**Version C (semver lead):**
+Most teams save major versions for big features. We just spent one on a
+deletion — because removing a subsystem people *could* have depended on
+is the change that deserves the loudest signal.
+
+**Version D (confession lead):**
+We built a knowledge graph for AI memory because it sounded like the
+right architecture. Telemetry says nobody ever called it. Today we
+deleted all 7,440 lines — here's the process that made that decision
+easy.


### PR DESCRIPTION
## Summary

LinkedIn article draft for the **10.0.0** release at `docs/blog/social/linkedin_v10_release.md`, following the house format of `linkedin_memory_suite.md` (frontmatter, ~450 words, ASCII markers, closing question, 3 alternative hooks).

**Angle:** lean into the deletion instead of hiding it — *"We just shipped a major version. The headline feature is 7,000 lines we deleted."*

Grounded in the repo's own receipts:
- Value-gate evidence from `docs/specs/memorygraph-value-gate/` — 0 telemetry invocations, zero live consumers, no doc story
- D1: straight removal, no deprecation window (zero usage protects nobody); pointed removal errors name the curated-file successor
- Diff stats from #1256: 41 files, 7,440 deletions, 395 insertions
- Ties back to the measured memory-suite article (#1255) as the other half of the same discipline

Docs-only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)