### PR TITLE
docs(specs): flip two shipped memory specs to complete (status truthing)

### DIFF
--- a/docs/specs/memory-unification/requirements.md
+++ b/docs/specs/memory-unification/requirements.md
@@ -1,9 +1,12 @@
 # Memory Unification — Requirements
 
-**Status:** approved (2026-07-04) — Patrick locked D1 (files +
-Redis, NO graph middle layer), OQ1 (dedicated curated dir —
-RE-LOCKED same day after reversing the first call, see
-decisions.md), OQ2 (retire curated_graph.json). Phase 4 un-gated.
+**Status:** complete (2026-07-04) — shipped in 9.6.0 (PR #1239);
+T1–T5 executed same day, receipts in migration-receipt.md; T6
+(deferred value-gate) executed as the memorygraph-value-gate spec,
+shipped in 10.0.0. Locks: D1 (files + Redis, NO graph middle
+layer), OQ1 (dedicated curated dir — RE-LOCKED same day after
+reversing the first call, see decisions.md), OQ2 (retire
+curated_graph.json).
 **Owner:** patrick + agent
 
 ---

--- a/docs/specs/memorygraph-value-gate/requirements.md
+++ b/docs/specs/memorygraph-value-gate/requirements.md
@@ -1,6 +1,8 @@
 # MemoryGraph Value-Gate — Requirements
 
-**Status:** approved (2026-07-05) · **Owner:** Patrick + agent
+**Status:** complete (2026-07-05) — shipped in 10.0.0: removal
+landed via PR #1256 (T1–T6 all checked, receipts inline), released
+in #1257. · **Owner:** Patrick + agent
 **Born:** memory-unification T6 (the deferred value-gate exercise).
 
 ## Problem


### PR DESCRIPTION
## Summary
Housekeeping 2026-07-05: `memory-unification` and `memorygraph-value-gate` both shipped — 9.6.0 (#1239) and 10.0.0 (#1256, released #1257) respectively — with every task checked, but their `requirements.md` **Status:** headers still said `approved`. The session-start spec triage was surfacing both as in-flight.

Two header-only edits, receipts cited inline. Specs stay in place (not archived) because the 10.0.0 CHANGELOG entry links `docs/specs/memorygraph-value-gate/` directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)