### PR TITLE
feat(redis): redis_memory_forget — delete AMS long-term records by ID (#1264)

### DIFF
--- a/attune_redis/mcp_tools.py
+++ b/attune_redis/mcp_tools.py
@@ -1,11 +1,12 @@
 """Redis MCP tool definitions and handlers.
 
-Provides 5 MCP tools for Redis Agent Memory Server
+Provides 6 MCP tools for Redis Agent Memory Server
 operations:
 
 - ``redis_memory_store`` — store to AMS working memory
 - ``redis_memory_retrieve`` — get from AMS working memory
 - ``redis_memory_search`` — semantic search via long-term
+- ``redis_memory_forget`` — delete long-term records by ID
 - ``redis_memory_promote`` — promote working to long-term
 - ``redis_health_check`` — AMS + Redis health status
 
@@ -87,6 +88,27 @@ TOOL_DEFINITIONS: dict[str, dict[str, Any]] = {
                 },
             },
             "required": ["query"],
+        },
+    },
+    "redis_memory_forget": {
+        "name": "redis_memory_forget",
+        "description": (
+            "Delete specific long-term memories from Redis Agent Memory Server "
+            "by record ID. IDs come from redis_memory_search results — the "
+            "correction path when a stashed finding is wrong or stale."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "ids": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": (
+                        "Record IDs to delete (the `id` field from redis_memory_search results)"
+                    ),
+                },
+            },
+            "required": ["ids"],
         },
     },
     "redis_memory_promote": {
@@ -275,6 +297,40 @@ async def handle_redis_memory_promote(server: Any, args: dict[str, Any]) -> dict
         return {"success": False, "error": str(e)}
 
 
+async def handle_redis_memory_forget(server: Any, args: dict[str, Any]) -> dict[str, Any]:
+    """Delete long-term AMS memories by record ID.
+
+    Args:
+        server: MCP server instance.
+        args: Tool arguments (ids: list of record IDs).
+
+    Returns:
+        Result dict with deleted count.
+    """
+    try:
+        backend = _get_backend(server)
+        ids = args["ids"]
+        if not isinstance(ids, list) or not all(isinstance(i, str) for i in ids):
+            return {"success": False, "error": "ids must be a list of record-ID strings"}
+
+        deleted = backend.forget(ids)
+        return {
+            "success": deleted > 0 or not ids,
+            "requested": len(ids),
+            "deleted": deleted,
+            "source": "redis-ams",
+        }
+    except ImportError:
+        return {
+            "success": False,
+            "error": "Redis support not installed. Run: pip install 'attune-ai[redis]'",
+        }
+    except Exception as e:  # noqa: BLE001
+        # INTENTIONAL: Graceful degradation for MCP tool errors
+        logger.exception("redis_memory_forget failed")
+        return {"success": False, "error": str(e)}
+
+
 async def handle_redis_health_check(server: Any, args: dict[str, Any]) -> dict[str, Any]:
     """Check AMS health and connection status.
 
@@ -311,6 +367,7 @@ TOOL_HANDLERS: dict[str, Any] = {
     "redis_memory_store": handle_redis_memory_store,
     "redis_memory_retrieve": handle_redis_memory_retrieve,
     "redis_memory_search": handle_redis_memory_search,
+    "redis_memory_forget": handle_redis_memory_forget,
     "redis_memory_promote": handle_redis_memory_promote,
     "redis_health_check": handle_redis_health_check,
 }

--- a/attune_redis/memory.py
+++ b/attune_redis/memory.py
@@ -18,6 +18,7 @@ import asyncio
 import fnmatch
 import hashlib
 import logging
+import re
 import threading
 from typing import Any
 
@@ -647,6 +648,33 @@ class AMSMemoryBackend:
         except Exception as e:  # noqa: BLE001
             # INTENTIONAL: Graceful degradation for AMS HTTP errors
             logger.error("prune_failed: max_age_days=%s error=%s", age, e)
+            return 0
+
+    def forget(self, ids: list[str]) -> int:
+        """Delete specific long-term memories by record ID.
+
+        The IDs are the ``id`` values returned by :meth:`search` /
+        :meth:`recent`. Complements :meth:`prune` (age-based sweep)
+        with precise removal — the correction path when a stashed
+        finding turns out to be wrong or stale. Best-effort; returns
+        the number of memories deleted (0 on failure or empty input),
+        never raises.
+        """
+        if not ids:
+            return 0
+        try:
+            response = _run_sync(self._client.delete_long_term_memories(ids))
+            # AMS acks with a status string like "ok, deleted 3 memories"
+            # (no numeric field) — parse the count out, falling back to
+            # len(ids) on a bare "ok".
+            status = str(getattr(response, "status", "") or "")
+            match = re.search(r"deleted (\d+)", status)
+            if match:
+                return int(match.group(1))
+            return len(ids) if status.startswith("ok") else 0
+        except Exception as e:  # noqa: BLE001
+            # INTENTIONAL: Graceful degradation for AMS HTTP errors
+            logger.error("forget_failed: ids=%d error=%s", len(ids), e)
             return 0
 
     # =========================================================================

--- a/attune_redis/tests/test_mcp_tools.py
+++ b/attune_redis/tests/test_mcp_tools.py
@@ -23,11 +23,11 @@ from attune_redis.mcp_tools import (
 
 
 class TestToolDefinitions:
-    """Verify all 5 tools have valid JSON schemas."""
+    """Verify all 6 tools have valid JSON schemas."""
 
-    def test_five_tools_defined(self):
-        """Exactly 5 tools must be defined."""
-        assert len(TOOL_DEFINITIONS) == 5
+    def test_six_tools_defined(self):
+        """Exactly 6 tools must be defined."""
+        assert len(TOOL_DEFINITIONS) == 6
 
     @pytest.mark.parametrize(
         "tool_name",
@@ -35,6 +35,7 @@ class TestToolDefinitions:
             "redis_memory_store",
             "redis_memory_retrieve",
             "redis_memory_search",
+            "redis_memory_forget",
             "redis_memory_promote",
             "redis_health_check",
         ],
@@ -53,6 +54,7 @@ class TestToolDefinitions:
             "redis_memory_store",
             "redis_memory_retrieve",
             "redis_memory_search",
+            "redis_memory_forget",
             "redis_memory_promote",
             "redis_health_check",
         ],
@@ -80,13 +82,19 @@ class TestToolDefinitions:
         schema = TOOL_DEFINITIONS["redis_memory_search"]["input_schema"]
         assert "query" in schema["required"]
 
+    def test_forget_requires_ids(self):
+        """redis_memory_forget must require ids (array of strings)."""
+        schema = TOOL_DEFINITIONS["redis_memory_forget"]["input_schema"]
+        assert schema["required"] == ["ids"]
+        assert schema["properties"]["ids"]["type"] == "array"
+
 
 class TestToolHandlers:
     """Verify handler dispatch table matches definitions."""
 
-    def test_five_handlers(self):
-        """Exactly 5 handlers must be registered."""
-        assert len(TOOL_HANDLERS) == 5
+    def test_six_handlers(self):
+        """Exactly 6 handlers must be registered."""
+        assert len(TOOL_HANDLERS) == 6
 
     def test_handlers_match_definitions(self):
         """Every defined tool must have a handler."""
@@ -241,7 +249,7 @@ class TestRegisterTools:
 
         register_tools(server)
 
-        assert len(server.tools) == 5
+        assert len(server.tools) == 6
         assert "redis_memory_store" in server.tools
         assert "redis_health_check" in server.tools
 
@@ -253,7 +261,7 @@ class TestRegisterTools:
 
         register_tools(server)
 
-        assert len(server._plugin_handlers) == 5
+        assert len(server._plugin_handlers) == 6
         assert "redis_memory_store" in server._plugin_handlers
 
     def test_creates_plugin_handlers_if_missing(self):

--- a/docs/plans/mcp-server-refactor.md
+++ b/docs/plans/mcp-server-refactor.md
@@ -26,7 +26,7 @@ Before refactoring, key discoveries from exploration:
   This is why some handlers use `getattr()`.
 - Tool count assertion in
   `tests/unit/test_mcp_memory_tools.py:32` is `== 33`
-  (28 core + 5 redis). Must update if tools change.
+  (28 core + 6 redis). Must update if tools change.
 
 ---
 

--- a/src/attune/mcp/memory_handlers.py
+++ b/src/attune/mcp/memory_handlers.py
@@ -276,7 +276,14 @@ class MemoryHandlersMixin:
             }
         except Exception as e:  # noqa: BLE001
             logger.exception("memory_forget failed")
-            return {"success": False, "error": str(e)}
+            return {
+                "success": False,
+                "error": (
+                    f"{e} — memory_forget targets the session/pattern store. "
+                    "For AMS long-term records (IDs from redis_memory_search), "
+                    "use redis_memory_forget."
+                ),
+            }
 
     # ------------------------------------------------------------------
     # Personal cross-session memory

--- a/src/attune/memory/mixins/backend_init_mixin.py
+++ b/src/attune/memory/mixins/backend_init_mixin.py
@@ -161,11 +161,15 @@ class BackendInitMixin:
                 if self.config.redis_required and not (
                     self._redis_status and self._redis_status.available
                 ):
+                    attempted = self.config.redis_url or "default localhost"
                     raise RuntimeError(
-                        "Redis is required but not available. "
+                        "Redis is required but not available "
+                        f"(attempted: {attempted}). "
                         f"Config requires Redis (redis_required=True, environment={self.config.environment.value}). "
                         "Either: (1) Start Redis server, (2) Set REDIS_URL environment variable, "
-                        "or (3) Set redis_required=False in MemoryConfig.",
+                        "or (3) Set redis_required=False in MemoryConfig. "
+                        "Note: this is the unified-memory store, not the AMS server — "
+                        "redis_memory_* tools may still work if AMS is reachable.",
                     )
 
             except RuntimeError:

--- a/tests/unit/memory/test_ams_forget.py
+++ b/tests/unit/memory/test_ams_forget.py
@@ -1,0 +1,121 @@
+"""Unit tests for ``AMSMemoryBackend.forget`` and the
+``redis_memory_forget`` MCP tool (issue #1264).
+
+``forget(ids)`` is the precise-removal counterpart to ``prune()`` —
+deleting specific long-term records by the ``id`` values that
+``search()``/``recent()`` return. Same test strategy as
+``test_ams_prune.py``: fake client, ``_run_sync`` as identity
+passthrough, no live AMS server required.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import MagicMock
+
+import pytest
+
+import attune_redis.memory as ams
+from attune_redis.mcp_tools import (
+    TOOL_DEFINITIONS,
+    TOOL_HANDLERS,
+    handle_redis_memory_forget,
+)
+from attune_redis.memory import AMSMemoryBackend
+
+
+class _FakeAck:
+    """AMS acks deletes with a status string, not a numeric field."""
+
+    def __init__(self, status: str) -> None:
+        self.status = status
+
+
+@pytest.fixture
+def backend(monkeypatch):
+    """An ``AMSMemoryBackend`` with a fake client, bypassing the real
+    ``__init__`` (which would construct a live HTTP client)."""
+    be = object.__new__(AMSMemoryBackend)
+    be._client = MagicMock()
+    be._namespace = "itest-ns"
+    monkeypatch.setattr(ams, "_run_sync", lambda coro: coro)
+    return be
+
+
+# ---------------------------------------------------------------------------
+# Backend
+# ---------------------------------------------------------------------------
+
+
+def test_forget_parses_deleted_count_from_status(backend):
+    backend._client.delete_long_term_memories.return_value = _FakeAck("ok, deleted 3 memories")
+    assert backend.forget(["a", "b", "c"]) == 3
+    backend._client.delete_long_term_memories.assert_called_once_with(["a", "b", "c"])
+
+
+def test_forget_bare_ok_falls_back_to_len_ids(backend):
+    backend._client.delete_long_term_memories.return_value = _FakeAck("ok")
+    assert backend.forget(["a", "b"]) == 2
+
+
+def test_forget_empty_ids_short_circuits(backend):
+    assert backend.forget([]) == 0
+    backend._client.delete_long_term_memories.assert_not_called()
+
+
+def test_forget_non_ok_status_returns_zero(backend):
+    backend._client.delete_long_term_memories.return_value = _FakeAck("error: nope")
+    assert backend.forget(["a"]) == 0
+
+
+def test_forget_swallows_client_error(backend):
+    backend._client.delete_long_term_memories.side_effect = RuntimeError("AMS 503")
+    assert backend.forget(["a"]) == 0
+
+
+# ---------------------------------------------------------------------------
+# MCP tool surface
+# ---------------------------------------------------------------------------
+
+
+def test_tool_registered_in_definitions_and_handlers():
+    assert "redis_memory_forget" in TOOL_DEFINITIONS
+    assert TOOL_DEFINITIONS["redis_memory_forget"]["input_schema"]["required"] == ["ids"]
+    assert TOOL_HANDLERS["redis_memory_forget"] is handle_redis_memory_forget
+
+
+def test_handler_deletes_by_ids(backend):
+    server = MagicMock()
+    server._redis_backend = backend
+    backend._client.delete_long_term_memories.return_value = _FakeAck("ok, deleted 2 memories")
+
+    result = asyncio.run(handle_redis_memory_forget(server, {"ids": ["x", "y"]}))
+
+    assert result == {
+        "success": True,
+        "requested": 2,
+        "deleted": 2,
+        "source": "redis-ams",
+    }
+
+
+def test_handler_rejects_non_list_ids(backend):
+    server = MagicMock()
+    server._redis_backend = backend
+
+    result = asyncio.run(handle_redis_memory_forget(server, {"ids": "not-a-list"}))
+
+    assert result["success"] is False
+    assert "list of record-ID strings" in result["error"]
+    backend._client.delete_long_term_memories.assert_not_called()
+
+
+def test_handler_reports_failure_when_nothing_deleted(backend):
+    server = MagicMock()
+    server._redis_backend = backend
+    backend._client.delete_long_term_memories.side_effect = RuntimeError("AMS down")
+
+    result = asyncio.run(handle_redis_memory_forget(server, {"ids": ["x"]}))
+
+    assert result["success"] is False
+    assert result["deleted"] == 0

--- a/tests/unit/test_mcp_memory_tools.py
+++ b/tests/unit/test_mcp_memory_tools.py
@@ -27,23 +27,24 @@ class TestToolRegistration:
     """Verify all tools are registered (46 core + 5 optional redis plugin)."""
 
     def test_tools_list_returns_at_least_core_count(self, server: EmpathyMCPServer):
-        """Core tools (47) are always registered; attune-redis adds 5 more."""
+        """Core tools (47) are always registered; attune-redis adds 6 more."""
         tools = server.get_tool_list()
         tool_names = {t["name"] for t in tools}
 
         # 47 core tools must always be present (incl. elicitation_render_widget)
         assert len(tools) >= 47
 
-        # When attune-redis plugin is installed, all 5 redis tools are present
+        # When attune-redis plugin is installed, all 6 redis tools are present
         redis_tools = {
             "redis_health_check",
+            "redis_memory_forget",
             "redis_memory_promote",
             "redis_memory_retrieve",
             "redis_memory_search",
             "redis_memory_store",
         }
         if redis_tools.issubset(tool_names):
-            assert len(tools) == 52, f"Expected 52 tools with redis plugin, got {len(tools)}"
+            assert len(tools) == 53, f"Expected 53 tools with redis plugin, got {len(tools)}"
 
     def test_memory_tools_registered(self, server: EmpathyMCPServer):
         """Test that all memory tools are in the tool list."""


### PR DESCRIPTION
## Summary
Closes #1264. If `redis_memory_search` can surface a record, the same surface must be able to correct it — today's garbled-stash cleanup had to bypass the product and call `agent_memory_client` by hand.

- **`AMSMemoryBackend.forget(ids)`** — precise removal by record ID, complementing the age-based `prune()`. Parses AMS's `"ok, deleted N memories"` ack.
- **`redis_memory_forget` MCP tool** — `ids`-only (deletion by semantic query is a foot-gun; discussed and rejected).
- **False-alarm fix** — `memory_forget`'s error now names the store split and points to `redis_memory_forget`; the unified-memory redis-required error now includes the attempted URL and notes AMS tools may still work.
- Tool count pin 52 → 53; stale plan-doc count updated.

## Testing
- 9 new unit tests (backend + handler, fake-client pattern mirroring `test_ams_prune.py`); 239 pass across the affected suites.
- **Live dogfood** against local AMS: store → search (ID returned) → `forget([id])` → 1 deleted → search confirms gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)