### PR TITLE
feat(jit-recall): command-shape regex triggers for generated-Bash traps (#1265)

### DIFF
--- a/plugin/hooks/_recall_map.py
+++ b/plugin/hooks/_recall_map.py
@@ -18,6 +18,12 @@ Authoring rules:
   serialized ``tool_input`` contains the substring — REQUIRED for
   broad tools like ``Bash`` so the rule fires only at the actual
   decision point, not on the session's first bash call.
+- Optional ``match_regex`` scopes a rule by ``re.search`` over the
+  RAW string fields of ``tool_input`` (not the JSON dump — so shell
+  backslashes match as written). Use for command SHAPES a substring
+  can't pin down (issue #1265: prompt-keyed recall misses traps in
+  generated commands). Either filter satisfies the broad-tool
+  scoping requirement; a rule may use both (AND).
 - Optional ``lesson_ref`` names a lessons-corpus slug (an
   ``attune.lessons`` entry path like ``tag-mechanics-….md``); the
   hook resolves it through ``LessonsIndex`` at fire time and appends
@@ -102,6 +108,52 @@ RECALL_MAP: dict[str, list[dict[str, str]]] = {
                 "UNSIGNED — re-sign with `git commit --amend -S "
                 "--no-edit` (or re-sign the replayed range) before "
                 "pushing, or the pushed commits lose their GPG signature."
+            ),
+        },
+        # zsh command shapes (#1265, added 2026-07-06): the corpus held
+        # these lessons and prompt-keyed recall still missed both traps
+        # in generated commands during the 2026-07-05 housekeeping run.
+        {
+            "rule_id": "zsh-bracket-string-compare",
+            "match_regex": r"\[[^]\n]*\\<",
+            "text": (
+                "zsh (this Bash tool's shell): `[ a \\< b ]` dies with "
+                '\'condition expected: <\' — use `[[ "$a" < "$b" ]]` '
+                "for string comparison, never escaped `\\<` in `[ ]`."
+            ),
+        },
+        {
+            "rule_id": "zsh-eqword-expansion",
+            "match_regex": r"(?:^|[\s;|&])=[A-Za-z=][A-Za-z0-9=_-]+",
+            "text": (
+                "zsh expands an unquoted word starting with `=` as a "
+                "PATH lookup (`=word` -> 'word not found') — quote it "
+                "('===' separators, `=value` args)."
+            ),
+        },
+        {
+            "rule_id": "zsh-status-readonly",
+            "match_substring": "status=",
+            "text": (
+                "zsh: `status` (also `path`, `pipestatus`, `prompt`) is "
+                "a READ-ONLY special variable — `status=$(...)` kills "
+                "the whole script with 'read-only variable'. Name it "
+                "`st`/`result` instead."
+            ),
+        },
+    ],
+    # Format-on-save strips a just-added import whose usage lands in a
+    # LATER edit (#1265; corpus lesson #864, re-hit 2026-07-05 on
+    # attune_redis/memory.py `import re`).
+    "Edit": [
+        {
+            "rule_id": "formatter-strips-lone-import",
+            "match_substring": "import ",
+            "text": (
+                "Adding an import whose USAGE lands in a separate later "
+                "edit lets the format-on-save hook strip it as unused "
+                "in between — put the import and its first usage in the "
+                "SAME edit, or re-verify imports after the usage edit."
             ),
         },
     ],

--- a/plugin/hooks/hooks.json
+++ b/plugin/hooks/hooks.json
@@ -60,7 +60,7 @@
     ],
     "PreToolUse": [
       {
-        "matcher": "AskUserQuestion|Bash",
+        "matcher": "AskUserQuestion|Bash|Edit",
         "hooks": [
           {
             "type": "command",

--- a/plugin/hooks/jit_recall.py
+++ b/plugin/hooks/jit_recall.py
@@ -139,15 +139,26 @@ def main() -> int:
             return 0
 
         session_id = payload.get("session_id")
-        tool_input_text = json.dumps(payload.get("tool_input") or {})
+        tool_input = payload.get("tool_input") or {}
+        tool_input_text = json.dumps(tool_input)
+        # Raw (un-JSON-escaped) string fields, for regex shapes that
+        # contain backslashes — `\<` becomes `\\<` in the JSON dump.
+        raw_input_text = " ".join(v for v in tool_input.values() if isinstance(v, str))
         fresh = []
         for rule in rules:
-            # Optional content filter (e.g. a Bash rule scoped to one
-            # command shape) — without it a Bash-keyed rule would fire
+            # Optional content filters (e.g. a Bash rule scoped to one
+            # command shape) — without one a Bash-keyed rule would fire
             # on the first bash call of every session (R3: low noise).
             needle = rule.get("match_substring")
             if needle and needle not in tool_input_text:
                 continue
+            pattern = rule.get("match_regex")
+            if pattern:
+                try:
+                    if not re.search(pattern, raw_input_text):
+                        continue
+                except re.error:
+                    continue  # bad pattern never blocks the call (R4)
             sentinel = _sentinel_path(session_id, rule["rule_id"])
             if sentinel is not None and sentinel.exists():
                 continue

--- a/tests/unit/hooks/test_jit_recall.py
+++ b/tests/unit/hooks/test_jit_recall.py
@@ -84,15 +84,102 @@ def test_map_entries_have_stable_safe_rule_ids(jit_mod):
             assert rule["text"].strip(), f"{tool}: empty rule text"
 
 
-def test_broad_tool_entries_require_match_substring(jit_mod):
-    """A rule keyed on a broad tool MUST scope itself via match_substring,
-    or it fires on the session's first such call (R3: low noise)."""
+def test_broad_tool_entries_require_content_filter(jit_mod):
+    """A rule keyed on a broad tool MUST scope itself via match_substring
+    or match_regex, or it fires on the session's first such call (R3)."""
     for tool in ("Bash", "Edit", "Write", "Read"):
         for rule in jit_mod.RECALL_MAP.get(tool, []):
-            assert rule.get("match_substring"), (
-                f"{tool}/{rule['rule_id']}: broad-tool rule without "
-                "match_substring would fire on every session's first call"
+            assert rule.get("match_substring") or rule.get("match_regex"), (
+                f"{tool}/{rule['rule_id']}: broad-tool rule without a "
+                "content filter would fire on every session's first call"
             )
+
+
+def test_map_regexes_compile(jit_mod):
+    """Every match_regex in the map must be a valid pattern."""
+    import re as _re
+
+    for _tool, rules in jit_mod.RECALL_MAP.items():
+        for rule in rules:
+            pattern = rule.get("match_regex")
+            if pattern:
+                _re.compile(pattern)  # raises on a bad pattern
+
+
+# ==========================================================================
+# Command-shape regex scoping (#1265)
+# ==========================================================================
+
+
+def _bash_payload(command: str, session: str = "sess-rx") -> dict:
+    return {
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Bash",
+        "session_id": session,
+        "tool_input": {"command": command},
+    }
+
+
+def test_zsh_bracket_compare_fires_on_escaped_lt(jit_mod, monkeypatch, capsys):
+    rc, out = _run(jit_mod, monkeypatch, capsys, _bash_payload('[ "$a" \\< "$b" ] && echo lt'))
+    assert rc == 0
+    assert "zsh-bracket-string-compare" not in out  # rule_id never leaks
+    assert "condition expected" in out
+
+
+def test_zsh_bracket_compare_silent_on_plain_test(jit_mod, monkeypatch, capsys):
+    rc, out = _run(jit_mod, monkeypatch, capsys, _bash_payload('[ "$a" = "$b" ] && echo eq'))
+    assert rc == 0
+    assert "condition expected" not in out
+
+
+def test_zsh_eqword_fires_on_separator(jit_mod, monkeypatch, capsys):
+    rc, out = _run(jit_mod, monkeypatch, capsys, _bash_payload("echo ===LEAD==="))
+    assert rc == 0
+    assert "PATH lookup" in out
+
+
+def test_zsh_eqword_silent_on_flag_assignment(jit_mod, monkeypatch, capsys):
+    # --flag=value and a==b comparisons must NOT trip the =word rule.
+    rc, out = _run(
+        jit_mod, monkeypatch, capsys, _bash_payload('grep --color=auto x; [ "$a" == "$b" ]')
+    )
+    assert rc == 0
+    assert "PATH lookup" not in out
+
+
+def test_zsh_status_readonly_fires_on_assignment(jit_mod, monkeypatch, capsys):
+    rc, out = _run(jit_mod, monkeypatch, capsys, _bash_payload("status=$(gh pr checks 1)"))
+    assert rc == 0
+    assert "READ-ONLY" in out
+
+
+def test_edit_import_rule_fires_once(jit_mod, monkeypatch, capsys):
+    payload = {
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Edit",
+        "session_id": "sess-ed",
+        "tool_input": {"file_path": "x.py", "new_string": "import re\n"},
+    }
+    rc, out = _run(jit_mod, monkeypatch, capsys, payload)
+    assert rc == 0
+    assert "SAME edit" in out
+    rc2, out2 = _run(jit_mod, monkeypatch, capsys, payload)
+    assert rc2 == 0
+    assert out2 == ""  # surface-once sentinel
+
+
+def test_bad_regex_never_blocks(jit_mod, monkeypatch, capsys):
+    """A malformed pattern degrades to silent no-op for that rule (R4)."""
+    jit_mod.RECALL_MAP["Bash"].append(
+        {"rule_id": "bad-regex", "match_regex": "([unclosed", "text": "never shown"}
+    )
+    try:
+        rc, out = _run(jit_mod, monkeypatch, capsys, _bash_payload("echo hello"))
+        assert rc == 0
+        assert "never shown" not in out
+    finally:
+        jit_mod.RECALL_MAP["Bash"].pop()
 
 
 # ==========================================================================


### PR DESCRIPTION
## Summary
Closes #1265. Lessons existed for both zsh traps hit during the 2026-07-05 session — recall never fired because the traps were in *generated commands*, not prompts. This extends jit-recall's trigger side from prompt-keyed to command-shape-keyed:

- **`match_regex`** on recall-map rules, matched against the raw string fields of `tool_input` (backslashes as written, not JSON-escaped). Composes with `match_substring`; malformed patterns never block a call.
- **4 new rules**, all observed slip-points per the map's R3 bar: `[ a \< b ]` string-compare, `=word` PATH expansion, `status=$(...)` read-only assignment (Bash), and the formatter-strips-lone-import trap (Edit — re-hit live on #1267 an hour before this PR).
- `hooks.json` matcher extended to `Edit` — the existing drift-guard test caught the omission.

## Testing
538 hook tests pass (9 new). Live-fired the hook script with the three verbatim trap commands from the originating session: each fires its rule; `git log --oneline -1` stays silent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)