### PR TITLE
fix(memory): stash extractor provenance — stop promoting content-read-as-data (#1263)

### DIFF
--- a/docs/specs/stash-extractor-provenance/decisions.md
+++ b/docs/specs/stash-extractor-provenance/decisions.md
@@ -1,0 +1,35 @@
+# Stash Extractor Provenance — Decisions
+
+## D1 — Filter at tail construction (2026-07-06)
+
+**Decision:** `_text_of` skips `tool_result`/`tool_use` blocks,
+emitting `[tool output omitted]`; consecutive markers collapse.
+Deterministic, model-free, and fixes the heuristic fallback for free.
+
+**Rejected:** filtering only in the Ollama path (leaves the
+heuristic poisoned); post-extraction filtering (the model has
+already seen mislabeled text — garbage in, plausible garbage out).
+
+## D2 — Prompt provenance rules (2026-07-06)
+
+**Decision:** the extraction prompt additionally instructs: extract
+only assistant conclusions / user decisions; never restate file or
+tool contents. Belt-and-suspenders on top of D1 — now truthful
+because the tail really is role-faithful.
+
+## D3 — No schema change (2026-07-06)
+
+**Decision:** drop ambient content at extraction; no `provenance`
+field on stash records. Smallest blast radius (stash schema, recall
+digest, and hydration untouched). Revisit as its own evidence pass
+if post-fix stashes still carry ambient findings.
+
+**Decided by:** Patrick, via AskUserQuestion ("Go as proposed" over
+the provenance-field variant), 2026-07-06.
+
+## D4 — Eval is a deterministic unit replay (2026-07-06)
+
+**Decision:** no live-Ollama eval. Synthetic transcript JSONL
+reproducing the failure shape; assertions on the tail builder, the
+heuristic, and the prompt text. The real-model behavior is bounded
+by what it can no longer see.

--- a/docs/specs/stash-extractor-provenance/requirements.md
+++ b/docs/specs/stash-extractor-provenance/requirements.md
@@ -1,0 +1,48 @@
+# Stash Extractor Provenance — Requirements
+
+**Status:** complete (2026-07-06) — shipped with the fix PR (single
+PR, spec + change, the memorygraph-value-gate precedent).
+**Born:** issue #1263 (2026-07-05 housekeeping session dogfood).
+
+## Problem
+
+The Stop-hook stash extractor (`plugin/hooks/session_stash.py`)
+promotes *content the session merely read* into "session findings."
+Evidence (2026-07-05): a session that spent most of its time reading
+and editing memory files as data produced a stash where 3 of 5
+findings were garbled paraphrases of the files under edit — one
+inverted a memory file's meaning ("fatigue or ego does not
+necessarily imply a low-quality work session"), one conflated two
+unrelated memory files. The bad records had to be deleted by ID via
+`agent_memory_client` (that gap is #1264 → `redis_memory_forget`).
+
+## Root cause
+
+`_read_transcript_tail` → `_text_of` recursively collects **all**
+content blocks, including `tool_result` blocks — which are user-role
+messages in the transcript JSONL. Every file the assistant Read
+entered the extractor's input as `user: <file contents>`: the leaked
+prose was not merely ambient, it was **mislabeled as user speech**.
+Neither the Ollama prompt nor the heuristic fallback had any signal
+to distinguish asserted-by-the-session from present-in-context.
+
+## Requirements
+
+- **R1 — role-faithful tail.** The extractor's transcript tail MUST
+  exclude `tool_result` / `tool_use` block content, leaving a short
+  omission marker so narrative flow survives. Assistant prose and
+  genuine user text remain.
+- **R2 — provenance-aware prompt.** The extraction prompt MUST
+  instruct the model to extract only what the assistant concluded or
+  the user decided, never restating file/tool contents.
+- **R3 — heuristic parity.** The marker-line heuristic fallback
+  benefits from R1 automatically (it reads the same tail); no
+  separate filter.
+- **R4 — no schema change.** Ambient content is dropped at
+  extraction, not tagged; stash records keep their shape. A
+  provenance ranking field is future work if evidence demands it.
+- **R5 — deterministic failure replay.** Tests reproduce the
+  2026-07-05 poisoning shape (tool_result carrying memory-file prose
+  alongside real assistant conclusions) and assert: tool-result text
+  absent from the tail, heuristic surfaces nothing from it, real
+  assistant/user content survives.

--- a/plugin/hooks/session_stash.py
+++ b/plugin/hooks/session_stash.py
@@ -155,11 +155,36 @@ def _read_transcript_tail(transcript_path: str | None, max_chars: int = _TAIL_CH
     except OSError:
         return ""
     joined = "\n".join(chunks)
+    # Collapse runs of marker-only lines (each behind its `role: ` prefix)
+    # left by tool-heavy stretches, so they don't eat the char budget
+    # (R1, stash-extractor-provenance).
+    marker = re.escape(_OMITTED_MARKER)
+    joined = re.sub(
+        rf"(?:^\S*: {marker}\s*$\n?){{2,}}",
+        f"{_OMITTED_MARKER}\n",
+        joined,
+        flags=re.MULTILINE,
+    )
     return joined[-max_chars:]
 
 
+#: Replaces tool_result/tool_use block content in the extractor's tail.
+#: Tool results are user-ROLE messages in the transcript JSONL, so
+#: without this filter every file the assistant read entered the tail as
+#: `user: <file contents>` — mislabeled as user speech, and the source
+#: of the 2026-07-05 garbled-stash incident (#1263). See
+#: docs/specs/stash-extractor-provenance/.
+_OMITTED_MARKER = "[tool output omitted]"
+_AMBIENT_BLOCK_TYPES = {"tool_result", "tool_use"}
+
+
 def _text_of(content: object) -> str:
-    """Collect the string text from a transcript message body (recursive)."""
+    """Collect the ROLE-FAITHFUL string text from a transcript message body.
+
+    Recursive over the block structure; ``tool_result``/``tool_use``
+    blocks contribute only an omission marker (R1) — their content is
+    context the session saw, not something a participant said.
+    """
     if content is None:
         return ""
     if isinstance(content, str):
@@ -167,6 +192,8 @@ def _text_of(content: object) -> str:
     if isinstance(content, list):
         return " ".join(_text_of(p) for p in content).strip()
     if isinstance(content, dict):
+        if content.get("type") in _AMBIENT_BLOCK_TYPES:
+            return _OMITTED_MARKER
         parts: list[str] = []
         t = content.get("text")
         if isinstance(t, str):
@@ -194,7 +221,11 @@ def _extract_via_ollama(text: str) -> list[dict] | None:
         "- At most 5 findings; fewer is better. Skip chit-chat and routine steps.\n"
         "- Each finding is a single reusable insight worth recalling next session.\n"
         "- type is one of: decision, pattern, bug, reference, note.\n"
-        "- content is one concise sentence, <= 280 chars, no secrets/paths-as-secrets.\n\n"
+        "- content is one concise sentence, <= 280 chars, no secrets/paths-as-secrets.\n"
+        "- PROVENANCE: extract only what the ASSISTANT concluded or the USER\n"
+        "  decided IN THIS SESSION. Never restate file contents, docs, or\n"
+        "  tool output the session merely read — reading a claim is not\n"
+        "  finding it. When unsure whether the session asserted it, skip it.\n\n"
         f"TRANSCRIPT TAIL:\n{text}\n"
     )
     payload = json.dumps(

--- a/tests/unit/hooks/test_session_memory_hooks.py
+++ b/tests/unit/hooks/test_session_memory_hooks.py
@@ -511,3 +511,117 @@ def test_recall_main_disabled_via_env(recall_mod, monkeypatch, capsys):
     _stdin(monkeypatch, {"source": "startup"})
     assert recall_mod.main() == 0
     assert capsys.readouterr().out == ""
+
+
+# ==========================================================================
+# Provenance filtering (#1263, docs/specs/stash-extractor-provenance/)
+# ==========================================================================
+
+
+def _jsonl_line(role: str, content) -> str:
+    return json.dumps({"message": {"role": role, "content": content}})
+
+
+@pytest.fixture
+def poisoned_transcript(tmp_path):
+    """The 2026-07-05 failure shape: a Read tool_result carrying
+    memory-file prose (as a user-ROLE message), between genuine turns."""
+    ambient_prose = (
+        "Patrick has self-identified that pushing through exhaustion "
+        "creates downstream debug cost. Lesson learned: compact reply "
+        "vocab should be used consistently."
+    )
+    lines = [
+        _jsonl_line("user", "please run the memory corpus lint"),
+        _jsonl_line(
+            "assistant",
+            [
+                {"type": "text", "text": "Reading the memory files now."},
+                {"type": "tool_use", "id": "t1", "name": "Read", "input": {"file_path": "x.md"}},
+            ],
+        ),
+        _jsonl_line(
+            "user",
+            [
+                {
+                    "type": "tool_result",
+                    "tool_use_id": "t1",
+                    "content": [{"type": "text", "text": ambient_prose}],
+                }
+            ],
+        ),
+        _jsonl_line(
+            "assistant",
+            "Root cause found: the bulk regen wrote an empty-string "
+            "source hash — that bug gutted all 36 template files.",
+        ),
+    ]
+    p = tmp_path / "poisoned.jsonl"
+    p.write_text("\n".join(lines), encoding="utf-8")
+    return p
+
+
+def test_tail_excludes_tool_result_content(stash_mod, poisoned_transcript):
+    tail = stash_mod._read_transcript_tail(str(poisoned_transcript))
+    assert "exhaustion" not in tail
+    assert "compact reply vocab" not in tail
+    assert stash_mod._OMITTED_MARKER in tail
+    # Genuine turns survive, correctly attributed.
+    assert "memory corpus lint" in tail
+    assert "empty-string" in tail
+
+
+def test_tail_excludes_tool_use_input(stash_mod, poisoned_transcript):
+    tail = stash_mod._read_transcript_tail(str(poisoned_transcript))
+    assert "x.md" not in tail  # tool_use input is ambient too
+
+
+def test_heuristic_cannot_surface_ambient_prose(stash_mod, poisoned_transcript):
+    """The poisoned line contains a marker word ('Lesson learned') — with
+    the filter it never reaches the heuristic at all."""
+    tail = stash_mod._read_transcript_tail(str(poisoned_transcript))
+    found = stash_mod._extract_heuristic(tail)
+    assert all("compact reply vocab" not in f["content"] for f in found)
+    assert all("exhaustion" not in f["content"] for f in found)
+
+
+def test_consecutive_omission_markers_collapse(stash_mod, tmp_path):
+    result_block = [
+        {
+            "type": "tool_result",
+            "tool_use_id": "t",
+            "content": [{"type": "text", "text": "dump"}],
+        }
+    ]
+    lines = [_jsonl_line("user", result_block) for _ in range(6)]
+    lines.append(_jsonl_line("assistant", "Decision: ship it."))
+    p = tmp_path / "toolheavy.jsonl"
+    p.write_text("\n".join(lines), encoding="utf-8")
+    tail = stash_mod._read_transcript_tail(str(p))
+    assert tail.count(stash_mod._OMITTED_MARKER) < 6
+    assert "Decision: ship it." in tail
+
+
+def test_prompt_carries_provenance_rules(stash_mod, monkeypatch):
+    """The Ollama prompt must instruct assertion-only extraction (R2)."""
+    captured = {}
+
+    class _Resp:
+        def read(self):
+            return json.dumps({"response": json.dumps({"findings": []})}).encode()
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+    def fake_urlopen(req, timeout=0):
+        captured["body"] = json.loads(req.data.decode("utf-8"))
+        return _Resp()
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+    stash_mod._extract_via_ollama("assistant: concluded X")
+    prompt = captured["body"]["prompt"]
+    assert "PROVENANCE" in prompt
+    assert "merely read" in prompt


### PR DESCRIPTION
## Summary
Closes #1263, the last of the three memory-dogfood issues. Root cause turned out sharper than filed: `tool_result` blocks are **user-role** messages in the transcript JSONL, so `_text_of` fed every Read'd file into the extractor as `user: <file contents>` — ambient text mislabeled as user speech. The extractor never stood a chance.

- **Role-faithful tail (D1, load-bearing):** `tool_result`/`tool_use` blocks reduce to a `[tool output omitted]` marker; consecutive marker lines collapse. One fix covers both the Ollama path and the heuristic fallback.
- **Prompt provenance rules (D2):** assistant conclusions / user decisions only — "reading a claim is not finding it."
- **No schema change (D3);** revisit as its own evidence pass if post-fix stashes still carry ambient findings.
- **Mini-spec** with evidence and decisions at `docs/specs/stash-extractor-provenance/` (value-gate single-PR precedent).

## Testing
Deterministic replay of the 2026-07-05 poisoning shape (D4): ambient memory-file prose in a tool_result → excluded from tail, unreachable by the heuristic, genuine assistant/user turns survive; prompt-content assertion via a stubbed urlopen. 535 hook tests pass (5 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)