### PR TITLE
release: attune-ai 10.0.1 — memory-suite quality patch

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "Spec-driven development for Claude Code — take an idea through requirements, design, tasks, and gated execution with an approval loop. Plus 23 auto-triggering skills: security audits, code review, test generation, release prep.",
-    "version": "10.0.0"
+    "version": "10.0.1"
   },
   "plugins": [
     {
       "name": "attune-ai",
       "description": "Spec-driven development is the core workflow: /spec carries an idea through brainstorm, requirements, design, and task execution with quality gates and your approval at each stage. Backed by 23 auto-triggering skills — security audits, code reviews, test generation, bug prediction, and release preparation. For help content tools, also install attune-help and attune-author from this marketplace.",
       "source": "./plugin",
-      "version": "10.0.0",
+      "version": "10.0.1",
       "author": {
         "name": "Smart AI Memory",
         "email": "patrick.roebuck@smartaimemory.com"

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,4 +1,4 @@
-# Attune AI Framework v10.0.0
+# Attune AI Framework v10.0.1
 
 AI-powered developer workflows with cost optimization and multi-agent orchestration.
 
@@ -148,7 +148,7 @@ attune_redis/          # attune-redis plugin (pip install attune-redis)
 
 ---
 
-**Version:** 10.0.0 | **License:** Apache 2.0 | **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)
+**Version:** 10.0.1 | **License:** Apache 2.0 | **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)
 
 ## Lessons — core
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [10.0.1] — 2026-07-06
+
+Memory-suite quality patch: three defects surfaced by a live dogfood
+session on release day (2026-07-05), filed with session evidence
+(#1263–#1265) and each fixed with its own receipt.
+
+### Added
+
+- **redis_memory_forget** MCP tool + `AMSMemoryBackend.forget(ids)`:
+  delete specific AMS long-term records by the IDs
+  `redis_memory_search` returns — the correction path when a stashed
+  finding is wrong or stale. ids-only by design (deletion by semantic
+  query is a foot-gun). Redis tool count 5 → 6. (#1264, #1267)
+- **jit-recall command shapes:** recall-map rules accept
+  `match_regex` over the raw tool-input text, closing the
+  trigger-side gap where lessons existed but never fired on traps in
+  *generated* commands. Seeded with four observed slip-points: zsh
+  `[ a \< b ]` string-compare, `=word` PATH expansion, read-only
+  `status=$(...)`, and the formatter-strips-lone-import Edit trap.
+  (#1265, #1268)
+
+### Fixed
+
+- **memory:** the Stop-hook stash extractor no longer promotes
+  content the session merely *read* into findings. Root cause:
+  `tool_result` blocks are user-role transcript messages, so every
+  file the assistant read entered the extractor as user speech —
+  the extractor tail is now role-faithful (`[tool output omitted]`
+  markers), and the extraction prompt carries provenance rules
+  ("reading a claim is not finding it"). Spec + failure replay in
+  `docs/specs/stash-extractor-provenance/`. (#1263, #1269)
+- **memory:** `memory_forget`'s Redis-required error now names the
+  URL it attempted and points AMS-record deletions at
+  `redis_memory_forget` instead of implying all Redis memory is
+  down. (#1264)
+
 ## [10.0.0] — 2026-07-05
 
 Breaking release: the legacy memory-graph API is removed. Curated

--- a/docs/reference/API_REFERENCE.md
+++ b/docs/reference/API_REFERENCE.md
@@ -1,6 +1,6 @@
 # Attune AI API Reference
 
-**Version:** 10.0.0
+**Version:** 10.0.1
 **License:** Apache License 2.0
 **Copyright:** 2025-2026 Smart AI Memory, LLC
 
@@ -1152,5 +1152,5 @@ msg = format_error(
 
 ---
 
-**Version:** 10.0.0 | **License:** Apache 2.0
+**Version:** 10.0.1 | **License:** Apache 2.0
 **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)

--- a/plugin/.claude-plugin/marketplace.json
+++ b/plugin/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "Spec-driven development for Claude Code — /spec plans, reviews, and executes with quality gates; plus security audits, code reviews, test generation, and release prep from /attune.",
-    "version": "10.0.0"
+    "version": "10.0.1"
   },
   "plugins": [
     {
       "name": "attune-ai",
       "description": "Spec-driven development for Claude Code — /spec plans, reviews, and executes with quality gates; plus security audits, code reviews, test generation, and release prep from /attune.",
       "source": "./",
-      "version": "10.0.0",
+      "version": "10.0.1",
       "author": {
         "name": "Smart AI Memory",
         "email": "patrick.roebuck@smartaimemory.com"

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "attune-ai",
-  "version": "10.0.0",
+  "version": "10.0.1",
   "description": "Spec-driven development for Claude Code — /spec plans, reviews, and executes with quality gates; plus security audits, code reviews, test generation, and release prep from /attune.",
   "author": {
     "name": "Smart AI Memory",

--- a/plugin/core/__init__.py
+++ b/plugin/core/__init__.py
@@ -5,4 +5,4 @@ This module provides the core workflow functionality when the full
 attune-ai package is not installed via pip.
 """
 
-__version__ = "10.0.0"
+__version__ = "10.0.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "attune-ai"
-version = "10.0.0"
+version = "10.0.1"
 description = "AI-powered developer workflows for Claude with cost optimization, multi-agent orchestration, and workflow automation."
 readme = {file = "README.md", content-type = "text/markdown"}
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -253,7 +253,7 @@ wheels = [
 
 [[package]]
 name = "attune-ai"
-version = "10.0.0"
+version = "10.0.1"
 source = { editable = "." }
 dependencies = [
     { name = "agent-memory-client" },

--- a/website/app/page.tsx
+++ b/website/app/page.tsx
@@ -58,7 +58,7 @@ export default function Home() {
             <div className="grid lg:grid-cols-2 gap-16 items-center">
               <div className="z-10">
                 <div className="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-[var(--surface-container-high)] text-[var(--primary)] text-xs font-bold tracking-widest mb-6 uppercase">
-                  <span>v10.0.0</span>
+                  <span>v10.0.1</span>
                   <span className="w-1 h-1 rounded-full bg-[var(--primary)]"></span>
                   <span className="opacity-80">Spec-driven development platform</span>
                 </div>

--- a/website/lib/features.ts
+++ b/website/lib/features.ts
@@ -32,7 +32,7 @@ export const PRODUCTS: Product[] = [
     id: "attune-ai",
     name: "Attune AI",
     pypiName: "attune-ai",
-    version: "10.0.0",
+    version: "10.0.1",
     tagline: "Generate, maintain, and serve help from your code",
     installCommand: "pip install attune-ai",
     marketplaceInstall:
@@ -101,7 +101,7 @@ export const PRODUCTS: Product[] = [
     id: "claude-code-plugin",
     name: "Claude Code Plugin",
     pypiName: "attune-ai",
-    version: "10.0.0",
+    version: "10.0.1",
     tagline: "Progressive help right in your terminal",
     installCommand:
       "claude plugin marketplace add Smart-AI-Memory/attune-ai",


### PR DESCRIPTION
## Summary
Patch release carrying the three memory-dogfood fixes from the 2026-07-05 session, per the arc: live dogfood → issues #1263–#1265 with session evidence → fixes #1267/#1268/#1269 → this release.

- `redis_memory_forget` + `AMSMemoryBackend.forget(ids)` (correction path; tool count 5→6)
- jit-recall `match_regex` command shapes (4 observed slip-points seeded)
- stash extractor provenance (role-faithful tail + prompt rules; spec at `docs/specs/stash-extractor-provenance/`)

Bumps all 9 version sites via `scripts/bump_version.py`; uv.lock own-version only. **Docs regen skipped on purpose** — the regenerator's empty-source-hash bug (`task_d79c0226`) is unfixed; regen ships as a follow-up once that lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)