### PR TITLE
test(memory): literal loopback IP in redis-bootstrap probe (windows getaddrinfo segfault)

### DIFF
--- a/tests/unit/memory/test_redis_bootstrap.py
+++ b/tests/unit/memory/test_redis_bootstrap.py
@@ -92,8 +92,12 @@ class TestCheckRedisRunning:
 
     def test_returns_false_when_redis_not_available(self):
         """Test returns False when Redis is not available on default port."""
-        # Test against a port that's almost certainly not running Redis
-        result = _check_redis_running(host="localhost", port=16379)
+        # Literal loopback IP, NOT "localhost": hostname resolution goes
+        # through native getaddrinfo(), which intermittently segfaults
+        # xdist workers on windows-latest (exit 139; hit twice on the
+        # 10.0.1 release SHA). Same remedy as test_uses_custom_host_and_port
+        # below (windows-xdist-flakes inventory).
+        result = _check_redis_running(host="127.0.0.1", port=16379)
         assert result is False
 
     def test_uses_custom_host_and_port(self):


### PR DESCRIPTION
## Summary
Unblocks the v10.0.1 tag. Main's `test (windows-latest, 3.12)` segfaulted (exit 139, no FAILED lines) twice at `test_returns_false_when_redis_not_available` — the one probe in the file still passing hostname `localhost` through native `getaddrinfo()`, the exact crash class the sibling test's comment documents from the windows-xdist-flakes inventory, with the same one-line remedy: literal `127.0.0.1` + closed port.

Test-only; 84 pass locally. Also a new triage datapoint: exit-139 with a clean log is a third Windows failure signature (vs runner-hang and concurrency-cancel) — the standard greps classify it as 'no signature'.

🤖 Generated with [Claude Code](https://claude.com/claude-code)