### PR TITLE
fix(attune-ai-dev): redirect /privacy and /terms to smartaimemory.com

### DIFF
--- a/.claude/lessons.md
+++ b/.claude/lessons.md
@@ -13995,3 +13995,17 @@ def ", start_idx + 1)` for module-
   Also note the update requires a Claude Code restart to apply —
   a same-session `ls` of the cache dir shows the new version dir
   but the running session keeps serving the old one.
+
+- **"Coverage ≥94%" conflates a MEASURED value with an ENFORCED
+  gate — outward-facing quality claims must name which one they
+  are**: the marketplace submission pack (drafted "every claim
+  receipt-backed") said "coverage gate ≥94%"; the codecov badge
+  reads 94% but the enforced gate is `fail_under = 85` /
+  `--cov-fail-under=85` in pyproject. A reviewer checking the
+  repo would find the claim falsifiable even though both numbers
+  are real. The safe shape: "coverage 94% (codecov, live badge;
+  CI gate enforces ≥85%)". Generalization for any external claim
+  (submission forms, READMEs, blog posts): a metric can be true
+  as a measurement and false as a policy — grep the enforcing
+  config (`fail_under`, branch protection, required checks)
+  before writing "gate"/"required"/"enforced" next to a number.

--- a/attune-ai-dev/vercel.json
+++ b/attune-ai-dev/vercel.json
@@ -2,6 +2,18 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "cleanUrls": true,
   "trailingSlash": false,
+  "redirects": [
+    {
+      "source": "/privacy",
+      "destination": "https://smartaimemory.com/privacy",
+      "permanent": false
+    },
+    {
+      "source": "/terms",
+      "destination": "https://smartaimemory.com/terms",
+      "permanent": false
+    }
+  ],
   "headers": [
     {
       "source": "/(.*)",


### PR DESCRIPTION
attune-ai.dev/privacy and attune-ai.dev/terms 404 — the static site never had legal pages, and the marketplace submission form asks for a privacy-policy link.

## What

- Adds a `redirects` block to `attune-ai-dev/vercel.json`: `/privacy` and `/terms` → the canonical policies on smartaimemory.com (verified live 200, titled "Privacy Policy | Attune AI").
- `permanent: false` (307) deliberately — if the domain consolidation later moves the policies TO attune-ai.dev, a 308 would fight browser caches forever.
- Rides along: one session lesson in `.claude/lessons.md` (measured value vs enforced gate in outward-facing claims).

## Verify after deploy

`curl -sIL https://attune-ai.dev/privacy | grep -E 'HTTP|location'` → 307 then 200 at smartaimemory.com.

🤖 Generated with [Claude Code](https://claude.com/claude-code)