### PR TITLE
chore: weekly report 2026-07-06

### DIFF
--- a/weekly-reports/2026-07-06.md
+++ b/weekly-reports/2026-07-06.md
@@ -1,0 +1,232 @@
+# Anthropic Ecosystem Weekly — 2026-07-06
+
+## Summary
+
+Claude Sonnet 5 launched June 30 with three breaking changes; the stack
+already uses `claude-sonnet-5` as the "capable" tier but
+`_normalize_api_kwargs_for_model`'s regex doesn't cover it — test
+generation workflows are returning 400 errors right now. Six Claude Code
+releases shipped (v2.1.196–v2.1.201). Fable 5 and Mythos 5 restored July 1.
+
+---
+
+## Recommendations
+
+**1. Fix `_OPUS_NO_SAMPLING_RE` to cover Sonnet 5 — active 400s in test
+generation (HIGH)**
+
+`src/attune/llm/providers/anthropic.py:21`:
+
+```python
+_OPUS_NO_SAMPLING_RE = re.compile(r"opus-4-(?:[7-9]|\d{2,})")
+```
+
+This regex matches only Opus 4.7+. Sonnet 5 also rejects `temperature`,
+`top_p`, and `top_k` at non-default values with a 400 error, but the
+normalizer won't strip them for Sonnet-class calls.
+
+Two active crash sites:
+
+- `src/attune/orchestration/tools/testing.py:370` — passes `temperature=0.3`
+  directly to `self._llm.messages.create(model="claude-sonnet-5", ...)`,
+  bypassing the normalizer entirely. Every `/smart-test` or test-gen call
+  is 400-ing.
+- `src/attune/orchestration/tools/test_generation.py:213` — same pattern,
+  same bug.
+- `AnthropicProvider.generate()` defaults `temperature=0.7` (the Claude API
+  default is 1.0, so 0.7 is "non-default" and will 400).
+
+**Fix**: Broaden the regex to cover all models that reject sampling params:
+
+```python
+_OPUS_NO_SAMPLING_RE = re.compile(
+    r"(?:opus-4-(?:[7-9]|\d{2,})|sonnet-5|fable-\d+|mythos-\d+)"
+)
+```
+
+Then remove the hardcoded `temperature=0.3` from the two `messages.create()`
+call sites in `testing.py` and `test_generation.py` — those bypass
+`_normalize_api_kwargs_for_model` entirely.
+
+- **Applies to:** `src/attune/llm/providers/anthropic.py`,
+  `src/attune/agent_factory/adapters/langgraph_adapter.py`,
+  `src/attune/orchestration/tools/testing.py`,
+  `src/attune/orchestration/tools/test_generation.py`
+- **Urgency:** High — test generation is broken today.
+- **Alternative:** Set `CAPABLE_MODEL=claude-sonnet-4-6` to revert to the
+  prior generation while the fix lands, at the cost of capability regression.
+
+---
+
+**2. Handle `stop_reason: "refusal"` — now active on two models (HIGH)**
+
+June-15 Rec #1 is no longer deferred. Fable 5 is restored AND Sonnet 5
+ships with real-time cybersecurity safeguards that can trigger `stop_reason:
+"refusal"` on security-adjacent prompts. The `security_audit`,
+`discovery_sweep`, and `deep_review` workflows will hit this.
+
+The refusal returns HTTP 200, not an error, so it silently falls through to
+the caller as a legitimate response with empty content. Unbilled if nothing
+was generated before the refusal, but callers will see a blank result with
+no exception.
+
+Minimal fix: check `stop_reason == "refusal"` in `AnthropicProvider.generate()`
+(line ~257, where `finish_reason=response.stop_reason` is already set) and
+raise a distinguishable exception or return a structured sentinel. The
+`agent_sdk_adapter.py:1336` already captures `stop_reason` into
+`result_metadata` — wire a log line and a non-zero exit status there too.
+
+- **Applies to:** `src/attune/llm/providers/anthropic.py`,
+  `src/attune/workflows/agent_sdk_adapter.py`
+- **Urgency:** High — silent blank results from security-adjacent workflows
+  are already possible with Fable 5 (restored July 1).
+
+---
+
+**3. Fix `max_tokens=8192` in MODEL_REGISTRY for Sonnet 5 (MEDIUM)**
+
+`src/attune/models/registry.py:142`:
+
+```python
+"capable": ModelInfo(
+    id="claude-sonnet-5",
+    max_tokens=8192,   # actual API max is 128k
+    ...
+)
+```
+
+Sonnet 5 supports 128k max output tokens. The registry cap of 8192 matters
+because Sonnet 5 has **adaptive thinking on by default** — thinking tokens
+count against `max_tokens`. A caller that passes `max_tokens=8192` from the
+registry will have the thinking budget eat most of it, leaving the actual
+response truncated. Same issue for `claude-opus-4-8` (also capped at 8192
+in the registry).
+
+Bump both to at least `32768` (a conservative safe value) or `131072` (the
+full 128k cap). Workflows that depend on the registry value for output
+budgeting will immediately get much more usable headroom.
+
+- **Applies to:** `src/attune/models/registry.py`
+- **Urgency:** Medium — silent truncation in any workflow using the registry's
+  `max_tokens` for its API calls.
+- **Note:** The Batch API supports up to 300k output tokens with
+  `output-300k-2026-03-24` beta header — a separate ceiling.
+
+---
+
+**4. Adaptive thinking is ON by default for Sonnet 5 — audit `max_tokens`
+call sites (MEDIUM)**
+
+Any Sonnet 5 call that doesn't explicitly pass `thinking: {type: "disabled"}`
+will run with adaptive thinking. Since `max_tokens` is a hard ceiling on
+thinking + response combined, callers with a tight `max_tokens` (like
+`max_tokens=1024` in `AnthropicProvider.generate()`'s default) will see
+heavily truncated responses.
+
+Pass `thinking: {"type": "disabled"}` on any Sonnet 5 call where you don't
+want thinking — latency-sensitive tool calls, classifiers, single-sentence
+outputs. Use `thinking: {"type": "adaptive"}` (the default) for analysis and
+code generation where quality matters.
+
+- **Applies to:** All call sites that don't set `thinking` explicitly,
+  especially `AnthropicProvider.generate()` with its 1024-token default.
+- **Urgency:** Medium — silent quality regression on calls with low
+  `max_tokens` budgets.
+
+---
+
+**5. Update intro pricing in MODEL_REGISTRY (LOW)**
+
+`src/attune/models/registry.py:145`:
+
+```python
+input_cost_per_million=3.00,   # wrong until Aug 31
+output_cost_per_million=15.00, # wrong until Aug 31
+```
+
+Sonnet 5 intro pricing is **$2/$10 per MTok through August 31, 2026**,
+reverting to $3/$15 after. The registry has the post-intro price, so
+`cost_tracker` will overstate Sonnet 5 input costs by 50% for the next
+eight weeks.
+
+- **Applies to:** `src/attune/models/registry.py`
+- **Urgency:** Low — cost tracking inaccuracy only; no runtime impact.
+
+---
+
+## Carry-overs
+
+| # | First raised | Recommendation | Status |
+|---|---|---|---|
+| June-29 Rec #1 | 2026-06-29 | Set `CLAUDE_CODE_MCP_TOOL_IDLE_TIMEOUT` for long tools | Open. v2.1.196 also added a streaming idle watchdog (5-min no-event abort, retries). Both affect long MCP tools; the env var is still unset. |
+| June-29 Rec #2 | 2026-06-29 | Verify hook matchers for hyphenated MCP names | Open. Low urgency. |
+| June-29 Rec #3 | 2026-06-29 | `autoMode.classifyAllShell` awareness | Open. Low urgency. |
+| June-22 Rec #1 | 2026-06-22 | Adjust release workflows for destructive git blocking | Open. Medium urgency. |
+| June-22 Rec #2 | 2026-06-22 | Investigate prompt caching on `_CITATION_BASE_URL` | Open. |
+| June-22 Rec #3 | 2026-06-22 | `Tool(param:value)` permission rules for cost control | Open. Low urgency. |
+| June-22 Rec #4 | 2026-06-22 | Set `CLAUDE_CLIENT_PRESENCE_FILE` for scheduled runs | Open. Low urgency. |
+| June-15 Rec #1 | 2026-06-15 | Handle `stop_reason: "refusal"` | **Escalated to Rec #2 above.** Fable 5 restored + Sonnet 5 adds refusals. No longer deferrable. |
+| June-8 Rec #4 | 2026-06-08 | Stop hooks `additionalContext` for session-stash | Open. Low urgency (8 weeks). |
+| May-25 #2 | 2026-05-25 | `attune-ops`: switch to `claude agents --json` | Open. 6 weeks. Background agent improvements in v2.1.196–v2.1.200 add more reason. |
+| May-25 #3 | 2026-05-25 | Cache diagnostics for attune-author polish pipeline | 9 weeks old. **Close this explicitly** if cache misses aren't causing pain — it's noise. |
+| May-25 #4 | 2026-05-25 | Update plugin docs: `/simplify` → `/code-review` | 9 weeks old. It's a one-liner. Do it or close it. |
+| May-11 #6 | 2026-05-11 | 1-hour cache TTL for attune-author polish | 12 weeks old. **Close.** |
+| May-11 #7 | 2026-05-11 | Surface `api_error_status` from `ResultMessage` | 12 weeks old. **Close.** |
+
+The May-11 items are 12 weeks old. Close them on the next interactive session
+unless they've become painful — keeping dead carry-overs obscures live ones.
+
+---
+
+## Watch list
+
+- **Sonnet 5 intro pricing expires August 31.** Input goes from $2 to $3 per
+  MTok on September 1. The capable tier (attune-ai's workhorse) gets 50% more
+  expensive overnight. Worth benchmarking Haiku 4.5 for any workflows where
+  Sonnet 5 is overkill.
+- **Opus 4.7 fast mode removal July 24.** Not in the stack (confirmed via
+  grep). No action needed, but if routing ever adds Opus 4.7, verify fast
+  mode isn't used before July 24.
+- **Opus 4.1 retirement August 5.** Not in the stack. No action needed.
+- **Managed Agents API additions (June 30).** Event deltas, backward
+  pagination, and per-session config overrides are additive. Potentially
+  useful for `agent_sdk_adapter.py` — per-session overrides could replace
+  some of the manual model-switching code. No breaking changes, no action
+  needed now.
+- **v2.1.198: Background agents auto-commit/push/open draft PRs.** If
+  attune-ai ever uses Claude Code native background agents (not the SDK
+  adapter), they'll auto-create PRs without being asked. Keep this in mind
+  for CI environments.
+
+---
+
+## No-ops
+
+| Item | Why skipped |
+|---|---|
+| Fable 5 / Mythos 5 restored (July 1) | Good news; no Python stack change needed |
+| Stacked slash-skill invocations (v2.1.199) | UX improvement; no plugin code change needed |
+| Claude in Chrome GA (v2.1.198) | Browser product feature; no Python impact |
+| Organization default models (v2.1.196) | Org console feature; no code change |
+| Streaming idle watchdog on by default (v2.1.196) | Claude Code client-side; noted in carry-over Rec #1 |
+| Default permission mode renamed "Manual" (v2.1.200) | Rename only; no `.claude/settings.json` impact confirmed |
+| AskUserQuestion no auto-continue (v2.1.200) | Only affects unattended flows; attune-ai elicitation is interactive |
+| Opus 4.6 fast mode removed (June 29 API) | Not in stack |
+| SSL error guidance improvements (v2.1.199) | No TLS issues in current stack |
+| Jailbreak severity framework (July 2, industry) | Informational; no API change |
+| Claude Science workbench (June 30) | Not relevant to developer tooling stack |
+| `stop_reason: "refusal"` no longer billed | Good news; financial risk reduced, but handling still needed (Rec #2) |
+
+---
+
+## Sources checked
+
+- `platform.claude.com/docs/en/release-notes/overview` (through July 1, 2026)
+- `platform.claude.com/docs/en/about-claude/models/whats-new-sonnet-5`
+- `platform.claude.com/docs/en/about-claude/models/overview`
+- GitHub releases: `anthropics/claude-code` (v2.1.196–v2.1.201, June 29–July 3)
+- `www.anthropic.com/news` (Sonnet 5 announcement, Fable 5 redeployment, July 2 safeguards post)
+- `releasebot.io/updates/anthropic/claude-code` (July 2026)
+- Grep: `_OPUS_NO_SAMPLING_RE`, `temperature=`, `thinking`, `stop_reason`, `max_tokens=8192`
+  in `src/attune/`
+- Prior report: `weekly-reports/2026-06-29.md`


### PR DESCRIPTION
## Description

Weekly Anthropic ecosystem report for the week of June 29 – July 6, 2026.

## Type of Change

- [x] 📝 Documentation update

## Changes Made

- Added `weekly-reports/2026-07-06.md`

## Report Contents

---

# Anthropic Ecosystem Weekly — 2026-07-06

## Summary

Claude Sonnet 5 launched June 30 with three breaking changes; the stack
already uses `claude-sonnet-5` as the "capable" tier but
`_normalize_api_kwargs_for_model`'s regex doesn't cover it — test
generation workflows are returning 400 errors right now. Six Claude Code
releases shipped (v2.1.196–v2.1.201). Fable 5 and Mythos 5 restored July 1.

---

## Recommendations

**1. Fix `_OPUS_NO_SAMPLING_RE` to cover Sonnet 5 — active 400s in test generation (HIGH)**

`src/attune/llm/providers/anthropic.py:21`:

```python
_OPUS_NO_SAMPLING_RE = re.compile(r"opus-4-(?:[7-9]|\d{2,})")
```

This regex matches only Opus 4.7+. Sonnet 5 also rejects `temperature`,
`top_p`, and `top_k` at non-default values with a 400 error, but the
normalizer won't strip them for Sonnet-class calls.

Two active crash sites:

- `src/attune/orchestration/tools/testing.py:370` — passes `temperature=0.3`
  directly to `self._llm.messages.create(model="claude-sonnet-5", ...)`,
  bypassing the normalizer entirely. Every `/smart-test` or test-gen call is 400-ing.
- `src/attune/orchestration/tools/test_generation.py:213` — same pattern, same bug.
- `AnthropicProvider.generate()` defaults `temperature=0.7` (the Claude API
  default is 1.0, so 0.7 is "non-default" and will 400).

**Fix**:

```python
_OPUS_NO_SAMPLING_RE = re.compile(
    r"(?:opus-4-(?:[7-9]|\d{2,})|sonnet-5|fable-\d+|mythos-\d+)"
)
```

Then remove the hardcoded `temperature=0.3` from the two `messages.create()` call sites.

- **Applies to:** `src/attune/llm/providers/anthropic.py`, `src/attune/orchestration/tools/testing.py`, `src/attune/orchestration/tools/test_generation.py`
- **Urgency:** High — test generation is broken today.

---

**2. Handle `stop_reason: "refusal"` — now active on two models (HIGH)**

June-15 Rec #1 is no longer deferred. Fable 5 is restored AND Sonnet 5
ships with real-time cybersecurity safeguards. The `security_audit`,
`discovery_sweep`, and `deep_review` workflows will hit this. The refusal
returns HTTP 200, not an error, so it silently falls through as a blank result.

Minimal fix: check `stop_reason == "refusal"` in `AnthropicProvider.generate()`
and `agent_sdk_adapter.py:1336`.

- **Urgency:** High — silent blank results from security-adjacent workflows are already possible with Fable 5 (restored July 1).

---

**3. Fix `max_tokens=8192` in MODEL_REGISTRY for Sonnet 5 (MEDIUM)**

`src/attune/models/registry.py:142` has `max_tokens=8192` for Sonnet 5
(actual API max: 128k). With adaptive thinking ON by default, thinking tokens
eat into this small budget, leaving the actual response truncated.

Bump to at least `32768`.

---

**4. Adaptive thinking ON by default for Sonnet 5 — audit `max_tokens` call sites (MEDIUM)**

Pass `thinking: {"type": "disabled"}` on latency-sensitive calls. The
`AnthropicProvider.generate()` default of `max_tokens=1024` will be nearly
fully consumed by thinking tokens.

---

**5. Update intro pricing in MODEL_REGISTRY (LOW)**

`registry.py` has Sonnet 5 at $3/$15. Intro pricing is $2/$10 through Aug 31.
Cost tracker will overstate Sonnet 5 input costs by 50% for the next 8 weeks.

---

## Carry-overs (selected high-priority)

- **June-29 Rec #1** — `CLAUDE_CODE_MCP_TOOL_IDLE_TIMEOUT` still unset; v2.1.196 streaming watchdog also now on by default.
- **June-15 Rec #1** — Escalated to Rec #2 above. No longer deferrable.
- **May-11 #6, #7** — 12 weeks old. Close unless actively painful.

## Watch list

- Sonnet 5 intro pricing expires **August 31** — capable tier goes 50% more expensive.
- Opus 4.7 fast mode removed **July 24** — not in stack.
- Opus 4.1 retired **August 5** — not in stack.

---

## Testing

- [x] Report only — no code changes

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code

## License Acknowledgment

- [x] I confirm that my contributions are made under the Apache License 2.0

---
_Generated by [Claude Code](https://claude.ai/code/session_01SFMb2WLZ1ZnApgsNEVzaV7)_