### PR TITLE
feat(memory): self-measuring telemetry for the short-term memory hooks

### DIFF
--- a/.claude/lessons.md
+++ b/.claude/lessons.md
@@ -14026,3 +14026,18 @@ def ", start_idx + 1)` for module-
   in `~/.claude/settings.json`), NOT a repo hook — repo PRs can't
   instrument it; only the three `plugin/hooks/` memory hooks
   (session_recall / jit_recall / session_stash) are in-tree.
+
+- **Windows-only test failure class: hardcoded POSIX literals asserted
+  against values that passed through `str(Path(...))`** — PR #1279's
+  only red lane was `assert event["where"] == "/x"` failing as
+  `'\\x' == '/x'` (the helper serializes non-JSON values via
+  `json.dumps(default=str)`, and `str(Path("/x"))` is `\x` on
+  Windows). Fix pattern: compare via the SAME conversion the code
+  under test applies (`== str(Path("/x"))`), never a hardcoded POSIX
+  string. Cost of missing it locally: one full ~20-min windows-latest
+  round trip per iteration. Cheap preflight when a test asserts on
+  anything Path-derived: ask "what does this literal look like under
+  `WindowsPath`?" This was also a confirming instance of the existing
+  "wait for ALL OS lanes on filesystem-touching PRs before merging"
+  lesson — waiting caught the bug pre-merge instead of burying it on
+  main.

--- a/.claude/lessons.md
+++ b/.claude/lessons.md
@@ -14009,3 +14009,20 @@ def ", start_idx + 1)` for module-
   as a measurement and false as a policy — grep the enforcing
   config (`fail_under`, branch protection, required checks)
   before writing "gate"/"required"/"enforced" next to a number.
+
+- **New local-only telemetry files must dodge the `usage*.jsonl` glob —
+  that prefix is the phone-home boundary**: the opt-in usage ping
+  (`usage_ping.py`) syncs every `telemetry_dir.glob("usage*.jsonl")`
+  file (current + rotated), so naming a new local-only event log
+  `usage_<x>.jsonl` would silently enroll it in the consented upload
+  the moment a user opts in. `memory_events.jsonl` (PR #1279) stays
+  local precisely because it misses the glob. Rule when adding any
+  file under `~/.attune/telemetry/`: check what reads the directory
+  (`grep -n 'glob' src/attune/telemetry/*.py`) and pick a name on the
+  right side of the consent boundary — local-only files avoid the
+  `usage` prefix; ping-eligible data goes IN `usage.jsonl` proper, not
+  a sibling. Related scoping fact: the SessionStart Redis hydration
+  step is personal infra (`~/.attune/memory/session_hydrate.py`, wired
+  in `~/.claude/settings.json`), NOT a repo hook — repo PRs can't
+  instrument it; only the three `plugin/hooks/` memory hooks
+  (session_recall / jit_recall / session_stash) are in-tree.

--- a/plugin/hooks/_memory_telemetry.py
+++ b/plugin/hooks/_memory_telemetry.py
@@ -1,0 +1,120 @@
+"""Best-effort event log for the short-term memory hooks.
+
+The memory layer (session recall at the door, JIT rule recall at the
+decision point, the Stop-hook stash) had no self-measurement: a
+cost-savings analysis had to MODEL its token impact instead of reading
+it. This module gives each hook a one-call way to record what it
+actually injected, to ``~/.attune/telemetry/memory_events.jsonl`` — the
+same local-only JSONL style as ``usage.jsonl``.
+
+One event = one JSON line:
+
+- ``v`` / ``ts`` — schema version, UTC ISO-8601 timestamp.
+- ``event`` — ``session_recall`` | ``jit_recall`` | ``session_stash``.
+- ``session_id`` — Claude Code session id (local file only; the
+  opt-in usage ping reads ``usage*.jsonl`` and never this file).
+- ``injected_chars`` / ``est_tokens`` — size of the context the hook
+  injected (tokens estimated at 4 chars/token).
+- event-specific fields (entry counts, tool name, rule ids, ...).
+
+Fires-per-session (recall vs JIT counts) fall out of grouping lines by
+``session_id`` + ``event``. JIT events carry ``tool`` + ``rules`` so a
+later analysis can correlate "rule surfaced at time T" with whether the
+matching failure occurred afterwards (prevented-failure estimation).
+
+Consent model: matches the existing telemetry split — LOCAL recording
+is default-on (like ``usage.jsonl``), and only the separate opt-in
+usage ping ever leaves the machine (this file is not in its glob).
+``DO_NOT_TRACK`` (the same signal ``usage_consent_notice.py`` honors)
+or ``ATTUNE_MEMORY_TELEMETRY=0`` disables even the local log.
+
+Never raises — the memory hooks are best-effort and their telemetry
+must be too.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under Apache 2.0
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+
+_FALSEY = {"", "0", "false", "no", "off"}
+
+#: Rotate when the live file exceeds this (events are ~200 bytes; this
+#: is a years-of-headroom backstop, not an expected path).
+_MAX_BYTES = 5 * 1024 * 1024
+
+#: Rough chars-per-token divisor for the ``est_tokens`` convenience field.
+_CHARS_PER_TOKEN = 4
+
+
+def _enabled() -> bool:
+    """False when local memory telemetry is switched off via env."""
+    if os.environ.get("ATTUNE_MEMORY_TELEMETRY", "1").strip().lower() in _FALSEY:
+        return False
+    dnt = os.environ.get("DO_NOT_TRACK")
+    return dnt is None or dnt.strip().lower() in _FALSEY
+
+
+def _events_path() -> Path:
+    """Resolve the live events file under ATTUNE_HOME (default ~/.attune)."""
+    home = os.environ.get("ATTUNE_HOME")
+    base = Path(home).expanduser() if home else Path.home() / ".attune"
+    return base / "telemetry" / "memory_events.jsonl"
+
+
+def _rotate_if_huge(path: Path) -> None:
+    """Best-effort size backstop: rotate to a dated sibling when huge."""
+    try:
+        if path.stat().st_size < _MAX_BYTES:
+            return
+        stamp = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+        rotated = path.with_name(f"memory_events.{stamp}.jsonl")
+        counter = 1
+        while rotated.exists():
+            rotated = path.with_name(f"memory_events.{stamp}.{counter}.jsonl")
+            counter += 1
+        path.replace(rotated)
+    except OSError:
+        pass  # rotation is a nicety; the append below still works
+
+
+def log_memory_event(event: str, session_id: str | None = None, **fields: object) -> None:
+    """Append one memory-hook event line. Best-effort, never raises.
+
+    Args:
+        event: Event name (``session_recall`` / ``jit_recall`` /
+            ``session_stash``).
+        session_id: Claude Code session id, when the payload carried one.
+        **fields: Event-specific data. An int ``injected_chars`` field
+            gains a derived ``est_tokens`` sibling automatically.
+    """
+    try:
+        if not _enabled():
+            return
+        record: dict[str, object] = {
+            "v": "1.0",
+            "ts": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
+            "event": event,
+        }
+        if session_id:
+            record["session_id"] = str(session_id)[:64]
+        record.update(fields)
+        chars = record.get("injected_chars")
+        if isinstance(chars, int) and "est_tokens" not in record:
+            record["est_tokens"] = chars // _CHARS_PER_TOKEN
+
+        path = _events_path()
+        path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+        _rotate_if_huge(path)
+        with path.open("a", encoding="utf-8") as fh:
+            json.dump(record, fh, separators=(",", ":"), default=str)
+            fh.write("\n")
+    except Exception:  # noqa: BLE001
+        # INTENTIONAL: telemetry about best-effort hooks must never
+        # break the hook (or the session) it observes.
+        pass

--- a/plugin/hooks/jit_recall.py
+++ b/plugin/hooks/jit_recall.py
@@ -22,6 +22,10 @@ Flow (all best-effort, never blocks a tool call):
 Tunables (env): ``ATTUNE_JIT_RECALL`` (set ``0`` to disable),
 ``ATTUNE_AI_SENTINEL_DIR`` (sentinel dir override, for tests).
 
+Each fire is logged to ``~/.attune/telemetry/memory_events.jsonl``
+(tool, rule ids, injected size; see ``_memory_telemetry``) so fire
+rate and context cost are measurable per session.
+
 Exit 0 always — a crash or missing corpus degrades to silent no-op (R4).
 
 Copyright 2026 Smart-AI-Memory
@@ -53,6 +57,14 @@ try:
 except Exception:  # noqa: BLE001 — hook must never crash a tool call
     RECALL_MAP = {}  # type: ignore[assignment]
     _sentinel_dir = None  # type: ignore[assignment]
+
+try:
+    from _memory_telemetry import log_memory_event
+except Exception:  # noqa: BLE001 — telemetry is optional, never load-bearing
+
+    def log_memory_event(event: str, session_id: str | None = None, **fields: object) -> None:
+        return
+
 
 _SENTINEL_PREFIX = ".jit-recalled-"
 _SENTINEL_TTL_SECONDS = 7 * 24 * 3600  # match _state's compact-warned TTL
@@ -174,17 +186,30 @@ def main() -> int:
                 resolved = _resolve_lesson(ref)
                 if resolved:
                     lines.append(f"  Full lesson — {resolved}")
+        context = "\n".join(lines)
         sys.stdout.write(
             json.dumps(
                 {
                     "hookSpecificOutput": {
                         "hookEventName": "PreToolUse",
-                        "additionalContext": "\n".join(lines),
+                        "additionalContext": context,
                     }
                 }
             )
         )
         sys.stdout.flush()
+
+        # Telemetry: which rules surfaced, for which tool, and how much
+        # context they cost — the (tool, rules, ts) triple also lets a
+        # later analysis estimate prevented-failure rate by checking
+        # whether the matching failure still occurred after the fire.
+        log_memory_event(
+            "jit_recall",
+            session_id=session_id,
+            tool=tool_name,
+            rules=[rule["rule_id"] for rule in fresh],
+            injected_chars=len(context),
+        )
 
         # Sentinels AFTER the emit so a mid-work crash retries next fire.
         for rule in fresh:

--- a/plugin/hooks/session_recall.py
+++ b/plugin/hooks/session_recall.py
@@ -14,6 +14,10 @@ opening context. Never raises — a crash must not break the session.
 Tunables (env): ``ATTUNE_MEMORY_RECALL`` (set ``0`` to disable),
 ``ATTUNE_MEMORY_RECALL_TOPK`` (default 5).
 
+Each emission is logged to ``~/.attune/telemetry/memory_events.jsonl``
+(size + entry count; see ``_memory_telemetry``) so the layer's token
+cost is measured, not modeled.
+
 Copyright 2026 Smart-AI-Memory
 Licensed under Apache 2.0
 """
@@ -29,6 +33,18 @@ from pathlib import Path
 for _stream in (sys.stdout, sys.stderr):
     if _stream.encoding and _stream.encoding.lower() != "utf-8":
         _stream.reconfigure(encoding="utf-8", errors="replace")
+
+_HOOKS_DIR = str(Path(__file__).resolve().parent)
+if _HOOKS_DIR not in sys.path:
+    sys.path.insert(0, _HOOKS_DIR)
+
+try:
+    from _memory_telemetry import log_memory_event
+except Exception:  # noqa: BLE001 — telemetry is optional, never load-bearing
+
+    def log_memory_event(event: str, session_id: str | None = None, **fields: object) -> None:
+        return
+
 
 _DEFAULT_TOPK = 5
 _CONTENT_BUDGET = 1_400  # ~350 tokens of finding text
@@ -121,8 +137,15 @@ def main() -> int:
             return 0
         block = _format(entries)
         # Only print if we actually rendered at least one finding line.
-        if any(line.startswith("- [") for line in block.splitlines()):
+        rendered = sum(1 for line in block.splitlines() if line.startswith("- ["))
+        if rendered:
             print(block)
+            log_memory_event(
+                "session_recall",
+                session_id=payload.get("session_id"),
+                entries=rendered,
+                injected_chars=len(block),
+            )
         if health:
             print(health)
         return 0

--- a/plugin/hooks/session_stash.py
+++ b/plugin/hooks/session_stash.py
@@ -32,6 +32,10 @@ llama3.1:8b can exceed a tighter cap and starve extraction),
 ``ATTUNE_MEMORY_STASH_CONTEXT`` (set ``0`` to suppress the
 ``additionalContext`` emission while still stashing to disk).
 
+Each stash is logged to ``~/.attune/telemetry/memory_events.jsonl``
+(findings/written counts, extractor, injected size; see
+``_memory_telemetry``) so the capture side is measurable too.
+
 Exit 0 always.
 
 Copyright 2026 Smart-AI-Memory
@@ -66,6 +70,14 @@ try:
 except Exception:  # noqa: BLE001 — hook must never crash a session
     _sentinel_dir = None  # type: ignore[assignment]
     estimate_utilization = None  # type: ignore[assignment]
+
+try:
+    from _memory_telemetry import log_memory_event
+except Exception:  # noqa: BLE001 — telemetry is optional, never load-bearing
+
+    def log_memory_event(event: str, session_id: str | None = None, **fields: object) -> None:
+        return
+
 
 _VALID_TYPES = {"decision", "pattern", "bug", "reference", "note"}
 _MAX_FINDINGS = 5
@@ -352,7 +364,7 @@ def _context_enabled() -> bool:
     }
 
 
-def _emit_additional_context(findings: list[dict], written: int) -> None:
+def _emit_additional_context(findings: list[dict], written: int) -> int:
     """Print a compact findings summary as Stop-hook ``additionalContext``.
 
     Emits the Claude Code >= 2.1.163 envelope
@@ -360,9 +372,12 @@ def _emit_additional_context(findings: list[dict], written: int) -> None:
     "additionalContext": "..."}}`` on stdout so the just-stashed insights
     surface into the current session's next turn. No-op when nothing was
     written or the feature is disabled; never raises (best-effort).
+
+    Returns the character count of the injected summary (0 when skipped),
+    so the caller's telemetry can record the context cost.
     """
     if written <= 0 or not findings or not _context_enabled():
-        return
+        return 0
     lines = [
         f"\U0001f9e0 Stashed {written} session finding(s) to attune memory "
         "(recall later with /recall):"
@@ -385,10 +400,11 @@ def _emit_additional_context(findings: list[dict], written: int) -> None:
             )
         )
         sys.stdout.flush()
+        return len(summary)
     except (OSError, ValueError, TypeError):
         # INTENTIONAL: context injection is best-effort; the disk stash
         # already succeeded, so a stdout failure must not change exit status.
-        pass
+        return 0
 
 
 def main() -> int:
@@ -425,10 +441,12 @@ def main() -> int:
 
         raw = _extract_via_ollama(text)
         findings = _normalize(raw) if raw else []
+        extractor = "ollama"
         if not findings:
             # Ollama unavailable, timed out, or yielded nothing usable —
             # fall back to the heuristic rather than stash nothing.
             findings = _normalize(_extract_heuristic(text))
+            extractor = "heuristic"
         if not findings:
             _diag(f"skip session={session_id} extraction yielded no findings")
             return 0
@@ -451,7 +469,15 @@ def main() -> int:
 
         # Surface the stashed findings into the current session's next turn
         # via Stop-hook additionalContext (best-effort; older CC ignores it).
-        _emit_additional_context(findings, written)
+        injected = _emit_additional_context(findings, written)
+        log_memory_event(
+            "session_stash",
+            session_id=session_id,
+            findings=len(findings),
+            written=written,
+            extractor=extractor,
+            injected_chars=injected,
+        )
         return 0
     except Exception:  # noqa: BLE001 — a Stop hook must never crash the session
         traceback.print_exc(file=sys.stderr)

--- a/tests/unit/hooks/test_memory_telemetry.py
+++ b/tests/unit/hooks/test_memory_telemetry.py
@@ -110,7 +110,8 @@ def test_log_never_raises_on_unwritable_dir(telem_mod, tmp_path, monkeypatch):
 def test_log_serializes_non_json_values_via_default_str(telem_mod, tmp_path, monkeypatch):
     monkeypatch.setenv("ATTUNE_HOME", str(tmp_path / ".attune"))
     telem_mod.log_memory_event("session_stash", where=Path("/x"))
-    assert _events(tmp_path)[0]["where"] == "/x"
+    # str(Path("/x")) is "\\x" on Windows — compare via the same conversion.
+    assert _events(tmp_path)[0]["where"] == str(Path("/x"))
 
 
 def test_log_truncates_long_session_ids(telem_mod, tmp_path, monkeypatch):

--- a/tests/unit/hooks/test_memory_telemetry.py
+++ b/tests/unit/hooks/test_memory_telemetry.py
@@ -1,0 +1,244 @@
+"""Tests for the memory-hook event log (``_memory_telemetry``).
+
+Covers the helper's contract (JSONL shape, env gates, never-raises)
+and the integration points: a session_recall emission, a jit_recall
+fire, and a session_stash run each append one measurable event to
+``<ATTUNE_HOME>/telemetry/memory_events.jsonl``.
+
+The hooks are standalone scripts; they're loaded via importlib (the
+``test_session_memory_hooks.py`` pattern).
+
+Copyright 2026 Smart-AI-Memory
+Licensed under Apache 2.0
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+_HOOKS_DIR = Path(__file__).resolve().parents[3] / "plugin" / "hooks"
+
+
+def _load_module(name: str):
+    if str(_HOOKS_DIR) not in sys.path:
+        sys.path.insert(0, str(_HOOKS_DIR))
+    if name in sys.modules:
+        del sys.modules[name]  # fresh load so module-level state is clean
+    spec = importlib.util.spec_from_file_location(name, _HOOKS_DIR / f"{name}.py")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def telem_mod():
+    return _load_module("_memory_telemetry")
+
+
+def _events(tmp_path: Path) -> list[dict]:
+    """Parse the events file written under the test's ATTUNE_HOME."""
+    path = tmp_path / ".attune" / "telemetry" / "memory_events.jsonl"
+    if not path.is_file():
+        return []
+    return [
+        json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line.strip()
+    ]
+
+
+# ==========================================================================
+# Helper contract
+# ==========================================================================
+
+
+def test_log_writes_one_json_line_with_schema_fields(telem_mod, tmp_path, monkeypatch):
+    monkeypatch.setenv("ATTUNE_HOME", str(tmp_path / ".attune"))
+    telem_mod.log_memory_event("jit_recall", session_id="sess-1", tool="Bash", injected_chars=400)
+    events = _events(tmp_path)
+    assert len(events) == 1
+    e = events[0]
+    assert e["v"] == "1.0"
+    assert e["event"] == "jit_recall"
+    assert e["session_id"] == "sess-1"
+    assert e["tool"] == "Bash"
+    assert e["injected_chars"] == 400
+    assert e["est_tokens"] == 100  # 4 chars/token
+    assert e["ts"].endswith("Z")
+
+
+def test_log_appends_multiple_events(telem_mod, tmp_path, monkeypatch):
+    monkeypatch.setenv("ATTUNE_HOME", str(tmp_path / ".attune"))
+    telem_mod.log_memory_event("session_recall", entries=3)
+    telem_mod.log_memory_event("session_stash", written=2)
+    assert [e["event"] for e in _events(tmp_path)] == ["session_recall", "session_stash"]
+
+
+def test_log_disabled_via_env(telem_mod, tmp_path, monkeypatch):
+    monkeypatch.setenv("ATTUNE_HOME", str(tmp_path / ".attune"))
+    monkeypatch.setenv("ATTUNE_MEMORY_TELEMETRY", "0")
+    telem_mod.log_memory_event("jit_recall")
+    assert _events(tmp_path) == []
+
+
+def test_log_honors_do_not_track(telem_mod, tmp_path, monkeypatch):
+    monkeypatch.setenv("ATTUNE_HOME", str(tmp_path / ".attune"))
+    monkeypatch.setenv("DO_NOT_TRACK", "1")
+    telem_mod.log_memory_event("jit_recall")
+    assert _events(tmp_path) == []
+
+
+def test_log_falsey_do_not_track_still_records(telem_mod, tmp_path, monkeypatch):
+    monkeypatch.setenv("ATTUNE_HOME", str(tmp_path / ".attune"))
+    monkeypatch.setenv("DO_NOT_TRACK", "0")
+    telem_mod.log_memory_event("jit_recall")
+    assert len(_events(tmp_path)) == 1
+
+
+def test_log_never_raises_on_unwritable_dir(telem_mod, tmp_path, monkeypatch):
+    blocker = tmp_path / "blocked"
+    blocker.write_text("a file where the dir should be", encoding="utf-8")
+    monkeypatch.setenv("ATTUNE_HOME", str(blocker))  # mkdir under a file fails
+    telem_mod.log_memory_event("jit_recall")  # must not raise
+
+
+def test_log_serializes_non_json_values_via_default_str(telem_mod, tmp_path, monkeypatch):
+    monkeypatch.setenv("ATTUNE_HOME", str(tmp_path / ".attune"))
+    telem_mod.log_memory_event("session_stash", where=Path("/x"))
+    assert _events(tmp_path)[0]["where"] == "/x"
+
+
+def test_log_truncates_long_session_ids(telem_mod, tmp_path, monkeypatch):
+    monkeypatch.setenv("ATTUNE_HOME", str(tmp_path / ".attune"))
+    telem_mod.log_memory_event("jit_recall", session_id="x" * 200)
+    assert len(_events(tmp_path)[0]["session_id"]) == 64
+
+
+def test_rotate_if_huge_moves_live_file_aside(telem_mod, tmp_path, monkeypatch):
+    monkeypatch.setenv("ATTUNE_HOME", str(tmp_path / ".attune"))
+    monkeypatch.setattr(telem_mod, "_MAX_BYTES", 10)
+    telem_mod.log_memory_event("jit_recall", tool="Bash")  # >10 bytes
+    telem_mod.log_memory_event("jit_recall", tool="Edit")  # triggers rotation
+    tdir = tmp_path / ".attune" / "telemetry"
+    rotated = list(tdir.glob("memory_events.*.jsonl"))
+    assert len(rotated) == 1
+    live = _events(tmp_path)
+    assert len(live) == 1 and live[0]["tool"] == "Edit"
+
+
+# ==========================================================================
+# Hook integration — each hook appends a measurable event
+# ==========================================================================
+
+
+def _run(mod, monkeypatch, payload: dict) -> int:
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(payload)))
+    return mod.main()
+
+
+def test_session_recall_emission_logs_event(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("ATTUNE_HOME", str(tmp_path / ".attune"))
+    mod = _load_module("session_recall")
+    entries = [{"text": "decided the widget uses tables", "topics": ["type:decision"]}]
+
+    import attune.memory.session_stash as stash_pkg
+
+    monkeypatch.setattr(stash_pkg, "recent_entries", lambda top_k, cwd: entries)
+    monkeypatch.setattr(stash_pkg, "backend_status", lambda: {})
+    rc = _run(mod, monkeypatch, {"source": "startup", "session_id": "sess-r", "cwd": str(tmp_path)})
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "Recalled memories" in out
+
+    events = _events(tmp_path)
+    assert len(events) == 1
+    e = events[0]
+    assert e["event"] == "session_recall"
+    assert e["session_id"] == "sess-r"
+    assert e["entries"] == 1
+    assert e["injected_chars"] > 0 and e["est_tokens"] > 0
+
+
+def test_jit_recall_fire_logs_tool_and_rules(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("ATTUNE_HOME", str(tmp_path / ".attune"))
+    monkeypatch.setenv("ATTUNE_AI_SENTINEL_DIR", str(tmp_path / "sentinels"))
+    _load_module("_state")
+    mod = _load_module("jit_recall")
+    payload = {
+        "hook_event_name": "PreToolUse",
+        "tool_name": "AskUserQuestion",
+        "session_id": "sess-j",
+        "tool_input": {"questions": []},
+    }
+    rc = _run(mod, monkeypatch, payload)
+    assert rc == 0
+    assert "additionalContext" in capsys.readouterr().out
+
+    events = _events(tmp_path)
+    assert len(events) == 1
+    e = events[0]
+    assert e["event"] == "jit_recall"
+    assert e["session_id"] == "sess-j"
+    assert e["tool"] == "AskUserQuestion"
+    assert e["rules"] and all(isinstance(r, str) for r in e["rules"])
+    assert e["injected_chars"] > 0
+
+
+def test_jit_recall_no_match_logs_nothing(tmp_path, monkeypatch):
+    monkeypatch.setenv("ATTUNE_HOME", str(tmp_path / ".attune"))
+    monkeypatch.setenv("ATTUNE_AI_SENTINEL_DIR", str(tmp_path / "sentinels"))
+    _load_module("_state")
+    mod = _load_module("jit_recall")
+    payload = {
+        "hook_event_name": "PreToolUse",
+        "tool_name": "NoSuchTool",
+        "session_id": "sess-j2",
+        "tool_input": {},
+    }
+    assert _run(mod, monkeypatch, payload) == 0
+    assert _events(tmp_path) == []
+
+
+def test_session_stash_logs_counts_and_extractor(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("ATTUNE_HOME", str(tmp_path / ".attune"))
+    monkeypatch.setenv("ATTUNE_AI_SENTINEL_DIR", str(tmp_path / "sentinels"))
+    _load_module("_state")
+    mod = _load_module("session_stash")
+
+    transcript = tmp_path / "t.jsonl"
+    transcript.write_text(
+        json.dumps(
+            {
+                "message": {
+                    "role": "assistant",
+                    "content": "we decided to use the file backend for the stash layer",
+                }
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(mod, "estimate_utilization", lambda _p: 0.9)
+    monkeypatch.setattr(mod, "_extract_via_ollama", lambda _t: None)  # heuristic path
+    monkeypatch.setattr(mod, "_stash_findings", lambda findings, **k: len(findings))
+    payload = {
+        "session_id": "sess-s",
+        "transcript_path": str(transcript),
+        "cwd": str(tmp_path),
+    }
+    assert _run(mod, monkeypatch, payload) == 0
+
+    events = _events(tmp_path)
+    assert len(events) == 1
+    e = events[0]
+    assert e["event"] == "session_stash"
+    assert e["session_id"] == "sess-s"
+    assert e["extractor"] == "heuristic"
+    assert e["findings"] >= 1
+    assert e["written"] == e["findings"]
+    assert e["injected_chars"] > 0  # additionalContext summary was emitted


### PR DESCRIPTION
## Why

The Redis short-term memory layer (session recall at the door, JIT rule recall at the decision point, the Stop-hook stash) had no telemetry measuring its own token/cost impact — the 2026-07-06 cost-savings analysis had to **model** the counterfactuals instead of measuring them.

## What

**New `plugin/hooks/_memory_telemetry.py`** — a best-effort, never-raising event logger. One JSON line per hook fire to `~/.attune/telemetry/memory_events.jsonl` (`ATTUNE_HOME`-aware), the same local-only style as `usage.jsonl`:

- `v` / `ts` / `event` / `session_id` (truncated to 64 chars)
- `injected_chars` + derived `est_tokens` (4 chars/token)
- event-specific fields (below)

Consent model matches the existing telemetry split: local recording is default-on like `usage.jsonl`; the opt-in usage ping reads only `usage*.jsonl`, so this file **never leaves the machine**. `DO_NOT_TRACK` (the same signal `usage_consent_notice.py` honors) or `ATTUNE_MEMORY_TELEMETRY=0` disables even the local log. 0700 dir, 5 MB rotation backstop.

**Instrumented hooks** (each fire = one event):

| Hook | Fields |
|------|--------|
| `session_recall` | rendered entry count, injected size |
| `jit_recall` | tool name, rule ids, injected size |
| `session_stash` | findings/written counts, extractor (`ollama`/`heuristic`), `additionalContext` size |

- Fires-per-session = group lines by `session_id` + `event` (no separate counter needed).
- Prevented-failure estimation: the `jit_recall` `(tool, rules, ts)` triple lets a later analysis check whether the matching failure still occurred after the rule surfaced.

All logging sits behind guarded imports with a no-op fallback, so a broken/missing helper degrades to exactly today's behavior — the hooks stay best-effort/never-blocking.

## Tests

`tests/unit/hooks/test_memory_telemetry.py` — 12 new tests: helper contract (schema fields, env gates, never-raises on unwritable dir, rotation, session-id truncation) + one integration test per hook proving a fire appends a measurable event. Full hook test files pass: 85 passed.

Not instrumented here: the SessionStart hydration script lives at `~/.attune/memory/session_hydrate.py` (personal infra, outside this repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
