### PR TITLE
release: attune-ai 10.0.2 — hook portability (python -> python3)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "Spec-driven development for Claude Code — take an idea through requirements, design, tasks, and gated execution with an approval loop. Plus 23 auto-triggering skills: security audits, code review, test generation, release prep.",
-    "version": "10.0.1"
+    "version": "10.0.2"
   },
   "plugins": [
     {
       "name": "attune-ai",
       "description": "Spec-driven development is the core workflow: /spec carries an idea through brainstorm, requirements, design, and task execution with quality gates and your approval at each stage. Backed by 23 auto-triggering skills — security audits, code reviews, test generation, bug prediction, and release preparation. For help content tools, also install attune-help and attune-author from this marketplace.",
       "source": "./plugin",
-      "version": "10.0.1",
+      "version": "10.0.2",
       "author": {
         "name": "Smart AI Memory",
         "email": "patrick.roebuck@smartaimemory.com"

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,4 +1,4 @@
-# Attune AI Framework v10.0.1
+# Attune AI Framework v10.0.2
 
 AI-powered developer workflows with cost optimization and multi-agent orchestration.
 
@@ -148,7 +148,7 @@ attune_redis/          # attune-redis plugin (pip install attune-redis)
 
 ---
 
-**Version:** 10.0.1 | **License:** Apache 2.0 | **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)
+**Version:** 10.0.2 | **License:** Apache 2.0 | **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)
 
 ## Lessons — core
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [10.0.2] — 2026-07-06
+
+Hook-portability patch: plugin hooks now launch with `python3` instead
+of `python`. On stock macOS and many Linux distros no `python` shim
+exists, so every hook (memory stash/recall, jit-recall, security guard)
+silently no-opped for users installing from the marketplace. Surfaced
+by the pre-submission sweep for the plugin-marketplace listing.
+
+### Fixed
+
+- **plugin hooks: `python` → `python3`** in all 13 hook commands in
+  `plugin/hooks/hooks.json`, plus the `/handoff` command's
+  `allowed-tools` and helper invocation — hooks now work on machines
+  without a `python` alias. (`.mcp.json` is unaffected: its `python`
+  resolves inside the uvx-managed environment, not the system PATH.)
+
 ## [10.0.1] — 2026-07-06
 
 Memory-suite quality patch: three defects surfaced by a live dogfood

--- a/docs/reference/API_REFERENCE.md
+++ b/docs/reference/API_REFERENCE.md
@@ -1,6 +1,6 @@
 # Attune AI API Reference
 
-**Version:** 10.0.1
+**Version:** 10.0.2
 **License:** Apache License 2.0
 **Copyright:** 2025-2026 Smart AI Memory, LLC
 
@@ -1152,5 +1152,5 @@ msg = format_error(
 
 ---
 
-**Version:** 10.0.1 | **License:** Apache 2.0
+**Version:** 10.0.2 | **License:** Apache 2.0
 **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)

--- a/plugin/.claude-plugin/marketplace.json
+++ b/plugin/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "Spec-driven development for Claude Code — /spec plans, reviews, and executes with quality gates; plus security audits, code reviews, test generation, and release prep from /attune.",
-    "version": "10.0.1"
+    "version": "10.0.2"
   },
   "plugins": [
     {
       "name": "attune-ai",
       "description": "Spec-driven development for Claude Code — /spec plans, reviews, and executes with quality gates; plus security audits, code reviews, test generation, and release prep from /attune.",
       "source": "./",
-      "version": "10.0.1",
+      "version": "10.0.2",
       "author": {
         "name": "Smart AI Memory",
         "email": "patrick.roebuck@smartaimemory.com"

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "attune-ai",
-  "version": "10.0.1",
+  "version": "10.0.2",
   "description": "Spec-driven development for Claude Code — /spec plans, reviews, and executes with quality gates; plus security audits, code reviews, test generation, and release prep from /attune.",
   "author": {
     "name": "Smart AI Memory",

--- a/plugin/commands/handoff.md
+++ b/plugin/commands/handoff.md
@@ -1,6 +1,6 @@
 ---
 description: Generate a copy-pasteable resume prompt for a fresh Claude Code session
-allowed-tools: Bash(python:*)
+allowed-tools: Bash(python3:*)
 ---
 
 You are generating a *resume prompt* the user will copy into a
@@ -9,7 +9,7 @@ new Claude Code session to pick up where this one left off.
 Run the helper to produce the resume prompt:
 
 ```bash
-python "${CLAUDE_PLUGIN_ROOT}/hooks/_handoff_cli.py"
+python3 "${CLAUDE_PLUGIN_ROOT}/hooks/_handoff_cli.py"
 ```
 
 Print the helper's stdout **verbatim** as your reply. Do not add

--- a/plugin/core/__init__.py
+++ b/plugin/core/__init__.py
@@ -5,4 +5,4 @@ This module provides the core workflow functionality when the full
 attune-ai package is not installed via pip.
 """
 
-__version__ = "10.0.1"
+__version__ = "10.0.2"

--- a/plugin/hooks/hooks.json
+++ b/plugin/hooks/hooks.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python ${CLAUDE_PLUGIN_ROOT}/hooks/welcome.py",
+            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/welcome.py",
             "timeout": 3000
           }
         ]
@@ -14,7 +14,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python ${CLAUDE_PLUGIN_ROOT}/hooks/usage_consent_notice.py",
+            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/usage_consent_notice.py",
             "timeout": 2000
           }
         ]
@@ -23,7 +23,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python ${CLAUDE_PLUGIN_ROOT}/hooks/spec_orient.py",
+            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/spec_orient.py",
             "timeout": 4000
           }
         ]
@@ -32,7 +32,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python ${CLAUDE_PLUGIN_ROOT}/hooks/session_recall.py",
+            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/session_recall.py",
             "timeout": 3000
           }
         ]
@@ -43,7 +43,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python ${CLAUDE_PLUGIN_ROOT}/hooks/compact_warning.py",
+            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/compact_warning.py",
             "timeout": 4000
           }
         ]
@@ -52,7 +52,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python ${CLAUDE_PLUGIN_ROOT}/hooks/session_stash.py",
+            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/session_stash.py",
             "timeout": 15000
           }
         ]
@@ -64,7 +64,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python ${CLAUDE_PLUGIN_ROOT}/hooks/jit_recall.py",
+            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/jit_recall.py",
             "timeout": 3000
           }
         ]
@@ -74,7 +74,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python ${CLAUDE_PLUGIN_ROOT}/hooks/security_guard.py",
+            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/security_guard.py",
             "timeout": 5000
           }
         ]
@@ -84,7 +84,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python ${CLAUDE_PLUGIN_ROOT}/hooks/security_guard.py",
+            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/security_guard.py",
             "timeout": 5000
           }
         ]
@@ -96,7 +96,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python ${CLAUDE_PLUGIN_ROOT}/hooks/format_on_save.py",
+            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/format_on_save.py",
             "timeout": 10000
           }
         ]
@@ -106,7 +106,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python ${CLAUDE_PLUGIN_ROOT}/hooks/help_on_error.py",
+            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/help_on_error.py",
             "timeout": 3000
           }
         ]
@@ -116,7 +116,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python ${CLAUDE_PLUGIN_ROOT}/hooks/help_post_commit.py",
+            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/help_post_commit.py",
             "timeout": 5000
           }
         ]
@@ -127,7 +127,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python ${CLAUDE_PLUGIN_ROOT}/hooks/lesson_recall.py",
+            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/lesson_recall.py",
             "timeout": 5000
           }
         ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "attune-ai"
-version = "10.0.1"
+version = "10.0.2"
 description = "AI-powered developer workflows for Claude with cost optimization, multi-agent orchestration, and workflow automation."
 readme = {file = "README.md", content-type = "text/markdown"}
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -253,7 +253,7 @@ wheels = [
 
 [[package]]
 name = "attune-ai"
-version = "10.0.1"
+version = "10.0.2"
 source = { editable = "." }
 dependencies = [
     { name = "agent-memory-client" },

--- a/website/app/page.tsx
+++ b/website/app/page.tsx
@@ -58,7 +58,7 @@ export default function Home() {
             <div className="grid lg:grid-cols-2 gap-16 items-center">
               <div className="z-10">
                 <div className="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-[var(--surface-container-high)] text-[var(--primary)] text-xs font-bold tracking-widest mb-6 uppercase">
-                  <span>v10.0.1</span>
+                  <span>v10.0.2</span>
                   <span className="w-1 h-1 rounded-full bg-[var(--primary)]"></span>
                   <span className="opacity-80">Spec-driven development platform</span>
                 </div>

--- a/website/lib/features.ts
+++ b/website/lib/features.ts
@@ -32,7 +32,7 @@ export const PRODUCTS: Product[] = [
     id: "attune-ai",
     name: "Attune AI",
     pypiName: "attune-ai",
-    version: "10.0.1",
+    version: "10.0.2",
     tagline: "Generate, maintain, and serve help from your code",
     installCommand: "pip install attune-ai",
     marketplaceInstall:
@@ -101,7 +101,7 @@ export const PRODUCTS: Product[] = [
     id: "claude-code-plugin",
     name: "Claude Code Plugin",
     pypiName: "attune-ai",
-    version: "10.0.1",
+    version: "10.0.2",
     tagline: "Progressive help right in your terminal",
     installCommand:
       "claude plugin marketplace add Smart-AI-Memory/attune-ai",


### PR DESCRIPTION
## Summary

Patch release. All 13 hook commands in `plugin/hooks/hooks.json` invoked hooks via `python`, which doesn't exist on stock macOS and many Linux distros — every hook (memory stash/recall, jit-recall, security guard) **silently no-opped** for marketplace installs. Found by the plugin-marketplace pre-submission sweep.

## Changes
- `python` → `python3` in all 13 hook commands (`plugin/hooks/hooks.json`) and the `/handoff` command (`allowed-tools` + helper invocation)
- `.mcp.json` intentionally unchanged — its `python` resolves inside the uvx-managed env, not system PATH
- Version bump 10.0.1 → 10.0.2 across 9 sites (`scripts/bump_version.py`), changelog promoted, `uv.lock` self-version line

🤖 Generated with [Claude Code](https://claude.com/claude-code)