### PR TITLE
docs(ci-runner-hang): exit-139 №3 evidence + windows-exit139-segfault class split

### DIFF
--- a/docs/specs/ci-runner-hang/decisions.md
+++ b/docs/specs/ci-runner-hang/decisions.md
@@ -156,3 +156,24 @@ outcome — Phase 1's diagnostics + fast-fail already retire most of the
 intervention tax. Mark the spec `monitoring` and let the next captured
 stack reopen Phase 2. Tar-pit guard: do not chase an unreproducible
 hang past two investigation attempts.
+
+---
+
+## D-2026-07-06: exit-139 split into its own tracked class
+
+The 5th capture's tripwire (third exit-139 sighting) fired on run
+`28806701681` (PR #1279) — and the capture also met the standing
+reopen criterion (a test frame in a complete worker dump). Decision:
+
+- **Split**, don't reopen: the exit-139 class now lives at
+  `docs/specs/windows-exit139-segfault/` with a confirmed H1/H2
+  mechanism (unit test → unmocked `UnifiedMemory` → live
+  `getaddrinfo("localhost")` in redis-py `_connect`, not bounded by
+  `socket_connect_timeout`) and a narrow fix plan per step 4 above.
+- **This spec stays `monitoring`** for the original end-of-session
+  wedge (captures 1–4): still no test frame, still unreproducible,
+  tar-pit guard still applies.
+- Rationale for the split over a reopen: the two shapes now have
+  different mechanisms, different evidence quality, and different
+  dispositions (fixable vs monitored) — one spec status can't honestly
+  cover both.

--- a/docs/specs/ci-runner-hang/evidence/run-28806701681/hang-controller-proc.txt
+++ b/docs/specs/ci-runner-hang/evidence/run-28806701681/hang-controller-proc.txt
@@ -1,0 +1,5 @@
+# ci-runner-hang process-state probe (worker=controller pid=4400 ppid=1744)
+## socket-inode -> pid map (all /proc)
+## ps tree
+ps: unknown option -- w
+Try `ps --help' for more information.

--- a/docs/specs/ci-runner-hang/evidence/run-28806701681/hang-controller.txt
+++ b/docs/specs/ci-runner-hang/evidence/run-28806701681/hang-controller.txt
@@ -1,0 +1,33 @@
+Timeout (0:20:00)!
+Thread 0x00001b20 (most recent call first):
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\execnet\gateway_base.py", line 534 in read
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\execnet\gateway_base.py", line 567 in from_io
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\execnet\gateway_base.py", line 1160 in _thread_receiver
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\execnet\gateway_base.py", line 341 in run
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\execnet\gateway_base.py", line 411 in _perform_spawn
+
+Thread 0x00001e98 (most recent call first):
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\execnet\gateway_base.py", line 534 in read
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\execnet\gateway_base.py", line 567 in from_io
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\execnet\gateway_base.py", line 1160 in _thread_receiver
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\execnet\gateway_base.py", line 341 in run
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\execnet\gateway_base.py", line 411 in _perform_spawn
+
+Thread 0x00001858 (most recent call first):
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\execnet\gateway_base.py", line 534 in read
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\execnet\gateway_base.py", line 567 in from_io
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\execnet\gateway_base.py", line 1160 in _thread_receiver
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\execnet\gateway_base.py", line 341 in run
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\execnet\gateway_base.py", line 411 in _perform_spawn
+
+Thread 0x00001f34 (most recent call first):
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\execnet\gateway_base.py", line 534 in read
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\execnet\gateway_base.py", line 567 in from_io
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\execnet\gateway_base.py", line 1160 in _thread_receiver
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\execnet\gateway_base.py", line 341 in run
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\execnet\gateway_base.py", line 411 in _perform_spawn
+
+Thread 0x00000750 (most recent call first):
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\re\_parser.py", line 260 in _parse
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\re\_parser.py", line 171 in __getitem__
+  File

--- a/docs/specs/ci-runner-hang/evidence/run-28806701681/hang-gw0-proc.txt
+++ b/docs/specs/ci-runner-hang/evidence/run-28806701681/hang-gw0-proc.txt
@@ -1,0 +1,4 @@
+# ci-runner-hang process-state probe (worker=gw0 pid=7588 ppid=4400)
+## ps tree
+ps: unknown option -- w
+Try `ps --help' for more information.

--- a/docs/specs/ci-runner-hang/evidence/run-28806701681/hang-gw0.txt
+++ b/docs/specs/ci-runner-hang/evidence/run-28806701681/hang-gw0.txt
@@ -1,0 +1,107 @@
+Timeout (0:20:00)!
+Thread 0x00001924 (most recent call first):
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\subprocess.py", line 1599 in _readerthread
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\threading.py", line 1012 in run
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\threading.py", line 1075 in _bootstrap_inner
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\threading.py", line 1032 in _bootstrap
+
+Thread 0x00000ed8 (most recent call first):
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\subprocess.py", line 1599 in _readerthread
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\threading.py", line 1012 in run
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\threading.py", line 1075 in _bootstrap_inner
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\threading.py", line 1032 in _bootstrap
+
+Thread 0x0000077c (most recent call first):
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\threading.py", line 359 in wait
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\threading.py", line 655 in wait
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\threading.py", line 1431 in run
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\threading.py", line 1075 in _bootstrap_inner
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\threading.py", line 1032 in _bootstrap
+
+Thread 0x00001610 (most recent call first):
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\asyncio\windows_events.py", line 774 in _poll
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\asyncio\windows_events.py", line 445 in select
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\asyncio\base_events.py", line 1961 in _run_once
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\asyncio\base_events.py", line 645 in run_forever
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\asyncio\windows_events.py", line 322 in run_forever
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\threading.py", line 1012 in run
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\threading.py", line 1075 in _bootstrap_inner
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\threading.py", line 1032 in _bootstrap
+
+Thread 0x00001f9c (most recent call first):
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\threading.py", line 1169 in _wait_for_tstate_lock
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\threading.py", line 1153 in join
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\subprocess.py", line 1628 in _communicate
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\subprocess.py", line 1209 in communicate
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\subprocess.py", line 550 in run
+  File "D:\a\attune-ai\attune-ai\tests\conftest.py", line 170 in _dump_process_state
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\threading.py", line 1433 in run
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\threading.py", line 1075 in _bootstrap_inner
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\threading.py", line 1032 in _bootstrap
+
+Thread 0x000020c8 (most recent call first):
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\threading.py", line 359 in wait
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\threading.py", line 655 in wait
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\execnet\gateway_base.py", line 470 in waitall
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\execnet\gateway_base.py", line 1239 in _terminate_execution
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\execnet\gateway_base.py", line 1176 in _thread_receiver
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\execnet\gateway_base.py", line 341 in run
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\execnet\gateway_base.py", line 411 in _perform_spawn
+
+Thread 0x00002274 (most recent call first):
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\redis\connection.py", line 1566 in _connect
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\redis\connection.py", line 1034 in connect_check_health
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\redis\connection.py", line 1008 in <lambda>
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\redis\retry.py", line 120 in call_with_retry
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\redis\connection.py", line 1007 in connect
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\redis\connection.py", line 3163 in get_connection
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\redis\utils.py", line 258 in wrapper
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\redis\client.py", line 804 in _execute_command
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\redis\client.py", line 798 in execute_command
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\redis\commands\core.py", line 2031 in ping
+  File "D:\a\attune-ai\attune-ai\src\attune\memory\features.py", line 96 in is_redis_running
+  File "D:\a\attune-ai\attune-ai\src\attune\memory\features.py", line 147 in get_feature_status
+  File "D:\a\attune-ai\attune-ai\src\attune\memory\features.py", line 183 in check_redis
+  File "D:\a\attune-ai\attune-ai\src\attune\memory\short_term\facade.py", line 161 in __init__
+  File "D:\a\attune-ai\attune-ai\src\attune\memory\config.py", line 110 in get_redis_memory
+  File "D:\a\attune-ai\attune-ai\src\attune\memory\mixins\backend_init_mixin.py", line 129 in _initialize_backends
+  File "D:\a\attune-ai\attune-ai\src\attune\memory\unified.py", line 190 in __post_init__
+  File "<string>", line 7 in __init__
+  File "D:\a\attune-ai\attune-ai\tests\unit\meta_workflows\test_session_context.py", line 252 in test_record_execution_success
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\_pytest\python.py", line 167 in pytest_pyfunc_call
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\pluggy\_callers.py", line 121 in _multicall
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\pluggy\_manager.py", line 120 in _hookexec
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\pluggy\_hooks.py", line 512 in __call__
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\_pytest\python.py", line 1707 in runtest
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\_pytest\runner.py", line 184 in pytest_runtest_call
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\pluggy\_callers.py", line 121 in _multicall
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\pluggy\_manager.py", line 120 in _hookexec
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\pluggy\_hooks.py", line 512 in __call__
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\_pytest\runner.py", line 250 in <lambda>
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\_pytest\runner.py", line 361 in from_call
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\_pytest\runner.py", line 249 in call_and_report
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\_pytest\runner.py", line 139 in runtestprotocol
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\_pytest\runner.py", line 118 in pytest_runtest_protocol
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\pluggy\_callers.py", line 121 in _multicall
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\pluggy\_manager.py", line 120 in _hookexec
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\pluggy\_hooks.py", line 512 in __call__
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\xdist\remote.py", line 227 in run_one_test
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\xdist\remote.py", line 206 in pytest_runtestloop
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\pluggy\_callers.py", line 121 in _multicall
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\pluggy\_manager.py", line 120 in _hookexec
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\pluggy\_hooks.py", line 512 in __call__
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\_pytest\main.py", line 384 in _main
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\_pytest\main.py", line 330 in wrap_session
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\_pytest\main.py", line 377 in pytest_cmdline_main
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\pluggy\_callers.py", line 121 in _multicall
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\pluggy\_manager.py", line 120 in _hookexec
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\pluggy\_hooks.py", line 512 in __call__
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\xdist\remote.py", line 427 in <module>
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\execnet\gateway_base.py", line 1291 in executetask
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\execnet\gateway_base.py", line 341 in run
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\execnet\gateway_base.py", line 411 in _perform_spawn
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\execnet\gateway_base.py", line 389 in integrate_as_primary_thread
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\execnet\gateway_base.py", line 1273 in serve
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\execnet\gateway_base.py", line 1806 in serve
+  File "<string>", line 8 in <module>
+  File "<string>", line 1 in <module>

--- a/docs/specs/ci-runner-hang/phase2-findings.md
+++ b/docs/specs/ci-runner-hang/phase2-findings.md
@@ -478,3 +478,73 @@ unchanged, plus one addition: if a THIRD exit-139 arrives, consider
 splitting "Windows teardown segfault" into its own tracked class —
 two sightings in two days on the same lane suggests it may recur at
 a higher rate than the wedge itself.
+
+---
+
+## Monitoring log — 6th capture: exit-139 №3, and this one has a TEST FRAME (2026-07-06)
+
+PR #1279's `test (windows-latest, 3.12)` lane (run `28806701681`,
+attempt 1) died with **exit 139** after the 20-min watchdog fired.
+Dumps saved under [evidence/run-28806701681/](evidence/run-28806701681/).
+Third exit-139 sighting — the 5th-capture tripwire fires. But unlike
+every prior capture, **this one satisfies the reopen criterion**: the
+worker dump is complete and its main thread is inside a test, not
+end-of-session.
+
+### Timeline (from the job log)
+
+- Other workers progressed to **96%**, everything passing (last
+  `PASSED` 16:47:00Z) while gw0 sat wedged.
+- 16:47:33Z: `558 Segmentation fault   pytest -n auto --timeout=60
+  --timeout-method=thread …` → exit 139 at 16:47:38Z.
+- The `if: always()` upload preserved the dumps (artifact
+  `8115726398`) — controller + gw0 only; gw1–3 watchdogs never fired.
+
+### What the stacks show — the polluter has a name
+
+- **gw0 main thread (complete stack, no truncation):**
+  `tests/unit/meta_workflows/test_session_context.py:252
+  test_record_execution_success` → `UnifiedMemory(user_id="test_user")`
+  → `unified.py:190 __post_init__` → `backend_init_mixin.py:129`
+  → `config.py:110 get_redis_memory` → `short_term/facade.py:161`
+  → `features.py:96 is_redis_running` → `redis …
+  connection.py:1566 _connect` — **blocked in a live Redis connect,
+  inside a unit test, in the `not network` lane, for 20 minutes.**
+- **The 1s connect timeout was set and didn't help.**
+  `features.py:95` passes `socket_connect_timeout=1`, but that bounds
+  the socket phase only — the `getaddrinfo("localhost")` resolution
+  inside `_connect` runs BEFORE any socket timeout applies. A 20-min
+  block with a 1s timeout in force is only explicable in the
+  pre-timeout phase. This **confirms the #1272 getaddrinfo
+  hypothesis** at a production call site: #1272's literal-loopback fix
+  patched one TEST probe (`test_redis_bootstrap.py`); the
+  `host="localhost"` defaults across `src/attune/memory/` (unified.py,
+  features.py, redis_bootstrap.py, short_term/facade.py,
+  redis_auto_detect.py, control_panel*.py, types.py) were untouched.
+- **Controller:** the stable H4 `_thread_receiver` signature, and the
+  main thread again cut off in `re/_parser` — second consecutive
+  capture where the segfault killed the process while faulthandler
+  was writing. The dump machinery's own probe threads
+  (`conftest.py:170 _dump_process_state`, `subprocess._readerthread`)
+  are visible in gw0.
+- **PR #1279 is exonerated:** it touches `plugin/hooks/` only;
+  `test_record_execution_success` and the unmocked `UnifiedMemory`
+  init path are on `main`.
+
+### Classification and disposition
+
+Per decisions.md step 3 this is the **H1/H2 I/O-polluter family** —
+a worker wedged in a C-level socket call — now confirmed with a named
+frame, not inferred. The tar-pit rationale ("no test frame, nothing
+fixable") no longer holds for this class:
+
+- **Tripwire executed:** exit-139 splits into its own tracked class →
+  [../windows-exit139-segfault/](../windows-exit139-segfault/README.md).
+- **This spec stays `monitoring`** for the original end-of-session
+  wedge (captures 1–4, whose shape remains unexplained and
+  unreproducible). The new class carries the fixable hypothesis and
+  the narrow fix per decisions.md step 4.
+
+**Monitoring tally: 6 captures** (3 Linux timeout-kill, 1 Windows
+timeout-kill, 2 Windows exit-139 — both now filed under the split
+class, which also claims the #1272 sighting as its first).

--- a/docs/specs/windows-exit139-segfault/README.md
+++ b/docs/specs/windows-exit139-segfault/README.md
@@ -1,0 +1,64 @@
+# windows-exit139-segfault — tracked failure class
+
+**Status:** open — fixable hypothesis confirmed (2026-07-06)
+**Split from:** [ci-runner-hang](../ci-runner-hang/) per the 5th-capture
+tripwire ("if a THIRD exit-139 arrives, consider splitting"). The third
+arrived within 24 hours of the second, on the same lane.
+
+## Class signature
+
+`test (windows-latest, 3.12)`: pytest run wedges, the 20-minute
+conftest watchdog fires and writes faulthandler dumps, then the pytest
+process dies with **exit 139 (segfault)** — twice now *while
+faulthandler was mid-write* (controller dump truncated in
+`re/_parser`). Distinct from the parent spec's end-of-session wedge
+(exit 124 timeout-kill, workers idle in `serve()`).
+
+## Sightings
+
+| # | Date | Run | Where | Evidence |
+|---|------|-----|-------|----------|
+| 1 | 2026-07-05 | 10.0.1 release chain | #1272 | clean-log; getaddrinfo hypothesis formed, literal-loopback fix applied to the bootstrap-probe test |
+| 2 | 2026-07-06 | `28772959348` | PR #1274 | [ci-runner-hang capture #5](../ci-runner-hang/evidence/run-28772959348/) — end-of-session shape, controller dump truncated, worker dumps empty |
+| 3 | 2026-07-06 | `28806701681` | PR #1279 | [ci-runner-hang capture #6](../ci-runner-hang/evidence/run-28806701681/) — **complete worker dump with a test frame** |
+
+## Confirmed mechanism (sighting 3)
+
+`test_session_context.py::test_record_execution_success` constructs
+`UnifiedMemory(user_id="test_user")` unmocked → real backend init →
+`features.is_redis_running(host="localhost")` → redis-py `_connect` —
+**blocked 20 minutes despite `socket_connect_timeout=1`**. The socket
+timeout bounds only the socket phase; `getaddrinfo("localhost")` runs
+before it and is not interruptible by `--timeout-method=thread` (a
+C-level call — exactly decisions.md step 3's H1/H2 I/O-polluter
+family). When the runner's resolver stalls, the worker wedges; the
+watchdog fires; the subsequent segfault during dump/teardown produces
+exit 139.
+
+#1272 fixed one test probe. The `host="localhost"` defaults remain at
+production call sites in `src/attune/memory/`: `unified.py` (77, 133),
+`features.py` (78), `redis_bootstrap.py` (61, 67),
+`short_term/facade.py` (134), `redis_auto_detect.py` (163),
+`control_panel.py` (92), `control_panel_api.py` (308), `types.py` (71).
+Any unit test that builds `UnifiedMemory` without mocking walks into
+the same resolver.
+
+## Fix plan (narrow, per parent decisions.md step 4)
+
+1. **Default the memory stack's Redis host to the literal loopback**
+   `127.0.0.1` (or resolve-once-and-cache), eliminating per-call
+   `getaddrinfo` on the default path. Env-provided hosts unchanged.
+2. **Test-lane belt-and-suspenders:** set `REDIS_HOST=127.0.0.1` in
+   `tests/conftest.py` so no unit test ever name-resolves, even where
+   a future call site regresses.
+3. Do **not** chase the segfault-during-faulthandler itself — it is
+   downstream of the wedge (interpreter/teardown internals); with no
+   wedge there is no dump to segfault in.
+
+**Verification bar (parent design.md G3):** the wedge is intermittent —
+require ≥10 clean `windows-latest` reruns under `-n auto` after the
+fix, and no new exit-139 sighting over a monitoring window.
+
+**Reopen/expand criteria:** an exit-139 with the fix in place and no
+`getaddrinfo`/connect frame in the dump means a second mechanism —
+capture and re-classify here, don't fold it back into ci-runner-hang.


### PR DESCRIPTION
## Summary

Third exit-139 sighting (run 28806701681, on #1279's windows-latest 3.12 lane) — the 5th-capture tripwire fires, and this capture **also meets the standing reopen criterion**: the worker dump is complete with a test frame.

**The polluter has a name.** `test_session_context.py::test_record_execution_success` builds `UnifiedMemory` unmocked → `is_redis_running("localhost")` → blocked **20 minutes** in redis-py `_connect` *despite* `socket_connect_timeout=1` — only the pre-timeout `getaddrinfo` phase explains that, confirming #1272's hypothesis at production call sites (that fix covered one test probe; ~10 `host="localhost"` defaults remain in `src/attune/memory/`).

## Changes
- Evidence: `docs/specs/ci-runner-hang/evidence/run-28806701681/` (controller + gw0 dumps, artifact 8115726398)
- `phase2-findings.md`: 6th-capture monitoring entry; tally 5 → 6
- `decisions.md`: D-2026-07-06 — split, don't reopen (two shapes, two mechanisms, two dispositions)
- **New tracked class:** `docs/specs/windows-exit139-segfault/README.md` — open, fixable; fix plan = loopback-literal defaults + conftest `REDIS_HOST=127.0.0.1`, verification bar ≥10 clean reruns

Docs + evidence only — the fix itself is a follow-up code PR. #1279 is exonerated (touches `plugin/hooks/` only; the trap is on main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)