### PR TITLE
fix(memory): literal loopback defaults — stop getaddrinfo wedging Windows CI workers

### DIFF
--- a/src/attune/memory/config.py
+++ b/src/attune/memory/config.py
@@ -29,7 +29,7 @@ def parse_redis_url(url: str) -> dict:
     parsed = urlparse(url)
 
     return {
-        "host": parsed.hostname or "localhost",
+        "host": parsed.hostname or "127.0.0.1",
         "port": parsed.port or 6379,
         "password": parsed.password,
         "db": int(parsed.path.lstrip("/") or 0) if parsed.path else 0,
@@ -80,7 +80,7 @@ def get_redis_memory(
         memory = get_redis_memory()
 
         # Explicit URL
-        memory = get_redis_memory(url="redis://localhost:6379")
+        memory = get_redis_memory(url="redis://127.0.0.1:6379")
 
         # Force mock mode
         memory = get_redis_memory(use_mock=True)

--- a/src/attune/memory/control_panel.py
+++ b/src/attune/memory/control_panel.py
@@ -89,7 +89,7 @@ logger = structlog.get_logger(__name__)
 class ControlPanelConfig:
     """Configuration for control panel."""
 
-    redis_host: str = "localhost"
+    redis_host: str = "127.0.0.1"
     redis_port: int = 6379
     storage_dir: str = "./memdocs_storage"
     audit_dir: str = "./logs"

--- a/src/attune/memory/control_panel_api.py
+++ b/src/attune/memory/control_panel_api.py
@@ -305,7 +305,7 @@ class MemoryAPIHandler(BaseHTTPRequestHandler):
 
 def run_api_server(
     panel: MemoryControlPanel,
-    host: str = "localhost",
+    host: str = "127.0.0.1",
     port: int = 8765,
     api_key: str | None = None,
     enable_rate_limit: bool = True,

--- a/src/attune/memory/control_panel_display.py
+++ b/src/attune/memory/control_panel_display.py
@@ -176,7 +176,7 @@ Quick Start:
     )
     parser.add_argument(
         "--host",
-        default="localhost",
+        default="127.0.0.1",
         help="Redis host (or API host for 'api' command)",
     )
     parser.add_argument("--port", type=int, default=6379, help="Redis port")

--- a/src/attune/memory/features.py
+++ b/src/attune/memory/features.py
@@ -75,11 +75,14 @@ class MemoryFeatures:
             return False
 
     @staticmethod
-    def is_redis_running(host: str = "localhost", port: int = 6379) -> bool:
+    def is_redis_running(host: str = "127.0.0.1", port: int = 6379) -> bool:
         """Check if Redis server is running and accessible.
 
         Args:
-            host: Redis host (default: localhost)
+            host: Redis host (default: 127.0.0.1 — literal loopback, not
+                "localhost": getaddrinfo runs before socket timeouts
+                apply and has wedged Windows CI workers for 20 minutes;
+                see docs/specs/windows-exit139-segfault/)
             port: Redis port (default: 6379)
 
         Returns:

--- a/src/attune/memory/recall_digest.py
+++ b/src/attune/memory/recall_digest.py
@@ -45,7 +45,7 @@ def fetch_digest_nodes(count: int = 9, client: Any = None) -> list[dict[str, Any
         count: How many nodes to request (most-recent first).
         client: An optional connected ``redis.Redis`` client. When None,
             one is created from ``REDIS_URL`` (default
-            ``redis://localhost:6379/0``).
+            ``redis://127.0.0.1:6379/0``).
 
     Returns:
         A list of node dicts (``name``, ``type``, ``description``,
@@ -60,7 +60,7 @@ def fetch_digest_nodes(count: int = 9, client: Any = None) -> list[dict[str, Any
     if client is None:
         import redis  # noqa: PLC0415 — optional dependency, import at use
 
-        url = os.environ.get("REDIS_URL", "redis://localhost:6379/0")
+        url = os.environ.get("REDIS_URL", "redis://127.0.0.1:6379/0")
         client = redis.Redis.from_url(url, decode_responses=True)
 
     raw = client.fcall(DIGEST_FUNCTION, 0, str(count))

--- a/src/attune/memory/redis_auto_detect.py
+++ b/src/attune/memory/redis_auto_detect.py
@@ -160,7 +160,7 @@ class RedisAutoDetector:
         except ImportError:
             return False
 
-    def _check_server_reachable(self, host: str = "localhost", port: int = 6379) -> bool:
+    def _check_server_reachable(self, host: str = "127.0.0.1", port: int = 6379) -> bool:
         """Check if Redis server responds to ping.
 
         Uses a short timeout to avoid slowing down CLI startup.

--- a/src/attune/memory/redis_bootstrap.py
+++ b/src/attune/memory/redis_bootstrap.py
@@ -58,13 +58,13 @@ class RedisStatus:
 
     available: bool
     method: RedisStartMethod
-    host: str = "localhost"
+    host: str = "127.0.0.1"
     port: int = 6379
     message: str = ""
     pid: int | None = None
 
 
-def _check_redis_running(host: str = "localhost", port: int = 6379) -> bool:
+def _check_redis_running(host: str = "127.0.0.1", port: int = 6379) -> bool:
     """Check if Redis is responding to ping."""
     try:
         import redis
@@ -344,7 +344,7 @@ def _start_via_wsl() -> bool:
 
 
 def ensure_redis(
-    host: str = "localhost",
+    host: str = "127.0.0.1",
     port: int = 6379,
     auto_start: bool = True,
     verbose: bool = True,
@@ -574,7 +574,7 @@ def stop_redis(method: RedisStartMethod) -> bool:
 
 
 # Convenience function for simple usage
-def get_redis_or_mock(host: str = "localhost", port: int = 6379):
+def get_redis_or_mock(host: str = "127.0.0.1", port: int = 6379):
     """Get a Redis connection, starting Redis if needed, or return mock.
 
     Returns:

--- a/src/attune/memory/short_term/base.py
+++ b/src/attune/memory/short_term/base.py
@@ -102,7 +102,7 @@ class BaseOperations:
 
     def __init__(
         self,
-        host: str = "localhost",
+        host: str = "127.0.0.1",
         port: int = 6379,
         db: int = 0,
         password: str | None = None,
@@ -153,7 +153,7 @@ class BaseOperations:
             else:
                 # Check if caller provided non-default args (backward compatibility)
                 caller_overrode = (
-                    host != "localhost" or port != 6379 or db != 0 or password is not None
+                    host != "127.0.0.1" or port != 6379 or db != 0 or password is not None
                 )
                 if caller_overrode:
                     self._config = RedisConfig(

--- a/src/attune/memory/short_term/facade.py
+++ b/src/attune/memory/short_term/facade.py
@@ -131,7 +131,7 @@ class RedisShortTermMemory:
 
     def __init__(
         self,
-        host: str = "localhost",
+        host: str = "127.0.0.1",
         port: int = 6379,
         db: int = 0,
         password: str | None = None,

--- a/src/attune/memory/types.py
+++ b/src/attune/memory/types.py
@@ -68,7 +68,7 @@ class RedisConfig:
     - Retry with exponential backoff
     """
 
-    host: str = "localhost"
+    host: str = "127.0.0.1"
     port: int = 6379
     db: int = 0
     password: str | None = None

--- a/src/attune/memory/unified.py
+++ b/src/attune/memory/unified.py
@@ -74,7 +74,7 @@ class MemoryConfig:
 
     # Short-term memory settings (Redis - optional enhancement)
     redis_url: str | None = None
-    redis_host: str = "localhost"
+    redis_host: str = "127.0.0.1"
     redis_port: int = 6379
     redis_mock: bool = False
     redis_auto_start: bool = False  # File-first: Redis is optional
@@ -130,7 +130,7 @@ class MemoryConfig:
             file_session_dir=get_attune_env("FILE_SESSION_DIR", ".attune") or ".attune",
             # Redis settings (optional)
             redis_url=os.getenv("REDIS_URL"),
-            redis_host=get_attune_env("REDIS_HOST", "localhost") or "localhost",
+            redis_host=get_attune_env("REDIS_HOST", "127.0.0.1") or "127.0.0.1",
             redis_port=int(get_attune_env("REDIS_PORT", "6379") or "6379"),
             redis_mock=(get_attune_env("REDIS_MOCK", "") or "").lower() == "true",
             redis_auto_start=(get_attune_env("REDIS_AUTO_START", "false") or "false").lower()

--- a/src/attune/redis_config.py
+++ b/src/attune/redis_config.py
@@ -73,7 +73,10 @@ logger = logging.getLogger(__name__)
 REDIS_MODE_CLOUD = "cloud"
 REDIS_MODE_LOCAL = "local"
 _VALID_REDIS_MODES = {REDIS_MODE_CLOUD, REDIS_MODE_LOCAL}
-_LOCAL_HOSTS = {"127.0.0.1", ""}
+# "localhost" stays here for MODE INFERENCE only — it's a plain string
+# compare, no DNS. Local mode then connects with the literal 127.0.0.1,
+# so REDIS_HOST=localhost never reaches getaddrinfo.
+_LOCAL_HOSTS = {"localhost", "127.0.0.1", ""}
 
 
 def _resolve_redis_mode() -> str:

--- a/src/attune/redis_config.py
+++ b/src/attune/redis_config.py
@@ -54,7 +54,7 @@ Usage:
 
     # Or with explicit config
     from attune.memory.short_term import RedisConfig
-    config = RedisConfig(host="localhost", ssl=True)
+    config = RedisConfig(host="127.0.0.1", ssl=True)
     memory = get_redis_memory(config=config)
 
 Copyright 2025 Smart AI Memory, LLC
@@ -73,7 +73,7 @@ logger = logging.getLogger(__name__)
 REDIS_MODE_CLOUD = "cloud"
 REDIS_MODE_LOCAL = "local"
 _VALID_REDIS_MODES = {REDIS_MODE_CLOUD, REDIS_MODE_LOCAL}
-_LOCAL_HOSTS = {"localhost", "127.0.0.1", ""}
+_LOCAL_HOSTS = {"127.0.0.1", ""}
 
 
 def _resolve_redis_mode() -> str:
@@ -130,7 +130,7 @@ def parse_redis_url(url: str) -> dict:
     ssl = parsed.scheme == "rediss"
 
     return {
-        "host": parsed.hostname or "localhost",
+        "host": parsed.hostname or "127.0.0.1",
         "port": parsed.port or 6379,
         "password": parsed.password,
         "db": int(parsed.path.lstrip("/") or 0) if parsed.path else 0,
@@ -203,9 +203,13 @@ def get_redis_config() -> RedisConfig:
     common = _get_common_connection_kwargs()
 
     if mode == REDIS_MODE_LOCAL:
-        # Local mode: localhost, no password, ignore REDIS_PASSWORD
+        # Local mode: loopback, no password, ignore REDIS_PASSWORD.
+        # Literal 127.0.0.1, NOT "localhost": hostname resolution
+        # (getaddrinfo) runs before any socket timeout applies and has
+        # wedged Windows CI workers for 20 minutes
+        # (docs/specs/windows-exit139-segfault/).
         return RedisConfig(
-            host="localhost",
+            host="127.0.0.1",
             port=int(os.getenv("REDIS_PORT", "6379")),
             password=None,
             db=int(os.getenv("REDIS_DB", "0")),
@@ -231,7 +235,7 @@ def get_redis_config() -> RedisConfig:
         )
 
     return RedisConfig(
-        host=host or "localhost",
+        host=host or "127.0.0.1",
         port=int(os.getenv("REDIS_PORT", "6379")),
         password=password,
         db=int(os.getenv("REDIS_DB", "0")),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,6 +29,25 @@ import pydantic.root_model  # noqa: F401  (import for side effect: sys.modules w
 import pytest
 
 # =============================================================================
+# Redis host guard — literal loopback, never a resolvable name
+# (windows-exit139-segfault spec)
+# =============================================================================
+# A unit test that builds the real memory stack (e.g. an unmocked
+# ``UnifiedMemory``) ends up in redis-py's ``_connect``, where
+# ``getaddrinfo("localhost")`` runs BEFORE ``socket_connect_timeout``
+# applies and is uninterruptible by ``--timeout-method=thread``. On a
+# Windows runner with a stalled resolver that wedged a worker for 20
+# minutes (run 28806701681 — dump in
+# docs/specs/windows-exit139-segfault/). Source defaults are now the
+# literal ``127.0.0.1``; this guard covers env-driven paths and any
+# future call site that regresses to a hostname. Runs at conftest
+# import time, so it applies in the xdist controller and every worker.
+# Deliberately NOT overriding an explicit non-default REDIS_HOST — an
+# integration lane pointing at a real server stays functional.
+if os.environ.get("REDIS_HOST", "localhost") in ("localhost", ""):
+    os.environ["REDIS_HOST"] = "127.0.0.1"
+
+# =============================================================================
 # CI hang watchdog (ci-runner-hang spec, Phase 1)
 # =============================================================================
 # The Ubuntu coverage/test lanes intermittently wedge *inside* the pytest

--- a/tests/memory/test_control_panel.py
+++ b/tests/memory/test_control_panel.py
@@ -73,7 +73,7 @@ class TestControlPanelConfig:
     def test_control_panel_config_defaults(self):
         """Test default configuration values"""
         config = ControlPanelConfig()
-        assert config.redis_host == "localhost"
+        assert config.redis_host == "127.0.0.1"
         assert config.redis_port == 6379
         assert config.storage_dir == "./memdocs_storage"
         assert config.audit_dir == "./logs"
@@ -101,7 +101,7 @@ class TestMemoryControlPanelInit:
         """Test initialization with default config"""
         panel = MemoryControlPanel()
         assert panel.config is not None
-        assert panel.config.redis_host == "localhost"
+        assert panel.config.redis_host == "127.0.0.1"
         assert panel._redis_status is None
         assert panel._short_term is None
         assert panel._long_term is None

--- a/tests/memory/test_redis_bootstrap.py
+++ b/tests/memory/test_redis_bootstrap.py
@@ -72,7 +72,7 @@ class TestRedisStatus:
             available=False,
             method=RedisStartMethod.MOCK,
         )
-        assert status.host == "localhost"
+        assert status.host == "127.0.0.1"
         assert status.port == 6379
         assert status.message == ""
         assert status.pid is None

--- a/tests/memory/test_redis_config.py
+++ b/tests/memory/test_redis_config.py
@@ -197,7 +197,7 @@ class TestGetRedisConfig:
 
             try:
                 config = get_redis_config()
-                assert config.host == "localhost"
+                assert config.host == "127.0.0.1"
                 assert config.port == 6379
                 assert config.db == 0
             finally:
@@ -358,7 +358,7 @@ class TestRedisMode:
             assert config.use_mock is False
 
     def test_local_mode_ignores_password(self):
-        """Test local mode uses localhost and ignores REDIS_PASSWORD."""
+        """Test local mode uses literal loopback and ignores REDIS_PASSWORD."""
         env = {
             "REDIS_MODE": "local",
             "REDIS_HOST": "should-be-ignored.com",
@@ -369,7 +369,7 @@ class TestRedisMode:
         }
         with patch.dict(os.environ, env, clear=False):
             config = get_redis_config()
-            assert config.host == "localhost"
+            assert config.host == "127.0.0.1"
             assert config.password is None
             assert config.use_mock is False
 

--- a/tests/memory/test_short_term.py
+++ b/tests/memory/test_short_term.py
@@ -90,7 +90,7 @@ class TestRedisConfig:
     def test_default_values(self):
         """Test RedisConfig default values."""
         config = RedisConfig()
-        assert config.host == "localhost"
+        assert config.host == "127.0.0.1"
         assert config.port == 6379
         assert config.db == 0
         assert config.password is None
@@ -122,7 +122,7 @@ class TestRedisConfig:
         """Test to_redis_kwargs returns correct dict."""
         config = RedisConfig()
         kwargs = config.to_redis_kwargs()
-        assert kwargs["host"] == "localhost"
+        assert kwargs["host"] == "127.0.0.1"
         assert kwargs["port"] == 6379
         assert kwargs["db"] == 0
         assert kwargs["decode_responses"] is True

--- a/tests/memory/test_unified_memory.py
+++ b/tests/memory/test_unified_memory.py
@@ -41,7 +41,7 @@ class TestMemoryConfig:
         """Test default configuration values"""
         config = MemoryConfig()
         assert config.environment == Environment.DEVELOPMENT
-        assert config.redis_host == "localhost"
+        assert config.redis_host == "127.0.0.1"
         assert config.redis_port == 6379
         assert config.redis_mock is False
         assert config.redis_auto_start is False  # File-first: Redis is optional
@@ -106,7 +106,7 @@ class TestMemoryConfig:
         """Test from_environment with no env vars set"""
         config = MemoryConfig.from_environment()
         assert config.environment == Environment.DEVELOPMENT
-        assert config.redis_host == "localhost"
+        assert config.redis_host == "127.0.0.1"
         assert config.redis_mock is False
 
 

--- a/tests/unit/memory/test_backend_init_mixin.py
+++ b/tests/unit/memory/test_backend_init_mixin.py
@@ -26,7 +26,7 @@ class FakeConfig:
     redis_url: str | None = None
     redis_auto_start: bool = False
     redis_required: bool = False
-    redis_host: str = "localhost"
+    redis_host: str = "127.0.0.1"
     redis_port: int = 6379
     claude_memory_enabled: bool = False
     load_enterprise_memory: bool = False

--- a/tests/unit/memory/test_control_panel.py
+++ b/tests/unit/memory/test_control_panel.py
@@ -479,7 +479,7 @@ class TestControlPanelConfig:
     def test_default_initialization(self):
         """Test ControlPanelConfig with default values."""
         config = ControlPanelConfig()
-        assert config.redis_host == "localhost"
+        assert config.redis_host == "127.0.0.1"
         assert config.redis_port == 6379
         assert config.storage_dir == "./memdocs_storage"
         assert config.audit_dir == "./logs"
@@ -512,7 +512,7 @@ class TestMemoryControlPanelInitialization:
         """Test initialization with default config."""
         panel = MemoryControlPanel()
         assert panel.config is not None
-        assert panel.config.redis_host == "localhost"
+        assert panel.config.redis_host == "127.0.0.1"
         assert panel._redis_status is None
         assert panel._short_term is None
         assert panel._long_term is None
@@ -537,7 +537,7 @@ class TestMemoryControlPanelStatus:
 
         assert "timestamp" in status
         assert status["redis"]["status"] == "running"
-        assert status["redis"]["host"] == "localhost"
+        assert status["redis"]["host"] == "127.0.0.1"
         assert status["redis"]["port"] == 6379
 
     @patch("attune.memory.control_panel._check_redis_running")

--- a/tests/unit/memory/test_redis_bootstrap.py
+++ b/tests/unit/memory/test_redis_bootstrap.py
@@ -45,7 +45,7 @@ class TestRedisStatus:
 
         assert status.available is True
         assert status.method == RedisStartMethod.ALREADY_RUNNING
-        assert status.host == "localhost"
+        assert status.host == "127.0.0.1"
         assert status.port == 6379
         assert status.message == ""
         assert status.pid is None
@@ -525,7 +525,7 @@ class TestGetRedisOrMock:
 
         assert status.available is True
         assert memory is mock_memory
-        mock_memory_cls.assert_called_once_with(host="localhost", port=6379, use_mock=False)
+        mock_memory_cls.assert_called_once_with(host="127.0.0.1", port=6379, use_mock=False)
 
     @patch("attune.memory.redis_bootstrap.ensure_redis")
     def test_returns_mock_status_when_unavailable(self, mock_ensure):

--- a/tests/unit/memory/test_types.py
+++ b/tests/unit/memory/test_types.py
@@ -83,7 +83,7 @@ class TestRedisConfig:
         """Test default configuration values."""
         config = RedisConfig()
 
-        assert config.host == "localhost"
+        assert config.host == "127.0.0.1"
         assert config.port == 6379
         assert config.db == 0
         assert config.password is None
@@ -114,7 +114,7 @@ class TestRedisConfig:
         config = RedisConfig()
         kwargs = config.to_redis_kwargs()
 
-        assert kwargs["host"] == "localhost"
+        assert kwargs["host"] == "127.0.0.1"
         assert kwargs["port"] == 6379
         assert kwargs["db"] == 0
         assert kwargs["decode_responses"] is True

--- a/tests/unit/memory/test_unified.py
+++ b/tests/unit/memory/test_unified.py
@@ -56,7 +56,7 @@ class TestMemoryConfig:
 
         assert config.environment == Environment.DEVELOPMENT
         assert config.redis_url is None
-        assert config.redis_host == "localhost"
+        assert config.redis_host == "127.0.0.1"
         assert config.redis_port == 6379
         assert config.redis_mock is False
         assert config.redis_auto_start is False  # File-first: Redis is optional

--- a/tests/unit/test_redis_fallback.py
+++ b/tests/unit/test_redis_fallback.py
@@ -47,7 +47,7 @@ _PATCH_AUTO_DETECT = patch(
 def _redis_running() -> bool:
     """Check if Redis is actually running on localhost."""
     try:
-        r = redis.Redis(host="localhost", port=6379, socket_connect_timeout=1)
+        r = redis.Redis(host="127.0.0.1", port=6379, socket_connect_timeout=1)
         r.ping()
         return True
     except Exception:
@@ -108,7 +108,7 @@ class TestRedisFallbackBehavior:
 
         # Should raise exception after retries exhausted
         with pytest.raises(redis.ConnectionError):
-            _ = RedisShortTermMemory(host="localhost", port=6379)
+            _ = RedisShortTermMemory(host="127.0.0.1", port=6379)
 
         # Verify it attempted to connect
         assert mock_redis_cls.called
@@ -130,7 +130,7 @@ class TestRedisFallbackBehavior:
 
         # Auth errors are not retried (not ConnectionError/TimeoutError)
         with pytest.raises(redis.AuthenticationError):
-            _ = RedisShortTermMemory(host="localhost", port=6379, password="wrong")
+            _ = RedisShortTermMemory(host="127.0.0.1", port=6379, password="wrong")
 
     @patch("attune.memory.redis_auto_detect.RedisAutoDetector")
     @patch("attune.memory.features.MemoryFeatures.check_redis", return_value=True)
@@ -159,7 +159,7 @@ class TestRedisFallbackBehavior:
         mock_redis_cls.return_value = mock_client
 
         # Should succeed after retries
-        memory = RedisShortTermMemory(host="localhost", port=6379)
+        memory = RedisShortTermMemory(host="127.0.0.1", port=6379)
 
         # Verify it retried 3 times
         assert call_count == 3
@@ -168,7 +168,7 @@ class TestRedisFallbackBehavior:
     @patch("attune.memory.short_term.base.REDIS_AVAILABLE", False)
     def test_uses_mock_when_redis_not_installed(self):
         """Test that mock storage is used when Redis package not available."""
-        memory = RedisShortTermMemory(host="localhost", port=6379)
+        memory = RedisShortTermMemory(host="127.0.0.1", port=6379)
         creds = AgentCredentials("test_agent", AccessTier.CONTRIBUTOR)
 
         # Should use mock
@@ -275,7 +275,7 @@ class TestDataConsistencyDuringFailover:
         mock_client.ping.return_value = True
         mock_redis_cls.return_value = mock_client
 
-        memory = RedisShortTermMemory(host="localhost", port=6379)
+        memory = RedisShortTermMemory(host="127.0.0.1", port=6379)
 
         # Stash should raise exception after retries exhausted
         with pytest.raises(redis.ConnectionError):
@@ -305,7 +305,7 @@ class TestConnectionRecovery:
         mock_redis_cls.return_value = mock_client
 
         # First connection attempt fails, retries succeed
-        memory = RedisShortTermMemory(host="localhost", port=6379)
+        memory = RedisShortTermMemory(host="127.0.0.1", port=6379)
 
         # Should have recovered and ping should work
         assert memory.ping() is True
@@ -349,7 +349,7 @@ class TestErrorHandlingEdgeCases:
         mock_client.setex.side_effect = redis.ResponseError("OOM command not allowed")
         mock_redis_cls.return_value = mock_client
 
-        memory = RedisShortTermMemory(host="localhost", port=6379)
+        memory = RedisShortTermMemory(host="127.0.0.1", port=6379)
 
         # Should raise ResponseError (not fallback - this is a config issue)
         with pytest.raises(redis.ResponseError):
@@ -384,7 +384,7 @@ class TestConfigurationValidation:
     def test_validates_retry_configuration(self):
         """Test that retry configuration is validated."""
         config = RedisConfig(
-            host="localhost",
+            host="127.0.0.1",
             port=6379,
             retry_max_attempts=3,
             retry_base_delay=0.1,
@@ -414,7 +414,7 @@ class TestConfigurationValidation:
     def test_socket_timeout_configuration(self):
         """Test socket timeout configuration."""
         config = RedisConfig(
-            host="localhost",
+            host="127.0.0.1",
             port=6379,
             socket_timeout=10.0,
             socket_connect_timeout=5.0,


### PR DESCRIPTION
## Summary

Implements the fix plan from `docs/specs/windows-exit139-segfault/` (#1281): `getaddrinfo("localhost")` runs **before** `socket_connect_timeout` applies and is uninterruptible by `--timeout-method=thread` — a stalled Windows resolver wedged workers for 20 minutes inside redis-py `_connect`, reached from unmocked `UnifiedMemory` in unit tests. Two dumps name the identical chain: runs 28806701681 (#1279's lane, `test_session_context.py:252`) and 28810092051 (#1281's **docs-only** lane, `test_session_context.py:440` — sighting 4, proving the trap is on main, not in any diff).

## Changes
- `"localhost"` → `"127.0.0.1"` at 24 sites across `src/attune/memory/` + `src/attune/redis_config.py` (defaults, URL fallbacks, and `short_term/base.py`'s caller-override sentinel, swapped together)
- `tests/conftest.py`: pin `REDIS_HOST=127.0.0.1` at import time (controller + every xdist worker) unless an explicit non-default host is set — belt-and-suspenders for env-driven paths and future regressions
- Rationale comments at the two chokepoints (`features.is_redis_running`, `redis_config` local mode); test default-assertions updated to match

## Verification
- Full unit sweep local: **16,783 passed**, 65 skipped, 7 xfailed
- Per the spec's bar, one green windows lane is NOT proof — the wedge is intermittent. Requires ≥10 clean `windows-latest` reruns and a no-new-sighting monitoring window before the class closes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)