### PR TITLE
feat(memory): stash lifecycle UX — task-note expiry, review affordance, zsh trap #5

### DIFF
--- a/.agents/skills/recall/SKILL.md
+++ b/.agents/skills/recall/SKILL.md
@@ -86,6 +86,34 @@ the backend that answered: "no hits" from the file tier while
 dark, not empty. Suggest the user keep working; the soak fills the
 store over time.
 
+## Review / Drop Findings
+
+The stash chip (`🧠 Stashed N session finding(s)…`) shows each
+finding with a short id like `` `3f2a9c1b` ``. Two correction modes:
+
+**`/recall drop <id> [<id> ...]`** — delete specific findings by
+short id prefix. Run:
+
+```bash
+IDS="3f2a9c1b,77bd0e21" python -c "import os; from attune.memory.session_stash import forget_by_prefix; print(forget_by_prefix(os.environ['IDS'].split(','), cwd=os.getcwd()))"
+```
+
+Report how many were deleted. A prefix matching zero or multiple
+records is skipped (deletion never guesses) — tell the user which
+ids were skipped and show the candidates via the recent-findings
+snippet so they can retry with a longer prefix.
+
+**`/recall review`** — interactive pruning. Fetch the recent
+findings (snippet above), then present ONE multi-select question —
+via the `elicitation_render_form` MCP tool when available (a single
+`multi_select` field; map to `AskUserQuestion` with
+`multiSelect: true`), else directly via `AskUserQuestion` — where
+each option is one finding: label = short id + `[type]`, description
+= the finding text (truncated ~100 chars). Question: "Which findings
+should be deleted?" Then delete the picked ids with the
+`forget_by_prefix` snippet and report the count. If the user picks
+nothing, delete nothing.
+
 ## Promote A Keeper
 
 If a recalled finding is worth keeping permanently, the user can

--- a/.claude/lessons.md
+++ b/.claude/lessons.md
@@ -14058,3 +14058,37 @@ def ", start_idx + 1)` for module-
   Digits after the colon (`$HOST:8080`) and `:/` (`PATH=$PATH:/usr/bin`)
   are safe. Promoted to the JIT recall map as
   `zsh-var-colon-modifier` (4th zsh command-shape rule).
+
+- **zsh does NOT word-split unquoted `$VAR` (SH_WORD_SPLIT off) — a
+  space-separated file list in a variable passes as ONE argument, and
+  the symptom is a deceptive "(no files to check)Skipped" from
+  pre-commit, not an error**: hit 2026-07-06 pre-flighting pinned
+  black/ruff: `FILES=$(git status ... | tr '\n' ' ')` then
+  `pre-commit run black --files $FILES` silently checked nothing —
+  in bash that expands to N args, in zsh (this Bash tool's shell) it
+  stays one arg containing spaces, matching no file. The skip reads
+  as a pass if you don't notice the "no files" tail. Fix: pipe
+  through xargs (`git status --short | awk '{print $2}' | xargs
+  pre-commit run black --files`) or `${(z)FILES}` / arrays. Sibling
+  of the existing zsh command-shape traps (bracket-compare, =word,
+  status, $var:modifier) — same family: commands drafted in
+  bash-idiom run under zsh semantics.
+
+- **Stash-extractor provenance gap #2: content the ASSISTANT QUOTES
+  into its own reply (an article draft, a doc excerpt, pasted
+  deliverable text) is role-faithful assistant speech, so the
+  tool_result provenance filter (#1263) cannot catch it — the
+  extractor promotes the quoted document's claims as session
+  "findings"**: observed 2026-07-06 (dogfood week day 2): the turn
+  that pasted the LinkedIn article into the reply produced a stash
+  chip where 4-5/5 findings restated ARTICLE content (67x, 5%->0%,
+  the article's own closing question garbled into a "note"), not
+  session conclusions. This is the delivery-turn twin of day-1's
+  "all findings duplicated a committed spec doc" — together they
+  make the capture-side filter candidate concrete: skip findings
+  whose content substring-matches a document the session wrote or
+  quoted verbatim (pairs with docs/specs/stash-extractor-provenance
+  and the "already in a committed artifact?" filter idea in the
+  2026-07-06 starter). Until that ships, expect deliverable-heavy
+  turns to produce low-precision chips and prune them via the new
+  `/recall review`.

--- a/.claude/lessons.md
+++ b/.claude/lessons.md
@@ -14041,3 +14041,20 @@ def ", start_idx + 1)` for module-
   "wait for ALL OS lanes on filesystem-touching PRs before merging"
   lesson — waiting caught the bug pre-merge instead of burying it on
   main.
+
+- **zsh csh-style modifiers silently mangle `$var:word` path
+  concatenation — `$REPO:tests/unit` expands to
+  `<basename-of-REPO>ests/unit`, and double quotes do NOT
+  protect**: hit 2026-07-06 in a generated pytest command. zsh
+  parses `$var:X` as a history-style modifier when `X` is a
+  modifier letter: probed empirically, the CONSUMING (dangerous)
+  letters are `a A c e h l P q Q r s t u` (`:t` basename, `:h`
+  dirname, `:l` lowercase — so `$IMG:latest` is a live instance
+  of the same trap; `:s` dies outright with "no previous
+  substitution"), while `g p x` and any non-modifier letter pass
+  through literally. `"$var:t..."` inside double quotes STILL
+  applies the modifier. **Fix: brace the expansion —
+  `${REPO}:tests/unit` is immune** (the expansion ends at `}`).
+  Digits after the colon (`$HOST:8080`) and `:/` (`PATH=$PATH:/usr/bin`)
+  are safe. Promoted to the JIT recall map as
+  `zsh-var-colon-modifier` (4th zsh command-shape rule).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Task-note expiry (recall-time reconcile + forget)**: the
+  SessionStart recall hook now checks each recalled finding's
+  `PR #N` referents against live GitHub state (bounded, best-effort)
+  and drops + forgets notes whose every referent is merged/closed —
+  a stale "CI is re-running on PR #X" note no longer resurfaces for
+  30 days. Disable with `ATTUNE_MEMORY_RECALL_RECONCILE=0`.
+- **Stash review affordance**: the Stop-hook stash chip shows a
+  short id per finding, and `/recall drop <id>` / `/recall review`
+  (checklist form) delete wrong captures — backed by new
+  `forget_entries` / `forget_by_prefix` in
+  `attune.memory.session_stash` and `FileStashBackend.forget`
+  (parity with the AMS backend).
+- **JIT recall map: zsh `$var:X` modifier trap** — a fourth zsh
+  command-shape rule warns before `$REPO:tests/...`-style expansions
+  silently mangle (`:t` basename, `:l` lowercase; braces are immune).
+
 ## [10.0.2] — 2026-07-06
 
 Hook-portability patch: plugin hooks now launch with `python3` instead

--- a/docs/blog/social/linkedin_memory_metrics.md
+++ b/docs/blog/social/linkedin_memory_metrics.md
@@ -1,0 +1,95 @@
+---
+description: "LinkedIn Article — the Attune AI memory suite mapped to metrics users actually feel: what it costs, whether it's right, whether it tells the truth, and how fast a mistake gets fixed. Every number measured, most of them this week."
+---
+
+# LinkedIn Article — Memory features, in metrics you actually feel
+
+*Format: LinkedIn Article (long-form, supports headers). ~500 words.
+ASCII markers only — LinkedIn mangles Unicode arrows on paste.*
+
+---
+
+**Nobody buys "persistent memory." People buy cheaper recall, right answers, honest notes, and fast corrections. Here's our memory suite in those units.**
+
+AI-memory features are usually described by their architecture. Users
+don't feel architecture. They feel four questions: What does it cost
+me? Does it find the right thing? Is what it remembers TRUE? And when
+it's wrong, how fast can I fix it? We've now measured all four on our
+own live system.
+
+**1. What does it cost me? -> 67x fewer tokens.**
+
+The naive way to "give AI memory" is stuffing your whole history into
+context — for us that corpus is 300K+ tokens, every session, priced
+like every other input token. The suite inverts it: memory lives in
+git-tracked files, serves from Redis, and a session pulls only the
+relevant slice — capped at ~3,000 tokens at the moment it's needed.
+Measured on our own store: **67x fewer tokens** than corpus-loading,
+and the gap widens as memory grows because the cap doesn't.
+
+(That's the per-recall cost. "Memory makes whole sessions cheaper" is
+a harder claim — we're benchmarking it right now rather than
+asserting it, and the early runs say it isn't automatic.)
+
+**2. Does it find the right thing? -> 96% precision-at-3.**
+
+On a frozen benchmark of real "trap moments" from our sessions, the
+right lesson is in the top 3 results **96%** of the time — **100%**
+on the high-severity subset. Recall itself is one warm Redis call
+(sub-millisecond), so there's no latency tax for asking.
+
+**3. Is what it remembers TRUE? -> ambient-garble rate 5% -> 0%.**
+
+The uncomfortable one. This week we caught our own extractor
+promoting things a session merely *read* into "findings" — file
+contents restated as decisions nobody made. So we built a replay
+harness, ran old-vs-new over real session transcripts with a pinned
+local model, and measured the failure class directly:
+
+-> broad replay, 8 sessions, 39 findings each: **5% ambient-sourced
+   before the fix, 0% after**
+-> replaying the exact incident that exposed the bug: the old
+   extractor faithfully regenerated the garbled findings; the new
+   one produced five findings, **all traceable to things the session
+   actually did**
+
+Memory that can't tell "I read it" from "I concluded it" isn't
+memory — it's contamination. Now it's a measured, regression-tested
+distinction.
+
+**4. When it's wrong, how fast is the fix? -> one tool call.**
+
+Wrong memories used to require bypassing the product with a raw
+client script. Now any record that search can surface, one call can
+delete — precise, by ID, in seconds. Corrections are part of the
+loop, not an admin chore.
+
+All of this shipped or was verified this week (v10.0.2), and every
+number above comes from a benchmark or replay you can re-run — the
+same discipline that had us delete a 7,000-line subsystem when its
+measured value was zero. Storage was never the hard part of AI
+memory. Truth and lifecycle are — and they're finally on the
+scoreboard.
+
+What would YOUR AI's memory score on question 3?
+
+#AIDevelopment #DeveloperTools #Python #OpenSource #AIMemory
+
+---
+
+## Alternative hooks
+
+**Version B (four-questions lead):**
+What does it cost? Does it find the right thing? Is it TRUE? How fast
+do mistakes get fixed? We measured our AI memory suite on all four —
+here are the numbers.
+
+**Version C (confession lead):**
+This week we caught our AI's memory system confidently "remembering"
+things nobody ever said — it was restating files it had read. We
+measured the failure, fixed it, and re-measured: 5% -> 0%.
+
+**Version D (data lead):**
+67x cheaper. 96% precision-at-3. Ambient-garble rate measured at 5%
+and driven to 0%. Corrections in one tool call. AI memory, in the
+only metrics users actually feel.

--- a/plugin/hooks/_recall_map.py
+++ b/plugin/hooks/_recall_map.py
@@ -141,6 +141,21 @@ RECALL_MAP: dict[str, list[dict[str, str]]] = {
                 "`st`/`result` instead."
             ),
         },
+        # zsh csh-style modifiers on $var:word (trap #5, added
+        # 2026-07-06): `$REPO:tests/unit` silently expands to
+        # `<basename>ests/unit` (`:t` = tail); double quotes do NOT
+        # protect. Dangerous letters probed empirically — `g p x` and
+        # non-modifier letters pass through and are excluded.
+        {
+            "rule_id": "zsh-var-colon-modifier",
+            "match_regex": r"\$\w+:[aAcehlPqQrstu]",
+            "text": (
+                "zsh parses `$var:X` as a modifier (`$REPO:tests/...` "
+                "-> `<basename-of-REPO>ests/...`; `$IMG:latest` "
+                "lowercases) — even inside double quotes. Brace the "
+                "expansion: `${var}:word` is immune."
+            ),
+        },
     ],
     # Format-on-save strips a just-added import whose usage lands in a
     # LATER edit (#1265; corpus lesson #864, re-hit 2026-07-05 on

--- a/plugin/hooks/session_recall.py
+++ b/plugin/hooks/session_recall.py
@@ -26,6 +26,8 @@ from __future__ import annotations
 
 import json
 import os
+import re
+import subprocess
 import sys
 import traceback
 from pathlib import Path
@@ -49,9 +51,100 @@ except Exception:  # noqa: BLE001 — telemetry is optional, never load-bearing
 _DEFAULT_TOPK = 5
 _CONTENT_BUDGET = 1_400  # ~350 tokens of finding text
 
+# --- Task-note reconciliation (stale "PR #N" findings) -------------------
+# A stashed note like "CI is re-running on PR #1282" goes stale the moment
+# the PR merges — often within hours, far inside any TTL. Reconcile at
+# recall time: check each referenced PR's live state (bounded, best-effort)
+# and drop+forget notes whose every referent is MERGED/CLOSED.
+_PR_REF_RE = re.compile(r"\bPR\s*#(\d+)", re.IGNORECASE)
+_MAX_PR_CHECKS = 3  # bound the gh calls per session start
+_GH_TIMEOUT_SECONDS = 4.0
+_RESOLVED_STATES = {"MERGED", "CLOSED"}
+
 
 def _enabled() -> bool:
     return os.environ.get("ATTUNE_MEMORY_RECALL", "1").strip() not in {"0", "false", "no"}
+
+
+def _reconcile_enabled() -> bool:
+    return os.environ.get("ATTUNE_MEMORY_RECALL_RECONCILE", "1").strip() not in {
+        "0",
+        "false",
+        "no",
+    }
+
+
+def _pr_refs(content: str) -> list[str]:
+    """Extract 'PR #N' referents from a finding's text."""
+    return _PR_REF_RE.findall(content or "")
+
+
+def _pr_state(number: str, cwd: str | None) -> str | None:
+    """Live PR state via gh (MERGED/OPEN/CLOSED), or None on any failure."""
+
+    try:
+        proc = subprocess.run(  # noqa: S603, S607 — fixed argv, no shell
+            ["gh", "pr", "view", number, "--json", "state"],
+            capture_output=True,
+            text=True,
+            timeout=_GH_TIMEOUT_SECONDS,
+            cwd=cwd or None,
+        )
+        if proc.returncode != 0:
+            return None
+        state = json.loads(proc.stdout).get("state")
+        return state if isinstance(state, str) else None
+    except Exception:  # noqa: BLE001 — gh missing/slow/offline -> keep the note
+        return None
+
+
+def _reconcile(entries: list[dict], cwd: str | None) -> tuple[list[dict], list[str]]:
+    """Partition entries into (fresh, stale-ids); best-effort, conservative.
+
+    An entry is stale only when it references at least one PR and EVERY
+    referenced PR is definitively MERGED/CLOSED — an unknown state (gh
+    missing, timeout, cross-repo number) keeps the note. Checks are
+    bounded to :data:`_MAX_PR_CHECKS` unique PR numbers per session start.
+    """
+    if not _reconcile_enabled():
+        return entries, []
+    checked: dict[str, str | None] = {}
+    fresh: list[dict] = []
+    stale_ids: list[str] = []
+    for e in entries:
+        if not isinstance(e, dict):
+            continue
+        refs = _pr_refs(str(e.get("text") or e.get("content") or ""))
+        resolved = bool(refs)
+        for n in dict.fromkeys(refs):
+            if n not in checked:
+                if len(checked) >= _MAX_PR_CHECKS:
+                    resolved = False
+                    break
+                checked[n] = _pr_state(n, cwd)
+            if checked[n] not in _RESOLVED_STATES:
+                resolved = False
+                break
+        if resolved:
+            # Stale: drop from render either way; forget only when the
+            # record carries an id to delete by.
+            if e.get("id"):
+                stale_ids.append(str(e["id"]))
+            continue
+        fresh.append(e)
+    return fresh, stale_ids
+
+
+def _forget(ids: list[str]) -> int:
+    """Best-effort backend deletion of reconciled-stale findings."""
+    if not ids:
+        return 0
+    try:
+        from attune.memory.session_stash import forget_entries
+
+        return forget_entries(ids)
+    except Exception:  # noqa: BLE001 — older attune without forget_entries
+        return 0
 
 
 def _type_of(topics: object) -> str:
@@ -131,7 +224,21 @@ def main() -> int:
             pass
 
         entries = recent_entries(top_k=topk, cwd=cwd)
+        # Drop task notes whose PR referents have since merged/closed —
+        # and forget them so they never resurface (task-note expiry).
+        entries, stale_ids = _reconcile(entries, cwd)
+        forgotten = _forget(stale_ids)
         if not entries:
+            if stale_ids:
+                # Everything recalled was stale — still record the reconcile.
+                log_memory_event(
+                    "session_recall",
+                    session_id=payload.get("session_id"),
+                    entries=0,
+                    injected_chars=0,
+                    reconciled_stale=len(stale_ids),
+                    forgotten=forgotten,
+                )
             if health:
                 print(health)
             return 0
@@ -145,6 +252,8 @@ def main() -> int:
                 session_id=payload.get("session_id"),
                 entries=rendered,
                 injected_chars=len(block),
+                reconciled_stale=len(stale_ids),
+                forgotten=forgotten,
             )
         if health:
             print(health)

--- a/plugin/hooks/session_stash.py
+++ b/plugin/hooks/session_stash.py
@@ -343,6 +343,9 @@ def _stash_findings(findings: list[dict], session_id: str, cwd: str) -> int:
             )
             if stash_entry(entry):
                 written += 1
+                # Attach the record id so the chip can offer per-finding
+                # review/deletion (short prefix is enough to forget by).
+                f["id"] = entry.id
         except Exception:  # noqa: BLE001 — one bad finding must not abort the rest
             continue
     if written:
@@ -382,11 +385,17 @@ def _emit_additional_context(findings: list[dict], written: int) -> int:
         f"\U0001f9e0 Stashed {written} session finding(s) to attune memory "
         "(recall later with /recall):"
     ]
-    for f in findings[:written]:
+    stashed = [f for f in findings if f.get("id")] or findings[:written]
+    for f in stashed:
         content = str(f.get("content", "")).strip().replace("\n", " ")
         if len(content) > 160:
             content = content[:157] + "..."
-        lines.append(f"- [{f.get('type', 'note')}] {content}")
+        short_id = str(f.get("id", ""))[:8]
+        id_part = f" `{short_id}`" if short_id else ""
+        lines.append(f"- [{f.get('type', 'note')}]{id_part} {content}")
+    lines.append(
+        "Review: `/recall review` prunes with a checklist; " "`/recall drop <id>` deletes one."
+    )
     summary = "\n".join(lines)
     try:
         sys.stdout.write(

--- a/plugin/skills/recall/SKILL.md
+++ b/plugin/skills/recall/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: recall
 description: "Pull relevant findings stashed from past sessions — on demand. Triggers on: recall, remember, what did I learn, prior session, past findings, did I hit this before, what do we know about."
-argument-hint: "<topic to recall | leave empty for recent>"
+argument-hint: "<topic | empty for recent | drop <id> | review>"
 ---
 
 # Recall
@@ -87,6 +87,34 @@ the backend that answered: "no hits" from the file tier while
 `status.unreachable_upgrade` is set means the real store may simply be
 dark, not empty. Suggest the user keep working; the soak fills the
 store over time.
+
+## Review / Drop Findings
+
+The stash chip (`🧠 Stashed N session finding(s)…`) shows each
+finding with a short id like `` `3f2a9c1b` ``. Two correction modes:
+
+**`/recall drop <id> [<id> ...]`** — delete specific findings by
+short id prefix. Run:
+
+```bash
+IDS="3f2a9c1b,77bd0e21" python -c "import os; from attune.memory.session_stash import forget_by_prefix; print(forget_by_prefix(os.environ['IDS'].split(','), cwd=os.getcwd()))"
+```
+
+Report how many were deleted. A prefix matching zero or multiple
+records is skipped (deletion never guesses) — tell the user which
+ids were skipped and show the candidates via the recent-findings
+snippet so they can retry with a longer prefix.
+
+**`/recall review`** — interactive pruning. Fetch the recent
+findings (snippet above), then present ONE multi-select question —
+via the `elicitation_render_form` MCP tool when available (a single
+`multi_select` field; map to `AskUserQuestion` with
+`multiSelect: true`), else directly via `AskUserQuestion` — where
+each option is one finding: label = short id + `[type]`, description
+= the finding text (truncated ~100 chars). Question: "Which findings
+should be deleted?" Then delete the picked ids with the
+`forget_by_prefix` snippet and report the count. If the user picks
+nothing, delete nothing.
 
 ## Promote A Keeper
 

--- a/src/attune/memory/backend.py
+++ b/src/attune/memory/backend.py
@@ -229,6 +229,26 @@ class SearchableMemoryBackend(MemoryBackend, Protocol):
         """
         ...
 
+    def forget(self, ids: list[str]) -> int:
+        """Delete specific findings by record ID.
+
+        The IDs are the ``id`` values returned by ``search`` / ``recent``.
+        Complements ``prune`` (age-based sweep) with precise removal — the
+        correction path when a stashed finding is wrong or stale (e.g. a
+        task note whose PR has since merged). Best-effort; returns the
+        number of entries deleted (0 on failure or empty input), never
+        raises. Backends predating this method are handled by callers via
+        ``getattr``.
+
+        Args:
+            ids: Record IDs to delete.
+
+        Returns:
+            Count of deleted entries (best-effort).
+
+        """
+        ...
+
     def recent(self, limit: int = 5, **filters: Any) -> list[dict]:
         """Return the most-recent findings without a query.
 

--- a/src/attune/memory/backend.py
+++ b/src/attune/memory/backend.py
@@ -247,7 +247,7 @@ class SearchableMemoryBackend(MemoryBackend, Protocol):
             Count of deleted entries (best-effort).
 
         """
-        ...
+        pass
 
     def recent(self, limit: int = 5, **filters: Any) -> list[dict]:
         """Return the most-recent findings without a query.

--- a/src/attune/memory/file_stash.py
+++ b/src/attune/memory/file_stash.py
@@ -276,6 +276,41 @@ class FileStashBackend:
             logger.warning("file_stash_prune_failed", error=str(e))
         return dropped
 
+    def forget(self, ids: list[str]) -> int:
+        """Delete specific findings by record ID.
+
+        The IDs are the ``id`` values returned by :meth:`search` /
+        :meth:`recent`. Complements :meth:`prune` (age-based sweep) with
+        precise removal — the correction path when a stashed finding is
+        wrong or stale. Best-effort; returns the number of findings
+        deleted (0 on failure or empty input), never raises. Parity with
+        ``AMSMemoryBackend.forget``.
+        """
+        if not ids or not self._findings.exists():
+            return 0
+        targets = set(ids)
+        kept: list[dict[str, Any]] = []
+        dropped = 0
+        try:
+            for line in self._findings.read_text(encoding="utf-8").splitlines():
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    rec = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if isinstance(rec, dict) and rec.get("id") in targets:
+                    dropped += 1
+                else:
+                    kept.append(rec)
+            if dropped:
+                self._rewrite(kept)
+        except OSError as e:
+            logger.warning("file_stash_forget_failed", error=str(e))
+            return 0
+        return dropped
+
     # ------------------------------------------------------------------ #
     # MemoryBackend — key/value
     # ------------------------------------------------------------------ #

--- a/src/attune/memory/session_stash.py
+++ b/src/attune/memory/session_stash.py
@@ -327,6 +327,93 @@ def recall_entries(
     return results
 
 
+def forget_entries(
+    ids: list[str],
+    backend: SearchableMemoryBackend | None = None,
+) -> int:
+    """Delete stashed findings by record ID. 0 when unavailable.
+
+    The precise-removal correction path (vs. ``prune``'s age sweep):
+    used by the recall reconciler when a task note's referent (e.g. a
+    PR) has since resolved, and by per-finding review deletion. Returns
+    the number of entries deleted. Never raises — safe to call from a
+    hook. Backends predating ``forget`` degrade to 0.
+
+    Args:
+        ids: Record IDs (the ``id`` values from ``search``/``recent``).
+        backend: Optional injected backend; resolved from the entry
+            point when omitted.
+
+    Returns:
+        Count of deleted entries (best-effort).
+    """
+    if not ids:
+        return 0
+    target = resolve_backend(backend)
+    if target is None:
+        return 0
+    forget = getattr(target, "forget", None)
+    if not callable(forget):
+        return 0
+    try:
+        return int(forget(list(ids)) or 0)
+    except Exception as exc:  # noqa: BLE001
+        # INTENTIONAL: forget is best-effort; never break the host session.
+        logger.warning("session stash forget failed: %s", exc)
+        return 0
+
+
+def forget_by_prefix(
+    prefixes: list[str],
+    limit: int = 100,
+    cwd: str | None = None,
+    backend: SearchableMemoryBackend | None = None,
+) -> int:
+    """Delete stashed findings by short (unique) ID prefix. 0 when none.
+
+    The review-affordance path: the Stop-hook chip shows each finding
+    with a short id prefix; this resolves those prefixes against the
+    most-recent records and deletes exact, UNAMBIGUOUS matches. An
+    ambiguous prefix (two records match) or an unknown one is skipped —
+    deletion must never guess. Never raises.
+
+    Args:
+        prefixes: Short id prefixes (e.g. the first 8 chars shown in
+            the stash chip). Full ids work too.
+        limit: How many recent records to resolve against.
+        cwd: Optional project filter passed to ``recent``.
+        backend: Optional injected backend; resolved from the entry
+            point when omitted.
+
+    Returns:
+        Count of deleted entries (best-effort).
+    """
+    wanted = [p.strip() for p in prefixes if p and p.strip()]
+    if not wanted:
+        return 0
+    target = resolve_backend(backend)
+    if target is None:
+        return 0
+    recent = getattr(target, "recent", None)
+    if not callable(recent):
+        return 0
+    try:
+        records = recent(limit=limit, cwd=cwd) or []
+    except Exception as exc:  # noqa: BLE001
+        # INTENTIONAL: resolution is best-effort; never break the caller.
+        logger.warning("forget_by_prefix recent-listing failed: %s", exc)
+        return 0
+    ids = [str(r.get("id")) for r in records if isinstance(r, dict) and r.get("id")]
+    full_ids: list[str] = []
+    for prefix in wanted:
+        matches = [i for i in ids if i.startswith(prefix)]
+        if len(matches) == 1:
+            full_ids.append(matches[0])
+        else:
+            logger.info("forget_by_prefix: prefix %r skipped (%d matches)", prefix, len(matches))
+    return forget_entries(full_ids, backend=target)
+
+
 def recent_entries(
     top_k: int = 5,
     cwd: str | None = None,

--- a/tests/unit/hooks/test_jit_recall.py
+++ b/tests/unit/hooks/test_jit_recall.py
@@ -154,6 +154,32 @@ def test_zsh_status_readonly_fires_on_assignment(jit_mod, monkeypatch, capsys):
     assert "READ-ONLY" in out
 
 
+def test_zsh_colon_modifier_fires_on_var_path_concat(jit_mod, monkeypatch, capsys):
+    # `$REPO:tests/...` — zsh consumes `:t` as the tail modifier.
+    rc, out = _run(jit_mod, monkeypatch, capsys, _bash_payload("pytest $REPO:tests/unit"))
+    assert rc == 0
+    assert "Brace the expansion" in out
+
+
+def test_zsh_colon_modifier_fires_inside_double_quotes(jit_mod, monkeypatch, capsys):
+    # Double quotes do NOT protect — the modifier still applies.
+    rc, out = _run(jit_mod, monkeypatch, capsys, _bash_payload('ls "$IMG:latest"'))
+    assert rc == 0
+    assert "Brace the expansion" in out
+
+
+def test_zsh_colon_modifier_silent_on_safe_shapes(jit_mod, monkeypatch, capsys):
+    # Braced expansion, digit ports, and PATH-style `:/` never trip it.
+    rc, out = _run(
+        jit_mod,
+        monkeypatch,
+        capsys,
+        _bash_payload("pytest ${REPO}:tests/unit; curl $HOST:8080; PATH=$PATH:/usr/bin"),
+    )
+    assert rc == 0
+    assert "Brace the expansion" not in out
+
+
 def test_edit_import_rule_fires_once(jit_mod, monkeypatch, capsys):
     payload = {
         "hook_event_name": "PreToolUse",

--- a/tests/unit/hooks/test_session_memory_hooks.py
+++ b/tests/unit/hooks/test_session_memory_hooks.py
@@ -728,7 +728,7 @@ def test_recall_main_silent_when_all_entries_stale(recall_mod, monkeypatch, caps
         ss, "recent_entries", lambda **k: [{"id": "s1", "text": "on PR #5", "topics": []}]
     )
     monkeypatch.setattr(ss, "backend_status", lambda: dict(_HEALTHY))
-    monkeypatch.setattr(ss, "forget_entries", lambda ids: len(ids))
+    monkeypatch.setattr(ss, "forget_entries", len)
     monkeypatch.setattr(recall_mod, "_pr_state", lambda n, cwd: "CLOSED")
     _stdin(monkeypatch, {"source": "startup", "cwd": "/proj"})
     assert recall_mod.main() == 0

--- a/tests/unit/hooks/test_session_memory_hooks.py
+++ b/tests/unit/hooks/test_session_memory_hooks.py
@@ -625,3 +625,162 @@ def test_prompt_carries_provenance_rules(stash_mod, monkeypatch):
     prompt = captured["body"]["prompt"]
     assert "PROVENANCE" in prompt
     assert "merely read" in prompt
+
+
+# ==========================================================================
+# Task-note reconciliation (stale "PR #N" findings expire at recall time)
+# ==========================================================================
+
+
+def test_pr_refs_extracts_numbers(recall_mod):
+    assert recall_mod._pr_refs("CI re-running on PR #1282 and pr #7") == ["1282", "7"]
+    assert recall_mod._pr_refs("no refs here, not even #123 bare") == []
+    assert recall_mod._pr_refs("") == []
+
+
+def _entries():
+    return [
+        {"id": "stale-1", "text": "CI is re-running on PR #1282", "topics": ["type:reference"]},
+        {"id": "fresh-1", "text": "plain durable insight", "topics": ["type:note"]},
+    ]
+
+
+def test_reconcile_drops_merged_pr_note(recall_mod, monkeypatch):
+    monkeypatch.setattr(recall_mod, "_pr_state", lambda n, cwd: "MERGED")
+    fresh, stale = recall_mod._reconcile(_entries(), "/proj")
+    assert [e["id"] for e in fresh] == ["fresh-1"]
+    assert stale == ["stale-1"]
+
+
+def test_reconcile_keeps_open_pr_note(recall_mod, monkeypatch):
+    monkeypatch.setattr(recall_mod, "_pr_state", lambda n, cwd: "OPEN")
+    fresh, stale = recall_mod._reconcile(_entries(), "/proj")
+    assert len(fresh) == 2 and stale == []
+
+
+def test_reconcile_keeps_note_on_unknown_state(recall_mod, monkeypatch):
+    # gh missing / timeout / cross-repo number -> conservative keep.
+    monkeypatch.setattr(recall_mod, "_pr_state", lambda n, cwd: None)
+    fresh, stale = recall_mod._reconcile(_entries(), "/proj")
+    assert len(fresh) == 2 and stale == []
+
+
+def test_reconcile_mixed_refs_kept_unless_all_resolved(recall_mod, monkeypatch):
+    states = {"1": "MERGED", "2": "OPEN"}
+    monkeypatch.setattr(recall_mod, "_pr_state", lambda n, cwd: states[n])
+    entries = [{"id": "e1", "text": "touches PR #1 and PR #2", "topics": []}]
+    fresh, stale = recall_mod._reconcile(entries, None)
+    assert len(fresh) == 1 and stale == []
+
+
+def test_reconcile_bounds_gh_calls(recall_mod, monkeypatch):
+    calls: list[str] = []
+
+    def _counting_state(n, cwd):
+        calls.append(n)
+        return "MERGED"
+
+    monkeypatch.setattr(recall_mod, "_pr_state", _counting_state)
+    entries = [{"id": f"e{i}", "text": f"note about PR #{100 + i}", "topics": []} for i in range(6)]
+    fresh, stale = recall_mod._reconcile(entries, None)
+    assert len(calls) == recall_mod._MAX_PR_CHECKS
+    # Beyond the check budget, notes are conservatively kept.
+    assert len(stale) == recall_mod._MAX_PR_CHECKS
+    assert len(fresh) == 3
+
+
+def test_reconcile_disabled_via_env(recall_mod, monkeypatch):
+    monkeypatch.setenv("ATTUNE_MEMORY_RECALL_RECONCILE", "0")
+    monkeypatch.setattr(
+        recall_mod, "_pr_state", lambda n, cwd: pytest.fail("must not call gh when disabled")
+    )
+    fresh, stale = recall_mod._reconcile(_entries(), "/proj")
+    assert len(fresh) == 2 and stale == []
+
+
+def test_reconcile_missing_id_drops_render_but_skips_forget(recall_mod, monkeypatch):
+    monkeypatch.setattr(recall_mod, "_pr_state", lambda n, cwd: "MERGED")
+    entries = [{"text": "on PR #9", "topics": []}]  # no id -> nothing to forget
+    fresh, stale = recall_mod._reconcile(entries, None)
+    assert fresh == [] and stale == []
+
+
+def test_recall_main_drops_and_forgets_stale(recall_mod, monkeypatch, capsys):
+    import attune.memory.session_stash as ss
+
+    monkeypatch.setattr(ss, "recent_entries", lambda **k: _entries())
+    monkeypatch.setattr(ss, "backend_status", lambda: dict(_HEALTHY))
+    forgotten: list[list[str]] = []
+    monkeypatch.setattr(ss, "forget_entries", lambda ids: forgotten.append(list(ids)) or 1)
+    monkeypatch.setattr(recall_mod, "_pr_state", lambda n, cwd: "MERGED")
+    _stdin(monkeypatch, {"source": "startup", "cwd": "/proj"})
+    assert recall_mod.main() == 0
+    out = capsys.readouterr().out
+    assert "plain durable insight" in out
+    assert "PR #1282" not in out
+    assert forgotten == [["stale-1"]]
+
+
+def test_recall_main_silent_when_all_entries_stale(recall_mod, monkeypatch, capsys):
+    import attune.memory.session_stash as ss
+
+    monkeypatch.setattr(
+        ss, "recent_entries", lambda **k: [{"id": "s1", "text": "on PR #5", "topics": []}]
+    )
+    monkeypatch.setattr(ss, "backend_status", lambda: dict(_HEALTHY))
+    monkeypatch.setattr(ss, "forget_entries", lambda ids: len(ids))
+    monkeypatch.setattr(recall_mod, "_pr_state", lambda n, cwd: "CLOSED")
+    _stdin(monkeypatch, {"source": "startup", "cwd": "/proj"})
+    assert recall_mod.main() == 0
+    assert capsys.readouterr().out == ""
+
+
+def test_pr_state_parses_gh_json(recall_mod, monkeypatch):
+    class _Proc:
+        returncode = 0
+        stdout = '{"state": "MERGED"}'
+
+    monkeypatch.setattr(recall_mod.subprocess, "run", lambda *a, **k: _Proc())
+    assert recall_mod._pr_state("1282", None) == "MERGED"
+
+
+def test_pr_state_none_on_gh_failure(recall_mod, monkeypatch):
+    def _boom(*a, **k):
+        raise FileNotFoundError("gh not installed")
+
+    monkeypatch.setattr(recall_mod.subprocess, "run", _boom)
+    assert recall_mod._pr_state("1", None) is None
+
+
+# ==========================================================================
+# Stash chip review affordance (short ids + drop/review hint)
+# ==========================================================================
+
+
+def test_stash_findings_attaches_ids(stash_mod, monkeypatch):
+    import attune.memory.session_stash as ss
+
+    monkeypatch.setattr(ss, "stash_entry", lambda e: True)
+    findings = [{"type": "note", "content": "a finding"}]
+    assert stash_mod._stash_findings(findings, session_id="s", cwd="/p") == 1
+    assert len(findings[0].get("id", "")) == 36  # uuid4 attached on write
+
+
+def test_emit_context_shows_short_ids_and_review_hint(stash_mod, capsys):
+    findings = [
+        {"type": "note", "content": "keep me honest", "id": "3f2a9c1b-0000-4000-8000-caf0caf0caf0"}
+    ]
+    injected = stash_mod._emit_additional_context(findings, written=1)
+    assert injected > 0
+    payload = json.loads(capsys.readouterr().out)
+    ctx = payload["hookSpecificOutput"]["additionalContext"]
+    assert "`3f2a9c1b`" in ctx
+    assert "/recall review" in ctx and "/recall drop" in ctx
+
+
+def test_emit_context_without_ids_falls_back(stash_mod, capsys):
+    # Older path: findings without attached ids still render (no id chunk).
+    findings = [{"type": "note", "content": "plain"}]
+    assert stash_mod._emit_additional_context(findings, written=1) > 0
+    ctx = json.loads(capsys.readouterr().out)["hookSpecificOutput"]["additionalContext"]
+    assert "- [note] plain" in ctx

--- a/tests/unit/memory/test_file_stash.py
+++ b/tests/unit/memory/test_file_stash.py
@@ -375,3 +375,38 @@ def test_recent_returns_search_shape(backend):
     assert set(hit) == {"id", "text", "topics", "cwd", "session_id", "ts", "created_at"}
     assert isinstance(hit["ts"], float)
     assert isinstance(hit["created_at"], str)
+
+
+# --------------------------------------------------------------------------
+# forget (precise removal by id — the task-note-expiry correction path)
+# --------------------------------------------------------------------------
+
+
+def test_forget_removes_by_id(backend):
+    for i in range(3):
+        backend.remember(f"finding number {i}", memory_id=f"m{i}")
+    assert backend.forget(["m0", "m2"]) == 2
+    remaining = backend.recent(limit=10)
+    assert [r["id"] for r in remaining] == ["m1"]
+
+
+def test_forget_empty_ids_returns_zero(backend):
+    backend.remember("keep me", memory_id="m1")
+    assert backend.forget([]) == 0
+    assert len(backend.recent()) == 1
+
+
+def test_forget_unknown_id_keeps_all(backend):
+    backend.remember("keep me", memory_id="m1")
+    assert backend.forget(["nope"]) == 0
+    assert len(backend.recent()) == 1
+
+
+def test_forget_no_findings_file_returns_zero(backend):
+    assert backend.forget(["m1"]) == 0
+
+
+def test_forget_is_idempotent(backend):
+    backend.remember("once", memory_id="m1")
+    assert backend.forget(["m1"]) == 1
+    assert backend.forget(["m1"]) == 0

--- a/tests/unit/memory/test_file_stash.py
+++ b/tests/unit/memory/test_file_stash.py
@@ -410,3 +410,25 @@ def test_forget_is_idempotent(backend):
     backend.remember("once", memory_id="m1")
     assert backend.forget(["m1"]) == 1
     assert backend.forget(["m1"]) == 0
+
+
+def test_forget_skips_blank_and_corrupt_lines(backend):
+    backend.remember("valid one", memory_id="m1")
+    backend.remember("valid two", memory_id="m2")
+    # Inject noise the forget scan must tolerate (mirrors prune's test).
+    with backend._findings.open("a", encoding="utf-8") as fh:
+        fh.write("\n")
+        fh.write("{not json at all\n")
+    assert backend.forget(["m1"]) == 1
+    remaining = [r["id"] for r in backend.recent(limit=10)]
+    assert remaining == ["m2"]
+
+
+def test_forget_swallows_read_error(backend, monkeypatch):
+    backend.remember("unreadable store", memory_id="m1")
+
+    def _boom(*a, **k):
+        raise OSError("disk detached")
+
+    monkeypatch.setattr(type(backend._findings), "read_text", _boom)
+    assert backend.forget(["m1"]) == 0

--- a/tests/unit/memory/test_session_stash.py
+++ b/tests/unit/memory/test_session_stash.py
@@ -648,3 +648,22 @@ def test_forget_by_prefix_backend_without_recent_degrades():
     from attune.memory.session_stash import forget_by_prefix
 
     assert forget_by_prefix(["abc"], backend=_ForgetBackend()) == 0
+
+
+def test_forget_by_prefix_noop_without_backend():
+    from attune.memory.session_stash import forget_by_prefix
+
+    # Ambient resolution isolated by the autouse fixture -> no backend.
+    assert forget_by_prefix(["abc"]) == 0
+
+
+def test_forget_by_prefix_swallows_recent_error():
+    from attune.memory.session_stash import forget_by_prefix
+
+    class _RecentBoom(_ForgetBackend):
+        def recent(self, limit=5, **filters):
+            raise RuntimeError("listing failed")
+
+    fb = _RecentBoom()
+    assert forget_by_prefix(["abc"], backend=fb) == 0
+    assert fb.forgotten == []

--- a/tests/unit/memory/test_session_stash.py
+++ b/tests/unit/memory/test_session_stash.py
@@ -14,6 +14,7 @@ from attune.memory.session_stash import (
     DEFAULT_TTL_DAYS,
     MAX_CONTENT_CHARS,
     SessionStashEntry,
+    forget_entries,
     recall_entries,
     recent_entries,
     resolve_backend,
@@ -547,3 +548,103 @@ def test_file_fallback_roundtrip_no_infra(tmp_path, monkeypatch):
     assert hits, "stashed finding must be recallable with zero infra"
     assert any("retry loop" in (h.get("text") or "") for h in hits)
     assert hits[0]["cwd"] == "/proj"
+
+
+# --------------------------------------------------------------------------
+# forget_entries
+# --------------------------------------------------------------------------
+
+
+class _ForgetBackend(_FakeBackend):
+    """Searchable backend that also implements precise forget()."""
+
+    def __init__(self, results=None):
+        super().__init__(results)
+        self.forgotten: list[list[str]] = []
+
+    def forget(self, ids):
+        self.forgotten.append(list(ids))
+        return len(ids)
+
+
+def test_forget_entries_delegates_to_backend():
+    fb = _ForgetBackend()
+    assert forget_entries(["a", "b"], backend=fb) == 2
+    assert fb.forgotten == [["a", "b"]]
+
+
+def test_forget_entries_empty_ids_noop():
+    fb = _ForgetBackend()
+    assert forget_entries([], backend=fb) == 0
+    assert fb.forgotten == []
+
+
+def test_forget_entries_noop_without_backend():
+    assert forget_entries(["a"]) == 0  # ambient resolution isolated -> None
+
+
+def test_forget_entries_backend_without_forget_degrades():
+    assert forget_entries(["a"], backend=_FakeBackend()) == 0
+
+
+def test_forget_entries_swallows_backend_error():
+    class _Boom(_ForgetBackend):
+        def forget(self, ids):
+            raise RuntimeError("ams down")
+
+    assert forget_entries(["a"], backend=_Boom()) == 0
+
+
+# --------------------------------------------------------------------------
+# forget_by_prefix
+# --------------------------------------------------------------------------
+
+
+class _RecentForgetBackend(_ForgetBackend):
+    """Forget-capable backend with a recent() listing to resolve against."""
+
+    def __init__(self, ids):
+        super().__init__()
+        self._ids = list(ids)
+
+    def recent(self, limit=5, **filters):
+        return [{"id": i, "text": "x", "topics": []} for i in self._ids[:limit]]
+
+
+def test_forget_by_prefix_resolves_unique_prefix():
+    from attune.memory.session_stash import forget_by_prefix
+
+    fb = _RecentForgetBackend(["aaaa1111-x", "bbbb2222-y"])
+    assert forget_by_prefix(["aaaa1111"], backend=fb) == 1
+    assert fb.forgotten == [["aaaa1111-x"]]
+
+
+def test_forget_by_prefix_skips_ambiguous_and_unknown():
+    from attune.memory.session_stash import forget_by_prefix
+
+    fb = _RecentForgetBackend(["abc-1", "abc-2", "def-3"])
+    # "abc" matches two records, "zzz" matches none -> both skipped.
+    assert forget_by_prefix(["abc", "zzz", "def"], backend=fb) == 1
+    assert fb.forgotten == [["def-3"]]
+
+
+def test_forget_by_prefix_full_id_works():
+    from attune.memory.session_stash import forget_by_prefix
+
+    fb = _RecentForgetBackend(["abc-1"])
+    assert forget_by_prefix(["abc-1"], backend=fb) == 1
+
+
+def test_forget_by_prefix_empty_or_blank_noop():
+    from attune.memory.session_stash import forget_by_prefix
+
+    fb = _RecentForgetBackend(["abc-1"])
+    assert forget_by_prefix([], backend=fb) == 0
+    assert forget_by_prefix(["  ", ""], backend=fb) == 0
+    assert fb.forgotten == []
+
+
+def test_forget_by_prefix_backend_without_recent_degrades():
+    from attune.memory.session_stash import forget_by_prefix
+
+    assert forget_by_prefix(["abc"], backend=_ForgetBackend()) == 0


### PR DESCRIPTION
## Summary

Three ranked backlog items from the 10.0.1 feedback pass, plus the LinkedIn memory-metrics article grounding fix.

### 1. Task-note expiry (recall-time reconcile + forget)
- SessionStart recall now checks recalled findings' `PR #N` referents against live `gh` state (bounded to 3 checks, 4s timeout each, best-effort) and drops + forgets notes whose every referent is MERGED/CLOSED.
- Conservative by design: unknown state (gh missing, timeout, cross-repo number) keeps the note; ambiguity never deletes.
- Kill switch: `ATTUNE_MEMORY_RECALL_RECONCILE=0`. Telemetry: `reconciled_stale` / `forgotten` fields on the `session_recall` event.
- **Dogfood receipt**: this morning's stale *"CI is re-running on PR #1282"* note was reconciled, dropped from render, and durably forgotten on a live hook run (telemetry: `reconciled_stale=1, forgotten=1`; second run confirms gone).

### 2. Stash review affordance (ids + checklist form)
- Stop-hook chip lines now carry a short id (```3f2a9c1b```) + review hint.
- `/recall drop <id>` deletes by unique prefix; `/recall review` renders a multi-select checklist (elicitation form → AskUserQuestion) and deletes the picks.
- New surface: `forget_entries` / `forget_by_prefix` in `attune.memory.session_stash`, `FileStashBackend.forget` (parity with `AMSMemoryBackend.forget`), `forget` on the `SearchableMemoryBackend` protocol.
- **Dogfood receipt**: live stash → `forget_by_prefix` → gone round-trip verified against the real backend.

### 3. JIT recall map trap #5 (zsh `$var:X` modifier)
- zsh parses `$REPO:tests/...` as the `:t` modifier → `<basename>ests/...`; `$IMG:latest` lowercases; double quotes do NOT protect; `${var}` braces are immune. Dangerous modifier letters probed empirically (`a A c e h l P q Q r s t u`; `g p x` pass through).
- Lesson appended to `.claude/lessons.md`; promoted as the fourth zsh command-shape `match_regex` rule. (Deliberately no promotion pipeline — n=5 traps doesn't justify automation yet.)

### 4. LinkedIn article grounding (docs-only, unpublished orphan surface)
- `docs/blog/social/linkedin_memory_metrics.md`: 'cheaper sessions' lead conflicted with the session_savings A/B (#1276, +28% cost/task one-shot) → per-recall framing + explicit 'whole-session savings is being benchmarked, not asserted' note; version ref → 10.0.2.

## Tests
- 3 new jit-recall rule tests, 12 reconcile/forget hook tests, 5 `FileStashBackend.forget` tests, 10 `forget_entries`/`forget_by_prefix` tests — all touched suites green locally (167+ passing).
- `scripts/sync_agents_skills.py` re-run (recall skill mirror in sync).

🤖 Generated with [Claude Code](https://claude.com/claude-code)