### PR TITLE
docs(spec): mark anthropic-memory-tool-backend complete

### DIFF
--- a/docs/specs/anthropic-memory-tool-backend/design.md
+++ b/docs/specs/anthropic-memory-tool-backend/design.md
@@ -4,7 +4,7 @@
 > attune's memory backends. See
 > [`requirements.md`](requirements.md) for scope.
 
-**Status:** partial — Phase 1 shipped (`memory/memory_tool.py`, PR #671); Phase 2 (MCP/CLI surfacing) is forward work — verified 2026-06-08 spec triage
+**Status:** complete — Phase 1 shipped (`memory/memory_tool.py`, PR #671); Phase 2 surfacing shipped as the `attune memory-agent` CLI; Option ③ (SDK-native-workflow surfacing) re-scoped out — see Phase 2 below.
 
 ---
 

--- a/docs/specs/anthropic-memory-tool-backend/requirements.md
+++ b/docs/specs/anthropic-memory-tool-backend/requirements.md
@@ -12,7 +12,7 @@
 > suggests" into "our memory layer **is** a backend for Anthropic's
 > Memory tool, persisted on Redis's Agent Memory Server."
 
-**Status:** Phase 1 shipped (`memory/memory_tool.py`, #671) + exported from `attune.memory`; Phase 2 surfacing shipped as the `attune memory-agent` CLI. Option ③ (SDK-native-workflow surfacing) re-scoped out — see design.md Phase 2.
+**Status:** complete — Phase 1 shipped (`memory/memory_tool.py`, #671) + exported from `attune.memory`; Phase 2 surfacing shipped as the `attune memory-agent` CLI. Option ③ (SDK-native-workflow surfacing) re-scoped out — see design.md Phase 2.
 morning review
 **Owner:** Patrick + agent
 **Related:**


### PR DESCRIPTION
Sets the Status of both phase files for `anthropic-memory-tool-backend` to **complete**:

- **requirements.md** — Phase 1 (`memory/memory_tool.py`, #671) + `attune.memory` export, Phase 2 surfacing (`attune memory-agent` CLI) shipped; Option ③ (SDK-native surfacing) re-scoped out.
- **design.md** — updated from the stale `partial — Phase 2 is forward work` line to match (Phase 2 shipped).

The dashboard's spec card reads the *most-advanced* phase's status (design.md), so both needed updating for it to read `complete`.

Provenance preserved on both lines. Recovered from an uncommitted, detached-HEAD state in the main checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)