### PR TITLE
chore(release): 10.1.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "Spec-driven development for Claude Code — take an idea through requirements, design, tasks, and gated execution with an approval loop. Plus 23 auto-triggering skills: security audits, code review, test generation, release prep.",
-    "version": "10.0.2"
+    "version": "10.1.0"
   },
   "plugins": [
     {
       "name": "attune-ai",
       "description": "Spec-driven development is the core workflow: /spec carries an idea through brainstorm, requirements, design, and task execution with quality gates and your approval at each stage. Backed by 23 auto-triggering skills — security audits, code reviews, test generation, bug prediction, and release preparation. For help content tools, also install attune-help and attune-author from this marketplace.",
       "source": "./plugin",
-      "version": "10.0.2",
+      "version": "10.1.0",
       "author": {
         "name": "Smart AI Memory",
         "email": "patrick.roebuck@smartaimemory.com"

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,4 +1,4 @@
-# Attune AI Framework v10.0.2
+# Attune AI Framework v10.1.0
 
 AI-powered developer workflows with cost optimization and multi-agent orchestration.
 
@@ -148,7 +148,7 @@ attune_redis/          # attune-redis plugin (pip install attune-redis)
 
 ---
 
-**Version:** 10.0.2 | **License:** Apache 2.0 | **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)
+**Version:** 10.1.0 | **License:** Apache 2.0 | **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)
 
 ## Lessons — core
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [10.1.0] — 2026-07-08
+
+Memory-suite minor: stash lifecycle UX (task-note expiry, review
+affordance, zsh trap coverage), self-measuring memory telemetry, and
+a Windows-CI-hardening fix for Redis host resolution.
+
 ### Added
 
 - **Task-note expiry (recall-time reconcile + forget)**: the

--- a/docs/reference/API_REFERENCE.md
+++ b/docs/reference/API_REFERENCE.md
@@ -1,6 +1,6 @@
 # Attune AI API Reference
 
-**Version:** 10.0.2
+**Version:** 10.1.0
 **License:** Apache License 2.0
 **Copyright:** 2025-2026 Smart AI Memory, LLC
 
@@ -1152,5 +1152,5 @@ msg = format_error(
 
 ---
 
-**Version:** 10.0.2 | **License:** Apache 2.0
+**Version:** 10.1.0 | **License:** Apache 2.0
 **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)

--- a/plugin/.claude-plugin/marketplace.json
+++ b/plugin/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "Spec-driven development for Claude Code — /spec plans, reviews, and executes with quality gates; plus security audits, code reviews, test generation, and release prep from /attune.",
-    "version": "10.0.2"
+    "version": "10.1.0"
   },
   "plugins": [
     {
       "name": "attune-ai",
       "description": "Spec-driven development for Claude Code — /spec plans, reviews, and executes with quality gates; plus security audits, code reviews, test generation, and release prep from /attune.",
       "source": "./",
-      "version": "10.0.2",
+      "version": "10.1.0",
       "author": {
         "name": "Smart AI Memory",
         "email": "patrick.roebuck@smartaimemory.com"

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "attune-ai",
-  "version": "10.0.2",
+  "version": "10.1.0",
   "description": "Spec-driven development for Claude Code — /spec plans, reviews, and executes with quality gates; plus security audits, code reviews, test generation, and release prep from /attune.",
   "author": {
     "name": "Smart AI Memory",

--- a/plugin/core/__init__.py
+++ b/plugin/core/__init__.py
@@ -5,4 +5,4 @@ This module provides the core workflow functionality when the full
 attune-ai package is not installed via pip.
 """
 
-__version__ = "10.0.2"
+__version__ = "10.1.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "attune-ai"
-version = "10.0.2"
+version = "10.1.0"
 description = "AI-powered developer workflows for Claude with cost optimization, multi-agent orchestration, and workflow automation."
 readme = {file = "README.md", content-type = "text/markdown"}
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -253,7 +253,7 @@ wheels = [
 
 [[package]]
 name = "attune-ai"
-version = "10.0.2"
+version = "10.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "agent-memory-client" },

--- a/website/app/page.tsx
+++ b/website/app/page.tsx
@@ -58,7 +58,7 @@ export default function Home() {
             <div className="grid lg:grid-cols-2 gap-16 items-center">
               <div className="z-10">
                 <div className="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-[var(--surface-container-high)] text-[var(--primary)] text-xs font-bold tracking-widest mb-6 uppercase">
-                  <span>v10.0.2</span>
+                  <span>v10.1.0</span>
                   <span className="w-1 h-1 rounded-full bg-[var(--primary)]"></span>
                   <span className="opacity-80">Spec-driven development platform</span>
                 </div>

--- a/website/lib/features.ts
+++ b/website/lib/features.ts
@@ -32,7 +32,7 @@ export const PRODUCTS: Product[] = [
     id: "attune-ai",
     name: "Attune AI",
     pypiName: "attune-ai",
-    version: "10.0.2",
+    version: "10.1.0",
     tagline: "Generate, maintain, and serve help from your code",
     installCommand: "pip install attune-ai",
     marketplaceInstall:
@@ -101,7 +101,7 @@ export const PRODUCTS: Product[] = [
     id: "claude-code-plugin",
     name: "Claude Code Plugin",
     pypiName: "attune-ai",
-    version: "10.0.2",
+    version: "10.1.0",
     tagline: "Progressive help right in your terminal",
     installCommand:
       "claude plugin marketplace add Smart-AI-Memory/attune-ai",

--- a/website/lib/features.ts
+++ b/website/lib/features.ts
@@ -54,7 +54,7 @@ export const PRODUCTS: Product[] = [
     id: "attune-help",
     name: "Attune Help",
     pypiName: "attune-help",
-    version: "0.11.1",
+    version: "0.12.0",
     tagline: "Lightweight reader for help templates",
     installCommand: "pip install attune-help",
     marketplaceInstall:


### PR DESCRIPTION
Release prep for **10.1.0** (minor).

## What ships
- feat(memory) #1283 — stash lifecycle UX: task-note expiry, review affordance, zsh trap #5
- feat(memory) #1279 — self-measuring telemetry for the short-term memory hooks
- fix(memory) #1282 — Redis host default `localhost` → `127.0.0.1` (Windows CI getaddrinfo wedge)

## This PR
- `scripts/bump_version.py 10.1.0` — all 9 version sites
- CHANGELOG: `[Unreleased]` → `[10.1.0] — 2026-07-08` with release intro
- `uv lock` (self-version only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)