### PR TITLE
chore(release): 10.1.0 close-out — lesson + reach snapshot (partial)

### DIFF
--- a/.claude/lessons.md
+++ b/.claude/lessons.md
@@ -14133,3 +14133,20 @@ def ", start_idx + 1)` for module-
   missing keys is the tell. Same family as "registered ≠ working"
   — the fix ships with non-mocked round-trip tests on the real
   route.
+
+- **Starter-file pre-authorization is invisible to the auto-mode
+  classifier — get an explicit in-session green light (one
+  AskUserQuestion) before the first `gh pr merge --admin`**: the
+  morning starter pre-staged the exact admin-merge command for a
+  changelog PR, but the classifier blocked it ("no in-session
+  approval is visible") — it reads the conversation, not
+  `~/.attune/next_session_starter.md`. One AskUserQuestion
+  confirming the merge(s) unblocked it, and per the durable
+  in-session-auth precedent the approval covered subsequent
+  admin-merges that session. Pattern: when a handoff file
+  authorizes classifier-gated actions (admin merges, protection
+  changes), convert that into in-session approval FIRST — one
+  question batching all the gated actions — instead of burning a
+  blocked attempt per action. Extends the "harness safety
+  classifier blocks bundled-destructive scripts" lesson: same
+  classifier, new surface (pre-staged authorization vs bundling).

--- a/docs/specs/usage-signals/snapshots/2026-07-08.json
+++ b/docs/specs/usage-signals/snapshots/2026-07-08.json
@@ -1,0 +1,12 @@
+{
+  "date": "2026-07-08",
+  "github": {},
+  "pypi_recent": {
+    "attune-ai": {
+      "last_day": 37,
+      "last_month": 5092,
+      "last_week": 2316
+    }
+  },
+  "taken_at": "2026-07-08T05:00:55.367753+00:00"
+}


### PR DESCRIPTION
Post-release close-out for v10.1.0:

- **lessons.md**: starter-file pre-authorization is invisible to the auto-mode classifier — convert handoff-file authorization into one in-session AskUserQuestion before the first gated action.
- **Reach snapshot 2026-07-08** (usage-signals R4): partial — 1/5 packages (attune-ai: 5,092/month). pypistats rate-limit penalty outlasted two cooldown retries; remaining packages can be backfilled by the next scheduled snapshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)