### PR TITLE
docs: social-content lesson + archive the posted 10.1.0 announcement

### DIFF
--- a/.claude/lessons.md
+++ b/.claude/lessons.md
@@ -14150,3 +14150,21 @@ def ", start_idx + 1)` for module-
   blocked attempt per action. Extends the "harness safety
   classifier blocks bundled-destructive scripts" lesson: same
   classifier, new surface (pre-staged authorization vs bundling).
+
+- **Social-content state lives OFF-repo — the drafts folder and
+  memory's published/unpublished ledger don't tell you what's
+  actually posted; confirm the referent before drafting companion
+  content**: (2026-07-08) asked for "a brief post about the
+  article to announce it," I anchored on the next-in-queue draft
+  (the 10.0.0 "deletion release" Article) and drafted an
+  announcement for the WRONG release — the just-shipped version
+  was 10.1.0; the "article" then turned out to be a THIRD piece
+  (`docs/blog/social/linkedin_memory_metrics.md`) that had been
+  published without any memory record. Two rules: (1) a release
+  announcement anchors to the latest SHIPPED version
+  (release_state memory / PyPI), never to the newest draft in
+  `docs/blog/social/`; (2) when the user says "the article/post"
+  and ≥2 drafted-or-published pieces could match, ask which one —
+  posting happens outside the repo, so the memory ledger is
+  best-effort, not authoritative; reconcile it (posted-status,
+  URLs) whenever the user mentions having posted something.

--- a/docs/blog/social/linkedin_v10_1_announcement.md
+++ b/docs/blog/social/linkedin_v10_1_announcement.md
@@ -1,0 +1,41 @@
+---
+description: "LinkedIn Post — Attune AI 10.1.0 announcement (posted 2026-07-08): telemetry-lead brief post; the memory layer now measures itself. Companion to the 'memory features, in metrics you actually feel' Article."
+---
+
+# LinkedIn Post — Attune AI 10.1.0 announcement
+
+*Posted 2026-07-08. ~150 words, no hashtags (deliberate).
+ASCII markers only — LinkedIn mangles Unicode arrows on paste.*
+
+Post URL:
+<https://www.linkedin.com/posts/patrick-roebuck-attune-ai_aidevelopment-developertools-python-activity-7480585093829308416-41yk>
+
+Companion Article ("Memory features, in metrics you actually
+feel", `linkedin_memory_metrics.md`):
+<https://www.linkedin.com/posts/patrick-roebuck-attune-ai_aidevelopment-developertools-python-activity-7480583188466196480-hZzd>
+
+---
+
+Attune AI 10.1.0 is out -- the memory-suite release.
+
+Last week I published an article with hard numbers on what our
+persistent AI memory saves (67x fewer tokens per recall, sub-ms
+lookups). The obvious follow-up question: how do we KNOW, on an
+ongoing basis, what the memory layer costs?
+
+10.1.0's answer: the memory layer now measures itself. Every
+recall, rule lookup, and session stash logs its own footprint --
+tokens injected, entries recalled, one local-only JSON line per
+event. Opt-in, never phoned home. Measured, not modeled.
+
+Also in this release:
+
+-> Stale-note expiry: recalled findings that reference merged PRs
+   auto-expire instead of resurfacing for 30 days
+-> A review affordance to delete wrong memory captures in one step
+-> A Redis host-resolution fix that was quietly wedging Windows CI
+
+Full memory-suite story with the benchmark receipts:
+[ARTICLE LINK]
+
+pip install --upgrade attune-ai


### PR DESCRIPTION
Two small docs items from the 2026-07-08 LinkedIn session:

- **Lesson** (`.claude/lessons.md`): social-content posting state lives off-repo — anchor release announcements to the latest shipped version and confirm which piece "the article" means before drafting companion content.
- **Archive** (`docs/blog/social/linkedin_v10_1_announcement.md`): the 10.1.0 announcement post as actually posted, with the post URL and the companion "metrics you actually feel" Article URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)