### PR TITLE
feat(ops): read and surface short-term memory telemetry

### DIFF
--- a/.claude/lessons.md
+++ b/.claude/lessons.md
@@ -9830,6 +9830,34 @@ files.
     these entries are local-only and can't/shouldn't be committed —
     they hold machine-specific absolute paths. "Commit the launch
     config" is a no-op; don't force-add past the ignore.
+  - **To run the WORKTREE's code (not main's) in the dashboard, wrap
+    the launch in `env` to inject PYTHONPATH** (2026-07-08). The
+    known-good recipe above uses the main venv + `--project-root
+    /main`, which runs MAIN's editable-mapped code — fine for just
+    viewing, wrong when you're actively editing worktree source. To
+    exercise your edits, set `runtimeExecutable` = `env` and
+    `runtimeArgs` =
+    `["PYTHONPATH=<worktree>/src", "/Users/.../attune-ai/.venv/bin/
+    python", "-m", "attune.ops", "--project-root", "<worktree>",
+    "--port", "8765", "--no-browser"]`. Main venv supplies the
+    `[ops]` extras; the PYTHONPATH override wins over the editable
+    MAPPING so the worktree's modules load. Confirm with `curl -s
+    localhost:8765/api/info` — `project_root` should read the
+    worktree path.
+  - **The dashboard dev server imports route/data `.py` at STARTUP
+    and does NOT hot-reload them — only Jinja templates render fresh
+    from disk per request** (2026-07-08). Editing a template
+    (`templates/*.html`) shows up on the next reload; editing a
+    route (`routes/*.py`) or `ops/data.py` does NOT until you
+    `preview_stop` + `preview_start`. The trap signature: the
+    template change renders, but a NEW context var the route was
+    supposed to pass comes through empty/undefined (Jinja silently
+    renders missing vars as falsy), so a freshly-added section hits
+    its `{% else %}` empty-state despite correct data on disk. Cost
+    a verify cycle this session (empty KPIs → diagnosed as stale
+    module code → restart fixed it). Rule: after editing any Python
+    the dashboard serves, RESTART the preview server before
+    verifying; a template-only edit can skip the restart.
 
 - **Cross-repo work from a worktree-rooted session: `worktree_path_guard`
   blocks Write/Edit into sibling repos, `EnterWorktree` can't cross

--- a/.claude/plans/memory-telemetry-analyzer.md
+++ b/.claude/plans/memory-telemetry-analyzer.md
@@ -1,0 +1,310 @@
+# Memory Telemetry Analyzer
+
+**Created:** 2026-07-08
+**Status:** EXECUTED 2026-07-08 — all 5 tasks landed, verified live
+**Owner:** Patrick + agent
+
+**Execution note:** Task 4 ships the benefit signal as counts (rule
+surfacings, distinct rules, top rules) captioned as an upper bound —
+never a savings percentage. A module constant
+(`INTERVENTION_SIGNAL_CAPTION`) is asserted verbatim by a test so the
+discredited "memory saves X%" framing cannot creep back in.
+
+---
+
+## Context
+
+PR #1279 (shipped 10.1.0) added a self-measuring producer for the
+short-term memory hooks: [`_memory_telemetry.py`](../../plugin/hooks/_memory_telemetry.py)
+appends one JSON line per hook fire to
+`~/.attune/telemetry/memory_events.jsonl`. As of 2026-07-08 the live
+file holds **162 events across 99 sessions** (~24k est_tokens
+injected): 128 `session_recall`, 28 `jit_recall`, 6 `session_stash`.
+
+The producer is healthy and wired into all three hooks. **Nothing
+reads the file.** The recalled finding that motivated this work —
+"the Redis short-term memory layer had no telemetry for its
+token/cost impact, requiring counterfactual modeling instead of
+measurement" — is only half-closed: we now *record* impact but
+still can't *report* it.
+
+Event shapes (confirmed from live data):
+
+- `session_recall` — `entries`, `injected_chars`, `est_tokens`
+- `jit_recall` — `tool`, `rules[]`, `injected_chars`, `est_tokens`
+- `session_stash` — `findings`, `written`, `extractor`,
+  `injected_chars`, `est_tokens`
+
+---
+
+## Problem
+
+Memory injection is a real, measurable **cost** (tokens added to
+context every session) with an unmeasured **benefit** (failures
+avoided by surfacing the right rule/finding). Today neither side is
+visible: no CLI, no MCP field, no dashboard tile reads
+`memory_events.jsonl`.
+
+A load-bearing constraint governs this work. The first
+`session_savings` A/B run (2026-07-06) showed **+28% cost/task** on
+one-shot tasks — directly contradicting the informal "memory saves
+8%" claim (see `memory_cost_claim_grounding.md`). Therefore:
+
+> The analyzer reports **cost as measured fact** and **benefit as a
+> clearly-labeled, method-exposed, low-confidence estimate** — never
+> as a settled savings number. A defensible savings figure needs a
+> continuity/trap task set with repeats ≥3, which this data does not
+> contain.
+
+---
+
+## Goals
+
+1. A reader that turns `memory_events.jsonl` into cost aggregates
+   (per event type / per session / per day), reusing the existing
+   `usage.jsonl` reader pattern in `ops/data.py`.
+2. Surface the numbers two ways: a `memory` section in the
+   `telemetry_stats` MCP tool, and a row-group on the ops Telemetry
+   dashboard tab.
+3. A **labeled** benefit-inference estimate derived from
+   `jit_recall` rule surfacings — shipped after cost, gated behind
+   its own honesty caption, never blocking the cost report.
+4. Regression protection against the two documented telemetry-reader
+   traps: the `ts` vs `timestamp` field bug and test-pollution of
+   the real `~/.attune` JSONL.
+
+---
+
+## End State
+
+`attune`'s telemetry MCP tool and the ops dashboard both answer
+"what does short-term memory cost me?" from real logged data, and
+offer a captioned "estimated intervention signal" alongside it that
+is honest about being an upper-bound heuristic, not a savings claim.
+
+---
+
+## Decisions (record in decisions.md on execute)
+
+- **Measurement scope:** cost (measured) + benefit (labeled
+  estimate). Patrick chose benefit inference over cost-only
+  2026-07-08; honesty guardrail above is the binding constraint.
+- **Surfaces:** MCP tool + dashboard tile (both).
+- **Home:** reader extends `ops/data.py` rather than a new module —
+  it already owns telemetry reading and the dashboard imports from
+  it.
+
+---
+
+## Tasks
+
+Below are self-contained XML task specs for implementation. Tasks
+1–3 + 5 deliver the honest cost report and can ship without Task 4;
+Task 4 (benefit estimate) is additive and last.
+
+<task id="1" name="memory-events-reader">
+  <objective>
+    Add read_memory_summary() to ops/data.py: parse
+    memory_events.jsonl into cost aggregates grouped by event type,
+    session, and day. Pure function, never raises on malformed lines.
+  </objective>
+  <context>
+    <existing-code path="src/attune/ops/data.py">
+      read_telemetry_summary() already parses usage.jsonl and buckets
+      by_day. Mirror its shape, error tolerance, and return-dict
+      style. CRITICAL: memory events use the field "ts" (not
+      "timestamp") — read event.get("ts") or event.get("timestamp").
+    </existing-code>
+    <existing-code path="plugin/hooks/_memory_telemetry.py">
+      Canonical event schema: v, ts, event, session_id,
+      injected_chars, est_tokens, plus per-event fields (entries /
+      tool+rules / findings+written+extractor).
+    </existing-code>
+  </context>
+  <files-to-modify>
+    <file path="src/attune/ops/data.py">
+      <change location="new function read_memory_summary(path=None)">
+        Returns dict: {
+          "total_events": int, "total_est_tokens": int,
+          "distinct_sessions": int,
+          "by_event": {event: {"n": int, "est_tokens": int}},
+          "by_day": {YYYY-MM-DD: {"n": int, "est_tokens": int}},
+          "per_session_avg_tokens": float,
+        }. Skip unparseable lines silently. Missing file → zeroed
+        summary, not an exception.
+      </change>
+    </file>
+  </files-to-modify>
+  <validation>
+    <check>read_memory_summary on a 3-line fixture returns
+    total_events==3 and correct est_tokens sum</check>
+    <check>reads "ts" field: an event with only "ts" buckets into
+    by_day correctly (regression vs the timestamp bug)</check>
+    <check>missing file returns a zeroed dict, raises nothing</check>
+  </validation>
+  <risks>
+    <risk severity="medium">The ts-vs-timestamp trap already shipped
+    once (Home KPIs read 0). The by_day check above is the guard.</risk>
+  </risks>
+</task>
+
+<task id="2" name="telemetry-stats-mcp-memory-section">
+  <objective>
+    Extend the telemetry_stats MCP tool to include a "memory"
+    section sourced from read_memory_summary().
+  </objective>
+  <context>
+    <existing-code path="src/attune/mcp/tool_schemas.py">
+      telemetry_stats schema lives here; verify the handler location
+      via grep -rn "telemetry_stats" src/attune/mcp/.
+    </existing-code>
+  </context>
+  <files-to-modify>
+    <file path="src/attune/mcp/(telemetry_stats handler)">
+      <change location="handler result assembly">
+        Add result["memory"] = read_memory_summary(). Keep existing
+        usage stats untouched — additive only.
+      </change>
+    </file>
+  </files-to-modify>
+  <validation>
+    <check>calling telemetry_stats returns a "memory" key with
+    by_event and total_est_tokens</check>
+    <check>tool count / schema tests still pass (additive field, no
+    new tool)</check>
+  </validation>
+  <risks>
+    <risk severity="low">Handler location differs from schema file;
+    grep before editing.</risk>
+  </risks>
+</task>
+
+<task id="3" name="dashboard-memory-rowgroup">
+  <objective>
+    Add a "Short-term memory" row-group to the ops Telemetry tab
+    rendering read_memory_summary(): total tokens injected, per-event
+    breakdown, per-session average.
+  </objective>
+  <context>
+    <existing-code path="src/attune/ops/templates/telemetry.html">
+      Existing per-workflow rollup table is the styling template to
+      match. Data flows through ops/routes/dashboard.py.
+    </existing-code>
+    <existing-code path="src/attune/ops/routes/dashboard.py">
+      Telemetry route builds the context dict; add memory_summary to
+      it from read_memory_summary().
+    </existing-code>
+  </context>
+  <files-to-modify>
+    <file path="src/attune/ops/routes/dashboard.py">
+      <change location="telemetry route context">
+        context["memory_summary"] = read_memory_summary()
+      </change>
+    </file>
+    <file path="src/attune/ops/templates/telemetry.html">
+      <change location="after the per-workflow rollup">
+        New section rendering by_event rows + totals. Empty state:
+        "No memory events yet" when total_events == 0.
+      </change>
+    </file>
+  </files-to-modify>
+  <validation>
+    <check>dashboard Telemetry tab renders the memory section with
+    live totals (verify via preview_start + preview_snapshot)</check>
+    <check>empty-file case renders the empty-state string, not a
+    crash</check>
+  </validation>
+  <risks>
+    <risk severity="low">Template context wiring; verify against the
+    running worktree dashboard (already up on :8765).</risk>
+  </risks>
+</task>
+
+<task id="4" name="benefit-inference-labeled-estimate">
+  <objective>
+    Add estimate_intervention_signal() deriving a LABELED,
+    low-confidence benefit signal from jit_recall rule surfacings —
+    NOT a savings claim. Surface it captioned in both surfaces.
+  </objective>
+  <context>
+    <existing-code path="plugin/hooks/_memory_telemetry.py">
+      jit_recall events carry tool + rules[]. The producer docstring
+      notes these enable "rule surfaced at T → did the matching
+      failure occur after" correlation. memory_events.jsonl alone has
+      NO failure log, so the honest estimate is an UPPER BOUND:
+      count distinct (rule, tool) surfacings as potential
+      interventions, not confirmed prevented failures.
+    </existing-code>
+    <context-note>
+      Binding constraint from memory_cost_claim_grounding.md: output
+      must be captioned as an estimate with its method stated inline
+      ("N rule surfacings that MAY have prevented a failure; upper
+      bound, not measured savings"). No cost-savings percentage.
+    </context-note>
+  </context>
+  <files-to-modify>
+    <file path="src/attune/ops/data.py">
+      <change location="new function estimate_intervention_signal(path=None)">
+        Returns {"rule_surfacings": int, "distinct_rules": int,
+        "top_rules": [(rule, count)...], "caption": "<honesty
+        string>"}. Cost report never depends on this.
+      </change>
+    </file>
+  </files-to-modify>
+  <validation>
+    <check>returns distinct_rules and a non-empty caption string
+    containing "estimate" / "upper bound"</check>
+    <check>MCP + dashboard render the caption verbatim; no bare
+    percentage or "saves" wording appears</check>
+  </validation>
+  <risks>
+    <risk severity="high">Presenting this as measured savings
+    reintroduces the exact discredited "8% savings" claim. The
+    caption + no-percentage rule is the mitigation; a test asserts
+    the caption text is present.</risk>
+  </risks>
+</task>
+
+<task id="5" name="tests-and-regression-guards">
+  <objective>
+    Fixture-based tests for the reader and estimate, plus the two
+    documented-trap regression guards.
+  </objective>
+  <context>
+    <existing-code path="tests/unit/ops/">
+      Existing telemetry-reader tests are the pattern. Use a
+      tmp_path fixture JSONL with a few of each event type.
+    </existing-code>
+    <context-note>
+      Documented trap: telemetry trackers reached via production code
+      paths pollute the real ~/.attune JSONL. Add an autouse conftest
+      fixture setting ATTUNE_MEMORY_TELEMETRY=0 for these tests so no
+      test writes to the live file.
+    </context-note>
+  </context>
+  <files-to-create>
+    <file path="tests/unit/ops/test_memory_summary.py">
+      Aggregation totals; ts-field regression (by_day populated from
+      "ts"); missing-file → zeroed; malformed line skipped;
+      estimate caption present.
+    </file>
+  </files-to-create>
+  <files-to-modify>
+    <file path="tests/unit/ops/conftest.py">
+      <change location="autouse fixture">
+        Set ATTUNE_MEMORY_TELEMETRY=0 via monkeypatch.setenv so
+        production-path tracker calls no-op during tests.
+      </change>
+    </file>
+  </files-to-modify>
+  <validation>
+    <check>pytest tests/unit/ops/test_memory_summary.py -q passes</check>
+    <check>running the suite leaves ~/.attune/telemetry/memory_events.jsonl
+    line-count unchanged (no test pollution)</check>
+  </validation>
+  <risks>
+    <risk severity="medium">A conftest env change scoped too broadly
+    could mask real behavior in sibling tests; keep the fixture in
+    tests/unit/ops/ only.</risk>
+  </risks>
+</task>

--- a/src/attune/mcp/server.py
+++ b/src/attune/mcp/server.py
@@ -583,7 +583,28 @@ class EmpathyMCPServer(MemoryHandlersMixin, WorkflowHandlersMixin):
 
             tracker = UsageTracker()
             stats = tracker.get_stats(days=args.get("days", 30))
-            return {"success": True, **stats}
+            result: dict[str, Any] = {"success": True, **stats}
+
+            # Additive: short-term memory injection cost, read from the
+            # local memory_events.jsonl the memory hooks write. Guarded so
+            # a missing [ops] surface degrades to no memory section rather
+            # than failing the whole telemetry call.
+            try:
+                from attune.ops.data import (
+                    estimate_intervention_signal,
+                    read_memory_summary,
+                )
+
+                result["memory"] = read_memory_summary()
+                # Labeled benefit estimate — see the caption in the payload;
+                # this is an upper bound on interventions, not savings.
+                result["memory_intervention_signal"] = estimate_intervention_signal()
+            except Exception:  # noqa: BLE001
+                # INTENTIONAL: memory telemetry is a bonus section; never
+                # let it break the core usage stats.
+                logger.debug("memory summary unavailable", exc_info=True)
+
+            return result
         except ImportError as e:
             logger.warning("Telemetry module not available: %s", e)
             return {"success": False, "error": "Telemetry module not installed"}

--- a/src/attune/ops/config.py
+++ b/src/attune/ops/config.py
@@ -42,6 +42,15 @@ class Config:
         return self.attune_home / "telemetry" / "usage.jsonl"
 
     @property
+    def memory_events_path(self) -> Path:
+        """Local event log written by the short-term memory hooks.
+
+        Produced by ``plugin/hooks/_memory_telemetry.py``; one JSON line
+        per hook fire (session_recall / jit_recall / session_stash).
+        """
+        return self.attune_home / "telemetry" / "memory_events.jsonl"
+
+    @property
     def runs_dir(self) -> Path:
         """Disk root for persisted ops runs. May not exist until first write."""
         return self.attune_home / "ops" / "runs"

--- a/src/attune/ops/data.py
+++ b/src/attune/ops/data.py
@@ -18,7 +18,7 @@ from datetime import date, datetime, timezone
 from pathlib import Path
 from typing import Any
 
-from attune.ops.config import Config
+from attune.ops.config import Config, attune_home
 
 logger = logging.getLogger(__name__)
 
@@ -939,6 +939,171 @@ def read_telemetry_summary(
         by_day=recent_days_data,
         last_event_at=last_event_at,
     )
+
+
+def read_memory_summary(path: Path | None = None) -> dict[str, Any]:
+    """Aggregate ``memory_events.jsonl`` into a cost summary.
+
+    Reports what the short-term memory hooks (session recall, JIT rule
+    recall, the Stop-hook stash) actually inject — measured cost, not a
+    savings estimate. See ``plugin/hooks/_memory_telemetry.py`` for the
+    producer and event schema.
+
+    Args:
+        path: Override the events-file location (tests pass a fixture).
+            ``None`` resolves to ``<attune_home>/telemetry/
+            memory_events.jsonl``.
+
+    Returns:
+        A JSON-serializable dict. A missing file yields a zeroed summary
+        (never raises), so callers can render an empty state.
+    """
+    if path is None:
+        path = attune_home() / "telemetry" / "memory_events.jsonl"
+
+    zeroed: dict[str, Any] = {
+        "total_events": 0,
+        "total_est_tokens": 0,
+        "distinct_sessions": 0,
+        "by_event": {},
+        "by_day": {},
+        "per_session_avg_tokens": 0.0,
+    }
+    if not path.exists():
+        return zeroed
+
+    total_events = 0
+    total_est_tokens = 0
+    sessions: set[str] = set()
+    by_event_n: dict[str, int] = defaultdict(int)
+    by_event_tokens: dict[str, int] = defaultdict(int)
+    by_day_n: dict[str, int] = defaultdict(int)
+    by_day_tokens: dict[str, int] = defaultdict(int)
+
+    try:
+        with path.open("r", encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    event: dict[str, Any] = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+
+                name = str(event.get("event") or "unknown")
+                tokens = int(event.get("est_tokens", 0) or 0)
+                # Memory events use the ``ts`` key (v1.0 schema in
+                # _memory_telemetry.log_memory_event); ``timestamp`` is a
+                # defensive fallback. Without it every event misses the
+                # by_day bucketing — the same zero-KPI bug the usage
+                # reader documents just above.
+                ts = str(event.get("ts") or event.get("timestamp") or "")
+                sid = event.get("session_id")
+
+                total_events += 1
+                total_est_tokens += tokens
+                by_event_n[name] += 1
+                by_event_tokens[name] += tokens
+                if sid:
+                    sessions.add(str(sid))
+
+                day = _to_day(ts)
+                if day:
+                    by_day_n[day] += 1
+                    by_day_tokens[day] += tokens
+    except OSError:
+        return zeroed
+
+    distinct_sessions = len(sessions)
+    per_session_avg = round(total_est_tokens / distinct_sessions, 1) if distinct_sessions else 0.0
+
+    return {
+        "total_events": total_events,
+        "total_est_tokens": total_est_tokens,
+        "distinct_sessions": distinct_sessions,
+        "by_event": {
+            name: {"n": by_event_n[name], "est_tokens": by_event_tokens[name]}
+            for name in sorted(by_event_n)
+        },
+        "by_day": {
+            day: {"n": by_day_n[day], "est_tokens": by_day_tokens[day]} for day in sorted(by_day_n)
+        },
+        "per_session_avg_tokens": per_session_avg,
+    }
+
+
+#: Honesty caption shipped verbatim with every intervention-signal
+#: readout. The benefit of memory injection cannot be MEASURED from the
+#: event log alone (no failure log to correlate against), so this number
+#: is an upper bound on interventions, not a savings figure. Keeping the
+#: caption a module constant lets a test assert it renders unmodified —
+#: the guard against the discredited "memory saves X%" framing.
+INTERVENTION_SIGNAL_CAPTION = (
+    "Estimate, not measured savings: counts JIT rules surfaced before a "
+    "tool call. Each MAY have prevented a mistake, but the log has no "
+    "failure record to confirm it — treat this as an upper bound on "
+    "helpful interventions, never a cost-savings percentage."
+)
+
+
+def estimate_intervention_signal(path: Path | None = None) -> dict[str, Any]:
+    """Estimate a LABELED benefit signal from ``jit_recall`` surfacings.
+
+    Counts how often the JIT recall hook surfaced a rule right before a
+    tool call. This is deliberately NOT a savings number: the event log
+    records what was injected, not whether a failure was actually
+    avoided, so the honest reading is an upper bound on helpful
+    interventions. Every caller must render :data:`INTERVENTION_SIGNAL_CAPTION`
+    alongside these figures. See ``memory_cost_claim_grounding`` for why a
+    real savings claim needs a separate benchmark.
+
+    Args:
+        path: Override the events-file location (tests pass a fixture).
+            ``None`` resolves to the default ``memory_events.jsonl``.
+
+    Returns:
+        JSON-serializable dict with ``rule_surfacings`` (int),
+        ``distinct_rules`` (int), ``top_rules`` (list of ``[rule, count]``,
+        highest first), and ``caption`` (the verbatim honesty string).
+        A missing file yields zeroed counts, never an exception.
+    """
+    if path is None:
+        path = attune_home() / "telemetry" / "memory_events.jsonl"
+
+    rule_counts: dict[str, int] = defaultdict(int)
+    surfacings = 0
+
+    if path.exists():
+        try:
+            with path.open("r", encoding="utf-8") as f:
+                for line in f:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        event: dict[str, Any] = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+                    if event.get("event") != "jit_recall":
+                        continue
+                    rules = event.get("rules") or []
+                    if not isinstance(rules, list):
+                        continue
+                    for rule in rules:
+                        rule_counts[str(rule)] += 1
+                        surfacings += 1
+        except OSError:
+            rule_counts.clear()
+            surfacings = 0
+
+    top_rules = heapq.nlargest(10, rule_counts.items(), key=lambda kv: kv[1])
+    return {
+        "rule_surfacings": surfacings,
+        "distinct_rules": len(rule_counts),
+        "top_rules": [[rule, count] for rule, count in top_rules],
+        "caption": INTERVENTION_SIGNAL_CAPTION,
+    }
 
 
 # ---------------------------------------------------------------------------

--- a/src/attune/ops/routes/dashboard.py
+++ b/src/attune/ops/routes/dashboard.py
@@ -183,6 +183,13 @@ async def telemetry_page(request: Request) -> HTMLResponse:
         "rec_card_clicks": counters.top("rec_card_click", limit=10) if counters else [],
         "scope_picker_changes": (counters.top("scope_picker_change", limit=10) if counters else []),
     }
+    # Short-term memory injection cost — read from the memory hooks'
+    # local event log. Reports measured cost (tokens injected), not a
+    # savings estimate; the template captions it accordingly.
+    memory_summary = data.read_memory_summary(cfg.memory_events_path)
+    # Labeled benefit estimate — carries its own honesty caption; the
+    # template renders it verbatim so this never reads as measured savings.
+    memory_signal = data.estimate_intervention_signal(cfg.memory_events_path)
     return _render(
         request,
         "telemetry.html",
@@ -190,6 +197,8 @@ async def telemetry_page(request: Request) -> HTMLResponse:
         telemetry=summary,
         interaction_totals=interaction_totals,
         interaction_top=interaction_top,
+        memory_summary=memory_summary,
+        memory_signal=memory_signal,
     )
 
 

--- a/src/attune/ops/templates/telemetry.html
+++ b/src/attune/ops/templates/telemetry.html
@@ -58,6 +58,67 @@
 {% endif %}
 
 <section class="panel">
+  <h2>Short-term memory</h2>
+  <p class="page-sub">
+    Context the memory hooks inject each session, from
+    <code>{{ attune_home }}/telemetry/memory_events.jsonl</code>.
+    This is measured <em>cost</em> (tokens added to context) &mdash; not
+    a savings figure.
+  </p>
+  {% if memory_summary and memory_summary.total_events %}
+    <div class="kpi-grid">
+      <div class="kpi">
+        <div class="kpi-label">Tokens injected (est.)</div>
+        <div class="kpi-value">{{ '{:,}'.format(memory_summary.total_est_tokens) }}</div>
+      </div>
+      <div class="kpi">
+        <div class="kpi-label">Events</div>
+        <div class="kpi-value">{{ '{:,}'.format(memory_summary.total_events) }}</div>
+      </div>
+      <div class="kpi">
+        <div class="kpi-label">Avg tokens / session</div>
+        <div class="kpi-value">{{ '{:,.1f}'.format(memory_summary.per_session_avg_tokens) }}</div>
+      </div>
+    </div>
+    <table class="data-table">
+      <thead><tr><th>Event</th><th class="num">Fires</th><th class="num">Tokens (est.)</th></tr></thead>
+      <tbody>
+        {% for name, row in memory_summary.by_event.items() %}
+          <tr><td><code>{{ name }}</code></td><td class="num">{{ row.n }}</td><td class="num">{{ '{:,}'.format(row.est_tokens) }}</td></tr>
+        {% endfor %}
+      </tbody>
+    </table>
+
+    {% if memory_signal %}
+      <h3>Estimated intervention signal</h3>
+      <p class="meta">{{ memory_signal.caption }}</p>
+      <div class="kpi-grid">
+        <div class="kpi">
+          <div class="kpi-label">Rule surfacings (upper bound)</div>
+          <div class="kpi-value">{{ '{:,}'.format(memory_signal.rule_surfacings) }}</div>
+        </div>
+        <div class="kpi">
+          <div class="kpi-label">Distinct rules</div>
+          <div class="kpi-value">{{ '{:,}'.format(memory_signal.distinct_rules) }}</div>
+        </div>
+      </div>
+      {% if memory_signal.top_rules %}
+        <table class="data-table">
+          <thead><tr><th>Rule</th><th class="num">Surfaced</th></tr></thead>
+          <tbody>
+            {% for rule, count in memory_signal.top_rules %}
+              <tr><td><code>{{ rule }}</code></td><td class="num">{{ count }}</td></tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      {% endif %}
+    {% endif %}
+  {% else %}
+    <p class="empty">No memory events yet.</p>
+  {% endif %}
+</section>
+
+<section class="panel">
   <h2>Dashboard interactions (this session)</h2>
   <p class="page-sub">In-memory counters since the dashboard process started. Resets on restart; no PII, no disk write.</p>
   <div class="kpi-grid">

--- a/tests/unit/ops/conftest.py
+++ b/tests/unit/ops/conftest.py
@@ -23,3 +23,14 @@ def _bypass_client_token(monkeypatch):
     # require_client_token reads the module global at call time, so
     # nulling it here makes missing-header requests pass the gate.
     monkeypatch.setattr("attune.ops.security._SESSION_TOKEN", None)
+
+
+@pytest.fixture(autouse=True)
+def _no_memory_telemetry_pollution(monkeypatch):
+    # The memory hooks' local tracker (plugin/hooks/_memory_telemetry.py)
+    # is default-on and writes to the real ~/.attune JSONL. Any ops test
+    # that reaches it through a production code path would append fixture
+    # events to the user's live file (the documented HelpTracker trap).
+    # Setting the module's opt-out env var makes log_memory_event no-op
+    # for the duration of every test in this directory.
+    monkeypatch.setenv("ATTUNE_MEMORY_TELEMETRY", "0")

--- a/tests/unit/ops/test_memory_summary.py
+++ b/tests/unit/ops/test_memory_summary.py
@@ -1,0 +1,176 @@
+"""Tests for the short-term memory telemetry analyzer.
+
+Covers ``read_memory_summary`` (cost aggregation) and
+``estimate_intervention_signal`` (labeled benefit estimate) in
+``attune.ops.data``. Two regression guards are load-bearing:
+
+- The ``ts`` field bug: memory events use ``ts`` (not ``timestamp``);
+  reading the wrong key silently empties the by_day bucket, the exact
+  class of bug documented for the usage reader.
+- The savings-claim guard: the intervention estimate must ship its
+  honesty caption and must NOT present a numeric savings percentage,
+  per ``memory_cost_claim_grounding``.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+
+from attune.ops.data import (
+    INTERVENTION_SIGNAL_CAPTION,
+    estimate_intervention_signal,
+    read_memory_summary,
+)
+
+
+def _write_jsonl(path, events):
+    path.write_text("\n".join(json.dumps(e) for e in events) + "\n", encoding="utf-8")
+
+
+def _sample_events():
+    return [
+        {
+            "v": "1.0",
+            "ts": "2026-07-08T01:00:00.000Z",
+            "event": "session_recall",
+            "session_id": "s1",
+            "entries": 5,
+            "injected_chars": 400,
+            "est_tokens": 100,
+        },
+        {
+            "v": "1.0",
+            "ts": "2026-07-08T02:00:00.000Z",
+            "event": "jit_recall",
+            "session_id": "s1",
+            "tool": "Bash",
+            "rules": ["zsh-eqword-expansion"],
+            "injected_chars": 200,
+            "est_tokens": 50,
+        },
+        {
+            "v": "1.0",
+            "ts": "2026-07-09T03:00:00.000Z",
+            "event": "jit_recall",
+            "session_id": "s2",
+            "tool": "Edit",
+            "rules": ["zsh-eqword-expansion", "formatter-strips-import"],
+            "injected_chars": 320,
+            "est_tokens": 80,
+        },
+    ]
+
+
+# ---------------------------------------------------------------------------
+# read_memory_summary
+# ---------------------------------------------------------------------------
+
+
+def test_aggregates_totals(tmp_path):
+    path = tmp_path / "memory_events.jsonl"
+    _write_jsonl(path, _sample_events())
+
+    summary = read_memory_summary(path)
+
+    assert summary["total_events"] == 3
+    assert summary["total_est_tokens"] == 230
+    assert summary["distinct_sessions"] == 2
+    assert summary["by_event"]["jit_recall"] == {"n": 2, "est_tokens": 130}
+    assert summary["by_event"]["session_recall"] == {"n": 1, "est_tokens": 100}
+    # 230 tokens / 2 sessions
+    assert summary["per_session_avg_tokens"] == 115.0
+
+
+def test_reads_ts_field_into_by_day(tmp_path):
+    """Regression: by_day must populate from the ``ts`` key.
+
+    An event carrying only ``ts`` (the writer's canonical field) must
+    land in by_day. Reading ``timestamp`` instead would leave by_day
+    empty — the silent zero-KPI bug the usage reader already fixed.
+    """
+    path = tmp_path / "memory_events.jsonl"
+    _write_jsonl(path, _sample_events())
+
+    summary = read_memory_summary(path)
+
+    assert set(summary["by_day"]) == {"2026-07-08", "2026-07-09"}
+    assert summary["by_day"]["2026-07-08"] == {"n": 2, "est_tokens": 150}
+
+
+def test_skips_malformed_lines(tmp_path):
+    path = tmp_path / "memory_events.jsonl"
+    path.write_text(
+        json.dumps(_sample_events()[0]) + "\nNOT JSON\n" + json.dumps(_sample_events()[1]) + "\n",
+        encoding="utf-8",
+    )
+
+    summary = read_memory_summary(path)
+
+    assert summary["total_events"] == 2
+
+
+def test_missing_file_is_zeroed(tmp_path):
+    summary = read_memory_summary(tmp_path / "does-not-exist.jsonl")
+
+    assert summary["total_events"] == 0
+    assert summary["total_est_tokens"] == 0
+    assert summary["by_event"] == {}
+    assert summary["per_session_avg_tokens"] == 0.0
+
+
+# ---------------------------------------------------------------------------
+# estimate_intervention_signal
+# ---------------------------------------------------------------------------
+
+
+def test_intervention_signal_counts_rule_surfacings(tmp_path):
+    path = tmp_path / "memory_events.jsonl"
+    _write_jsonl(path, _sample_events())
+
+    sig = estimate_intervention_signal(path)
+
+    # Two jit_recall events: one rule + two rules = 3 surfacings.
+    assert sig["rule_surfacings"] == 3
+    assert sig["distinct_rules"] == 2
+    # zsh-eqword-expansion fired twice → ranks first.
+    assert sig["top_rules"][0] == ["zsh-eqword-expansion", 2]
+
+
+def test_intervention_signal_ships_honesty_caption(tmp_path):
+    path = tmp_path / "memory_events.jsonl"
+    _write_jsonl(path, _sample_events())
+
+    sig = estimate_intervention_signal(path)
+
+    assert sig["caption"] == INTERVENTION_SIGNAL_CAPTION
+    caption = sig["caption"].lower()
+    assert "estimate" in caption
+    assert "upper bound" in caption
+
+
+def test_intervention_signal_presents_no_savings_percentage(tmp_path):
+    """Guard: the estimate must never render a numeric savings figure.
+
+    The caption may say the words "savings"/"percentage" while NEGATING
+    such a claim; what is forbidden is an actual number-as-savings. This
+    asserts no ``NN% saved`` / ``saves NN`` construction is present.
+    """
+    path = tmp_path / "memory_events.jsonl"
+    _write_jsonl(path, _sample_events())
+
+    sig = estimate_intervention_signal(path)
+    blob = json.dumps(sig).lower()
+
+    # No "<number>%" and no "saves <number>" / "saved <number>".
+    assert not re.search(r"\d+\s*%", blob)
+    assert not re.search(r"sav(e|es|ed|ings)\s+\d", blob)
+
+
+def test_intervention_signal_missing_file_is_zeroed(tmp_path):
+    sig = estimate_intervention_signal(tmp_path / "nope.jsonl")
+
+    assert sig["rule_surfacings"] == 0
+    assert sig["distinct_rules"] == 0
+    assert sig["top_rules"] == []
+    assert sig["caption"] == INTERVENTION_SIGNAL_CAPTION


### PR DESCRIPTION
## What

Makes the short-term memory telemetry **readable**. The memory hooks
have logged injection cost to `~/.attune/telemetry/memory_events.jsonl`
since #1279, but nothing consumed it — the "no telemetry for memory's
token/cost impact" gap was only half-closed (recorded, not reported).

## Changes

- **`read_memory_summary()`** in `ops/data.py` — cost aggregates by
  event / session / day, mirroring the `usage.jsonl` reader and
  guarding the `ts`-vs-`timestamp` field trap.
- **MCP** — additive `memory` + `memory_intervention_signal` sections
  on `telemetry_stats` (no schema/tool-count change).
- **Dashboard** — a "Short-term memory" panel on the ops Telemetry tab.
- **`estimate_intervention_signal()`** — a **labeled** benefit estimate
  from `jit_recall` rule surfacings, shipped as upper-bound counts with
  a verbatim honesty caption, never a savings percentage.
- **Tests** — fixture coverage for both functions + `ts`-field and
  savings-claim regression guards, plus an autouse conftest fixture
  (`ATTUNE_MEMORY_TELEMETRY=0`) so tests can't pollute the live JSONL.

## Honesty guardrail

The first `session_savings` A/B run showed **+28% cost/task**,
contradicting the informal "memory saves 8%" claim. So the analyzer
reports **cost as measured fact** and **benefit as a captioned,
upper-bound estimate** — never a settled savings figure.
`INTERVENTION_SIGNAL_CAPTION` is a module constant asserted verbatim by
a test so that framing can't regress.

## Verification

- Dashboard panel verified **live** on the running ops server (KPIs +
  per-event + top-rules tables render real data: 24.3k est. tokens over
  165 events / 99 sessions).
- 8 new tests + 56 sibling ops/MCP tests green; **zero** live-file
  pollution (line count unchanged across the run).
- `black` + `ruff` clean on all touched files.

Spec: `.claude/plans/memory-telemetry-analyzer.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
