### PR TITLE
feat(memory): capture the injection noise signal (Phase 1)

### DIFF
--- a/.claude/plans/memory-injection-feedback-signal.md
+++ b/.claude/plans/memory-injection-feedback-signal.md
@@ -1,0 +1,221 @@
+# Memory Injection Feedback Signal
+
+**Created:** 2026-07-08
+**Status:** approved — executing Phase 1
+**Owner:** Patrick + agent
+
+---
+
+## Context
+
+The memory-telemetry analyzer (shipped #1291) measures the COST side
+of short-term memory honestly, and ships the benefit as a labeled
+upper-bound (`estimate_intervention_signal`). The frame ratified this
+session ([[project_memory_as_insurance]]): memory is insurance;
+measure it as premium efficiency + tail-prevention NET OF false
+surfacings. The analyzer has the numerator's raw material
+(surfacings) but no NOISE denominator.
+
+Key finding: **the noise signal already exists, uninstrumented.**
+`forget_entries` / `forget_by_prefix` in
+[`session_stash.py`](../../src/attune/memory/session_stash.py) are the
+deletion path behind `/recall drop`, `/recall review`, and the
+starter reconciler — every deletion is an explicit "this surfaced
+finding was wrong / irrelevant / resolved" verdict. Today it returns
+a count and logs nothing. This session's two stale findings (bugs
+already fixed) would each have been one such verdict.
+
+`forget_by_prefix` delegates to `forget_entries`, so the latter is a
+single chokepoint: instrument it once and every deletion path is
+captured.
+
+Design wrinkle: the existing producer
+(`plugin/hooks/_memory_telemetry.py`) is not importable from `src/`.
+So this adds a canonical src-side writer in
+`src/attune/telemetry/memory_events.py` (same format, same
+`ATTUNE_MEMORY_TELEMETRY` / `DO_NOT_TRACK` gate, never raises). The
+hook keeps its own copy for now; convergence is a noted follow-up.
+
+---
+
+## Problem
+
+Memory's benefit can't be a savings %, but it CAN be a bounded-noise
+tail-prevention rate — if the noise is measured. There is no signal
+today for "a surfaced finding was rejected as noise," even though the
+user already produces that signal every time they drop a finding.
+
+---
+
+## Goals
+
+1. Capture explicit rejection verdicts as `memory_feedback` events in
+   the same `memory_events.jsonl`, via a src-side writer that inherits
+   the existing local-only consent gate.
+2. Compute an honest rejection rate (rejected / stash findings
+   written) and surface it, labeled, in the MCP tool + dashboard
+   panel shipped in #1291.
+3. Zero new user friction — pure instrumentation of clicks already
+   made.
+
+---
+
+## End State
+
+The Telemetry dashboard and `telemetry_stats` MCP tool report a
+`memory_feedback` section: how many surfaced findings were later
+rejected as noise, by source, as a rate against findings stashed —
+the net-of-noise half of the insurance ledger.
+
+---
+
+## Non-goals (Phase 2 — recorded, NOT built)
+
+- acted-on vs ignored inference from the transcript (did a surfaced
+  item precede matching use). Needs transcript correlation; deferred.
+- Converging `plugin/hooks/_memory_telemetry.py` onto the new src
+  writer. Additive-safe to defer; both write the same format.
+- Task-shape injection routing ("don't inject into a one-shot"). That
+  falls out of this noise data later; not this PR.
+
+---
+
+## Decisions
+
+- Same file, new `event: "memory_feedback"` type — one analyzer, one
+  gate, and a rejection correlates directly against the surfacings it
+  rejects.
+- Single emit point: `forget_entries` only (forget_by_prefix
+  delegates to it). `forget_by_prefix` threads `source`/`cwd` down;
+  it does NOT emit, to avoid double-counting.
+- Denominator = session_stash `written` sum (of the findings we
+  stashed, how many were later dropped) — the cleanest interpretable
+  noise rate. Reported labeled, never as "savings".
+
+---
+
+## Tasks
+
+<task id="1" name="src-memory-events-writer">
+  <objective>
+    Add src/attune/telemetry/memory_events.py with log_memory_event()
+    — a canonical, importable-from-src writer mirroring the hook copy:
+    same JSONL format + ATTUNE_MEMORY_TELEMETRY / DO_NOT_TRACK gate,
+    never raises.
+  </objective>
+  <context>
+    <existing-code path="plugin/hooks/_memory_telemetry.py">
+      The format + gate to mirror exactly: v/ts/event/session_id +
+      fields, ~/.attune/telemetry/memory_events.jsonl, _FALSEY env
+      handling, silent on all exceptions.
+    </existing-code>
+  </context>
+  <validation>
+    <check>log_memory_event("memory_feedback", verdict="rejected",
+    count=2) appends one parseable line with event=="memory_feedback"</check>
+    <check>ATTUNE_MEMORY_TELEMETRY=0 makes it a no-op</check>
+    <check>never raises on an unwritable path</check>
+  </validation>
+</task>
+
+<task id="2" name="instrument-forget-seam">
+  <objective>
+    Emit a memory_feedback event from forget_entries when a deletion
+    succeeds. Thread optional source/cwd through forget_by_prefix.
+  </objective>
+  <context>
+    <existing-code path="src/attune/memory/session_stash.py">
+      forget_entries returns the deleted count; forget_by_prefix
+      delegates to it. Both are best-effort / never-raise.
+    </existing-code>
+  </context>
+  <files-to-modify>
+    <file path="src/attune/memory/session_stash.py">
+      <change location="forget_entries">
+        Add optional source="forget" and cwd=None params. After a
+        successful forget with count>0, best-effort
+        log_memory_event("memory_feedback", verdict="rejected",
+        source=source, count=count, cwd=cwd). Import guarded so a
+        writer failure never breaks deletion.
+      </change>
+      <change location="forget_by_prefix">
+        Add source/cwd; pass to forget_entries. Do NOT emit here.
+      </change>
+    </file>
+  </files-to-modify>
+  <validation>
+    <check>forget_entries with a fake backend deleting 2 ids emits one
+    memory_feedback event with count==2</check>
+    <check>forget_by_prefix path emits exactly once (no double count)</check>
+    <check>deletion still returns the right count when telemetry is
+    disabled</check>
+  </validation>
+  <risks>
+    <risk severity="medium">Double-counting if both functions emit.
+    Mitigation: only forget_entries emits; a test asserts one event
+    per prefix-delete.</risk>
+  </risks>
+</task>
+
+<task id="3" name="feedback-reader-and-surfaces">
+  <objective>
+    Add estimate_feedback_signal() to ops/data.py (rejected count,
+    by_source, findings_written, rejection_rate, labeled caption), and
+    surface it on the telemetry_stats MCP tool + dashboard panel.
+  </objective>
+  <files-to-modify>
+    <file path="src/attune/ops/data.py">
+      <change location="new estimate_feedback_signal(path=None)">
+        Parse memory_feedback events (rejected count, by source) and
+        session_stash `written` sum (denominator). rejection_rate =
+        rejected / written (0.0 when written==0). Include a caption
+        naming it a noise rate, not savings.
+      </change>
+    </file>
+    <file path="src/attune/mcp/server.py">
+      <change location="_get_telemetry_stats memory block">
+        Add result["memory_feedback"] = estimate_feedback_signal().
+      </change>
+    </file>
+    <file path="src/attune/ops/routes/dashboard.py">
+      <change location="telemetry route">
+        context["memory_feedback"] = estimate_feedback_signal(
+        cfg.memory_events_path).
+      </change>
+    </file>
+    <file path="src/attune/ops/templates/telemetry.html">
+      <change location="in the Short-term memory panel">
+        Render rejected count, rejection rate, by-source; caption
+        verbatim. Empty state when no feedback yet.
+      </change>
+    </file>
+  </files-to-modify>
+  <validation>
+    <check>estimate_feedback_signal on a fixture with 2 rejected + 10
+    written returns rejection_rate 0.2</check>
+    <check>MCP telemetry_stats returns a memory_feedback key</check>
+    <check>dashboard panel renders the rate + caption (verify live)</check>
+  </validation>
+</task>
+
+<task id="4" name="tests-and-guards">
+  <objective>
+    Fixture tests for the writer, the seam emit, and the reader;
+    reuse the autouse ATTUNE_MEMORY_TELEMETRY=0 pollution guard.
+  </objective>
+  <files-to-create>
+    <file path="tests/unit/ops/test_feedback_signal.py">
+      estimate_feedback_signal math + caption present + missing-file
+      zeroed.
+    </file>
+    <file path="tests/unit/memory/test_forget_feedback.py">
+      forget_entries emits one memory_feedback event on success (with
+      a stub backend + tmp events path); no event when count==0; no
+      double-emit via forget_by_prefix.
+    </file>
+  </files-to-create>
+  <validation>
+    <check>both test files pass</check>
+    <check>full run leaves the live memory_events.jsonl unchanged</check>
+  </validation>
+</task>

--- a/src/attune/mcp/server.py
+++ b/src/attune/mcp/server.py
@@ -591,6 +591,7 @@ class EmpathyMCPServer(MemoryHandlersMixin, WorkflowHandlersMixin):
             # than failing the whole telemetry call.
             try:
                 from attune.ops.data import (
+                    estimate_feedback_signal,
                     estimate_intervention_signal,
                     read_memory_summary,
                 )
@@ -599,6 +600,8 @@ class EmpathyMCPServer(MemoryHandlersMixin, WorkflowHandlersMixin):
                 # Labeled benefit estimate — see the caption in the payload;
                 # this is an upper bound on interventions, not savings.
                 result["memory_intervention_signal"] = estimate_intervention_signal()
+                # Noise side: findings surfaced then dropped as noise.
+                result["memory_feedback"] = estimate_feedback_signal()
             except Exception:  # noqa: BLE001
                 # INTENTIONAL: memory telemetry is a bonus section; never
                 # let it break the core usage stats.

--- a/src/attune/memory/session_stash.py
+++ b/src/attune/memory/session_stash.py
@@ -327,9 +327,36 @@ def recall_entries(
     return results
 
 
+def _record_rejection(count: int, source: str, cwd: str | None) -> None:
+    """Best-effort ``memory_feedback`` event for a deletion (never raises).
+
+    A deletion is an explicit "this surfaced finding was wrong /
+    irrelevant / resolved" verdict — the noise signal the insurance
+    frame needs (see ``project_memory_as_insurance``). Emitted from the
+    single ``forget_entries`` chokepoint so every deletion path
+    (``/recall drop``, review, reconciler) is captured exactly once.
+    """
+    try:
+        from attune.telemetry.memory_events import log_memory_event
+
+        log_memory_event(
+            "memory_feedback",
+            verdict="rejected",
+            source=source,
+            count=count,
+            cwd=cwd,
+        )
+    except Exception:  # noqa: BLE001
+        # INTENTIONAL: feedback telemetry must never break a deletion.
+        pass
+
+
 def forget_entries(
     ids: list[str],
     backend: SearchableMemoryBackend | None = None,
+    *,
+    source: str = "forget",
+    cwd: str | None = None,
 ) -> int:
     """Delete stashed findings by record ID. 0 when unavailable.
 
@@ -339,10 +366,19 @@ def forget_entries(
     the number of entries deleted. Never raises — safe to call from a
     hook. Backends predating ``forget`` degrade to 0.
 
+    A successful deletion (count > 0) emits one ``memory_feedback``
+    event tagged with ``source``/``cwd`` — the noise denominator for
+    the memory analyzer. This is the single emit point; delegating
+    callers (``forget_by_prefix``) pass ``source``/``cwd`` through and
+    must NOT emit again.
+
     Args:
         ids: Record IDs (the ``id`` values from ``search``/``recent``).
         backend: Optional injected backend; resolved from the entry
             point when omitted.
+        source: Rejection origin for the feedback event
+            (``recall_drop`` / ``review`` / ``reconciler`` / ``forget``).
+        cwd: Optional project path recorded on the feedback event.
 
     Returns:
         Count of deleted entries (best-effort).
@@ -356,11 +392,14 @@ def forget_entries(
     if not callable(forget):
         return 0
     try:
-        return int(forget(list(ids)) or 0)
+        count = int(forget(list(ids)) or 0)
     except Exception as exc:  # noqa: BLE001
         # INTENTIONAL: forget is best-effort; never break the host session.
         logger.warning("session stash forget failed: %s", exc)
         return 0
+    if count > 0:
+        _record_rejection(count=count, source=source, cwd=cwd)
+    return count
 
 
 def forget_by_prefix(
@@ -368,6 +407,8 @@ def forget_by_prefix(
     limit: int = 100,
     cwd: str | None = None,
     backend: SearchableMemoryBackend | None = None,
+    *,
+    source: str = "recall_drop",
 ) -> int:
     """Delete stashed findings by short (unique) ID prefix. 0 when none.
 
@@ -381,9 +422,12 @@ def forget_by_prefix(
         prefixes: Short id prefixes (e.g. the first 8 chars shown in
             the stash chip). Full ids work too.
         limit: How many recent records to resolve against.
-        cwd: Optional project filter passed to ``recent``.
+        cwd: Optional project filter passed to ``recent``; also
+            recorded on the emitted feedback event.
         backend: Optional injected backend; resolved from the entry
             point when omitted.
+        source: Rejection origin threaded to ``forget_entries`` for the
+            feedback event (defaults to ``recall_drop``).
 
     Returns:
         Count of deleted entries (best-effort).
@@ -411,7 +455,8 @@ def forget_by_prefix(
             full_ids.append(matches[0])
         else:
             logger.info("forget_by_prefix: prefix %r skipped (%d matches)", prefix, len(matches))
-    return forget_entries(full_ids, backend=target)
+    # forget_entries is the single emit point; pass source/cwd through.
+    return forget_entries(full_ids, backend=target, source=source, cwd=cwd)
 
 
 def recent_entries(

--- a/src/attune/ops/data.py
+++ b/src/attune/ops/data.py
@@ -1106,6 +1106,82 @@ def estimate_intervention_signal(path: Path | None = None) -> dict[str, Any]:
     }
 
 
+#: Honesty caption for the feedback (noise) signal. A rejection rate is
+#: the NOISE side of the insurance ledger — how often a surfaced finding
+#: was later dropped as wrong/irrelevant — NOT an inverse-quality score
+#: or a savings figure. Kept a constant so a test can assert it renders.
+FEEDBACK_SIGNAL_CAPTION = (
+    "Noise signal: findings that were surfaced by recall and then "
+    "explicitly dropped as wrong/irrelevant/resolved, as a share of "
+    "findings stashed. Lower is less noise injected — it is not a "
+    "quality score or a savings figure."
+)
+
+
+def estimate_feedback_signal(path: Path | None = None) -> dict[str, Any]:
+    """Aggregate ``memory_feedback`` rejections into a noise rate.
+
+    Reads the explicit "this surfaced finding was noise" verdicts
+    emitted by the deletion seam (``attune.memory.session_stash``) and
+    expresses them as a share of the findings the Stop-hook stashed —
+    the net-of-noise half of the memory analyzer. See
+    ``project_memory_as_insurance``.
+
+    Args:
+        path: Override the events-file location (tests pass a fixture).
+            ``None`` resolves to the default ``memory_events.jsonl``.
+
+    Returns:
+        JSON-serializable dict: ``rejected`` (total rejected findings),
+        ``by_source`` (``{source: count}``), ``findings_written``
+        (denominator, from ``session_stash`` events), ``rejection_rate``
+        (rejected / written, 0.0 when none written), and ``caption``.
+        A missing file yields zeroed counts, never an exception.
+    """
+    if path is None:
+        path = attune_home() / "telemetry" / "memory_events.jsonl"
+
+    rejected = 0
+    by_source: dict[str, int] = defaultdict(int)
+    findings_written = 0
+
+    if path.exists():
+        try:
+            with path.open("r", encoding="utf-8") as f:
+                for line in f:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        event: dict[str, Any] = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+                    name = event.get("event")
+                    if name == "memory_feedback":
+                        count = int(event.get("count", 0) or 0)
+                        rejected += count
+                        by_source[str(event.get("source") or "unknown")] += count
+                    elif name == "session_stash":
+                        findings_written += int(event.get("written", 0) or 0)
+        except OSError:
+            return {
+                "rejected": 0,
+                "by_source": {},
+                "findings_written": 0,
+                "rejection_rate": 0.0,
+                "caption": FEEDBACK_SIGNAL_CAPTION,
+            }
+
+    rate = round(rejected / findings_written, 3) if findings_written else 0.0
+    return {
+        "rejected": rejected,
+        "by_source": {src: by_source[src] for src in sorted(by_source)},
+        "findings_written": findings_written,
+        "rejection_rate": rate,
+        "caption": FEEDBACK_SIGNAL_CAPTION,
+    }
+
+
 # ---------------------------------------------------------------------------
 # Spend anomaly alarm — R6 of docs/specs/usage-signals/. Surfaces the
 # "$1,200-night" class of event within a day. See decisions.md D13.

--- a/src/attune/ops/routes/dashboard.py
+++ b/src/attune/ops/routes/dashboard.py
@@ -190,6 +190,8 @@ async def telemetry_page(request: Request) -> HTMLResponse:
     # Labeled benefit estimate — carries its own honesty caption; the
     # template renders it verbatim so this never reads as measured savings.
     memory_signal = data.estimate_intervention_signal(cfg.memory_events_path)
+    # Noise side — findings surfaced then dropped as noise.
+    memory_feedback = data.estimate_feedback_signal(cfg.memory_events_path)
     return _render(
         request,
         "telemetry.html",
@@ -199,6 +201,7 @@ async def telemetry_page(request: Request) -> HTMLResponse:
         interaction_top=interaction_top,
         memory_summary=memory_summary,
         memory_signal=memory_signal,
+        memory_feedback=memory_feedback,
     )
 
 

--- a/src/attune/ops/templates/telemetry.html
+++ b/src/attune/ops/templates/telemetry.html
@@ -113,6 +113,35 @@
         </table>
       {% endif %}
     {% endif %}
+
+    {% if memory_feedback %}
+      <h3>Noise signal</h3>
+      <p class="meta">{{ memory_feedback.caption }}</p>
+      <div class="kpi-grid">
+        <div class="kpi">
+          <div class="kpi-label">Findings rejected</div>
+          <div class="kpi-value">{{ '{:,}'.format(memory_feedback.rejected) }}</div>
+        </div>
+        <div class="kpi">
+          <div class="kpi-label">Findings stashed</div>
+          <div class="kpi-value">{{ '{:,}'.format(memory_feedback.findings_written) }}</div>
+        </div>
+        <div class="kpi">
+          <div class="kpi-label">Rejection rate</div>
+          <div class="kpi-value">{{ '{:.1%}'.format(memory_feedback.rejection_rate) }}</div>
+        </div>
+      </div>
+      {% if memory_feedback.by_source %}
+        <table class="data-table">
+          <thead><tr><th>Source</th><th class="num">Rejected</th></tr></thead>
+          <tbody>
+            {% for src, count in memory_feedback.by_source.items() %}
+              <tr><td><code>{{ src }}</code></td><td class="num">{{ count }}</td></tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      {% endif %}
+    {% endif %}
   {% else %}
     <p class="empty">No memory events yet.</p>
   {% endif %}

--- a/src/attune/telemetry/memory_events.py
+++ b/src/attune/telemetry/memory_events.py
@@ -1,0 +1,99 @@
+"""Canonical, src-importable writer for short-term memory events.
+
+The memory hooks record what they *inject* via their own copy of this
+logic in ``plugin/hooks/_memory_telemetry.py`` (not importable from
+``src/``). This module is the src-side sibling: it lets code inside the
+package — notably the deletion seam in
+``attune.memory.session_stash`` — append ``memory_feedback`` events to
+the same ``~/.attune/telemetry/memory_events.jsonl``, in the same
+format and under the same local-only consent gate.
+
+One event = one JSON line: ``v`` / ``ts`` / ``event`` / optional
+``session_id`` / event-specific fields.
+
+Consent model matches the hook copy: LOCAL recording is default-on
+(like ``usage.jsonl``); nothing here ever leaves the machine.
+``DO_NOT_TRACK`` or ``ATTUNE_MEMORY_TELEMETRY=0`` disables the local
+log. Never raises — callers are best-effort and their telemetry must
+be too.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under Apache 2.0
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+
+_FALSEY = {"", "0", "false", "no", "off"}
+
+#: Rotate when the live file exceeds this (events are ~200 bytes; a
+#: years-of-headroom backstop, not an expected path). Mirrors the hook.
+_MAX_BYTES = 5 * 1024 * 1024
+
+
+def _enabled() -> bool:
+    """False when local memory telemetry is switched off via env."""
+    if os.environ.get("ATTUNE_MEMORY_TELEMETRY", "1").strip().lower() in _FALSEY:
+        return False
+    dnt = os.environ.get("DO_NOT_TRACK")
+    return dnt is None or dnt.strip().lower() in _FALSEY
+
+
+def _events_path() -> Path:
+    """Resolve the live events file under ATTUNE_HOME (default ~/.attune)."""
+    home = os.environ.get("ATTUNE_HOME")
+    base = Path(home).expanduser() if home else Path.home() / ".attune"
+    return base / "telemetry" / "memory_events.jsonl"
+
+
+def _rotate_if_huge(path: Path) -> None:
+    """Best-effort size backstop: rotate to a dated sibling when huge."""
+    try:
+        if path.stat().st_size < _MAX_BYTES:
+            return
+        stamp = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+        rotated = path.with_name(f"memory_events.{stamp}.jsonl")
+        counter = 1
+        while rotated.exists():
+            rotated = path.with_name(f"memory_events.{stamp}.{counter}.jsonl")
+            counter += 1
+        path.replace(rotated)
+    except OSError:
+        pass  # rotation is a nicety; the append below still works
+
+
+def log_memory_event(event: str, session_id: str | None = None, **fields: object) -> None:
+    """Append one memory event line. Best-effort, never raises.
+
+    Args:
+        event: Event name (e.g. ``memory_feedback``).
+        session_id: Claude Code session id, when the caller has one.
+        **fields: Event-specific data (e.g. ``verdict``, ``source``,
+            ``count``, ``cwd``).
+    """
+    try:
+        if not _enabled():
+            return
+        record: dict[str, object] = {
+            "v": "1.0",
+            "ts": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
+            "event": event,
+        }
+        if session_id:
+            record["session_id"] = str(session_id)[:64]
+        record.update(fields)
+
+        path = _events_path()
+        path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+        _rotate_if_huge(path)
+        with path.open("a", encoding="utf-8") as fh:
+            json.dump(record, fh, separators=(",", ":"), default=str)
+            fh.write("\n")
+    except Exception:  # noqa: BLE001
+        # INTENTIONAL: telemetry about best-effort paths must never
+        # break the caller (or the session) it observes.
+        pass

--- a/tests/unit/memory/test_forget_feedback.py
+++ b/tests/unit/memory/test_forget_feedback.py
@@ -1,0 +1,94 @@
+"""The deletion seam emits exactly one memory_feedback event.
+
+A deletion is an explicit "this surfaced finding was noise" verdict —
+the noise denominator for the memory analyzer. ``forget_entries`` is
+the single emit point; ``forget_by_prefix`` delegates to it and must
+not double-count. No deletion (count == 0) emits nothing.
+
+The tests point ATTUNE_HOME at a tmp dir and keep local telemetry
+enabled, so the event is observable without touching the real
+~/.attune/telemetry/memory_events.jsonl.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from attune.memory import session_stash as ss
+
+
+class _StubBackend:
+    """Minimal SearchableMemoryBackend stand-in for delete/list."""
+
+    def __init__(self, ids):
+        self._ids = list(ids)
+
+    def forget(self, ids):
+        hit = [i for i in ids if i in self._ids]
+        self._ids = [i for i in self._ids if i not in ids]
+        return len(hit)
+
+    def recent(self, limit=100, cwd=None):
+        return [{"id": i} for i in self._ids]
+
+
+@pytest.fixture
+def events_path(tmp_path, monkeypatch):
+    monkeypatch.setenv("ATTUNE_HOME", str(tmp_path))
+    monkeypatch.setenv("ATTUNE_MEMORY_TELEMETRY", "1")
+    monkeypatch.delenv("DO_NOT_TRACK", raising=False)
+    return tmp_path / "telemetry" / "memory_events.jsonl"
+
+
+def _events(path):
+    if not path.exists():
+        return []
+    return [json.loads(line) for line in path.read_text().splitlines() if line.strip()]
+
+
+def test_forget_entries_emits_one_rejection(events_path):
+    backend = _StubBackend(["aaa", "bbb", "ccc"])
+
+    deleted = ss.forget_entries(["aaa", "bbb"], backend=backend, source="reconciler", cwd="/p")
+
+    assert deleted == 2
+    evs = _events(events_path)
+    assert len(evs) == 1
+    assert evs[0]["event"] == "memory_feedback"
+    assert evs[0]["verdict"] == "rejected"
+    assert evs[0]["source"] == "reconciler"
+    assert evs[0]["count"] == 2
+    assert evs[0]["cwd"] == "/p"
+
+
+def test_forget_by_prefix_emits_once_not_twice(events_path):
+    backend = _StubBackend(["abc123", "def456"])
+
+    deleted = ss.forget_by_prefix(["abc"], cwd="/p", backend=backend)
+
+    assert deleted == 1
+    evs = _events(events_path)
+    assert len(evs) == 1  # single emit point — no double count
+    assert evs[0]["source"] == "recall_drop"
+    assert evs[0]["count"] == 1
+
+
+def test_no_event_when_nothing_deleted(events_path):
+    backend = _StubBackend(["aaa"])
+
+    deleted = ss.forget_entries(["zzz"], backend=backend)
+
+    assert deleted == 0
+    assert _events(events_path) == []
+
+
+def test_telemetry_disabled_still_deletes(events_path, monkeypatch):
+    monkeypatch.setenv("ATTUNE_MEMORY_TELEMETRY", "0")
+    backend = _StubBackend(["aaa", "bbb"])
+
+    deleted = ss.forget_entries(["aaa"], backend=backend)
+
+    assert deleted == 1  # deletion works even with telemetry off
+    assert _events(events_path) == []  # but no event written

--- a/tests/unit/ops/test_feedback_signal.py
+++ b/tests/unit/ops/test_feedback_signal.py
@@ -1,0 +1,69 @@
+"""Tests for the memory feedback (noise) signal reader.
+
+``estimate_feedback_signal`` turns ``memory_feedback`` rejection events
+into a noise rate against findings stashed. The caption guard keeps it
+framed as a noise share, never a quality score or savings figure.
+"""
+
+from __future__ import annotations
+
+import json
+
+from attune.ops.data import FEEDBACK_SIGNAL_CAPTION, estimate_feedback_signal
+
+
+def _write_jsonl(path, events):
+    path.write_text("\n".join(json.dumps(e) for e in events) + "\n", encoding="utf-8")
+
+
+def test_rejection_rate_math(tmp_path):
+    path = tmp_path / "memory_events.jsonl"
+    _write_jsonl(
+        path,
+        [
+            {"event": "session_stash", "written": 5},
+            {"event": "session_stash", "written": 5},
+            {"event": "memory_feedback", "source": "recall_drop", "count": 1},
+            {"event": "memory_feedback", "source": "reconciler", "count": 1},
+        ],
+    )
+
+    sig = estimate_feedback_signal(path)
+
+    assert sig["rejected"] == 2
+    assert sig["findings_written"] == 10
+    assert sig["rejection_rate"] == 0.2
+    assert sig["by_source"] == {"recall_drop": 1, "reconciler": 1}
+
+
+def test_zero_written_is_not_a_division_error(tmp_path):
+    path = tmp_path / "memory_events.jsonl"
+    _write_jsonl(path, [{"event": "memory_feedback", "source": "recall_drop", "count": 3}])
+
+    sig = estimate_feedback_signal(path)
+
+    assert sig["rejected"] == 3
+    assert sig["findings_written"] == 0
+    assert sig["rejection_rate"] == 0.0
+
+
+def test_caption_present_and_not_a_savings_claim(tmp_path):
+    path = tmp_path / "memory_events.jsonl"
+    _write_jsonl(path, [{"event": "session_stash", "written": 4}])
+
+    sig = estimate_feedback_signal(path)
+
+    assert sig["caption"] == FEEDBACK_SIGNAL_CAPTION
+    caption = sig["caption"].lower()
+    assert "noise" in caption
+    assert "not a quality score or a savings figure" in caption
+
+
+def test_missing_file_is_zeroed(tmp_path):
+    sig = estimate_feedback_signal(tmp_path / "nope.jsonl")
+
+    assert sig["rejected"] == 0
+    assert sig["findings_written"] == 0
+    assert sig["rejection_rate"] == 0.0
+    assert sig["by_source"] == {}
+    assert sig["caption"] == FEEDBACK_SIGNAL_CAPTION


### PR DESCRIPTION
## What

Phase 1 of the memory injection feedback signal — the **noise
denominator** the insurance frame needs. Builds directly on the memory
analyzer (#1291).

The analyzer measures cost and a labeled benefit estimate, but had no
signal for *"a surfaced finding was rejected as noise."* That signal
already existed, uninstrumented: every `/recall drop`, review, and
reconciler deletion flows through `forget_entries` and is an explicit
"this was wrong/irrelevant/resolved" verdict — it returned a count and
logged nothing. (This session's two stale `/recall telemetry` findings
would each have been one.)

## Changes

- **New `attune/telemetry/memory_events.py`** — a src-importable writer
  mirroring the hook copy's format + local-only consent gate
  (`ATTUNE_MEMORY_TELEMETRY` / `DO_NOT_TRACK`), never raises. (The hook
  in `plugin/hooks/` isn't importable from `src/`; convergence is a
  noted follow-up.)
- **Instrument the single chokepoint** — `forget_entries` emits one
  `memory_feedback` event on a successful deletion; `forget_by_prefix`
  threads `source`/`cwd` through and does **not** double-count.
- **`estimate_feedback_signal()`** — rejection rate (rejected /
  findings stashed), by source, surfaced on the `telemetry_stats` MCP
  tool + a "Noise signal" block in the ops Telemetry panel. Captioned
  as a noise share, **never a quality score or savings figure**
  (`FEEDBACK_SIGNAL_CAPTION`, asserted by a test).
- **Tests** — reader math + caption guard; seam emits once / no
  double-count / no event on zero-delete / still deletes with telemetry
  off. Pollution-safe (`ATTUNE_HOME`→tmp).

## Why this shape

Pure instrumentation of clicks already made — zero new user friction —
and it's the dataset that later informs *when not to inject* (task-shape
routing, Phase 2, recorded not built). Per the ratified frame: cost is
fact, benefit is a captioned estimate, and now noise is measured too.

## Verification

- "Noise signal" block verified **live** on the ops dashboard (rejected
  / stashed / rate + verbatim caption; honest 0% until real drops
  accrue).
- MCP `telemetry_stats` returns `memory_feedback`.
- 8 new tests + 48 `session_stash` tests green; black + ruff clean;
  **zero** live-file pollution across the run.

Spec: `.claude/plans/memory-injection-feedback-signal.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
