### PR TITLE
chore(release): 10.2.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "Spec-driven development for Claude Code — take an idea through requirements, design, tasks, and gated execution with an approval loop. Plus 23 auto-triggering skills: security audits, code review, test generation, release prep.",
-    "version": "10.1.0"
+    "version": "10.2.0"
   },
   "plugins": [
     {
       "name": "attune-ai",
       "description": "Spec-driven development is the core workflow: /spec carries an idea through brainstorm, requirements, design, and task execution with quality gates and your approval at each stage. Backed by 23 auto-triggering skills — security audits, code reviews, test generation, bug prediction, and release preparation. For help content tools, also install attune-help and attune-author from this marketplace.",
       "source": "./plugin",
-      "version": "10.1.0",
+      "version": "10.2.0",
       "author": {
         "name": "Smart AI Memory",
         "email": "patrick.roebuck@smartaimemory.com"

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,4 +1,4 @@
-# Attune AI Framework v10.1.0
+# Attune AI Framework v10.2.0
 
 AI-powered developer workflows with cost optimization and multi-agent orchestration.
 
@@ -148,7 +148,7 @@ attune_redis/          # attune-redis plugin (pip install attune-redis)
 
 ---
 
-**Version:** 10.1.0 | **License:** Apache 2.0 | **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)
+**Version:** 10.2.0 | **License:** Apache 2.0 | **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)
 
 ## Lessons — core
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,45 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [10.2.0] — 2026-07-08
+
+Memory-ledger minor: the short-term memory layer's cost, benefit, and
+noise are now readable on the ops dashboard and the `telemetry_stats`
+MCP tool — measured honestly (cost as fact, benefit as a captioned
+upper-bound estimate, never a savings percentage). Plus three
+guardrail test suites that pin previously prose-only policies.
+
+### Added
+
+- **Short-term memory panel on the ops Telemetry tab** (#1291): what
+  the memory hooks actually inject — total est. tokens, per-event
+  breakdown (session recall / JIT rule recall / stash), per-session
+  average, and an "estimated intervention signal" (JIT rule
+  surfacings as a labeled upper bound — explicitly not a savings
+  figure). Same data via `read_memory_summary()` and a new `memory`
+  section on the `telemetry_stats` MCP tool.
+- **Injection noise signal** (#1292): deleting a stashed finding
+  (`/recall drop`, `/recall review`, the recall reconciler) now
+  records a `memory_feedback` rejection event — every drop is an
+  explicit "this surfaced item was noise" verdict. A "Noise signal"
+  block (rejection rate = rejected / findings stashed) joins the
+  dashboard panel and MCP tool. New src-importable writer
+  `attune.telemetry.memory_events` mirrors the hook's local-only
+  consent gate (`ATTUNE_MEMORY_TELEMETRY`, `DO_NOT_TRACK`).
+- **CI spend guard** (#1293): `secrets.ANTHROPIC_API_KEY` can no
+  longer ride push/PR workflows — keyed workflows require an explicit
+  test-level allowlist, schedule/dispatch-only triggers, and a
+  verified spend control (the 2026-06-10 $1,200 burn, made
+  structural).
+- **Consent-surface guard** (#1294): the privacy promises are now
+  tests — phone-home ping defaults OFF, `DO_NOT_TRACK` beats every
+  opt-in (config and env, in both memory-writer copies), and the
+  ping's record source can never include `memory_events.jsonl`.
+- **Extras-honesty guard** (#1295): install hints in error messages
+  must point at extras that actually install something — undefined
+  extras fail, and empty back-compat aliases (like `[redis]`, core
+  since 10.0) are allowed only via a documented allowlist.
+
 ## [10.1.0] — 2026-07-08
 
 Memory-suite minor: stash lifecycle UX (task-note expiry, review

--- a/docs/reference/API_REFERENCE.md
+++ b/docs/reference/API_REFERENCE.md
@@ -1,6 +1,6 @@
 # Attune AI API Reference
 
-**Version:** 10.1.0
+**Version:** 10.2.0
 **License:** Apache License 2.0
 **Copyright:** 2025-2026 Smart AI Memory, LLC
 
@@ -1152,5 +1152,5 @@ msg = format_error(
 
 ---
 
-**Version:** 10.1.0 | **License:** Apache 2.0
+**Version:** 10.2.0 | **License:** Apache 2.0
 **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)

--- a/plugin/.claude-plugin/marketplace.json
+++ b/plugin/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "Spec-driven development for Claude Code — /spec plans, reviews, and executes with quality gates; plus security audits, code reviews, test generation, and release prep from /attune.",
-    "version": "10.1.0"
+    "version": "10.2.0"
   },
   "plugins": [
     {
       "name": "attune-ai",
       "description": "Spec-driven development for Claude Code — /spec plans, reviews, and executes with quality gates; plus security audits, code reviews, test generation, and release prep from /attune.",
       "source": "./",
-      "version": "10.1.0",
+      "version": "10.2.0",
       "author": {
         "name": "Smart AI Memory",
         "email": "patrick.roebuck@smartaimemory.com"

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "attune-ai",
-  "version": "10.1.0",
+  "version": "10.2.0",
   "description": "Spec-driven development for Claude Code — /spec plans, reviews, and executes with quality gates; plus security audits, code reviews, test generation, and release prep from /attune.",
   "author": {
     "name": "Smart AI Memory",

--- a/plugin/core/__init__.py
+++ b/plugin/core/__init__.py
@@ -5,4 +5,4 @@ This module provides the core workflow functionality when the full
 attune-ai package is not installed via pip.
 """
 
-__version__ = "10.1.0"
+__version__ = "10.2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "attune-ai"
-version = "10.1.0"
+version = "10.2.0"
 description = "AI-powered developer workflows for Claude with cost optimization, multi-agent orchestration, and workflow automation."
 readme = {file = "README.md", content-type = "text/markdown"}
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -253,7 +253,7 @@ wheels = [
 
 [[package]]
 name = "attune-ai"
-version = "10.1.0"
+version = "10.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "agent-memory-client" },

--- a/website/app/page.tsx
+++ b/website/app/page.tsx
@@ -58,7 +58,7 @@ export default function Home() {
             <div className="grid lg:grid-cols-2 gap-16 items-center">
               <div className="z-10">
                 <div className="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-[var(--surface-container-high)] text-[var(--primary)] text-xs font-bold tracking-widest mb-6 uppercase">
-                  <span>v10.1.0</span>
+                  <span>v10.2.0</span>
                   <span className="w-1 h-1 rounded-full bg-[var(--primary)]"></span>
                   <span className="opacity-80">Spec-driven development platform</span>
                 </div>

--- a/website/lib/features.ts
+++ b/website/lib/features.ts
@@ -32,7 +32,7 @@ export const PRODUCTS: Product[] = [
     id: "attune-ai",
     name: "Attune AI",
     pypiName: "attune-ai",
-    version: "10.1.0",
+    version: "10.2.0",
     tagline: "Generate, maintain, and serve help from your code",
     installCommand: "pip install attune-ai",
     marketplaceInstall:
@@ -101,7 +101,7 @@ export const PRODUCTS: Product[] = [
     id: "claude-code-plugin",
     name: "Claude Code Plugin",
     pypiName: "attune-ai",
-    version: "10.1.0",
+    version: "10.2.0",
     tagline: "Progressive help right in your terminal",
     installCommand:
       "claude plugin marketplace add Smart-AI-Memory/attune-ai",


### PR DESCRIPTION
## 10.2.0 — memory-ledger minor

The short-term memory layer's **cost, benefit, and noise** become readable — on the ops Telemetry tab and the `telemetry_stats` MCP tool — measured honestly: cost as fact, benefit as a captioned upper-bound estimate, never a savings percentage.

### What ships (five PRs since 10.1.0)

- **#1291** — Short-term memory panel (ops dashboard) + `memory` section on `telemetry_stats`: tokens injected, per-event breakdown, per-session average, labeled intervention estimate
- **#1292** — Injection noise signal: every `/recall drop` records a rejection; rejection rate joins both surfaces; new src-importable `attune.telemetry.memory_events` writer under the same local-only consent gate
- **#1293** — CI spend guard: the real Anthropic key structurally cannot ride push/PR workflows (the $1,200 lesson, pinned)
- **#1294** — Consent-surface guard: ping default-OFF, DNT precedence, ping never reads `memory_events.jsonl`
- **#1295** — Extras-honesty guard: install hints must point at extras that actually install something

### Release mechanics

- `scripts/bump_version.py 10.2.0` — all 9 sites (incl. website refs)
- Changelog promoted with fresh `[Unreleased]`
- `uv.lock`: 1-line delta (attune-ai version only)
- Help templates: 0 stale / 27 manual — no regen needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)