### PR TITLE
docs: harvest lessons/docs/CI fix from 10 stale branches (2026-07-09 cleanup)

### DIFF
--- a/.claude/lessons.md
+++ b/.claude/lessons.md
@@ -14255,3 +14255,306 @@ def ", start_idx + 1)` for module-
   tail first, the PR's after). Applies to any self-referential corpus
   file (lessons, docs about git) — the content defeats naive marker
   detection precisely because the file teaches about conflicts.
+
+<!-- Harvested lessons — 2026-07-09 stale-branch cleanup. Each block is the
+     verbatim added text of an unmerged lessons commit; source noted per block. -->
+
+<!-- from 041e0587e docs(lessons): attune-gui sibling-env false-stale + dropped pull_request webhook -->
+
+
+- **attune-gui's "all N templates stale" is the attune-author
+  false-stale bug re-surfacing through a SIBLING env — the
+  dashboard computes staleness with whatever attune-author ITS OWN
+  environment resolves, and attune-gui 0.8.0's pyproject caps it at
+  `attune-author[ai]>=0.14.0,<0.15` (pre-0.23.0 fix)**: hit
+  2026-07-06 launching `/attune-gui` against ~/attune-ai — Home
+  showed "FRESH RATIO 0%, 296 stale of 296" plus "no features.yaml
+  found · Features: 0" even though the plugin-side false-stale was
+  RESOLVED 2026-07-04 (attune-author 0.23.0, attune-ai pin bumped
+  PR #1246). The uniform N-of-N tell from the 2026-07-04 lesson
+  applies unchanged; the trap is thinking "we fixed that" — the fix
+  only landed in envs whose PIN allows 0.23.0, and each attune-*
+  consumer (attune-gui, worktree venvs, CI) re-introduces the bug
+  until its own ceiling moves. Two sub-traps hit en route:
+  (1) `uv pip install --python <project-venv> attune-author==0.23`
+  reported success but the NEXT `uv run --directory <project> ...`
+  launch silently re-synced the env to uv.lock and DOWNGRADED it
+  back — `uv run` auto-sync is the same wipe as the known "later
+  uv sync WIPES direct installs" lesson, but it fires on every
+  launch, so a venv-level fix for a uv-run-launched app never
+  sticks. Launch-time fix that DOES stick:
+  `uv run --with 'attune-author[ai]>=0.23,<0.24' attune-gui`
+  (overlay env, survives re-sync); durable fix = bump the consumer's
+  pyproject ceiling + `uv lock` + publish (the `<0.15` cap ships in
+  PyPI metadata, so every fresh install resolves the buggy version
+  until a patch release). (2) Diagnose which env computes a
+  dashboard's numbers from the UI's own provenance line ("Probed
+  under <python>") — after the --with overlay it read the ephemeral
+  `~/.cache/uv/builds-v0/...` path with 0.23.0, confirming the live
+  process, not the project venv, was answering.
+
+- **GitHub can silently DROP `pull_request` synchronize webhooks —
+  zero workflow runs schedule for a pushed SHA while earlier pushes
+  scheduled within seconds; poll the runs API and fall back to
+  `workflow_dispatch`**: hit twice in one hour on attune-gui PR #82
+  (2026-07-07). After `git push` to a PR branch, `gh pr checks`
+  said "no checks reported" for 7+ minutes; `gh api
+  "repos/<o>/<r>/actions/runs?head_sha=<sha>" -q .total_count`
+  returned 0 — the synchronize event never fired workflows (trigger
+  config was fine: `on: pull_request` bare). Detection recipe:
+  poll that runs-by-head_sha count for ~90s; if still 0, the
+  webhook is gone — it does not arrive late. Recovery: `gh workflow
+  run tests.yml --ref <branch>` (+ lint.yml) — dispatch runs
+  execute on the branch HEAD and their check-runs attach to that
+  SHA, so they satisfy PR checks and codecov posts normally. The
+  next push may auto-trigger fine (flaky, not systemic). Corollary
+  for release trains: after ANY push that must gate a merge, verify
+  runs actually SCHEDULED (count > 0), not just that none failed.
+  Same session also confirmed the fixed pin must reach the
+  PUBLISHED artifact to stick: attune-gui 0.9.1 shipped the
+  `attune-author >=0.23,<0.24` pin, and the dashboard launch was
+  repointed from the local checkout to the shipped wheel
+  (`uv tool run attune-gui@0.9.1` in launch.json — bump the pinned
+  version on each release; a `--directory` launch runs whatever the
+  checkout's HEAD happens to be, including detached stale state).
+
+<!-- from caf236e7f docs(lessons): 0%-coverage from missing optional dep is structural deadness -->
+
+
+- **A module at EXACTLY 0% in the QA coverage baseline can be 0%
+  because an OPTIONAL dep gating the WHOLE module isn't installed —
+  not because it's testable-but-untested; `grep <dep> pyproject.toml`
+  before scoping a suite**: 2026-06-14 (Sun-1 auto-run), the
+  `attune.workflows` baseline flagged `progress_server.py` (327 lines,
+  0%) as a top gap. But the module does `try: import websockets …
+  except ImportError: WEBSOCKETS_AVAILABLE = False`, and
+  `ProgressServer.__init__` RAISES `ImportError` when the flag is
+  False. `websockets` is NOT a declared dep (`grep websockets
+  pyproject.toml` → nothing) and isn't in the venv, so the class can't
+  even instantiate in CI either — the 0% is structural deadness, not a
+  missing test. Covering it would need a dep addition (risky /
+  out-of-QA-scope) or module-global mock gymnastics (patch
+  `WEBSOCKETS_AVAILABLE=True` + inject a fake `websockets` exposing
+  `exceptions.ConnectionClosed`/`serve`) that don't reflect real usage
+  — low value. Pick the next clean target instead (here:
+  `test_maintenance_cli.py`, a pure argparse CLI with mockable
+  collaborators — the proven 99% pattern from #876). Refines the
+  QA-baseline "a module here is a HYPOTHESIS" reminder: when a module
+  is at *exactly* 0% (not partial), suspect a whole-module import guard
+  and grep the gating dep BEFORE committing effort.
+
+<!-- from 87ac6f655 docs(lessons): subprocess check=False + parse-stdout masks a crash as "empty/clean" -->
+
+
+- **A `subprocess.run(..., check=False)` consumer that parses stdout
+  turns a SUBPROCESS CRASH into a false "clean/empty" result — verify
+  the exit code (or that the CLI is even importable) before trusting
+  parsed-empty output**: 2026-07-01, absorbing attune-author's staleness
+  machinery, dogfooding the live consumer
+  (`attune.ops.help_data._attune_author_stale_features`) revealed it
+  shells `attune-author status` via `subprocess.run(check=False)` and
+  feeds `result.stdout` to a markdown parser. On this machine the
+  `attune-author` PATH shim points at a Python without `attune_author`
+  installed → the subprocess dies with `ModuleNotFoundError`, exits
+  non-zero, stdout empty. `_parse_status_output("")` returns
+  `frozenset()`, so a **crash reads as "nothing stale"** — and because
+  the function returns an empty set (not `None`), callers never reach
+  their age-based fallback. The graceful-degradation shape
+  (`check=False` + parse-whatever-came-back) silently converts "the tool
+  is broken" into "the tool says everything's fine." Rules: (1) a
+  subprocess whose EMPTY output is a valid answer MUST check
+  `returncode` (or `check=True` + catch) — treat non-zero as *unknown*,
+  not as the empty answer; (2) map *unknown* to the real fallback
+  (here: `None` → age-based), never to the same value as a genuine empty
+  result; (3) when a consumer "returns nothing wrong," confirm the
+  underlying tool actually RAN — `which <tool>` finding a shim is not
+  proof it's importable/runnable. Pairs with "registered ≠ working —
+  dogfood the live loop" (a broken dependency masquerading as success)
+  and the workflow-failure-exit-propagation family (swallowed non-zero
+  exits). Recorded in attune-author-consolidation decisions.md D8.
+
+<!-- from 96a46aaae docs(CLAUDE.md): three session lessons from worktree cleanup -->
+
+
+- **`git stash pop` after fast-forwarding to upstream
+  inverts `--ours` / `--theirs` semantics — and the
+  most common conflict shape is a spec status field
+  that upstream changed since the stash**: classic
+  flow during the "merge + restore wip" dance when
+  the main checkout has uncommitted spec edits.
+  Stash → ff merge → pop → conflicts on any file
+  where both sides edited the same line. During the
+  pop, the merge base is HEAD (the just-merged
+  upstream content), so `--ours` = upstream (HEAD),
+  `--theirs` = the stashed content. This is INVERTED
+  from a regular merge. Concretely, hit on
+  2026-05-12 with spec status field collisions —
+  upstream had moved `coverage-canonical-pattern`
+  to "paused 2026-05-12" while the stash had stale
+  "approved" edits. `git checkout --ours <file>`
+  on each conflicted file took the upstream
+  (correct) version. ALWAYS follow a deliberate-
+  discard resolution with `git stash drop` to clear
+  the stash entry — otherwise it lingers with stale
+  content and is easy to revive later by mistake.
+  The conflict shape (status fields, sometimes
+  status-line + decisions reference) is predictable
+  enough that a one-line resolution checklist works:
+  `git checkout --ours <conflicted files> && git add
+  <files> && git stash drop`.
+
+- **Scheduled-tasks display time uses Claude Code's
+  configured local timezone, NOT the timezone you
+  passed in the ISO offset — verify by reading the
+  display in the user's local time, not by trusting
+  the offset you specified**: passed
+  `fireAt="2026-05-12T19:30:00-07:00"` (intending 7:30
+  PM Pacific). Display showed "5/12/2026, 10:30:00
+  PM" — which is 7:30 PM Pacific rendered in Eastern
+  time (the user's locale). The stored ISO is
+  canonical; the display is just rendered for the
+  user. If user said "7:30 PM" and the display shows
+  a different hour, the schedule is wrong for THEIR
+  intent. Confirm user's timezone separately (their
+  daily-briefing cron `fireAt` minus the cron
+  `cronExpression` time-of-day gives the local
+  offset). Update via
+  `update_scheduled_task(fireAt="<correct-offset>")`.
+
+- **Subagent-vs-Batches questions need a Phase 0
+  measurement before drafting the full spec**: when
+  considering whether to replace a Batches API pipeline
+  with subagent fan-out (e.g., per-kind polish
+  specialization in attune-author), the prior is that
+  Batches already wins on speed/cost — 50% discount
+  plus automatic parallelism. The only axis where
+  subagents can beat Batches is *quality
+  differentiation* (different prompts, models, or
+  strategies per task type). Don't draft a full spec
+  on that prior alone. Phase 0 design: run the same
+  fixed corpus through three arms — (1) status quo
+  Batches with global prompt, (2) subagents with
+  regular API per-kind (no batching — worst case for
+  subagents, exposes the discount loss), (3) subagents
+  that each submit their own Batches call (preserves
+  discount, isolates the per-kind effect). Capture
+  wall-clock, input/output tokens, total $, and 5
+  sampled outputs per arm for quality eyeball.
+  Pre-commit a decision matrix to
+  `docs/specs/<spec>/decisions.md` BEFORE running so
+  the result routes the decision cleanly without
+  goalpost-moving (see the existing "Pre-committed
+  decision matrices survive contact with data"
+  lesson). Same pattern as the Agent Surface
+  Rebalance retirement (2026-05-12): $8.78 of
+  measurement was strictly cheaper than implementing
+  a conversion that would have saved zero bytes. Test
+  budget here is similarly cheap (~$5-15 for a 12-
+  template corpus on Sonnet). Generalize: any "swap
+  Anthropic-native infrastructure for orchestration
+  layer above it" question in this ecosystem needs
+  Phase 0 measurement first.
+
+<!-- from 8fce6bd18 docs(CLAUDE.md): add stale-branch git-status gotcha lesson -->
+
+
+- **`git diff --stat` on an abandoned branch shows
+  working-tree-vs-branch-HEAD, not vs current main —
+  the insert/delete counts mislead when assessing
+  "what's worth salvaging" from a stale branch**: hit
+  during today's worktree audit on
+  `silly-shamir-a723b0` (PR #262 CLOSED, dirty). The
+  `git status` showed `M` on 3 files in
+  `.help/templates/memory/` and the `--stat` reported
+  214 inserts / 264 deletes — a substantial-looking
+  rewrite. But that diff was working-tree-vs-the-
+  branch's-OWN-old-base. The actual diff vs current
+  main was 6 lines per file: just regenerated
+  frontmatter (`generated_at` timestamp +
+  `source_hash`). Body content was identical because
+  the templates auto-regenerate from `src/attune/
+  memory/` source and main had a NEWER regeneration.
+  Pattern: when evaluating whether to "salvage"
+  uncommitted work from an abandoned branch, always
+  `diff <worktree-file> <main-file>` directly, not
+  `git diff --stat` inside the worktree. The latter
+  compares against a base that's typically weeks
+  behind main. Saved a no-op PR today. Pairs with
+  the existing "Audits with 'possibly delete if X'
+  qualifiers require verifying both X and the
+  alternative before acting" lesson — same shape,
+  different mechanism.
+
+<!-- from 263d4f379 docs(lessons): 4 from worktree/staging/stash mechanics -->
+
+
+- **Editable install from a sub-worktree binds to
+  the parent worktree's filesystem for project-
+  relative reads, not just code**: the existing
+  lesson on `uv run attune from a worktree serves
+  the MAIN repo's code, not the worktree's` covers
+  Python imports. The corollary: anything resolving
+  `config.project_root / "docs" / "specs"` (or any
+  other project-relative path) reads the PARENT
+  worktree's disk too — `project_root` is set at
+  server startup from where the binary was
+  launched. Concrete observation: ops dashboard's
+  `/api/specs` returned 18 specs while the
+  sub-worktree had 20 on disk; the 2 missing
+  existed in `origin/main` but the parent's local
+  main was 16 commits behind. The dashboard wasn't
+  filtering or caching — it was scanning a stale
+  filesystem. Generalization: when an
+  editable-install-served service shows stale
+  data, check the PARENT worktree's git state, not
+  the sub-worktree where you made changes.
+
+- **Replicating prepared staged work onto a moved
+  main: use `git apply --3way` of the diff, not
+  content overwrites**: prepared work in a parent
+  worktree's staging area may be against a
+  POINT-IN-TIME version of main that has since
+  evolved. Wholesale-copying the staged content
+  into a fresh branch off current main reverts the
+  upstream evolution. Caught when
+  `test-quality-program/decisions.md` showed a
+  279-line deletion — main had grown a Phase-2
+  decisions section that the staged version
+  predated. Fix template: `git -C <parent> diff
+  --cached -- <paths> > /tmp/x.patch` to extract
+  the prepared diff, then `git apply --3way
+  /tmp/x.patch` on a fresh branch off current
+  main. 3-way picks up the surgical change,
+  preserves the upstream growth, and flags only
+  the actual conflicts.
+
+- **`git merge --ff-only` can fail silently when
+  staged changes conflict with incoming files**:
+  the error ("Your local changes to the following
+  files would be overwritten by merge") prints and
+  exit is non-zero, but a user pasting a
+  multi-command block may not see it scroll past.
+  Always verify post-merge HEAD: `git rev-parse
+  main` and `git rev-parse origin/main` should
+  match. Diagnostic check before merging:
+  `git merge-base --is-ancestor main origin/main`
+  (must be true) AND look for overlap between
+  `git diff --cached --name-only` and `git diff
+  main..origin/main --name-only` — must be empty
+  for ff to succeed with a staged tree. If
+  non-empty, unstage or stash those files before
+  the merge.
+
+- **`git stash pop` after a ff-merge that touched
+  the same files: resolve with `--ours` to keep
+  main, NOT `--theirs`**: counterintuitive flag
+  direction. For `git stash pop`, `--ours` is the
+  WORKING TREE state (main's authoritative content
+  after the ff) and `--theirs` is the STASHED
+  content. Memory hook: stash-pop has `git apply`
+  semantics — what's CURRENTLY in the tree is
+  "ours", what you're applying is "theirs". Same
+  direction as `git merge`, opposite of `git
+  rebase`. When the goal is to keep main's newer
+  content over older stashed prep, `git checkout
+  --ours <file>`.

--- a/.claude/lessons.md
+++ b/.claude/lessons.md
@@ -14237,3 +14237,21 @@ def ", start_idx + 1)` for module-
   into one AskUserQuestion confirmation up front — cheaper than
   burning a blocked attempt, and the in-session-auth precedent
   then covers the rest of the session.
+
+- **Resolving a lessons.md merge conflict with a script: whole-string
+  marker asserts can NEVER pass — the corpus itself contains literal
+  conflict-marker text inside lesson bodies** (2026-07-08, fixing PR
+  #1290's append-tail collision): lessons documenting merge/stash
+  conflicts legitimately embed `<<<<<<< ` / `>>>>>>> ` as CONTENT, so
+  a resolution script asserting `"<<<<<<< " not in text` fails even
+  after a perfect resolve (two attempts died on their own safety
+  asserts; the second failure also left a marker-laden file STAGED —
+  reconcile with `git status` + `grep -c '^<<<<<<<'` + check HEAD's
+  copy before retrying). Correct checks are LINE-ANCHORED: detect
+  hunks via `line.startswith("<<<<<<< ")` (assert exactly the expected
+  count), and post-resolve assert no LINE starts with a marker —
+  `grep -c "^<<<<<<< "` not substring search. The conflict itself is
+  the standard both-appended-to-tail shape: keep BOTH sides (main's
+  tail first, the PR's after). Applies to any self-referential corpus
+  file (lessons, docs about git) — the content defeats naive marker
+  detection precisely because the file teaches about conflicts.

--- a/.claude/rules/attune/decision-routine.md
+++ b/.claude/rules/attune/decision-routine.md
@@ -140,8 +140,30 @@ Stage 2 review is the worked consumer.
 
 ---
 
+## Acting on a terse "go"
+
+Two gates fire before executing a `go` / `do it` / `y` (full rule in
+the `feedback_go_referent_and_spend_gates` memory):
+
+- **Referent gate (A).** Execute only when exactly one action is the
+  obvious referent from my immediately-prior turn. If that turn listed
+  multiple options or open items, the referent is unresolved — resolve
+  it first (one line or `AskUserQuestion`) before acting. The precision
+  burden is mine, not the user's shorthand.
+- **Spend gate (B).** Before the first billable API call of a task,
+  state what + a rough cost estimate and get an explicit go for the
+  spend — even when a spec pre-authorizes the work. Then it's
+  session-durable. Free/local actions never trip this.
+
+An ambiguous referent that resolves to a paid action trips both →
+hard stop.
+
+---
+
 ## Cross-references
 
+- `feedback_go_referent_and_spend_gates` memory — the two gates above
+  in full, with the origin and how-to-apply
 - `.claude/rules/attune/xml-enhanced-prompts.md` — canonical for
   XML prompt criteria and schema
 - `.claude/CLAUDE.md` — Critical Rules section names when to use

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -12,7 +12,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   security:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -12,7 +12,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   security:

--- a/README.md
+++ b/README.md
@@ -208,6 +208,33 @@ workflow brainstorms, then plans, then executes. `planning` clarifies
 scope before writing a line of code. This eliminates the most common
 failure mode: confidently solving the wrong problem.
 
+**Dynamic communication — the agent adapts how it talks to you.**
+The headline of this release: instead of a fixed wall of prose, Attune
+now *dynamically* shapes each exchange to fit the moment — rendering an
+interactive form in response to your prompt whenever a structured turn
+communicates better than text. A multi-part question becomes one form
+you answer with a click; a recommendation arrives as weighable cards; a
+disagreement is shown side-by-side so you can overrule it in one tap.
+This is a deliberate effort to *improve human/AI communication* — making
+the back-and-forth faster, clearer, and less ambiguous. The agent picks
+the right *construct* for the moment:
+
+- **intake** — gathers several independent decisions as a single
+  (multi-select-capable) form, instead of N back-and-forth questions.
+- **decision** — offers a *recommended* option with a rationale and
+  per-option tradeoffs, rendered as cards (consumed by the `/spec`
+  approval gate).
+- **pushback** — when the agent disagrees with your stated approach, it
+  shows "your approach" beside "I'd suggest instead" with a "why", and
+  you overrule or switch with one pick (`/spec` plan review).
+- **progress** — a done / in-progress / blocked status board whose
+  blocked items are a picker for what to fix next (`/spec` execute).
+
+All constructs share one declarative form model and validator, render
+richly on widget-capable surfaces (e.g. claude.ai / Cowork) and degrade
+gracefully to a recommendation-first menu elsewhere. The terse reply
+vocab (`y` / `go` / `1`) answers any of them.
+
 ### 4. RAG-grounded generation
 
 `attune-rag` (core dep) grounds LLM generation in retrieved corpus

--- a/content/blog/what-ai-memory-actually-saved-in-one-day.md
+++ b/content/blog/what-ai-memory-actually-saved-in-one-day.md
@@ -1,0 +1,116 @@
+---
+title: "What an AI Memory System Actually Saved in One Day"
+date: "2026-07-05"
+author: "Patrick Roebuck"
+excerpt: "I measured a full day of Claude Code sessions from their transcripts: 11 sessions, 694 million tokens of context re-read. A memory architecture change cut that by 8% — but the real savings never showed up in the token counts at all."
+tags: ["token economics", "memory", "prompt caching", "Claude Code", "Redis"]
+published: true
+---
+# What an AI Memory System Actually Saved in One Day
+
+Yesterday I priced a single long Claude Code session from its
+transcript and found that 94% of everything the model processed was
+re-reading its own history. Today I want to answer the follow-up
+question: we ship a cross-session memory suite in attune-ai — what
+did it actually save us?
+
+I picked a good day to measure. July 4th was a three-release day in
+the attune-ai repo: a bug-fix release of a sibling package, a minor
+release that made our Redis memory client a core dependency, and a
+docs patch. Eleven Claude Code sessions, 2,262 assistant messages.
+Here's the day, straight from the transcripts:
+
+| What | Tokens |
+|---|---|
+| Fresh input (text the model had never seen) | 807,564 |
+| Output (everything the model wrote) | 1,985,207 |
+| Cache writes (context stored for reuse) | 17,263,230 |
+| Cache reads (context re-read from cache) | 693,637,455 |
+| **Total processed** | **~713 million** |
+
+Same shape as the single session, scaled up: 97% of the day was the
+model re-reading context it already had. Prompt caching makes that
+affordable, but 694 million tokens of re-reading is the number any
+savings claim has to be measured against.
+
+## The multiplier that makes memory architecture matter
+
+Here's the mechanic that took me embarrassingly long to internalize:
+anything that sits in your session's baseline context — rules files,
+instructions, memory indexes — is re-read on *every single turn*.
+Not once per session. Every turn.
+
+So a context file that costs 26,000 tokens doesn't cost 26,000
+tokens. Across a 200-turn session it costs 5.2 million cache reads.
+Across my 2,262-turn day, a 26,000-token baseline item costs about
+59 million.
+
+That's exactly the size of the change we shipped this week. Our
+engineering-rules corpus had grown to 116KB of always-loaded
+context. We cut it over to just-in-time recall: a 13KB index stays
+resident, and the full rule bodies are retrieved only at the moment
+a tool call or prompt actually needs them — a few hundred tokens per
+hit, maybe a dozen hits a day.
+
+Measured against the transcripts, that one change avoided roughly
+**59 million cache reads — 8% of the entire day's context
+throughput**. The same pattern covers our project memory: a 412KB
+corpus of decisions and findings never enters context wholesale.
+A 17KB index loads, Redis serves a few hundred exactly-relevant
+tokens on demand, and our benchmarks put query-first recall at about
+6× cheaper than the grep-and-read alternative.
+
+## The savings that never show up in token counts
+
+Here's the honest part, and the part I find more interesting: the
+8% was saved by the recall *architecture*. The memory *loop* — the
+part that stashes findings when a session ends and recalls them when
+the next one starts — saved almost nothing in tokens. It saved
+something better.
+
+Four concrete moments from the same day, all reconstructable from
+the transcripts:
+
+**A silent API failure, avoided twice.** Approving a PyPI publish
+gate through the GitHub API requires a typed array parameter; the
+obvious string form silently does nothing and leaves your release
+stuck at "waiting" with no error. We learned that the hard way weeks
+ago and it became a memory entry. Yesterday it was retrieved
+automatically at the exact tool call it governs — at both publish
+gates. That's a known 30-minute debug cycle, avoided twice, by a few
+hundred tokens of recall.
+
+**Three tags, all from verified commits.** A past release shipped
+from the wrong ref, and the lesson — verify the version and
+changelog are actually *in* the commit you're about to tag — now
+fires at tag time. It ran before all three of yesterday's tags.
+
+**A mid-task takeover with zero re-derivation.** I stopped one
+session partway through a release and another picked it up. The
+incoming session started with the full task chain — what was merged,
+what was pending, what the acceptance criteria were — from
+session-start recall, instead of spending its first twenty minutes
+reconstructing state.
+
+**A release race, prevented.** The incoming session also knew from
+memory that a parallel session existed and had been working the same
+repo — so instead of duplicating the release, it stood down and
+monitored. Two agents racing the same `git checkout` and PyPI
+publish is a genuinely expensive mess to clean up.
+
+## What it adds up to
+
+On a subscription plan none of this shows up on a bill — the token
+savings buy context headroom and speed, not dollars. Priced at the
+API rates I used in yesterday's post, the day would have run about
+a thousand dollars, and the architecture change trimmed roughly
+sixty of that. Real, but not the headline.
+
+The headline is the second category. The memory loop converted past
+failures into a few hundred tokens of exactly-timed context, and
+those firings saved over an hour of debugging and one potential
+release collision — on a day we shipped three releases.
+
+Measure your memory system both ways. The token math tells you
+whether your architecture is honest. The rework math tells you
+whether your memory is worth having.

--- a/docs/specs/product-direction-review/assessment.md
+++ b/docs/specs/product-direction-review/assessment.md
@@ -1,0 +1,150 @@
+# Product Direction Review — Assessment
+
+**Status:** assessment (2026-06-17) — decisions pending Patrick
+**Owner:** Patrick (+ agent)
+**Type:** strategic assessment / decision record (not a build spec)
+**Trigger:** Patrick asked for a critical review of attune-ai
+(2026-06-17 session).
+
+> This is a deliberately single-file artifact. A multi-file spec
+> here would be an instance of Finding 3 (scaffolding outweighing
+> product). It records evidence and the decisions to make — it does
+> not itself schedule work.
+
+---
+
+## Verdict
+
+Not a competence problem. The engineering is unusually disciplined
+(privacy-first telemetry, a real institutional-knowledge system,
+security rigor). The problem is that the competence is pointed at a
+**demand hypothesis that has never been tested**. ~184k lines of
+product and ~349k lines of tests, built solo at ~10 commits/day for
+90 straight days, for a user base that cannot currently be observed.
+Findings 2–6 are downstream of Finding 1.
+
+---
+
+## Evidence (ground truth, 2026-06-17)
+
+| Metric | Value | Source |
+|--------|-------|--------|
+| Product code | 183,768 LOC / 712 files | `wc` src/attune |
+| Test code | 349,399 LOC / 968 files / ~20,160 `test_*` | `wc` tests |
+| Test-to-product ratio | 1.9 : 1 | derived |
+| Commits, last 90 days | 882 (~9.8/day, every day) | `git log` |
+| Last 200 commits: `feat` | 27 (13.5%) | `git log %s` |
+| Last 200: test+docs+chore+ci | 148 (74%) | `git log %s` |
+| Last 300 commits: ci/hang/flake/runner | 54 (~18%) | `git log` |
+| Open spec directories | 49 (most partial/draft/deferred) | `ls docs/specs` |
+| `lessons.md` | 9,356 lines | `wc` |
+| Dependencies | 311 lines in pyproject | `grep` |
+| Version | 8.5.0 (young project) | pyproject |
+| Human authors, all time | 1 (Patrick: 197 of last 200) | `git log %an` |
+| attune-ai downloads | 636/week, 2,836/month | usage-signals D1 |
+| Real behavioral signal | ~0 (opt-in, default-OFF telemetry) | `usage_ping.py` |
+
+The download numbers come from the [usage-signals](../usage-signals/)
+spec, whose own headline interpretation is that **our CI is the
+biggest "user"** — i.e. downloads are not adoption.
+
+---
+
+## Ranked findings
+
+### 1 — Optimizing a function that can't be measured (existential)
+
+`usage_ping.py` is well-built (frozen 8-key payload, `DO_NOT_TRACK`
+honored, default-OFF) and therefore near-zero signal: opt-in
+default-off telemetry over an unknown user base transmits nothing in
+practice. The only "users" number is the pepy badge, which counts CI,
+mirrors, and bots. Every prioritization call across 49 specs, 70
+workflow files, the ops dashboard (10k LOC), the socratic subsystem
+(14k LOC) is made on taste, not evidence. This is the root cause of
+2–6.
+
+**Proof that resolves it:** 5 conversations with humans who ran
+attune-ai on a real repo. Not the phone-home endpoint (passive, slow,
+opt-in) — actual calls. If 5 can't be found, that is the finding.
+
+### 2 — The test suite guards the wrong thing
+
+1.9 : 1 test-to-code is ballast at this stage, not rigor. The proof is
+the project's own blocker: the SDK 0.2 migration is stuck because
+17,857 mocked tests are green while real integration systematically
+breaks (`project_sdk_0_2_migration_blocked`). 20,160 tests means every
+refactor drags a 349k-line anchor, and the suite generates work (70 of
+the last 200 commits are `test`). Direction: keep a thin layer of real
+non-mocked round-trip tests; stop ratcheting coverage on mocked
+internals.
+
+### 3 — Scaffolding outweighs product
+
+13.5% of recent commits add features. The rest maintain the machine
+that maintains the machine: a 9,356-line lessons file, 49 specs, 17
+hooks, 14 rule docs, 22 CI workflows, 500 docs files, 108 scripts, and
+a spec-status-self-truthing spec whose job is to make the other specs
+stop lying about their status. MEMORY.md overflowed its own 200-line
+limit. Some of this is real leverage (the lessons corpus); the line has
+been crossed where process competes with the product for hours.
+
+### 4 — Identity blurred across six packages
+
+The README opens with four pillars (workflows, memory, RAG grounding,
+verification) and points at attune-gui, attune-rag, attune-author,
+attune-help, attune-lite, attune-redis. That is a platform, the hardest
+thing for a solo founder pre-PMF to sell, position, or maintain. 311
+dependencies is the cost of that ambition. One sharp tool that 20
+people love beats four pillars zero people have evaluated.
+
+### 5 — Version 8.5.0 is major-version inflation
+
+Eight majors in a young project means frequent breaking changes — a tax
+levied on users who can't be seen, for a stability contract nobody
+relies on. Signals churn, not maturity.
+
+### 6 — CI firefighting is a recurring tar-pit
+
+~18% of recent commits touch CI/hangs/flakes/runners. The project's own
+global rules name a "tar-pit trip-wire" for exactly this. The
+runner-hang saga (H1–H4, multiple captured frames) is real engineering
+and almost certainly not worth its cost relative to validating demand.
+
+---
+
+## Decisions to make (pending Patrick)
+
+These are proposals, not adopted. Record the call inline with a date
+when made.
+
+- **DEC-1 — Freeze new product surface for two weeks.** No new specs,
+  workflows, or pillars. *(pending)*
+- **DEC-2 — Run 5 user conversations.** People who ran attune-ai on a
+  real repo. Owner: Patrick. *(pending)*
+- **DEC-3 — Pick the one pillar** those users actually used; let the
+  others idle. *(pending)*
+- **DEC-4 — Stop the test/coverage ratchet;** real round-trip tests
+  only. *(pending)*
+- **DEC-5 — Time-box CI flake-chasing;** mark unresolved hangs
+  known-flaky and move on. *(pending)*
+
+---
+
+## Counterweight (kept honest)
+
+The talent here is real and rare: the privacy engineering is exemplary
+and done, the lessons system is genuine institutional memory, security
+discipline is mature. None of that is the problem. The problem is aim,
+not skill. The highest-value artifact this month is the email that gets
+Patrick on a call with a user.
+
+---
+
+## Related
+
+- [usage-signals](../usage-signals/) — download baseline + opt-in ping
+  design; already proves downloads ≠ adoption.
+- `project_telemetry_local_only` memory — telemetry state and the
+  "talk to users" conclusion.
+- `project_next_work_sequence` memory — the backlog this assessment
+  argues should be paused pending DEC-2.


### PR DESCRIPTION
One reviewable PR rolling up everything worth keeping from the stale-branch triage (37 branches: 24 deleted as provably-in-main, 3 archived as `archive/*` tags, 10 harvested here then deleted).

**Cherry-picked as-is:**
- lessons.md self-referential conflict-marker resolve trap (`docs/lessons-marker-resolve-trap`)
- decision-routine "go" referent + spend gates (`docs/decision-routine-go-gates`)
- product-direction-review ranked assessment (`claude/focused-archimedes-cfc780`)
- security.yml `cancel-in-progress: true→false` to quiet the cosmetic cancelled-guard red X (`ci/quiet-security-cancel-noise`) — **confirm still wanted**
- README dynamic-communication section (`docs/readme-communication-grammar`) — **review copy**

**Ported verbatim into lessons.md** (source commits annotated inline): gui sibling-env false-stale, 0%-coverage structural deadness, subprocess check=False crash-masking, stash-pop ours/theirs inversion, stale-branch git-status gotcha, worktree/staging/stash mechanics ×4.

**Plus** the memory-savings blog draft (`content/blog/what-ai-memory-actually-saved-in-one-day.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)