### PR TITLE
feat(hooks): spec-status-integrity — PR-link drift signal, vocabulary lint, drift cache, reminder workflow

### DIFF
--- a/.github/workflows/spec-status-reminder.yml
+++ b/.github/workflows/spec-status-reminder.yml
@@ -1,0 +1,154 @@
+# Spec-status reminder (spec-status-integrity, workspace design §5).
+#
+# Reusable workflow: canonical logic lives here; the umbrella and the
+# four layer repos call it with a 6-line `uses:` caller. On a MERGED PR
+# it scans the PR body, commit messages, and changed paths for spec-dir
+# references (specs/<slug>/, docs/specs/<slug>/); every referenced spec
+# whose status is still in-flight in the merged tree earns ONE reminder
+# comment. Guards:
+#
+# - merged only — closed-unmerged PRs are ignored;
+# - self-reference carve-out (design §5 amendment 2026-07-10): a spec
+#   whose own files the PR modifies is skipped — editing the spec is
+#   proof of awareness, so spec-authoring PRs are never heckled;
+# - marker comment — the reminder is posted at most once per PR.
+#
+# The status parser is intentionally self-contained (a condensed mirror
+# of plugin/hooks/_state.py's leading-token semantics): a reusable
+# workflow runs against the CALLER's checkout, where the vendored hook
+# path differs per repo (or is absent in the umbrella).
+name: spec-status-reminder
+
+on:
+  pull_request:
+    types: [closed]
+  workflow_call: {}
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  remind:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # The merged tree — statuses are judged post-merge, so a PR
+          # that flips its spec's status silences its own reminder.
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
+
+      - name: Remind about referenced in-flight specs
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          python3 - <<'PYEOF'
+          import json
+          import os
+          import re
+          import subprocess
+          import sys
+          from pathlib import Path
+
+          MARKER = "<!-- spec-status-reminder -->"
+          SPEC_REF = re.compile(r"\b((?:docs/)?specs/[a-z0-9][a-z0-9-]*)\b")
+          STATUS_LINE = re.compile(
+              r"^\s*\**\s*Status\**\s*:\s*\**\s*(.+?)\s*$",
+              re.IGNORECASE | re.MULTILINE,
+          )
+          LEAD_TOKEN = re.compile(r"[a-z][a-z-]*")
+          # Condensed mirror of _state.py's verdict sets: anything whose
+          # leading token is terminal / ongoing / parked is NOT in-flight.
+          SETTLED = {
+              "closed", "complete", "completed", "retired", "superseded",
+              "shipped", "done", "implemented",   # terminal
+              "living", "ongoing",                # ongoing-by-design
+              "parked", "paused", "blocked", "deferred",  # parked family
+          }
+          PHASE_FILES = ("tasks.md", "design.md", "requirements.md")
+
+          def gh_api(path, *extra):
+              proc = subprocess.run(
+                  ["gh", "api", path, "--paginate", *extra],
+                  capture_output=True, text=True, timeout=60,
+              )
+              if proc.returncode != 0:
+                  print(f"gh api {path} failed: {proc.stderr.strip()}", file=sys.stderr)
+                  return None
+              return json.loads(proc.stdout)
+
+          def in_flight(status: str) -> bool:
+              value = status.strip().lstrip("*_`").strip()
+              if value.startswith(("✓", "✅")):  # ✓ / ✅ glyphs
+                  return False
+              match = LEAD_TOKEN.search(value.lower())
+              token = match.group(0) if match else ""
+              return token not in SETTLED
+
+          repo = os.environ["REPO"]
+          pr = os.environ["PR_NUMBER"]
+
+          detail = gh_api(f"repos/{repo}/pulls/{pr}")
+          if not isinstance(detail, dict) or not detail.get("merged"):
+              print("PR not merged — nothing to do.")
+              sys.exit(0)
+
+          commits = gh_api(f"repos/{repo}/pulls/{pr}/commits") or []
+          files = gh_api(f"repos/{repo}/pulls/{pr}/files") or []
+          changed = [f.get("filename") or "" for f in files]
+
+          texts = [detail.get("body") or ""]
+          texts += [c.get("commit", {}).get("message") or "" for c in commits]
+          texts += changed
+          refs = {m.group(1) for text in texts for m in SPEC_REF.finditer(text)}
+
+          # Self-reference carve-out: the PR touched files under the spec.
+          touched = {r for r in refs if any(f.startswith(r + "/") for f in changed)}
+
+          hits = []
+          for ref in sorted(refs - touched):
+              spec_dir = Path(ref)
+              if not spec_dir.is_dir():
+                  continue
+              for fname in PHASE_FILES:
+                  fpath = spec_dir / fname
+                  if not fpath.is_file():
+                      continue
+                  match = STATUS_LINE.search(
+                      fpath.read_text(encoding="utf-8", errors="replace")
+                  )
+                  status = match.group(1).strip() if match else ""
+                  if in_flight(status):
+                      hits.append((ref, status or "no status"))
+                  break  # highest-priority phase file decides
+
+          if not hits:
+              print("No in-flight spec references — nothing to do.")
+              sys.exit(0)
+
+          comments = gh_api(f"repos/{repo}/issues/{pr}/comments") or []
+          if any(MARKER in (c.get("body") or "") for c in comments):
+              print("Reminder already posted — not commenting twice.")
+              sys.exit(0)
+
+          lines = [MARKER]
+          for ref, status in hits:
+              lines.append(
+                  f"This PR references `{ref}` (status: {status}) — "
+                  "flip the status or mark it `parked`."
+              )
+          body = "\n\n".join(lines)
+          proc = subprocess.run(
+              ["gh", "api", f"repos/{repo}/issues/{pr}/comments",
+               "-X", "POST", "-f", f"body={body}"],
+              capture_output=True, text=True, timeout=60,
+          )
+          if proc.returncode != 0:
+              print(f"comment failed: {proc.stderr.strip()}", file=sys.stderr)
+              sys.exit(1)
+          print(f"Reminded about {len(hits)} spec(s).")
+          PYEOF

--- a/docs/specs/spec-status-integrity-hooks/requirements.md
+++ b/docs/specs/spec-status-integrity-hooks/requirements.md
@@ -1,0 +1,221 @@
+# Spec: Spec-Status Integrity Hooks (attune-ai)
+
+> Companion spec to the attune workspace spec
+> [`specs/spec-status-integrity/`](https://github.com/Smart-AI-Memory/attune)
+> (requirements + design + tasks all approved 2026-07-10). The workspace
+> spec owns the full feature — problem analysis, cross-repo design, and
+> the 9-task execution plan. This spec covers the attune-ai plugin slice
+> (workspace tasks 1–6): the canonical hook changes and the reusable
+> reminder workflow. Same companion pattern as fable-model-tiers ↔
+> fable-premium-tier.
+
+---
+
+## Phase 1: Requirements
+
+**Status**: approved (2026-07-10 — by reference: workspace spec
+`specs/spec-status-integrity/requirements.md` approved by Patrick
+2026-07-10; this companion restates the plugin-scoped subset)
+
+### Problem statement
+
+Spec status lines across the five attune repos drift from reality —
+specs sit at `draft`/`approved` long after their implementing PRs merge
+(the 2026-06-17 audit found the orientation hook advertising already-
+shipped work). The attune-ai plugin owns the canonical spec tooling
+(`plugin/hooks/_state.py`, `spec_audit.py`, `spec_orient.py`, vendored
+into the four layer repos via `make sync-hooks`), so the drift-detection
+machinery lands here: a PR-link signal (primary), a status-vocabulary
+lint, a drift cache consumed offline at session start, and a reusable
+PR-merge reminder workflow.
+
+### Scope
+
+**In scope (workspace tasks 1–6, all in this repo):**
+
+- `plugin/hooks/_state.py` — `PrRef` + `extract_pr_refs()` (four
+  citation styles), `lint_status_token()`, terminal-verdict additions
+  (`implemented`, bare `✓`/`✅`), `parked`-semantics set (`parked`,
+  `paused`, `blocked`, `deferred` — skipped by drift checks).
+- `plugin/hooks/spec_audit.py` — `--pr-links` mode (gh-backed,
+  merged-PRs-only, bounded + cached calls), `--offline` degradation,
+  `--json` output, `.attune/spec-drift.json` cache write.
+- `plugin/hooks/spec_orient.py` — drift-cache read (< 8 days fresh),
+  `⚠ drifted: <repo> #<n> merged` annotation, `ATTUNE_SPEC_AUDIT=off`
+  kill switch. The hook stays offline (no-network invariant).
+- `.github/workflows/spec-status-reminder.yml` — reusable
+  (`workflow_call` + own `pull_request: [closed]`): comments on merged
+  PRs that reference still-in-flight specs, with a self-reference
+  carve-out and a never-comment-twice guard.
+
+**Out of scope (workspace tasks 7–9, other repos):**
+
+- Sibling re-sync (`make sync-hooks` in attune-rag/gui/help/author) and
+  their thin caller workflows.
+- Umbrella `Makefile`, weekly `spec-audit.yml` CI, baseline validation
+  sweep, and any hand-flipping of drifted statuses.
+- Mass rewrite of historical status tokens (~127 `complete` variants) —
+  aliases stay accepted; only new specs are linted toward the canonical 8.
+
+### User stories
+
+1. As a session starting in any attune repo, I want in-flight spec lines
+   annotated `⚠ drifted` when a merged PR already implemented them, so I
+   don't plan work that's already shipped.
+2. As a maintainer running `spec_audit.py --pr-links`, I want merged-PR
+   evidence (not just deliverable existence) driving the drift verdict,
+   with `--json` output CI can upsert into a tracking issue.
+3. As a PR author merging work that references a spec, I want one
+   reminder comment when the spec's status is still in-flight — and no
+   nag when my PR itself updates the spec.
+4. As an offline or gh-less user, I want the audit to degrade to the
+   existing deliverable-existence signal and the session hook to never
+   make network calls.
+
+### Affected components
+
+- [ ] Skills (`plugin/skills/`) — none
+- [ ] Agents (`plugin/agents/`) — none
+- [x] Hooks (`plugin/hooks/_state.py`, `spec_audit.py`, `spec_orient.py`)
+- [x] CI workflows (`.github/workflows/spec-status-reminder.yml`, reusable)
+- [x] PyPI package (`pyproject.toml`) — ships as a plugin release before
+  the sibling re-sync (workspace task 7) can run
+- [ ] Personal command (`~/.claude/commands/`) — N/A
+
+Cross-repo dependency: the four layer repos vendor these hooks
+byte-for-byte (drift-guard tests); the umbrella weekly CI invokes
+`spec_audit.py` from this package. Contract changes here propagate via
+`make sync-hooks` under the workspace spec's tasks 7–8.
+
+### Invocation & triggers
+
+| Component | Trigger |
+|-----------|---------|
+| `spec_orient.py` | Existing SessionStart hook — gains the `⚠ drifted` suffix, no new invocation |
+| `spec_audit.py` | `make spec-audit` / direct CLI; new flags `--pr-links`, `--offline`, `--json` |
+| Reminder workflow | `pull_request: [closed]` (merged only) in this repo; `workflow_call` from sibling/umbrella callers |
+| Kill switch | `ATTUNE_SPEC_AUDIT=off` env var suppresses session-start annotations |
+
+### Tool scope
+
+N/A — no new skill/agent. `spec_audit.py` shells out to `gh` (subprocess,
+patched at that boundary in tests); `spec_orient.py` gains file reads
+only. The reminder workflow needs `pull-requests: write` +
+`contents: read`, nothing more.
+
+### Coverage areas
+
+| Area | Status | Notes |
+|------|--------|-------|
+| **Problem & scope** | addressed | Above; full analysis in workspace requirements.md |
+| **Skill/agent contracts** | addressed | No SKILL.md changes; hook CLI gains flags, exit contract unchanged (warn + exit 0, `--strict` exits 1) |
+| **User interaction** | addressed | One-line `⚠ drifted` suffix per spec (3-spec orientation budget unchanged); one reminder comment per merged PR |
+| **Edge cases** | addressed | gh absent/failing → `--offline` degradation; stale (≥ 8 days)/absent/malformed cache → current behavior; bare `#NNN` may be an issue — resolved merged-PRs-only at check time |
+| **Plugin compatibility** | addressed | `classify_staleness` behavior unchanged for already-recognized tokens; deliverable-existence signal kept as fallback; sibling parity via existing drift-guard suites |
+| **Error handling** | addressed | Hook stays crash-proof (existing try/except); audit never blocks by default; workflow no-ops on closed-unmerged PRs |
+| **Tradeoffs & alternatives** | addressed | Workspace design.md tradeoff table (extend `_state.py` vs standalone checker; cache vs gh-in-hook; lint-new vs mass rewrite) |
+| **Rollback strategy** | addressed | `ATTUNE_SPEC_AUDIT=off`; drift cache disposable; workflow deletable; hooks revert via canonical repo + `make sync-hooks`; PyPI version pin |
+
+### Edge cases & open questions
+
+| Question / Edge case | Resolution |
+|----------------------|------------|
+| Bare `#NNN` cites an issue, not a PR | `gh api .../pulls/{n}` resolution at check time; non-PR / unmerged refs ignored |
+| Cross-repo PR reference | Markdown pull-URL is the required style; `PrRef.repo` carries the explicit repo |
+| gh unauthenticated / rate-limited / absent | Degrade to deliverable-existence signal; never block; `--offline` forces it |
+| Unbounded gh calls on a big workspace | Per-run cap (mirrors `session_recall.py` `_MAX_PR_CHECKS`) + in-run cache |
+| Drift cache goes stale between weekly CI runs | 8-day freshness window (one weekly period + slack); stale = ignored |
+| Unknown status token | Linted as `unparseable`, never guessed; lint message names the canonical 8 |
+| Spec intentionally on hold | `parked` family (`parked`/`paused`/`blocked`/`deferred`) skipped by drift checks, listed as parked |
+| Reminder heckles spec-authoring PRs | Self-reference carve-out: PRs modifying files under the referenced spec dir are skipped (design §5 amendment 2026-07-10) |
+| Reminder double-comments on re-run | Marker-comment guard: never comment twice on the same PR |
+
+### Gaps (if any)
+
+None plugin-side. The live baseline validation (workspace task 9) runs
+in the umbrella after the release + re-sync and is tracked there.
+
+---
+
+## Phase 2: Design
+
+**Status**: approved (2026-07-10 — by reference: workspace
+`specs/spec-status-integrity/design.md` §1–3 + §5, approved via attune
+PR #29 with the 2026-07-10 amendments)
+
+The authoritative design lives in the workspace spec. Plugin-relevant
+sections:
+
+- **§1 Signal layer** — `extract_pr_refs()` citation-style table and
+  `PrRef {repo: str|None, number: int, explicit: bool}`; vocabulary lint
+  built on the existing `_TERMINAL_VERDICTS` / `_ONGOING_VERDICTS` sets.
+- **§2 Checker** — `--pr-links` pipeline over `discover_specs()`;
+  `.attune/spec-drift.json` schema
+  `{generated_at, specs: {path: {verdict, prs, signal}}}`.
+- **§3 Session surface** — cache-read-only annotation; no-network
+  invariant preserved (`_state.py:2`, 4 s hook timeout).
+- **§5 PR-merge reminder** — reusable workflow contract, self-reference
+  carve-out, minimal permissions.
+
+### Distribution
+
+- [x] PyPI release required (plugin release precedes workspace task 7)
+- [ ] Personal command update only
+- [x] Plugin marketplace update (rides the release)
+- [ ] No distribution change
+
+---
+
+## Phase 3: Tasks
+
+**Status**: approved (2026-07-10 — by reference: workspace
+`specs/spec-status-integrity/tasks.md`, approved by Patrick 2026-07-10)
+
+The execution plan is workspace tasks 1–6, one commit each on
+`feat/spec-status-integrity-hooks`:
+
+| # | Task (workspace #) | Component | Status | Notes |
+|---|--------------------|-----------|--------|-------|
+| 1 | This companion spec (ws 1) | docs/specs | done | |
+| 2 | `extract_pr_refs()` + `PrRef` (ws 2) | `_state.py` | pending | |
+| 3 | `lint_status_token()` + vocabulary (ws 3) | `_state.py` | pending | |
+| 4 | `--pr-links` + drift cache + `--json` (ws 4) | `spec_audit.py` | pending | |
+| 5 | Drift-cache read + `⚠ drifted` (ws 5) | `spec_orient.py` | pending | |
+| 6 | Reusable reminder workflow (ws 6) | `.github/workflows` | pending | |
+
+Testing strategy, rollback plan, and the full XML execution plan live in
+the workspace `tasks.md` — not duplicated here.
+
+---
+
+## Phase 4: Implementation
+
+**Status**: in-progress
+
+### Completion checklist
+
+- [ ] All tasks marked done
+- [ ] pytest + ruff green after each task
+- [ ] No live gh calls in the default suite (testing-conventions)
+- [ ] Existing `classify_staleness` / `spec_orient` behavior unchanged
+      for already-recognized tokens (regression check)
+- [ ] Version bumped for the plugin release (three files:
+      pyproject.toml + plugin.json + uv.lock)
+- [ ] Committed one task per commit, conventional messages
+- [ ] PR opened linking this spec and the workspace spec
+
+---
+
+## Cross-references
+
+- Workspace spec: `specs/spec-status-integrity/` in the attune repo —
+  [requirements](https://github.com/Smart-AI-Memory/attune/blob/main/specs/spec-status-integrity/requirements.md) ·
+  [design](https://github.com/Smart-AI-Memory/attune/blob/main/specs/spec-status-integrity/design.md) ·
+  [tasks](https://github.com/Smart-AI-Memory/attune/blob/main/specs/spec-status-integrity/tasks.md)
+- Approval trail: attune PRs #29 (design), #32/#33 (tasks), #34
+  (amendments: self-reference carve-out, CI token secret).
+- Pattern precedent: `docs/specs/fable-premium-tier/` ↔ workspace
+  `specs/fable-model-tiers/`.
+- Existing machinery this extends: `plugin/hooks/_state.py`
+  (`classify_staleness`, `_DRIFT_OPT_OUT`), `plugin/hooks/spec_audit.py`,
+  `plugin/hooks/spec_orient.py`, `Makefile: spec-audit`.

--- a/docs/specs/spec-status-integrity-hooks/requirements.md
+++ b/docs/specs/spec-status-integrity-hooks/requirements.md
@@ -177,11 +177,11 @@ The execution plan is workspace tasks 1–6, one commit each on
 | # | Task (workspace #) | Component | Status | Notes |
 |---|--------------------|-----------|--------|-------|
 | 1 | This companion spec (ws 1) | docs/specs | done | |
-| 2 | `extract_pr_refs()` + `PrRef` (ws 2) | `_state.py` | pending | |
-| 3 | `lint_status_token()` + vocabulary (ws 3) | `_state.py` | pending | |
-| 4 | `--pr-links` + drift cache + `--json` (ws 4) | `spec_audit.py` | pending | |
-| 5 | Drift-cache read + `⚠ drifted` (ws 5) | `spec_orient.py` | pending | |
-| 6 | Reusable reminder workflow (ws 6) | `.github/workflows` | pending | |
+| 2 | `extract_pr_refs()` + `PrRef` (ws 2) | `_state.py` | done | 4 styles + negatives; 17 tests |
+| 3 | `lint_status_token()` + vocabulary (ws 3) | `_state.py` | done | `implemented`/glyphs terminal; parked family |
+| 4 | `--pr-links` + drift cache + `--json` (ws 4) | `spec_audit.py` | done | Golden test mirrors SPEC-AUDIT-2026-06-17 |
+| 5 | Drift-cache read + `⚠ drifted` (ws 5) | `spec_orient.py` | done | 8-day freshness; `ATTUNE_SPEC_AUDIT=off` |
+| 6 | Reusable reminder workflow (ws 6) | `.github/workflows` | done | yaml.safe_load test suite |
 
 Testing strategy, rollback plan, and the full XML execution plan live in
 the workspace `tasks.md` — not duplicated here.
@@ -194,15 +194,18 @@ the workspace `tasks.md` — not duplicated here.
 
 ### Completion checklist
 
-- [ ] All tasks marked done
-- [ ] pytest + ruff green after each task
-- [ ] No live gh calls in the default suite (testing-conventions)
-- [ ] Existing `classify_staleness` / `spec_orient` behavior unchanged
-      for already-recognized tokens (regression check)
+- [x] All tasks marked done
+- [x] pytest + ruff green after each task
+- [x] No live gh calls in the default suite (testing-conventions) —
+      gh is patched at the `_run_gh` subprocess boundary
+- [x] Existing `classify_staleness` / `spec_orient` behavior unchanged
+      for already-recognized tokens (regression check — full hook suite
+      green)
 - [ ] Version bumped for the plugin release (three files:
-      pyproject.toml + plugin.json + uv.lock)
-- [ ] Committed one task per commit, conventional messages
-- [ ] PR opened linking this spec and the workspace spec
+      pyproject.toml + plugin.json + uv.lock) — rides the release-prep
+      PR per the standard flow, not this feature PR
+- [x] Committed one task per commit, conventional messages
+- [x] PR opened linking this spec and the workspace spec
 
 ---
 

--- a/plugin/hooks/_state.py
+++ b/plugin/hooks/_state.py
@@ -59,7 +59,7 @@ _STATUS_LINE = re.compile(
 # done (see decisions.md DECIDE-2).
 _TERMINAL_LINE = re.compile(
     r"^\s*\**\s*(?:Spec\s+)?Status\**\s*:\s*\**\s*"
-    r"(closed|complete|completed|retired|superseded|shipped|done)\b",
+    r"(closed|complete|completed|retired|superseded|shipped|done|implemented)\b",
     re.IGNORECASE | re.MULTILINE,
 )
 _CHECKLIST_HEADING = re.compile(
@@ -76,12 +76,30 @@ _DEFERRED_MARKERS = re.compile(
 )
 _NEXT_H2 = re.compile(r"^##\s+", re.MULTILINE)
 _TERMINAL_VERDICTS = frozenset(
-    {"closed", "complete", "completed", "retired", "superseded", "shipped", "done"}
+    {
+        "closed",
+        "complete",
+        "completed",
+        "retired",
+        "superseded",
+        "shipped",
+        "done",
+        # spec-status-integrity additions (design §1): ``implemented``
+        # and the bare check glyphs are terminal — the wild-scan found
+        # both in real headers.
+        "implemented",
+        "✓",
+        "✅",
+    }
 )
 # Ongoing-by-design statuses: a living roadmap / continuous program is not
 # pending work, so it should NOT show as in-flight — but it is also not
 # "done". Excluded from the in-flight list, kept distinct from terminal.
 _ONGOING_VERDICTS = frozenset({"living", "ongoing"})
+# Parked-semantics statuses (spec-status-integrity, design §1): work
+# deliberately on hold. Skipped by drift checks and excluded from the
+# in-flight orientation list; the audit still lists them (as parked).
+_PARKED_VERDICTS = frozenset({"parked", "paused", "blocked", "deferred"})
 
 # Leading alphabetic word of a status value, for first-word tokenization:
 # ``complete (2026-06-09) — shipped #694`` -> ``complete``.
@@ -96,11 +114,71 @@ def _leading_verdict(status: str) -> str:
     not exact-string membership. This is the fix for the class of bug
     where a correctly-marked-``complete`` spec stayed in-flight forever
     because ``"complete (date) — ..."`` is not in ``_TERMINAL_VERDICTS``.
+
+    A bare check glyph (``✓`` / ``✅``) leading the value is returned
+    as-is — the glyphs are members of ``_TERMINAL_VERDICTS``
+    (spec-status-integrity, design §1) but are not alphabetic, so the
+    word regex would otherwise skip past them to whatever word follows.
     """
+    stripped = status.strip().lstrip("*_`").strip()
+    for glyph in ("✅", "✓"):
+        if stripped.startswith(glyph):
+            return glyph
     # search (not match) so a stray leading ``**``/punctuation doesn't
     # swallow the verdict — the first alphabetic run is the word we want.
     m = _LEADING_WORD.search(status)
     return m.group(0).lower() if m else ""
+
+
+# ── Status-vocabulary lint (spec-status-integrity, design §1) ─
+#
+# The canonical vocabulary for NEW specs. Historical aliases
+# (``_TERMINAL_VERDICTS`` / ``_ONGOING_VERDICTS`` members and the
+# in-flight forms below) stay accepted — no mass rewrite of ~127
+# existing status lines — but the lint steers authors to these 8.
+_CANONICAL_STATUS_TOKENS = (
+    "draft",
+    "in-review",
+    "approved",
+    "in-progress",
+    "implemented",
+    "complete",
+    "superseded",
+    "parked",
+)
+# In-flight forms honored by the checker (design §2): the canonical
+# in-flight 4 plus the historical ``not started`` / ``open`` / ``pending``.
+# ``not`` is the leading token of ``not started``.
+_IN_FLIGHT_TOKENS = frozenset(
+    {"draft", "in-review", "approved", "in-progress", "not", "open", "pending"}
+)
+# Lint tokenization keeps hyphens (``in-review``), unlike
+# ``_LEADING_WORD`` which stops at the first non-alpha char.
+_LINT_TOKEN = re.compile(r"[A-Za-z][A-Za-z-]*")
+
+
+def lint_status_token(status: str) -> str | None:
+    """Lint a status value's leading token against the known vocabulary.
+
+    Returns ``None`` when the leading token is recognized — one of the
+    canonical 8, a historical terminal/ongoing alias, a parked-family
+    token, an accepted in-flight form, or a bare check glyph. Otherwise
+    returns a one-line ``unparseable`` message naming the canonical 8;
+    the token is never guessed at.
+    """
+    stripped = status.strip().lstrip("*_`").strip()
+    for glyph in ("✅", "✓"):
+        if stripped.startswith(glyph):
+            return None
+    match = _LINT_TOKEN.search(status)
+    token = match.group(0).lower() if match else ""
+    recognized = (
+        _TERMINAL_VERDICTS | _ONGOING_VERDICTS | _PARKED_VERDICTS | _IN_FLIGHT_TOKENS
+    ) | set(_CANONICAL_STATUS_TOKENS)
+    if token in recognized:
+        return None
+    shown = token or status.strip() or "(empty)"
+    return f'unparseable status "{shown}" — use one of: ' + ", ".join(_CANONICAL_STATUS_TOKENS)
 
 
 # ── PR-reference extraction (spec-status-integrity, design §1) ──
@@ -607,7 +685,9 @@ def classify_staleness(spec_text: str, header_status: str, roots: list[Path]) ->
     # done deeper in the file is not falsely flagged.
     effective, _source, _conflict = _reconcile_status(header_status, spec_text)
     lead = _leading_verdict(effective)
-    if lead in _TERMINAL_VERDICTS or lead in _ONGOING_VERDICTS:
+    # Parked-family statuses are deliberately on hold — skipped by drift
+    # checks (design §1), so they classify ``ok`` alongside terminal.
+    if lead in _TERMINAL_VERDICTS or lead in _ONGOING_VERDICTS or lead in _PARKED_VERDICTS:
         return "ok"
     return "suspected-stale"
 
@@ -668,6 +748,9 @@ def _is_in_flight(phase: str, effective_status: str) -> bool:
       phase.
     - First word is ongoing-by-design (living / ongoing) → a continuous
       program / living roadmap is not pending work, exclude.
+    - First word is parked-family (parked / paused / blocked /
+      deferred) → deliberately on hold, not pending work, exclude
+      (spec-status-integrity, design §1).
     - Empty status (malformed) → still in-flight (don't drop a
       working spec because the heading was malformed).
     - Anything else (draft / approved / in-progress / …) → in-flight.
@@ -677,7 +760,7 @@ def _is_in_flight(phase: str, effective_status: str) -> bool:
     (the self-truthing improvement).
     """
     lead = _leading_verdict(effective_status)
-    if lead in _TERMINAL_VERDICTS or lead in _ONGOING_VERDICTS:
+    if lead in _TERMINAL_VERDICTS or lead in _ONGOING_VERDICTS or lead in _PARKED_VERDICTS:
         return False
     return True
 

--- a/plugin/hooks/_state.py
+++ b/plugin/hooks/_state.py
@@ -103,6 +103,97 @@ def _leading_verdict(status: str) -> str:
     return m.group(0).lower() if m else ""
 
 
+# ── PR-reference extraction (spec-status-integrity, design §1) ──
+#
+# ``extract_pr_refs()`` parses the four PR-citation styles found in the
+# wild (workspace spec design.md §1): explicit ``PR #212`` /
+# ``PRs #303, #304`` lists, bare ``#1191`` (ambiguous — may be an
+# issue; resolved at check time via the pulls API, merged-only), and
+# the markdown pull-URL — the required style for cross-repo refs.
+# Code fences and inline code spans are blanked first so quoted
+# examples (`` `#NNN` `` in docs) never count as citations.
+_CODE_FENCE = re.compile(r"```.*?```", re.DOTALL)
+_INLINE_CODE = re.compile(r"`[^`\n]+`")
+_PULL_URL = re.compile(r"https://github\.com/(?P<repo>[\w.-]+/[\w.-]+)/pull/(?P<number>\d+)\b")
+# Whole markdown links are blanked AFTER pull-URLs are extracted, so a
+# link text like ``[#95](…/pull/95)`` doesn't ALSO scan as a bare
+# current-repo ref — and issue-links yield nothing at all.
+_MD_LINK = re.compile(r"\[[^\]\n]*\]\([^)\n]*\)")
+_PR_LIST = re.compile(r"\bPRs?\s*#\d+(?:\s*,\s*#\d+)*", re.IGNORECASE)
+_REF_NUMBER = re.compile(r"#(\d+)")
+# Bare ``#NNN``: not preceded by a word char / ``#`` / ``/`` (rejects
+# ``foo#12``, anchors, URL paths) and not followed by a word char
+# (rejects ``#12abc``).
+_BARE_REF = re.compile(r"(?<![\w#/])#(\d+)(?![\w#])")
+
+
+@dataclass(frozen=True)
+class PrRef:
+    """One PR citation extracted from a spec's text.
+
+    ``repo`` is the explicit ``owner/name`` slug from a pull-URL
+    citation; ``None`` means "current repo". ``explicit`` is True when
+    the citation is unambiguously a PR (``PR #N`` / ``PRs #N, …`` /
+    pull-URL); a bare ``#NNN`` is ``explicit=False`` — it may be an
+    issue, which the checker resolves via the pulls API at check time.
+    """
+
+    number: int
+    repo: str | None = None
+    explicit: bool = False
+
+
+def _blank(match: re.Match[str]) -> str:
+    """Length-preserving mask so match positions stay comparable."""
+    return " " * (match.end() - match.start())
+
+
+def extract_pr_refs(text: str) -> list[PrRef]:
+    """Extract PR citations from spec text — deduped, document order.
+
+    Styles recognized (workspace design §1): ``PR #212``,
+    ``PRs #303, #304``, bare ``#1191``, and
+    ``https://github.com/<owner>/<repo>/pull/<n>`` (markdown-wrapped or
+    bare). Duplicate ``(repo, number)`` pairs collapse to the earliest
+    occurrence, upgraded to ``explicit`` if any occurrence was.
+    """
+    scrubbed = _CODE_FENCE.sub(_blank, text)
+    scrubbed = _INLINE_CODE.sub(_blank, scrubbed)
+
+    hits: list[tuple[int, str | None, int, bool]] = []  # (pos, repo, number, explicit)
+
+    for match in _PULL_URL.finditer(scrubbed):
+        hits.append((match.start(), match.group("repo"), int(match.group("number")), True))
+    # Blank markdown links wholesale (pull-URLs already harvested), then
+    # any bare pull-URLs outside links, before the plain-text scans.
+    scrubbed = _MD_LINK.sub(_blank, scrubbed)
+    scrubbed = _PULL_URL.sub(_blank, scrubbed)
+
+    for match in _PR_LIST.finditer(scrubbed):
+        for num in _REF_NUMBER.finditer(match.group(0)):
+            hits.append((match.start() + num.start(), None, int(num.group(1)), True))
+    scrubbed = _PR_LIST.sub(_blank, scrubbed)
+
+    for match in _BARE_REF.finditer(scrubbed):
+        hits.append((match.start(), None, int(match.group(1)), False))
+
+    # Dedupe on (repo, number): earliest position wins the slot; the
+    # explicit flag is OR-merged across occurrences.
+    best: dict[tuple[str | None, int], tuple[int, bool]] = {}
+    for pos, repo, number, explicit in hits:
+        key = (repo, number)
+        if key in best:
+            prev_pos, prev_explicit = best[key]
+            best[key] = (prev_pos, prev_explicit or explicit)
+        else:
+            best[key] = (pos, explicit)
+    ordered = sorted(best.items(), key=lambda item: item[1][0])
+    return [
+        PrRef(number=number, repo=repo, explicit=explicit)
+        for (repo, number), (_pos, explicit) in ordered
+    ]
+
+
 # ── Deliverables block (spec-status-integrity, DECIDE-3) ──────
 #
 # A machine-readable "## Deliverables" section names the paths/globs

--- a/plugin/hooks/_state.py
+++ b/plugin/hooks/_state.py
@@ -21,12 +21,56 @@ Licensed under Apache 2.0
 
 from __future__ import annotations
 
+import json
 import os
 import re
 import subprocess
 import time
 from dataclasses import dataclass
 from pathlib import Path
+
+# ── Drift-cache read (spec-status-integrity, design §3) ───────
+#
+# ``spec_audit.py --pr-links`` writes ``.attune/spec-drift.json`` per
+# workspace root; ``spec_orient`` reads it back so the SessionStart
+# annotation stays offline (the hook's no-network invariant). Entries
+# older than one weekly-CI period + slack are ignored.
+_DRIFT_CACHE_MAX_AGE_SECONDS = 8 * 24 * 60 * 60
+
+
+def read_drift_cache(roots: list[Path], now: float | None = None) -> dict[str, dict]:
+    """Merge fresh drift-cache entries across workspace roots.
+
+    Returns ``{"<layer>/<slug>": {verdict, prs, signal}}`` from every
+    root whose ``.attune/spec-drift.json`` is present, well-formed, and
+    fresher than :data:`_DRIFT_CACHE_MAX_AGE_SECONDS`. Anything else —
+    absent file, malformed JSON, wrong shapes, stale ``generated_at`` —
+    contributes nothing and never raises (the cache is advisory; the
+    annotation simply falls back to current behavior).
+    """
+    current = time.time() if now is None else now
+    merged: dict[str, dict] = {}
+    for root in roots:
+        cache_path = Path(root) / ".attune" / "spec-drift.json"
+        try:
+            data = json.loads(cache_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError, ValueError, UnicodeDecodeError):
+            continue
+        if not isinstance(data, dict):
+            continue
+        generated = data.get("generated_at")
+        if not isinstance(generated, int | float):
+            continue
+        if current - float(generated) > _DRIFT_CACHE_MAX_AGE_SECONDS:
+            continue
+        specs = data.get("specs")
+        if not isinstance(specs, dict):
+            continue
+        for key, entry in specs.items():
+            if isinstance(key, str) and isinstance(entry, dict):
+                merged.setdefault(key, entry)
+    return merged
+
 
 # Phases checked, highest-priority first. The first phase file
 # present in a spec directory determines the displayed phase

--- a/plugin/hooks/spec_audit.py
+++ b/plugin/hooks/spec_audit.py
@@ -8,9 +8,24 @@ against its declared ``## Deliverables`` block, and prints a matrix:
     Spec | Layer | Status | Staleness | Unresolved
 
 D-7 — **warn by default, gate opt-in.** Exits ``0`` even when stale
-specs exist; ``--strict`` exits ``1`` on any ``suspected-stale`` so a
-repo can wire a hard CI gate. Crash-proof: any unexpected error prints
-what we have and still exits ``0`` (warn-by-default never hard-fails).
+specs exist; ``--strict`` exits ``1`` on any ``suspected-stale`` (or,
+with ``--pr-links``, any ``drifted``) so a repo can wire a hard CI
+gate. Crash-proof: any unexpected error prints what we have and still
+exits ``0`` (warn-by-default never hard-fails).
+
+spec-status-integrity additions (workspace design §2):
+
+- ``--pr-links`` — the PRIMARY drift signal. For each in-flight spec,
+  extract PR citations from its phase files and resolve them via
+  ``gh`` (merged PRs only; bounded + cached per run). ≥1 merged
+  implementing PR + in-flight status ⇒ **drifted**. Results are
+  written to ``<root>/.attune/spec-drift.json`` for the offline
+  ``spec_orient`` annotation.
+- ``--offline`` — skip all ``gh`` calls (the deliverable-existence
+  signal still runs). A missing/failing ``gh`` degrades the same way —
+  the audit never blocks on network state.
+- ``--json`` — machine-readable output for the weekly CI's
+  tracking-issue upsert.
 
 Run via ``make spec-audit`` or ``python plugin/hooks/spec_audit.py``.
 
@@ -20,7 +35,10 @@ Licensed under Apache 2.0
 
 from __future__ import annotations
 
+import json
+import subprocess
 import sys
+import time
 import traceback
 from dataclasses import dataclass
 from pathlib import Path
@@ -37,24 +55,152 @@ if _HOOKS_DIR not in sys.path:
     sys.path.insert(0, _HOOKS_DIR)
 
 from _state import (  # noqa: E402 — sys.path bootstrap above
+    PrRef,
+    _is_in_flight,
     _resolve_entry,
     discover_specs,
+    extract_pr_refs,
     workspace_roots,
 )
 
-# Display order — suspected-stale rows surface first; ``ok`` sinks last.
+# Display order — drifted (merged-PR evidence) outranks even
+# suspected-stale; ``ok`` sinks last.
 _STALENESS_ORDER = {
-    "suspected-stale": 0,
-    "partial": 1,
-    "unknown": 2,
-    "docs-only": 3,
-    "opted-out": 4,
-    "ok": 5,
+    "drifted": 0,
+    "suspected-stale": 1,
+    "partial": 2,
+    "unknown": 3,
+    "docs-only": 4,
+    "opted-out": 5,
+    "ok": 6,
 }
-# Only suspected-stale gets a glyph; the rest render verbatim.
-_STALENESS_LABEL = {"suspected-stale": "⚠ suspected-stale"}
+# Only the actionable verdicts get a glyph; the rest render verbatim.
+_STALENESS_LABEL = {"suspected-stale": "⚠ suspected-stale", "drifted": "⚠ drifted"}
 
 _HEADERS = ("Spec", "Layer", "Status", "Staleness", "Unresolved")
+
+# ── PR-link resolution (workspace design §2) ──────────────────
+
+# Bound gh calls per run — same discipline as session_recall.py's
+# _MAX_PR_CHECKS, sized for an audit sweep rather than a session start.
+_MAX_GH_CALLS = 30
+_GH_TIMEOUT_SECONDS = 6.0
+# All three phase files are scanned for citations, not just the
+# highest-priority one — a requirements.md often carries the approval
+# trail ("shipped in #N") even when tasks.md exists.
+_PHASE_FILENAMES = ("tasks.md", "design.md", "requirements.md")
+
+
+def _run_gh(args: list[str], cwd: Path | None) -> subprocess.CompletedProcess[str] | None:
+    """Invoke ``gh`` — the subprocess boundary tests patch.
+
+    Returns ``None`` when the binary is missing or the call times out;
+    callers treat that as "unknown", never as evidence.
+    """
+    try:
+        return subprocess.run(  # noqa: S603, S607 — fixed argv, no shell
+            ["gh", *args],
+            capture_output=True,
+            text=True,
+            timeout=_GH_TIMEOUT_SECONDS,
+            cwd=str(cwd) if cwd else None,
+        )
+    except FileNotFoundError:
+        raise
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+
+
+class _PrResolver:
+    """Resolves PR refs to merged/not-merged via ``gh``, bounded + cached.
+
+    - Results are cached per ``(repo-or-layer, number)`` for the run, so
+      a PR cited from three phase files costs one call.
+    - At most ``max_calls`` gh invocations per run; past the cap every
+      further ref is "unknown" (not merged) — conservative, no false
+      drift claims.
+    - A missing ``gh`` binary marks the resolver dead: all subsequent
+      lookups short-circuit to "unknown" (offline degradation, design
+      §2 — never blocks).
+    """
+
+    def __init__(self, max_calls: int = _MAX_GH_CALLS) -> None:
+        self.calls = 0
+        self.dead = False
+        self._cache: dict[tuple[str, int], bool] = {}
+
+    def merged(self, ref: PrRef, spec_dir: Path, layer: str) -> bool:
+        """True iff ``ref`` resolves to a MERGED pull request."""
+        key = (ref.repo or f"local:{layer}", ref.number)
+        if key in self._cache:
+            return self._cache[key]
+        if self.dead or self.calls >= _MAX_GH_CALLS:
+            return False
+        self.calls += 1
+        try:
+            verdict = self._check(ref, spec_dir)
+        except FileNotFoundError:
+            # gh binary absent — go dead for the rest of the run
+            # (offline degradation; the deliverable signal still stands).
+            self.dead = True
+            return False
+        self._cache[key] = verdict
+        return verdict
+
+    def _check(self, ref: PrRef, spec_dir: Path) -> bool:
+        # Explicit cross-repo slug → REST pulls endpoint ("merged" is a
+        # single-PR-GET field; an issue number 404s here, which is
+        # exactly the merged-only filter the design wants). Local refs
+        # resolve through the spec dir's own git context, so the right
+        # repo is picked per layer without any hardcoded slug map.
+        if ref.repo:
+            proc = _run_gh(["api", f"repos/{ref.repo}/pulls/{ref.number}"], cwd=None)
+        else:
+            proc = _run_gh(
+                ["pr", "view", str(ref.number), "--json", "state"],
+                cwd=spec_dir,
+            )
+        if proc is None or proc.returncode != 0:
+            return False
+        try:
+            data = json.loads(proc.stdout)
+        except (json.JSONDecodeError, ValueError):
+            return False
+        if not isinstance(data, dict):
+            return False
+        if ref.repo:
+            return bool(data.get("merged"))
+        return data.get("state") == "MERGED"
+
+
+def _collect_refs(spec_dir: Path) -> list[PrRef]:
+    """Union of PR citations across a spec's phase files, deduped."""
+    seen: set[tuple[str | None, int]] = set()
+    refs: list[PrRef] = []
+    for fname in _PHASE_FILENAMES:
+        fpath = spec_dir / fname
+        if not fpath.is_file():
+            continue
+        try:
+            text = fpath.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        for ref in extract_pr_refs(text):
+            key = (ref.repo, ref.number)
+            if key in seen:
+                continue
+            seen.add(key)
+            refs.append(ref)
+    return refs
+
+
+def _pr_label(ref: PrRef, layer: str) -> str:
+    """Human label for a merged PR — ``attune-author #95`` / ``#67``."""
+    if ref.repo:
+        return f"{ref.repo.rsplit('/', 1)[-1]} #{ref.number}"
+    if layer and layer != "workspace":
+        return f"{layer} #{ref.number}"
+    return f"#{ref.number}"
 
 
 @dataclass(frozen=True)
@@ -67,14 +213,45 @@ class AuditResult:
     staleness: str
     resolved: int  # entries that resolve on disk
     total: int  # entries declared
+    # spec-status-integrity additions — defaults keep older callers
+    # (and the pre-existing tests) constructing rows unchanged.
+    in_flight: bool = False
+    drifted: bool = False
+    merged_prs: tuple[str, ...] = ()
+    signal: str = "deliverables"
+    cache_key: str = ""  # "<layer>/<slug>" — the drift-cache key
+    root: str = ""  # workspace root the spec lives under
 
 
-def audit_specs(roots: list[Path] | None = None) -> list[AuditResult]:
+def _root_for(spec_path: Path, roots: list[Path]) -> str:
+    """The workspace root ``spec_path`` lives under (no symlink resolve —
+    spec paths are built by prefixing the root, so prefix-match holds)."""
+    for root in roots:
+        try:
+            if spec_path.is_relative_to(root):
+                return str(root)
+        except (TypeError, ValueError):
+            continue
+    return ""
+
+
+def audit_specs(
+    roots: list[Path] | None = None,
+    *,
+    pr_links: bool = False,
+    resolver: _PrResolver | None = None,
+) -> list[AuditResult]:
     """Classify every discovered spec (terminal included) into a row.
 
     Resolution counts are recomputed per spec so the report can show how
     many declared deliverables are present. Per-spec failures degrade to
     a zero-count row rather than aborting the whole audit.
+
+    With ``pr_links`` (and a resolver), each IN-FLIGHT spec's phase
+    files are additionally scanned for PR citations; ≥1 merged
+    implementing PR marks the row ``drifted`` (workspace design §2).
+    Terminal/parked specs are never queried — no gh spend on settled
+    specs.
     """
     if roots is None:
         roots = workspace_roots()
@@ -89,6 +266,20 @@ def audit_specs(roots: list[Path] | None = None) -> list[AuditResult]:
                 resolved = sum(1 for e in spec.deliverables if _resolve_entry(e, roots))
             except Exception:  # noqa: BLE001 — one bad spec must not abort the audit
                 resolved = 0
+        in_flight = _is_in_flight(spec.phase, spec.effective_status)
+        drifted = False
+        merged_prs: tuple[str, ...] = ()
+        checked = pr_links and resolver is not None and in_flight
+        if checked:
+            try:
+                merged_prs = tuple(
+                    _pr_label(ref, spec.layer)
+                    for ref in _collect_refs(spec.path)
+                    if resolver.merged(ref, spec.path, spec.layer)
+                )
+            except Exception:  # noqa: BLE001 — one bad spec must not abort the audit
+                merged_prs = ()
+            drifted = bool(merged_prs)
         results.append(
             AuditResult(
                 slug=spec.slug,
@@ -97,9 +288,79 @@ def audit_specs(roots: list[Path] | None = None) -> list[AuditResult]:
                 staleness=spec.staleness,
                 resolved=resolved,
                 total=total,
+                in_flight=in_flight,
+                drifted=drifted,
+                merged_prs=merged_prs,
+                signal="pr-links" if checked else "deliverables",
+                cache_key=f"{spec.layer}/{spec.slug}",
+                root=_root_for(spec.path, roots),
             )
         )
     return results
+
+
+def write_drift_cache(results: list[AuditResult], roots: list[Path]) -> list[Path]:
+    """Write ``.attune/spec-drift.json`` under each workspace root.
+
+    Schema (workspace design §2):
+    ``{generated_at, specs: {"<layer>/<slug>": {verdict, prs, signal}}}``.
+    Only in-flight specs are recorded — terminal/parked rows carry no
+    drift signal. A clean (empty) specs map is still written so
+    ``spec_orient`` can tell "checked and clean" from "never checked".
+    Per-root write failures are swallowed: the cache is an optimization,
+    never a blocker.
+    """
+    now = time.time()
+    written: list[Path] = []
+    for root in roots:
+        entries = {
+            r.cache_key: {
+                "verdict": "drifted" if r.drifted else "ok",
+                "prs": list(r.merged_prs),
+                "signal": r.signal,
+            }
+            for r in results
+            if r.in_flight and r.root == str(root)
+        }
+        cache_path = Path(root) / ".attune" / "spec-drift.json"
+        try:
+            cache_path.parent.mkdir(parents=True, exist_ok=True)
+            cache_path.write_text(
+                json.dumps({"generated_at": now, "specs": entries}, indent=2) + "\n",
+                encoding="utf-8",
+            )
+        except OSError:
+            continue
+        written.append(cache_path)
+    return written
+
+
+def format_json(results: list[AuditResult]) -> str:
+    """Machine-readable audit payload for the tracking-issue upsert."""
+    drifted = sorted(r.cache_key for r in results if r.drifted)
+    payload = {
+        "generated_at": time.time(),
+        "counts": {
+            "specs": len(results),
+            "drifted": len(drifted),
+            "suspected_stale": sum(1 for r in results if r.staleness == "suspected-stale"),
+        },
+        "drifted": drifted,
+        "specs": {
+            r.cache_key: {
+                "layer": r.layer,
+                "slug": r.slug,
+                "status": r.status,
+                "staleness": r.staleness,
+                "in_flight": r.in_flight,
+                "drifted": r.drifted,
+                "prs": list(r.merged_prs),
+                "signal": r.signal,
+            }
+            for r in results
+        },
+    }
+    return json.dumps(payload, indent=2)
 
 
 def _truncate(text: str, limit: int) -> str:
@@ -109,6 +370,8 @@ def _truncate(text: str, limit: int) -> str:
 
 def _detail(result: AuditResult) -> str:
     """Render the ``Unresolved`` column for one row."""
+    if result.drifted:
+        return ", ".join(result.merged_prs) + " merged"
     if result.staleness == "opted-out":
         return "(opt-out)"
     if result.staleness == "docs-only":
@@ -121,15 +384,23 @@ def _detail(result: AuditResult) -> str:
     return "—"
 
 
+def _verdict(result: AuditResult) -> str:
+    """Displayed verdict — merged-PR evidence outranks the staleness
+    heuristic for the same row."""
+    return "drifted" if result.drifted else result.staleness
+
+
 def format_report(results: list[AuditResult]) -> str:
     """Render the full audit matrix as a string."""
-    stale = [r for r in results if r.staleness == "suspected-stale"]
+    stale = [r for r in results if r.staleness == "suspected-stale" and not r.drifted]
+    drifted = [r for r in results if r.drifted]
     noun = "spec" if len(results) == 1 else "specs"
-    title = f"SPEC STATUS AUDIT — {len(results)} {noun} ({len(stale)} suspected-stale)"
+    counts = f"{len(drifted)} drifted, {len(stale)} suspected-stale"
+    title = f"SPEC STATUS AUDIT — {len(results)} {noun} ({counts})"
     if not results:
         return f"{title}\n\n(no specs found)"
 
-    ordered = sorted(results, key=lambda r: (_STALENESS_ORDER.get(r.staleness, 9), r.slug))
+    ordered = sorted(results, key=lambda r: (_STALENESS_ORDER.get(_verdict(r), 9), r.slug))
     rows = [
         (
             _truncate(r.slug, 44),
@@ -138,7 +409,7 @@ def format_report(results: list[AuditResult]) -> str:
             # whole paragraph — truncate so one long status doesn't blow
             # the column out (e.g. integration-coverage's 1k-char line).
             _truncate(r.status, 32),
-            _STALENESS_LABEL.get(r.staleness, r.staleness),
+            _STALENESS_LABEL.get(_verdict(r), _verdict(r)),
             _detail(r),
         )
         for r in ordered
@@ -151,24 +422,38 @@ def format_report(results: list[AuditResult]) -> str:
     out = [title, "", _line(_HEADERS), "─" * len(_line(_HEADERS))]
     out.extend(_line(row) for row in rows)
     out.append("")
+    if drifted:
+        out.append(
+            f"⚠ {len(drifted)} spec(s) have merged implementing PRs but an "
+            "in-flight status — flip the status or mark them parked."
+        )
     if stale:
         out.append(
             f"⚠ {len(stale)} spec(s) have shipped deliverables but a "
             "non-terminal status — verify & update."
         )
-    else:
-        out.append("✓ No suspected-stale specs.")
+    if not drifted and not stale:
+        out.append("✓ No drifted or suspected-stale specs.")
     return "\n".join(out)
 
 
 def main(argv: list[str] | None = None) -> int:
-    """Print the audit matrix; exit per ``--strict``. Never hard-crashes."""
+    """Print the audit report; exit per ``--strict``. Never hard-crashes."""
     try:
         args = sys.argv[1:] if argv is None else argv
         strict = "--strict" in args
-        results = audit_specs()
-        print(format_report(results))
-        if strict and any(r.staleness == "suspected-stale" for r in results):
+        offline = "--offline" in args
+        pr_links = "--pr-links" in args and not offline
+        as_json = "--json" in args
+        roots = workspace_roots()
+        resolver = _PrResolver() if pr_links else None
+        results = audit_specs(roots, pr_links=pr_links, resolver=resolver)
+        if pr_links:
+            # The cache is what lets the offline SessionStart hook
+            # annotate drift without network calls (design §3).
+            write_drift_cache(results, roots)
+        print(format_json(results) if as_json else format_report(results))
+        if strict and any(r.drifted or r.staleness == "suspected-stale" for r in results):
             return 1
         return 0
     except Exception:  # noqa: BLE001 — warn-by-default: report and exit 0

--- a/plugin/hooks/spec_orient.py
+++ b/plugin/hooks/spec_orient.py
@@ -24,6 +24,7 @@ Licensed under Apache 2.0
 from __future__ import annotations
 
 import json
+import os
 import sys
 import traceback
 from pathlib import Path
@@ -46,8 +47,20 @@ from _state import (  # noqa: E402 — sys.path bootstrap above
     SpecInfo,
     discover_specs,
     prune_stale_sentinels,
+    read_drift_cache,
     workspace_roots,
 )
+
+
+def _audit_annotations_enabled() -> bool:
+    """Kill switch (spec-status-integrity, design §3).
+
+    ``ATTUNE_SPEC_AUDIT=off`` suppresses both the ``⚠ drifted``
+    drift-cache annotation and the existing suspected-stale hint.
+    Anything else (including unset) leaves them on.
+    """
+    return os.environ.get("ATTUNE_SPEC_AUDIT", "").strip().lower() != "off"
+
 
 # Char budget for the post-compact spec body. Generous so the
 # spec survives compaction with full content; the model sees this
@@ -58,8 +71,12 @@ _POST_COMPACT_CHAR_BUDGET = 8_000
 _ORIENTATION_MAX_SPECS = 3
 
 
-def _format_phase(spec: SpecInfo) -> str:
+def _format_phase(spec: SpecInfo, annotate: bool = True) -> str:
     """Short ``(phase status)`` blurb for the orientation list.
+
+    ``annotate=False`` (the ``ATTUNE_SPEC_AUDIT=off`` kill switch)
+    suppresses the suspected-stale hint; the status_conflict hint is
+    self-truthing, not an audit annotation, and always renders.
 
     Renders the reconciled ``effective_status`` (not the raw header
     ``status``) so a stale "draft" header above a closed checklist
@@ -91,20 +108,40 @@ def _format_phase(spec: SpecInfo) -> str:
         }.get(spec.status_source, spec.status_source)
         raw = spec.status or "no header"
         return f'{base} — {source_label}; header says "{raw}", worth fixing'
-    if spec.staleness == "suspected-stale":
+    if annotate and spec.staleness == "suspected-stale":
         raw = spec.status or "no status"
-        return f'{base} — ⚠ deliverables present, status still "{raw}"; ' "verify before building"
+        return f'{base} — ⚠ deliverables present, status still "{raw}"; verify before building'
     return base
 
 
-def format_orientation(specs: list[SpecInfo]) -> str:
+def _drift_suffix(spec: SpecInfo, drift_cache: dict[str, dict]) -> str:
+    """`` ⚠ drifted: attune-author #95 merged`` when the drift cache
+    marks this spec drifted; empty otherwise (design §3). The cache is
+    read from disk only — the hook makes no network calls."""
+    entry = drift_cache.get(f"{spec.layer}/{spec.slug}")
+    if not isinstance(entry, dict) or entry.get("verdict") != "drifted":
+        return ""
+    prs = [p for p in entry.get("prs") or [] if isinstance(p, str)]
+    detail = f": {', '.join(prs)} merged" if prs else ""
+    return f" ⚠ drifted{detail}"
+
+
+def format_orientation(
+    specs: list[SpecInfo],
+    drift_cache: dict[str, dict] | None = None,
+    annotate: bool = True,
+) -> str:
     """Short markdown list of in-flight specs for non-compact starts."""
     if not specs:
         return ""
+    drift = drift_cache or {}
     lines = ["attune workspace — in-flight specs:"]
     for spec in specs[:_ORIENTATION_MAX_SPECS]:
         layer_prefix = "" if spec.layer == "workspace" else f"{spec.layer}/"
-        lines.append(f"- {layer_prefix}specs/{spec.slug}/  ({_format_phase(spec)})")
+        line = f"- {layer_prefix}specs/{spec.slug}/  ({_format_phase(spec, annotate=annotate)})"
+        if annotate:
+            line += _drift_suffix(spec, drift)
+        lines.append(line)
     leftover = len(specs) - _ORIENTATION_MAX_SPECS
     if leftover > 0:
         lines.append(f"- (+{leftover} more)")
@@ -167,7 +204,11 @@ def main() -> int:
             if body:
                 print(body)
         else:
-            orient = format_orientation(specs)
+            annotate = _audit_annotations_enabled()
+            # Offline by design: the drift signal comes from the cache
+            # spec_audit --pr-links wrote, never from a network call.
+            drift_cache = read_drift_cache(roots) if annotate else {}
+            orient = format_orientation(specs, drift_cache=drift_cache, annotate=annotate)
             if orient:
                 print(orient)
         return 0

--- a/tests/unit/ci/test_spec_status_reminder_yaml.py
+++ b/tests/unit/ci/test_spec_status_reminder_yaml.py
@@ -1,0 +1,102 @@
+"""Tests for the reusable spec-status-reminder workflow.
+
+Task 6 of docs/specs/spec-status-integrity-hooks (workspace design §5).
+Per the spec's testing strategy the workflow is validated via
+``yaml.safe_load`` — triggers, permissions, workflow_call interface,
+and the guard properties of the inline script — with no ``act`` dry
+runs and no live gh calls.
+"""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+import yaml
+
+_WORKFLOW = (
+    Path(__file__).resolve().parents[3] / ".github" / "workflows" / "spec-status-reminder.yml"
+)
+
+
+@pytest.fixture(scope="module")
+def workflow() -> dict:
+    with open(_WORKFLOW, encoding="utf-8") as f:
+        return yaml.safe_load(f)
+
+
+@pytest.fixture(scope="module")
+def triggers(workflow) -> dict:
+    # yaml.safe_load parses an unquoted ``on:`` key as boolean True.
+    return workflow.get(True) or workflow.get("on")
+
+
+@pytest.fixture(scope="module")
+def script(workflow) -> str:
+    """The inline python payload of the reminder step."""
+    steps = workflow["jobs"]["remind"]["steps"]
+    run_blocks = [s["run"] for s in steps if "run" in s]
+    assert len(run_blocks) == 1
+    body = run_blocks[0]
+    start = body.index("<<'PYEOF'") + len("<<'PYEOF'")
+    end = body.rindex("PYEOF")
+    return textwrap.dedent(body[start:end])
+
+
+class TestTriggersAndInterface:
+    def test_fires_on_closed_prs_only(self, triggers) -> None:
+        assert triggers["pull_request"]["types"] == ["closed"]
+
+    def test_exposes_workflow_call_for_thin_callers(self, triggers) -> None:
+        # No inputs/secrets — the 6-line caller passes nothing.
+        assert "workflow_call" in triggers
+        assert not triggers["workflow_call"]
+
+    def test_job_gate_is_merged_only(self, workflow) -> None:
+        # closed-unmerged PRs must never run the job at all.
+        assert workflow["jobs"]["remind"]["if"] == "github.event.pull_request.merged == true"
+
+
+class TestPermissions:
+    def test_minimal_permissions(self, workflow) -> None:
+        assert workflow["permissions"] == {
+            "contents": "read",
+            "pull-requests": "write",
+        }
+
+
+class TestCheckout:
+    def test_checks_out_the_merged_tree(self, workflow) -> None:
+        steps = workflow["jobs"]["remind"]["steps"]
+        checkout = next(s for s in steps if "checkout" in (s.get("uses") or ""))
+        assert "merge_commit_sha" in checkout["with"]["ref"]
+
+
+class TestInlineScript:
+    def test_script_is_valid_python(self, script) -> None:
+        compile(script, "spec-status-reminder-inline", "exec")
+
+    def test_marker_comment_guard(self, script) -> None:
+        # Never comment twice on the same PR.
+        assert "<!-- spec-status-reminder -->" in script
+        assert "not commenting twice" in script
+
+    def test_self_reference_carve_out(self, script) -> None:
+        # A PR that modifies files under the referenced spec dir is
+        # exempt (design §5 amendment 2026-07-10).
+        assert 'f.startswith(r + "/")' in script
+        assert "refs - touched" in script
+
+    def test_merged_only_double_check(self, script) -> None:
+        # Defense in depth behind the job-level if-gate.
+        assert 'detail.get("merged")' in script
+
+    def test_reminder_wording(self, script) -> None:
+        assert "flip the status or mark it `parked`" in script
+
+    def test_settled_vocabulary_mirrors_state_py(self, script) -> None:
+        # The condensed parser must recognize the terminal additions and
+        # the parked family shipped in tasks 3 of this spec.
+        for token in ("implemented", "parked", "paused", "blocked", "deferred"):
+            assert f'"{token}"' in script

--- a/tests/unit/hooks/test_spec_audit.py
+++ b/tests/unit/hooks/test_spec_audit.py
@@ -17,7 +17,9 @@ Licensed under Apache 2.0
 from __future__ import annotations
 
 import importlib.util
+import json as _json
 import sys
+import types as _types
 from pathlib import Path
 
 import pytest
@@ -690,3 +692,237 @@ class TestParkedAndGlyphSemantics:
     def test_glyph_leading_verdict(self, state_mod) -> None:
         assert state_mod._leading_verdict("✓ (2026-07-10)") == "✓"
         assert state_mod._leading_verdict("✅") == "✅"
+
+
+# ── --pr-links mode + drift cache + --json (task 4) ───────────
+#
+# Golden fixture: a miniature of the specs/SPEC-AUDIT-2026-06-17
+# findings — in-flight specs whose implementing PRs merged (drifted),
+# one with no PR trail (not drifted), one citing an unmerged PR
+# (merged-only filter), one citing an issue number (404s on the pulls
+# endpoint), and a terminal spec that must never be queried. gh is
+# patched at the subprocess boundary (testing-conventions.md — no live
+# calls in the default suite).
+
+
+def _pr_spec(spec_dir: Path, *, status: str, body: str) -> None:
+    spec_dir.mkdir(parents=True, exist_ok=True)
+    (spec_dir / "tasks.md").write_text(
+        f"# Tasks\n\n**Status**: {status}\n\n{body}\n", encoding="utf-8"
+    )
+
+
+@pytest.fixture
+def golden_tree(tmp_path: Path):
+    specs = tmp_path / "specs"
+    # DONE-in-reality, header still approved → drifted (local merged PR).
+    _pr_spec(
+        specs / "gui-batch-status-sse",
+        status="approved (2026-06-14)",
+        body="SSE endpoint shipped in #67 with 10 tests.",
+    )
+    # DONE via a cross-repo PR → drifted (explicit pull-URL).
+    _pr_spec(
+        specs / "rag-gate-accuracy-baseline",
+        status="approved (2026-06-04)",
+        body="Tasks 1-8 merged via [#51](https://github.com/Smart-AI-Memory/attune-author/pull/51).",
+    )
+    # Genuinely open — no PR citations → not drifted.
+    _pr_spec(
+        specs / "long-cache-ttl-citations",
+        status="approved (2026-06-14)",
+        body="No implementation yet; best no-key build candidate.",
+    )
+    # Cites a PR that is still OPEN → merged-only filter keeps it clean.
+    _pr_spec(
+        specs / "help-memory-tool",
+        status="approved (2026-06-14)",
+        body="Option A landing via #99 (in review).",
+    )
+    # Cites a number that is an ISSUE, not a PR → resolver says no.
+    _pr_spec(
+        specs / "hash-regenerate-button",
+        status="draft",
+        body="Tracked alongside issue #400.",
+    )
+    # Terminal — must never be queried even though it cites a PR.
+    _pr_spec(
+        specs / "template-path-rename",
+        status="complete (2026-06-17)",
+        body="Shipped in PR #212.",
+    )
+    return tmp_path
+
+
+class _FakeGh:
+    """Canned gh responses keyed by PR number; records every call."""
+
+    #: number -> ("merged" | "open" | "issue")
+    STATES = {"67": "merged", "51": "merged", "99": "open", "400": "issue", "212": "merged"}
+
+    def __init__(self) -> None:
+        self.calls: list[list[str]] = []
+        self.cwds: list[object] = []
+
+    def __call__(self, args, cwd=None):
+        self.calls.append(list(args))
+        self.cwds.append(cwd)
+        number = next(
+            (tok.rstrip("/").rsplit("/", 1)[-1] for tok in args if tok[-1:].isdigit()), ""
+        )
+        state = self.STATES.get(number)
+        if state == "issue":
+            return _types.SimpleNamespace(returncode=1, stdout="", stderr="Not Found (404)")
+        if args[0] == "api":
+            payload = {"merged": state == "merged", "number": int(number or 0)}
+        else:
+            payload = {"state": "MERGED" if state == "merged" else "OPEN"}
+        return _types.SimpleNamespace(returncode=0, stdout=_json.dumps(payload), stderr="")
+
+
+@pytest.fixture
+def fake_gh(audit_mod, monkeypatch):
+    fake = _FakeGh()
+    monkeypatch.setattr(audit_mod, "_run_gh", fake)
+    return fake
+
+
+class TestPrLinksGolden:
+    def _audit(self, audit_mod, golden_tree):
+        return audit_mod.audit_specs([golden_tree], pr_links=True, resolver=audit_mod._PrResolver())
+
+    def test_reproduces_2026_06_17_verdicts(self, audit_mod, golden_tree, fake_gh) -> None:
+        by_slug = {r.slug: r for r in self._audit(audit_mod, golden_tree)}
+        assert by_slug["gui-batch-status-sse"].drifted is True
+        assert by_slug["gui-batch-status-sse"].merged_prs == ("#67",)
+        assert by_slug["rag-gate-accuracy-baseline"].drifted is True
+        assert by_slug["rag-gate-accuracy-baseline"].merged_prs == ("attune-author #51",)
+        assert by_slug["long-cache-ttl-citations"].drifted is False
+        assert by_slug["help-memory-tool"].drifted is False  # unmerged PR
+        assert by_slug["hash-regenerate-button"].drifted is False  # issue ref
+        assert by_slug["template-path-rename"].drifted is False  # terminal
+
+    def test_terminal_specs_never_queried(self, audit_mod, golden_tree, fake_gh) -> None:
+        self._audit(audit_mod, golden_tree)
+        assert not any("212" in tok for call in fake_gh.calls for tok in call)
+
+    def test_cross_repo_uses_api_endpoint(self, audit_mod, golden_tree, fake_gh) -> None:
+        self._audit(audit_mod, golden_tree)
+        api_calls = [c for c in fake_gh.calls if c[0] == "api"]
+        assert api_calls == [["api", "repos/Smart-AI-Memory/attune-author/pulls/51"]]
+
+    def test_local_refs_resolve_via_spec_dir_cwd(self, audit_mod, golden_tree, fake_gh) -> None:
+        self._audit(audit_mod, golden_tree)
+        view_cwds = [
+            cwd
+            for call, cwd in zip(fake_gh.calls, fake_gh.cwds, strict=True)
+            if call[0] == "pr" and "67" in call
+        ]
+        assert view_cwds and all("gui-batch-status-sse" in str(c) for c in view_cwds)
+
+
+class TestPrResolverBounds:
+    def test_cache_dedupes_repeat_lookups(self, audit_mod, fake_gh, state_mod, tmp_path) -> None:
+        resolver = audit_mod._PrResolver()
+        ref = state_mod.PrRef(number=67, repo=None, explicit=True)
+        assert resolver.merged(ref, tmp_path, "workspace") is True
+        assert resolver.merged(ref, tmp_path, "workspace") is True
+        assert resolver.calls == 1
+
+    def test_call_cap_bounds_gh_spend(
+        self, audit_mod, fake_gh, state_mod, tmp_path, monkeypatch
+    ) -> None:
+        monkeypatch.setattr(audit_mod, "_MAX_GH_CALLS", 3)
+        resolver = audit_mod._PrResolver()
+        for n in range(1, 10):
+            resolver.merged(state_mod.PrRef(number=n, repo=None, explicit=True), tmp_path, "x")
+        assert resolver.calls == 3
+        assert len(fake_gh.calls) == 3
+
+    def test_missing_gh_goes_dead_not_fatal(
+        self, audit_mod, state_mod, tmp_path, monkeypatch
+    ) -> None:
+        def _absent(args, cwd=None):
+            raise FileNotFoundError("gh")
+
+        monkeypatch.setattr(audit_mod, "_run_gh", _absent)
+        resolver = audit_mod._PrResolver()
+        ref = state_mod.PrRef(number=1, repo=None, explicit=True)
+        assert resolver.merged(ref, tmp_path, "x") is False
+        assert resolver.dead is True
+        # Subsequent lookups short-circuit without touching gh again.
+        assert (
+            resolver.merged(state_mod.PrRef(number=2, repo=None, explicit=True), tmp_path, "x")
+            is False
+        )
+        assert resolver.calls == 1
+
+    def test_malformed_gh_output_is_not_merged(
+        self, audit_mod, state_mod, tmp_path, monkeypatch
+    ) -> None:
+        monkeypatch.setattr(
+            audit_mod,
+            "_run_gh",
+            lambda args, cwd=None: _types.SimpleNamespace(
+                returncode=0, stdout="not json", stderr=""
+            ),
+        )
+        resolver = audit_mod._PrResolver()
+        assert (
+            resolver.merged(state_mod.PrRef(number=5, repo=None, explicit=True), tmp_path, "x")
+            is False
+        )
+
+
+class TestDriftCache:
+    def test_cache_schema_and_content(self, audit_mod, golden_tree, fake_gh) -> None:
+        results = audit_mod.audit_specs(
+            [golden_tree], pr_links=True, resolver=audit_mod._PrResolver()
+        )
+        written = audit_mod.write_drift_cache(results, [golden_tree])
+        assert written == [golden_tree / ".attune" / "spec-drift.json"]
+        data = _json.loads(written[0].read_text(encoding="utf-8"))
+        assert isinstance(data["generated_at"], float)
+        entry = data["specs"]["workspace/gui-batch-status-sse"]
+        assert entry == {"verdict": "drifted", "prs": ["#67"], "signal": "pr-links"}
+        # Clean in-flight specs are recorded too (checked-and-clean).
+        assert data["specs"]["workspace/long-cache-ttl-citations"]["verdict"] == "ok"
+        # Terminal specs carry no drift signal.
+        assert "workspace/template-path-rename" not in data["specs"]
+
+
+class TestPrLinksMain:
+    def test_offline_makes_no_gh_calls(self, audit_mod, golden_tree, monkeypatch, capsys) -> None:
+        def _boom(args, cwd=None):
+            raise AssertionError("gh must not be invoked with --offline")
+
+        monkeypatch.setattr(audit_mod, "_run_gh", _boom)
+        monkeypatch.setenv("ATTUNE_AI_WORKSPACE_ROOTS", str(golden_tree))
+        assert audit_mod.main(["--pr-links", "--offline"]) == 0
+        assert not (golden_tree / ".attune" / "spec-drift.json").exists()
+
+    def test_default_exit_zero_with_drift(
+        self, audit_mod, golden_tree, fake_gh, monkeypatch, capsys
+    ) -> None:
+        monkeypatch.setenv("ATTUNE_AI_WORKSPACE_ROOTS", str(golden_tree))
+        assert audit_mod.main(["--pr-links"]) == 0
+        out = capsys.readouterr().out
+        assert "⚠ drifted" in out
+        assert "flip the status or mark them parked" in out
+        # main --pr-links writes the cache as a side effect.
+        assert (golden_tree / ".attune" / "spec-drift.json").exists()
+
+    def test_strict_exit_one_on_drift(self, audit_mod, golden_tree, fake_gh, monkeypatch) -> None:
+        monkeypatch.setenv("ATTUNE_AI_WORKSPACE_ROOTS", str(golden_tree))
+        assert audit_mod.main(["--pr-links", "--strict"]) == 1
+
+    def test_json_output_parses(self, audit_mod, golden_tree, fake_gh, monkeypatch, capsys) -> None:
+        monkeypatch.setenv("ATTUNE_AI_WORKSPACE_ROOTS", str(golden_tree))
+        assert audit_mod.main(["--pr-links", "--json"]) == 0
+        payload = _json.loads(capsys.readouterr().out)
+        assert payload["counts"]["drifted"] == 2
+        assert sorted(payload["drifted"]) == [
+            "workspace/gui-batch-status-sse",
+            "workspace/rag-gate-accuracy-baseline",
+        ]
+        assert payload["specs"]["workspace/help-memory-tool"]["drifted"] is False

--- a/tests/unit/hooks/test_spec_audit.py
+++ b/tests/unit/hooks/test_spec_audit.py
@@ -504,3 +504,98 @@ class TestMainExitCodes:
         monkeypatch.setattr(audit_mod, "audit_specs", _boom)
         # Warn-by-default: a thrown audit still exits 0.
         assert audit_mod.main([]) == 0
+
+
+# ── extract_pr_refs (spec-status-integrity-hooks, task 2) ─────
+
+
+class TestExtractPrRefs:
+    """Four citation styles + negatives, per workspace design §1."""
+
+    def test_pr_hash_style(self, state_mod) -> None:
+        refs = state_mod.extract_pr_refs("Shipped via PR #212 yesterday.")
+        assert refs == [state_mod.PrRef(number=212, repo=None, explicit=True)]
+
+    def test_bare_hash_is_ambiguous(self, state_mod) -> None:
+        refs = state_mod.extract_pr_refs("landed in attune #1191 last week")
+        assert refs == [state_mod.PrRef(number=1191, repo=None, explicit=False)]
+
+    def test_inline_in_status_single(self, state_mod) -> None:
+        refs = state_mod.extract_pr_refs("**Status**: complete — shipped in #567")
+        assert refs == [state_mod.PrRef(number=567, repo=None, explicit=False)]
+
+    def test_inline_in_status_pr_list(self, state_mod) -> None:
+        refs = state_mod.extract_pr_refs("**Status**: complete — shipped (PRs #303, #304)")
+        assert refs == [
+            state_mod.PrRef(number=303, repo=None, explicit=True),
+            state_mod.PrRef(number=304, repo=None, explicit=True),
+        ]
+
+    def test_markdown_pull_url_resolves_repo(self, state_mod) -> None:
+        text = "Done in [#95](https://github.com/Smart-AI-Memory/attune-author/pull/95)."
+        refs = state_mod.extract_pr_refs(text)
+        # Exactly one ref: the link text ``#95`` must NOT also produce a
+        # bare current-repo ref.
+        assert refs == [
+            state_mod.PrRef(number=95, repo="Smart-AI-Memory/attune-author", explicit=True)
+        ]
+
+    def test_bare_pull_url(self, state_mod) -> None:
+        text = "See https://github.com/Smart-AI-Memory/attune-rag/pull/188 for details."
+        refs = state_mod.extract_pr_refs(text)
+        assert refs == [
+            state_mod.PrRef(number=188, repo="Smart-AI-Memory/attune-rag", explicit=True)
+        ]
+
+    # ── negatives ────────────────────────────────────────────
+
+    def test_issue_url_yields_nothing(self, state_mod) -> None:
+        text = "Tracked in [#12](https://github.com/Smart-AI-Memory/attune/issues/12)."
+        assert state_mod.extract_pr_refs(text) == []
+
+    def test_non_pull_github_url_yields_nothing(self, state_mod) -> None:
+        text = "[the repo](https://github.com/Smart-AI-Memory/attune-rag/tree/main/src)"
+        assert state_mod.extract_pr_refs(text) == []
+
+    def test_hash_followed_by_word_chars_rejected(self, state_mod) -> None:
+        assert state_mod.extract_pr_refs("commit #12abc is unrelated") == []
+
+    def test_word_char_prefix_rejected(self, state_mod) -> None:
+        assert state_mod.extract_pr_refs("channel foo#42 and anchor ##7") == []
+
+    def test_code_fence_content_ignored(self, state_mod) -> None:
+        text = "before\n```\nPR #999 and #888\n```\nafter"
+        assert state_mod.extract_pr_refs(text) == []
+
+    def test_inline_code_ignored(self, state_mod) -> None:
+        assert state_mod.extract_pr_refs("cite specs as `PR #NNN` or `#123`") == []
+
+    def test_empty_text(self, state_mod) -> None:
+        assert state_mod.extract_pr_refs("") == []
+
+    # ── dedupe + ordering ────────────────────────────────────
+
+    def test_duplicates_dedupe_to_first_occurrence(self, state_mod) -> None:
+        refs = state_mod.extract_pr_refs("PR #212 shipped this; see #212 again")
+        assert refs == [state_mod.PrRef(number=212, repo=None, explicit=True)]
+
+    def test_bare_then_explicit_upgrades_flag(self, state_mod) -> None:
+        refs = state_mod.extract_pr_refs("see #212, later merged as PR #212")
+        assert refs == [state_mod.PrRef(number=212, repo=None, explicit=True)]
+
+    def test_same_number_different_repo_is_distinct(self, state_mod) -> None:
+        text = "local #95 and [#95](https://github.com/Smart-AI-Memory/attune-author/pull/95)"
+        refs = state_mod.extract_pr_refs(text)
+        assert state_mod.PrRef(number=95, repo=None, explicit=False) in refs
+        assert (
+            state_mod.PrRef(number=95, repo="Smart-AI-Memory/attune-author", explicit=True) in refs
+        )
+        assert len(refs) == 2
+
+    def test_document_order_across_styles(self, state_mod) -> None:
+        text = (
+            "First [#7](https://github.com/Smart-AI-Memory/attune-gui/pull/7), "
+            "then PR #3, then bare #9."
+        )
+        refs = state_mod.extract_pr_refs(text)
+        assert [r.number for r in refs] == [7, 3, 9]

--- a/tests/unit/hooks/test_spec_audit.py
+++ b/tests/unit/hooks/test_spec_audit.py
@@ -599,3 +599,94 @@ class TestExtractPrRefs:
         )
         refs = state_mod.extract_pr_refs(text)
         assert [r.number for r in refs] == [7, 3, 9]
+
+
+# ── vocabulary lint + parked/glyph semantics (task 3) ─────────
+
+
+class TestLintStatusToken:
+    """Token table per workspace design §1 — recognized forms lint
+    clean; unknown leading tokens are named unparseable, never guessed."""
+
+    @pytest.mark.parametrize(
+        "status",
+        [
+            # canonical 8
+            "draft",
+            "in-review",
+            "approved",
+            "in-progress",
+            "implemented",
+            "complete",
+            "superseded",
+            "parked",
+            # historical terminal/ongoing aliases
+            "closed",
+            "completed",
+            "retired",
+            "shipped",
+            "done",
+            "living",
+            "ongoing",
+            # parked family
+            "paused",
+            "blocked",
+            "deferred",
+            # accepted in-flight forms
+            "not started",
+            "open",
+            "pending",
+            # glyphs
+            "✓",
+            "✅",
+            "✓ (2026-07-10)",
+            # informative decoration around a recognized token
+            "approved (2026-07-10 — Patrick)",
+            "**in-review** (attune #32)",
+            "complete (2026-06-09) — shipped #694",
+        ],
+    )
+    def test_recognized_tokens_lint_clean(self, state_mod, status) -> None:
+        assert state_mod.lint_status_token(status) is None
+
+    @pytest.mark.parametrize("status", ["wibble", "TODO: revisit", "phase-two", ""])
+    def test_unknown_tokens_are_unparseable(self, state_mod, status) -> None:
+        message = state_mod.lint_status_token(status)
+        assert message is not None
+        assert "unparseable" in message
+        # The lint names the canonical 8, never guesses.
+        for token in ("draft", "in-review", "approved", "implemented", "parked"):
+            assert token in message
+
+
+class TestParkedAndGlyphSemantics:
+    def _spec(self, status: str) -> str:
+        return f"# Spec\n\n**Status**: {status}\n\n## Deliverables\n\n- attune-rag/src/attune_rag/foo.py\n"
+
+    @pytest.mark.parametrize("status", ["parked", "paused (til Q3)", "blocked on #12", "deferred"])
+    def test_parked_family_not_in_flight(self, state_mod, status) -> None:
+        assert state_mod._is_in_flight("tasks", status) is False
+
+    @pytest.mark.parametrize("status", ["implemented (2026-07-10)", "✓", "✅ shipped"])
+    def test_new_terminal_forms_not_in_flight(self, state_mod, status) -> None:
+        assert state_mod._is_in_flight("tasks", status) is False
+
+    def test_draft_still_in_flight(self, state_mod) -> None:
+        assert state_mod._is_in_flight("tasks", "draft") is True
+
+    @pytest.mark.parametrize("status", ["parked (2026-07-10)", "implemented", "✓"])
+    def test_all_resolved_but_parked_or_terminal_is_ok(self, state_mod, workspace, status) -> None:
+        # Parked family + new terminal forms are skipped by drift checks.
+        text = self._spec(status)
+        assert state_mod.classify_staleness(text, status, [workspace]) == "ok"
+
+    def test_body_implemented_line_is_terminal_signal(self, state_mod) -> None:
+        verdict, source = state_mod._completion_signal(
+            "# Spec\n\nprose\n\nStatus: implemented in #99\n"
+        )
+        assert verdict == "implemented"
+        assert source == "terminal-line"
+
+    def test_glyph_leading_verdict(self, state_mod) -> None:
+        assert state_mod._leading_verdict("✓ (2026-07-10)") == "✓"
+        assert state_mod._leading_verdict("✅") == "✅"

--- a/tests/unit/hooks/test_spec_audit.py
+++ b/tests/unit/hooks/test_spec_audit.py
@@ -17,8 +17,10 @@ Licensed under Apache 2.0
 from __future__ import annotations
 
 import importlib.util
+import io as _io
 import json as _json
 import sys
+import time as _time
 import types as _types
 from pathlib import Path
 
@@ -926,3 +928,148 @@ class TestPrLinksMain:
             "workspace/rag-gate-accuracy-baseline",
         ]
         assert payload["specs"]["workspace/help-memory-tool"]["drifted"] is False
+
+
+# ── spec_orient drift annotation + kill switch (task 5) ───────
+
+
+def _load_spec_orient_module():
+    """Load spec_orient.py fresh, same convention as the other loaders."""
+    if str(_HOOKS_DIR) not in sys.path:
+        sys.path.insert(0, str(_HOOKS_DIR))
+    spec = importlib.util.spec_from_file_location("spec_orient", _HOOKS_DIR / "spec_orient.py")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["spec_orient"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def orient_mod():
+    return _load_spec_orient_module()
+
+
+def _orient_spec(state_mod, *, slug: str = "foo", staleness: str = "unknown"):
+    return state_mod.SpecInfo(
+        slug=slug,
+        path=Path("/tmp/x"),
+        layer="workspace",
+        phase="requirements",
+        status="draft",
+        mtime=0.0,
+        effective_status="draft",
+        staleness=staleness,
+    )
+
+
+def _write_drift_cache_file(root: Path, *, generated_at: float, specs: dict) -> None:
+    cache_dir = root / ".attune"
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    (cache_dir / "spec-drift.json").write_text(
+        _json.dumps({"generated_at": generated_at, "specs": specs}), encoding="utf-8"
+    )
+
+
+class TestReadDriftCache:
+    _SPECS = {"workspace/foo": {"verdict": "drifted", "prs": ["attune-author #95"]}}
+
+    def test_fresh_cache_is_read(self, state_mod, tmp_path) -> None:
+        _write_drift_cache_file(tmp_path, generated_at=1_000_000.0, specs=self._SPECS)
+        merged = state_mod.read_drift_cache([tmp_path], now=1_000_000.0 + 3600)
+        assert merged["workspace/foo"]["verdict"] == "drifted"
+
+    def test_eight_day_old_cache_ignored(self, state_mod, tmp_path) -> None:
+        _write_drift_cache_file(tmp_path, generated_at=1_000_000.0, specs=self._SPECS)
+        stale_now = 1_000_000.0 + 8 * 24 * 3600 + 60
+        assert state_mod.read_drift_cache([tmp_path], now=stale_now) == {}
+
+    def test_absent_cache_is_empty(self, state_mod, tmp_path) -> None:
+        assert state_mod.read_drift_cache([tmp_path], now=0.0) == {}
+
+    @pytest.mark.parametrize(
+        "payload",
+        [
+            "{not json",
+            "[]",
+            '{"specs": {}}',
+            '{"generated_at": "yesterday", "specs": {}}',
+            '{"generated_at": 1000000.0, "specs": []}',
+        ],
+    )
+    def test_malformed_cache_never_raises(self, state_mod, tmp_path, payload) -> None:
+        cache_dir = tmp_path / ".attune"
+        cache_dir.mkdir(parents=True, exist_ok=True)
+        (cache_dir / "spec-drift.json").write_text(payload, encoding="utf-8")
+        assert state_mod.read_drift_cache([tmp_path], now=1_000_000.0 + 60) == {}
+
+
+class TestDriftAnnotation:
+    def test_drifted_spec_gets_suffix(self, state_mod, orient_mod) -> None:
+        spec = _orient_spec(state_mod)
+        cache = {"workspace/foo": {"verdict": "drifted", "prs": ["attune-author #95"]}}
+        out = orient_mod.format_orientation([spec], drift_cache=cache)
+        assert "specs/foo/" in out
+        assert "⚠ drifted: attune-author #95 merged" in out
+
+    def test_ok_verdict_gets_no_suffix(self, state_mod, orient_mod) -> None:
+        spec = _orient_spec(state_mod)
+        cache = {"workspace/foo": {"verdict": "ok", "prs": []}}
+        assert "drifted" not in orient_mod.format_orientation([spec], drift_cache=cache)
+
+    def test_unmatched_spec_gets_no_suffix(self, state_mod, orient_mod) -> None:
+        spec = _orient_spec(state_mod)
+        cache = {"workspace/other": {"verdict": "drifted", "prs": ["#1"]}}
+        assert "drifted" not in orient_mod.format_orientation([spec], drift_cache=cache)
+
+    def test_no_cache_is_current_behavior(self, state_mod, orient_mod) -> None:
+        spec = _orient_spec(state_mod)
+        out = orient_mod.format_orientation([spec])
+        assert "specs/foo/" in out
+        assert "drifted" not in out
+
+    def test_kill_switch_suppresses_drift_and_stale(self, state_mod, orient_mod) -> None:
+        spec = _orient_spec(state_mod, staleness="suspected-stale")
+        cache = {"workspace/foo": {"verdict": "drifted", "prs": ["#9"]}}
+        out = orient_mod.format_orientation([spec], drift_cache=cache, annotate=False)
+        assert "drifted" not in out
+        assert "deliverables present" not in out
+        # The spec line itself still renders.
+        assert "specs/foo/" in out
+
+    def test_stale_hint_still_renders_when_enabled(self, state_mod, orient_mod) -> None:
+        spec = _orient_spec(state_mod, staleness="suspected-stale")
+        assert "deliverables present" in orient_mod.format_orientation([spec])
+
+    @pytest.mark.parametrize(
+        ("value", "expected"), [("off", False), ("OFF", False), ("", True), ("on", True)]
+    )
+    def test_env_kill_switch(self, orient_mod, monkeypatch, value, expected) -> None:
+        monkeypatch.setenv("ATTUNE_SPEC_AUDIT", value)
+        assert orient_mod._audit_annotations_enabled() is expected
+
+    def _arrange_workspace(self, tmp_path: Path, monkeypatch) -> None:
+        _pr_spec(tmp_path / "specs" / "foo", status="draft", body="work pending")
+        _write_drift_cache_file(
+            tmp_path,
+            generated_at=_time.time(),
+            specs={"workspace/foo": {"verdict": "drifted", "prs": ["#67"]}},
+        )
+        monkeypatch.setenv("ATTUNE_AI_WORKSPACE_ROOTS", str(tmp_path))
+        monkeypatch.setattr("sys.stdin", _io.StringIO(_json.dumps({"cwd": str(tmp_path)})))
+
+    def test_main_end_to_end_annotates_from_cache(
+        self, state_mod, orient_mod, tmp_path, monkeypatch, capsys
+    ) -> None:
+        self._arrange_workspace(tmp_path, monkeypatch)
+        assert orient_mod.main() == 0
+        assert "⚠ drifted: #67 merged" in capsys.readouterr().out
+
+    def test_main_kill_switch_yields_zero_annotations(
+        self, state_mod, orient_mod, tmp_path, monkeypatch, capsys
+    ) -> None:
+        self._arrange_workspace(tmp_path, monkeypatch)
+        monkeypatch.setenv("ATTUNE_SPEC_AUDIT", "off")
+        assert orient_mod.main() == 0
+        out = capsys.readouterr().out
+        assert "drifted" not in out
+        assert "specs/foo/" in out


### PR DESCRIPTION
## Summary

Implements tasks 1–6 of the workspace spec [`specs/spec-status-integrity/`](https://github.com/Smart-AI-Memory/attune/tree/main/specs/spec-status-integrity) (all phases approved 2026-07-10) — the attune-ai canonical slice. Companion spec: `docs/specs/spec-status-integrity-hooks/` (in this PR).

One commit per task:

1. **Companion TEMPLATE-AI spec** — `docs/specs/spec-status-integrity-hooks/requirements.md`, statuses approved-by-reference, cross-linked both directions.
2. **`PrRef` + `extract_pr_refs()`** (`_state.py`) — parses the four PR-citation styles (`PR #N`, bare `#N`, inline `PRs #a, #b` lists, markdown pull-URL for cross-repo); code fences / inline code / markdown-link texts masked; deduped in document order.
3. **`lint_status_token()` + vocabulary** — `implemented` and bare `✓`/`✅` become terminal; new parked family (`parked`/`paused`/`blocked`/`deferred`) is excluded from in-flight and skipped by drift checks; unknown leading tokens lint as `unparseable` naming the canonical 8. Historical aliases stay accepted — no mass rewrite.
4. **`spec_audit.py --pr-links`** — the primary drift signal: merged PRs only (issue refs 404 on the pulls endpoint, unmerged ignored), calls capped (`_MAX_GH_CALLS=30`) + cached per run, writes `.attune/spec-drift.json` per workspace root, `--json` for the tracking-issue upsert, `--offline`/missing-gh degrades to the deliverable-existence signal. Exit contract unchanged (warn + 0; `--strict` → 1).
5. **`spec_orient.py` drift annotation** — reads the cache (fresh < 8 days) and appends `⚠ drifted: <repo> #N merged` to in-flight lines; hook stays offline; `ATTUNE_SPEC_AUDIT=off` kill switch suppresses drift + suspected-stale annotations.
6. **Reusable `spec-status-reminder.yml`** — `workflow_call` + own `pull_request: [closed]`; comments once per merged PR that references a still-in-flight spec; self-reference carve-out (spec-authoring PRs exempt); minimal permissions.

## Testing

- 94 new tests (hooks: extract/lint/parked/golden/resolver/cache/orient; ci: workflow yaml + inline-script asserts). Full `tests/unit/hooks/` (660) and `tests/unit/ci/` (289) green; ruff clean.
- Golden test reproduces the `specs/SPEC-AUDIT-2026-06-17.md` findings in miniature with gh patched at the `_run_gh` subprocess boundary — no live gh calls in the default suite.

## Follow-ups (workspace tasks 7–9, other repos)

Plugin release → `make sync-hooks` fan-out to the four layer repos (attune-rag also clears the owed `_sdk_gate` re-sync) + thin caller workflows → umbrella Makefile/weekly CI → live baseline sweep. Version bump rides the release-prep PR per the standard flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)