### PR TITLE
fix(llm): strip sampling params for Claude 5 family models

### DIFF
--- a/src/attune/llm/providers/anthropic.py
+++ b/src/attune/llm/providers/anthropic.py
@@ -14,11 +14,13 @@ from .base import BaseLLMProvider, LLMResponse
 
 logger = logging.getLogger(__name__)
 
-# Opus 4.7 and later reject temperature/top_p/top_k and the
-# enabled-thinking shape (HTTP 400). Matches opus-4-7, opus-4-8, and any
-# future opus-4-9 / opus-4-1x. Older models (Opus 4.6-, Sonnet, Haiku)
-# still accept these params, so they're left untouched.
-_OPUS_NO_SAMPLING_RE = re.compile(r"opus-4-(?:[7-9]|\d{2,})")
+# Opus 4.7+ and the entire Claude 5 family (sonnet-5, fable-5, ...) reject
+# temperature/top_p/top_k and the enabled-thinking shape (HTTP 400:
+# "`temperature` is deprecated for this model" — seen live on claude-sonnet-5,
+# integration-auth run 2026-07-06). The second alternative requires a letter
+# run before "-5" so claude-haiku-4-5 / claude-sonnet-4-5 stay untouched.
+# Older models (Opus 4.6-, Sonnet 4.x, Haiku 4.x) still accept these params.
+_NO_SAMPLING_MODELS_RE = re.compile(r"opus-4-(?:[7-9]|\d{2,})|[a-z]+-5(?:[.-]|$)")
 
 
 def _cache_control() -> dict[str, str]:
@@ -46,12 +48,13 @@ def _normalize_api_kwargs_for_model(api_kwargs: dict[str, Any]) -> None:
     """Drop request params that newer Claude models reject (in place).
 
     This provider defaults ``temperature=0.7`` and can set extended
-    thinking, both of which Opus 4.7+ reject with a 400 — so without this,
-    any premium-tier (Opus 4.8) call through this path would fail. Strip
-    the sampling params and convert ``enabled`` thinking to ``adaptive``
+    thinking, both of which Opus 4.7+ and Claude 5 models reject with a
+    400 — so without this, any premium-tier (Opus 4.8) or Claude 5
+    (sonnet-5, fable-5) call through this path would fail. Strip the
+    sampling params and convert ``enabled`` thinking to ``adaptive``
     for those models; leave older models that still accept them untouched.
     """
-    if not _OPUS_NO_SAMPLING_RE.search(api_kwargs.get("model", "")):
+    if not _NO_SAMPLING_MODELS_RE.search(api_kwargs.get("model", "")):
         return
     for param in ("temperature", "top_p", "top_k"):
         api_kwargs.pop(param, None)
@@ -290,8 +293,7 @@ class AnthropicProvider(BaseLLMProvider):
             write_cost_per_token = input_cost_per_token * 1.25
             write_cost = cache_creation * write_cost_per_token
             logger.debug(
-                f"Cache WRITE: {cache_creation:,} tokens written to cache "
-                f"(cost ${write_cost:.4f})",
+                f"Cache WRITE: {cache_creation:,} tokens written to cache (cost ${write_cost:.4f})",
             )
 
     async def analyze_large_codebase(

--- a/tests/llm/test_llm_toolkit_providers.py
+++ b/tests/llm/test_llm_toolkit_providers.py
@@ -218,7 +218,9 @@ class TestAnthropicProvider:
         mock_client.messages.create = AsyncMock(return_value=mock_response)
         mock_anthropic_class.return_value = mock_client
 
-        provider = AnthropicProvider(api_key="sk-test", use_thinking=True)
+        provider = AnthropicProvider(
+            api_key="sk-test", use_thinking=True, model="claude-sonnet-4-5"
+        )
 
         result = await provider.generate(
             messages=[{"role": "user", "content": "Complex question"}],
@@ -247,7 +249,7 @@ class TestAnthropicProvider:
         mock_block.type = "text"
         mock_block.text = "ok"
         mock_response.content = [mock_block]
-        mock_response.model = "claude-sonnet-5"
+        mock_response.model = "claude-sonnet-4-5"
         mock_response.usage = MagicMock(input_tokens=10, output_tokens=5)
         mock_response.stop_reason = "end_turn"
 
@@ -255,7 +257,9 @@ class TestAnthropicProvider:
         mock_client.messages.create = AsyncMock(return_value=mock_response)
         mock_anthropic_class.return_value = mock_client
 
-        provider = AnthropicProvider(api_key="sk-test", use_thinking=True)
+        provider = AnthropicProvider(
+            api_key="sk-test", use_thinking=True, model="claude-sonnet-4-5"
+        )
 
         # Default thinking_budget=10000, max_tokens=2048 — the exact shape
         # that 400'd in the nightly integration-auth run.
@@ -279,7 +283,7 @@ class TestAnthropicProvider:
         mock_block.type = "text"
         mock_block.text = "ok"
         mock_response.content = [mock_block]
-        mock_response.model = "claude-sonnet-5"
+        mock_response.model = "claude-sonnet-4-5"
         mock_response.usage = MagicMock(input_tokens=10, output_tokens=5)
         mock_response.stop_reason = "end_turn"
 
@@ -287,7 +291,9 @@ class TestAnthropicProvider:
         mock_client.messages.create = AsyncMock(return_value=mock_response)
         mock_anthropic_class.return_value = mock_client
 
-        provider = AnthropicProvider(api_key="sk-test", use_thinking=True, thinking_budget=2000)
+        provider = AnthropicProvider(
+            api_key="sk-test", use_thinking=True, thinking_budget=2000, model="claude-sonnet-4-5"
+        )
 
         await provider.generate(
             messages=[{"role": "user", "content": "Q"}],

--- a/tests/llm/test_providers.py
+++ b/tests/llm/test_providers.py
@@ -608,7 +608,7 @@ class TestAnthropicProviderGenerate:
 
 
 class TestSamplingParamNormalization:
-    """Opus 4.7+ reject temperature/top_p/top_k + enabled-thinking (400)."""
+    """Opus 4.7+ and Claude 5 reject temperature/top_p/top_k + enabled-thinking (400)."""
 
     def test_normalize_strips_sampling_params_for_opus_48(self):
         from attune.llm.providers.anthropic import _normalize_api_kwargs_for_model
@@ -617,10 +617,19 @@ class TestSamplingParamNormalization:
         _normalize_api_kwargs_for_model(kw)
         assert "temperature" not in kw and "top_p" not in kw and "top_k" not in kw
 
-    def test_normalize_keeps_sampling_params_for_sonnet_and_opus_46(self):
+    def test_normalize_strips_sampling_params_for_claude_5_family(self):
+        """Live 400 on claude-sonnet-5 (integration-auth, 2026-07-06)."""
         from attune.llm.providers.anthropic import _normalize_api_kwargs_for_model
 
-        for model in ("claude-sonnet-5", "claude-haiku-4-5", "claude-opus-4-6"):
+        for model in ("claude-sonnet-5", "claude-fable-5", "claude-sonnet-5-20260301"):
+            kw = {"model": model, "temperature": 0.7, "top_p": 0.9}
+            _normalize_api_kwargs_for_model(kw)
+            assert "temperature" not in kw and "top_p" not in kw, model
+
+    def test_normalize_keeps_sampling_params_for_older_models(self):
+        from attune.llm.providers.anthropic import _normalize_api_kwargs_for_model
+
+        for model in ("claude-haiku-4-5", "claude-sonnet-4-5", "claude-opus-4-6"):
             kw = {"model": model, "temperature": 0.7}
             _normalize_api_kwargs_for_model(kw)
             assert kw["temperature"] == 0.7, model
@@ -657,7 +666,30 @@ class TestSamplingParamNormalization:
         assert sent["model"] == "claude-opus-4-8"
 
     @pytest.mark.asyncio
-    async def test_generate_keeps_temperature_for_sonnet(self):
+    async def test_generate_keeps_temperature_for_sonnet_45(self):
+        mock_anthropic = MagicMock()
+        mock_client = MagicMock()
+        mock_anthropic.AsyncAnthropic.return_value = mock_client
+        mock_response = MagicMock()
+        mock_response.model = "claude-sonnet-4-5"
+        mock_response.stop_reason = "end_turn"
+        mock_response.usage = MagicMock(input_tokens=1, output_tokens=1)
+        block = MagicMock()
+        block.type = "text"
+        block.text = "ok"
+        mock_response.content = [block]
+        mock_client.messages.create = AsyncMock(return_value=mock_response)
+
+        with patch.dict("sys.modules", {"anthropic": mock_anthropic}):
+            provider = AnthropicProvider(api_key="test-key", model="claude-sonnet-4-5")
+            await provider.generate([{"role": "user", "content": "hi"}], temperature=0.3)
+
+        sent = mock_client.messages.create.await_args.kwargs
+        assert sent["temperature"] == 0.3
+
+    @pytest.mark.asyncio
+    async def test_generate_omits_temperature_for_sonnet_5(self):
+        """End-to-end: a Claude 5 call must not send temperature (would 400)."""
         mock_anthropic = MagicMock()
         mock_client = MagicMock()
         mock_anthropic.AsyncAnthropic.return_value = mock_client
@@ -676,7 +708,7 @@ class TestSamplingParamNormalization:
             await provider.generate([{"role": "user", "content": "hi"}], temperature=0.3)
 
         sent = mock_client.messages.create.await_args.kwargs
-        assert sent["temperature"] == 0.3
+        assert "temperature" not in sent
 
 
 if __name__ == "__main__":

--- a/tests/llm/test_providers.py
+++ b/tests/llm/test_providers.py
@@ -690,9 +690,7 @@ class TestSamplingParamNormalization:
     @pytest.mark.asyncio
     async def test_generate_omits_temperature_for_sonnet_5(self):
         """End-to-end: a Claude 5 call must not send temperature (would 400)."""
-        mock_anthropic = MagicMock()
         mock_client = MagicMock()
-        mock_anthropic.AsyncAnthropic.return_value = mock_client
         mock_response = MagicMock()
         mock_response.model = "claude-sonnet-5"
         mock_response.stop_reason = "end_turn"
@@ -703,7 +701,7 @@ class TestSamplingParamNormalization:
         mock_response.content = [block]
         mock_client.messages.create = AsyncMock(return_value=mock_response)
 
-        with patch.dict("sys.modules", {"anthropic": mock_anthropic}):
+        with patch("anthropic.AsyncAnthropic", return_value=mock_client):
             provider = AnthropicProvider(api_key="test-key", model="claude-sonnet-5")
             await provider.generate([{"role": "user", "content": "hi"}], temperature=0.3)
 

--- a/tests/unit/agent_factory/test_langchain_adapter.py
+++ b/tests/unit/agent_factory/test_langchain_adapter.py
@@ -39,11 +39,18 @@ class TestLangChainAdapterGetLLMNormalization:
         assert "top_k" not in kwargs
         assert kwargs["model"] == "claude-opus-4-8"
 
-    def test_anthropic_keeps_temperature_for_sonnet(self):
-        """Sonnet still accepts temperature → passed through."""
+    def test_anthropic_strips_temperature_for_sonnet_5(self):
+        """Claude 5 family rejects temperature → stripped."""
         with patch("langchain_anthropic.ChatAnthropic") as mock_chat:
             adapter = LangChainAdapter(provider="anthropic", api_key="sk-test")
             adapter._get_llm(_config("claude-sonnet-5"))
+        assert "temperature" not in mock_chat.call_args.kwargs
+
+    def test_anthropic_keeps_temperature_for_sonnet_4_5(self):
+        """Sonnet 4.5 still accepts temperature → passed through."""
+        with patch("langchain_anthropic.ChatAnthropic") as mock_chat:
+            adapter = LangChainAdapter(provider="anthropic", api_key="sk-test")
+            adapter._get_llm(_config("claude-sonnet-4-5"))
         assert "temperature" in mock_chat.call_args.kwargs
 
     def test_anthropic_keeps_temperature_for_opus_4_6(self):

--- a/tests/unit/agent_factory/test_langgraph_adapter.py
+++ b/tests/unit/agent_factory/test_langgraph_adapter.py
@@ -569,12 +569,23 @@ class TestLangGraphAdapterGetLLM:
         assert "top_k" not in kwargs
         assert kwargs["model"] == "claude-opus-4-8"
 
-    def test_anthropic_keeps_temperature_for_sonnet(self):
-        """Sonnet still accepts temperature → passed through."""
+    def test_anthropic_strips_temperature_for_sonnet_5(self):
+        """Claude 5 family rejects temperature → stripped."""
         with patch("langchain_anthropic.ChatAnthropic") as mock_chat:
             adapter = LangGraphAdapter(provider="anthropic", api_key="sk-test")
             config = AgentConfig(
                 name="t", role=AgentRole.COORDINATOR, model_override="claude-sonnet-5"
+            )
+            adapter._get_llm(config)
+        kwargs = mock_chat.call_args.kwargs
+        assert "temperature" not in kwargs
+
+    def test_anthropic_keeps_temperature_for_sonnet_4_5(self):
+        """Sonnet 4.5 still accepts temperature → passed through."""
+        with patch("langchain_anthropic.ChatAnthropic") as mock_chat:
+            adapter = LangGraphAdapter(provider="anthropic", api_key="sk-test")
+            config = AgentConfig(
+                name="t", role=AgentRole.COORDINATOR, model_override="claude-sonnet-4-5"
             )
             adapter._get_llm(config)
         kwargs = mock_chat.call_args.kwargs

--- a/tests/unit/test_batch_provider.py
+++ b/tests/unit/test_batch_provider.py
@@ -253,7 +253,7 @@ class TestBatchRequestFormatConversion:
 
             old_format = {
                 "custom_id": "test_id",
-                "model": "claude-sonnet-5",
+                "model": "claude-sonnet-4-5",
                 "messages": [{"role": "user", "content": "Test"}],
                 "max_tokens": 1024,
                 "temperature": 0.8,


### PR DESCRIPTION
## Summary
The weekly **Integration Tests (auth)** run failed 2026-07-06 with a live 400 on `claude-sonnet-5`: `temperature is deprecated for this model`. The `_normalize_api_kwargs_for_model` strip only matched `opus-4-7+`; the Claude 5 family (sonnet-5, fable-5) shares that API surface (no temperature/top_p/top_k, adaptive-only thinking).

## Changes
- Widen `_NO_SAMPLING_MODELS_RE` (renamed from `_OPUS_NO_SAMPLING_RE`) to also match `<family>-5` model ids. A letter run is required before `-5`, so `claude-haiku-4-5` / `claude-sonnet-4-5` are untouched.
- Flip tests that encoded the old assumption (sonnet-5 keeps temperature) to assert stripping; add fable-5 and dated-id cases.
- Pin the enabled-thinking/max_tokens-growth and batch optional-param tests to `claude-sonnet-4-5` — they exercise the legacy path, which is model-independent logic that runs before normalization.

## Testing
- `tests/llm/`, `tests/unit/agent_factory/`, `tests/agent_factory/`, `tests/unit/test_batch_provider.py` + related: **1026 passed, 3 skipped**
- Failing scheduled workflow will be re-verified after merge (next cron ~7/13, or manual dispatch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)