### PR TITLE
chore(release): v10.3.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "Spec-driven development for Claude Code — take an idea through requirements, design, tasks, and gated execution with an approval loop. Plus 23 auto-triggering skills: security audits, code review, test generation, release prep.",
-    "version": "10.2.0"
+    "version": "10.3.0"
   },
   "plugins": [
     {
       "name": "attune-ai",
       "description": "Spec-driven development is the core workflow: /spec carries an idea through brainstorm, requirements, design, and task execution with quality gates and your approval at each stage. Backed by 23 auto-triggering skills — security audits, code reviews, test generation, bug prediction, and release preparation. For help content tools, also install attune-help and attune-author from this marketplace.",
       "source": "./plugin",
-      "version": "10.2.0",
+      "version": "10.3.0",
       "author": {
         "name": "Smart AI Memory",
         "email": "patrick.roebuck@smartaimemory.com"

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,4 +1,4 @@
-# Attune AI Framework v10.2.0
+# Attune AI Framework v10.3.0
 
 AI-powered developer workflows with cost optimization and multi-agent orchestration.
 
@@ -148,7 +148,7 @@ attune_redis/          # attune-redis plugin (pip install attune-redis)
 
 ---
 
-**Version:** 10.2.0 | **License:** Apache 2.0 | **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)
+**Version:** 10.3.0 | **License:** Apache 2.0 | **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)
 
 ## Lessons — core
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [10.3.0] — 2026-07-11
+
+Spec-integrity minor: the spec-status-integrity hook suite lands
+(drift between spec files and their PRs is now flagged at session
+start), `.help` retrieval gains path-keyed LLM-polished summaries,
+and the Anthropic provider stops sending sampling params that
+Claude 5 models reject.
+
+### Added
+
+- **spec-status-integrity hooks** (#1305): PR-link drift signal,
+  status-vocabulary lint, drift cache, and a `spec-status-reminder`
+  PR workflow — spec statuses that lag or contradict their merged
+  PRs are surfaced instead of silently rotting
+  (spec: `docs/specs/spec-status-integrity/`).
+- **Path-keyed `.help/summaries.json`** (#1300, #1301): retrieval
+  sidecar seeded for all 296 templates, then LLM-polished with
+  provenance metadata — summary matches get the retriever's 1.5x
+  boost (mirrors the attune-rag path-keyed summary design).
+
+### Fixed
+
+- **Claude 5 family sampling params** (#1310): the Anthropic
+  provider now strips `temperature`/`top_p`/`top_k` and converts
+  `enabled` thinking to `adaptive` for Claude 5 models (sonnet-5,
+  fable-5) as it already did for Opus 4.7+ — these models reject
+  the params with HTTP 400 ("`temperature` is deprecated for this
+  model", seen live in the 2026-07-06 integration-auth run).
+
 ## [10.2.0] — 2026-07-08
 
 Memory-ledger minor: the short-term memory layer's cost, benefit, and

--- a/docs/reference/API_REFERENCE.md
+++ b/docs/reference/API_REFERENCE.md
@@ -1,6 +1,6 @@
 # Attune AI API Reference
 
-**Version:** 10.2.0
+**Version:** 10.3.0
 **License:** Apache License 2.0
 **Copyright:** 2025-2026 Smart AI Memory, LLC
 
@@ -1152,5 +1152,5 @@ msg = format_error(
 
 ---
 
-**Version:** 10.2.0 | **License:** Apache 2.0
+**Version:** 10.3.0 | **License:** Apache 2.0
 **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)

--- a/plugin/.claude-plugin/marketplace.json
+++ b/plugin/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "Spec-driven development for Claude Code — /spec plans, reviews, and executes with quality gates; plus security audits, code reviews, test generation, and release prep from /attune.",
-    "version": "10.2.0"
+    "version": "10.3.0"
   },
   "plugins": [
     {
       "name": "attune-ai",
       "description": "Spec-driven development for Claude Code — /spec plans, reviews, and executes with quality gates; plus security audits, code reviews, test generation, and release prep from /attune.",
       "source": "./",
-      "version": "10.2.0",
+      "version": "10.3.0",
       "author": {
         "name": "Smart AI Memory",
         "email": "patrick.roebuck@smartaimemory.com"

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "attune-ai",
-  "version": "10.2.0",
+  "version": "10.3.0",
   "description": "Spec-driven development for Claude Code — /spec plans, reviews, and executes with quality gates; plus security audits, code reviews, test generation, and release prep from /attune.",
   "author": {
     "name": "Smart AI Memory",

--- a/plugin/core/__init__.py
+++ b/plugin/core/__init__.py
@@ -5,4 +5,4 @@ This module provides the core workflow functionality when the full
 attune-ai package is not installed via pip.
 """
 
-__version__ = "10.2.0"
+__version__ = "10.3.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "attune-ai"
-version = "10.2.0"
+version = "10.3.0"
 description = "AI-powered developer workflows for Claude with cost optimization, multi-agent orchestration, and workflow automation."
 readme = {file = "README.md", content-type = "text/markdown"}
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -253,7 +253,7 @@ wheels = [
 
 [[package]]
 name = "attune-ai"
-version = "10.2.0"
+version = "10.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "agent-memory-client" },

--- a/website/app/page.tsx
+++ b/website/app/page.tsx
@@ -58,7 +58,7 @@ export default function Home() {
             <div className="grid lg:grid-cols-2 gap-16 items-center">
               <div className="z-10">
                 <div className="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-[var(--surface-container-high)] text-[var(--primary)] text-xs font-bold tracking-widest mb-6 uppercase">
-                  <span>v10.2.0</span>
+                  <span>v10.3.0</span>
                   <span className="w-1 h-1 rounded-full bg-[var(--primary)]"></span>
                   <span className="opacity-80">Spec-driven development platform</span>
                 </div>

--- a/website/lib/features.ts
+++ b/website/lib/features.ts
@@ -32,7 +32,7 @@ export const PRODUCTS: Product[] = [
     id: "attune-ai",
     name: "Attune AI",
     pypiName: "attune-ai",
-    version: "10.2.0",
+    version: "10.3.0",
     tagline: "Generate, maintain, and serve help from your code",
     installCommand: "pip install attune-ai",
     marketplaceInstall:
@@ -101,7 +101,7 @@ export const PRODUCTS: Product[] = [
     id: "claude-code-plugin",
     name: "Claude Code Plugin",
     pypiName: "attune-ai",
-    version: "10.2.0",
+    version: "10.3.0",
     tagline: "Progressive help right in your terminal",
     installCommand:
       "claude plugin marketplace add Smart-AI-Memory/attune-ai",

--- a/website/lib/features.ts
+++ b/website/lib/features.ts
@@ -76,7 +76,7 @@ export const PRODUCTS: Product[] = [
     id: "attune-author",
     name: "Attune Author",
     pypiName: "attune-author",
-    version: "0.23.0",
+    version: "0.25.0",
     tagline: "Author and polish help content with AI",
     installCommand: "pip install 'attune-author[plugin]'",
     marketplaceInstall:


### PR DESCRIPTION
## Release 10.3.0 (minor)

Spec-integrity minor. See CHANGELOG for full entries:

- **Added — spec-status-integrity hooks** (#1305): PR-link drift signal, vocabulary lint, drift cache, reminder workflow
- **Added — path-keyed `.help/summaries.json`** (#1300, #1301): 296 templates, LLM-polished with provenance
- **Fixed — Claude 5 sampling params** (#1310): strip temperature/top_p/top_k + adaptive thinking for sonnet-5/fable-5

Version bump via `scripts/bump_version.py` (all 9 sites), `uv lock` diff is version-only. No docs regen in this PR (standalone regen currently produces empty-hash output — follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)