### PR TITLE
docs(specs): spec-status-integrity-hooks → implemented (v10.3.0)

### DIFF
--- a/docs/specs/spec-status-integrity-hooks/requirements.md
+++ b/docs/specs/spec-status-integrity-hooks/requirements.md
@@ -13,9 +13,11 @@
 
 ## Phase 1: Requirements
 
-**Status**: approved (2026-07-10 — by reference: workspace spec
-`specs/spec-status-integrity/requirements.md` approved by Patrick
-2026-07-10; this companion restates the plugin-scoped subset)
+**Status**: implemented (2026-07-11) — tasks 1–6 shipped via #1305,
+released in v10.3.0; siblings re-synced (spec-status-integrity task 7).
+Approved 2026-07-10 by reference: workspace spec
+`specs/spec-status-integrity/requirements.md` (Patrick); this companion
+restates the plugin-scoped subset.
 
 ### Problem statement
 


### PR DESCRIPTION
Confirmed drift from the first live workspace spec-audit sweep (task 9 of the workspace spec-status-integrity spec): the companion spec's status lagged its own shipped implementation (#1305, released in v10.3.0, siblings re-synced). Docs-only status flip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)