### PR TITLE
docs(usage-signals): reach snapshot 2026-07-11 — v10.3.0 baseline

### DIFF
--- a/docs/specs/usage-signals/snapshots/2026-07-11.json
+++ b/docs/specs/usage-signals/snapshots/2026-07-11.json
@@ -1,0 +1,37 @@
+{
+  "date": "2026-07-11",
+  "github": {
+    "clones_14d": 66764,
+    "forks": 0,
+    "stars": 8,
+    "views_14d": 749
+  },
+  "pypi_recent": {
+    "attune-ai": {
+      "last_day": 37,
+      "last_month": 5497,
+      "last_week": 2034
+    },
+    "attune-author": {
+      "last_day": 157,
+      "last_month": 2435,
+      "last_week": 543
+    },
+    "attune-help": {
+      "last_day": 16,
+      "last_month": 546,
+      "last_week": 377
+    },
+    "attune-rag": {
+      "last_day": 249,
+      "last_month": 28838,
+      "last_week": 2895
+    },
+    "attune-verify": {
+      "last_day": 470,
+      "last_month": 42640,
+      "last_week": 6079
+    }
+  },
+  "taken_at": "2026-07-11T15:01:01.413163+00:00"
+}


### PR DESCRIPTION
Completes the 2026-07-11 reach snapshot (5/5 packages + GitHub signals) so the v10.3.0 release has its before/after pair.

Captured across resumable runs while waiting out pypistats 429 cooldowns (the penalty outlasted the advertised 15 minutes; each retry window admitted ~1 request until the final run completed the set).

| Package | last_day | last_week | last_month |
|---|---|---|---|
| attune-ai | 37 | 2034 | 5497 |
| attune-author | 157 | 543 | 2435 |
| attune-help | 16 | 377 | 546 |
| attune-rag | 249 | 2895 | 28838 |
| attune-verify | 470 | 6079 | 42640 |

GitHub: stars=8, forks=0, clones_14d=66764, views_14d=749

Spec: docs/specs/usage-signals/

🤖 Generated with [Claude Code](https://claude.com/claude-code)