### PR TITLE
feat(hooks): worktree-drift alarm (task 10) + spec-audit PR-ref precision (#1314)

### DIFF
--- a/docs/specs/analysis-workflow-output-widgets/requirements.md
+++ b/docs/specs/analysis-workflow-output-widgets/requirements.md
@@ -6,7 +6,7 @@
 "parallel acceptable").
 
 Formalize the rich `show_widget` output pattern — already shipped for
-discovery-sweep (#1148, triage board) and security-audit (#1149,
+discovery-sweep (`#1148`, triage board) and security-audit (`#1149`,
 severity dashboard) — into a program that (a) extracts a **shared
 renderer** and (b) extends rich output to the other analysis workflows.
 
@@ -17,8 +17,8 @@ otherwise — their MCP responses split into two shapes:
 
 | Workflow | Handler pick | Output shape | Widget family |
 |---|---|---|---|
-| security-audit | `findings` | structured `Finding` | **A** (done #1149) |
-| discovery-sweep | bespoke buckets | structured `Finding` | **A** (done #1148) |
+| security-audit | `findings` | structured `Finding` | **A** (done `#1149`) |
+| discovery-sweep | bespoke buckets | structured `Finding` | **A** (done `#1148`) |
 | **perf-audit** (`performance_audit`) | `findings` + score | structured `Finding` | **A** |
 | **bug-predict** | `predictions` (findings-like → report findings) | structured *iff* report has a `FindingsSection` | **A?** (confirm) |
 | **code-review** | `feedback` + `quality_score` | `feedback` is NOT findings-like → text | **B** |
@@ -52,8 +52,8 @@ are NOT the structured `severity/file/line/message` shape either.
   the contract.
 - **FR-1 (shared renderer).** Extract `attune.workflows.findings_widget`
   — the severity palette + `esc`/`location` + finding-card primitives —
-  and migrate the discovery-sweep board (#1148) and security-audit
-  dashboard (#1149) onto it. No behaviour change; pure de-dup.
+  and migrate the discovery-sweep board (`#1148`) and security-audit
+  dashboard (`#1149`) onto it. No behaviour change; pure de-dup.
 - **FR-2 (Family A rollout).** Apply the structured dashboard to the
   confirmed Family-A workflows via their existing `findings`/`predictions`
   picks → `dashboard_html`, skill Output wiring, tests.
@@ -64,14 +64,14 @@ are NOT the structured `severity/file/line/message` shape either.
 ## Non-goals
 
 - No new MCP tools (the 47-count guard / README / features.ts). Extend
-  existing responses with `*_html` fields, as #1148/#1149 did.
+  existing responses with `*_html` fields, as `#1148`/#1149 did.
 - No reworking SDK-native workflows to manufacture structured findings
   where the LLM emits prose — Family B renders what's actually there.
 - `slider`/`color` controls stay deferred (elicitation D11).
 
 ## Sequencing & parallelism (user OK'd parallel)
 
-1. **FR-1 shared renderer** — must land FIRST (after #1148+#1149 merge)
+1. **FR-1 shared renderer** — must land FIRST (after `#1148`+`#1149` merge)
    so A-family widgets build on it, not on copies.
 2. **FR-0 confirm** — parallel per-workflow (read-only).
 3. **FR-2 / FR-3** — parallelizable per workflow (one PR each, or grouped
@@ -84,4 +84,4 @@ are NOT the structured `severity/file/line/message` shape either.
 - Each in-scope workflow's response carries the right `*_html`
   (dashboard for A, panel for B); skill prefers it, markdown fallback.
 - Every helper injection-safe + unit-tested; no exact-dict response test
-  broken (pop `*_html`, keep legacy keys exact — see #1149 lesson).
+  broken (pop `*_html`, keep legacy keys exact — see `#1149` lesson).

--- a/docs/specs/trap-battery/requirements.md
+++ b/docs/specs/trap-battery/requirements.md
@@ -14,7 +14,7 @@
   `project_memory_as_insurance.md` — the ratified frame this spec
   serves: cost is fact, benefit is tail-prevention net of noise;
   this spec measures the prevention numerator
-- `benchmarks/session_savings.py` (PR #1276) — the existing A/B
+- `benchmarks/session_savings.py` (`PR #1276`) — the existing A/B
   harness (headless `claude -p`, `ATTUNE_JIT_RECALL` /
   `ATTUNE_LESSON_RECALL` toggles, per-arm medians). It measures
   COST per arm; it has no outcome scoring. This spec adds the
@@ -25,7 +25,7 @@
 - `docs/specs/memory-recall-eval/` — sibling, different axis:
   that spec asks "does retrieval return the right memories";
   this one asks "does a surfaced memory change behavior"
-- `tests/unit/ci/test_ci_spend_guard.py` (#1293) — constraint:
+- `tests/unit/ci/test_ci_spend_guard.py` (`#1293`) — constraint:
   the battery must never become a per-PR keyed CI job
 
 ---
@@ -67,11 +67,11 @@ occur. Δp is entirely unmeasured.** Without it:
 
 - A savings percentage. Output is failure rates and Δp per class,
   never a dollar or token savings claim (insurance frame; caption
-  discipline from #1291).
+  discipline from `#1291`).
 - Retrieval accuracy (that is `memory-recall-eval`).
 - "When not to inject" routing — that falls out of noise data
   soaking, not this spec.
-- Per-PR CI integration — forbidden by the CI spend guard (#1293).
+- Per-PR CI integration — forbidden by the CI spend guard (`#1293`).
   The battery is a scheduled/manual, budget-capped, keyed run.
 
 ## Trap classes — cut 1 (from measured exposure)
@@ -147,7 +147,7 @@ bar):**
 - **Output:** per-cell counts (fired / total), per-class Δp with
   raw counts always shown; pilot-scale numbers are labeled
   pilot — no rate is quoted externally below 20/cell.
-- **Verify-the-trap receipt (per #1293 discipline):** before any
+- **Verify-the-trap receipt (per `#1293` discipline):** before any
   arm comparison is trusted, each trap must be shown to fire on a
   synthetic run known to lack the lesson (the discrimination
   gate).

--- a/plugin/hooks/_state.py
+++ b/plugin/hooks/_state.py
@@ -247,6 +247,23 @@ _REF_NUMBER = re.compile(r"#(\d+)")
 # ``foo#12``, anchors, URL paths) and not followed by a word char
 # (rejects ``#12abc``).
 _BARE_REF = re.compile(r"(?<![\w#/])#(\d+)(?![\w#])")
+# Shipping vocabulary that promotes a bare ref to citation confidence.
+# First live sweep (attune-ai#1314) showed bare ``#N`` matching ordinal
+# prose ("failure-shape #1", "open item #2") and resolving to unrelated
+# ancient PRs; a bare ref only reads as a PR citation when its own line
+# says something shipped through it ("shipped in #67", "landed via #95").
+_SHIPPING_CONTEXT = re.compile(
+    r"\b(ship(?:ped|s|ping)?|merged?|land(?:ed|s)?|implement(?:ed|s|ing|ation)?"
+    r"|deliver(?:ed|s)?|released?|fix(?:ed|es)?|via|clos(?:ed|es))\b",
+    re.IGNORECASE,
+)
+
+
+def _line_around(text: str, pos: int) -> str:
+    """The full line of ``text`` containing offset ``pos``."""
+    start = text.rfind("\n", 0, pos) + 1
+    end = text.find("\n", pos)
+    return text[start : end if end != -1 else len(text)]
 
 
 @dataclass(frozen=True)
@@ -255,9 +272,11 @@ class PrRef:
 
     ``repo`` is the explicit ``owner/name`` slug from a pull-URL
     citation; ``None`` means "current repo". ``explicit`` is True when
-    the citation is unambiguously a PR (``PR #N`` / ``PRs #N, …`` /
-    pull-URL); a bare ``#NNN`` is ``explicit=False`` — it may be an
-    issue, which the checker resolves via the pulls API at check time.
+    the citation reads as a PR with confidence: ``PR #N`` /
+    ``PRs #N, …`` / pull-URL, or a bare ``#NNN`` whose own line carries
+    shipping vocabulary ("shipped in #67"). Other bare refs stay
+    ``explicit=False`` — ordinal prose ("failure-shape #1") must not
+    drive the drift signal (attune-ai#1314).
     """
 
     number: int
@@ -297,7 +316,11 @@ def extract_pr_refs(text: str) -> list[PrRef]:
     scrubbed = _PR_LIST.sub(_blank, scrubbed)
 
     for match in _BARE_REF.finditer(scrubbed):
-        hits.append((match.start(), None, int(match.group(1)), False))
+        # attune-ai#1314: a bare ref earns citation confidence only when
+        # its line carries shipping vocabulary; ordinal prose stays
+        # explicit=False and the drift signal ignores it.
+        confident = bool(_SHIPPING_CONTEXT.search(_line_around(scrubbed, match.start())))
+        hits.append((match.start(), None, int(match.group(1)), confident))
 
     # Dedupe on (repo, number): earliest position wins the slot; the
     # explicit flag is OR-merged across occurrences.
@@ -929,6 +952,110 @@ def _run_git(cwd: Path, *args: str) -> str:
     if result.returncode != 0:
         return ""
     return result.stdout
+
+
+# ── Worktree spec-drift alarm (spec-status-integrity task 10) ──
+#
+# Motivating incident: approved spec content sat uncommitted in a
+# worktree for six weeks while the SessionStart hook read those local
+# files and reported the spec "approved" — masking the drift. CI can
+# never see local worktrees, so this scan must live in the local hook.
+
+_WORKTREE_DRIFT_AGE_DAYS = 7
+_MAX_WORKTREES_SCANNED = 12
+_WORKTREE_SCAN_BUDGET_SECONDS = 2.5
+_SPEC_STATUS_PATHSPECS = ("specs", "docs/specs")
+
+
+@dataclass(frozen=True)
+class WorktreeSpecDrift:
+    """Uncommitted spec content sitting in one worktree past the age gate."""
+
+    worktree: str  # basename of the worktree directory
+    since: str  # YYYY-MM-DD of the oldest stale file's mtime
+    sample: str  # one repo-relative path, for the alarm line
+    count: int  # total stale spec files in this worktree
+
+
+def _stale_spec_files(worktree: Path, cutoff: float) -> list[tuple[float, str]]:
+    """(mtime, relpath) for uncommitted spec files older than ``cutoff``."""
+    porcelain = _run_git(
+        worktree, "status", "--porcelain", "--no-renames", "--", *_SPEC_STATUS_PATHSPECS
+    )
+    stale: list[tuple[float, str]] = []
+    for line in porcelain.splitlines():
+        rel = line[3:].strip().strip('"')
+        if not rel:
+            continue
+        path = worktree / rel
+        candidates = [path]
+        if rel.endswith("/") or path.is_dir():
+            # Untracked directories are reported as one entry; look one
+            # level of rglob deep enough to date the content (bounded).
+            candidates = [f for f in path.rglob("*") if f.is_file()][:50]
+        for f in candidates:
+            try:
+                mtime = f.stat().st_mtime
+            except OSError:
+                continue
+            if mtime <= cutoff:
+                try:
+                    shown = str(f.relative_to(worktree))
+                except ValueError:
+                    shown = rel
+                stale.append((mtime, shown))
+    return stale
+
+
+def scan_worktree_spec_drift(
+    repo_dir: Path,
+    *,
+    age_days: int = _WORKTREE_DRIFT_AGE_DAYS,
+    now: float | None = None,
+) -> list[WorktreeSpecDrift]:
+    """Week-old uncommitted spec content across the repo's worktrees.
+
+    Scans every worktree ``git worktree list`` reports for ``repo_dir``
+    (the main checkout included), looking at dirty/untracked files under
+    ``specs/`` and ``docs/specs/`` whose mtime is older than
+    ``age_days``. Best-effort and bounded: at most
+    ``_MAX_WORKTREES_SCANNED`` worktrees, one 2s-capped git call each,
+    and an overall ``_WORKTREE_SCAN_BUDGET_SECONDS`` wall-clock budget —
+    a slow or broken repo yields fewer findings, never an error.
+    """
+    started = time.monotonic()
+    cutoff = (now if now is not None else time.time()) - age_days * 86400
+    listing = _run_git(repo_dir, "worktree", "list", "--porcelain")
+    if not listing:
+        return []
+    worktrees = [
+        Path(line[len("worktree ") :].strip())
+        for line in listing.splitlines()
+        if line.startswith("worktree ")
+    ]
+    findings: list[WorktreeSpecDrift] = []
+    for worktree in worktrees[:_MAX_WORKTREES_SCANNED]:
+        if time.monotonic() - started > _WORKTREE_SCAN_BUDGET_SECONDS:
+            break
+        if not worktree.is_dir():
+            continue
+        try:
+            stale = _stale_spec_files(worktree, cutoff)
+        except Exception:  # noqa: BLE001 — one bad worktree must not kill the scan
+            continue
+        if not stale:
+            continue
+        stale.sort()
+        oldest_mtime, sample = stale[0]
+        findings.append(
+            WorktreeSpecDrift(
+                worktree=worktree.name,
+                since=time.strftime("%Y-%m-%d", time.localtime(oldest_mtime)),
+                sample=sample,
+                count=len(stale),
+            )
+        )
+    return findings
 
 
 def git_state(cwd: Path) -> GitState:

--- a/plugin/hooks/spec_audit.py
+++ b/plugin/hooks/spec_audit.py
@@ -36,6 +36,7 @@ Licensed under Apache 2.0
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 import sys
 import time
@@ -81,9 +82,20 @@ _HEADERS = ("Spec", "Layer", "Status", "Staleness", "Unresolved")
 
 # ── PR-link resolution (workspace design §2) ──────────────────
 
+
 # Bound gh calls per run — same discipline as session_recall.py's
 # _MAX_PR_CHECKS, sized for an audit sweep rather than a session start.
-_MAX_GH_CALLS = 30
+# The first full-workspace sweep (94 specs) capped out at 30 even after
+# the #1314 precision fix, so the weekly CI raises it via env; local
+# runs keep the conservative default.
+def _max_gh_calls() -> int:
+    try:
+        return int(os.environ.get("ATTUNE_SPEC_AUDIT_MAX_GH_CALLS", "30"))
+    except ValueError:
+        return 30
+
+
+_MAX_GH_CALLS = _max_gh_calls()
 _GH_TIMEOUT_SECONDS = 6.0
 # All three phase files are scanned for citations, not just the
 # highest-priority one — a requirements.md often carries the approval
@@ -126,9 +138,15 @@ class _PrResolver:
       §2 — never blocks).
     """
 
-    def __init__(self, max_calls: int = _MAX_GH_CALLS) -> None:
+    def __init__(self, max_calls: int | None = None) -> None:
         self.calls = 0
+        # Resolved at construction (not def-time) so tests can tune the
+        # module constant; the explicit param was silently ignored
+        # pre-#1314.
+        self.max_calls = _MAX_GH_CALLS if max_calls is None else max_calls
         self.dead = False
+        self.failures = 0  # transient gh errors (timeout / non-zero exit)
+        self.capped = False  # ran out of the per-run call budget
         self._cache: dict[tuple[str, int], bool] = {}
 
     def merged(self, ref: PrRef, spec_dir: Path, layer: str) -> bool:
@@ -136,7 +154,14 @@ class _PrResolver:
         key = (ref.repo or f"local:{layer}", ref.number)
         if key in self._cache:
             return self._cache[key]
-        if self.dead or self.calls >= _MAX_GH_CALLS:
+        if self.dead:
+            return False
+        if self.calls >= self.max_calls:
+            # Surfaced in the JSON payload — a capped run means "some
+            # refs unchecked", which reads very differently from clean
+            # (attune-ai#1314: silent gaps made consecutive runs
+            # disagree).
+            self.capped = True
             return False
         self.calls += 1
         try:
@@ -146,10 +171,15 @@ class _PrResolver:
             # (offline degradation; the deliverable signal still stands).
             self.dead = True
             return False
+        if verdict is None:
+            # Transient failure: report it, and do NOT cache — a retry
+            # in the same run (other phase file) may still succeed.
+            self.failures += 1
+            return False
         self._cache[key] = verdict
         return verdict
 
-    def _check(self, ref: PrRef, spec_dir: Path) -> bool:
+    def _check(self, ref: PrRef, spec_dir: Path) -> bool | None:
         # Explicit cross-repo slug → REST pulls endpoint ("merged" is a
         # single-PR-GET field; an issue number 404s here, which is
         # exactly the merged-only filter the design wants). Local refs
@@ -162,14 +192,19 @@ class _PrResolver:
                 ["pr", "view", str(ref.number), "--json", "state"],
                 cwd=spec_dir,
             )
-        if proc is None or proc.returncode != 0:
-            return False
+        if proc is None:
+            return None  # timeout / OSError — transient, retryable
+        if proc.returncode != 0:
+            # Non-zero is definitive for cross-repo (404 = not a PR) but
+            # can be transient for local gh auth hiccups; treating it as
+            # a failure keeps the run honest either way.
+            return None
         try:
             data = json.loads(proc.stdout)
         except (json.JSONDecodeError, ValueError):
-            return False
+            return None
         if not isinstance(data, dict):
-            return False
+            return None
         if ref.repo:
             return bool(data.get("merged"))
         return data.get("state") == "MERGED"
@@ -274,10 +309,13 @@ def audit_specs(
         checked = pr_links and resolver is not None and in_flight
         if checked:
             try:
+                # Only confident citations drive drift (attune-ai#1314):
+                # explicit PR #N / pull-URLs / shipping-context bare refs.
+                # Ordinal prose ("failure-shape #1") never reaches gh.
                 merged_prs = tuple(
                     _pr_label(ref, spec.layer)
                     for ref in _collect_refs(spec.path)
-                    if resolver.merged(ref, spec.path, spec.layer)
+                    if ref.explicit and resolver.merged(ref, spec.path, spec.layer)
                 )
             except Exception:  # noqa: BLE001 — one bad spec must not abort the audit
                 merged_prs = ()
@@ -337,7 +375,7 @@ def write_drift_cache(results: list[AuditResult], roots: list[Path]) -> list[Pat
     return written
 
 
-def format_json(results: list[AuditResult]) -> str:
+def format_json(results: list[AuditResult], resolver: _PrResolver | None = None) -> str:
     """Machine-readable audit payload for the tracking-issue upsert."""
     drifted = sorted(r.cache_key for r in results if r.drifted)
     payload = {
@@ -346,6 +384,14 @@ def format_json(results: list[AuditResult]) -> str:
             "specs": len(results),
             "drifted": len(drifted),
             "suspected_stale": sum(1 for r in results if r.staleness == "suspected-stale"),
+        },
+        # attune-ai#1314: a capped or failure-ridden run means "refs went
+        # unchecked" — consumers (the weekly issue upsert, humans) must
+        # be able to tell that apart from a genuinely clean sweep.
+        "resolver": {
+            "calls": resolver.calls if resolver else 0,
+            "failures": resolver.failures if resolver else 0,
+            "capped": bool(resolver.capped) if resolver else False,
         },
         "drifted": drifted,
         "specs": {
@@ -454,7 +500,14 @@ def main(argv: list[str] | None = None) -> int:
             # The cache is what lets the offline SessionStart hook
             # annotate drift without network calls (design §3).
             write_drift_cache(results, roots)
-        print(format_json(results) if as_json else format_report(results))
+        print(format_json(results, resolver) if as_json else format_report(results))
+        if resolver and (resolver.failures or resolver.capped):
+            print(
+                f"note: PR resolution degraded — {resolver.failures} lookup "
+                f"failure(s){', call budget hit' if resolver.capped else ''}; "
+                "unchecked refs count as not-drifted this run",
+                file=sys.stderr,
+            )
         if strict and any(r.drifted or r.staleness == "suspected-stale" for r in results):
             return 1
         return 0

--- a/plugin/hooks/spec_orient.py
+++ b/plugin/hooks/spec_orient.py
@@ -45,9 +45,11 @@ if _HOOKS_DIR not in sys.path:
 
 from _state import (  # noqa: E402 — sys.path bootstrap above
     SpecInfo,
+    WorktreeSpecDrift,
     discover_specs,
     prune_stale_sentinels,
     read_drift_cache,
+    scan_worktree_spec_drift,
     workspace_roots,
 )
 
@@ -148,6 +150,26 @@ def format_orientation(
     return "\n".join(lines)
 
 
+def format_worktree_drift(findings: list[WorktreeSpecDrift]) -> str:
+    """Alarm block for week-old uncommitted spec content in worktrees.
+
+    Task 10 (spec-status-integrity): this hook reads local files, so a
+    spec that lives only in a worktree still renders as "approved" in
+    the orientation above — these lines expose that instead of masking
+    it. Empty string when there is nothing to report.
+    """
+    if not findings:
+        return ""
+    lines = []
+    for f in findings:
+        more = f" (+{f.count - 1} more)" if f.count > 1 else ""
+        lines.append(
+            f"⚠ approved-looking spec content uncommitted in worktree "
+            f"{f.worktree} since {f.since}: {f.sample}{more} — commit or sweep it"
+        )
+    return "\n".join(lines)
+
+
 def render_spec_pin(spec: SpecInfo, char_budget: int = _POST_COMPACT_CHAR_BUDGET) -> str:
     """Render a spec body for post-compact context restoration.
 
@@ -211,6 +233,15 @@ def main() -> int:
             orient = format_orientation(specs, drift_cache=drift_cache, annotate=annotate)
             if orient:
                 print(orient)
+            if annotate:
+                # Task 10 — worktree-drift alarm. Same kill switch as the
+                # other audit annotations; bounded + best-effort inside.
+                try:
+                    alarm = format_worktree_drift(scan_worktree_spec_drift(cwd))
+                except Exception:  # noqa: BLE001 — never break SessionStart
+                    alarm = ""
+                if alarm:
+                    print(alarm)
         return 0
     except Exception:  # noqa: BLE001 — hook must never crash a session
         # Log the full traceback to stderr so plugin authors can

--- a/tests/unit/hooks/test_spec_audit.py
+++ b/tests/unit/hooks/test_spec_audit.py
@@ -19,6 +19,8 @@ from __future__ import annotations
 import importlib.util
 import io as _io
 import json as _json
+import os as _os
+import subprocess as _subprocess
 import sys
 import time as _time
 import types as _types
@@ -520,13 +522,26 @@ class TestExtractPrRefs:
         refs = state_mod.extract_pr_refs("Shipped via PR #212 yesterday.")
         assert refs == [state_mod.PrRef(number=212, repo=None, explicit=True)]
 
-    def test_bare_hash_is_ambiguous(self, state_mod) -> None:
+    def test_bare_hash_with_shipping_context_is_confident(self, state_mod) -> None:
+        # attune-ai#1314: "landed in #N" reads as a shipping citation —
+        # it must reach the drift signal, unlike ordinal prose below.
         refs = state_mod.extract_pr_refs("landed in attune #1191 last week")
-        assert refs == [state_mod.PrRef(number=1191, repo=None, explicit=False)]
+        assert refs == [state_mod.PrRef(number=1191, repo=None, explicit=True)]
+
+    def test_bare_hash_in_ordinal_prose_stays_ambiguous(self, state_mod) -> None:
+        # The two live false-positive shapes from the first sweep
+        # (attune-ai#1314): ordinal prose must never earn confidence.
+        for text in (
+            "advisory lane blocking the trigger is failure-shape #1",
+            "open item #2, hasn't started yet in earnest",
+        ):
+            refs = state_mod.extract_pr_refs(text)
+            assert len(refs) == 1, text
+            assert refs[0].explicit is False, text
 
     def test_inline_in_status_single(self, state_mod) -> None:
         refs = state_mod.extract_pr_refs("**Status**: complete — shipped in #567")
-        assert refs == [state_mod.PrRef(number=567, repo=None, explicit=False)]
+        assert refs == [state_mod.PrRef(number=567, repo=None, explicit=True)]
 
     def test_inline_in_status_pr_list(self, state_mod) -> None:
         refs = state_mod.extract_pr_refs("**Status**: complete — shipped (PRs #303, #304)")
@@ -1073,3 +1088,202 @@ class TestDriftAnnotation:
         out = capsys.readouterr().out
         assert "drifted" not in out
         assert "specs/foo/" in out
+
+
+# ── attune-ai#1314 precision + resolver honesty ──────────────────────
+
+
+class TestDriftSignalPrecision:
+    """Only confident citations reach gh; degraded runs say so."""
+
+    def test_ordinal_prose_never_queries_gh(self, audit_mod, tmp_path, fake_gh) -> None:
+        _pr_spec(
+            tmp_path / "specs" / "lane-isolation",
+            status="draft (2026-06-15)",
+            body="advisory lane blocking the trigger is failure-shape #1; open item #2 pending.",
+        )
+        resolver = audit_mod._PrResolver()
+        results = audit_mod.audit_specs([tmp_path], pr_links=True, resolver=resolver)
+        (row,) = [r for r in results if r.slug == "lane-isolation"]
+        assert row.drifted is False
+        assert resolver.calls == 0
+        assert fake_gh.calls == []
+
+    def test_shipping_context_bare_ref_still_drifts(self, audit_mod, tmp_path, fake_gh) -> None:
+        _pr_spec(
+            tmp_path / "specs" / "sse-endpoint",
+            status="approved (2026-06-14)",
+            body="SSE endpoint shipped in #67 with 10 tests.",
+        )
+        results = audit_mod.audit_specs([tmp_path], pr_links=True, resolver=audit_mod._PrResolver())
+        (row,) = [r for r in results if r.slug == "sse-endpoint"]
+        assert row.drifted is True
+        assert row.merged_prs == ("#67",)
+
+    def test_transient_failure_counts_and_is_not_cached(self, audit_mod, monkeypatch) -> None:
+        attempts = {"n": 0}
+
+        def flaky_gh(args, cwd=None):
+            attempts["n"] += 1
+            return None  # timeout / OSError shape
+
+        monkeypatch.setattr(audit_mod, "_run_gh", flaky_gh)
+        resolver = audit_mod._PrResolver()
+        ref = audit_mod.PrRef(number=67, repo=None, explicit=True)
+        assert resolver.merged(ref, Path("."), "workspace") is False
+        assert resolver.merged(ref, Path("."), "workspace") is False
+        assert resolver.failures == 2  # retried, not cached as a verdict
+        assert attempts["n"] == 2
+
+    def test_call_budget_cap_sets_capped_flag(self, audit_mod, fake_gh) -> None:
+        resolver = audit_mod._PrResolver(max_calls=1)
+        first = audit_mod.PrRef(number=67, repo=None, explicit=True)
+        second = audit_mod.PrRef(number=51, repo="Smart-AI-Memory/attune-author", explicit=True)
+        assert resolver.merged(first, Path("."), "workspace") is True
+        assert resolver.merged(second, Path("."), "workspace") is False
+        assert resolver.capped is True
+
+    def test_format_json_reports_resolver_state(self, audit_mod) -> None:
+        resolver = audit_mod._PrResolver(max_calls=1)
+        resolver.calls = 1
+        resolver.failures = 2
+        resolver.capped = True
+        payload = _json.loads(audit_mod.format_json([], resolver))
+        assert payload["resolver"] == {"calls": 1, "failures": 2, "capped": True}
+
+    def test_format_json_without_resolver_is_clean(self, audit_mod) -> None:
+        payload = _json.loads(audit_mod.format_json([]))
+        assert payload["resolver"] == {"calls": 0, "failures": 0, "capped": False}
+
+
+# ── task 10 — worktree spec-drift alarm ──────────────────────────────
+
+
+def _git(cwd: Path, *args: str) -> None:
+    _subprocess.run(
+        ["git", "-c", "user.email=t@t", "-c", "user.name=t", *args],
+        cwd=str(cwd),
+        check=True,
+        capture_output=True,
+    )
+
+
+@pytest.fixture
+def repo_with_worktree(tmp_path: Path):
+    """A real repo + one linked worktree, with a committed spec."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-q", "-b", "main")
+    spec = repo / "specs" / "seed" / "requirements.md"
+    spec.parent.mkdir(parents=True)
+    spec.write_text("**Status**: draft\n", encoding="utf-8")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-q", "-m", "seed")
+    worktree = tmp_path / "wt"
+    _git(repo, "worktree", "add", "-q", str(worktree), "-b", "feat/x")
+    return repo, worktree
+
+
+def _age(path: Path, days: float) -> None:
+    old = _time.time() - days * 86400
+    _os.utime(path, (old, old))
+
+
+class TestScanWorktreeSpecDrift:
+    def test_flags_week_old_untracked_spec_content(self, state_mod, repo_with_worktree) -> None:
+        repo, worktree = repo_with_worktree
+        stale = worktree / "specs" / "orphan" / "requirements.md"
+        stale.parent.mkdir(parents=True)
+        stale.write_text("**Status**: approved\n", encoding="utf-8")
+        _age(stale, days=8)
+        findings = state_mod.scan_worktree_spec_drift(repo)
+        assert len(findings) == 1
+        finding = findings[0]
+        assert finding.worktree == "wt"
+        assert "orphan" in finding.sample
+        assert finding.count == 1
+        # since == the stale file's mtime date
+        assert finding.since == _time.strftime("%Y-%m-%d", _time.localtime(stale.stat().st_mtime))
+
+    def test_flags_dirty_tracked_spec_file(self, state_mod, repo_with_worktree) -> None:
+        repo, worktree = repo_with_worktree
+        tracked = worktree / "specs" / "seed" / "requirements.md"
+        tracked.write_text("**Status**: approved — big amendment\n", encoding="utf-8")
+        _age(tracked, days=9)
+        findings = state_mod.scan_worktree_spec_drift(repo)
+        assert [f.worktree for f in findings] == ["wt"]
+
+    def test_fresh_files_do_not_alarm(self, state_mod, repo_with_worktree) -> None:
+        repo, worktree = repo_with_worktree
+        fresh = worktree / "specs" / "new" / "requirements.md"
+        fresh.parent.mkdir(parents=True)
+        fresh.write_text("**Status**: draft\n", encoding="utf-8")
+        assert state_mod.scan_worktree_spec_drift(repo) == []
+
+    def test_old_non_spec_files_do_not_alarm(self, state_mod, repo_with_worktree) -> None:
+        repo, worktree = repo_with_worktree
+        stray = worktree / "notes.md"
+        stray.write_text("scratch\n", encoding="utf-8")
+        _age(stray, days=30)
+        assert state_mod.scan_worktree_spec_drift(repo) == []
+
+    def test_non_repo_dir_yields_nothing(self, state_mod, tmp_path: Path) -> None:
+        assert state_mod.scan_worktree_spec_drift(tmp_path / "nope") == []
+
+    def test_age_gate_is_configurable(self, state_mod, repo_with_worktree) -> None:
+        repo, worktree = repo_with_worktree
+        f = worktree / "specs" / "seed" / "requirements.md"
+        f.write_text("**Status**: approved\n", encoding="utf-8")
+        _age(f, days=2)
+        assert state_mod.scan_worktree_spec_drift(repo) == []
+        assert state_mod.scan_worktree_spec_drift(repo, age_days=1) != []
+
+
+class TestOrientWorktreeAlarm:
+    def test_format_matches_spec_wording(self, state_mod, orient_mod) -> None:
+        findings = [
+            state_mod.WorktreeSpecDrift(
+                worktree="adoring-merkle",
+                since="2026-05-30",
+                sample="specs/heading-based-chunking/requirements.md",
+                count=3,
+            ),
+        ]
+        out = orient_mod.format_worktree_drift(findings)
+        assert (
+            "⚠ approved-looking spec content uncommitted in worktree "
+            "adoring-merkle since 2026-05-30" in out
+        )
+        assert "(+2 more)" in out
+
+    def test_empty_findings_render_nothing(self, orient_mod) -> None:
+        assert orient_mod.format_worktree_drift([]) == ""
+
+    def test_main_surfaces_alarm(
+        self, state_mod, orient_mod, repo_with_worktree, monkeypatch, capsys
+    ) -> None:
+        repo, worktree = repo_with_worktree
+        stale = worktree / "specs" / "orphan" / "requirements.md"
+        stale.parent.mkdir(parents=True)
+        stale.write_text("**Status**: approved\n", encoding="utf-8")
+        _age(stale, days=8)
+        monkeypatch.setenv("ATTUNE_AI_WORKSPACE_ROOTS", str(repo))
+        monkeypatch.delenv("ATTUNE_SPEC_AUDIT", raising=False)
+        monkeypatch.setattr("sys.stdin", _io.StringIO(_json.dumps({"cwd": str(repo)})))
+        assert orient_mod.main() == 0
+        out = capsys.readouterr().out
+        assert "⚠ approved-looking spec content uncommitted in worktree wt" in out
+
+    def test_kill_switch_silences_alarm(
+        self, state_mod, orient_mod, repo_with_worktree, monkeypatch, capsys
+    ) -> None:
+        repo, worktree = repo_with_worktree
+        stale = worktree / "specs" / "orphan" / "requirements.md"
+        stale.parent.mkdir(parents=True)
+        stale.write_text("**Status**: approved\n", encoding="utf-8")
+        _age(stale, days=8)
+        monkeypatch.setenv("ATTUNE_AI_WORKSPACE_ROOTS", str(repo))
+        monkeypatch.setenv("ATTUNE_SPEC_AUDIT", "off")
+        monkeypatch.setattr("sys.stdin", _io.StringIO(_json.dumps({"cwd": str(repo)})))
+        assert orient_mod.main() == 0
+        assert "uncommitted in worktree" not in capsys.readouterr().out


### PR DESCRIPTION
Two paired hook improvements — the follow-ups from closing out the workspace spec-status-integrity spec.

## Task 10 — worktree-drift alarm (workspace spec amendment 2026-07-10)
`scan_worktree_spec_drift()` (`_state.py`) + a `spec_orient` alarm line: dirty/untracked `specs/**` / `docs/specs/**` content older than 7 days in ANY of the repo's worktrees renders as *"⚠ approved-looking spec content uncommitted in worktree X since <date>"* at SessionStart. Bounded (≤12 worktrees, 2.5s wall budget, 2s per git call), crash-proof, same `ATTUNE_SPEC_AUDIT=off` kill switch. Live-verified against this repo's 11 worktrees (clean → silent; unit tests prove the aged-file detection with a real git worktree fixture).

## Fixes #1314 — drift-signal precision
1. **Bare-ref shipping context**: bare `#N` only counts as a citation when its line carries shipping vocabulary. Kills all five ordinal-prose false positives from the first sweep; the golden 2026-06-17 case ("shipped in #67") still drifts.
2. **Evidence citations**: prior-art refs in `analysis-workflow-output-widgets` and `trap-battery` are now code-spanned (extraction skips code) — the convention for "context, not deliverable".
3. **Resolver honesty**: transient failures counted + uncached (retryable), budget-cap flagged, both in `--json` (`resolver: {calls, failures, capped}`) + a stderr note. `max_calls` param now actually honored; default env-tunable via `ATTUNE_SPEC_AUDIT_MAX_GH_CALLS` for the weekly umbrella sweep.

## Live before/after (94-spec workspace)
- Before: 11–13 drifted, membership varying run-to-run, 7 false positives, silent gaps.
- After: ordinal-prose FPs gone; degraded-run note fires ("7 lookup failure(s), call budget hit"); freed budget reaches previously-unchecked refs — several genuinely stale approved specs now surface for the weekly issue to triage (left for triage, deliberately not chased here).

Tests: 157 in test_spec_audit.py (19 new), 740 across hook suites. Follow-up after merge: sibling re-sync (task-7 mechanism) picks up the three changed hook files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)