### PR TITLE
fix(cli): first-run setup frictions F1-F5 from the 2026-07-11 friction log

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,7 +300,11 @@ Then say "what can attune do?" in Claude Code.
 
 ```bash
 pip install attune-ai
+attune            # shows your next steps
 ```
+
+Then check your setup with `attune validate` and run your first
+workflow: `attune workflow run code-review --path src/`.
 
 The core install includes the CLI, all workflows, and the MCP
 server. See [Installation Options](#installation-options) for

--- a/src/attune/cli_commands/provider_commands.py
+++ b/src/attune/cli_commands/provider_commands.py
@@ -38,7 +38,7 @@ def cmd_provider_show(args: Namespace) -> int:
         else:
             print("\n  ⚠️  No API keys detected")
             print("  Set ANTHROPIC_API_KEY")
-            print("  Run: python -m attune.models.auth_cli setup")
+            print("  Run: attune auth setup")
 
         print("-" * 60)
         return 0

--- a/src/attune/cli_commands/utility_commands.py
+++ b/src/attune/cli_commands/utility_commands.py
@@ -207,10 +207,31 @@ def cmd_validate(args: Namespace) -> int:
             keys_found += 1
 
     if keys_found == 0:
-        errors.append(
-            "No API keys found. Set ANTHROPIC_API_KEY\n"
-            "   Run: python -m attune.models.auth_cli setup",
+        # Missing key is only an ERROR when there's no subscription-auth
+        # evidence either — a Claude Code login (`~/.claude` present /
+        # OAuth token set) is a fully working configuration
+        # (setup-friction F2/F3: validate used to hard-fail machines
+        # that subscription-first routing serves fine).
+        import os as _os
+        from pathlib import Path as _Path
+
+        has_subscription_evidence = (
+            bool(_os.environ.get("CLAUDE_CODE_OAUTH_TOKEN", "").strip())
+            or (_Path.home() / ".claude").exists()
         )
+        if has_subscription_evidence:
+            print("  ✅ Claude Code (subscription) auth evidence found")
+            warnings.append(
+                "No ANTHROPIC_API_KEY set — workflows will use "
+                "subscription (Claude Code) auth; large-module API "
+                "fallback is unavailable",
+            )
+        else:
+            errors.append(
+                "No auth found. Log in to Claude Code (run `claude` once) "
+                "or set ANTHROPIC_API_KEY\n"
+                "   Run: attune auth setup",
+            )
 
     # Check workflows
     try:

--- a/src/attune/cli_commands/workflow_commands.py
+++ b/src/attune/cli_commands/workflow_commands.py
@@ -144,6 +144,19 @@ def cmd_workflow_run(args: Namespace) -> int:
         # for nested dataclasses).
         input_data["output_format"] = "json"
 
+    # Auth pre-flight (setup-friction F1/F4) — BEFORE the spend gate,
+    # so a machine with no auth path at all gets one clean sentence
+    # instead of (a) a spend warning about dollars it cannot spend,
+    # then (b) an SDK traceback. Only blocks when NEITHER auth path
+    # exists: no ANTHROPIC_API_KEY and no `claude` CLI. A present-but-
+    # unauthenticated CLI can't be verified cheaply, so it proceeds
+    # (that failure is handled by SdkSubprocessError messaging).
+    if not getattr(args, "no_llm", False):
+        preflight_error = _auth_preflight()
+        if preflight_error:
+            print(preflight_error)
+            return EXIT_CLI_ERROR
+
     # Spend gate (collaboration-gates Phase 1) — guard the first
     # billable run of the session. Free/local runs never reach it
     # (R8): a ``--no-llm`` run makes no billable call. The gate's own
@@ -191,6 +204,49 @@ def cmd_workflow_run(args: Namespace) -> int:
             verbose=bool(getattr(args, "verbose", False)),
         ),
         on_result=_record_envelope_cost if record_cost else None,
+    )
+
+
+def _auth_preflight() -> str | None:
+    """Return an actionable error when no LLM auth evidence exists.
+
+    CLI *presence* can't be the test — ``claude-agent-sdk`` ships a
+    bundled ``claude`` binary, so one always exists after
+    ``pip install attune-ai``. What distinguishes a machine that can
+    run workflows from a fresh one is evidence of *credentials*:
+
+    - ``ANTHROPIC_API_KEY`` in the environment, or
+    - ``CLAUDE_CODE_OAUTH_TOKEN`` in the environment, or
+    - a ``~/.claude`` directory — Claude Code has been run (and
+      possibly logged in) on this machine at least once. Existence
+      only; the directory is never read (macOS keeps credentials in
+      the Keychain, so requiring a credentials *file* would
+      false-positive on logged-in Macs).
+
+    Conservative by design: any evidence passes, and a stale/logged-
+    out state still fails later with the SdkSubprocessError guidance.
+    Only the nothing-at-all machine is blocked here, before the spend
+    gate can warn it about dollars it cannot spend (setup-friction
+    F1/F4).
+    """
+    import os
+    from pathlib import Path
+
+    if os.environ.get("ANTHROPIC_API_KEY", "").strip():
+        return None
+    if os.environ.get("CLAUDE_CODE_OAUTH_TOKEN", "").strip():
+        return None
+    if (Path.home() / ".claude").exists():
+        return None
+
+    return (
+        "\n🔑 No auth found — workflows make LLM calls and need one "
+        "of these:\n"
+        "   - Claude Code (subscription): install it "
+        "(npm install -g @anthropic-ai/claude-code), run `claude` "
+        "once to log in, then re-run this workflow.\n"
+        "   - API key: export ANTHROPIC_API_KEY=... and re-run.\n"
+        "   For guided configuration: attune auth setup"
     )
 
 

--- a/src/attune/cli_minimal.py
+++ b/src/attune/cli_minimal.py
@@ -666,8 +666,7 @@ def _show_welcome() -> int:
     except Exception:  # noqa: BLE001
         # INTENTIONAL: version is non-critical for welcome message
         ver = "?"
-    print(
-        f"""Attune AI v{ver} — AI-powered developer workflows
+    print(f"""Attune AI v{ver} — AI-powered developer workflows
 
 Get started:
   attune workflow list        See all available workflows
@@ -681,9 +680,29 @@ For interactive development in Claude Code:
   /testing      Run tests, coverage, generate tests
   /wizard run   Guided multi-step wizards
 
-More: attune --help | Docs: https://smartaimemory.com/framework-docs/"""
-    )
+More: attune --help | Docs: https://smartaimemory.com/framework-docs/""")
     return 0
+
+
+class _OneLineLogFormatter(logging.Formatter):
+    """Formatter that suppresses tracebacks on non-verbose CLI runs.
+
+    A full traceback on a user's first failed workflow reads as a crash
+    even when the workflow returns a structured, actionable error right
+    below it (setup-friction F1). Errors stay one line; ``--verbose``
+    restores complete tracebacks via the default formatter.
+    """
+
+    def format(self, record: logging.LogRecord) -> str:
+        exc_info, exc_text = record.exc_info, record.exc_text
+        record.exc_info, record.exc_text = None, None
+        try:
+            message = super().format(record)
+        finally:
+            record.exc_info, record.exc_text = exc_info, exc_text
+        if exc_info:
+            message += " (re-run with --verbose for the full traceback)"
+        return message
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -691,8 +710,14 @@ def main(argv: list[str] | None = None) -> int:
     parser = create_parser()
     args = parser.parse_args(argv)
 
-    # Configure logging
-    logging.basicConfig(level=logging.DEBUG if args.verbose else logging.WARNING)
+    # Configure logging (one-line records unless --verbose; see
+    # _OneLineLogFormatter).
+    if args.verbose:
+        logging.basicConfig(level=logging.DEBUG)
+    else:
+        _handler = logging.StreamHandler()
+        _handler.setFormatter(_OneLineLogFormatter(fmt="%(levelname)s:%(name)s:%(message)s"))
+        logging.basicConfig(level=logging.WARNING, handlers=[_handler])
 
     command = args.command
 

--- a/src/attune/cli_minimal.py
+++ b/src/attune/cli_minimal.py
@@ -666,7 +666,8 @@ def _show_welcome() -> int:
     except Exception:  # noqa: BLE001
         # INTENTIONAL: version is non-critical for welcome message
         ver = "?"
-    print(f"""Attune AI v{ver} — AI-powered developer workflows
+    print(
+        f"""Attune AI v{ver} — AI-powered developer workflows
 
 Get started:
   attune workflow list        See all available workflows
@@ -680,7 +681,8 @@ For interactive development in Claude Code:
   /testing      Run tests, coverage, generate tests
   /wizard run   Guided multi-step wizards
 
-More: attune --help | Docs: https://smartaimemory.com/framework-docs/""")
+More: attune --help | Docs: https://smartaimemory.com/framework-docs/"""
+    )
     return 0
 
 

--- a/src/attune/models/auth_cli.py
+++ b/src/attune/models/auth_cli.py
@@ -90,8 +90,13 @@ def cmd_auth_status(args: Any) -> int:
 
     """
     try:
-        # Load strategy
+        # Load strategy. Track whether it came from a real config file:
+        # a fresh install runs on zero-config defaults, and rendering
+        # those as "Setup Completed: Yes / Tier: PRO" reads as state the
+        # user never created (setup-friction F3). Same values, honest
+        # labels.
         strategy = AuthStrategy.load()
+        configured = AUTH_STRATEGY_FILE.exists()
         output_json = getattr(args, "json", False)
 
         if output_json:
@@ -105,6 +110,7 @@ def cmd_auth_status(args: Any) -> int:
                 "prefer_subscription": strategy.prefer_subscription,
                 "cost_optimization": strategy.cost_optimization,
                 "setup_completed": strategy.setup_completed,
+                "configured": configured,
                 "config_file": str(AUTH_STRATEGY_FILE),
             }
             print(json.dumps(config, indent=2))
@@ -115,15 +121,30 @@ def cmd_auth_status(args: Any) -> int:
             console = Console()
 
             # Configuration panel
+            default_note = "" if configured else " (default)"
             config_text = Text()
             config_text.append("Subscription Tier: ", style="cyan")
-            config_text.append(f"{strategy.subscription_tier.value.upper()}\n", style="bold")
-            config_text.append("Default Mode: ", style="cyan")
-            config_text.append(f"{strategy.default_mode.value.upper()}\n", style="bold")
-            config_text.append("Setup Completed: ", style="cyan")
             config_text.append(
-                "✅ Yes\n" if strategy.setup_completed else "❌ No (run 'attune auth setup')\n",
+                f"{strategy.subscription_tier.value.upper()}{default_note}\n", style="bold"
             )
+            config_text.append("Default Mode: ", style="cyan")
+            config_text.append(
+                f"{strategy.default_mode.value.upper()}{default_note}\n", style="bold"
+            )
+            config_text.append("Setup: ", style="cyan")
+            if configured:
+                config_text.append(
+                    (
+                        "✅ Configured\n"
+                        if strategy.setup_completed
+                        else "❌ Incomplete (run 'attune auth setup')\n"
+                    ),
+                )
+            else:
+                config_text.append(
+                    "Not configured — using zero-config defaults "
+                    "(run 'attune auth setup' to customize)\n",
+                )
 
             console.print(Panel(config_text, title="Authentication Strategy", border_style="blue"))
 
@@ -161,16 +182,24 @@ def cmd_auth_status(args: Any) -> int:
             console.print(threshold_table)
 
             # File location
-            console.print(f"\n[dim]Configuration file: {AUTH_STRATEGY_FILE}[/dim]")
+            file_note = "" if configured else " (not created yet)"
+            console.print(f"\n[dim]Configuration file: {AUTH_STRATEGY_FILE}{file_note}[/dim]")
 
         else:
             # Plain text fallback
             print("\n" + "=" * 60)
             print("AUTHENTICATION STRATEGY")
             print("=" * 60)
-            print(f"\nSubscription Tier: {strategy.subscription_tier.value.upper()}")
-            print(f"Default Mode: {strategy.default_mode.value.upper()}")
-            print(f"Setup Completed: {'Yes' if strategy.setup_completed else 'No'}")
+            plain_note = "" if configured else " (default)"
+            print(f"\nSubscription Tier: {strategy.subscription_tier.value.upper()}{plain_note}")
+            print(f"Default Mode: {strategy.default_mode.value.upper()}{plain_note}")
+            if configured:
+                print(f"Setup Completed: {'Yes' if strategy.setup_completed else 'No'}")
+            else:
+                print(
+                    "Setup: not configured — using zero-config defaults "
+                    "(run 'attune auth setup' to customize)"
+                )
 
             print("\nModule Size Thresholds:")
             print(f"  Small: < {strategy.small_module_threshold} LOC")
@@ -186,7 +215,9 @@ def cmd_auth_status(args: Any) -> int:
                 print("  Small/Medium → Subscription")
                 print("  Large → API (1M context window)")
 
-            print(f"\nConfiguration file: {AUTH_STRATEGY_FILE}")
+            print(
+                f"\nConfiguration file: {AUTH_STRATEGY_FILE}{'' if configured else ' (not created yet)'}"
+            )
             print("=" * 60)
 
         return 0

--- a/src/attune/workflows/agent_sdk_adapter.py
+++ b/src/attune/workflows/agent_sdk_adapter.py
@@ -730,12 +730,56 @@ class SdkSubprocessError(Exception):
         view (persisted by Phase 3).
         """
         if self.kind == "unknown":
+            if _stderr_carries_no_signal(self.stderr):
+                # No stderr was recoverable — the most common real-world
+                # cause on a fresh machine is no working auth (no
+                # ANTHROPIC_API_KEY and a `claude` CLI that isn't logged
+                # in). Say so instead of pointing at stderr that doesn't
+                # exist (setup-friction F1).
+                key_state = (
+                    "ANTHROPIC_API_KEY is not set"
+                    if not os.environ.get("ANTHROPIC_API_KEY", "").strip()
+                    else "ANTHROPIC_API_KEY is set but may be invalid"
+                )
+                return (
+                    "The claude CLI subprocess failed without producing "
+                    "any error output.\n\n"
+                    f"On this machine, {key_state} — the most common "
+                    "cause is missing or logged-out auth.\n"
+                    "Most likely fixes:\n"
+                    "  - Log in to Claude Code: run `claude` once "
+                    "interactively, or\n"
+                    "  - Set an API key: export ANTHROPIC_API_KEY=..., or\n"
+                    "  - Run `attune auth setup` for guided configuration."
+                )
             return (
                 f"{self.message}\n\n"
                 "Underlying error (raw stderr from the claude CLI):\n"
                 f"{self.stderr.strip()}"
             )
         return f"{self.message}\n\nFull stderr is available on /runs/<id>/view."
+
+
+def _stderr_carries_no_signal(stderr: str) -> bool:
+    """True when captured "stderr" has nothing a user could act on.
+
+    ``capture_subprocess_failure()`` returns synthetic single-line
+    parenthetical markers — e.g. ``"(the SDK reported a subprocess
+    failure but exposed no command or stderr to capture)"`` or
+    ``"(claude exited 1 with no stderr/stdout)"`` — when no real
+    output was recoverable. Rendering those under an "Underlying
+    error" heading points the user at evidence that doesn't exist
+    (setup-friction F1). Treat text as no-signal when it is empty or
+    every non-empty line is such a parenthetical marker.
+    """
+    text = stderr.strip()
+    if not text:
+        return True
+    return all(
+        line.startswith("(") and line.endswith(")")
+        for line in (ln.strip() for ln in text.splitlines())
+        if line
+    )
 
 
 # (compiled_re, kind, message) tuples. Ordered most-specific first so

--- a/tests/unit/cli/test_workflow_exit_codes.py
+++ b/tests/unit/cli/test_workflow_exit_codes.py
@@ -35,6 +35,10 @@ def _disable_spend_gate(monkeypatch):
     semantics for non-gated runs; with it off, behavior is unchanged.
     """
     monkeypatch.setenv("ATTUNE_SPEND_GATE", "off")
+    # Auth-evidence for the pre-gate auth pre-flight (setup-friction
+    # F1/F4): CI runners have no ~/.claude and an empty key, and these
+    # tests target dispatch, not auth.
+    monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", "test-evidence")  # pragma: allowlist secret
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/cli_commands/test_utility_commands.py
+++ b/tests/unit/cli_commands/test_utility_commands.py
@@ -491,7 +491,10 @@ class TestCmdValidate:
         monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
 
-        with patch.dict("sys.modules", {"attune.workflows": MagicMock(WORKFLOW_REGISTRY={})}):
+        # patch the attr, not sys.modules — the ratchet in
+        # tests/unit/ci/test_no_new_sys_modules_patch.py blocks new
+        # sys.modules-dict patching in this file.
+        with patch("attune.workflows.discover_workflows", return_value={}):
             result = cmd_validate(args)
 
         assert result == 0

--- a/tests/unit/cli_commands/test_utility_commands.py
+++ b/tests/unit/cli_commands/test_utility_commands.py
@@ -456,10 +456,14 @@ class TestCmdValidate:
         monkeypatch.chdir(tmp_path)
         (tmp_path / "attune.config.json").write_text("{}")
 
-        # Remove all API keys
+        # Remove all API keys AND all subscription-auth evidence
+        # (setup-friction F2/F3: keyless is only an error when there's
+        # no Claude Code login evidence either).
         monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
         monkeypatch.delenv("OPENAI_API_KEY", raising=False)
         monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
+        monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
 
         with patch.dict("sys.modules", {"attune.workflows": MagicMock(WORKFLOW_REGISTRY={})}):
             result = cmd_validate(args)
@@ -467,7 +471,33 @@ class TestCmdValidate:
         assert result == 1
         captured = capsys.readouterr()
         assert "Validation failed" in captured.out
-        assert "No API keys found" in captured.out
+        assert "No auth found" in captured.out
+
+    def test_no_api_key_with_subscription_evidence_warns_and_passes(
+        self,
+        capsys: pytest.CaptureFixture[str],
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Keyless + a ~/.claude dir = working subscription config: warn,
+        don't fail (setup-friction F2/F3)."""
+        args = self._make_args()
+
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "attune.config.json").write_text("{}")
+        (tmp_path / ".claude").mkdir()
+
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+        with patch.dict("sys.modules", {"attune.workflows": MagicMock(WORKFLOW_REGISTRY={})}):
+            result = cmd_validate(args)
+
+        assert result == 0
+        captured = capsys.readouterr()
+        assert "subscription" in captured.out.lower()
+        assert "Configuration is valid" in captured.out
 
     def test_no_config_file_shows_warning(
         self,
@@ -648,13 +678,15 @@ class TestCmdValidate:
         monkeypatch.setenv("ANTHROPIC_API_KEY", "")
         monkeypatch.delenv("OPENAI_API_KEY", raising=False)
         monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
+        monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
 
         with patch.dict("sys.modules", {"attune.workflows": MagicMock(WORKFLOW_REGISTRY={})}):
             result = cmd_validate(args)
 
         assert result == 1
         captured = capsys.readouterr()
-        assert "No API keys found" in captured.out
+        assert "No auth found" in captured.out
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/cli_commands/test_workflow_auth_preflight.py
+++ b/tests/unit/cli_commands/test_workflow_auth_preflight.py
@@ -1,0 +1,105 @@
+"""Tests for the workflow-run auth pre-flight (setup-friction F1/F4).
+
+The pre-flight sits BEFORE the spend gate in ``cmd_workflow_run`` so a
+machine with no auth evidence at all gets one actionable message
+instead of (a) a spend warning about dollars it cannot spend and then
+(b) an SDK traceback. Evidence = ``ANTHROPIC_API_KEY`` or
+``CLAUDE_CODE_OAUTH_TOKEN`` in the environment, or a ``~/.claude``
+directory (Claude Code has been run on this machine).
+
+Copyright 2026 Smart-AI-Memory
+Licensed under Apache 2.0
+"""
+
+from __future__ import annotations
+
+import types
+from pathlib import Path
+
+import pytest
+
+from attune.cli_commands import workflow_commands
+from attune.cli_commands.workflow_commands import _auth_preflight
+
+
+@pytest.fixture()
+def no_auth_evidence(monkeypatch, tmp_path):
+    """Simulate a truly fresh machine: no keys, no ~/.claude."""
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+
+class TestAuthPreflight:
+    def test_blocks_when_no_evidence(self, no_auth_evidence):
+        message = _auth_preflight()
+        assert message is not None
+        assert "No auth found" in message
+        assert "attune auth setup" in message
+
+    def test_empty_string_key_is_not_evidence(self, no_auth_evidence, monkeypatch):
+        """CI sets ANTHROPIC_API_KEY to the empty string — that's keyless."""
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "")
+        assert _auth_preflight() is not None
+
+    def test_api_key_passes(self, no_auth_evidence, monkeypatch):
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")  # pragma: allowlist secret
+        assert _auth_preflight() is None
+
+    def test_oauth_token_passes(self, no_auth_evidence, monkeypatch):
+        monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", "tok")  # pragma: allowlist secret
+        assert _auth_preflight() is None
+
+    def test_claude_dir_passes(self, no_auth_evidence, tmp_path):
+        """A ~/.claude directory is evidence Claude Code has been run.
+
+        Existence only — the directory contents are never read (macOS
+        keeps credentials in the Keychain, not in a file).
+        """
+        (tmp_path / ".claude").mkdir()
+        assert _auth_preflight() is None
+
+
+class TestPreflightOrdering:
+    """The pre-flight fires BEFORE the spend gate (F4: never warn a
+    keyless machine about spend it cannot incur)."""
+
+    def _args(self) -> types.SimpleNamespace:
+        return types.SimpleNamespace(name="wf", input=None, path=None, target=None, json=False)
+
+    def test_preflight_blocks_before_spend_gate(self, no_auth_evidence, monkeypatch, capsys):
+        gate_evaluated = {"called": False}
+
+        def _gate(*a, **k):
+            gate_evaluated["called"] = True
+            raise AssertionError("spend gate must not be reached")
+
+        monkeypatch.setattr("attune.gates.spend_gate.evaluate_spend_gate", _gate)
+        monkeypatch.setattr("attune.workflows.get_workflow", lambda name: object)
+
+        rc = workflow_commands.cmd_workflow_run(self._args())
+
+        assert rc == 3  # EXIT_CLI_ERROR
+        assert gate_evaluated["called"] is False
+        out = capsys.readouterr().out
+        assert "No auth found" in out
+        assert "$" not in out  # no spend framing on the no-auth path
+
+    def test_no_llm_run_skips_preflight(self, no_auth_evidence, monkeypatch):
+        """--no-llm makes no billable call; a fresh machine may run it."""
+        ran = {"called": False}
+
+        def _runner(*a, **k):
+            ran["called"] = True
+            return 0
+
+        monkeypatch.setattr("attune.cli_commands._exit_codes.run_workflow_with_exit_code", _runner)
+        monkeypatch.setattr("attune.workflows.get_workflow", lambda name: object)
+        monkeypatch.setenv("ATTUNE_SPEND_GATE", "off")
+
+        args = self._args()
+        args.no_llm = True
+        rc = workflow_commands.cmd_workflow_run(args)
+
+        assert rc == 0
+        assert ran["called"] is True

--- a/tests/unit/cli_commands/test_workflow_commands.py
+++ b/tests/unit/cli_commands/test_workflow_commands.py
@@ -25,6 +25,10 @@ def _disable_spend_gate(monkeypatch):
     The gate has dedicated tests in ``test_workflow_spend_gate.py``.
     """
     monkeypatch.setenv("ATTUNE_SPEND_GATE", "off")
+    # Auth-evidence for the pre-gate auth pre-flight (setup-friction
+    # F1/F4): CI runners have no ~/.claude and an empty key, and these
+    # tests target dispatch, not auth.
+    monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", "test-evidence")  # pragma: allowlist secret
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/cli_commands/test_workflow_spend_gate.py
+++ b/tests/unit/cli_commands/test_workflow_spend_gate.py
@@ -64,6 +64,15 @@ def env_file(tmp_path, monkeypatch):
     return path
 
 
+@pytest.fixture(autouse=True)
+def auth_preflight_passes(monkeypatch):
+    """These tests target the SPEND GATE, which sits behind the auth
+    pre-flight (setup-friction F1/F4). Neutralize the pre-flight so the
+    gate is reachable regardless of the runner's auth evidence (CI has
+    no ``~/.claude`` and an empty ``ANTHROPIC_API_KEY``)."""
+    monkeypatch.setattr(workflow_commands, "_auth_preflight", lambda: None)
+
+
 @pytest.fixture
 def fake_runner(monkeypatch):
     """Patch the workflow runner; capture whether it ran + its on_result."""

--- a/tests/unit/test_cli_minimal.py
+++ b/tests/unit/test_cli_minimal.py
@@ -16,6 +16,7 @@ import pytest
 
 from attune.cli_minimal import (
     _SUBCOMMAND_DISPATCH,
+    _OneLineLogFormatter,
     create_parser,
     get_version,
     main,
@@ -317,6 +318,61 @@ class TestMainEdgeCases:
         ctx, mock_fn = _mock_subcmd("workflow", "list", return_value=1)
         with ctx:
             assert main(["workflow", "list"]) == 1
+
+
+class TestOneLineLogFormatter:
+    """Tests for _OneLineLogFormatter (setup-friction F1)."""
+
+    def _record(self, exc_info=None) -> logging.LogRecord:
+        return logging.LogRecord(
+            name="attune.test",
+            level=logging.ERROR,
+            pathname=__file__,
+            lineno=1,
+            msg="workflow failed",
+            args=(),
+            exc_info=exc_info,
+        )
+
+    def test_plain_record_formats_one_line(self) -> None:
+        fmt = _OneLineLogFormatter(fmt="%(levelname)s:%(name)s:%(message)s")
+        message = fmt.format(self._record())
+        assert message == "ERROR:attune.test:workflow failed"
+
+    def test_exception_record_suppresses_traceback(self) -> None:
+        try:
+            raise ValueError("boom")
+        except ValueError:
+            import sys
+
+            record = self._record(exc_info=sys.exc_info())
+        fmt = _OneLineLogFormatter(fmt="%(levelname)s:%(name)s:%(message)s")
+        message = fmt.format(record)
+        assert "Traceback" not in message
+        assert "\n" not in message
+        assert message.endswith("(re-run with --verbose for the full traceback)")
+
+    def test_record_exc_info_restored_after_format(self) -> None:
+        # Other handlers on the same record must still see the exception.
+        try:
+            raise ValueError("boom")
+        except ValueError:
+            import sys
+
+            record = self._record(exc_info=sys.exc_info())
+        exc_info = record.exc_info
+        _OneLineLogFormatter(fmt="%(message)s").format(record)
+        assert record.exc_info == exc_info
+
+    def test_main_non_verbose_installs_one_line_formatter(self) -> None:
+        ctx, mock_fn = _mock_simple("version")
+        with ctx, patch("logging.basicConfig") as mock_config:
+            main(["version"])
+        call = next(c for c in mock_config.call_args_list if "handlers" in c.kwargs)
+        assert call.kwargs["level"] == logging.WARNING
+        handlers = call.kwargs["handlers"]
+        assert len(handlers) == 1
+        assert isinstance(handlers[0].formatter, _OneLineLogFormatter)
 
 
 class TestCreateParserAuth:

--- a/tests/unit/test_utility_commands.py
+++ b/tests/unit/test_utility_commands.py
@@ -160,15 +160,25 @@ class TestCmdValidate:
         """Create args namespace for validate command."""
         return argparse.Namespace()
 
-    def test_validate_no_api_keys(self, capsys: pytest.CaptureFixture) -> None:
-        """Test validate returns 1 when no API keys are set."""
+    def test_validate_no_api_keys(
+        self,
+        capsys: pytest.CaptureFixture,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Test validate returns 1 when no API keys and no subscription auth."""
         args = self._make_args()
 
         env = {
             "ANTHROPIC_API_KEY": "",
             "OPENAI_API_KEY": "",
             "GOOGLE_API_KEY": "",
+            "CLAUDE_CODE_OAUTH_TOKEN": "",
         }
+        # No ~/.claude dir under tmp_path → no subscription-auth evidence
+        # (setup-friction F2/F3: keyless is only an error when there's no
+        # Claude Code login evidence either).
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
 
         with patch.dict("os.environ", env, clear=False):
             with patch("os.environ.get", side_effect=lambda k, *a: env.get(k, "")):
@@ -181,7 +191,7 @@ class TestCmdValidate:
         assert result == 1
         captured = capsys.readouterr()
         assert "Validation failed" in captured.out
-        assert "No API keys found" in captured.out
+        assert "No auth found" in captured.out
 
     def test_validate_with_anthropic_key(self, capsys: pytest.CaptureFixture) -> None:
         """Test validate succeeds with ANTHROPIC_API_KEY set."""
@@ -207,13 +217,22 @@ class TestCmdValidate:
         assert "Anthropic" in captured.out
         assert "Configuration is valid" in captured.out
 
-    def test_validate_without_any_key(self, capsys: pytest.CaptureFixture) -> None:
-        """Test validate fails when no API key is set."""
+    def test_validate_without_any_key(
+        self,
+        capsys: pytest.CaptureFixture,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Test validate fails when no API key and no subscription auth."""
         args = self._make_args()
 
         env_patch = {
             "ANTHROPIC_API_KEY": "",
+            "CLAUDE_CODE_OAUTH_TOKEN": "",
         }
+        # No ~/.claude dir under tmp_path → no subscription-auth evidence,
+        # regardless of the developer machine running the test.
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
 
         with (
             patch.dict("os.environ", env_patch, clear=False),

--- a/tests/unit/voice/test_voice_wiring.py
+++ b/tests/unit/voice/test_voice_wiring.py
@@ -27,6 +27,10 @@ def _disable_spend_gate(monkeypatch):
     non-TTY run before execution).
     """
     monkeypatch.setenv("ATTUNE_SPEND_GATE", "off")
+    # Auth-evidence for the pre-gate auth pre-flight (setup-friction
+    # F1/F4): CI runners have no ~/.claude and an empty key, and these
+    # tests target dispatch, not auth.
+    monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", "test-evidence")  # pragma: allowlist secret
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/workflows/test_sdk_error_no_signal_stderr.py
+++ b/tests/unit/workflows/test_sdk_error_no_signal_stderr.py
@@ -1,0 +1,97 @@
+"""Tests for no-signal stderr rendering (setup-friction F1).
+
+When ``capture_subprocess_failure()`` recovers nothing real, the
+"unknown" rendering used to point the user at "raw stderr below" that
+was just a synthetic placeholder. It now says what the placeholder
+means and names the most likely fixes (auth), keyed on whether
+``ANTHROPIC_API_KEY`` is present.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under Apache 2.0
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from attune.workflows.agent_sdk_adapter import (
+    SdkSubprocessError,
+    _stderr_carries_no_signal,
+)
+
+
+class TestStderrCarriesNoSignal:
+    def test_empty_is_no_signal(self):
+        assert _stderr_carries_no_signal("") is True
+        assert _stderr_carries_no_signal("   \n ") is True
+
+    def test_synthetic_placeholder_is_no_signal(self):
+        assert (
+            _stderr_carries_no_signal(
+                "(the SDK reported a subprocess failure but exposed no "
+                "command or stderr to capture)"
+            )
+            is True
+        )
+
+    def test_exit_marker_is_no_signal(self):
+        assert _stderr_carries_no_signal("(claude exited 1 with no stderr/stdout)") is True
+
+    def test_probe_note_plus_marker_is_no_signal(self):
+        text = (
+            "(could not recover the exact failing command from the SDK; "
+            "ran a minimal `claude` health probe instead)\n"
+            "(capture-call timed out after 10s)"
+        )
+        assert _stderr_carries_no_signal(text) is True
+
+    def test_real_stderr_is_signal(self):
+        assert _stderr_carries_no_signal("Error: invalid api key (401)") is False
+
+    def test_probe_note_plus_real_output_is_signal(self):
+        text = (
+            "(could not recover the exact failing command from the SDK; "
+            "ran a minimal `claude` health probe instead)\n"
+            "Error: not logged in"
+        )
+        assert _stderr_carries_no_signal(text) is False
+
+
+class TestFormatUserMessageNoSignal:
+    def _err(self) -> SdkSubprocessError:
+        return SdkSubprocessError(
+            message="The claude CLI subprocess failed; see raw stderr below.",
+            stderr=(
+                "(the SDK reported a subprocess failure but exposed no "
+                "command or stderr to capture)"
+            ),
+            kind="unknown",
+        )
+
+    def test_keyless_names_auth_and_next_steps(self, monkeypatch):
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "")
+        rendered = self._err().format_user_message()
+        assert "ANTHROPIC_API_KEY is not set" in rendered
+        assert "attune auth setup" in rendered
+        # The dead-end pointer is gone:
+        assert "see raw stderr below" not in rendered
+
+    def test_with_key_suggests_invalid(self, monkeypatch):
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-something")  # pragma: allowlist secret
+        rendered = self._err().format_user_message()
+        assert "may be invalid" in rendered
+
+    def test_real_stderr_still_rendered_inline(self):
+        err = SdkSubprocessError(
+            message="The claude CLI subprocess failed; see raw stderr below.",
+            stderr="weird error nobody recognized",
+            kind="unknown",
+        )
+        rendered = err.format_user_message()
+        assert "weird error nobody recognized" in rendered
+
+
+@pytest.mark.parametrize("kind", ["api_quota", "auth", "rate_limit"])
+def test_classified_kinds_unchanged(kind):
+    err = SdkSubprocessError(message="summary", stderr="blob", kind=kind)  # type: ignore[arg-type]
+    assert "/runs/<id>/view" in err.format_user_message()


### PR DESCRIPTION
## What

Fixes the five ranked first-run frictions from
`docs/specs/product-direction-review/setup-friction-log.md`, found by
reproducing a fresh-machine install after user conversation 1 reported
"setup issues" as their primary concern.

- **F1/F4 — auth pre-flight before the spend gate** in
  `attune workflow run`: a machine with no auth evidence (no
  `ANTHROPIC_API_KEY`, no `CLAUDE_CODE_OAUTH_TOKEN`, no `~/.claude`)
  gets one actionable message instead of a $10 spend warning followed
  by an SDK traceback. Evidence check is existence-only — no file
  contents are read.
- **F1 — no-signal stderr rendering**: when
  `capture_subprocess_failure()` recovers only synthetic placeholders,
  the "unknown" message now names the likely cause (auth) and three
  concrete fixes instead of pointing at "raw stderr below" that
  doesn't exist.
- **F1 — one-line error logs** on non-verbose CLI runs
  (`_OneLineLogFormatter`); full tracebacks behind `--verbose`.
- **F2 — one canonical setup command**: error strings point at
  `attune auth setup` (already existed) instead of
  `python -m attune.models.auth_cli setup`.
- **F2/F3 — `attune validate` keyless contract**: subscription-auth
  evidence (Claude Code login) now validates with a warning about the
  missing API fallback instead of hard-failing a working config.
- **F3 — honest fresh-install `auth status`**: zero-config defaults
  render as "Not configured — using zero-config defaults", not
  "Setup Completed: ✅ Yes / Tier: PRO".
- **F5 — README pip quickstart** says what to type after
  `pip install`.

## Verification

Before/after table in the friction log's "Post-fix verification"
section. Re-run keyless with a bare `HOME` (CI-faithful,
`ANTHROPIC_API_KEY=""`):

- fresh machine → 🔑 pre-flight message, spend gate never reached
- logged-out CLI → clean auth guidance, no traceback
- keyless + `~/.claude` → `validate` passes with warning
- 357 unit tests green; +13 new
  (`test_workflow_auth_preflight.py`,
  `test_sdk_error_no_signal_stderr.py`); spend-gate/dispatch fixtures
  gain auth evidence so they still target the gate on keyless runners

Pre-existing `test_token_estimator.py::TestGetEncodingPaths` failures
reproduce on unmodified main (environmental; tiktoken download).

## Notes for review

- The pre-flight is deliberately conservative: `~/.claude` existing
  passes it (macOS keeps credentials in the Keychain, so requiring a
  credentials file would false-block logged-in Macs). A logged-out
  machine falls through to the improved SdkSubprocessError message.
- `--no-llm` runs skip the pre-flight (no billable call).
- Wheel-build verification wasn't possible in the authoring sandbox;
  worth one clean-container `pip install` from this branch before
  merge.
