### PR TITLE
docs: rescue checkout WIP — usage-signals, product-direction-review, blog drafts

### DIFF
--- a/docs/blog/12-we-benchmarked-our-own-marketing-claim.md
+++ b/docs/blog/12-we-benchmarked-our-own-marketing-claim.md
@@ -1,0 +1,128 @@
+---
+description: "We wanted to claim our AI memory saves 8% on costs. We built the benchmark to prove it — and measured +28% instead. Published the table anyway. Here's why that's the feature."
+---
+
+# We Benchmarked Our Own Marketing Claim. It Lost.
+
+**Date:** July 6, 2026
+**Author:** Patrick Roebuck
+
+---
+
+## TL;DR
+
+I wanted to write "our memory features lower your Anthropic costs by
+8%" in a LinkedIn post. Before publishing, we built an A/B benchmark
+to back the number: same tasks, real headless Claude Code sessions,
+memory suite toggled on and off.
+
+The result: on that task set, memory ON cost **28% more** per task,
+not less. The table is committed to our repo, next to the harness
+that produced it, next to a bug the run itself flushed out.
+
+We still think the memory suite is the best thing we've built. This
+post is about why publishing the losing number makes that claim
+stronger, not weaker.
+
+## The claim I almost shipped
+
+Every AI-memory pitch eventually writes the same sentence: "saves you
+N% on tokens." I had the sentence half-drafted. The N was 8.
+
+The problem: nothing we had measured produced that number. What we
+HAD measured was per-recall economics — our recall injects a
+budget-capped ~3,000-token slice instead of a 300K-token store (67x
+fewer tokens per recall, precision-at-3 of 96% on a frozen
+benchmark). Real numbers, but they answer "what does one recall
+cost?" — not "what does memory do to your bill?"
+
+Converting one into the other without measuring is how marketing
+debt gets created. So we measured.
+
+## The experiment
+
+`benchmarks/session_savings.py` — about 400 lines, in the repo:
+
+- 5 read-only analysis tasks against our own codebase
+- each task runs twice via headless `claude -p` (read-only tools,
+  turn-capped)
+- ONE difference between arms: the memory suite's injection hooks,
+  toggled by their env kill-switches
+- compare medians: uncached input tokens, cache reads, output,
+  turns, wall-clock, dollars
+
+Total spend for the run: $6.59. Ten sessions, ten clean results.
+
+## The result
+
+| Metric (median/task) | Memory on | Memory off | Delta |
+|---|--:|--:|--:|
+| Uncached input tokens | 56,552 | 51,921 | +8.9% |
+| Turns | 6 | 4 | +50% |
+| Wall-clock | 52.0s | 38.6s | +34.8% |
+| Cost | $0.654 | $0.510 | **+28.4%** |
+
+The 8% I wanted to claim as savings showed up as +8.9% OVERHEAD.
+Every metric pointed the same direction.
+
+## Why (and what the number actually means)
+
+The harness docstring predicted this outcome before the first run:
+
+> Savings only appear on tasks where recall actually prevents
+> re-derivation. A task set that never hits a trap moment will show
+> memory as pure overhead — that is a true and useful result, not a
+> benchmark failure.
+
+These were one-shot analysis tasks. No prior session to resume, no
+known trap for a recalled lesson to prevent. On that profile, memory
+injects context and gets nothing back — and the memory-on sessions
+explored more (6 vs 4 turns), which may mean better answers or just
+more expensive ones; we didn't score quality. n=1 per task per arm:
+directional, not gospel.
+
+Where memory is DESIGNED to pay — "we solved this exact failure two
+weeks ago, don't repeat the dead end" — is exactly what this task
+set doesn't exercise. That benchmark is next, and until it exists,
+we don't get to claim a savings percentage. Neither does anyone
+else, by the way: if a memory product quotes you a % without
+publishing the task profile, ask which profile.
+
+## The bonus bug
+
+The first run returned all zeros and claimed 10/10 success. Turns
+out the CLI can emit `subtype: "success"` WITH `is_error: true`
+(an auth failure), and our parser trusted the first field. Ten auth
+failures aggregated into a beautiful all-zero "result."
+
+A benchmark that can silently count failures as data is worse than
+no benchmark. The fix and its regression test shipped the same
+morning. That's the second thing the run paid for.
+
+## What we can honestly say
+
+- Recall injects <=3K tokens from a 300K+ token store: **67x fewer
+  tokens per recall**, and the cap holds as memory grows.
+- The right lesson is in the top-3 results **96%** of the time
+  (100% on high-severity traps).
+- On one-shot tasks, the suite costs ~9% extra uncached input.
+  Turn it down for that profile; that's why the kill-switches exist.
+- The session-level savings claim is UNPROVEN, and we published the
+  benchmark that will prove or kill it.
+
+## Why this is the lead
+
+"Trust our memory system" is a claim every vendor makes. "Here's the
+benchmark where our marketing lost, in the repo, re-runnable" is a
+claim almost nobody makes — and it's the only kind that makes the
+67x and the 96% believable.
+
+Storage was never the hard part of AI memory. Truth is. That
+includes truth in the marketing.
+
+---
+
+*The harness, the raw JSON, and the unflattering table:
+`benchmarks/session_savings*` in the attune-ai repo (PR #1276).
+Run it on your own setup — and if your task set makes our memory
+suite look good, publish that too. We'll take it.*

--- a/docs/blog/13-memory-that-survives-sessions.md
+++ b/docs/blog/13-memory-that-survives-sessions.md
@@ -1,0 +1,121 @@
+---
+description: "Long-form product lead: Claude Code forgets everything between sessions. attune-ai's memory suite makes what you learned durable — files as truth, Redis as speed, a 3K-token budget cap as the contract — with every claim tied to a published benchmark."
+---
+
+# Your AI Assistant Forgets Everything. Here's the Fix — With the Receipts.
+
+**Date:** July 6, 2026
+**Author:** Patrick Roebuck
+
+---
+
+## TL;DR
+
+Every Claude Code session starts from zero: yesterday's debugging
+session, the dead end you burned an hour on, the decision your team
+already litigated — gone. The obvious fix (stuff history into
+context) doesn't scale: our own memory corpus is past 300K tokens.
+
+attune-ai's memory suite makes memory durable AND cheap: git-tracked
+files as the source of truth, Redis as the serving layer, and a hard
+~3K-token budget on what any moment injects. 67x fewer tokens per
+recall than corpus-loading, 96% precision-at-3 on a frozen
+benchmark, ~5 MB of Redis at current scale, local-first. Every one
+of those numbers has a published, re-runnable benchmark behind it —
+including the one where our own marketing hope lost.
+
+## The forgetting tax
+
+You pay it in three currencies:
+
+- **Repeated dead ends.** The trap you debugged two weeks ago is
+  re-debugged, because the lesson lived in a session that's gone.
+- **Re-derivation.** "How does our release automation work again?"
+  gets re-explored from scratch, tokens and minutes each time.
+- **Re-litigated decisions.** The AI proposes the approach your team
+  already rejected, persuasively, because it never heard the verdict.
+
+The naive fix — load your notes into every prompt — trades the
+forgetting tax for a context tax that grows forever. At 300K tokens
+of accumulated memory, corpus-loading isn't a strategy, it's a bill.
+
+## The architecture: files are truth, Redis is speed, the cap is the contract
+
+**Files as the store.** Every memory is a markdown file in git —
+reviewable, diffable, portable, yours. No vendor database owns what
+your team learned. Delete a file, the memory is gone. Multi-machine
+sync is a git pull.
+
+**Redis as the serving layer.** A SessionStart hook hydrates the
+corpus into Redis (about 5 MB at our current scale of ~875 keys
+including the search index). Recall is one warm function call —
+sub-millisecond, measured at 0.6ms against 4.6ms for re-reading the
+corpus files.
+
+**The budget cap as the contract.** No moment injects more than
+~3K tokens, no matter how large the store grows. This is the number
+that makes memory scale: your corpus can grow 10x and your
+per-session context cost doesn't move. Measured on our dogfood
+store: 67x fewer tokens per recall than loading the corpus.
+
+**Local-first, degradable.** No Redis? Everything falls back to the
+file backend with clear guidance. Nothing leaves your machine.
+
+## Recall at the trap moment, not in bulk
+
+The suite's sharpest edge is WHEN it recalls. A UserPromptSubmit
+hook matches what you're about to do against known traps — the
+command shape, the file, the failure pattern — and injects only the
+relevant lesson, only then.
+
+On a frozen benchmark built from real trap moments in our own
+sessions, the right lesson is in the top 3 results 96% of the time,
+and 100% on the high-severity subset. Recall precision is the whole
+game: memory that surfaces the wrong lesson is noise with
+confidence.
+
+## Memory that can be wrong — and fixed
+
+Two disciplines most memory systems skip:
+
+**Provenance.** We caught our own extractor promoting things a
+session merely READ into "findings" — file contents restated as
+decisions nobody made. We built a replay harness, measured the
+failure class (5% of findings), fixed it, re-measured (0%), and
+regression-tested the distinction. Memory that can't tell "I read
+it" from "I concluded it" isn't memory, it's contamination.
+
+**One-call correction.** Any record that search can surface, one
+tool call can delete — by ID, in seconds. Corrections are part of
+the loop, not an admin chore.
+
+## The receipt you didn't expect
+
+This week we also published the benchmark where memory LOSES.
+
+We wanted to claim session-level cost savings. So we built an A/B
+harness — same tasks, memory on vs off, real headless sessions —
+and measured: on one-shot analysis tasks, memory ON costs 28% MORE
+per task. No trap to avoid, no work to resume, nothing for recall
+to save. The table is committed to the repo next to the harness.
+
+Why lead a product post with the losing number? Because it's the
+only thing that makes the winning numbers credible. The 67x and the
+96% come from the same discipline, the same repo, the same
+willingness to publish whatever the benchmark says. A savings
+percentage will only ever appear in our marketing after the
+continuity-task benchmark produces one.
+
+## Try it
+
+```bash
+pip install attune-ai
+```
+
+Works with plain files out of the box; add Redis when you want the
+speed. The benchmarks are in `benchmarks/` — `memory_savings.py`
+for the recall economics, `session_savings.py` for the on/off A/B.
+Run them on your own corpus. Publish what you find, either way.
+
+Your team is already generating the lessons. The only question is
+whether anything remembers them.

--- a/docs/specs/product-direction-review/assessment-2026-07-11.md
+++ b/docs/specs/product-direction-review/assessment-2026-07-11.md
@@ -1,0 +1,236 @@
+# Product Direction Review — Follow-up Assessment
+
+**Status:** assessment (2026-07-11) — decisions pending Patrick
+**Owner:** Patrick (+ agent)
+**Type:** strategic assessment / decision record (not a build spec)
+**Trigger:** Patrick asked for a second critical review, 24 days after
+[assessment.md](assessment.md) (2026-06-17).
+**Method:** identical to the first — every number re-measured from the
+repo itself; same sources where possible, noted where not.
+
+---
+
+## Verdict
+
+The June report was executed selectively — and the selection is the
+finding. Every recommendation a solo engineer could satisfy *inside
+the repo* got real, high-quality follow-through: ~30k LOC of dead
+subsystems deleted, a working value-gate process, CI firefighting cut
+from ~18% to ~4% of commits, a spend alarm built. The one
+recommendation that required *leaving* the repo — DEC-2, talk to five
+users — produced zero commits, zero memory entries, zero recorded
+decisions. All five DECs still read "(pending)" in a file last touched
+2026-07-10. Meanwhile commit velocity **doubled** to ~20/day and two
+more major versions shipped. Finding 1 is not just unresolved; the
+repo has gotten better at absorbing the energy that was supposed to
+resolve it.
+
+---
+
+## Evidence (ground truth, 2026-07-11 vs 2026-06-17)
+
+| Metric | 2026-06-17 | 2026-07-11 | Δ | Source |
+|--------|-----------|-----------|---|--------|
+| Product code (`.py`) | 183,768 LOC / 712 files | 169,169 LOC / 652 files | **−14.6k** | `find src/attune -name "*.py" \| xargs cat \| wc -l` |
+| Test code (`.py`) | 349,399 LOC / 968 files | 327,136 LOC / 980 files | −22.3k | same, `tests/` |
+| `test_` functions | ~20,160 | 20,393 | +233 | `grep -rE "def test_"` |
+| Test-to-product ratio | 1.9 : 1 | 1.93 : 1 | flat | derived |
+| Commit rate | 9.8/day (90d) | **20.3/day** (487 in 24d) | ×2.1 | `git log --since=2026-06-17` |
+| Last 200: `feat` | 27 (13.5%) | 38 (19%) | +5.5pt | `git log -200 --format=%s` |
+| Last 200: chore+docs+test+ci | 148 (74%) | 129 (64.5%) | −9.5pt | same |
+| CI/hang/flake/runner commits | ~18% of 300 | **~4%** (20 of 487) | −14pt | `grep -cE "^ci\|hang\|flake\|runner"` |
+| Open spec directories | 49 | **60** | +11 | `ls docs/specs` |
+| `lessons.md` | 9,356 lines | **14,560 lines** | +56% | `wc -l` |
+| CI workflows | 22 | 26 | +4 | `ls .github/workflows` |
+| Docs `.md` files | ~500 | 693 | +39% | `find docs -name "*.md"` |
+| Scripts | 108 | 120 | +12 | `ls scripts` |
+| Dependency lines (pyproject) | 311 | ~402 (36 core + 366 optional) | +29% | `awk` over dep sections |
+| Version | 8.5.0 | **10.3.0** | +2 majors | pyproject |
+| Releases since 6/17 | — | **16 tags** (9.0.0 → 10.3.0) | 1 per 1.5 days | `git tag` |
+| Human authors, last 200 | 1 | 1 (162 Patrick, 38 bots) | — | `git log %an` |
+| Downloads/week | 636 | 2,316 | ×3.6 | usage-signals snapshot 07-08 |
+| Real behavioral signal | ~0 | ~0 | — | see Finding F1 |
+| User conversations (DEC-2) | 0 | **1 of 5** | +1 | [user-conversations.md](user-conversations.md) |
+
+---
+
+## Prior findings — status audit
+
+### F1 — Demand hypothesis untested *(existential)* → **FIRST SIGNAL (1 of 5)**
+
+> **Correction (2026-07-11, same day):** this section originally
+> reported zero conversations. Patrick had in fact held one on
+> 2026-07-09 — it was simply recorded nowhere in the repo, which is
+> N1's point made empirically: the repo's measurement systems see
+> commits, not calls. Now logged in
+> [user-conversations.md](user-conversations.md).
+
+One conversation held (2026-07-09). Its primary finding: **setup
+issues** — the first behavioral datum ever collected, and it
+implicates the platform's width (F4: ~402 dependency lines,
+multi-package surface) at the front door, before any pillar is
+reached. Four calls remain, with the uncaptured questions listed in
+the log. Beyond that single datum the picture stands: nothing else
+in 487 commits, `memory/`, or 5,200 new lessons lines. Worse, the downloads number now *looks* like traction —
+636/wk → 2,316/wk — and no interpretation of the surge is recorded
+anywhere in usage-signals. The surge correlates exactly with the
+release cadence (16 releases in 24 days; snapshots jump on tag
+dates: 921 on 07-03 → 1,500 on 07-04, the v9.5–9.7 window). The
+project's own D1 finding — "our CI is the biggest user" — predicts
+precisely this artifact, yet the README now carries three download
+badges. The risk has evolved from *no signal* to *self-generated
+signal mistaken for demand*.
+
+### F2 — Test suite guards the wrong thing → **PARTIAL**
+
+Real movement: test LOC down 22k, growth nearly stopped (+233
+functions vs thousands prior), and deletions came with receipts
+(`memorygraph-value-gate`). But the structure is intact: 20,393
+tests, ratio flat at 1.93:1, codecov gate still ratcheting (80%
+project / 50% patch), and the SDK 0.2 migration — the original proof
+that mocked-green ≠ working — is *still* an open spec
+(`claude-agent-sdk-0-2-migration`, created since 6/17).
+
+### F3 — Scaffolding outweighs product → **WORSE, with one honest offset**
+
+The offset first: the subsystem-value-gate is real and it worked —
+socratic (~16k LOC, #1060) and the memory-graph API (10.0.0) are
+gone, with documented verdicts. That is the pruning muscle the June
+report asked for. Everything else grew: specs 49→60 (43 spec dirs
+received new files in 24 days), lessons +56%, docs +39%, workflows
++4, scripts +12, and three new *gate* specs (`claim-drift-gates`,
+`master-factcheck-gate`, `spec-gate-real-review`) — governance built
+to govern the governance. DEC-1 (two-week freeze on new surface) was
+not adopted: 11 net-new spec directories, and 43 spec dirs received
+new files, in the 24 days after it was proposed.
+
+### F4 — Identity blurred across packages → **WORSE**
+
+June counted six packages. The root directory now also contains
+`attune-verify` (a new `packages/` stub alongside attune-author,
+-help, and -rag), `attune-healthcare-fork`,
+`attune-software`, `attune-ai-dev`, `mcp-publisher`,
+`vscode-extension`, and `website`. Nothing was consolidated
+(`attune-author-consolidation` is another open spec, not a done one).
+The platform got wider while the user count stayed unobservable.
+
+### F5 — Major-version inflation → **WORSE**
+
+Two majors in 24 days: 9.0.0 (06-26) and 10.0.0 (07-05), nine days
+apart, inside a run of 16 releases — one every 1.5 days. 10.0.0's own
+changelog admits the breaking change affected nobody ("telemetry says
+nobody did"). Breaking-change ceremony for an audience of zero is
+pure cost: it churns CI, inflates the download badge (see F1), and
+spends the credibility a real 2.0 moment would need.
+
+### F6 — CI firefighting tar-pit → **RESOLVED (genuinely)**
+
+~18% → ~4% of commits. The tar-pit trip-wire worked. This is what
+closing a finding looks like; it is cited here as the standard the
+other five are measured against.
+
+### DEC-1 … DEC-5 — **none recorded**
+
+The June file instructed: "Record the call inline with a date when
+made." Twenty-four days and 487 commits later, all five still read
+"(pending)". Not declined — *unanswered*. The repo executed the parts
+of the assessment that could become commits and silently dropped the
+parts that could only become decisions.
+
+---
+
+## New findings
+
+### N1 — The review loop doesn't close (meta, most important)
+
+This document's predecessor was high-quality, evidence-based — and
+functionally shelfware: zero decisions recorded, its existential
+finding untouched, its freeze ignored. The failure mode is specific:
+**recommendations get translated into build work** (gates, alarms,
+pruning specs — all shipped) **because build work is the comfortable
+dialect here; decisions and outreach have no pipeline to land in.**
+Prediction: absent a forcing mechanism, this assessment meets the
+same fate. The forcing mechanism must be non-repo-shaped — a calendar
+entry, an email, a call — or it will be converted into a spec.
+
+### N2 — The machine outspends its observable value ~∞
+
+`usage-signals/decisions.md` records a **$1,200/month API burn on
+CI** against a $350/month ceiling (`user_monthly_spend_budget`),
+while local (human) usage ran ~$126/month. The response was
+characteristic: a well-engineered spend *alarm* (18 tests, z-score
+anomaly detection, source-precedence design). The alarm is good
+engineering. But the finding isn't that spend was invisible — it's
+that ~$1,200/month of LLM calls validate a product with zero
+confirmed users. That's ~$14k/year buying green checkmarks. DEC-5's
+logic applies: time-box it, cap CI model spend hard, spend the
+difference on anything that touches a human.
+
+### N3 — Release cadence is manufacturing its own evidence
+
+16 releases in 24 days is a treadmill: each tag triggers CI, mirrors,
+and scanners, which inflate the download badges, which are the only
+"adoption" number on the README. The project is now measurably
+generating the metric it is in danger of believing. Freeze releases
+for two weeks and watch the download curve — that is a free,
+zero-code experiment that would settle F1's data question.
+
+### N4 — Repo-root hygiene has slipped below the project's own bar
+
+The root holds ~80 entries, including: a stray `MagicMock/` directory
+(a mock that escaped to disk — ironic given F2), `scratchpad_pushback.html`,
+six loose `test_*.py` files (tracked), untracked `build/`, `dist/`,
+`htmlcov/`, `site/`, `coverage.json`, and both `ACKNOWLEDGEMENTS.md`
+*and* `ACKNOWLEDGMENTS.md`. Also 2.4 GB across nine
+`.claude/worktrees/`. None of this is expensive individually; together
+it signals that the hygiene systems watch everything except the front
+door. An afternoon fixes it.
+
+---
+
+## Decisions to make (pending Patrick)
+
+DEC-2 through DEC-5 from June carry forward unchanged. New:
+
+- **DEC-6 — Answer DEC-1…5 in writing, this week,** even if every
+  answer is "no". An explicit "no" is a decision; silence is drift.
+  *(pending)*
+- **DEC-7 — Release freeze, 14 days.** No tags. Observe the download
+  badge. Publishes the F1/N3 experiment at zero cost. *(pending)*
+- **DEC-8 — Hard-cap CI LLM spend at $100/month.** The alarm exists;
+  add enforcement. Redirect the ~$1,100/month delta toward anything
+  user-facing. *(pending)*
+- **DEC-9 — One root-hygiene pass** (N4), time-boxed to half a day.
+  *(pending)*
+
+DEC-2 remains the only decision that matters. One of five
+conversations is done (2026-07-09, logged in
+[user-conversations.md](user-conversations.md)); its finding —
+setup friction — is already the most valuable product input of the
+quarter. Four remain. The June bar stands: if the other four users
+cannot be found, *that is the finding* — and it is worth more than
+the next 487 commits.
+
+---
+
+## Counterweight (kept honest)
+
+The pruning was real: ~30k LOC of well-tested dead weight deleted
+with documented verdicts, which most engineers never manage. F6 was
+closed properly. The consent-surface tests pin privacy promises in
+CI. Feature share of commits rose. The discipline critiqued here is
+the same discipline that, pointed at five phone calls instead of the
+next gate spec, would resolve F1 in a week.
+
+---
+
+## Related
+
+- [assessment.md](assessment.md) — the 2026-06-17 review this
+  follows up; DEC-1…5 defined there, all still pending.
+- [usage-signals](../usage-signals/) — snapshots (download surge
+  data), spend-alarm decision record ($1,200 CI burn).
+- [memorygraph-value-gate](../memorygraph-value-gate/) — receipts for
+  the 10.0.0 deletion; the pruning pattern working as designed.
+- [subsystem-value-gate](../subsystem-value-gate/) — the gate
+  process itself (BEP, hot_reload receipts).

--- a/docs/specs/product-direction-review/setup-friction-log.md
+++ b/docs/specs/product-direction-review/setup-friction-log.md
@@ -1,0 +1,131 @@
+# Setup Friction Log — Fresh-Machine Reproduction
+
+**Run:** 2026-07-11, clean Linux sandbox (Ubuntu 22.04, Python
+3.10.12), fresh venv, zero prior attune state. Agent executed the
+README exactly as a new user would. Package: attune-ai 10.3.0 from
+PyPI.
+**Context:** weekend-plan Block 1; motivated by conversation 1's
+"setup issues" signal.
+**Caveats:** non-TTY shell, so the D11 consent prompt path was not
+exercised; sandbox network is fast (home installs will be slower);
+the venv-without-pip hiccup at the start was an Ubuntu artifact, not
+attune's.
+
+---
+
+## Timeline
+
+| t | Step | Result |
+|---|------|--------|
+| 0:00 | Read README for the pip path | "Get Started in 60 Seconds" ends at `pip install attune-ai` — **no first command given** (F5) |
+| 0:01 | `pip install attune-ai` | Clean. 72 packages, ~40 s on fast network, no build errors |
+| 0:02 | Guessed `attune` (README didn't say) | **Excellent** getting-started screen, 114 ms |
+| 0:03 | `attune workflow list` | Clean, 22 workflows, 0.6 s |
+| 0:04 | `attune auth status` | Claims "Subscription Tier: PRO / Setup Completed: ✅ Yes" on a never-configured machine; silently wrote `~/.attune/auth_strategy.json` (F3) |
+| 0:05 | `attune validate` | "❌ Validation failed: No API keys found" — contradicts auth status; fix points at `python -m attune.models.auth_cli setup` (F2, F3) |
+| 0:06 | `attune workflow run code-review` | Spend gate fires first: "≈ up to $10.00" — before checking there's no key to spend with (F4) |
+| 0:07 | Same, gate authorized, still keyless | **The wall (F1):** raw 25-line traceback, `Exception: Claude Code returned an error result: success`, then a "🚀 Running workflow" banner *after* the error, then "This one didn't go as planned" with $0.0000. Cause never stated, no next step |
+| 0:08 | `python -m attune.models.auth_cli setup` | Interactive wizard starts (needs TTY). Note `attune setup` exists but does something else entirely — installs slash commands (F2) |
+
+**Time-to-first-successful-workflow (CLI path, no key, no Claude
+Code auth): not reached.** The keyless requirement is by design
+(README says so) — the friction is that nothing on the failure path
+says so.
+
+---
+
+## Ranked frictions
+
+### F1 — The first-workflow failure is a traceback, not a message *(fix first)*
+
+A keyless user's first workflow attempt ends in an unhandled
+traceback whose message is self-contradictory ("error result:
+success"), followed by a success banner, followed by a failure
+banner. The actual cause — no API key and no authenticated Claude
+Code — is never stated; no remediation is offered. This is almost
+certainly what conversation 1's user hit. (Known class: the
+`sdk-error-message-fidelity` spec — this is the highest-traffic
+instance of it.) **Fix shape:** pre-flight auth before dispatching
+the SDK; one sentence — "No API key found and Claude Code isn't
+authenticated. Run `attune auth setup`, or set
+`ANTHROPIC_API_KEY`." Suppress the traceback outside `--debug`.
+
+### F2 — Three competing "setup" surfaces
+
+`attune setup` installs slash commands; `attune auth` manages
+auth; the error text recommends `python -m attune.models.auth_cli
+setup`. A stuck user cannot tell which fixes "No API keys found."
+**Fix shape:** one canonical `attune auth setup` (alias the
+`python -m` path to it); make every error message point at that one
+string; rename or fold `attune setup`.
+
+### F3 — Fresh install misreports its own state
+
+`auth status` says "PRO / Setup Completed: Yes" before any setup;
+`validate` simultaneously fails. Contradictory diagnostics on
+minute one teach the user the tool's self-reports can't be
+trusted. **Fix shape:** defaults must render as defaults ("not
+configured — using defaults"), not as completed setup.
+
+### F4 — Spend gate fires before the no-key check
+
+A user with no key is warned about "$10.00" of spend they cannot
+incur, and the remediation offered is to *authorize spending* —
+wrong order, alarming number. **Fix shape:** check key presence
+before the spend gate; scale the estimate to the workflow.
+
+### F5 — README pip path has no first command
+
+"Get Started in 60 Seconds" ends at `pip install`. The bare
+`attune` screen is genuinely good — but users must guess to type
+it. **Fix shape:** one line in the README: "Then run `attune` to
+see your next steps." Cheapest fix in this log.
+
+---
+
+## What worked (keep)
+
+Install itself is clean and fast; no compile/dependency errors on
+3.10. The bare `attune` screen is the best onboarding surface in
+the product. `workflow list` is instant and legible. The spend gate
+existing at all is right (F4 is ordering, not existence).
+
+---
+
+## Next (maps to weekend plan)
+
+Block 2/4 fix order: F1 → F2 → F3 (F5 is a one-liner to slip in;
+F4 rides along with F1's pre-flight). Re-run this exact sequence in
+a clean container after each fix; append the new wall, if any,
+below.
+
+---
+
+## Post-fix verification — 2026-07-11 (branch `fix/setup-friction`, commit 6a628f2)
+
+Same sequence, fresh HOME + empty `ANTHROPIC_API_KEY`, worktree code
+via the documented `PYTHONPATH` pattern:
+
+| Step | Before | After |
+|------|--------|-------|
+| `auth status` (fresh) | "PRO / Setup Completed: ✅ Yes" | "PRO (default) / Not configured — using zero-config defaults (run 'attune auth setup')" |
+| `validate` (fresh, no auth) | ❌ + `python -m attune.models.auth_cli setup` | ❌ "No auth found. Log in to Claude Code … or set ANTHROPIC_API_KEY / Run: attune auth setup" |
+| `validate` (keyless, `~/.claude` present) | ❌ failed | ✅ valid, warning: subscription auth in use, API fallback unavailable |
+| `workflow run` (no auth at all) | 💸 $10 spend warning first | 🔑 one-paragraph no-auth message; spend gate never reached; exit 3 |
+| `workflow run` (CLI present, logged out) | 25-line traceback, "error result: success", dead-end "see raw stderr below" | one-line log ("re-run with --verbose for the full traceback") + "failed without producing any error output… most likely fixes" naming `claude` login / API key / `attune auth setup` |
+| README pip path | ends at `pip install` | `attune` next-step line + validate + first-workflow command |
+
+**New wall:** none of the friction class remains for a keyless user —
+the sequence now ends at an explicit instruction to acquire auth,
+which is inherent, not friction. Remaining known rough edge (minor,
+untouched): the 🚀 banner and result blocks interleave oddly when
+stdout is piped.
+
+Tests: 357 unit tests green CI-faithfully (empty key, bare HOME);
+spend-gate/dispatch fixtures updated to carry auth evidence so they
+still target the gate on keyless runners; 2 `validate` tests updated
+to the new keyless contract; +13 new tests
+(`test_workflow_auth_preflight.py`,
+`test_sdk_error_no_signal_stderr.py`). Pre-existing
+`test_token_estimator.py::TestGetEncodingPaths` failures reproduce on
+unmodified main (environmental; tiktoken download).

--- a/docs/specs/product-direction-review/user-conversations.md
+++ b/docs/specs/product-direction-review/user-conversations.md
@@ -1,0 +1,55 @@
+# User Conversations — DEC-2 Evidence Log
+
+**Bar (from [assessment.md](assessment.md)):** 5 conversations with
+humans who ran attune-ai on a real repo. Count: **1 of 5.**
+
+Record each conversation here within a day of having it. Unrecorded
+signal doesn't compound (assessment-2026-07-11, N1).
+
+---
+
+## Conversation 1 — 2026-07-09
+
+**Recorded:** 2026-07-11 (verbal report from Patrick; two-day lag).
+
+### What the user said
+
+- **Setup issues were the primary concern.** First and dominant
+  product signal. Not a pillar complaint — a front-door complaint.
+- General industry-trends discussion; shared conclusion that
+  **architectural skills are core to working with AI coding tools
+  successfully**.
+
+### Not captured (ask next time)
+
+- Which pillar(s) they actually touched, if setup let them get
+  that far.
+- What specifically broke or confused them in setup.
+- Whether they would run it again unprompted.
+- How the conversation was sourced (the repeatable part for
+  conversations 2–5).
+
+### Interpretation (agent, kept separate from the data)
+
+- One datum, but it lands squarely on the width critique (F4/June
+  F4): ~402 dependency lines, optional extras, multi-package
+  surface — the cost is paid at setup, by the first real user to
+  report anything.
+- Half the conversation was industry trends. Useful personally
+  (see action below), but the DEC-2 bar is product evidence — the
+  four questions above are the checklist for the next four calls.
+
+### Action taken by Patrick
+
+- Prioritize the Anthropic architecture course — personal skill
+  investment prompted by the shared conclusion above.
+
+---
+
+## Conversation 2 — *(open)*
+
+## Conversation 3 — *(open)*
+
+## Conversation 4 — *(open)*
+
+## Conversation 5 — *(open)*

--- a/docs/specs/product-direction-review/weekend-plan-2026-07-12.md
+++ b/docs/specs/product-direction-review/weekend-plan-2026-07-12.md
@@ -1,0 +1,104 @@
+# Weekend Plan — 10 Hours, 2026-07-12/13 (rev 2)
+
+**Derived from:** [assessment-2026-07-11.md](assessment-2026-07-11.md)
+and conversation 1's setup-friction signal.
+**Rev 2 (2026-07-11):** Patrick's constraints — setup first; no
+direct outreach (no user contact list exists). Outreach replaced
+with a zero-contact inbound channel (Block 5). No phone anywhere;
+DEC-2 "conversations" includes async text threads.
+**Rule for the weekend:** no new specs, no new gates. Every hour
+either removes friction the user hit, opens a door for users to
+report friction, or closes a decision.
+
+---
+
+## Saturday (5h) — reproduce and understand
+
+### Block 1 — Fresh-machine setup reproduction (2.5h)
+
+Be user 1. Zero prior state.
+
+- `docker run -it --rm python:3.12-slim bash` (and/or a clean
+  macOS user account).
+- Follow README top-to-bottom exactly as written — no memory
+  allowed. `pip install attune-ai`, first command, first workflow.
+- Repeat with the extras a real user plausibly picks (`[all]`).
+- Stopwatch running: log every stall, error, ambiguity, and
+  "wait, what now" with a timestamp into `setup-friction-log.md`
+  (this directory).
+- Headline number: **time-to-first-successful-workflow**.
+
+**Done when:** the log exists with a ranked top-5 friction list.
+Fix nothing yet — ranking before fixing keeps the 3h fix budget on
+the right targets.
+
+### Block 2 — Fix friction #1 (1.5h)
+
+Start the highest-ranked fix while the reproduction is fresh.
+Direct fix only — no spec, no abstraction.
+
+### Block 3 — DEC-6: answer the open decisions in writing (1h)
+
+In [assessment.md](assessment.md) and
+[assessment-2026-07-11.md](assessment-2026-07-11.md), replace every
+"(pending)" on DEC-1…5 and DEC-7…9 with a dated call. "No" is a
+valid answer; silence isn't. DEC-7 (release freeze) decides whether
+this weekend's fixes get tagged now or held.
+
+**Done when:** zero "(pending)" remain in either file.
+
+---
+
+## Sunday (5h) — fix and open the door
+
+### Block 4 — Fix frictions #2 and #3 (2.5h, hard stop)
+
+From the ranked log. Likely shapes: README quickstart that matches
+reality, clearer first-run errors, a smaller default install, one
+fewer decision before the first workflow runs. Re-run the Block 1
+container against each fix to confirm the stall is gone; append the
+new time-to-first-success to the log.
+
+### Block 5 — Zero-contact inbound channel (1h)
+
+The no-contact-list replacement for outreach. Users exist (one
+found you); give the rest a path that costs them 60 seconds:
+
+- Pin a GitHub Discussion (or issue template) titled roughly:
+  *"Did setup fight you? Tell me where — I'm fixing these this
+  month."* Three questions, plain text, no format police.
+- Link it from the README quickstart section and — highest-value
+  spot — from the CLI's first-run output and setup error paths,
+  where the frustrated user is already standing.
+- Log the channel in
+  [user-conversations.md](user-conversations.md); every substantive
+  reply counts toward the 5.
+
+**Done when:** a stranger hitting a setup error is one click from
+telling you about it.
+
+### Block 6 — Root hygiene + CI spend cap (1.5h, hard stop)
+
+- DEC-9: delete `MagicMock/`, `scratchpad_pushback.html`, stale
+  `coverage.json` / `security_scan_results.json`; gitignore
+  `build/`, `dist/`, `htmlcov/`, `site/`; move the six root
+  `test_*.py` into `tests/`; merge the two ACKNOWLEDG(E)MENTS
+  files; prune the 2.4 GB of stale worktrees.
+- DEC-8 (if yes in Block 3): confirm per-push/PR workflows carry
+  `ANTHROPIC_API_KEY: ""`; set `ATTUNE_MAX_BUDGET_USD` on the
+  scheduled keyed jobs.
+
+---
+
+## Scorecard (fill in Sunday night)
+
+| Block | Target | Actual |
+|-------|--------|--------|
+| 1 | Friction log + time-to-first-success baseline | |
+| 2+4 | Top-3 frictions fixed, time re-measured | |
+| 3 | 0 "(pending)" decisions | |
+| 5 | Inbound channel live, linked from error paths | |
+| 6 | Root clean, CI spend capped | |
+
+Success = Blocks 1–5. Block 6 is the first to drop if time runs
+out.

--- a/docs/specs/usage-signals/decisions.md
+++ b/docs/specs/usage-signals/decisions.md
@@ -519,3 +519,27 @@ counted" note so the blind spot is explicit, not silent.
 The `ts`-not-`timestamp` field discipline (the #867 bug that made Home
 read zero) is honored in `read_daily_spend()` with a `timestamp` legacy
 fallback. Remaining: Phase 2c Reach dashboard, R5 telemetry watchdog.
+
+## Signal check — 2026-07-11 (agent, Vercel runtime logs)
+
+Three weeks after D8 go-live, first read of what the ingest has
+actually received. Method: Vercel observability aggregates for the
+`website` project (no DB/secret access needed).
+
+- Last 7 days, all `/api/usage` traffic: **6 × HTTP 405** (GETs —
+  scanners/browser pokes), **zero 2xx ingests**.
+- Last 24h by request path: `/api/usage/` absent from all 260
+  distinct paths.
+- Only known rows in Neon remain the two 2026-06-20 sentinels
+  (D8/D10). Raw log-line retention is shorter than the window, but
+  the 7-day aggregate is fully silent.
+
+Reading: the pipe works; the signal is zero — D9's prediction
+("opt-in default-off transmits ~nothing") confirmed empirically.
+Corollary for the reach question: 2,316 downloads/week alongside
+zero pings is further evidence the download curve is CI shadow, not
+humans at the CLI. This system cannot answer "do users exist" on
+any useful timescale; the product-direction-review instruments
+(user conversations, inbound friction channel) are the working
+ones. No further investment here recommended until a conversation
+or inbound report proves a human population to measure.


### PR DESCRIPTION
## Summary
Three docs-only commits rescued from uncommitted WIP that had accumulated in the primary `~/attune-ai` checkout (found during a workspace-wide worktree/branch cleanup):

- **`f96c615`** — `docs/specs/usage-signals/decisions.md`: 2026-07-11 signal check confirming zero real `/api/usage` ingest traffic 3 weeks post-launch.
- **`273e940`** — `docs/specs/product-direction-review/`: the 2026-07-11 follow-up cycle (second critical assessment, the fresh-machine setup-friction log that motivated PR #1318, a DEC-2 conversations evidence log, and the weekend-plan rev 2).
- **`ef36154`** — `docs/blog/`: two drafts (the marketing-claim benchmark post, the memory-suite product-lead piece).

A separate empty spec-design stub, a zero-byte scratch file, an already-consumed PR-body doc, and a dead post-merge dispatch script were found alongside this WIP and discarded rather than committed — no content lost, confirmed each was either boilerplate or fully superseded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)