### PR TITLE
chore(release): v10.4.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "Spec-driven development for Claude Code — take an idea through requirements, design, tasks, and gated execution with an approval loop. Plus 23 auto-triggering skills: security audits, code review, test generation, release prep.",
-    "version": "10.3.0"
+    "version": "10.4.0"
   },
   "plugins": [
     {
       "name": "attune-ai",
       "description": "Spec-driven development is the core workflow: /spec carries an idea through brainstorm, requirements, design, and task execution with quality gates and your approval at each stage. Backed by 23 auto-triggering skills — security audits, code reviews, test generation, bug prediction, and release preparation. For help content tools, also install attune-help and attune-author from this marketplace.",
       "source": "./plugin",
-      "version": "10.3.0",
+      "version": "10.4.0",
       "author": {
         "name": "Smart AI Memory",
         "email": "patrick.roebuck@smartaimemory.com"

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,4 +1,4 @@
-# Attune AI Framework v10.3.0
+# Attune AI Framework v10.4.0
 
 AI-powered developer workflows with cost optimization and multi-agent orchestration.
 
@@ -148,7 +148,7 @@ attune_redis/          # attune-redis plugin (pip install attune-redis)
 
 ---
 
-**Version:** 10.3.0 | **License:** Apache 2.0 | **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)
+**Version:** 10.4.0 | **License:** Apache 2.0 | **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)
 
 ## Lessons — core
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,47 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [10.4.0] — 2026-07-12
+
+First-run setup no longer traps keyless users in a raw traceback, and
+the hook layer now runs identically on macOS, Linux, and Windows.
+
+### Fixed
+
+- **First-run setup frictions F1–F5** (#1318): a keyless user's first
+  `workflow run` attempt used to end in an unhandled traceback
+  (`Exception: Claude Code returned an error result: success`)
+  followed by a contradictory success banner. Now: auth is checked
+  before the spend gate fires, `auth status` renders zero-config
+  defaults honestly instead of claiming completed setup, `validate`
+  no longer hard-fails a keyless machine with working subscription
+  auth, and non-verbose CLI runs log a one-line error instead of a
+  25-line traceback. README's pip quickstart now says what to type
+  after install.
+- **session_savings benchmark `is_error` counting** (#1319): the
+  benchmark counted a CLI result as a valid zero-token success
+  whenever `subtype == "success"`, without checking `is_error` — a
+  10-session auth-401 run aggregated as all-zero-cost "data,"
+  silently corrupting the cost comparison. Both are now required.
+
+### Changed
+
+- **Cross-platform hook layer** (#1313): every hook script and
+  registration now runs identically on macOS, Linux, and Windows —
+  UTF-8-safe stdin/stdout handling, atomic state writes, a
+  `_bootstrap.py` path resolver replacing `PYTHONPATH` env-prefixing,
+  and shell-family-aware security validation that fails closed for
+  unknown/PowerShell contexts. New README platform-support policy
+  documents the support tiers (macOS/Linux/WSL2 full,
+  Windows+Git Bash supported, Windows+PowerShell limited).
+
+### Added
+
+- **VS Code extension scaffold** (#1313): a minimal cross-platform
+  dashboard extension reading the file-telemetry contract (no direct
+  Redis connection); feature growth goes through
+  `specs/vscode-extension/`.
+
 ## [10.3.0] — 2026-07-11
 
 Spec-integrity minor: the spec-status-integrity hook suite lands

--- a/docs/reference/API_REFERENCE.md
+++ b/docs/reference/API_REFERENCE.md
@@ -1,6 +1,6 @@
 # Attune AI API Reference
 
-**Version:** 10.3.0
+**Version:** 10.4.0
 **License:** Apache License 2.0
 **Copyright:** 2025-2026 Smart AI Memory, LLC
 
@@ -1152,5 +1152,5 @@ msg = format_error(
 
 ---
 
-**Version:** 10.3.0 | **License:** Apache 2.0
+**Version:** 10.4.0 | **License:** Apache 2.0
 **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)

--- a/plugin/.claude-plugin/marketplace.json
+++ b/plugin/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "Spec-driven development for Claude Code — /spec plans, reviews, and executes with quality gates; plus security audits, code reviews, test generation, and release prep from /attune.",
-    "version": "10.3.0"
+    "version": "10.4.0"
   },
   "plugins": [
     {
       "name": "attune-ai",
       "description": "Spec-driven development for Claude Code — /spec plans, reviews, and executes with quality gates; plus security audits, code reviews, test generation, and release prep from /attune.",
       "source": "./",
-      "version": "10.3.0",
+      "version": "10.4.0",
       "author": {
         "name": "Smart AI Memory",
         "email": "patrick.roebuck@smartaimemory.com"

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "attune-ai",
-  "version": "10.3.0",
+  "version": "10.4.0",
   "description": "Spec-driven development for Claude Code — /spec plans, reviews, and executes with quality gates; plus security audits, code reviews, test generation, and release prep from /attune.",
   "author": {
     "name": "Smart AI Memory",

--- a/plugin/core/__init__.py
+++ b/plugin/core/__init__.py
@@ -5,4 +5,4 @@ This module provides the core workflow functionality when the full
 attune-ai package is not installed via pip.
 """
 
-__version__ = "10.3.0"
+__version__ = "10.4.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "attune-ai"
-version = "10.3.0"
+version = "10.4.0"
 description = "AI-powered developer workflows for Claude with cost optimization, multi-agent orchestration, and workflow automation."
 readme = {file = "README.md", content-type = "text/markdown"}
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -253,7 +253,7 @@ wheels = [
 
 [[package]]
 name = "attune-ai"
-version = "10.3.0"
+version = "10.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "agent-memory-client" },

--- a/website/app/page.tsx
+++ b/website/app/page.tsx
@@ -58,7 +58,7 @@ export default function Home() {
             <div className="grid lg:grid-cols-2 gap-16 items-center">
               <div className="z-10">
                 <div className="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-[var(--surface-container-high)] text-[var(--primary)] text-xs font-bold tracking-widest mb-6 uppercase">
-                  <span>v10.3.0</span>
+                  <span>v10.4.0</span>
                   <span className="w-1 h-1 rounded-full bg-[var(--primary)]"></span>
                   <span className="opacity-80">Spec-driven development platform</span>
                 </div>

--- a/website/lib/features.ts
+++ b/website/lib/features.ts
@@ -32,7 +32,7 @@ export const PRODUCTS: Product[] = [
     id: "attune-ai",
     name: "Attune AI",
     pypiName: "attune-ai",
-    version: "10.3.0",
+    version: "10.4.0",
     tagline: "Generate, maintain, and serve help from your code",
     installCommand: "pip install attune-ai",
     marketplaceInstall:
@@ -101,7 +101,7 @@ export const PRODUCTS: Product[] = [
     id: "claude-code-plugin",
     name: "Claude Code Plugin",
     pypiName: "attune-ai",
-    version: "10.3.0",
+    version: "10.4.0",
     tagline: "Progressive help right in your terminal",
     installCommand:
       "claude plugin marketplace add Smart-AI-Memory/attune-ai",


### PR DESCRIPTION
## Summary
Minor release: 10.3.0 → 10.4.0. First-run setup no longer traps keyless users in a raw traceback, and the hook layer now runs identically on macOS, Linux, and Windows.

### Fixed
- First-run setup frictions F1-F5 (#1318)
- session_savings `is_error` counting (#1319)

### Changed
- Cross-platform hook layer (#1313)

### Added
- VS Code extension scaffold (#1313)

This is the "one more release" ahead of the 14-day release freeze (DEC-7, starting 2026-07-13).

🤖 Generated with [Claude Code](https://claude.com/claude-code)