### PR TITLE
feat(setup): link the zero-contact inbound channel from every setup-error path

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,6 +306,8 @@ attune            # shows your next steps
 Then check your setup with `attune validate` and run your first
 workflow: `attune workflow run code-review --path src/`.
 
+Setup fight you? [Tell me where](https://github.com/Smart-AI-Memory/attune-ai/discussions/1325) — I'm actively fixing this.
+
 The core install includes the CLI, all workflows, and the MCP
 server. See [Installation Options](#installation-options) for
 per-surface extras (API-mode agents, ops dashboard, Redis memory).

--- a/docs/specs/product-direction-review/user-conversations.md
+++ b/docs/specs/product-direction-review/user-conversations.md
@@ -6,6 +6,14 @@ humans who ran attune-ai on a real repo. Count: **1 of 5.**
 Record each conversation here within a day of having it. Unrecorded
 signal doesn't compound (assessment-2026-07-11, N1).
 
+**Inbound channel (weekend-plan Block 5, live 2026-07-12):**
+[GitHub Discussion #1325](https://github.com/Smart-AI-Memory/attune-ai/discussions/1325),
+"Did setup fight you? Tell me where." Linked from the README
+quickstart, the CLI's bare `attune` welcome screen, and all three
+setup-related error paths (no-auth preflight, `attune validate`,
+the no-signal-stderr SDK failure). Any substantive reply counts
+toward the 5.
+
 ---
 
 ## Conversation 1 — 2026-07-09

--- a/src/attune/cli_commands/utility_commands.py
+++ b/src/attune/cli_commands/utility_commands.py
@@ -230,7 +230,9 @@ def cmd_validate(args: Namespace) -> int:
             errors.append(
                 "No auth found. Log in to Claude Code (run `claude` once) "
                 "or set ANTHROPIC_API_KEY\n"
-                "   Run: attune auth setup",
+                "   Run: attune auth setup\n"
+                "   Setup fight you? https://github.com/Smart-AI-Memory/"
+                "attune-ai/discussions/1325",
             )
 
     # Check workflows

--- a/src/attune/cli_commands/workflow_commands.py
+++ b/src/attune/cli_commands/workflow_commands.py
@@ -246,7 +246,9 @@ def _auth_preflight() -> str | None:
         "(npm install -g @anthropic-ai/claude-code), run `claude` "
         "once to log in, then re-run this workflow.\n"
         "   - API key: export ANTHROPIC_API_KEY=... and re-run.\n"
-        "   For guided configuration: attune auth setup"
+        "   For guided configuration: attune auth setup\n"
+        "   Setup fight you? https://github.com/Smart-AI-Memory/"
+        "attune-ai/discussions/1325"
     )
 
 

--- a/src/attune/cli_minimal.py
+++ b/src/attune/cli_minimal.py
@@ -681,7 +681,8 @@ For interactive development in Claude Code:
   /testing      Run tests, coverage, generate tests
   /wizard run   Guided multi-step wizards
 
-More: attune --help | Docs: https://smartaimemory.com/framework-docs/"""
+More: attune --help | Docs: https://smartaimemory.com/framework-docs/
+Setup fight you? https://github.com/Smart-AI-Memory/attune-ai/discussions/1325"""
     )
     return 0
 

--- a/src/attune/workflows/agent_sdk_adapter.py
+++ b/src/attune/workflows/agent_sdk_adapter.py
@@ -750,7 +750,9 @@ class SdkSubprocessError(Exception):
                     "  - Log in to Claude Code: run `claude` once "
                     "interactively, or\n"
                     "  - Set an API key: export ANTHROPIC_API_KEY=..., or\n"
-                    "  - Run `attune auth setup` for guided configuration."
+                    "  - Run `attune auth setup` for guided configuration.\n\n"
+                    "Still stuck? https://github.com/Smart-AI-Memory/"
+                    "attune-ai/discussions/1325"
                 )
             return (
                 f"{self.message}\n\n"


### PR DESCRIPTION
## Summary
Weekend-plan Block 5 (zero-contact inbound channel — no user contact list exists, so this replaces direct outreach).

Links [Discussion #1325](https://github.com/Smart-AI-Memory/attune-ai/discussions/1325) ("Did setup fight you? Tell me where.") from every place a frustrated setup-time user is already standing:

- README quickstart, right after the first-workflow command
- the bare `attune` welcome screen
- the no-auth preflight message (workflow_commands.py)
- `attune validate`'s no-auth error (utility_commands.py)
- the no-signal-stderr SDK failure message (agent_sdk_adapter.py) — the highest-value spot per the plan

Logged the channel in `user-conversations.md`; any substantive reply counts toward DEC-2's 5-conversation bar (1/5 so far).

## Test plan
- [x] 141 tests passed across all touched-message test files (substring assertions, unaffected by the addition)
- [x] pre-commit clean (black/ruff/bandit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)