### PR TITLE
docs(usage-signals): reach snapshot 2026-07-12 — v10.4.0 release baseline

### DIFF
--- a/docs/specs/usage-signals/snapshots/2026-07-12.json
+++ b/docs/specs/usage-signals/snapshots/2026-07-12.json
@@ -1,0 +1,27 @@
+{
+  "date": "2026-07-12",
+  "github": {},
+  "pypi_recent": {
+    "attune-ai": {
+      "last_day": 161,
+      "last_month": 5501,
+      "last_week": 2063
+    },
+    "attune-author": {
+      "last_day": 111,
+      "last_month": 2380,
+      "last_week": 547
+    },
+    "attune-help": {
+      "last_day": 315,
+      "last_month": 854,
+      "last_week": 688
+    },
+    "attune-rag": {
+      "last_day": 631,
+      "last_month": 27410,
+      "last_week": 2927
+    }
+  },
+  "taken_at": "2026-07-12T03:31:42.267868+00:00"
+}


### PR DESCRIPTION
Release-time reach snapshot (4/5 packages; attune-verify hit a pypistats 429 cooldown per the script's own guidance). This is the before-baseline for both v10.4.0 and the DEC-7 14-day release freeze starting 2026-07-13 — the download-badge/CI-shadow question (F1/N3) gets a real observation window now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)