### PR TITLE
feat(ci): DEC-8 enforcement — hard-cap CI LLM spend at $350/month

### DIFF
--- a/.github/workflows/help-freshness.yml
+++ b/.github/workflows/help-freshness.yml
@@ -74,6 +74,17 @@ jobs:
             echo "workflow with regen=true."
           } >> "$GITHUB_STEP_SUMMARY"
 
+      - name: DEC-8 spend gate — block if over the monthly ceiling
+        # Enforcement half of the R6 spend alarm (see
+        # scripts/ci_spend_gate.py). Only runs when we're about to
+        # actually spend (regen=true + stale features exist). Needs
+        # ANTHROPIC_ADMIN_API_KEY to verify spend; without it, fails
+        # open with a loud warning rather than blocking the regen.
+        if: steps.list_stale.outputs.count != '0' && github.event.inputs.regen == 'true'
+        env:
+          ANTHROPIC_ADMIN_API_KEY: ${{ secrets.ANTHROPIC_ADMIN_API_KEY }}
+        run: python scripts/ci_spend_gate.py
+
       - name: Regenerate stale features
         if: steps.list_stale.outputs.count != '0' && github.event.inputs.regen == 'true'
         env:

--- a/.github/workflows/integration-auth.yml
+++ b/.github/workflows/integration-auth.yml
@@ -55,6 +55,15 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e .[dev]
 
+      - name: DEC-8 spend gate — block if over the monthly ceiling
+        # Enforcement half of the R6 spend alarm (see
+        # scripts/ci_spend_gate.py). Needs ANTHROPIC_ADMIN_API_KEY to
+        # verify spend; without it, fails open with a loud warning
+        # rather than blocking every keyed run.
+        env:
+          ANTHROPIC_ADMIN_API_KEY: ${{ secrets.ANTHROPIC_ADMIN_API_KEY }}
+        run: python scripts/ci_spend_gate.py
+
       - name: Run auth integration bucket (real API)
         # -m "" / -o addopts="" override the repo defaults
         # (`-m "not integration"` and `-n auto`). Real-API workflow

--- a/scripts/ci_spend_gate.py
+++ b/scripts/ci_spend_gate.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""DEC-8 enforcement: block a CI job when month-to-date API spend is over budget.
+
+The R6 spend alarm (``attune.ops.data.spend_alarm``) surfaces overspend on
+the ops dashboard — visibility only, no matter how loud the alarm, nothing
+stops the next keyed workflow run from adding to the bill. This script is
+the enforcement half: a pre-flight step for CI jobs that use a real
+``ANTHROPIC_API_KEY`` (``integration-auth.yml``, ``help-freshness.yml``,
+``windows-payload-capture.yml``). Run it before the keyed step; a nonzero
+exit fails the job before any real API call happens.
+
+Requires the ``ANTHROPIC_ADMIN_API_KEY`` secret (org-wide cost-report
+read access — distinct from the workspace-scoped ``ANTHROPIC_API_KEY``
+used to actually run workflows). Without it, this script cannot see
+account-level spend and deliberately does not block: failing closed on
+missing configuration would silently break every keyed workflow the day
+this lands, before anyone wires up the new secret. The same reasoning
+covers transient fetch errors (rate limit, network) — CI flakiness in the
+cost-report call is not a reason to lose a real workflow run. Both cases
+print a loud warning and exit 0.
+
+The only case that blocks is a *confirmed* month-to-date figure at or
+over the ceiling. That matches DEC-8 (“hard-cap CI LLM spend”,
+docs/specs/product-direction-review/assessment-2026-07-11.md) and defers
+to the account-level ceiling already named in
+`user_monthly_spend_budget` and `attune.ops.data.MONTHLY_API_CEILING_USD`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+from attune.ops.anthropic_cost import fetch_summary
+from attune.ops.data import MONTHLY_API_CEILING_USD
+
+
+def check_budget(ceiling: float) -> int:
+    """Return the process exit code for the spend-gate check.
+
+    0: under the ceiling, or the ceiling couldn't be verified (fail-open,
+       with a loud warning — see the module docstring for why).
+    1: month-to-date spend is confirmed at or over the ceiling.
+    """
+    summary, error = fetch_summary(refresh=True)
+
+    if error is not None:
+        print(
+            f"::warning::ci_spend_gate: could not verify CI spend "
+            f"({error.kind}: {error.message}). Proceeding without "
+            f"enforcement — see scripts/ci_spend_gate.py for why this "
+            f"fails open rather than blocking the job."
+        )
+        return 0
+
+    assert summary is not None  # exactly one of summary/error is set
+    if summary.month_to_date_usd >= ceiling:
+        print(
+            f"::error::ci_spend_gate: month-to-date API spend "
+            f"${summary.month_to_date_usd:.2f} is at or over the "
+            f"${ceiling:.2f} ceiling (DEC-8). Blocking this job before "
+            f"it makes any real API calls."
+        )
+        return 1
+
+    print(
+        f"ci_spend_gate: month-to-date spend ${summary.month_to_date_usd:.2f} "
+        f"is under the ${ceiling:.2f} ceiling — proceeding."
+    )
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--ceiling",
+        type=float,
+        default=MONTHLY_API_CEILING_USD,
+        help=f"Monthly USD ceiling (default: ${MONTHLY_API_CEILING_USD:.2f}).",
+    )
+    args = parser.parse_args(argv)
+    return check_budget(args.ceiling)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/scripts/test_ci_spend_gate.py
+++ b/tests/scripts/test_ci_spend_gate.py
@@ -1,0 +1,105 @@
+"""Tests for ``scripts/ci_spend_gate.py`` — DEC-8 CI spend enforcement.
+
+Loaded via importlib.util because ``scripts/`` is not a Python package —
+matches the repo convention used in ``tests/unit/github_scripts/
+test_analyze_security_results.py``.
+
+Mock-only per testing-conventions.md: never hits the real Anthropic
+admin cost-report API. ``attune.ops.anthropic_cost.fetch_summary`` is
+patched at its import site inside the loaded module (``ci_spend_gate``
+does ``from attune.ops.anthropic_cost import fetch_summary``, so the
+patch target is the module's own bound name, not the origin module —
+patching the origin would miss this bound reference).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from attune.ops.anthropic_cost import CostFetchError, CostSummary
+from attune.ops.data import MONTHLY_API_CEILING_USD
+
+SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "ci_spend_gate.py"
+
+
+@pytest.fixture
+def gate():
+    spec = importlib.util.spec_from_file_location("_ci_spend_gate", SCRIPT)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["_ci_spend_gate"] = mod
+    spec.loader.exec_module(mod)
+    yield mod
+    sys.modules.pop("_ci_spend_gate", None)
+
+
+def _summary(month_to_date_usd: float) -> CostSummary:
+    return CostSummary(
+        today_usd=0.0,
+        seven_day_usd=0.0,
+        month_to_date_usd=month_to_date_usd,
+        thirty_day_usd=0.0,
+        by_day=[],
+        by_model=[],
+        by_cost_type=[],
+        fetched_at=datetime.now(timezone.utc),
+        source="live",
+    )
+
+
+class TestCheckBudget:
+    """check_budget's three outcomes: under, over, unverifiable."""
+
+    def test_under_ceiling_passes(self, gate) -> None:
+        with patch.object(gate, "fetch_summary", return_value=(_summary(100.0), None)):
+            assert gate.check_budget(ceiling=350.0) == 0
+
+    def test_exactly_at_ceiling_blocks(self, gate) -> None:
+        # The alarm uses >= for its ceiling trigger; the gate matches.
+        with patch.object(gate, "fetch_summary", return_value=(_summary(350.0), None)):
+            assert gate.check_budget(ceiling=350.0) == 1
+
+    def test_over_ceiling_blocks(self, gate) -> None:
+        with patch.object(gate, "fetch_summary", return_value=(_summary(1700.0), None)):
+            assert gate.check_budget(ceiling=350.0) == 1
+
+    def test_no_admin_key_fails_open(self, gate) -> None:
+        # Missing ANTHROPIC_ADMIN_API_KEY must never block a keyed
+        # workflow before the secret exists — see the module docstring.
+        error = CostFetchError(kind="no_key", message="No Anthropic admin key configured.")
+        with patch.object(gate, "fetch_summary", return_value=(None, error)):
+            assert gate.check_budget(ceiling=350.0) == 0
+
+    def test_transient_fetch_error_fails_open(self, gate) -> None:
+        error = CostFetchError(kind="rate_limited", message="429 from Anthropic")
+        with patch.object(gate, "fetch_summary", return_value=(None, error)):
+            assert gate.check_budget(ceiling=350.0) == 0
+
+    def test_custom_ceiling_respected(self, gate) -> None:
+        with patch.object(gate, "fetch_summary", return_value=(_summary(50.0), None)):
+            assert gate.check_budget(ceiling=20.0) == 1
+            assert gate.check_budget(ceiling=100.0) == 0
+
+
+class TestMainCLI:
+    """argparse wiring: default ceiling, --ceiling override, exit code passthrough."""
+
+    def test_main_uses_default_ceiling(self, gate) -> None:
+        with patch.object(
+            gate,
+            "fetch_summary",
+            return_value=(_summary(MONTHLY_API_CEILING_USD + 1), None),
+        ) as mock_fetch:
+            assert gate.main([]) == 1
+        mock_fetch.assert_called_once_with(refresh=True)
+
+    def test_main_ceiling_override(self, gate) -> None:
+        with patch.object(gate, "fetch_summary", return_value=(_summary(5.0), None)):
+            assert gate.main(["--ceiling", "1"]) == 1
+            assert gate.main(["--ceiling", "10"]) == 0


### PR DESCRIPTION
## Summary
The R6 spend alarm (`attune.ops.data.spend_alarm`) is visibility-only — it surfaces overspend on the ops dashboard, but nothing stops the next keyed CI run from adding to the bill. This adds the enforcement half decided at DEC-8.

- `scripts/ci_spend_gate.py`: a pre-flight CLI wired into keyed CI workflows. Fetches month-to-date spend via the existing account-level admin cost-report reader and blocks (nonzero exit) only on a **confirmed** figure at or over the $350 ceiling. Missing `ANTHROPIC_ADMIN_API_KEY` or a transient fetch error fails **open** with a loud warning — the secret doesn't exist yet, so failing closed on missing config would immediately break every keyed workflow.
- Wired into `integration-auth.yml` and `help-freshness.yml` (only when actually about to spend).
- **Deliberately not** wired into `windows-payload-capture.yml` — see commit message for why (no Python install, manual-only, already triple-capped at well under $0.25/dispatch).

## ⚠️ Action needed for this to actually enforce anything
Add an `ANTHROPIC_ADMIN_API_KEY` secret to the repo (org-wide cost-report read access — separate from the workspace-scoped `ANTHROPIC_API_KEY` used to run workflows). Without it, the gate fails open every time (by design) and provides no protection — it's a no-op until that secret exists. This is a GitHub repo settings action only you can take.

**Also recommended, not built here:** a provider-side spend limit on the Anthropic Console for the CI-facing API key(s), as defense in depth — this gate can't protect against a bug in itself or in how it's wired into future workflows, but an account-level hard cutoff can't be bypassed by CI code at all.

## Test plan
- [x] `tests/scripts/test_ci_spend_gate.py` — 8 tests, 100% coverage (under/at/over ceiling, no-key and transient-error fail-open paths, custom ceiling override, CLI wiring)
- [x] Both modified workflow YAML files validated
- [x] pre-commit clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)