### PR TITLE
fix(website): attune-help version drift — 0.12.0 → 0.13.0

### DIFF
--- a/website/lib/features.ts
+++ b/website/lib/features.ts
@@ -54,7 +54,7 @@ export const PRODUCTS: Product[] = [
     id: "attune-help",
     name: "Attune Help",
     pypiName: "attune-help",
-    version: "0.12.0",
+    version: "0.13.0",
     tagline: "Lightweight reader for help templates",
     installCommand: "pip install attune-help",
     marketplaceInstall:


### PR DESCRIPTION
## Summary
`website/lib/features.ts` hardcodes each product's published version; `attune-help`'s entry was never bumped after 0.13.0 shipped on PyPI. Flagged by the (non-required) website-accuracy check during tonight's v10.4.0 release PR.

## Test plan
- [x] `scripts/audit_website_versions.py` now reports all four products in sync with PyPI (previously flagged attune-help's drift)
- [x] The `version` field turns out not to be rendered anywhere in the UI — it's audit-only metadata, so there's no visual change to verify

🤖 Generated with [Claude Code](https://claude.com/claude-code)