### PR TITLE
docs: fix marketing claims not grounded in current fact

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ production codebase. Four definitions, for the systems-minded:
    Protocol server that turns Claude Code into a managed multi-agent
    platform. Instead of one monolithic prompt, it dispatches 2–6
    domain-specific subagents in parallel — code readers, validators,
-   test designers, refactor planners — across 22 workflows
-   (19 multi-stage) and 47 MCP tools, and an orchestrator synthesizes
+   test designers, refactor planners — across 20 workflows
+   and 47 MCP tools, and an orchestrator synthesizes
    their findings into one result.
 3. **A Socratic quality-gate engine.** Multi-stage workflows ask
    before they act: the `/spec` flow brainstorms, plans, then executes
@@ -51,14 +51,15 @@ production codebase. Four definitions, for the systems-minded:
    not a byproduct. Through decoupled modules (`attune-author`,
    `attune-rag`, `attune-help`), a citation-per-claim retrieval
    contract keeps mean per-claim faithfulness CI-gated at ≥ 0.97
-   (0.996 measured on the benchmark set) — grounding that both
-   engineers and agents use to verify implementation dependencies.
+   (0.98 currently measured, N=20 runs on the 40-query golden set) —
+   grounding that both engineers and agents use to verify
+   implementation dependencies.
 
 In short: the infrastructure to move AI from conversational
 autocomplete to a grounded, multi-agent software-engineering utility.
 The same system doubles as an authoring-and-assistance toolkit for
 knowledge bases at scale — and we run our own on it: the docs, help
-templates, and 380+ engineering lessons at
+templates, and 800+ engineering lessons at
 [attune-ai.dev](https://attune-ai.dev) are authored, grounded, and
 maintained entirely by Attune's own stack.
 
@@ -123,11 +124,13 @@ releases (curated promotion in 9.5, files-canonical unification in
 Memory is local-first — nothing leaves your machine, and without a
 Redis server everything degrades to the file backend with clear
 guidance. Your memory, your corpus: we dogfood the loop on our own
-380+ engineering lessons, retrieved via attune-rag at **P@3 96%**
+800+ engineering lessons, retrieved via attune-rag at **P@3 96%**
 (100% on the high-severity subset) on a frozen trap-moment benchmark.
 
-**The economics, measured.** Durable memory here is 303,205 tokens
-across 752 docs; a session recalls only the relevant slice:
+**The economics, measured (2026-07-05 snapshot; corpus has grown
+since — the ratios below only improve as it does).** Durable memory
+was 303,205 tokens across 752 docs at measurement time; a session
+recalls only the relevant slice:
 
 | Memory-suite recall | Instead of loading | You load | Win |
 |---|--:|--:|--:|
@@ -238,15 +241,17 @@ vocab (`y` / `go` / `1`) answers any of them.
 ### 4. RAG-grounded generation
 
 `attune-rag` (core dep) grounds LLM generation in retrieved corpus
-passages and enforces citation-per-claim, delivering **0.996 mean
-per-claim faithfulness on the benchmark set — over 99% of generated
-claims are grounded in their cited passages (under 1% hallucinated
-per claim)**. The conservative per-query bucket rate (a single
-ungrounded claim disqualifies the whole response) is 6.7%, down from
-46.7% without the citation contract. Retrieved passages are wrapped
-in sentinel tags to prevent prompt injection. The Claude provider
-automatically caches the stable RAG context prefix, eliminating
-repeated token costs across calls.
+passages and enforces citation-per-claim, delivering **0.98 mean
+per-claim faithfulness on the current CI-gated benchmark** (40
+queries, N=20 runs, floor ≥0.97) — the large majority of generated
+claims are grounded in their cited passages. The citation-per-claim
+design itself was chosen via an A/B comparison (2026-04-19): the
+conservative per-query bucket rate (a single ungrounded claim
+disqualifies the whole response) dropped from 46.7% without the
+contract to 6.7% with it. Retrieved passages are wrapped in sentinel
+tags to prevent prompt injection. The Claude provider automatically
+caches the stable RAG context prefix, eliminating repeated token
+costs across calls.
 
 ### 5. Memory that compounds across sessions
 

--- a/docs/specs/claim-drift-gates/decisions.md
+++ b/docs/specs/claim-drift-gates/decisions.md
@@ -76,25 +76,30 @@ every claim surface.
   a CI job, not a checker — and stages advisory→required over two
   weeks per the ci-matrix-right-sizing precedent.
 
-## Open decisions
+## Resolved decisions (continued)
 
-- **D4 — what README claims about workflow count/stages. OPEN —
-  needs Patrick.** The registry has 22 slugs over 20 distinct
-  classes (`release-prep`/`release-gate`,
-  `health-check`/`orchestrated-health-check` are deliberate alias
-  pairs); only ~3 workflows declare multiple `stages`
-  (documentation-orchestrator 4, help-maintenance 5, rag-code-gen 2).
-  Options:
-  (a) claim **"20 workflows"** (distinct classes) and drop the
-      multi-stage claim entirely — cleanest, slightly undersells;
-  (b) claim **"22 workflow commands"** (slugs) — defensible wording,
-      G1 binds to the slug count;
-  (c) keep "multi-stage" but redefine it against internal agent-team
-      steps and expose that number from the registry so G1 can bind
-      it — most work, preserves the marketing point honestly.
-  Recommendation: (a) or (b); (c) only if the multi-stage framing
-  matters for positioning. G1 ships with the claim manifest bound to
-  whichever is ratified.
+- **D4 — what README claims about workflow count/stages. RATIFIED
+  (2026-07-12), option (a).** Claim **"20 workflows"** (distinct
+  classes) and drop the multi-stage claim entirely.
+  `CAPABILITIES.workflows` in `website/lib/features.ts` now derives
+  from `len(set(discover_workflows().values()))` (20), not
+  `list_workflows()` filtered on a truthy `stages` field (19) — that
+  prior derivation counted nearly every workflow, since almost all of
+  them set *some* `stages` value; only 3
+  (`documentation-orchestrator` 4, `rag-code-gen` 2,
+  `release-prep`/`release-gate` 4 as one alias pair) actually declare
+  *multiple* stages, so "multi-stage" overclaimed what the number
+  measured. Surfaced during a marketing-accuracy review
+  (2026-07-12), independent of the four-pass external review that
+  opened this spec. Fixed alongside: README's "22 workflows (19
+  multi-stage)" → "20 workflows"; the two website copy sites
+  (RELIABILITY_LOOP stage 03, the "workflows" PILLARS entry) that
+  repeated "19 multi-stage workflows"; and
+  `test_workflows_count_matches_registry` in
+  `tests/unit/test_website_version_accuracy.py`, which now asserts
+  against the distinct-class count.
+
+## Open decisions
 
 - **D7 — G1/G2/G3 in pre-commit as well as CI? OPEN.** They need an
   importable `attune`, which pre-commit's isolated env doesn't

--- a/docs/specs/claim-drift-gates/requirements.md
+++ b/docs/specs/claim-drift-gates/requirements.md
@@ -1,6 +1,6 @@
 # Spec: Claim-drift gates
 
-**Status:** approved (2026-07-11) — see `decisions.md`; D4 (workflow-count wording), D7, D8 remain open; G1's claim manifest blocked on D4
+**Status:** approved (2026-07-11) — see `decisions.md`; D4 ratified 2026-07-12 (option a, "20 workflows"); D7, D8 remain open; G1's claim manifest is now unblocked
 **Opened:** 2026-07-11
 **Layer:** attune-ai (tests / pre-commit / docs / plugin metadata)
 **Owner:** Patrick + agent

--- a/tests/unit/test_website_version_accuracy.py
+++ b/tests/unit/test_website_version_accuracy.py
@@ -23,7 +23,11 @@ Three layers:
 3. **Deterministic count sync, network-free** — every field of
    ``features.ts`` ``CAPABILITIES`` MUST equal the live Python registry
    it claims to mirror (skills → ``plugin/skills/`` dirs; workflows →
-   multi-stage ``list_workflows()``; wizards → ``list_wizards()``;
+   distinct classes in ``discover_workflows()`` (D4, claim-drift-gates:
+   the prior "multi-stage" framing counted any workflow with a
+   ``stages`` field set, which is nearly all of them — only 3 actually
+   declare multiple stages, so the count is now the honest distinct-
+   workflow-class total instead); wizards → ``list_wizards()``;
    mcpTools → ``tool_schemas`` ``get_*_tools()`` total; templateKinds →
    ``attune_author.generator._ALL_TEMPLATE_NAMES``). This closes the
    blind spot that let the website advertise 17 skills while the plugin
@@ -203,12 +207,14 @@ class TestCapabilityCountsSync:
         )
 
     def test_workflows_count_matches_registry(self):
-        from attune.workflows import list_workflows
+        from attune.workflows import discover_workflows
 
-        live = sum(1 for w in list_workflows() if w.get("stages"))
+        live = len(set(discover_workflows().values()))
         assert _capabilities()["workflows"] == live, (
-            f"CAPABILITIES.workflows != live multi-stage workflow count ({live}) — "
-            "update website/lib/features.ts"
+            f"CAPABILITIES.workflows != live distinct workflow-class count "
+            f"({live}) — update website/lib/features.ts. (D4, "
+            f"claim-drift-gates: this counts distinct classes, not slugs — "
+            f"release-prep/release-gate are a deliberate alias pair.)"
         )
 
     def test_wizards_count_matches_registry(self):

--- a/website/app/docs/page.tsx
+++ b/website/app/docs/page.tsx
@@ -15,7 +15,7 @@ const faqItems = [
   {
     question: 'What is attune-ai?',
     answer:
-      'A spec-driven development platform that turns requirements into reliable software. It combines four pillars — AI workflows, project memory, retrieval grounding, and verification — into one reliability loop: specify with /spec, ground every change in your real code, build with multi-stage workflows, remember what worked across sessions, and verify the output before it ships.',
+      'A spec-driven development platform that turns requirements into reliable software. It combines four pillars — AI workflows, project memory, retrieval grounding, and verification — into one reliability loop: specify with /spec, ground every change in your real code, build with a team of workflows, remember what worked across sessions, and verify the output before it ships.',
   },
   {
     question: 'How does it keep generated content from drifting?',
@@ -177,7 +177,7 @@ export default function DocsPage() {
                   <p className="text-sm text-[var(--text-secondary)] mb-5 flex-1">
                     The whole platform: spec engine, AI workflows, project
                     memory, retrieval grounding, and verification.
-                    19 multi-stage workflows, 24 skills, 47 MCP tools.
+                    20 workflows, 24 skills, 47 MCP tools.
                   </p>
                   <div className="bg-[#213145] text-white/90 rounded-xl font-mono text-xs p-3">
                     <span className="text-white/50">$ </span>pip install attune-ai
@@ -572,8 +572,8 @@ export default function DocsPage() {
                 Workflows &amp; Skills
               </h2>
               <p className="text-center text-[var(--text-secondary)] mb-12 max-w-2xl mx-auto">
-                The build half of the loop: 19 multi-stage workflows
-                (22 workflows total), 24 auto-triggering Claude Code skills,
+                The build half of the loop: 20 workflows,
+                24 auto-triggering Claude Code skills,
                 and an MCP server with 47 registered tools — review, tests,
                 bug prediction, refactor, and release prep.
               </p>

--- a/website/app/faq/page.tsx
+++ b/website/app/faq/page.tsx
@@ -26,15 +26,15 @@ const faqData: FAQCategory[] = [
       },
       {
         question: 'What is the reliability loop?',
-        answer: 'The reliability loop is the arc Attune AI takes a requirement through on its way to shipped software: Specify, Ground, Build, Remember, Verify. You write a spec, ground every change in your real code, build with multi-stage workflows, carry what worked into the next session, and verify the output before it ships.',
+        answer: 'The reliability loop is the arc Attune AI takes a requirement through on its way to shipped software: Specify, Ground, Build, Remember, Verify. You write a spec, ground every change in your real code, build with a team of workflows, carry what worked into the next session, and verify the output before it ships.',
       },
       {
         question: 'What are the four pillars?',
-        answer: 'Attune AI is built on four pillars, each a real, shipped capability: AI workflows (19 multi-stage workflows for review, tests, bug prediction, and refactors), Project memory (cross-session findings and a retrievable lessons corpus), Retrieval grounding (citations back to your source via attune-rag), and Verification (fact-checking generated content before it reaches main).',
+        answer: 'Attune AI is built on four pillars, each a real, shipped capability: AI workflows (20 workflows for review, tests, bug prediction, and refactors), Project memory (cross-session findings and a retrievable lessons corpus), Retrieval grounding (citations back to your source via attune-rag), and Verification (fact-checking generated content before it reaches main).',
       },
       {
         question: 'What can Attune AI do, in numbers?',
-        answer: 'Attune AI ships 22 workflows (19 multi-stage), 47 MCP tools, 24 auto-triggering skills, 5 wizards, and 15 template kinds. The spec engine runs via /spec, progressive help via /coach, and cross-session recall via /recall.',
+        answer: 'Attune AI ships 20 workflows, 47 MCP tools, 24 auto-triggering skills, 5 wizards, and 15 template kinds. The spec engine runs via /spec, progressive help via /coach, and cross-session recall via /recall.',
       },
       {
         question: "What's the difference between attune-ai and attune-gui?",
@@ -132,7 +132,7 @@ const faqData: FAQCategory[] = [
     questions: [
       {
         question: 'What can I build with Attune AI?',
-        answer: 'You take requirements through to reliable software: write a spec with /spec, ground changes in your real code, run multi-stage workflows for code review, security scanning, test generation, bug prediction, and refactor planning, then verify the output before it ships. The lessons corpus and cross-session memory carry what worked into the next session.',
+        answer: 'You take requirements through to reliable software: write a spec with /spec, ground changes in your real code, run workflows for code review, security scanning, test generation, bug prediction, and refactor planning, then verify the output before it ships. The lessons corpus and cross-session memory carry what worked into the next session.',
       },
       {
         question: 'How does the spec engine work?',

--- a/website/app/page.tsx
+++ b/website/app/page.tsx
@@ -242,7 +242,7 @@ export default function Home() {
             <div className="grid grid-cols-2 md:grid-cols-5 gap-8 text-center">
               <div>
                 <div className="text-4xl font-extrabold text-[var(--primary)]">{CAPABILITIES.workflows}</div>
-                <div className="text-sm text-[var(--text-muted)] mt-1">multi-stage workflows</div>
+                <div className="text-sm text-[var(--text-muted)] mt-1">workflows</div>
               </div>
               <div>
                 <div className="text-4xl font-extrabold text-[var(--primary)]">{CAPABILITIES.mcpTools}</div>

--- a/website/app/pricing/page.tsx
+++ b/website/app/pricing/page.tsx
@@ -25,7 +25,7 @@ const PILLAR_COLOR: Record<string, { bg: string; text: string }> = {
 };
 
 const includedItems = [
-  `${CAPABILITIES.workflows} multi-stage AI workflows`,
+  `${CAPABILITIES.workflows} AI workflows`,
   `MCP server with ${CAPABILITIES.mcpTools} registered tools`,
   `${CAPABILITIES.skills} auto-triggering Claude Code skills`,
   'Spec-driven workflow with an approval gate (/spec)',

--- a/website/lib/features.ts
+++ b/website/lib/features.ts
@@ -248,10 +248,16 @@ export const DIFFERENTIATORS: Differentiator[] = [
 /**
  * Counts that appear in prose and stat callouts across the
  * site. Verified against the live Python code per the
- * website-content-accuracy rule (last verified 2026-06-28,
- * attune-ai 9.2.0):
+ * website-content-accuracy rule (last verified 2026-07-12,
+ * attune-ai 10.4.0):
  *
- *   workflows: attune.workflows.list_workflows() with stages
+ *   workflows: distinct classes in attune.workflows.discover_workflows()
+ *     (D4, claim-drift-gates, 2026-07-12: the prior count used
+ *     list_workflows() filtered on a truthy `stages` field, which is
+ *     set on nearly every workflow — only 3 actually declare more than
+ *     one stage. "Multi-stage workflows" overclaimed what the number
+ *     measured; this is the honest distinct-workflow-class total.
+ *     release-prep/release-gate count once — deliberate alias pair.)
  *   skills: plugin/skills/ directory count (test_skill_count)
  *   mcpTools: attune.mcp.tool_schemas get_*_tools() total
  *   templateKinds: attune_author.generator._ALL_TEMPLATE_NAMES length
@@ -262,7 +268,7 @@ export const DIFFERENTIATORS: Differentiator[] = [
  * and no page consumed them.)
  */
 export const CAPABILITIES = {
-  workflows: 19,
+  workflows: 20,
   skills: 24,
   mcpTools: 47,
   templateKinds: 15,
@@ -305,7 +311,7 @@ export const RELIABILITY_LOOP: LoopStage[] = [
     n: "03",
     name: "Build",
     description:
-      "19 multi-stage workflows: review, tests, bug prediction, refactor.",
+      "20 workflows: review, tests, bug prediction, refactor.",
   },
   {
     n: "04",
@@ -363,7 +369,7 @@ export const PILLARS: Pillar[] = [
     tag: "AI workflows",
     title: "Specialist teams, not one prompt",
     description:
-      "19 multi-stage workflows run teams of 2–6 Claude subagents to " +
+      "20 workflows run teams of 2–6 Claude subagents to " +
       "review code, surface vulnerabilities, generate tests, and plan " +
       "refactors — with cost-tiered model routing.",
     points: [


### PR DESCRIPTION
## Summary
Four findings from a marketing-accuracy review, all verified against real receipts before editing:

1. **D4 (claim-drift-gates, ratified option a)** — "22 workflows (19 multi-stage)" overclaimed. "19" counted any workflow with a truthy `stages` field (nearly all of them); only 3 actually declare *multiple* stages. Now "20 workflows" (distinct classes) everywhere, multi-stage framing dropped — README, 4 website pages, `CAPABILITIES.workflows`, and its backing test.
2. **"0.996... CI-gated at ≥0.97"** conflated a one-time April 19 A/B design-justification experiment (15 queries) with the ongoing CI gate. The real live gate (measured 2026-05-20, N=20 runs, 40-query set) shows mean 0.9801 / threshold 0.9698. README now cites the current gate and separately, correctly dates the historical A/B finding.
3. **Memory-economics table** was a real 2026-07-05 measurement, now dated as such — the live lessons corpus has grown to 857 entries (~47%+ growth since the cited snapshot).
4. **"380+ engineering lessons"** bumped to "800+" (857 actual), same round-floor convention as the tests badge.

## Test plan
- [x] `tests/unit/test_website_version_accuracy.py` — 14 passed, 1 skipped
- [x] `scripts/audit_website_versions.py` — all packages in sync
- [x] `tsc --noEmit` — clean
- [x] Verified in-browser across `/`, `/faq`, `/docs`, `/pricing` (DOM-checked via `document.body.innerHTML`, not just visible accordion text)
- [x] pre-commit clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)