### PR TITLE
docs: clarify dynamic-forms constructs — three fire at a fork, one is a report

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,19 +219,25 @@ communicates better than text. A multi-part question becomes one form
 you answer with a click; a recommendation arrives as weighable cards; a
 disagreement is shown side-by-side so you can overrule it in one tap.
 This is a deliberate effort to *improve human/AI communication* — making
-the back-and-forth faster, clearer, and less ambiguous. The agent picks
-the right *construct* for the moment:
+the back-and-forth faster, clearer, and less ambiguous. Three of the
+four constructs fire at a **fork** — a point where the conversation
+can't move forward without your choice; the fourth (**progress**) is a
+status report, not a fork. The agent picks the right *construct* for
+the moment:
 
-- **intake** — gathers several independent decisions as a single
-  (multi-select-capable) form, instead of N back-and-forth questions.
-- **decision** — offers a *recommended* option with a rationale and
-  per-option tradeoffs, rendered as cards (consumed by the `/spec`
-  approval gate).
-- **pushback** — when the agent disagrees with your stated approach, it
-  shows "your approach" beside "I'd suggest instead" with a "why", and
-  you overrule or switch with one pick (`/spec` plan review).
-- **progress** — a done / in-progress / blocked status board whose
-  blocked items are a picker for what to fix next (`/spec` execute).
+- **intake** *(fork)* — gathers several independent decisions as a
+  single (multi-select-capable) form, instead of N back-and-forth
+  questions.
+- **decision** *(fork)* — offers a *recommended* option with a
+  rationale and per-option tradeoffs, rendered as cards (consumed by
+  the `/spec` approval gate).
+- **pushback** *(fork)* — when the agent disagrees with your stated
+  approach, it shows "your approach" beside "I'd suggest instead" with
+  a "why", and you overrule or switch with one pick (`/spec` plan
+  review).
+- **progress** *(report)* — a done / in-progress / blocked status
+  board whose blocked items are a picker for what to fix next (`/spec`
+  execute).
 
 All constructs share one declarative form model and validator, render
 richly on widget-capable surfaces (e.g. claude.ai / Cowork) and degrade
@@ -273,15 +279,19 @@ prose, Attune renders the right form whenever a structured turn
 communicates better than text — a multi-part question becomes one
 form you answer with a click, a recommendation arrives as weighable
 cards, and a disagreement is shown side-by-side so you can overrule
-it in one tap:
+it in one tap. Three constructs fire at a **fork** — a point where
+the conversation needs your choice to continue; the fourth
+(**progress**) is a status report, not a fork:
 
-- **intake** — gather several independent decisions in one form
-- **decision** — a recommended option with rationale + per-option
-  tradeoffs (`/spec` approval gate)
-- **pushback** — agent dissent shown as "your approach" vs "I'd suggest
-  instead"; overrule or switch in one pick (`/spec` plan review)
-- **progress** — a done / in-progress / blocked board whose blocked
-  items are a fix-next picker (`/spec` execute)
+- **intake** *(fork)* — gather several independent decisions in one
+  form
+- **decision** *(fork)* — a recommended option with rationale +
+  per-option tradeoffs (`/spec` approval gate)
+- **pushback** *(fork)* — agent dissent shown as "your approach" vs
+  "I'd suggest instead"; overrule or switch in one pick (`/spec` plan
+  review)
+- **progress** *(report)* — a done / in-progress / blocked board
+  whose blocked items are a fix-next picker (`/spec` execute)
 
 All constructs share one declarative form model and validator, render
 richly on widget-capable surfaces (e.g. claude.ai / Cowork) and degrade

--- a/website/lib/features.ts
+++ b/website/lib/features.ts
@@ -357,7 +357,7 @@ export const PILLARS: Pillar[] = [
       "a disagreement is shown side-by-side so you overrule it in one " +
       "tap.",
     points: [
-      "Intake, decision, pushback, and progress constructs",
+      "Intake, decision, and pushback fire at a fork; progress reports status",
       "Rich on widget surfaces, graceful menu fallback elsewhere",
       "Answer with one click — or the terse y / go / 1 vocab",
     ],


### PR DESCRIPTION
## Summary
Adds the fork/report distinction already present in the internal spec's own vocabulary (`docs/specs/elicitation-form-surface/v5-requirements.md`: progress is described as "the first that is a report rather than a fork").

- **intake, decision, pushback** — each asks the user to choose. They fire at a conversational fork: a point the exchange can't move past without a human decision.
- **progress** — reports done/in-flight/blocked status; only its blocked items offer a picker. Not a fork.

Applied to both README "Dynamic forms" sections and the website's communication PILLARS card.

## Test plan
- [x] Verified in-browser (temp dev server) — the updated PILLARS points list renders correctly
- [x] `tsc --noEmit` — clean
- [x] pre-commit clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)