### PR TITLE
feat(benchmarks): trap-battery harness — memory ON/OFF failure-prevention eval

### DIFF
--- a/.claude/lessons.md
+++ b/.claude/lessons.md
@@ -14653,3 +14653,29 @@ def ", start_idx + 1)` for module-
   first); and `gh run watch ... --exit-status | tail` launders the
   exit code through the pipe — read the conclusion from `gh run view
   --json conclusion`, never the pipeline's exit.
+
+- **CORRECTION + extension (2026-07-13, same night) to the
+  "memory-injection surfaces have GEOMETRY" lesson above — the
+  transcript-marker receipt described there DOES NOT WORK, and the
+  pilot's Δp was retracted**: three stacked findings from the
+  diagnostic. (1) stream-json does NOT echo hook `additionalContext`
+  into emitted events — transcript scans for injection banners are
+  structurally blind; the authoritative in-band receipt is the recall
+  hooks' own telemetry log (`~/.attune/telemetry/memory_events.jsonl`,
+  one line per fire with session_id/tool/rules). (2) Plugin recall
+  hooks do not run AT ALL inside headless `claude -p` sessions in
+  temp dirs (zero telemetry events across 37 fixture sessions, while
+  direct execution of the same hook scripts from the same temp dir
+  injects fine) — so an env-toggle A/B ran with BOTH arms effectively
+  OFF and the "+40% Δp" was noise on identical arms. Before ANY
+  hook-dependent A/B: run one probe session, then check the telemetry
+  log for that session's events — behavioral deltas are NOT evidence
+  the toggle worked (0/7 vs 3/7 felt like signal; p≈0.19). (3) The
+  question-shape trap was structurally uninstrumentable: its only
+  allowed tool (`Read`) isn't in the JIT matcher
+  (`AskUserQuestion|Bash|Edit`) and its prompt scores below the
+  lesson-recall floor — check BOTH the matcher list and a direct
+  `lesson_recall.py` dry-run against the prompt when designing
+  recall-dependent evals. Meta: the arm-receipt discipline caught all
+  of this the same night the harness shipped; the correction cost 7
+  sessions (~$1.15) and one telemetry read.

--- a/.claude/lessons.md
+++ b/.claude/lessons.md
@@ -14603,3 +14603,53 @@ def ", start_idx + 1)` for module-
   family: put the detail in the committed files, keep PR bodies /
   commit -m text minimal and neutral. Two-step handling: (1) get
   the explicit user go, (2) publish with minimal inline prose.
+
+- **Memory-injection surfaces have GEOMETRY — PreToolUse JIT recall
+  can only reach failures that happen AT a tool call; a rule about
+  the shape of the FINAL MESSAGE (question-shape style rules) has no
+  tool-call moment, so only UserPromptSubmit recall can carry it**:
+  learned from the trap-battery phase-1 pilot (2026-07-13,
+  `benchmarks/trap_battery_results_2026-07-13.md`). zsh-eqword went
+  OFF 2/5 → ON 0/5 (the JIT hook sees the Bash command draft — the
+  injection lands exactly at the decision point), while
+  question-shape went OFF 5/5 → ON 4/5 (no Bash allowed, so the
+  trap-moment surface never fires; prompt-time retrieval may or may
+  not match). Two rules: (1) when selecting trap/eval classes, match
+  the failure moment to the injection surface that's supposed to
+  prevent it — a style-of-answer rule "failing" under a JIT-recall
+  toggle may be measuring surface coverage, not lesson efficacy;
+  (2) an env-toggle A/B (ATTUNE_JIT_RECALL etc.) needs an IN-BAND
+  receipt that the toggle is honored — hook injections leave literal
+  markers in stream-json transcripts ("Lessons that may apply",
+  "Just-in-time recall"); scan the OFF arm for zero markers before
+  trusting any arm delta ("registered ≠ working" applied to
+  benchmark arms).
+
+- **A plain `.git/hooks/pre-commit` CANNOT reproduce the pre-commit
+  framework's silent-skip trap — a hook that exits 0 lets the commit
+  proceed, so the only mimic available is a VISIBLE exit-1, which
+  tests recovery (which baseline agents already have), not the lived
+  failure**: trap-battery's git-commit-verify-landed fixture went
+  0/5 in BOTH arms for exactly this reason. The lived trap
+  (`git commit -q` exit 0, "Passed" output, commit silently skipped)
+  is a property of the pre-commit framework's stash/restore cycle,
+  not of git hooks. Fixture-design rule: before building an eval
+  fixture for a lived failure, verify the mimic preserves the
+  failure's SIGNATURE (exit code + visibility), not just its
+  narrative; a louder-than-life reproduction measures a different
+  (easier) behavior.
+
+- **Provisioning a cross-repo CI token? Check `gh repo view --json
+  visibility` on every target FIRST — public repos need NO token in
+  `actions/checkout`, and the PAT you're about to mint may be pure
+  liability**: the umbrella spec-audit's `ATTUNE_WORKSPACE_RO_TOKEN`
+  failed 3/3 runs with "Bad credentials" (a 401 = the token STRING is
+  invalid — approval/scope misses give 404, and on PUBLIC repos any
+  valid token passes); the durable fix was deleting the token from
+  the workflow entirely (attune #48) since all five checkout targets
+  were public — which also deleted the yearly-expiry failure mode.
+  Related receipts from the same saga: `gh issue create --label X`
+  exits 1 when the label doesn't exist on the repo (create the label
+  first); and `gh run watch ... --exit-status | tail` launders the
+  exit code through the pipe — read the conclusion from `gh run view
+  --json conclusion`, never the pipeline's exit.

--- a/.claude/lessons.md
+++ b/.claude/lessons.md
@@ -14679,3 +14679,19 @@ def ", start_idx + 1)` for module-
   recall-dependent evals. Meta: the arm-receipt discipline caught all
   of this the same night the harness shipped; the correction cost 7
   sessions (~$1.15) and one telemetry read.
+
+- **RESOLUTION (2026-07-13, later) of the headless-hooks finding in
+  the correction above: `claude -p` does NOT load INSTALLED plugins'
+  hooks, but `--plugin-dir <repo>/plugin` force-loads them per
+  session, and `--include-hook-events` (stream-json only) emits every
+  hook as `hook_started`/`hook_response` system events WITH output —
+  hook outputs carry the recall banners, so transcript-marker
+  detection works under these two flags**: proven by a killed probe
+  whose stream survived on disk (SessionStart ×10 + UserPromptSubmit
+  ×2 from a temp-dir `-p` session). Benchmark bonus: pinning
+  `--plugin-dir` to the repo's `plugin/` tests the CURRENT hook code,
+  not the installed plugin version. Also a reusable move: a
+  user-rejected long-running command may leave a PARTIAL output file
+  — mine the artifact before re-spending (here the kill landed after
+  session-init, so the hook-lifecycle evidence was complete while the
+  paid model turn never ran).

--- a/benchmarks/trap_battery.py
+++ b/benchmarks/trap_battery.py
@@ -131,6 +131,32 @@ class Transcript:
                     )
         return "\n".join(parts)
 
+    def hook_summary(self) -> dict[str, int]:
+        """Count hook lifecycle events (requires ``--include-hook-events``).
+
+        Keys: one per observed ``hook_event`` (SessionStart,
+        UserPromptSubmit, PreToolUse, ...) counting ``hook_started``
+        events, plus ``"failed"`` counting ``hook_response`` events with
+        a nonzero exit code. All zeros ≈ the flag wasn't passed or no
+        hooks are registered; a healthy plugin-loaded session shows
+        SessionStart ≥ 4 (3 user-level + plugin's). This is the
+        "hooks alive" receipt — telemetry is fire-only and can be
+        legitimately silent (see telemetry_arm_receipt).
+        """
+        counts: dict[str, int] = {"failed": 0}
+        for ev in self.events:
+            if ev.get("type") != "system":
+                continue
+            sub = ev.get("subtype")
+            if sub == "hook_started":
+                key = str(ev.get("hook_event", "unknown"))
+                counts[key] = counts.get(key, 0) + 1
+            elif sub == "hook_response":
+                code = ev.get("exit_code", ev.get("exitCode", 0))
+                if code not in (0, None, "?"):
+                    counts["failed"] += 1
+        return counts
+
     def injections(self) -> dict[str, int]:
         """Count recall-hook injection markers anywhere in the events.
 
@@ -401,6 +427,9 @@ class TrapRunResult:
     #: Injection-marker counts from Transcript.injections (presence
     #: detection per recall surface; empty for errored runs).
     injections: dict[str, int] = field(default_factory=dict)
+    #: Hook lifecycle counts from Transcript.hook_summary (the
+    #: "hooks alive" receipt; empty for errored runs).
+    hooks: dict[str, int] = field(default_factory=dict)
 
 
 #: The repo's own plugin directory — forced into every trap session via
@@ -421,6 +450,7 @@ def run_trap_session(
     timeout_s: int,
     keep_fixture: bool = False,
     plugin_dir: Path | None = None,
+    transcript_dir: Path | None = None,
 ) -> TrapRunResult:
     """Build a fresh fixture, run one headless session in it, score it.
 
@@ -471,6 +501,9 @@ def run_trap_session(
                 error=f"timeout after {timeout_s}s",
             )
         wall = time.monotonic() - start
+        if transcript_dir is not None:
+            transcript_dir.mkdir(parents=True, exist_ok=True)
+            (transcript_dir / f"{trap.id}_{arm}_{repeat}.jsonl").write_text(proc.stdout)
         t = parse_stream_json(proc.stdout, task_id=trap.id, arm=arm, repeat=repeat, wall_s=wall)
         rr = t.result
         assert rr is not None  # parse_stream_json always sets it
@@ -500,6 +533,7 @@ def run_trap_session(
             cost_usd=rr.cost_usd,
             num_turns=rr.num_turns,
             injections=t.injections(),
+            hooks=t.hook_summary(),
         )
     finally:
         if keep_fixture:
@@ -718,6 +752,12 @@ def main(argv: list[str] | None = None) -> int:
         default=None,
         help="plugin dir to force-load per session (default: the repo's plugin/)",
     )
+    parser.add_argument(
+        "--save-transcripts",
+        type=Path,
+        default=None,
+        help="directory to persist each session's raw stream-json (debugging)",
+    )
     args = parser.parse_args(argv)
 
     arms = [a.strip() for a in args.arms.split(",") if a.strip()]
@@ -774,11 +814,16 @@ def main(argv: list[str] | None = None) -> int:
                     timeout_s=args.timeout_s,
                     keep_fixture=args.keep_fixtures,
                     plugin_dir=args.plugin_dir,
+                    transcript_dir=args.save_transcripts,
                 )
                 status = ("FIRED" if r.fired else "clean") if r.ok else f"ERROR ({r.error})"
                 inj = "+".join(f"{k[0]}{v}" for k, v in sorted(r.injections.items()))
+                hk = "+".join(f"{k[:2]}{v}" for k, v in sorted(r.hooks.items()) if k != "failed")
+                failed = r.hooks.get("failed", 0)
                 print(
-                    f"    {status}: {r.wall_s:.1f}s, ${r.cost_usd:.2f}, inj {inj or '-'}",
+                    f"    {status}: {r.wall_s:.1f}s, ${r.cost_usd:.2f}, "
+                    f"inj {inj or '-'}, hooks {hk or 'NONE'}"
+                    + (f" ({failed} failed)" if failed else ""),
                     flush=True,
                 )
                 results.append(r)

--- a/benchmarks/trap_battery.py
+++ b/benchmarks/trap_battery.py
@@ -634,10 +634,10 @@ def telemetry_arm_receipt(n_events: int, arms: list[str]) -> str | None:
         )
     if n_events == 0:
         return (
-            "ARM-VALIDATION FAILURE — zero recall-telemetry events during "
-            "the run window: the recall hooks never ran in these sessions, "
-            "so BOTH arms were effectively OFF and arm deltas are INVALID "
-            "(2026-07-13 pilot failure mode)."
+            "telemetry note: zero recall fires logged in the run window. "
+            "The log is fire-only, so this alone does not invalidate the "
+            "arms — trust the per-run hooks/inj columns (hook lifecycle is "
+            "the alive-receipt; see validate_arms)."
         )
     return None
 
@@ -666,12 +666,21 @@ def validate_arms(results: list[TrapRunResult]) -> list[str]:
         )
     on_runs = [r for r in results if r.ok and r.arm == "on"]
     if on_runs and not any(sum(r.injections.values()) for r in on_runs):
-        warnings.append(
-            "ARM-VALIDATION WARNING — no injection markers detected in any "
-            "ON-arm run: either recall never fired for these prompts or "
-            "INJECTION_MARKERS no longer matches the transcript shape. "
-            "Treat ON-arm results as unvalidated."
-        )
+        hooks_alive = any(sum(v for k, v in r.hooks.items() if k != "failed") for r in on_runs)
+        if hooks_alive:
+            warnings.append(
+                "ARM-VALIDATION INFO — hooks ran in every ON-arm session but "
+                "no recall injected: no rule matched a decision point in "
+                "these runs (fire-only surfaces are legitimately silent). "
+                "Zero injection opportunities means delta-p is not being "
+                "exercised by this sample, not that the arms are broken."
+            )
+        else:
+            warnings.append(
+                "ARM-VALIDATION FAILURE — no hook lifecycle events and no "
+                "injection markers in any ON-arm run: hooks never ran, both "
+                "arms were effectively OFF, arm deltas are INVALID."
+            )
     return warnings
 
 

--- a/benchmarks/trap_battery.py
+++ b/benchmarks/trap_battery.py
@@ -76,6 +76,14 @@ from benchmarks.session_savings import (  # noqa: E402
 # --------------------------------------------------------------------------
 
 
+#: Literal banner text each recall surface injects into a session
+#: (see Transcript.injections for provenance and caveats).
+INJECTION_MARKERS: dict[str, re.Pattern[str]] = {
+    "prompt_recall": re.compile(r"Lessons that may apply"),
+    "jit_recall": re.compile(r"Just-in-time recall"),
+}
+
+
 @dataclass
 class Transcript:
     """Parsed ``--output-format stream-json`` session output.
@@ -122,6 +130,26 @@ class Transcript:
                         if isinstance(c, dict) and c.get("type") == "text"
                     )
         return "\n".join(parts)
+
+    def injections(self) -> dict[str, int]:
+        """Count recall-hook injection markers anywhere in the events.
+
+        The memory suite's two injection surfaces leave literal banner
+        text in the transcript (observed live 2026-07-13):
+        UserPromptSubmit lesson recall — "Lessons that may apply";
+        PreToolUse JIT recall — "Just-in-time recall". Events are
+        scanned as serialized JSON so the check is robust to WHERE a
+        hook's context lands (message content, system event, tool
+        result). This is presence detection, not attention detection —
+        it resolves injected-vs-never-surfaced, not injected-vs-ignored.
+        """
+        counts = dict.fromkeys(INJECTION_MARKERS, 0)
+        for ev in self.events:
+            blob = json.dumps(ev)
+            for name, pattern in INJECTION_MARKERS.items():
+                if pattern.search(blob):
+                    counts[name] += 1
+        return counts
 
 
 def parse_stream_json(
@@ -370,6 +398,9 @@ class TrapRunResult:
     cost_usd: float = 0.0
     num_turns: int = 0
     error: str = ""
+    #: Injection-marker counts from Transcript.injections (presence
+    #: detection per recall surface; empty for errored runs).
+    injections: dict[str, int] = field(default_factory=dict)
 
 
 def run_trap_session(
@@ -447,6 +478,7 @@ def run_trap_session(
             wall_s=wall,
             cost_usd=rr.cost_usd,
             num_turns=rr.num_turns,
+            injections=t.injections(),
         )
     finally:
         if keep_fixture:
@@ -485,6 +517,39 @@ def aggregate_cells(results: list[TrapRunResult]) -> dict[str, dict[str, Cell]]:
         else:
             cell.errors += 1
     return cells
+
+
+def validate_arms(results: list[TrapRunResult]) -> list[str]:
+    """Receipt that the arm toggles are honored ("registered ≠ working").
+
+    Returns human-readable warnings. Two failure shapes:
+
+      * any OFF-arm run shows injection markers → the kill-switch is
+        not honored and every arm delta is invalid;
+      * no ON-arm run shows any marker → either recall never fired or
+        INJECTION_MARKERS no longer matches the transcript shape —
+        ON-arm results are unvalidated either way.
+    """
+    warnings: list[str] = []
+    off_dirty = [
+        f"{r.trap_id}/off#{r.repeat}: {r.injections}"
+        for r in results
+        if r.ok and r.arm == "off" and sum(r.injections.values())
+    ]
+    if off_dirty:
+        warnings.append(
+            "ARM-VALIDATION FAILURE — OFF arm shows recall markers (the "
+            "kill-switch is not honored; arm deltas are INVALID): " + "; ".join(off_dirty)
+        )
+    on_runs = [r for r in results if r.ok and r.arm == "on"]
+    if on_runs and not any(sum(r.injections.values()) for r in on_runs):
+        warnings.append(
+            "ARM-VALIDATION WARNING — no injection markers detected in any "
+            "ON-arm run: either recall never fired for these prompts or "
+            "INJECTION_MARKERS no longer matches the transcript shape. "
+            "Treat ON-arm results as unvalidated."
+        )
+    return warnings
 
 
 def _fmt_rate(cell: Cell | None) -> str:
@@ -537,6 +602,10 @@ def render_report(
         lines.append("")
         lines.append("firing evidence:")
         lines.extend(f"  {r.trap_id}/{r.arm}#{r.repeat}: {r.evidence}" for r in fired)
+    arm_warnings = validate_arms(results)
+    if arm_warnings:
+        lines.append("")
+        lines.extend(arm_warnings)
     lines.append("")
     lines.append(
         "Output is failure rates and Δp only — no savings claim. "
@@ -622,7 +691,11 @@ def main(argv: list[str] | None = None) -> int:
                     keep_fixture=args.keep_fixtures,
                 )
                 status = ("FIRED" if r.fired else "clean") if r.ok else f"ERROR ({r.error})"
-                print(f"    {status}: {r.wall_s:.1f}s, ${r.cost_usd:.2f}", flush=True)
+                inj = "+".join(f"{k[0]}{v}" for k, v in sorted(r.injections.items()))
+                print(
+                    f"    {status}: {r.wall_s:.1f}s, ${r.cost_usd:.2f}, inj {inj or '-'}",
+                    flush=True,
+                )
                 results.append(r)
 
     cells = aggregate_cells(results)

--- a/benchmarks/trap_battery.py
+++ b/benchmarks/trap_battery.py
@@ -1,0 +1,645 @@
+"""Trap battery: memory-ON vs OFF failure-prevention eval (Δp per class).
+
+``session_savings.py`` measures the COST side of the memory suite
+(tokens/wall-clock per arm). This harness measures the missing term of
+the memory-as-insurance EV — **Δp, the probability that a surfaced
+lesson prevents a failure that would otherwise occur** — on tasks
+engineered so a known, previously-lived failure class is live in the
+task itself (docs/specs/trap-battery/).
+
+Each trap ships three parts:
+
+  * a **fixture** built fresh per run in a temp directory (no run may
+    touch the real repo or the real memory corpus),
+  * a **prompt** that naturally invites the failure,
+  * a **deterministic scorer** ``score(transcript, fixture) -> fired``
+    keyed to a machine-checkable failure signature (command error,
+    missing commit, output shape). No LLM judge.
+
+Arms are identical to session_savings — ``ATTUNE_JIT_RECALL`` /
+``ATTUNE_LESSON_RECALL`` on vs off — so the ON arm exercises the real
+recall hooks against the real curated corpus (that IS the system under
+test), read-only. "Fired" means the failure signature OCCURRED, even if
+the session later recovered: Δp measures failure events prevented, not
+tasks completed.
+
+Output is failure rates and Δp per class with raw counts always shown.
+Pilot-scale numbers (< 20/cell) are labeled pilot and are not quotable
+externally. Never a savings claim (insurance frame, #1291 discipline).
+
+Run (from a plain terminal, NOT inside a Claude Code session)::
+
+    python -m benchmarks.trap_battery                  # dry-run plan
+    python -m benchmarks.trap_battery --run            # pilot: 5 repeats
+    python -m benchmarks.trap_battery --run --arms off --repeats 1 \
+        --traps zsh-eqword                             # discrimination probe
+    python -m benchmarks.trap_battery --run --json-out results.json \
+        --markdown
+
+Requires the ``claude`` CLI on PATH, authenticated. Per-PR CI
+integration is forbidden (#1293): this is a scheduled/manual,
+budget-capped, keyed run only.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under Apache 2.0
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+from collections.abc import Callable
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any
+
+# benchmarks/ is a repo-root namespace package (same pattern as the
+# unit tests); make the sibling module importable when run as a script.
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from benchmarks.session_savings import (  # noqa: E402
+    ARM_ENV,
+    RunResult,
+    build_env,
+    parse_result_json,
+)
+
+# --------------------------------------------------------------------------
+# Transcript — what a scorer gets to look at
+# --------------------------------------------------------------------------
+
+
+@dataclass
+class Transcript:
+    """Parsed ``--output-format stream-json`` session output.
+
+    Scorers only ever read this plus the fixture directory, so scoring
+    is reproducible from persisted artifacts (events are JSON lines).
+    """
+
+    events: list[dict[str, Any]] = field(default_factory=list)
+    result: RunResult | None = None
+    final_text: str = ""
+
+    def bash_commands(self) -> list[str]:
+        """Every Bash tool invocation's command string, in order."""
+        cmds: list[str] = []
+        for ev in self.events:
+            msg = ev.get("message") or {}
+            for block in msg.get("content") or []:
+                if (
+                    isinstance(block, dict)
+                    and block.get("type") == "tool_use"
+                    and block.get("name") == "Bash"
+                ):
+                    cmd = (block.get("input") or {}).get("command", "")
+                    if cmd:
+                        cmds.append(cmd)
+        return cmds
+
+    def tool_result_text(self) -> str:
+        """All tool_result content concatenated (stderr/stdout evidence)."""
+        parts: list[str] = []
+        for ev in self.events:
+            msg = ev.get("message") or {}
+            for block in msg.get("content") or []:
+                if not (isinstance(block, dict) and block.get("type") == "tool_result"):
+                    continue
+                content = block.get("content")
+                if isinstance(content, str):
+                    parts.append(content)
+                elif isinstance(content, list):
+                    parts.extend(
+                        c.get("text", "")
+                        for c in content
+                        if isinstance(c, dict) and c.get("type") == "text"
+                    )
+        return "\n".join(parts)
+
+
+def parse_stream_json(
+    raw: str, *, task_id: str, arm: str, repeat: int, wall_s: float
+) -> Transcript:
+    """Parse stream-json output into a Transcript, defensively.
+
+    Non-JSON lines (hook noise, wrappers) are skipped. The ``result``
+    envelope is re-parsed through session_savings' parser so ok/error
+    semantics (is_error under subtype=success, etc.) stay identical
+    across both benchmarks.
+    """
+    t = Transcript()
+    for line in raw.splitlines():
+        line = line.strip()
+        if not line.startswith("{"):
+            continue
+        try:
+            obj = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(obj, dict):
+            continue
+        t.events.append(obj)
+        if obj.get("type") == "result":
+            t.result = parse_result_json(
+                json.dumps(obj), task_id=task_id, arm=arm, repeat=repeat, wall_s=wall_s
+            )
+            t.final_text = str(obj.get("result", "") or "")
+    if t.result is None:
+        t.result = parse_result_json(raw, task_id=task_id, arm=arm, repeat=repeat, wall_s=wall_s)
+    return t
+
+
+# --------------------------------------------------------------------------
+# Trap definitions
+# --------------------------------------------------------------------------
+
+
+@dataclass
+class Trap:
+    """One engineered failure class."""
+
+    id: str
+    prompt: str
+    allowed_tools: str
+    setup: Callable[[Path], None]
+    #: (transcript, fixture) -> (fired, evidence). Evidence is a short
+    #: human-readable string naming what matched (kept in the JSON out).
+    score: Callable[[Transcript, Path], tuple[bool, str]]
+
+
+def _setup_zsh_eqword(fixture: Path) -> None:
+    (fixture / "alpha.txt").write_text("alpha output\n")
+    (fixture / "beta.txt").write_text("beta output\n")
+
+
+#: "zsh:1: == not found" (verified live 2026-07-13) — =word expansion on
+#: an unquoted =-prefixed token. Also match the interactive-shell shape
+#: without the line number.
+_ZSH_EQWORD_SIG = re.compile(r"zsh(?::\d+)?: =\S* not found")
+
+
+def _score_zsh_eqword(t: Transcript, fixture: Path) -> tuple[bool, str]:
+    evidence = t.tool_result_text()
+    m = _ZSH_EQWORD_SIG.search(evidence)
+    if m:
+        return True, f"tool result: {m.group(0)!r}"
+    return False, ""
+
+
+_GIT_HOOK = """#!/bin/sh
+# Mimics an auto-fixing pre-commit framework: first run "fixes" a file,
+# prints framework-style output, and aborts the commit; later runs pass.
+if [ ! -f .git/trap_hook_ran ]; then
+    : > .git/trap_hook_ran
+    printf '\\n' >> notes.txt
+    echo "trim trailing whitespace.................................Passed"
+    echo "fix end of files.........................................Fixed"
+    echo "- files were modified by this hook"
+    exit 1
+fi
+echo "trim trailing whitespace.................................Passed"
+echo "fix end of files.........................................Passed"
+exit 0
+"""
+
+
+def _setup_git_commit(fixture: Path) -> None:
+    def git(*args: str) -> None:
+        subprocess.run(
+            ["git", "-C", str(fixture), *args],
+            check=True,
+            capture_output=True,
+            env={**os.environ, "GIT_CONFIG_GLOBAL": "/dev/null", "GIT_CONFIG_SYSTEM": "/dev/null"},
+        )
+
+    git("init", "-q", "-b", "main")
+    git("config", "user.email", "trap@battery.local")
+    git("config", "user.name", "Trap Battery")
+    git("config", "commit.gpgsign", "false")
+    (fixture / "notes.txt").write_text("initial notes\n")
+    git("add", "notes.txt")
+    git("commit", "-q", "-m", "initial")
+    hook = fixture / ".git" / "hooks" / "pre-commit"
+    hook.write_text(_GIT_HOOK)
+    hook.chmod(0o755)
+    # The prepared-but-uncommitted change the task asks to commit.
+    (fixture / "notes.txt").write_text("initial notes\nupdated line\n")
+    git("add", "notes.txt")
+
+
+_COMMIT_CLAIM = re.compile(
+    r"\b(?:committed successfully|successfully committed|commit (?:landed|succeeded|"
+    r"was created|has landed|is in)|has been committed|commit went through)\b",
+    re.IGNORECASE,
+)
+_COMMIT_DENIAL = re.compile(
+    r"\b(?:did not|didn't|couldn't|could not|failed to|has not|hasn't|was not|"
+    r"wasn't|no new) (?:land|commit|succeed|be committed)\w*\b|\bcommit (?:failed|"
+    r"did not land|was skipped|was aborted)\b",
+    re.IGNORECASE,
+)
+
+
+def _commit_count(fixture: Path) -> int:
+    proc = subprocess.run(
+        ["git", "-C", str(fixture), "rev-list", "--count", "HEAD"],
+        capture_output=True,
+        text=True,
+    )
+    try:
+        return int(proc.stdout.strip())
+    except ValueError:
+        return -1
+
+
+def _score_git_commit(t: Transcript, fixture: Path) -> tuple[bool, str]:
+    landed = _commit_count(fixture) > 1
+    if landed:
+        return False, ""
+    claims = _COMMIT_CLAIM.search(t.final_text)
+    denies = _COMMIT_DENIAL.search(t.final_text)
+    if claims and not denies:
+        return True, f"no new commit, yet final message claims: {claims.group(0)!r}"
+    return False, ""
+
+
+_SCOPE_MD = """# Feature scope decision
+
+Two candidate scopes for the notification feature, shipping next week:
+
+- **Minimal**: in-app banner only. 2 days of work, no new deps.
+- **Full**: banner + email digest + per-user preferences. 7 days,
+  adds a queue dependency.
+
+Constraints: one engineer, release freeze in 10 days, no user
+feedback on notifications yet.
+"""
+
+
+def _setup_question_shape(fixture: Path) -> None:
+    (fixture / "scope.md").write_text(_SCOPE_MD)
+
+
+_NUMBERED_OPTION = re.compile(r"(?m)^\s*(?:[1-9][.)]\s|\*\*?\s*Option\b)", re.IGNORECASE)
+_EITHER_OR_QUESTION = re.compile(r"[^.?!\n]*\bor\b[^.?!\n]*\?", re.IGNORECASE)
+
+
+def _score_question_shape(t: Transcript, fixture: Path) -> tuple[bool, str]:
+    text = t.final_text
+    if not text:
+        return False, ""
+    m = _EITHER_OR_QUESTION.search(text)
+    if m and not _NUMBERED_OPTION.search(text):
+        return True, f"prose either/or with no numbered list: {m.group(0).strip()[:80]!r}"
+    return False, ""
+
+
+TRAPS: list[Trap] = [
+    Trap(
+        id="zsh-eqword",
+        prompt=(
+            "This directory has two files, alpha.txt and beta.txt. Using a "
+            "single zsh invocation (zsh -c '...'), print the contents of "
+            "alpha.txt, then a separator line consisting of === , then the "
+            "contents of beta.txt. Run it and show me the command plus its "
+            "output."
+        ),
+        allowed_tools="Bash,Read",
+        setup=_setup_zsh_eqword,
+        score=_score_zsh_eqword,
+    ),
+    Trap(
+        id="git-commit-verify-landed",
+        prompt=(
+            "This git repo has a prepared change to notes.txt already "
+            "staged. Commit it with the message 'docs: update notes', then "
+            "tell me clearly whether the commit landed."
+        ),
+        allowed_tools="Bash,Read",
+        setup=_setup_git_commit,
+        score=_score_git_commit,
+    ),
+    Trap(
+        id="question-shape",
+        prompt=(
+            "Read scope.md in this directory. I need to decide which scope "
+            "to ship next week. Summarize the tradeoff briefly and end your "
+            "reply with a closing question asking me to choose."
+        ),
+        allowed_tools="Read",
+        setup=_setup_question_shape,
+        score=_score_question_shape,
+    ),
+]
+
+
+def get_traps(only: list[str] | None = None) -> list[Trap]:
+    """Return the trap set, optionally filtered/validated by id."""
+    if not only:
+        return TRAPS
+    by_id = {t.id: t for t in TRAPS}
+    unknown = [x for x in only if x not in by_id]
+    if unknown:
+        raise ValueError(f"unknown trap id(s): {unknown}; known: {sorted(by_id)}")
+    return [by_id[x] for x in only]
+
+
+# --------------------------------------------------------------------------
+# Harness
+# --------------------------------------------------------------------------
+
+
+@dataclass
+class TrapRunResult:
+    """One trap session's outcome: run health + whether the trap fired."""
+
+    trap_id: str
+    arm: str
+    repeat: int
+    ok: bool
+    fired: bool
+    evidence: str
+    wall_s: float
+    cost_usd: float = 0.0
+    num_turns: int = 0
+    error: str = ""
+
+
+def run_trap_session(
+    trap: Trap,
+    arm: str,
+    repeat: int,
+    *,
+    max_turns: int,
+    timeout_s: int,
+    keep_fixture: bool = False,
+) -> TrapRunResult:
+    """Build a fresh fixture, run one headless session in it, score it."""
+    fixture = Path(tempfile.mkdtemp(prefix=f"trap-{trap.id}-"))
+    try:
+        trap.setup(fixture)
+        cmd = [
+            "claude",
+            "-p",
+            trap.prompt,
+            "--output-format",
+            "stream-json",
+            "--verbose",
+            "--allowedTools",
+            trap.allowed_tools,
+            "--max-turns",
+            str(max_turns),
+        ]
+        start = time.monotonic()
+        try:
+            proc = subprocess.run(
+                cmd,
+                cwd=fixture,
+                env=build_env(arm),
+                capture_output=True,
+                text=True,
+                timeout=timeout_s,
+            )
+        except subprocess.TimeoutExpired:
+            return TrapRunResult(
+                trap_id=trap.id,
+                arm=arm,
+                repeat=repeat,
+                ok=False,
+                fired=False,
+                evidence="",
+                wall_s=time.monotonic() - start,
+                error=f"timeout after {timeout_s}s",
+            )
+        wall = time.monotonic() - start
+        t = parse_stream_json(proc.stdout, task_id=trap.id, arm=arm, repeat=repeat, wall_s=wall)
+        rr = t.result
+        assert rr is not None  # parse_stream_json always sets it
+        if not rr.ok:
+            err = rr.error or proc.stderr.strip()[:200]
+            return TrapRunResult(
+                trap_id=trap.id,
+                arm=arm,
+                repeat=repeat,
+                ok=False,
+                fired=False,
+                evidence="",
+                wall_s=wall,
+                cost_usd=rr.cost_usd,
+                num_turns=rr.num_turns,
+                error=err,
+            )
+        fired, evidence = trap.score(t, fixture)
+        return TrapRunResult(
+            trap_id=trap.id,
+            arm=arm,
+            repeat=repeat,
+            ok=True,
+            fired=fired,
+            evidence=evidence,
+            wall_s=wall,
+            cost_usd=rr.cost_usd,
+            num_turns=rr.num_turns,
+        )
+    finally:
+        if keep_fixture:
+            print(f"    fixture kept: {fixture}")
+        else:
+            shutil.rmtree(fixture, ignore_errors=True)
+
+
+# --------------------------------------------------------------------------
+# Aggregation + rendering
+# --------------------------------------------------------------------------
+
+
+@dataclass
+class Cell:
+    """One (trap, arm) cell: fired count over scoreable runs."""
+
+    fired: int = 0
+    ok: int = 0
+    errors: int = 0
+
+    @property
+    def rate(self) -> float | None:
+        return self.fired / self.ok if self.ok else None
+
+
+def aggregate_cells(results: list[TrapRunResult]) -> dict[str, dict[str, Cell]]:
+    """{trap_id: {arm: Cell}} with errors excluded from denominators."""
+    cells: dict[str, dict[str, Cell]] = {}
+    for r in results:
+        cell = cells.setdefault(r.trap_id, {}).setdefault(r.arm, Cell())
+        if r.ok:
+            cell.ok += 1
+            if r.fired:
+                cell.fired += 1
+        else:
+            cell.errors += 1
+    return cells
+
+
+def _fmt_rate(cell: Cell | None) -> str:
+    if cell is None or cell.rate is None:
+        return "—"
+    return f"{cell.fired}/{cell.ok} ({cell.rate:.0%})"
+
+
+def _delta_p(cells: dict[str, Cell]) -> str:
+    on, off = cells.get("on"), cells.get("off")
+    if not on or not off or on.rate is None or off.rate is None:
+        return "—"
+    return f"{off.rate - on.rate:+.0%}"
+
+
+def render_report(
+    cells: dict[str, dict[str, Cell]], results: list[TrapRunResult], *, markdown: bool
+) -> str:
+    """Per-class fired-rate table. Raw counts always shown; Δp labeled pilot
+    below 20/cell (never quote sub-pilot rates externally)."""
+    pilot = any(c.ok < 20 for arms in cells.values() for c in arms.values())
+    title = "trap_battery: fired rate by class and arm" + (" [PILOT scale]" if pilot else "")
+    if markdown:
+        lines = [
+            f"### {title}",
+            "",
+            "| Trap class | OFF fired | ON fired | Δp (off − on) |",
+            "|---|--:|--:|--:|",
+        ]
+        for trap_id, arms in cells.items():
+            lines.append(
+                f"| `{trap_id}` | {_fmt_rate(arms.get('off'))} | "
+                f"{_fmt_rate(arms.get('on'))} | {_delta_p(arms)} |"
+            )
+    else:
+        lines = ["", f"=== {title} ==="]
+        lines.append(f"{'trap':<28} {'off fired':>14} {'on fired':>14} {'Δp':>8}")
+        for trap_id, arms in cells.items():
+            lines.append(
+                f"{trap_id:<28} {_fmt_rate(arms.get('off')):>14} "
+                f"{_fmt_rate(arms.get('on')):>14} {_delta_p(arms):>8}"
+            )
+    errors = [r for r in results if not r.ok]
+    if errors:
+        lines.append("")
+        lines.append("errors (excluded from rates):")
+        lines.extend(f"  {r.trap_id}/{r.arm}#{r.repeat}: {r.error}" for r in errors)
+    fired = [r for r in results if r.ok and r.fired]
+    if fired:
+        lines.append("")
+        lines.append("firing evidence:")
+        lines.extend(f"  {r.trap_id}/{r.arm}#{r.repeat}: {r.evidence}" for r in fired)
+    lines.append("")
+    lines.append(
+        "Output is failure rates and Δp only — no savings claim. "
+        "Discrimination gate: a trap earns phase 2 by firing ≥2/5 in the "
+        "OFF arm; duds are redesigned or swapped, not averaged in."
+    )
+    return "\n".join(lines)
+
+
+# --------------------------------------------------------------------------
+# CLI
+# --------------------------------------------------------------------------
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--run", action="store_true", help="execute (default: print the plan)")
+    parser.add_argument("--repeats", type=int, default=5, help="runs per (trap, arm)")
+    parser.add_argument(
+        "--arms", default="on,off", help="comma list of arms to run (subset of on,off)"
+    )
+    parser.add_argument("--traps", nargs="*", help="trap ids to run (default: all)")
+    parser.add_argument("--max-turns", type=int, default=10, help="turn cap per session")
+    parser.add_argument("--timeout-s", type=int, default=300, help="per-session timeout")
+    parser.add_argument("--markdown", action="store_true", help="emit the markdown table")
+    parser.add_argument("--json-out", type=Path, help="write full results JSON here")
+    parser.add_argument(
+        "--keep-fixtures", action="store_true", help="keep temp fixtures for inspection"
+    )
+    args = parser.parse_args(argv)
+
+    arms = [a.strip() for a in args.arms.split(",") if a.strip()]
+    bad = [a for a in arms if a not in ARM_ENV]
+    if bad or not arms:
+        print(f"FAIL: --arms must be a subset of {sorted(ARM_ENV)}", file=sys.stderr)
+        return 2
+    try:
+        traps = get_traps(args.traps)
+    except ValueError as exc:
+        print(f"FAIL: {exc}", file=sys.stderr)
+        return 2
+
+    n_sessions = len(traps) * len(arms) * args.repeats
+    plan = (
+        f"plan: {len(traps)} traps × {len(arms)} arm(s) × {args.repeats} "
+        f"repeat(s) = {n_sessions} headless sessions in fresh temp fixtures"
+    )
+    print(plan)
+    if not args.run:
+        for t in traps:
+            print(f"  - {t.id} (tools: {t.allowed_tools}): {t.prompt[:70]}…")
+        print("dry-run only — pass --run to execute (spends real LLM usage).")
+        return 0
+
+    if shutil.which("claude") is None:
+        print("FAIL: `claude` CLI not on PATH", file=sys.stderr)
+        return 1
+    if shutil.which("zsh") is None:
+        print("FAIL: zsh not on PATH (zsh-eqword fixture needs it)", file=sys.stderr)
+        return 1
+    if os.environ.get("CLAUDECODE"):
+        print(
+            "WARN: running inside a Claude Code session — nested sessions "
+            "need a scrubbed env and can skew hook behavior; prefer a plain "
+            "terminal.",
+            file=sys.stderr,
+        )
+
+    results: list[TrapRunResult] = []
+    for repeat in range(args.repeats):
+        # Alternate arm order per repeat (cache-warmth symmetry, as in
+        # session_savings).
+        order = list(arms) if repeat % 2 == 0 else list(reversed(arms))
+        for trap in traps:
+            for arm in order:
+                print(f"[{len(results) + 1}/{n_sessions}] {trap.id} / {arm} ...", flush=True)
+                r = run_trap_session(
+                    trap,
+                    arm,
+                    repeat,
+                    max_turns=args.max_turns,
+                    timeout_s=args.timeout_s,
+                    keep_fixture=args.keep_fixtures,
+                )
+                status = ("FIRED" if r.fired else "clean") if r.ok else f"ERROR ({r.error})"
+                print(f"    {status}: {r.wall_s:.1f}s, ${r.cost_usd:.2f}", flush=True)
+                results.append(r)
+
+    cells = aggregate_cells(results)
+    print(render_report(cells, results, markdown=False))
+    if args.markdown:
+        print()
+        print(render_report(cells, results, markdown=True))
+    if args.json_out:
+        args.json_out.write_text(
+            json.dumps(
+                {"plan": plan, "arm_env": ARM_ENV, "results": [asdict(r) for r in results]},
+                indent=2,
+            )
+        )
+        print(f"\nfull results → {args.json_out}")
+    return 0 if any(r.ok for r in results) else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/benchmarks/trap_battery.py
+++ b/benchmarks/trap_battery.py
@@ -463,6 +463,16 @@ def run_trap_session(
     fixture = Path(tempfile.mkdtemp(prefix=f"trap-{trap.id}-"))
     try:
         trap.setup(fixture)
+        # Per-run sentinel isolation: jit_recall's surface-once gate is
+        # keyed by (session_id, rule) but headless payloads carry no
+        # session_id, so every headless session shares one "unknown"
+        # bucket — the FIRST fire anywhere suppresses all later ones
+        # for 7 days (root cause of the silent-recall pilots,
+        # 2026-07-13). A fixture-local dir gives each run a virgin
+        # gate AND stops runs writing sentinels into the real
+        # ~/.attune (the spec's isolation requirement).
+        sentinel_dir = fixture / ".attune-sentinels"
+        sentinel_dir.mkdir()
         cmd = [
             "claude",
             "-p",
@@ -481,10 +491,12 @@ def run_trap_session(
             cmd += ["--plugin-dir", str(effective_plugin)]
         start = time.monotonic()
         try:
+            env = build_env(arm)
+            env["ATTUNE_AI_SENTINEL_DIR"] = str(sentinel_dir)
             proc = subprocess.run(
                 cmd,
                 cwd=fixture,
-                env=build_env(arm),
+                env=env,
                 capture_output=True,
                 text=True,
                 timeout=timeout_s,

--- a/benchmarks/trap_battery.py
+++ b/benchmarks/trap_battery.py
@@ -519,6 +519,62 @@ def aggregate_cells(results: list[TrapRunResult]) -> dict[str, dict[str, Cell]]:
     return cells
 
 
+#: The recall hooks' own event log — the authoritative in-band receipt
+#: that injections happened. Discovered 2026-07-13: stream-json does
+#: NOT echo hook additionalContext into events, so transcript markers
+#: are structurally blind; the telemetry log is ground truth (every
+#: jit_recall/lesson_recall fire appends a line — see
+#: plugin/hooks/_memory_telemetry.py).
+MEMORY_EVENTS_LOG = Path.home() / ".attune" / "telemetry" / "memory_events.jsonl"
+
+
+def count_memory_events(since_iso: str, log_path: Path | None = None) -> int:
+    """Count recall-telemetry events at/after ``since_iso`` (UTC ISO).
+
+    Returns -1 when the log is unreadable (treated as "no receipt
+    available", reported but not fatal).
+    """
+    path = log_path or MEMORY_EVENTS_LOG
+    try:
+        lines = path.read_text().splitlines()
+    except OSError:
+        return -1
+    n = 0
+    for line in lines:
+        try:
+            ev = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(ev, dict) and ev.get("ts", "") >= since_iso:
+            n += 1
+    return n
+
+
+def telemetry_arm_receipt(n_events: int, arms: list[str]) -> str | None:
+    """Interpret the run-window telemetry count as an arms receipt.
+
+    The 2026-07-13 pilot lesson: plugin recall hooks may not run AT ALL
+    in headless temp-dir sessions, making both arms identical no matter
+    what the env toggles say. Zero events across a run that included an
+    ON arm means the A/B measured nothing about memory.
+    """
+    if "on" not in arms:
+        return None
+    if n_events < 0:
+        return (
+            "ARM-VALIDATION WARNING — recall telemetry log unreadable "
+            f"({MEMORY_EVENTS_LOG}); no injection receipt is available."
+        )
+    if n_events == 0:
+        return (
+            "ARM-VALIDATION FAILURE — zero recall-telemetry events during "
+            "the run window: the recall hooks never ran in these sessions, "
+            "so BOTH arms were effectively OFF and arm deltas are INVALID "
+            "(2026-07-13 pilot failure mode)."
+        )
+    return None
+
+
 def validate_arms(results: list[TrapRunResult]) -> list[str]:
     """Receipt that the arm toggles are honored ("registered ≠ working").
 
@@ -674,6 +730,7 @@ def main(argv: list[str] | None = None) -> int:
             file=sys.stderr,
         )
 
+    run_start_iso = time.strftime("%Y-%m-%dT%H:%M:%S", time.gmtime())
     results: list[TrapRunResult] = []
     for repeat in range(args.repeats):
         # Alternate arm order per repeat (cache-warmth symmetry, as in
@@ -699,7 +756,12 @@ def main(argv: list[str] | None = None) -> int:
                 results.append(r)
 
     cells = aggregate_cells(results)
+    n_events = count_memory_events(run_start_iso)
+    receipt = telemetry_arm_receipt(n_events, arms)
     print(render_report(cells, results, markdown=False))
+    print(f"\nrecall-telemetry events in run window: {n_events}")
+    if receipt:
+        print(receipt)
     if args.markdown:
         print()
         print(render_report(cells, results, markdown=True))

--- a/benchmarks/trap_battery.py
+++ b/benchmarks/trap_battery.py
@@ -403,6 +403,15 @@ class TrapRunResult:
     injections: dict[str, int] = field(default_factory=dict)
 
 
+#: The repo's own plugin directory — forced into every trap session via
+#: ``--plugin-dir``. Discovered 2026-07-13 (killed-probe receipt): the
+#: INSTALLED plugin's hooks do NOT load in headless ``claude -p``
+#: sessions, so without this flag both arms run with recall dead. The
+#: flag also pins the benchmark to the repo's CURRENT hook code rather
+#: than whatever plugin version is installed.
+DEFAULT_PLUGIN_DIR = Path(__file__).resolve().parents[1] / "plugin"
+
+
 def run_trap_session(
     trap: Trap,
     arm: str,
@@ -411,8 +420,16 @@ def run_trap_session(
     max_turns: int,
     timeout_s: int,
     keep_fixture: bool = False,
+    plugin_dir: Path | None = None,
 ) -> TrapRunResult:
-    """Build a fresh fixture, run one headless session in it, score it."""
+    """Build a fresh fixture, run one headless session in it, score it.
+
+    ``--include-hook-events`` puts each hook's lifecycle (and output)
+    into the stream as system events — hook outputs carry the recall
+    banners, which is what makes ``Transcript.injections()`` a working
+    receipt. ``--plugin-dir`` force-loads the repo plugin (see
+    DEFAULT_PLUGIN_DIR note).
+    """
     fixture = Path(tempfile.mkdtemp(prefix=f"trap-{trap.id}-"))
     try:
         trap.setup(fixture)
@@ -423,11 +440,15 @@ def run_trap_session(
             "--output-format",
             "stream-json",
             "--verbose",
+            "--include-hook-events",
             "--allowedTools",
             trap.allowed_tools,
             "--max-turns",
             str(max_turns),
         ]
+        effective_plugin = plugin_dir if plugin_dir is not None else DEFAULT_PLUGIN_DIR
+        if effective_plugin and effective_plugin.is_dir():
+            cmd += ["--plugin-dir", str(effective_plugin)]
         start = time.monotonic()
         try:
             proc = subprocess.run(
@@ -691,6 +712,12 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument(
         "--keep-fixtures", action="store_true", help="keep temp fixtures for inspection"
     )
+    parser.add_argument(
+        "--plugin-dir",
+        type=Path,
+        default=None,
+        help="plugin dir to force-load per session (default: the repo's plugin/)",
+    )
     args = parser.parse_args(argv)
 
     arms = [a.strip() for a in args.arms.split(",") if a.strip()]
@@ -746,6 +773,7 @@ def main(argv: list[str] | None = None) -> int:
                     max_turns=args.max_turns,
                     timeout_s=args.timeout_s,
                     keep_fixture=args.keep_fixtures,
+                    plugin_dir=args.plugin_dir,
                 )
                 status = ("FIRED" if r.fired else "clean") if r.ok else f"ERROR ({r.error})"
                 inj = "+".join(f"{k[0]}{v}" for k, v in sorted(r.injections.items()))

--- a/benchmarks/trap_battery_results_2026-07-13.md
+++ b/benchmarks/trap_battery_results_2026-07-13.md
@@ -214,3 +214,35 @@ The $0.15 probe with saved transcripts closed the case:
 Verification path: one $0.15 zsh ON probe should now show `inj j1`
 and a fresh telemetry event; then the pilot re-run (~$6) measures a
 real Δp for the first time.
+
+---
+
+## FINAL REFRAME (2026-07-13) — what a JIT-carried rule can and cannot prevent
+
+The post-fix probe was CLEAN with hooks fully alive (Se10/Pr5, all
+exit 0) and still zero injections — and this time that is the system
+working correctly: the agent's first draft was already quoted
+(`echo "==="`), the rule's match_regex requires an UNQUOTED =-word,
+so there was no decision point to fire at. Two structural findings:
+
+1. **PreToolUse injection cannot prevent the first occurrence.** The
+   hook's own docs: injected context "reaches the model while the
+   call proceeds" (D2, smoke-tested 2026-06-09). A JIT-carried rule
+   fires exactly when the mistaken command is already drafted — the
+   error still executes; the value is in RECOVERY (fewer flails,
+   correct diagnosis, faster retry). As scored (signature occurred),
+   zsh-eqword's Δp is structurally ~0. The original pilot's
+   "ON 0/5 prevention" was noise on dead arms, and could never have
+   been real prevention under these mechanics.
+2. **Injection surface determines what is measurable.**
+   UserPromptSubmit-carried rules (injected before any action) can
+   show first-occurrence prevention; PreToolUse-carried rules can
+   only show recovery differential. Phase-2 scorer design follows:
+   for JIT traps, score retries-to-recovery / wrong-diagnosis /
+   time-after-error between arms, not occurrence.
+
+Receipts recalibrated accordingly: hook lifecycle = alive-signal;
+zero banners with hooks alive = "no decision point hit" (INFO);
+zero telemetry = informational (fire-only). The harness, receipts,
+and isolation are now sound; the remaining phase-2 work is trap and
+scorer design, which is design work, not tonight's build.

--- a/benchmarks/trap_battery_results_2026-07-13.md
+++ b/benchmarks/trap_battery_results_2026-07-13.md
@@ -186,3 +186,31 @@ costs one $0.15 session instead of a $6 re-run. Open question for
 phase 2: WHICH plugin SessionStart hooks fail in fixture dirs and
 whether recall needs a repo-shaped cwd (hydrate) — answerable from
 one saved transcript.
+
+---
+
+## ROOT CAUSE (2026-07-13, final) — surface-once sentinel collapse
+
+The $0.15 probe with saved transcripts closed the case:
+
+- Hooks run fine in fixture sessions (probe: SessionStart ×10,
+  PreToolUse ×5, all recall-relevant hooks exit 0) — but jit_recall
+  emitted nothing because of its **surface-once sentinel**: headless
+  payloads carry no `session_id`, so every headless session shares
+  the literal `unknown` sentinel bucket in `~/.attune`. The first
+  fire anywhere (here: a direct diagnostic invocation at 03:38Z)
+  suppresses the rule for ALL headless sessions for 7 days.
+- Even unpolluted, a 30-session pilot would have had exactly ONE
+  ON-arm injection total — the A/B was structurally broken from the
+  first design, independent of plugin loading.
+- **Fix (shipped):** per-run `ATTUNE_AI_SENTINEL_DIR` isolation —
+  every session gets a virgin fixture-local sentinel dir, which also
+  stops benchmark runs writing sentinels into the real `~/.attune`
+  (the spec's isolation requirement, previously violated).
+- The underlying PRODUCT bug (headless users get each JIT rule once
+  per 7 days machine-wide) is flagged as its own task, out of this
+  spec's scope.
+
+Verification path: one $0.15 zsh ON probe should now show `inj j1`
+and a fresh telemetry event; then the pilot re-run (~$6) measures a
+real Δp for the first time.

--- a/benchmarks/trap_battery_results_2026-07-13.md
+++ b/benchmarks/trap_battery_results_2026-07-13.md
@@ -77,3 +77,55 @@ arm.
 4. **Cost model correction.** ~$0.19/session mean → a 20/cell rate
    run for two classes ≈ 80 sessions ≈ **$15**, well under the
    phase-2 assumptions.
+
+---
+
+## CORRECTION (2026-07-13, same night) — pilot INVALID as an A/B; Δp retracted
+
+The injection-detection diagnostic (7 further sessions + direct hook
+execution + telemetry audit) established, in order:
+
+1. **stream-json does not echo hook `additionalContext`** — the
+   transcript-marker scan above is structurally blind. Detection was
+   rebuilt on the authoritative channel:
+   `~/.attune/telemetry/memory_events.jsonl` (every recall fire
+   appends a line).
+2. **The recall hooks are plugin-level and DO work from a temp dir**
+   (direct execution of `jit_recall.py` with the zsh trap payload
+   from a scratch dir returned the zsh-eqword rule; with
+   `ATTUNE_JIT_RECALL=0` it returned nothing — the kill-switch
+   receipt is good).
+3. **But the telemetry log shows ZERO recall events from any of the
+   37 headless fixture sessions.** Every event in the window belongs
+   to interactive sessions or the direct hook tests. The plugin's
+   hooks never ran inside `claude -p` sessions in temp dirs — so
+   **both arms were effectively OFF for the entire pilot**, and every
+   Δp above is sampling noise on identical arms.
+
+**Retractions/re-readings:**
+
+- `zsh-eqword` Δp "+40%" → **retracted**. With both arms unaided,
+  the pooled firing rate is 3/14 (~21%); the observed 0/7-vs-3/7
+  split has p≈0.19 under a common rate — consistent with chance.
+- The trap DESIGNS retain their validated properties: zsh-eqword
+  discriminates unaided (~21% firing with no lesson present),
+  git-commit-verify-landed does not fire at all (0/14 pooled),
+  question-shape fires ~100% unaided.
+- `question-shape` gains a STRUCTURAL diagnosis independent of the
+  arms problem: its only allowed tool is `Read`, which the JIT
+  matcher (`AskUserQuestion|Bash|Edit`) does not cover, and direct
+  execution of `lesson_recall.py` on the trap prompt returns nothing
+  (below the 8.0 score floor). Even with hooks running, the ON arm
+  had zero injection paths. SWAP verdict stands, with the finding
+  re-filed to the recall-triggering axis.
+
+**Phase-2 preconditions (blocking):**
+
+1. Make the recall hooks actually run in harness sessions
+   (candidate: run fixtures under a trusted/plugin-enabled path;
+   discriminator test: one headless session cwd'd in the repo, then
+   check the telemetry log for its events).
+2. The harness now reads the telemetry log over the run window and
+   declares ARM-VALIDATION FAILURE on zero events with an ON arm —
+   re-running tonight's pilot under the fixed harness would have
+   refused to report Δp.

--- a/benchmarks/trap_battery_results_2026-07-13.md
+++ b/benchmarks/trap_battery_results_2026-07-13.md
@@ -1,0 +1,79 @@
+# Trap battery — phase 1 pilot results (2026-07-13)
+
+**Run:** 3 traps × 2 arms × 5 repeats = 30 headless sessions, all ok
+(0 errors). Executed by Patrick from a plain terminal on branch
+`feat/trap-battery-pilot`; live terminal transcript is the source of
+record for this doc. Total spend ≈ **$5.65** (vs the $30–60
+estimate). **PILOT scale — nothing below is quotable externally; the
+20+/cell rate run is where numbers earn quotes.**
+
+## Fired rate by class and arm
+
+| Trap class | OFF fired | ON fired | Δp (off − on) |
+|---|--:|--:|--:|
+| `zsh-eqword` | 2/5 (40%) | 0/5 (0%) | **+40%** |
+| `git-commit-verify-landed` | 0/5 (0%) | 0/5 (0%) | +0% |
+| `question-shape` | 5/5 (100%) | 4/5 (80%) | +20% |
+
+Output is failure rates and Δp only — no savings claim (insurance
+frame, #1291 discipline).
+
+## Discrimination receipts
+
+Gate: a trap earns phase 2 by firing ≥2/5 in the OFF (lesson-absent)
+arm.
+
+- **`zsh-eqword` — receipt obtained.** OFF repeats #2 and #3 fired
+  with tool-result evidence `zsh:1: == not found` (the exact
+  signature verified live before the regex was written). ON arm:
+  0/5 — every memory-on session quoted the separator.
+- **`question-shape` — receipt obtained, but see verdict.** OFF
+  5/5, all with prose either/or evidence (e.g. *"Which scope do you
+  want to ship — Minimal or Full?"*). The ON arm ALSO fired 4/5 —
+  the surfaced rule barely changes behavior.
+- **`git-commit-verify-landed` — no live receipt.** 0/5 OFF. The
+  scorer itself is receipt-proven on canned transcripts (unit
+  tests), but the live trap never fired: baseline sessions handled
+  the hook's visible exit-1, re-staged, retried, and verified. The
+  fixture's failure is louder than the lived original (`git commit
+  -q` exiting 0 with the commit silently skipped), which a plain
+  pre-commit hook cannot reproduce — hooks that exit 0 let the
+  commit proceed.
+
+## Class verdicts (phase-2 go/no-go)
+
+- **`zsh-eqword`: GO.** Discriminates at exactly the gate (2/5 OFF)
+  with a pilot Δp of +40% and a clean prevention story (ON 0/5).
+  Graduates to the 20+/cell rate run.
+- **`git-commit-verify-landed`: NO-GO as designed — redesign or
+  swap.** The trap tests recovery from a *visible* failure, which
+  current baseline behavior already handles. Either find a faithful
+  reproduction of the silent-skip (hard: needs the real pre-commit
+  framework's stash dance) or swap in `stale-claim` (pre-approved
+  candidate, requirements §swap).
+- **`question-shape`: SWAP, with a finding worth keeping.** It
+  passes the OFF-gate trivially (5/5) but ON≈OFF means the lesson
+  is either not being injected in fixture-repo sessions or is
+  injected and ignored — the current harness can't distinguish
+  these. Swap in `zsh-status-readonly` for phase 2 (pre-approved),
+  and carry the harness follow-up below.
+
+## Findings beyond the table
+
+1. **First measured Δp > 0 for the memory suite.** zsh-eqword is
+   the first behavioral (not cost) evidence that a surfaced lesson
+   prevents a lived failure class. Pilot-labeled, n=5/cell.
+2. **Failure has a visible cost signature.** The two OFF-arm
+   zsh firings ran ~13s / ~$0.18 vs ~8s / ~$0.15 for clean runs —
+   the error-and-recover loop costs ~60% more wall and ~20% more
+   spend even on a toy task. This is the insurance premium's
+   counterpart measured on the benefit side.
+3. **Harness follow-up (phase 2): injection detection.** Record
+   per-session whether the recall hooks actually injected content
+   (visible in the stream-json system/context events), so
+   "lesson ignored" and "lesson never surfaced" stop being
+   confounded — question-shape's ON 4/5 is uninterpretable without
+   it.
+4. **Cost model correction.** ~$0.19/session mean → a 20/cell rate
+   run for two classes ≈ 80 sessions ≈ **$15**, well under the
+   phase-2 assumptions.

--- a/benchmarks/trap_battery_results_2026-07-13.md
+++ b/benchmarks/trap_battery_results_2026-07-13.md
@@ -153,3 +153,36 @@ repo's current hook code). Three receipts stack: hook events
 (per-session), telemetry log (run window), and the OFF-arm marker
 scan. A valid pilot re-run is unblocked; Δp remains unmeasured until
 it happens.
+
+---
+
+## AMENDMENT 2 (2026-07-13) — pilot re-run ALSO refused; receipt hierarchy revised
+
+The re-run (30 sessions, ~$5.80) ran under the fixed harness — and the
+harness correctly **refused to report Δp again** (zero recall
+telemetry, zero banners). Forensics on the surviving probe stream
+revised the picture:
+
+- `--plugin-dir` DOES load the plugin in headless sessions (the
+  plugin's welcome banner appears in a hook_response: "attune-ai
+  loaded — 18 workflows, 31 MCP tools"). The earlier RESOLUTION
+  stands on that point.
+- **But 3 of the plugin's SessionStart hooks exit 1 in fixture
+  sessions**, and no recall telemetry appears — the recall subsystem
+  (hydrate → recall map → injection) is failing OUTSIDE a real repo
+  even though the hook scripts run fine when executed directly with
+  a full interactive env.
+- **Telemetry is fire-only** for jit/lesson recall, so zero events
+  alone cannot distinguish "hooks dead" from "hooks alive, nothing
+  matched". `session_recall` (logs every session start) is the
+  alive-signal: zero session_recall events across 30 sessions is
+  what proves the recall path never initialized.
+
+Receipt hierarchy (implemented): per-run **hook_summary** (lifecycle
+events — hooks alive?) → **injection banners** (did recall inject?)
+→ **telemetry window** (fire log). The harness now persists raw
+streams on request (`--save-transcripts DIR`), so the next diagnosis
+costs one $0.15 session instead of a $6 re-run. Open question for
+phase 2: WHICH plugin SessionStart hooks fail in fixture dirs and
+whether recall needs a repo-shaped cwd (hydrate) — answerable from
+one saved transcript.

--- a/benchmarks/trap_battery_results_2026-07-13.md
+++ b/benchmarks/trap_battery_results_2026-07-13.md
@@ -129,3 +129,27 @@ execution + telemetry audit) established, in order:
    declares ARM-VALIDATION FAILURE on zero events with an ON arm —
    re-running tonight's pilot under the fixed harness would have
    refused to report Δp.
+
+---
+
+## RESOLUTION (2026-07-13, later) — headless hook mechanism found
+
+A killed probe session (rejected mid-run, but its stream survived on
+disk) settled the phase-2 precondition at near-zero cost:
+
+- `claude -p --plugin-dir <repo>/plugin` **force-loads the plugin in
+  headless mode** — 10 plugin SessionStart hooks and 2
+  UserPromptSubmit hooks demonstrably started/responded from a temp
+  dir. (Patrick's repo-cwd probe confirmed the INSTALLED plugin's
+  hooks do NOT load in `-p` mode — the flag is required.)
+- `--include-hook-events` surfaces every hook as named
+  `hook_started`/`hook_response` system events, with output — and
+  hook outputs carry the recall banners, so transcript-marker
+  detection WORKS under these flags.
+
+The harness now always passes `--include-hook-events` and defaults
+`--plugin-dir` to the repo's `plugin/` (pinning the benchmark to the
+repo's current hook code). Three receipts stack: hook events
+(per-session), telemetry log (run window), and the OFF-arm marker
+scan. A valid pilot re-run is unblocked; Δp remains unmeasured until
+it happens.

--- a/docs/specs/product-direction-review/freeze-week-plan-2026-07-13.md
+++ b/docs/specs/product-direction-review/freeze-week-plan-2026-07-13.md
@@ -106,7 +106,7 @@ data point instead of a vibe.
 | 1 | 0 replies >24h; threads logged | |
 | 2 | N5 paragraph committed | **Done 2026-07-12** — usage-signals D11. |
 | 3 | Memory visibly pillar #1, sweep clean | **Done 2026-07-12** — README memory-first intro; PILLARS reordered; home/FAQ/how-it-works/docs/pricing copy reworded (pricing found only by the final broad grep); `next build` green. PyPI copy lags until first post-freeze release, as planned. |
-| 4 | Pilot discrimination results (or dated deferral) | |
+| 4 | Pilot discrimination results (or dated deferral) | **Run + corrected 2026-07-13.** Harness shipped (PR #1343); 30-session pilot executed (~$5.65); arm receipt then INVALIDATED the A/B (recall hooks dead in headless sessions — both arms OFF; Δp retracted, corrections in place). Fix found same night: `--plugin-dir` + `--include-hook-events`; valid re-run unblocked. Trap verdicts: zsh-eqword GO, git-commit NO-GO, question-shape SWAP (structural). |
 | 5 | fable tasks 3–8 done OR consciously dropped | |
 | 6 | Freeze interpretation written 07-27 | |
 

--- a/docs/specs/trap-battery/decisions.md
+++ b/docs/specs/trap-battery/decisions.md
@@ -94,3 +94,17 @@ never load headless, which is why the pilot arms were dead.
 as stream events. Harness updated to pass both by default; valid
 pilot re-run is unblocked (~$6, needs a stated-cost go). Runbook
 unchanged: plain terminal, `python -m benchmarks.trap_battery --run`.
+
+## 2026-07-13 (design finding) — injection surface bounds the measurand
+
+Chain of four root causes closed (plugin loading → visibility →
+sentinel collapse → match-scope mechanics); full narrative in the
+results doc. Standing design rule for phase 2: **PreToolUse-carried
+rules can only be measured on recovery differential** (the call
+proceeds; first error unavoidable); **first-occurrence prevention is
+only measurable for UserPromptSubmit-carried rules**. Phase-2 trap
+lineup and scorers must be re-derived under this rule before the
+next paid run — the ~$6 re-run is deferred until then (no point
+measuring a structurally-zero Δp). Harness receipts recalibrated:
+hook lifecycle = alive-signal; banners = injection; telemetry =
+fire log (informational).

--- a/docs/specs/trap-battery/decisions.md
+++ b/docs/specs/trap-battery/decisions.md
@@ -33,3 +33,27 @@
   itself still gets a stated-cost go at execution time per the
   spend gate.
 - DEC-1 note: existing spec directory — freeze-compatible.
+
+## 2026-07-13 — Phase 1 pilot EXECUTED; per-class go/no-go
+
+Run by Patrick from a plain terminal (30/30 sessions ok, ~$5.65 —
+6-10x under estimate). Full table + receipts:
+`benchmarks/trap_battery_results_2026-07-13.md`.
+
+- **zsh-eqword: GO to phase 2** (rate run at 20+/cell). OFF 2/5,
+  ON 0/5, pilot Δp +40% — first behavioral evidence that a surfaced
+  lesson prevents a lived failure class.
+- **git-commit-verify-landed: NO-GO — redesign or swap.** 0/5 both
+  arms; a plain pre-commit hook cannot reproduce the lived
+  silent-skip (exit 0 + skipped commit), so the fixture's visible
+  exit-1 tests recovery the baseline already has. Swap candidate:
+  `stale-claim`.
+- **question-shape: SWAP** (as pre-flagged at requirements time;
+  `zsh-status-readonly` comes in). OFF 5/5 but ON 4/5 — the rule
+  barely changes behavior, and the harness cannot yet distinguish
+  lesson-ignored from lesson-never-injected.
+- **Harness follow-up adopted for phase 2:** per-session injection
+  detection from the stream-json events, so ON-arm firings are
+  interpretable.
+- Phase-2 cost projection corrected: ~$0.19/session mean → 2
+  classes × 20/cell ≈ 80 sessions ≈ $15.

--- a/docs/specs/trap-battery/decisions.md
+++ b/docs/specs/trap-battery/decisions.md
@@ -83,3 +83,14 @@ arms effectively OFF). Full chain + retractions in
   to benchmark arms) caught this the same night it shipped — the
   detection feature's first real catch was the pilot that motivated
   it.
+
+## 2026-07-13 (final addendum) — phase-2 precondition RESOLVED
+
+`--plugin-dir <repo>/plugin` force-loads plugin hooks in headless
+`-p` sessions (killed-probe receipt: SessionStart ×10 +
+UserPromptSubmit ×2 fired from a temp dir); installed-plugin hooks
+never load headless, which is why the pilot arms were dead.
+`--include-hook-events` surfaces hook outputs (with recall banners)
+as stream events. Harness updated to pass both by default; valid
+pilot re-run is unblocked (~$6, needs a stated-cost go). Runbook
+unchanged: plain terminal, `python -m benchmarks.trap_battery --run`.

--- a/docs/specs/trap-battery/decisions.md
+++ b/docs/specs/trap-battery/decisions.md
@@ -57,3 +57,29 @@ Run by Patrick from a plain terminal (30/30 sessions ok, ~$5.65 —
   interpretable.
 - Phase-2 cost projection corrected: ~$0.19/session mean → 2
   classes × 20/cell ≈ 80 sessions ≈ $15.
+
+## 2026-07-13 (later, same night) — CORRECTION: pilot invalid as A/B
+
+The injection diagnostic invalidated the arm comparison: recall
+hooks never ran in the headless temp-dir sessions (zero events in
+`~/.attune/telemetry/memory_events.jsonl` for all 37 sessions; both
+arms effectively OFF). Full chain + retractions in
+`benchmarks/trap_battery_results_2026-07-13.md` (CORRECTION section).
+
+- **zsh-eqword GO → GO, re-based.** Δp +40% retracted (noise on
+  identical arms). What survives: the trap discriminates unaided
+  (3/14 pooled) and its scorer is receipt-proven. It stays the lead
+  phase-2 class — but Δp is still unmeasured.
+- **git-commit-verify-landed NO-GO — unchanged** (0/14 pooled).
+- **question-shape SWAP — unchanged and now structural**: `Read`
+  isn't in the JIT matcher and the prompt scores below the
+  lesson-recall floor; the ON arm had zero injection paths by
+  construction. Finding re-filed to the recall-triggering axis
+  (memory-recall-eval sibling).
+- **Blocking phase-2 precondition:** get recall hooks running in
+  harness sessions and verify via the telemetry-window receipt now
+  built into the harness (ARM-VALIDATION FAILURE on zero events).
+- Meta: the arm-receipt discipline ("registered ≠ working" applied
+  to benchmark arms) caught this the same night it shipped — the
+  detection feature's first real catch was the pilot that motivated
+  it.

--- a/docs/specs/trap-battery/requirements.md
+++ b/docs/specs/trap-battery/requirements.md
@@ -6,7 +6,7 @@
 > Δp (prevention) term of the memory-as-insurance EV — and, once
 > stable, doubles as the memory system's regression suite.
 
-**Status:** approved (2026-07-12) — phase 1 pilot authorized
+**Status:** phase 1 executed (2026-07-13) — pilot complete, verdicts in decisions.md
 **Owner:** Patrick + agent
 **Related:**
 

--- a/tests/unit/benchmarks/test_trap_battery.py
+++ b/tests/unit/benchmarks/test_trap_battery.py
@@ -421,3 +421,50 @@ class TestValidateArms:
         report = render_report(aggregate_cells(results), results, markdown=False)
         assert "ARM-VALIDATION FAILURE" in report
         assert "ARM-VALIDATION WARNING" in report
+
+
+class TestTelemetryArmReceipt:
+    def _log(self, tmp_path, rows):
+        p = tmp_path / "memory_events.jsonl"
+        p.write_text("\n".join(json.dumps(r) for r in rows))
+        return p
+
+    def test_counts_events_in_window(self, tmp_path):
+        from benchmarks.trap_battery import count_memory_events
+
+        log = self._log(
+            tmp_path,
+            [
+                {"ts": "2026-07-13T01:00:00Z", "event": "jit_recall"},
+                {"ts": "2026-07-13T03:00:00Z", "event": "jit_recall"},
+                {"ts": "2026-07-13T04:00:00Z", "event": "session_recall"},
+            ],
+        )
+        assert count_memory_events("2026-07-13T02:00:00", log_path=log) == 2
+
+    def test_unreadable_log_is_minus_one(self, tmp_path):
+        from benchmarks.trap_battery import count_memory_events
+
+        assert count_memory_events("2026-07-13", log_path=tmp_path / "nope.jsonl") == -1
+
+    def test_zero_events_with_on_arm_is_failure(self):
+        from benchmarks.trap_battery import telemetry_arm_receipt
+
+        msg = telemetry_arm_receipt(0, ["on", "off"])
+        assert msg is not None and "INVALID" in msg
+
+    def test_zero_events_off_only_is_fine(self):
+        from benchmarks.trap_battery import telemetry_arm_receipt
+
+        assert telemetry_arm_receipt(0, ["off"]) is None
+
+    def test_positive_count_is_clean(self):
+        from benchmarks.trap_battery import telemetry_arm_receipt
+
+        assert telemetry_arm_receipt(7, ["on", "off"]) is None
+
+    def test_unreadable_is_warning_not_failure(self):
+        from benchmarks.trap_battery import telemetry_arm_receipt
+
+        msg = telemetry_arm_receipt(-1, ["on"])
+        assert msg is not None and "WARNING" in msg and "INVALID" not in msg

--- a/tests/unit/benchmarks/test_trap_battery.py
+++ b/tests/unit/benchmarks/test_trap_battery.py
@@ -400,14 +400,22 @@ class TestValidateArms:
         assert len(warnings) == 1
         assert "INVALID" in warnings[0]
 
-    def test_markerless_on_arm_is_a_warning(self):
+    def test_markerless_on_arm_without_hooks_is_failure(self):
         results = [
             _ri("on", {"prompt_recall": 0, "jit_recall": 0}),
             _ri("off", {"prompt_recall": 0, "jit_recall": 0}),
         ]
         warnings = validate_arms(results)
         assert len(warnings) == 1
-        assert "unvalidated" in warnings[0]
+        assert "INVALID" in warnings[0]
+
+    def test_markerless_on_arm_with_hooks_alive_is_info(self):
+        alive = _ri("on", {"prompt_recall": 0, "jit_recall": 0})
+        alive.hooks = {"SessionStart": 10, "PreToolUse": 5, "failed": 0}
+        warnings = validate_arms([alive])
+        assert len(warnings) == 1
+        assert "INFO" in warnings[0]
+        assert "INVALID" not in warnings[0]
 
     def test_errored_runs_are_ignored(self):
         results = [_ri("off", {"prompt_recall": 5, "jit_recall": 5}, ok=False)]
@@ -419,8 +427,8 @@ class TestValidateArms:
             _ri("off", {"prompt_recall": 1, "jit_recall": 0}),
         ]
         report = render_report(aggregate_cells(results), results, markdown=False)
-        assert "ARM-VALIDATION FAILURE" in report
-        assert "ARM-VALIDATION WARNING" in report
+        # off-arm banner -> kill-switch failure; markerless hook-less on -> failure
+        assert report.count("ARM-VALIDATION FAILURE") == 2
 
 
 class TestTelemetryArmReceipt:
@@ -447,11 +455,12 @@ class TestTelemetryArmReceipt:
 
         assert count_memory_events("2026-07-13", log_path=tmp_path / "nope.jsonl") == -1
 
-    def test_zero_events_with_on_arm_is_failure(self):
+    def test_zero_events_with_on_arm_is_informational(self):
         from benchmarks.trap_battery import telemetry_arm_receipt
 
         msg = telemetry_arm_receipt(0, ["on", "off"])
-        assert msg is not None and "INVALID" in msg
+        assert msg is not None and "fire-only" in msg
+        assert "INVALID" not in msg
 
     def test_zero_events_off_only_is_fine(self):
         from benchmarks.trap_battery import telemetry_arm_receipt

--- a/tests/unit/benchmarks/test_trap_battery.py
+++ b/tests/unit/benchmarks/test_trap_battery.py
@@ -504,3 +504,33 @@ class TestHookEventReceipt:
         }
         t = _transcript(ev, _result("x"))
         assert sum(t.injections().values()) == 0
+
+
+class TestHookSummary:
+    def test_counts_started_by_event_and_failures(self):
+        events = [
+            {"type": "system", "subtype": "hook_started", "hook_event": "SessionStart"},
+            {"type": "system", "subtype": "hook_started", "hook_event": "SessionStart"},
+            {"type": "system", "subtype": "hook_started", "hook_event": "PreToolUse"},
+            {
+                "type": "system",
+                "subtype": "hook_response",
+                "hook_event": "SessionStart",
+                "exit_code": 1,
+            },
+            {
+                "type": "system",
+                "subtype": "hook_response",
+                "hook_event": "SessionStart",
+                "exit_code": 0,
+            },
+        ]
+        t = _transcript(*events, _result("x"))
+        summary = t.hook_summary()
+        assert summary["SessionStart"] == 2
+        assert summary["PreToolUse"] == 1
+        assert summary["failed"] == 1
+
+    def test_no_hook_events_is_all_zero(self):
+        t = _transcript(_result("x"))
+        assert t.hook_summary() == {"failed": 0}

--- a/tests/unit/benchmarks/test_trap_battery.py
+++ b/tests/unit/benchmarks/test_trap_battery.py
@@ -468,3 +468,39 @@ class TestTelemetryArmReceipt:
 
         msg = telemetry_arm_receipt(-1, ["on"])
         assert msg is not None and "WARNING" in msg and "INVALID" not in msg
+
+
+class TestHookEventReceipt:
+    """--include-hook-events puts hook outputs into the stream as
+    system events; injections() must count banners found there (the
+    2026-07-13 discovery that made transcript detection work)."""
+
+    def test_hook_response_output_counts_as_injection(self):
+        ev = {
+            "type": "system",
+            "subtype": "hook_response",
+            "hook_event": "UserPromptSubmit",
+            "output": "Lessons that may apply to this prompt:\n- foo",
+        }
+        t = _transcript(ev, _result("x"))
+        assert t.injections()["prompt_recall"] == 1
+
+    def test_jit_hook_response_counts(self):
+        ev = {
+            "type": "system",
+            "subtype": "hook_response",
+            "hook_event": "PreToolUse",
+            "output": '{"hookSpecificOutput": {"additionalContext": '
+            '"Just-in-time recall — rule(s) governing Bash: ..."}}',
+        }
+        t = _transcript(ev, _result("x"))
+        assert t.injections()["jit_recall"] == 1
+
+    def test_hook_started_without_output_does_not_count(self):
+        ev = {
+            "type": "system",
+            "subtype": "hook_started",
+            "hook_event": "UserPromptSubmit",
+        }
+        t = _transcript(ev, _result("x"))
+        assert sum(t.injections().values()) == 0

--- a/tests/unit/benchmarks/test_trap_battery.py
+++ b/tests/unit/benchmarks/test_trap_battery.py
@@ -1,0 +1,342 @@
+"""Unit tests for benchmarks/trap_battery.py (no sessions spawned).
+
+Pins the deterministic scorers on canned transcripts — the firing AND
+non-firing case per trap class, per the spec's acceptance criteria
+(docs/specs/trap-battery/requirements.md) — plus stream-json parsing,
+fixture construction, aggregation, and rendering. The live path
+(``run_trap_session`` → ``claude -p``) is exercised by the pilot run.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+# benchmarks/ is a repo-root namespace package, not part of src/attune.
+sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+
+from benchmarks.trap_battery import (  # noqa: E402
+    TRAPS,
+    Cell,
+    Transcript,
+    TrapRunResult,
+    aggregate_cells,
+    get_traps,
+    parse_stream_json,
+    render_report,
+)
+
+# --------------------------------------------------------------------------
+# canned stream-json builders
+# --------------------------------------------------------------------------
+
+
+def _assistant_bash(command: str) -> dict:
+    return {
+        "type": "assistant",
+        "message": {
+            "content": [{"type": "tool_use", "name": "Bash", "input": {"command": command}}]
+        },
+    }
+
+
+def _tool_result(text: str) -> dict:
+    return {
+        "type": "user",
+        "message": {
+            "content": [{"type": "tool_result", "content": [{"type": "text", "text": text}]}]
+        },
+    }
+
+
+def _result(final_text: str, *, ok: bool = True) -> dict:
+    return {
+        "type": "result",
+        "subtype": "success" if ok else "error_during_execution",
+        "is_error": not ok,
+        "result": final_text,
+        "num_turns": 3,
+        "total_cost_usd": 0.05,
+        "usage": {"input_tokens": 10, "output_tokens": 20},
+    }
+
+
+def _stream(*events: dict) -> str:
+    return "\n".join(json.dumps(e) for e in events)
+
+
+def _transcript(*events: dict) -> Transcript:
+    return parse_stream_json(_stream(*events), task_id="t", arm="off", repeat=0, wall_s=1.0)
+
+
+def _trap(trap_id: str):
+    return next(t for t in TRAPS if t.id == trap_id)
+
+
+def _git(fixture: Path, *args: str) -> str:
+    proc = subprocess.run(["git", "-C", str(fixture), *args], capture_output=True, text=True)
+    return proc.stdout.strip()
+
+
+# --------------------------------------------------------------------------
+# parse_stream_json / Transcript
+# --------------------------------------------------------------------------
+
+
+class TestParseStreamJson:
+    def test_collects_events_result_and_final_text(self):
+        t = _transcript(
+            _assistant_bash("echo hi"),
+            _tool_result("hi"),
+            _result("all done"),
+        )
+        assert len(t.events) == 3
+        assert t.result is not None and t.result.ok
+        assert t.final_text == "all done"
+        assert t.bash_commands() == ["echo hi"]
+        assert "hi" in t.tool_result_text()
+
+    def test_skips_noise_lines(self):
+        raw = "hook noise\n" + _stream(_result("done")) + "\nnot json {"
+        t = parse_stream_json(raw, task_id="t", arm="on", repeat=0, wall_s=1.0)
+        assert t.result is not None and t.result.ok
+
+    def test_missing_result_envelope_is_not_ok(self):
+        t = _transcript(_assistant_bash("echo hi"))
+        assert t.result is not None
+        assert not t.result.ok
+
+    def test_string_tool_result_content(self):
+        ev = {
+            "type": "user",
+            "message": {"content": [{"type": "tool_result", "content": "plain"}]},
+        }
+        t = _transcript(ev, _result("x"))
+        assert "plain" in t.tool_result_text()
+
+    def test_is_error_under_subtype_success_is_not_ok(self):
+        env = _result("looks fine")
+        env["is_error"] = True
+        t = _transcript(env)
+        assert t.result is not None
+        assert not t.result.ok
+
+
+# --------------------------------------------------------------------------
+# scorers — firing and non-firing per class
+# --------------------------------------------------------------------------
+
+
+class TestZshEqwordScorer:
+    def test_fires_on_real_signature(self, tmp_path):
+        # exact shape verified live: `zsh -c 'echo ==='` → "zsh:1: == not found"
+        t = _transcript(
+            _assistant_bash("zsh -c 'cat alpha.txt; echo ===; cat beta.txt'"),
+            _tool_result("alpha output\nzsh:1: == not found"),
+            _result("The command errored; here is the output."),
+        )
+        fired, evidence = _trap("zsh-eqword").score(t, tmp_path)
+        assert fired
+        assert "not found" in evidence
+
+    def test_fires_without_line_number(self, tmp_path):
+        t = _transcript(_tool_result("zsh: =foo not found"), _result("hmm"))
+        fired, _ = _trap("zsh-eqword").score(t, tmp_path)
+        assert fired
+
+    def test_clean_when_quoted(self, tmp_path):
+        t = _transcript(
+            _assistant_bash("zsh -c 'cat alpha.txt; echo \"===\"; cat beta.txt'"),
+            _tool_result("alpha output\n===\nbeta output"),
+            _result("Done — output shown above."),
+        )
+        fired, _ = _trap("zsh-eqword").score(t, tmp_path)
+        assert not fired
+
+    def test_unrelated_not_found_does_not_fire(self, tmp_path):
+        t = _transcript(_tool_result("zsh:1: command not found: foobar"), _result("x"))
+        fired, _ = _trap("zsh-eqword").score(t, tmp_path)
+        assert not fired
+
+    def test_fixture_setup(self, tmp_path):
+        _trap("zsh-eqword").setup(tmp_path)
+        assert (tmp_path / "alpha.txt").read_text() == "alpha output\n"
+        assert (tmp_path / "beta.txt").read_text() == "beta output\n"
+
+
+class TestGitCommitScorer:
+    @pytest.fixture()
+    def fixture(self, tmp_path):
+        _trap("git-commit-verify-landed").setup(tmp_path)
+        return tmp_path
+
+    def test_fixture_shape(self, fixture):
+        assert _git(fixture, "rev-list", "--count", "HEAD") == "1"
+        assert (fixture / ".git" / "hooks" / "pre-commit").stat().st_mode & 0o111
+        staged = _git(fixture, "diff", "--cached", "--name-only")
+        assert staged == "notes.txt"
+
+    def test_hook_blocks_first_commit_then_allows(self, fixture):
+        first = subprocess.run(
+            ["git", "-C", str(fixture), "commit", "-q", "-m", "docs: update notes"],
+            capture_output=True,
+            text=True,
+        )
+        assert first.returncode != 0
+        # git routes hook output to stderr on a failed commit; the
+        # session's Bash tool surfaces both streams either way.
+        assert "Fixed" in first.stdout + first.stderr
+        assert _git(fixture, "rev-list", "--count", "HEAD") == "1"
+        subprocess.run(
+            ["git", "-C", str(fixture), "add", "notes.txt"],
+            check=True,
+            capture_output=True,
+        )
+        second = subprocess.run(
+            ["git", "-C", str(fixture), "commit", "-q", "-m", "docs: update notes"],
+            capture_output=True,
+            text=True,
+        )
+        assert second.returncode == 0
+        assert _git(fixture, "rev-list", "--count", "HEAD") == "2"
+
+    def test_fires_on_false_claim(self, fixture):
+        t = _transcript(_result("The commit landed — notes.txt is committed successfully."))
+        fired, evidence = _trap("git-commit-verify-landed").score(t, fixture)
+        assert fired
+        assert "no new commit" in evidence
+
+    def test_clean_when_commit_actually_landed(self, fixture):
+        subprocess.run(
+            ["git", "-C", str(fixture), "commit", "-q", "--no-verify", "-m", "x"],
+            check=True,
+            capture_output=True,
+        )
+        t = _transcript(_result("The commit landed."))
+        fired, _ = _trap("git-commit-verify-landed").score(t, fixture)
+        assert not fired
+
+    def test_clean_on_honest_failure_report(self, fixture):
+        t = _transcript(_result("The pre-commit hook modified files, so the commit did not land."))
+        fired, _ = _trap("git-commit-verify-landed").score(t, fixture)
+        assert not fired
+
+
+class TestQuestionShapeScorer:
+    def test_fires_on_prose_either_or(self, tmp_path):
+        t = _transcript(
+            _result(
+                "Minimal ships fast; full is riskier.\n\n"
+                "Would you like to ship the minimal version or the full one?"
+            )
+        )
+        fired, evidence = _trap("question-shape").score(t, tmp_path)
+        assert fired
+        assert "either/or" in evidence
+
+    def test_clean_with_numbered_options(self, tmp_path):
+        t = _transcript(
+            _result(
+                "Tradeoff summarized. Which scope?\n\n"
+                "1. Minimal — 2 days, no deps\n"
+                "2. Full — 7 days, adds a queue\n"
+            )
+        )
+        fired, _ = _trap("question-shape").score(t, tmp_path)
+        assert not fired
+
+    def test_clean_with_option_labels(self, tmp_path):
+        t = _transcript(
+            _result(
+                "**Option A** minimal, **Option B** full.\n"
+                "Do you want the minimal or the full scope? Pick A or B."
+            )
+        )
+        fired, _ = _trap("question-shape").score(t, tmp_path)
+        assert not fired
+
+    def test_clean_on_empty_final_text(self, tmp_path):
+        t = _transcript(_result(""))
+        fired, _ = _trap("question-shape").score(t, tmp_path)
+        assert not fired
+
+    def test_fixture_setup(self, tmp_path):
+        _trap("question-shape").setup(tmp_path)
+        assert "Minimal" in (tmp_path / "scope.md").read_text()
+
+
+# --------------------------------------------------------------------------
+# trap registry / aggregation / rendering
+# --------------------------------------------------------------------------
+
+
+class TestGetTraps:
+    def test_default_is_all_three(self):
+        assert [t.id for t in get_traps()] == [
+            "zsh-eqword",
+            "git-commit-verify-landed",
+            "question-shape",
+        ]
+
+    def test_filter_and_unknown(self):
+        assert [t.id for t in get_traps(["question-shape"])] == ["question-shape"]
+        with pytest.raises(ValueError, match="unknown trap"):
+            get_traps(["nope"])
+
+
+def _r(trap_id="zsh-eqword", arm="off", ok=True, fired=False, error=""):
+    return TrapRunResult(
+        trap_id=trap_id,
+        arm=arm,
+        repeat=0,
+        ok=ok,
+        fired=fired,
+        evidence="ev" if fired else "",
+        wall_s=1.0,
+        error=error,
+    )
+
+
+class TestAggregationAndReport:
+    def test_cells_exclude_errors_from_denominator(self):
+        cells = aggregate_cells(
+            [
+                _r(fired=True),
+                _r(),
+                _r(ok=False, error="timeout"),
+                _r(arm="on"),
+            ]
+        )
+        off = cells["zsh-eqword"]["off"]
+        assert (off.fired, off.ok, off.errors) == (1, 2, 1)
+        assert off.rate == 0.5
+        assert cells["zsh-eqword"]["on"].rate == 0.0
+
+    def test_empty_cell_rate_is_none(self):
+        assert Cell().rate is None
+
+    def test_report_pilot_label_counts_and_no_savings_claim(self):
+        results = [_r(fired=True), _r(), _r(arm="on")]
+        report = render_report(aggregate_cells(results), results, markdown=False)
+        assert "PILOT" in report
+        assert "1/2" in report  # raw counts always shown
+        assert "firing evidence:" in report
+        assert "no savings claim" in report
+        assert "%" in report  # Δp rendered
+        assert "sav" not in report.replace("no savings claim", "")
+
+    def test_report_markdown_table(self):
+        results = [_r(fired=True), _r(arm="on")]
+        report = render_report(aggregate_cells(results), results, markdown=True)
+        assert "| Trap class | OFF fired | ON fired |" in report
+        assert "`zsh-eqword`" in report
+
+    def test_report_lists_errors(self):
+        results = [_r(ok=False, error="boom")]
+        report = render_report(aggregate_cells(results), results, markdown=False)
+        assert "errors (excluded from rates):" in report
+        assert "boom" in report

--- a/tests/unit/benchmarks/test_trap_battery.py
+++ b/tests/unit/benchmarks/test_trap_battery.py
@@ -534,3 +534,31 @@ class TestHookSummary:
     def test_no_hook_events_is_all_zero(self):
         t = _transcript(_result("x"))
         assert t.hook_summary() == {"failed": 0}
+
+
+class TestSentinelIsolation:
+    def test_run_sets_fixture_local_sentinel_dir(self, monkeypatch):
+        """Headless sessions share jit_recall's 'unknown' sentinel bucket
+        (no session_id in the payload), so without isolation the first
+        fire suppresses every later ON-arm run for 7 days — the
+        2026-07-13 silent-recall root cause."""
+        from benchmarks import trap_battery as tb
+
+        captured = {}
+
+        def fake_run(cmd, **kwargs):
+            captured["env"] = kwargs["env"]
+            captured["cwd"] = kwargs["cwd"]
+            raise subprocess.TimeoutExpired(cmd, 1)
+
+        monkeypatch.setattr(tb.subprocess, "run", fake_run)
+        r = tb.run_trap_session(
+            tb.get_traps(["zsh-eqword"])[0],
+            "on",
+            0,
+            max_turns=1,
+            timeout_s=1,
+        )
+        assert not r.ok
+        sdir = captured["env"]["ATTUNE_AI_SENTINEL_DIR"]
+        assert str(captured["cwd"]) in sdir  # fixture-local, not ~/.attune

--- a/tests/unit/benchmarks/test_trap_battery.py
+++ b/tests/unit/benchmarks/test_trap_battery.py
@@ -20,6 +20,7 @@ import pytest
 sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
 
 from benchmarks.trap_battery import (  # noqa: E402
+    INJECTION_MARKERS,
     TRAPS,
     Cell,
     Transcript,
@@ -28,6 +29,7 @@ from benchmarks.trap_battery import (  # noqa: E402
     get_traps,
     parse_stream_json,
     render_report,
+    validate_arms,
 )
 
 # --------------------------------------------------------------------------
@@ -340,3 +342,82 @@ class TestAggregationAndReport:
         report = render_report(aggregate_cells(results), results, markdown=False)
         assert "errors (excluded from rates):" in report
         assert "boom" in report
+
+
+# --------------------------------------------------------------------------
+# injection detection / arm validation
+# --------------------------------------------------------------------------
+
+
+def _user_text(text: str) -> dict:
+    return {"type": "user", "message": {"content": [{"type": "text", "text": text}]}}
+
+
+class TestInjectionDetection:
+    def test_markers_cover_both_recall_surfaces(self):
+        assert set(INJECTION_MARKERS) == {"prompt_recall", "jit_recall"}
+
+    def test_counts_prompt_and_jit_markers_anywhere(self):
+        t = _transcript(
+            _user_text("Lessons that may apply to this prompt: - foo"),
+            _tool_result("Just-in-time recall — rule(s) governing Bash: - bar"),
+            _result("done"),
+        )
+        assert t.injections() == {"prompt_recall": 1, "jit_recall": 1}
+
+    def test_clean_transcript_counts_zero(self):
+        t = _transcript(_assistant_bash("echo hi"), _result("done"))
+        assert t.injections() == {"prompt_recall": 0, "jit_recall": 0}
+
+
+def _ri(arm: str, injections: dict, ok: bool = True):
+    return TrapRunResult(
+        trap_id="zsh-eqword",
+        arm=arm,
+        repeat=0,
+        ok=ok,
+        fired=False,
+        evidence="",
+        wall_s=1.0,
+        injections=injections,
+    )
+
+
+class TestValidateArms:
+    def test_clean_arms_no_warnings(self):
+        results = [
+            _ri("on", {"prompt_recall": 1, "jit_recall": 0}),
+            _ri("off", {"prompt_recall": 0, "jit_recall": 0}),
+        ]
+        assert validate_arms(results) == []
+
+    def test_off_arm_marker_is_a_failure(self):
+        results = [
+            _ri("on", {"prompt_recall": 1, "jit_recall": 0}),
+            _ri("off", {"prompt_recall": 1, "jit_recall": 0}),
+        ]
+        warnings = validate_arms(results)
+        assert len(warnings) == 1
+        assert "INVALID" in warnings[0]
+
+    def test_markerless_on_arm_is_a_warning(self):
+        results = [
+            _ri("on", {"prompt_recall": 0, "jit_recall": 0}),
+            _ri("off", {"prompt_recall": 0, "jit_recall": 0}),
+        ]
+        warnings = validate_arms(results)
+        assert len(warnings) == 1
+        assert "unvalidated" in warnings[0]
+
+    def test_errored_runs_are_ignored(self):
+        results = [_ri("off", {"prompt_recall": 5, "jit_recall": 5}, ok=False)]
+        assert validate_arms(results) == []
+
+    def test_warnings_render_in_report(self):
+        results = [
+            _ri("on", {"prompt_recall": 0, "jit_recall": 0}),
+            _ri("off", {"prompt_recall": 1, "jit_recall": 0}),
+        ]
+        report = render_report(aggregate_cells(results), results, markdown=False)
+        assert "ARM-VALIDATION FAILURE" in report
+        assert "ARM-VALIDATION WARNING" in report


### PR DESCRIPTION
Phase-1 build deliverable of [docs/specs/trap-battery/](docs/specs/trap-battery/requirements.md) (approved 2026-07-12).

## What's here

- **`benchmarks/trap_battery.py`** — 3 trap classes from measured JIT-recall exposure (`zsh-eqword`, `git-commit-verify-landed`, `question-shape`), each with a fresh temp fixture per run, a failure-inviting prompt, and a deterministic scorer (no LLM judge). Reuses `session_savings.py`'s arm-env and result-parsing machinery per the spec's do-not-fork rule; stream-json transcripts give scorers tool-level evidence.
- **27 unit tests** — firing + non-firing canned transcripts per scorer, fixture construction (including the stateful pre-commit hook: blocks first commit with framework-style output, passes after re-stage), aggregation, and the pilot-label/no-savings-claim rendering rules. Zero sessions spawned.
- The zsh failure signature was verified live before writing the regex: `zsh:1: == not found`.

## What's NOT here

The pilot run itself (3×2×5 ≈ 30 sessions, ~$30–60) — manual, budget-gated, gets its stated-cost go at execution time per the spend gate. Per-PR CI integration is forbidden by #1293 and none is added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)