### PR TITLE
docs(usage-signals): reach snapshot 2026-07-13 — v10.4.1 freeze-anchor baseline

### DIFF
--- a/docs/specs/usage-signals/snapshots/2026-07-13.json
+++ b/docs/specs/usage-signals/snapshots/2026-07-13.json
@@ -1,0 +1,37 @@
+{
+  "date": "2026-07-13",
+  "github": {
+    "clones_14d": 67492,
+    "forks": 0,
+    "stars": 8,
+    "views_14d": 746
+  },
+  "pypi_recent": {
+    "attune-ai": {
+      "last_day": 140,
+      "last_month": 5392,
+      "last_week": 1809
+    },
+    "attune-author": {
+      "last_day": 34,
+      "last_month": 2412,
+      "last_week": 559
+    },
+    "attune-help": {
+      "last_day": 84,
+      "last_month": 938,
+      "last_week": 764
+    },
+    "attune-rag": {
+      "last_day": 510,
+      "last_month": 25540,
+      "last_week": 2714
+    },
+    "attune-verify": {
+      "last_day": 1098,
+      "last_month": 40871,
+      "last_week": 5710
+    }
+  },
+  "taken_at": "2026-07-13T05:01:19.242775+00:00"
+}


### PR DESCRIPTION
Release close-out for v10.4.1: the t=0 reach snapshot for the re-anchored DEC-7 observation window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)