### PR TITLE
docs(widgets): v3 design — construct protocol, control surfaces, standards landscape

### DIFF
--- a/docs/specs/analysis-workflow-output-widgets/design-v2-control-surfaces.md
+++ b/docs/specs/analysis-workflow-output-widgets/design-v2-control-surfaces.md
@@ -1,0 +1,94 @@
+# Output widgets v2 — control surfaces (stages 1 and 3)
+
+**Status:** design draft (2026-07-13) — for Patrick's review; build
+post-freeze (2026-07-28+).
+**Depends on:** the construct-response envelope defined in
+[elicitation-form-surface/v3-construct-protocol.md](../elicitation-form-surface/v3-construct-protocol.md)
+(that doc owns the protocol; this one applies it to the shipped
+report panel and triage board).
+
+---
+
+## Stage 1 — handles on the existing findings surfaces
+
+The universal report panel and the discovery-sweep triage board
+render findings today; v2 gives each finding item three handles:
+
+| Handle | Envelope action | What the agent does |
+|---|---|---|
+| explain | `action: explain` | deepen on that one finding — file read, context, severity rationale |
+| dismiss | `action: dismiss` | record to the noise ledger (memory event with reason), strike the item on re-render |
+| fix | `action: fix` | PROPOSE the change (diff in reply); committing stays a separate explicit go |
+
+Per-tier mapping (the three-tier table from D4/the section-shape
+map is unchanged — handles attach at render time):
+
+- **Deterministic-structured** (discovery-sweep): items are real
+  `Finding` objects — envelope ids are finding ids. Full handle
+  set.
+- **LLM-schema structured** (security-audit, code-review): items
+  are severity cards with file:line — envelope id is
+  `<severity>-<n> <slug> <file:line>` (self-describing; survives
+  reordering).
+- **Text-tier category bullets** (perf-audit, bug-predict, etc.):
+  bullets lack file:line reliably — ship explain + dismiss only;
+  no fix handle on unstructured items (a fix button on a vague
+  bullet invites hallucinated patches).
+
+### Implementation seams
+
+- `findings_widget` / `report_to_panel_html` gain an
+  `actions=True` render mode emitting the buttons; the envelope is
+  built at render time from the section item. OFF by default —
+  the `*_html` fields stay byte-compatible until the flag flips
+  (hard rule (a): every new response field breaks exact-dict
+  tests — pop/extend deliberately, keep legacy keys exact).
+- Skill/docs edits follow hard rule (b): `sync_agents_skills.py`
+  + commit the mirror.
+- The dismiss path writes one telemetry event
+  (`construct_response`, action, construct id) beside
+  memory_events.jsonl — same fire-only discipline.
+
+### Acceptance (stage 1)
+
+- One REAL workflow run (security-audit, live payload) rendered
+  with handles; explain, dismiss, and fix each clicked once; all
+  three round-trips visible in the transcript and correctly
+  parsed. (D4 scar: no hand-built demo payloads count.)
+- Dismiss produces the ledger event AND the re-rendered board
+  shows the item struck.
+- Text-tier render shows NO fix handle.
+- Exact-dict legacy tests still green with the flag off.
+
+## Stage 3 — tense (checkpoint re-render)
+
+Live constructs re-render at producer checkpoints:
+
+- **Producer side:** long workflows (discovery-sweep, deep-review)
+  already have per-section/per-audit boundaries; each boundary
+  writes a checkpoint row (JSON line: construct id, state delta)
+  to the session scratch dir.
+- **Surface side:** the agent re-renders the construct from the
+  latest checkpoint state at natural turn boundaries. No sockets,
+  no polling loops in the widget itself — a live widget may show
+  a "refresh ↗" handle that asks the agent to re-render (same
+  envelope, `action: refresh`).
+- **Progress construct** is the first live member: sections
+  scored / total, current section, cost so far, plus pause and
+  stop handles (stop = graceful: finish current section, render
+  final board).
+
+### Acceptance (stage 3)
+
+- One real discovery-sweep run rendered live: at least two
+  checkpoint re-renders visible, one refresh handle round-trip,
+  and the final render identical to what a cold render of the
+  finished result produces (tense must not fork the format).
+
+## Sequencing and non-goals
+
+Stage 1 → (v3 stage 2, sibling spec) → stage 3. Nothing here adds
+MCP tools, changes workflow output schemas, or touches the three
+render tiers' classification. The markdown-inline polish nit
+(raw `**bold**` in text-tier bullets) rides stage 1 as a warm-up
+change.

--- a/docs/specs/elicitation-form-surface/v3-construct-protocol.md
+++ b/docs/specs/elicitation-form-surface/v3-construct-protocol.md
@@ -1,0 +1,169 @@
+# Elicitation v3 — constructs gain handles and tense
+
+**Status:** design draft (2026-07-13) — for Patrick's review; no
+build during the release freeze (through 2026-07-27).
+**Origin:** freeze-week design session (Patrick: "take widgets to
+the next level", directions 1+2+3 combined).
+**Owns:** the construct-response protocol and the grammar
+extension. The output-surface application lives in
+[analysis-workflow-output-widgets/design-v2-control-surfaces.md](../analysis-workflow-output-widgets/design-v2-control-surfaces.md).
+
+---
+
+## The generalization
+
+Today's grammar members (decision, pushback, progress, report) are
+utterances: they render once and the conversation moves past them.
+v3 upgrades the construct to a **surface**: it holds state, carries
+**handles** (actions that speak back into the conversation), and has
+**tense** (final vs. live). The three "next level" directions are
+the three axes of this one change:
+
+| Direction | Axis |
+|---|---|
+| Round-trip widgets | handles on output constructs |
+| Elicitation v2 forms | richer input constructs, same reply channel |
+| Live widgets | tense (checkpoint re-render) |
+
+## The construct-response envelope (load-bearing)
+
+One reply shape for every handle on every construct:
+
+```text
+construct-response {board: security-audit, finding: high-1
+path-traversal workflows/config.py:112, action: fix} — propose the
+fix, do not commit
+```
+
+- **Prefix** `construct-response` — greppable, hook-matchable.
+  **CORRECTED (2026-07-13, standards-landscape review):** the
+  shipped widgets already postback via the
+  `__elicitation_response__` sentinel (fenced JSON over
+  `sendPrompt`, validated by `elicitation_collect_response`). The
+  v3 envelope EXTENDS that existing channel — same sentinel family
+  plus `action` + instance fields — rather than introducing a
+  parallel prefix. One reply channel, one validator (R4). The
+  braced-body example below is the human-readable rendering; the
+  wire form is the sentinel JSON.
+- **Braced body** — `construct`, instance id, `action`, optional
+  payload. Compact key:value, not strict JSON: it must survive
+  human editing in the composer (the user may modify the utterance
+  before sending — that is a feature, not a parsing hazard).
+- **Em-dash tail** — the human-readable intent, also the
+  instruction the agent actually follows. The braced body is
+  provenance and routing; the tail is the ask.
+
+### Transport: sendPrompt, deliberately
+
+`show_widget` handles call `sendPrompt(envelope)`. The reply lands
+as a USER message in the transcript. Chosen over any hidden side
+channel because:
+
+1. **Auditability** — every widget action is readable in the
+   transcript afterward; nothing moves invisibly.
+2. **Safety** — envelope text is user-ROLE but must be treated as
+   DATA: the receiving turn parses and validates, echoes intent,
+   and destructive verbs (fix-and-commit, delete, publish) retain
+   normal confirmation judgment. Constraint acknowledged: the
+   PreToolUse hook layer cannot see conversation context (existing
+   lesson — enforcement primitive sees only tool_name/tool_input),
+   so envelope validation is IN-BAND agent discipline plus a
+   UserPromptSubmit hook that can at least recognize the prefix
+   and inject the parsing rule.
+3. **Degradation for free** — a user on a non-widget surface can
+   type the same sentence by hand; the envelope IS the API.
+
+### Instance validation (added same-day — found by the FIRST live click)
+
+A construct-response must resolve against a **live construct
+instance** recorded at render time (id, construct type, item ids,
+producing run). Rendering a construct registers the instance
+(session-scoped registry — a scratch-dir JSON line is enough);
+receiving an envelope looks the instance up FIRST:
+
+- **Unknown instance** (demo card, stale board from a pruned
+  session, hand-typed id) → polite refusal naming why, never
+  fabricated work. The failure mode is real: the design-session
+  demo's mock findings were clicked minutes after rendering, and a
+  collector without validation would have "explained" a
+  path-traversal that doesn't exist and proposed fixes for a
+  properly-capped dependency.
+- **Known instance, stale state** (workflow re-ran since render) →
+  act on CURRENT state, note the drift in the reply.
+- Validation failures are themselves telemetry (one event, reason
+  code) — stale-click rate is a signal about widget lifetime.
+
+### Degradation ladder
+
+| Surface capability | Construct renders as | Reply arrives as |
+|---|---|---|
+| show_widget (desktop, Cowork) | interactive card + handles | sendPrompt envelope |
+| AskUserQuestion only (CLI) | question + numbered options | option pick (mapped to same envelope by the agent) |
+| plain text | numbered list | terse vocab (`1`, `go`) |
+
+The construct definition is surface-independent; only the renderer
+differs. This is v2 phase-0's surface fork, kept — v3 adds nothing
+new here.
+
+## Grammar extension: the fifth member
+
+Per the communication-grammar rule ("don't extend ad-hoc — propose
+deliberately"), v3 proposes ONE new member:
+
+- **board** — a set of items, each carrying the same small verb set
+  (explain / dismiss / act). Fires when a workflow's output is a
+  findings-shaped collection. Distinct from `report` (prose,
+  no handles) and from `decision` (one fork, one pick). The
+  dismiss verb feeds the memory noise ledger — every dismissal is
+  a labeled negative example the memory-as-insurance frame needs.
+
+Existing members gain handles WITHOUT changing their identity:
+decision options become buttons (already true on AskUserQuestion
+surfaces); pushback's "overrule / switch" become handles; progress
+gains pause / refocus / stop.
+
+## Tense
+
+A construct instance is `final` or `live`. Live = checkpoint
+re-render: the producing workflow emits at checkpoints (section
+scored, task done), and the surface re-renders the construct with
+updated state. No streaming socket — re-render works on every
+surface today; true streaming is a per-surface enhancement later.
+The progress construct is the first live member; `board` becomes
+live when a long sweep populates findings incrementally.
+
+## Ratified design constraints (Patrick, 2026-07-13)
+
+1. **Projector, not platform.** Any "factory" must follow the help
+   single-source pattern: one construct definition, projected to N
+   surfaces (show_widget HTML, AskUserQuestion fallback, MCP-native
+   elicitation, agent template). It REPLACES hand-built widgets; it
+   never becomes a new subsystem family. This is the only factory
+   shape in scope (F4 discipline from the product-direction
+   assessments).
+2. **Adapters, not foundations.** Emerging agent standards (MCP
+   elicitation, MCP Apps/UI, OpenAI Apps SDK, A2A, AG-UI, card
+   schemas) are projection TARGETS the grammar can emit to — never
+   structural dependencies. The grammar stays ours; standards get
+   adapters, chosen per the standards-landscape research memo.
+
+## Non-goals
+
+- No savings/effectiveness claims about handles until dogfooded
+  (D4 scar: real payloads, real clicks, real round-trips).
+- No new MCP tools in v3 design — `elicitation_render_widget` and
+  `elicitation_collect_response` are the existing seams; v3 changes
+  what they carry, not the tool surface.
+- No per-PR CI, no telemetry expansion beyond counting handle use
+  (one event per envelope received, mirroring memory_events.jsonl).
+
+## Sequencing
+
+1. Stage 1 (output handles) validates the envelope on the simplest
+   click — see the sibling design doc.
+2. Stage 2 ships the batched multi-dimension form as a construct
+   whose submit emits the same envelope.
+3. Stage 3 adds tense to progress + board.
+
+Build starts post-freeze (2026-07-28+); acceptance criteria live
+with each stage in the sibling doc.

--- a/docs/specs/elicitation-form-surface/v3-standards-landscape.md
+++ b/docs/specs/elicitation-form-surface/v3-standards-landscape.md
@@ -1,0 +1,76 @@
+# Elicitation v3 — standards landscape and the factory verdict
+
+**Status:** research memo (2026-07-13) — 26-agent verified sweep
+(6 standards researched from primary sources, top claims
+adversarially checked; grammar-as-built reviewed from repo).
+**Constraints honored (ratified 2026-07-13):** projector-not-
+platform; adapters-not-foundations.
+
+---
+
+## The verdict first: the factory already exists
+
+The grammar review found the single-source pattern is ALREADY the
+architecture: one `FormSchema` master (`attune.meta_workflows.models`,
+built via `form_from_dict`) projects to three render targets today —
+`form_to_widget_html` (show_widget), `form_to_elicitation_schema`
+(MCP native), and the AskUserQuestion mapping — all validated
+through the one `collect_form_response` seam (R4), zero API calls.
+
+So "build a widgets/agents factory" resolves to: **recognize
+FormSchema as the master, and add standards adapters as new
+projection targets.** No new subsystem. The opportunity is which
+targets to add, and one correction to v3.
+
+## Correction to v3-construct-protocol (from the grammar review)
+
+The shipped widget postback already has a sentinel channel:
+`__elicitation_response__`-marked fenced JSON through `sendPrompt`,
+parsed by `elicitation_collect_response`. The v3 construct-response
+envelope must EXTEND this channel (same sentinel family, add
+`action`/instance fields), not introduce a parallel
+`construct-response` prefix. One reply channel, one validator —
+R4 discipline holds.
+
+## The landscape (primary-source, verified)
+
+| Standard | State | Projection fit |
+|---|---|---|
+| **MCP Apps** (`io.modelcontextprotocol/ui`, ex SEP-1865) | **Stable official MCP extension 2026-01-26**, co-developed by Anthropic + OpenAI; Claude ships it on web/desktop/mobile/Cowork, all plans | **Tier 1 — the adapter to build.** Widgets are pre-declared MCP resources (`ui://` URIs, `text/html;profile=mcp-app`), tools link via `_meta.ui.resourceUri`, round-trip via `tools/call` from the iframe. attune already ships an MCP server: registering `ui://attune/<construct>` resources projects the whole grammar into every MCP Apps host |
+| **OpenAI Apps SDK** (ChatGPT apps) | Preview Oct 2025 → converged ON MCP Apps (same `ui://` + profile); app directory live | **Free-rider on the Tier-1 adapter** — one generic construct-renderer template reaches ChatGPT too |
+| **MCP elicitation** (`elicitation/create`) | Spec 2025-11-25 added multi-select (oneOf/anyOf-const), defaults, URL mode — the gaps D8/D10 hit are partially fixed at SPEC level; Claude Code still auto-declines (D10 stands locally) | Tier 2 — lossy flat-form fallback target; the `form_to_elicitation_schema` projector already emits it. Re-test per host as clients catch up |
+| **AG-UI** (CopilotKit) | Adopted agent-to-UI event protocol | Tier 2 — near-1:1: construct → `Tool` entry (fields as JSON Schema) in `RunAgentInput.tools`; build when a consumer exists |
+| **Google A2A** (Linux Foundation, v1.0.1) | Big-vendor backing; **no UI story** — elicitation = `TASK_STATE_INPUT_REQUIRED` lifecycle | Tier 3 — lifecycle mapping only; park until an A2A consumer is real |
+| **Adaptive Cards** (v1.5/1.6) | The 10-year prior art for portable widget grammars | Not a target — a design teacher: closed element catalogs + host-config adaptation + semantic (not pixel) schemas are what survive hosts. Validates the FormSchema approach |
+
+## The agent-factory half
+
+Agent-definition formats are fragmented at runtime but convergent
+at packaging: `{name, description, instructions, [tools], [model]}`
+in markdown + YAML frontmatter — exactly the Claude Code
+subagent/skill shape, now the **Agent Skills open standard**
+(agentskills.io, created by Anthropic, ~40 adopting clients incl.
+Codex, Copilot, Cursor, Gemini CLI). attune already authors
+skills/agents in this shape; a factory that emits the convergent
+tuple from a workflow/construct definition is a small projector,
+not a platform. No standard carries a form schema — the grammar
+remains differentiating IP that projects INTO these containers.
+
+## Recommended sequence (post-freeze; design-only until 07-28)
+
+1. **v3 envelope correction** — extend the shipped sentinel channel
+   (this memo's correction section) in the protocol doc. Free.
+2. **MCP Apps adapter** — `ui://attune/<construct>` resources on
+   the existing MCP server; one generic construct renderer,
+   grammar-driven. Reaches Claude (all surfaces) + ChatGPT with
+   one artifact. This is the widgets factory shipping as ~one
+   module + resources, replacing nothing and adding no family.
+3. **Skills projector** — emit Agent Skills-standard SKILL.md from
+   construct/workflow definitions where a real consumer exists.
+4. Re-test MCP elicitation per host quarterly (D10 is a host
+   behavior, not a spec limit anymore); AG-UI/A2A stay parked
+   until a consumer names itself.
+
+Full per-standard findings with sources: workflow
+`wf_c2de6139-e5a` journal (26 agents, verified claims noted
+per-standard).


### PR DESCRIPTION
Freeze-week design session (Patrick + agent, 2026-07-13): three design docs in existing spec dirs (DEC-1 compatible, design-only, build post-freeze).

- elicitation-form-surface/v3-construct-protocol.md — constructs gain handles + tense; envelope extends the shipped sentinel channel; instance validation (found by the first live click on the demo)
- elicitation-form-surface/v3-standards-landscape.md — verified 26-agent sweep; verdict: FormSchema already IS the factory; MCP Apps is the Tier-1 adapter target
- analysis-workflow-output-widgets/design-v2-control-surfaces.md — stages 1+3 applied to the shipped panels

🤖 Generated with [Claude Code](https://claude.com/claude-code)