### PR TITLE
build(deps): PEP 735 dev dependency-group — bare uv sync provisions the test toolchain

### DIFF
--- a/.claude/lessons.md
+++ b/.claude/lessons.md
@@ -14726,3 +14726,22 @@ def ", start_idx + 1)` for module-
   zero injections with hooks alive means "no decision point hit", not
   "arms broken" (receipt hierarchy: hook lifecycle events = alive,
   banners = injected, telemetry = fire-only log).
+
+- **The "fresh sibling/worktree venv lacks pytest/fastapi" class is
+  CLOSED by the PEP 735 dev dependency-group (#1350) — stop
+  hand-installing the extras list**: root cause was never missing
+  pyproject entries (the `[dev]` extra has been complete for a while
+  — fastapi, uvicorn[standard], jinja2, httpx, all pytest plugins;
+  jinja2/python-multipart are even CORE deps) but the provisioning
+  surface: `uv sync` / `uv run` include PEP 735 dependency GROUPS by
+  default and never extras, so any venv not synced with `--extra dev`
+  started bare (the 2026-07-13 attune-ai-fable checkout lacked even
+  pytest). Post-#1350, a bare `uv sync` provisions the full
+  toolchain; `tests/unit/test_dev_dependency_group_mirror.py` pins
+  group ≡ extra. The older worktree-venv lesson's hand-install list
+  (`uv pip install fastapi 'uvicorn[standard]' jinja2 …`) applies
+  ONLY to pre-#1350 checkouts. Related diagnosis trap (hit while
+  "confirming" the gap): a non-greedy regex across a TOML dep block
+  truncates at the first `]` inside specs like `bandit[toml]` and
+  fabricates "missing" deps — parse line-based, as
+  `test_extras_honesty.py`'s docstring already warns.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -392,6 +392,63 @@ all = [
     "filelock>=3.16.0,<4.0.0",  # CVE fix: GHSA-w853
 ]
 
+
+# PEP 735 dependency group mirroring the [dev] extra (drift-guarded by
+# tests/unit/test_dev_dependency_group_mirror.py). uv includes the `dev`
+# GROUP by default on every `uv sync` / `uv run`, so fresh worktree and
+# sibling-checkout venvs get the full test/tooling set without anyone
+# remembering `--extra dev` — closing the recurring "venv lacks pytest/
+# fastapi" class (2026-07-13). CI/pip keep installing the extra.
+[dependency-groups]
+dev = [
+    "pytest>=9.0.3,<10.0",  # CVE-2025-71176 fix
+    "pytest-asyncio>=0.21,<2.0",  # Updated for pytest-asyncio 1.x
+    "pytest-cov>=4.0,<8.0",  # Updated upper bound
+    "pytest-mock>=3.14.0,<4.0",  # Mock fixtures for testing
+    "pytest-xdist>=3.5.0,<4.0",  # Parallel test execution (4-8x faster)
+    "pytest-timeout>=2.3.0,<3.0",  # Per-test timeout — names hanging tests instead of cascading worker death (CI diagnostic)
+    "pytest-testmon>=2.1.0,<3.0",  # Run only tests affected by changes
+    "pytest-picked>=0.5.0,<1.0",  # Run tests for uncommitted changes
+    "black>=24.3.0,<27.0",  # CVE fix: PYSEC-2024-48
+    "mypy>=1.0,<3.0",
+    "types-PyYAML>=6.0,<7.0",  # Type stubs for PyYAML
+    "ruff>=0.1,<1.0",
+    "coverage>=7.0,<8.0",
+    "bandit>=1.7,<2.0",
+    "pre-commit>=3.0,<5.0",  # Updated for pre-commit 4.x
+    # Test dependencies for API and integration tests
+    "httpx>=0.27.0,<1.0.0",  # For API testing
+    "fastapi>=0.110.0,<1.0.0",  # For wizard API tests + attune.ops dashboard
+    # attune.ops dashboard runtime ([ops] extra) — mirrored into [dev]
+    # so worktree/dev syncs can run and test `python -m attune.ops`
+    # without a separate `--extra ops`. Keep pins in lock-step with the
+    # [ops] extra above.
+    "uvicorn[standard]>=0.27.0,<1.0",
+    "jinja2>=3.1.0,<4.0",
+    "requests>=2.28.0,<3.0.0",  # For notification tests
+    # Redis/AMS mirror removed 2026-07-04 — redis + agent-memory-client
+    # are CORE deps now (see the core dependencies comment), so every
+    # sync carries them; the 2026-07-02 worktree drift class is gone.
+    # RAG integration test coverage — attune-rag is an
+    # optional runtime dep but required for the rag_code_gen
+    # and rag_knowledge_query test paths to exercise their
+    # branches (rag tests use pytest.importorskip). Floor
+    # matches the [rag] extra so dev + runtime deps stay in
+    # lock-step.
+    "attune-rag>=0.1.5,<0.8",
+    # Test deps for paths that import optional runtime libs
+    # unconditionally. Without these, the unit suite fails at
+    # collection on a fresh `pip install -e .[dev]`. See
+    # docs/specs/ci-debt/ Phase A for the contract:
+    #   - langchain-anthropic: tests/unit/agent_factory/test_langgraph_adapter.py
+    #   - tiktoken: tests/unit/models/test_token_estimator.py
+    #     (tiktoken stays optional in production; tests cover
+    #      both TIKTOKEN_AVAILABLE paths)
+    # (redis entry removed 2026-07-04 — core dep now)
+    "langchain-anthropic>=0.3.0,<2.0.0",
+    "tiktoken>=0.7.0,<1.0.0",
+]
+
 [project.scripts]
 # Primary minimal CLI (v4.7.1+) - streamlined for automation/CI
 attune = "attune.cli_minimal:main"

--- a/tests/unit/test_dev_dependency_group_mirror.py
+++ b/tests/unit/test_dev_dependency_group_mirror.py
@@ -1,0 +1,68 @@
+"""Drift guard — the PEP 735 ``dev`` dependency-group mirrors the ``dev`` extra.
+
+Two provisioning surfaces install the dev toolchain:
+
+1. ``pip install -e .[dev]`` — CI and pip users (extras).
+2. ``uv sync`` / ``uv run`` — local checkouts and worktrees, which
+   include the ``dev`` *dependency group* by default (PEP 735) but do
+   NOT include extras unless ``--extra dev`` is remembered.
+
+Before the group existed, every fresh sibling/worktree venv started
+without pytest/fastapi and the failure recurred often enough to earn a
+lesson (the 2026-07-13 attune-ai-fable checkout was the latest hit).
+The group closes that class — but only while its contents stay
+identical to the extra. This test pins that equality so a dep added to
+one surface cannot silently drift from the other.
+
+Parsing is line-based bracket tracking, NOT a regex across the block —
+dep specs like ``"uvicorn[standard]>=0.27"`` contain ``]`` and
+silently truncate DOTALL matches (see test_extras_honesty.py, which
+hit the same bug).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PYPROJECT = REPO_ROOT / "pyproject.toml"
+
+
+def _dep_list(section_header: str, key: str) -> list[str]:
+    """Extract the quoted dep specs of ``key = [...]`` inside a section."""
+    text = PYPROJECT.read_text(encoding="utf-8")
+    block = re.search(
+        rf"^\[{re.escape(section_header)}\]\n(.*?)(?=^\[)",
+        text,
+        re.MULTILINE | re.DOTALL,
+    )
+    assert block, f"[{section_header}] not found in pyproject.toml"
+    deps: list[str] = []
+    in_key = False
+    for line in block.group(1).splitlines():
+        if re.match(rf"^{re.escape(key)}\s*=\s*\[", line):
+            in_key = True
+            continue
+        if in_key:
+            if line.strip() == "]":
+                break
+            match = re.match(r'\s*"([^"]+)"', line)
+            if match:
+                deps.append(match.group(1))
+    assert deps, f"{key} list not found under [{section_header}]"
+    return deps
+
+
+def test_dev_group_mirrors_dev_extra() -> None:
+    extra = _dep_list("project.optional-dependencies", "dev")
+    group = _dep_list("dependency-groups", "dev")
+    assert sorted(group) == sorted(extra), (
+        "The [dependency-groups] dev group has drifted from the "
+        "[project.optional-dependencies] dev extra. Keep them identical: "
+        "pip/CI install the extra, uv sync/uv run install the group — a "
+        "dep present in only one surface reintroduces the "
+        "fresh-venv-lacks-test-deps failure class.\n"
+        f"only in extra: {sorted(set(extra) - set(group))}\n"
+        f"only in group: {sorted(set(group) - set(extra))}"
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -489,6 +489,33 @@ windows = [
     { name = "colorama" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "attune-rag" },
+    { name = "bandit" },
+    { name = "black" },
+    { name = "coverage" },
+    { name = "fastapi" },
+    { name = "httpx" },
+    { name = "jinja2" },
+    { name = "langchain-anthropic" },
+    { name = "mypy" },
+    { name = "pre-commit" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "pytest-cov" },
+    { name = "pytest-mock" },
+    { name = "pytest-picked" },
+    { name = "pytest-testmon" },
+    { name = "pytest-timeout" },
+    { name = "pytest-xdist" },
+    { name = "requests" },
+    { name = "ruff" },
+    { name = "tiktoken" },
+    { name = "types-pyyaml" },
+    { name = "uvicorn", extra = ["standard"] },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "agent-memory-client", specifier = ">=0.14.0,<0.15" },
@@ -644,6 +671,33 @@ requires-dist = [
     { name = "uvicorn", extras = ["standard"], marker = "extra == 'ops'", specifier = ">=0.27.0,<1.0" },
 ]
 provides-extras = ["rag", "author", "memory", "redis", "anthropic", "llm", "memdocs", "agents", "cache", "agent-sdk", "software", "backend", "lsp", "windows", "ops", "otel", "docs", "dev", "developer", "enterprise", "full", "all"]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "attune-rag", specifier = ">=0.1.5,<0.8" },
+    { name = "bandit", specifier = ">=1.7,<2.0" },
+    { name = "black", specifier = ">=24.3.0,<27.0" },
+    { name = "coverage", specifier = ">=7.0,<8.0" },
+    { name = "fastapi", specifier = ">=0.110.0,<1.0.0" },
+    { name = "httpx", specifier = ">=0.27.0,<1.0.0" },
+    { name = "jinja2", specifier = ">=3.1.0,<4.0" },
+    { name = "langchain-anthropic", specifier = ">=0.3.0,<2.0.0" },
+    { name = "mypy", specifier = ">=1.0,<3.0" },
+    { name = "pre-commit", specifier = ">=3.0,<5.0" },
+    { name = "pytest", specifier = ">=9.0.3,<10.0" },
+    { name = "pytest-asyncio", specifier = ">=0.21,<2.0" },
+    { name = "pytest-cov", specifier = ">=4.0,<8.0" },
+    { name = "pytest-mock", specifier = ">=3.14.0,<4.0" },
+    { name = "pytest-picked", specifier = ">=0.5.0,<1.0" },
+    { name = "pytest-testmon", specifier = ">=2.1.0,<3.0" },
+    { name = "pytest-timeout", specifier = ">=2.3.0,<3.0" },
+    { name = "pytest-xdist", specifier = ">=3.5.0,<4.0" },
+    { name = "requests", specifier = ">=2.28.0,<3.0.0" },
+    { name = "ruff", specifier = ">=0.1,<1.0" },
+    { name = "tiktoken", specifier = ">=0.7.0,<1.0.0" },
+    { name = "types-pyyaml", specifier = ">=6.0,<7.0" },
+    { name = "uvicorn", extras = ["standard"], specifier = ">=0.27.0,<1.0" },
+]
 
 [[package]]
 name = "attune-author"


### PR DESCRIPTION
## What

Closes the recurring "fresh sibling/worktree venv lacks pytest/fastapi" class (latest hit: the attune-ai-fable checkout this morning — Patrick: *sounds like we should fix this*).

## Root cause

The dev toolchain existed only as the `[dev]` **extra** — which was already complete (fastapi/uvicorn/jinja2 all present; the old lesson's hand-install list is obsolete). But `uv sync` / `uv run` include PEP 735 dependency **groups** by default and never extras, so every fresh uv-managed venv started bare unless someone remembered `--extra dev`.

## Fix

- `[dependency-groups] dev` mirroring the dev extra verbatim → bare `uv sync`/`uv run` now provisions the full test/tooling set. CI and pip users keep installing the extra, unchanged.
- Drift-guard test pins **group ≡ extra** (line-based parsing per the `]`-inside-dep-specs trap documented in `test_extras_honesty.py`).
- `uv lock` regenerated (+54 lines, group metadata only).

## Receipt

This worktree's own venv lacked pytest; after the change a bare `uv sync` provisioned it and the guard suite passes (5/5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)