### PR TITLE
fix(hooks): SDK-gate — exempt sdk-cli so headless claude -p keeps its hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **SDK-gate no longer silences hooks in headless `claude -p`
+  sessions**: Claude Code stamps `CLAUDE_CODE_ENTRYPOINT=sdk-cli`
+  into every headless session (verified on 2.1.144), so the
+  SDK-subprocess gate's bare `sdk-` prefix check made every gated
+  attune hook (jit_recall, lesson_recall, session recall/stash, …) a
+  silent no-op for all `claude -p` users. `sdk-cli` is now exempt;
+  true SDK subprocesses (`ATTUNE_SDK_SUBPROCESS=1`, `sdk-py`,
+  `sdk-ts`, unknown `sdk-*`) stay gated. Adds
+  `ATTUNE_SDK_GATE_OVERRIDE=1` as a benchmark-only escape hatch.
+  (sdk-subprocess-isolation D9; discovered by the trap-battery
+  benchmark.)
+
 ## [10.4.1] — 2026-07-13
 
 Docs/metadata patch — no code changes. Ships the memory-first

--- a/docs/specs/archive/sdk-subprocess-isolation/decisions.md
+++ b/docs/specs/archive/sdk-subprocess-isolation/decisions.md
@@ -51,3 +51,53 @@
   still shows for unmigrated workflows on subscription — resolved
   per-workflow by the wrf T8 migrations (rendered reports already
   suppress it).
+
+## D9 — 2026-07-13 amendment: exempt `sdk-cli` from the entrypoint
+## prefix check (headless `claude -p` is not an SDK subprocess)
+
+D3's premise drifted: current Claude Code stamps
+`CLAUDE_CODE_ENTRYPOINT=sdk-cli` into EVERY plain headless
+`claude -p` session (verified live 2026-07-13 on 2.1.144), so the
+bare `sdk-` prefix check silenced every gated attune hook for ALL
+headless users — not just SDK subprocesses. Discovered by the
+trap-battery benchmark (docs/specs/trap-battery/decisions.md,
+"SDK-gate discovery" entry): phase-1 "hooks alive" receipts were
+lifecycle-only; gated hooks started and exited 0 with no output.
+
+**Decision:** keep both D3 signals, exempt the single entrypoint
+value verified to mean "plain headless CLI":
+`ATTUNE_SDK_SUBPROCESS=1` OR (`sdk-` prefix AND != `sdk-cli`).
+
+Alternatives rejected:
+
+- *Drop the prefix check, keep only `ATTUNE_SDK_SUBPROCESS=1`* —
+  regresses D3's third-party coverage: the Agent SDK still stamps
+  `sdk-py` (re-verified 2026-07-13, claude-agent-sdk 0.2.116 via
+  `scripts/probe_sdk_subprocess_env.py`), and those subprocesses
+  never touch attune's adapter.
+- *Allow-list (`sdk-py`, `sdk-ts` only)* — fails open: a future
+  SDK language stamp would un-gate and re-poison the stream-json
+  channel. The deny-list fails closed: unknown `sdk-*` values stay
+  gated (worst case a silent hook, the soft failure).
+- *`CLAUDECODE` nesting depth* — does not discriminate: an SDK
+  script run from a terminal is not nested; a plain headless run
+  inside a Claude Code session is.
+
+Also codified here: `ATTUNE_SDK_GATE_OVERRIDE=1` force-disables the
+gate — benchmark-only escape hatch (shipped for the trap-battery
+harness, whose children parse stream-json defensively). Nothing
+else should set it.
+
+Receipt (same-day A/B, one `zsh-eqword` trap session per arm,
+scrubbed env, worktree plugin force-loaded, per-run sentinel
+isolation): pre-fix ON-arm = hook lifecycle present, ZERO
+injections, trap fired; post-fix ON-arm = recall injection present
+with no override set. Unit contract: sdk-cli → not gated;
+sdk-py/sdk-ts/unknown sdk-* → gated; marker beats the exemption
+(`tests/unit/plugins/test_sdk_subprocess_gate.py`).
+
+Interaction note: un-gating headless hooks makes the jit_recall
+surface-once sentinel collapse (headless payloads carry no
+session_id → shared "unknown" bucket, 7-day machine-wide
+suppression) USER-VISIBLE for headless sessions. That bug has its
+own task; the two fixes compose but this one lands first.

--- a/plugin/hooks/_sdk_gate.py
+++ b/plugin/hooks/_sdk_gate.py
@@ -7,14 +7,27 @@ the SDK's stream-json channel (the failure that broke every SDK
 workflow for subscription users). Every hook script calls
 :func:`exit_if_sdk_subprocess` as its first ``__main__`` statement.
 
-Two detection signals (spec D3):
+Two detection signals (spec D3, amended by D9):
 
 - ``ATTUNE_SDK_SUBPROCESS=1`` — attune's explicit marker, set by
   ``agent_sdk_adapter.sdk_isolation_kwargs()`` (Phase 2).
 - ``CLAUDE_CODE_ENTRYPOINT`` starting with ``sdk-`` — stamped by the
-  Agent SDK itself into every subprocess env, so the gate also covers
-  third-party SDK scripts that never touch attune's adapter.
-  Interactive sessions carry other values (``claude-desktop``, etc.).
+  Agent SDK itself into every subprocess env (``sdk-py``/``sdk-ts``),
+  so the gate also covers third-party SDK scripts that never touch
+  attune's adapter. Interactive sessions carry other values
+  (``claude-desktop``, etc.).
+
+EXCEPT ``sdk-cli`` (spec D9): current Claude Code stamps
+``CLAUDE_CODE_ENTRYPOINT=sdk-cli`` into EVERY plain headless
+``claude -p`` session (verified live 2026-07-13 on 2.1.144), which is
+not an SDK subprocess — its hooks must work. Gating on the bare
+``sdk-`` prefix silenced every attune hook for all headless users
+(trap-battery decisions, 2026-07-13 "SDK-gate discovery").
+
+``ATTUNE_SDK_GATE_OVERRIDE=1`` force-disables the gate entirely —
+a benchmark-only escape hatch for harnesses that drive sessions
+through the SDK but parse stream-json defensively and need the
+hooks live. Nothing else should set it.
 
 Twin copy: ``src/attune/hooks/scripts/_sdk_gate.py`` (repo-level
 hooks). Keep both in sync — each is imported from its own script dir.
@@ -30,10 +43,19 @@ import sys
 
 
 def is_sdk_subprocess() -> bool:
-    """True when running inside an SDK-spawned ``claude`` subprocess."""
+    """True when running inside an SDK-spawned ``claude`` subprocess.
+
+    ``sdk-cli`` is exempt: it marks plain headless ``claude -p``, not
+    an SDK subprocess (spec D9). Unknown future ``sdk-*`` values stay
+    gated — over-gating is a silent hook, under-gating poisons the
+    SDK stream-json channel.
+    """
+    if os.environ.get("ATTUNE_SDK_GATE_OVERRIDE") == "1":
+        return False
     if os.environ.get("ATTUNE_SDK_SUBPROCESS") == "1":
         return True
-    return os.environ.get("CLAUDE_CODE_ENTRYPOINT", "").startswith("sdk-")
+    entrypoint = os.environ.get("CLAUDE_CODE_ENTRYPOINT", "")
+    return entrypoint.startswith("sdk-") and entrypoint != "sdk-cli"
 
 
 def exit_if_sdk_subprocess() -> None:

--- a/src/attune/hooks/scripts/_sdk_gate.py
+++ b/src/attune/hooks/scripts/_sdk_gate.py
@@ -7,14 +7,27 @@ the SDK's stream-json channel (the failure that broke every SDK
 workflow for subscription users). Every hook script calls
 :func:`exit_if_sdk_subprocess` as its first ``__main__`` statement.
 
-Two detection signals (spec D3):
+Two detection signals (spec D3, amended by D9):
 
 - ``ATTUNE_SDK_SUBPROCESS=1`` — attune's explicit marker, set by
   ``agent_sdk_adapter.sdk_isolation_kwargs()`` (Phase 2).
 - ``CLAUDE_CODE_ENTRYPOINT`` starting with ``sdk-`` — stamped by the
-  Agent SDK itself into every subprocess env, so the gate also covers
-  third-party SDK scripts that never touch attune's adapter.
-  Interactive sessions carry other values (``claude-desktop``, etc.).
+  Agent SDK itself into every subprocess env (``sdk-py``/``sdk-ts``),
+  so the gate also covers third-party SDK scripts that never touch
+  attune's adapter. Interactive sessions carry other values
+  (``claude-desktop``, etc.).
+
+EXCEPT ``sdk-cli`` (spec D9): current Claude Code stamps
+``CLAUDE_CODE_ENTRYPOINT=sdk-cli`` into EVERY plain headless
+``claude -p`` session (verified live 2026-07-13 on 2.1.144), which is
+not an SDK subprocess — its hooks must work. Gating on the bare
+``sdk-`` prefix silenced every attune hook for all headless users
+(trap-battery decisions, 2026-07-13 "SDK-gate discovery").
+
+``ATTUNE_SDK_GATE_OVERRIDE=1`` force-disables the gate entirely —
+a benchmark-only escape hatch for harnesses that drive sessions
+through the SDK but parse stream-json defensively and need the
+hooks live. Nothing else should set it.
 
 Twin copy: ``plugin/hooks/_sdk_gate.py`` (shipped plugin hooks).
 Keep both in sync — each is imported from its own script dir.
@@ -30,10 +43,19 @@ import sys
 
 
 def is_sdk_subprocess() -> bool:
-    """True when running inside an SDK-spawned ``claude`` subprocess."""
+    """True when running inside an SDK-spawned ``claude`` subprocess.
+
+    ``sdk-cli`` is exempt: it marks plain headless ``claude -p``, not
+    an SDK subprocess (spec D9). Unknown future ``sdk-*`` values stay
+    gated — over-gating is a silent hook, under-gating poisons the
+    SDK stream-json channel.
+    """
+    if os.environ.get("ATTUNE_SDK_GATE_OVERRIDE") == "1":
+        return False
     if os.environ.get("ATTUNE_SDK_SUBPROCESS") == "1":
         return True
-    return os.environ.get("CLAUDE_CODE_ENTRYPOINT", "").startswith("sdk-")
+    entrypoint = os.environ.get("CLAUDE_CODE_ENTRYPOINT", "")
+    return entrypoint.startswith("sdk-") and entrypoint != "sdk-cli"
 
 
 def exit_if_sdk_subprocess() -> None:

--- a/tests/unit/plugins/test_sdk_subprocess_gate.py
+++ b/tests/unit/plugins/test_sdk_subprocess_gate.py
@@ -67,18 +67,48 @@ class TestIsSdkSubprocess:
         monkeypatch.delenv("CLAUDE_CODE_ENTRYPOINT", raising=False)
         assert gate.is_sdk_subprocess() is True
 
-    def test_sdk_entrypoint_detected(self, monkeypatch):
-        """CLAUDE_CODE_ENTRYPOINT=sdk-py covers third-party SDK scripts."""
+    @pytest.mark.parametrize("entrypoint", ["sdk-py", "sdk-ts", "sdk-go"])
+    def test_sdk_entrypoint_detected(self, monkeypatch, entrypoint):
+        """sdk-py/sdk-ts (and unknown future sdk-*) cover third-party
+        SDK scripts — unknown values stay gated (D9 fail-safe)."""
         gate = _load_gate()
         monkeypatch.delenv("ATTUNE_SDK_SUBPROCESS", raising=False)
-        monkeypatch.setenv("CLAUDE_CODE_ENTRYPOINT", "sdk-py")
+        monkeypatch.setenv("CLAUDE_CODE_ENTRYPOINT", entrypoint)
         assert gate.is_sdk_subprocess() is True
+
+    def test_headless_cli_entrypoint_not_detected(self, monkeypatch):
+        """D9: sdk-cli marks plain headless ``claude -p`` (stamped into
+        every such session since at least CC 2.1.144) — NOT an SDK
+        subprocess. Gating it silenced all attune hooks headless."""
+        gate = _load_gate()
+        monkeypatch.delenv("ATTUNE_SDK_SUBPROCESS", raising=False)
+        monkeypatch.setenv("CLAUDE_CODE_ENTRYPOINT", "sdk-cli")
+        assert gate.is_sdk_subprocess() is False
+
+    def test_marker_still_gates_headless_entrypoint(self, monkeypatch):
+        """The explicit marker wins over the sdk-cli exemption: an
+        attune adapter subprocess is gated whatever the CLI stamps."""
+        gate = _load_gate()
+        monkeypatch.setenv("ATTUNE_SDK_SUBPROCESS", "1")
+        monkeypatch.setenv("CLAUDE_CODE_ENTRYPOINT", "sdk-cli")
+        assert gate.is_sdk_subprocess() is True
+
+    def test_override_force_disables_gate(self, monkeypatch):
+        """ATTUNE_SDK_GATE_OVERRIDE=1 (benchmark-only) beats both
+        signals — harnesses that parse stream-json defensively use it
+        to keep hooks live in SDK-driven sessions."""
+        gate = _load_gate()
+        monkeypatch.setenv("ATTUNE_SDK_GATE_OVERRIDE", "1")
+        monkeypatch.setenv("ATTUNE_SDK_SUBPROCESS", "1")
+        monkeypatch.setenv("CLAUDE_CODE_ENTRYPOINT", "sdk-py")
+        assert gate.is_sdk_subprocess() is False
 
     @pytest.mark.parametrize("entrypoint", ["claude-desktop", "cli", ""])
     def test_interactive_sessions_not_detected(self, monkeypatch, entrypoint):
         """Interactive entrypoints never match (AC3 precondition)."""
         gate = _load_gate()
         monkeypatch.delenv("ATTUNE_SDK_SUBPROCESS", raising=False)
+        monkeypatch.delenv("ATTUNE_SDK_GATE_OVERRIDE", raising=False)
         if entrypoint:
             monkeypatch.setenv("CLAUDE_CODE_ENTRYPOINT", entrypoint)
         else:
@@ -134,12 +164,19 @@ class TestGateDriftGuards:
 class TestHooksSilentInSdkSubprocess:
     """AC1/AC2: each registered hook exits 0 with zero output."""
 
+    @staticmethod
+    def _gated_env(**overrides: str) -> dict[str, str]:
+        """os.environ minus the benchmark override, plus the signal."""
+        env = {**os.environ, **overrides}
+        env.pop("ATTUNE_SDK_GATE_OVERRIDE", None)
+        return env
+
     @pytest.mark.parametrize("script", _plugin_hook_scripts(), ids=lambda p: p.name)
     def test_plugin_hook_silent_with_marker(self, script):
         """AC1: the explicit marker silences every plugin hook."""
         result = subprocess.run(  # noqa: S603
             [sys.executable, str(script)],
-            env={**os.environ, "ATTUNE_SDK_SUBPROCESS": "1"},
+            env=self._gated_env(ATTUNE_SDK_SUBPROCESS="1"),
             input="",
             capture_output=True,
             text=True,
@@ -155,7 +192,7 @@ class TestHooksSilentInSdkSubprocess:
 
     def test_plugin_hook_silent_with_sdk_entrypoint(self):
         """AC2: the SDK's own entrypoint stamp silences hooks too."""
-        env = {**os.environ, "CLAUDE_CODE_ENTRYPOINT": "sdk-py"}
+        env = self._gated_env(CLAUDE_CODE_ENTRYPOINT="sdk-py")
         env.pop("ATTUNE_SDK_SUBPROCESS", None)
         result = subprocess.run(  # noqa: S603
             [sys.executable, str(PLUGIN_HOOKS / "welcome.py")],
@@ -175,7 +212,7 @@ class TestHooksSilentInSdkSubprocess:
         script = REPO_ROOT / "src" / "attune" / "hooks" / "scripts" / "lessons_reminder.py"
         result = subprocess.run(  # noqa: S603
             [sys.executable, str(script)],
-            env={**os.environ, "ATTUNE_SDK_SUBPROCESS": "1"},
+            env=self._gated_env(ATTUNE_SDK_SUBPROCESS="1"),
             input="",
             capture_output=True,
             text=True,
@@ -210,6 +247,22 @@ class TestRepoGateTwin:
         monkeypatch.delenv("ATTUNE_SDK_SUBPROCESS", raising=False)
         monkeypatch.setenv("CLAUDE_CODE_ENTRYPOINT", "sdk-ts")
         assert _sdk_gate.is_sdk_subprocess() is True
+
+    def test_headless_cli_entrypoint_not_detected(self, monkeypatch):
+        """D9 in the repo twin: sdk-cli = plain headless, hooks live."""
+        from attune.hooks.scripts import _sdk_gate
+
+        monkeypatch.delenv("ATTUNE_SDK_SUBPROCESS", raising=False)
+        monkeypatch.setenv("CLAUDE_CODE_ENTRYPOINT", "sdk-cli")
+        assert _sdk_gate.is_sdk_subprocess() is False
+
+    def test_override_force_disables_gate(self, monkeypatch):
+        """The benchmark override disarms the repo twin too."""
+        from attune.hooks.scripts import _sdk_gate
+
+        monkeypatch.setenv("ATTUNE_SDK_GATE_OVERRIDE", "1")
+        monkeypatch.setenv("ATTUNE_SDK_SUBPROCESS", "1")
+        assert _sdk_gate.is_sdk_subprocess() is False
 
     def test_interactive_not_detected(self, monkeypatch):
         """No signal → not an SDK subprocess."""


### PR DESCRIPTION
## What

The SDK-subprocess gate silenced **every** gated attune hook (jit_recall, lesson_recall, session recall/stash, security_guard, …) in **all** headless `claude -p` sessions, not just SDK subprocesses: current Claude Code stamps `CLAUDE_CODE_ENTRYPOINT=sdk-cli` into every headless session (verified live 2026-07-13 on 2.1.144), and the gate's bare `sdk-` prefix check matched it. Discovered by the trap-battery benchmark (decisions entry "SDK-gate discovery" on #1351's branch): phase-1 "hooks alive" receipts were lifecycle-only — gated hooks started and exited 0 with no output.

## The discriminator (sdk-subprocess-isolation D9, appended to the archived spec)

Gate on `ATTUNE_SDK_SUBPROCESS=1` OR (`sdk-` prefix AND `!= sdk-cli`), in both `_sdk_gate.py` twins.

- **Rejected — marker-only (drop the prefix check):** regresses D3's third-party coverage; the Agent SDK still stamps `sdk-py` (re-verified today: claude-agent-sdk 0.2.116, `scripts/probe_sdk_subprocess_env.py` all-PASS) and those subprocesses never touch attune's adapter.
- **Rejected — allow-list (`sdk-py`/`sdk-ts` only):** fails open; a future SDK stamp would un-gate and re-poison the stream-json channel. The deny-list fails closed — unknown `sdk-*` stays gated (worst case a silent hook).
- **Rejected — `CLAUDECODE` nesting depth:** doesn't discriminate (SDK script from a terminal isn't nested; plain headless inside a session is).

Also codifies `ATTUNE_SDK_GATE_OVERRIDE=1` (benchmark-only escape hatch) with the same semantics as #1351's gate hunk, so the two PRs converge textually whichever merges first.

## Receipt — same-day A/B, one `zsh-eqword` trap session per arm

Main's trap-battery harness, scrubbed env (`env -i` recipe), worktree plugin force-loaded via `--plugin-dir`, per-run `ATTUNE_AI_SENTINEL_DIR` isolation, **no override set**:

| Arm | Hook lifecycle | Recall injections | Cost |
|---|---|---|---|
| pre-fix | `Se10 Us2 Pr10 Po3 St2` | **j0 + p0** | $0.19 |
| post-fix | `Se10 Us2 Pr10 Po3 St2` | **j1** — live jit_recall banner at `PreToolUse:Bash` | $0.18 |

The trap still fired once post-fix — expected: PreToolUse-carried rules can't prevent first occurrence, only recovery (the phase-2 injection-surface rule).

Unit contract (35 pass): `sdk-cli` → not gated; `sdk-py`/`sdk-ts`/unknown `sdk-*` → gated; explicit marker beats the exemption; override beats both; twins drift-guarded.

## Interaction note (stacking bug)

Un-gating headless hooks makes the jit_recall **sentinel-collapse** bug user-visible for headless sessions (payloads carry no `session_id` → shared "unknown" bucket → 7-day machine-wide suppression per rule). That fix is its own task chip (no PR landed yet); the two compose — this one lands first and is documented in D9.

Pre-existing, unrelated: `test_extract_via_ollama_real_round_trip` fails locally against the live Ollama daemon (CI skips it) — spawned as its own task chip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
