### PR TITLE
fix(tests): guard exec-bit assert on Windows — unbreak the OS matrix

### DIFF
--- a/tests/unit/benchmarks/test_trap_battery.py
+++ b/tests/unit/benchmarks/test_trap_battery.py
@@ -178,7 +178,10 @@ class TestGitCommitScorer:
 
     def test_fixture_shape(self, fixture):
         assert _git(fixture, "rev-list", "--count", "HEAD") == "1"
-        assert (fixture / ".git" / "hooks" / "pre-commit").stat().st_mode & 0o111
+        hook = fixture / ".git" / "hooks" / "pre-commit"
+        assert hook.is_file()
+        if sys.platform != "win32":  # exec bits don't exist on Windows
+            assert hook.stat().st_mode & 0o111
         staged = _git(fixture, "diff", "--cached", "--name-only")
         assert staged == "notes.txt"
 


### PR DESCRIPTION
## What

`tests/unit/benchmarks/test_trap_battery.py::TestGitCommitScorer::test_fixture_shape` (landed with #1343 this morning) asserts `st_mode & 0o111` on the git-commit trap fixture's pre-commit hook. Windows has no exec bits (mode is 0o666), so **all 5 windows-latest lanes have failed on every main run since #1343 merged** — including the run for #1352, which merged on the required (non-Windows) set and surfaced this.

Pre-existing evidence: main's own tests run at `cee4b1fc9` (before #1352) already concluded failure on the same assertion.

## Fix

Assert the hook file exists on every OS; check the mode bits only off-Windows — git-for-Windows executes hooks via sh without exec bits, which is why the sibling behavioral test (`test_hook_blocks_first_commit_then_allows`) passes on Windows already.

Local: 48/48 trap-battery tests pass; black/ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)