### PR TITLE
chore: weekly report 2026-07-13

### DIFF
--- a/weekly-reports/2026-07-13.md
+++ b/weekly-reports/2026-07-13.md
@@ -1,0 +1,123 @@
+# Anthropic Ecosystem Weekly — 2026-07-13
+
+## Summary
+
+Quiet week on the API side — one developer convenience feature (API key
+expiration in Console) and four Claude Code releases (v2.1.203–v2.1.207).
+No new models, no pricing changes, no breaking API changes. The four
+HIGH/MEDIUM carry-overs from July 6 remain the primary action items.
+
+---
+
+## Recommendations
+
+**1. Set an expiry + rotation reminder on the ANTHROPIC_API_KEY (LOW)**
+
+The July 8 Console update lets you set a lifetime on new API keys (preset or
+custom; email notification fires 7 days before expiry for keys with ≥7-day
+lifetime). Existing keys are unaffected, but the next time you rotate
+`ANTHROPIC_API_KEY` — whether by choice or forced rotation — set a 90-day
+expiry and add a calendar reminder. Scheduled routines (including this report
+agent) fail silently when the key expires; the email-before-expiry feature
+eliminates the "routine stopped working for no apparent reason" failure mode.
+
+- **Applies to:** `~/.attune/anthropic.env`, `.github/` secrets for CI
+- **Urgency:** Low — existing key unaffected; action on next rotation.
+- **Alternative:** Workload Identity Federation (GA since May 4) replaces
+  static keys entirely. More setup, but no expiry to track.
+
+---
+
+**2. Run `/doctor` in the next interactive session (LOW)**
+
+v2.1.206 upgraded `/doctor` from a basic health check to a full diagnostic
+and repair tool. It now inspects CLAUDE.md content and proposes trimming
+derivable sections. The session-start hook is showing `.help` as 1 incomplete.
+`/doctor` may fix or explain it without manual debugging.
+
+- **Applies to:** `.claude/CLAUDE.md`, `.help/` freshness state
+- **Urgency:** Low — cosmetic for now, but CLAUDE.md is growing (24 KB
+  with the full lessons corpus) and trimming derivable content reduces
+  cold-start token cost.
+
+---
+
+## Carry-overs
+
+| # | First raised | Recommendation | Status |
+|---|---|---|---|
+| July-6 Rec #1 | 2026-07-06 | Fix `_OPUS_NO_SAMPLING_RE` regex for Sonnet 5 — test generation broken | **Open (HIGH)** |
+| July-6 Rec #2 | 2026-07-06 | Handle `stop_reason: "refusal"` in `AnthropicProvider.generate()` | **Open (HIGH)** |
+| July-6 Rec #3 | 2026-07-06 | Bump `max_tokens=8192` in MODEL_REGISTRY for Sonnet 5 / Opus 4.8 | Open (MEDIUM) |
+| July-6 Rec #4 | 2026-07-06 | Audit `max_tokens` call sites for adaptive thinking on Sonnet 5 | Open (MEDIUM) |
+| July-6 Rec #5 | 2026-07-06 | Update intro pricing in MODEL_REGISTRY (Sonnet 5 $2/$10 → expires Aug 31) | Open (LOW, 49 days) |
+| June-29 Rec #1 | 2026-06-29 | Set `CLAUDE_CODE_MCP_TOOL_IDLE_TIMEOUT` for long-running MCP tools | Open |
+| June-29 Rec #2 | 2026-06-29 | Verify hook matchers for hyphenated MCP server names | Open (low) |
+| June-29 Rec #3 | 2026-06-29 | `autoMode.classifyAllShell` awareness | Open (low) |
+| June-22 Rec #1 | 2026-06-22 | Adjust release workflows for destructive git blocking | Open (medium) |
+| June-22 Rec #2 | 2026-06-22 | Investigate prompt caching on `_CITATION_BASE_URL` | Open |
+| June-22 Rec #3 | 2026-06-22 | `Tool(param:value)` permission rules for cost control | Open (low) |
+| June-22 Rec #4 | 2026-06-22 | Set `CLAUDE_CLIENT_PRESENCE_FILE` for scheduled runs | Open (low) |
+| June-8 Rec #4 | 2026-06-08 | Stop hooks `additionalContext` for session-stash | Open (low) |
+| May-25 #2 | 2026-05-25 | `attune-ops`: switch to `claude agents --json` | Open (12 weeks) |
+| May-25 #3 | 2026-05-25 | Cache diagnostics for attune-author polish | **Close** — 10 weeks, no reported pain |
+| May-25 #4 | 2026-05-25 | Update plugin docs `/simplify` → `/code-review` | **Do it or close** — one-liner, 10 weeks stale |
+| May-11 #6 | 2026-05-11 | 1-hour cache TTL for attune-author polish | **Close** — 13 weeks |
+| May-11 #7 | 2026-05-11 | Surface `api_error_status` from `ResultMessage` | **Close** — 13 weeks |
+
+The May-11 items are 13 weeks old with no reported impact. Close them in the
+next interactive session unless something specifically broke.
+
+---
+
+## Watch list
+
+- **Sonnet 5 intro pricing expires August 31 (49 days).** The capable tier
+  goes from $2/$10 to $3/$15 per MTok on September 1. Benchmark Haiku 4.5
+  for any workflows where Sonnet 5 is cost overkill — doing it now gives you
+  two weeks of real data before the price resets.
+- **Opus 4.7 fast mode removal July 24 (11 days).** Not in the stack
+  (confirmed by grep). No action, but if routing ever adds Opus 4.7 fast
+  mode, the deadline has passed.
+- **Opus 4.1 retirement August 5.** Not in the stack. No action.
+- **`agent-memory-2026-07-22` header becomes mandatory for Managed Agents
+  memory on July 22 (9 days).** The stack doesn't use the Managed Agents
+  memory API (confirmed: no `managed-agents-2026-04-01` in `src/`). The
+  stack is already on SDK 0.116.0, which sends the new header automatically.
+  No action needed.
+
+---
+
+## No-ops
+
+| Item | Why skipped |
+|---|---|
+| CMEK content preservation doc update (July 10) | Enterprise/compliance only; no API behavior change |
+| API key expiration (July 8) | Existing keys unaffected; actioned as Rec #1 above |
+| Claude Code terminal freeze fix (v2.1.207) | CLI quality-of-life; no code change needed |
+| Auto mode on Bedrock/Vertex/Foundry (v2.1.207) | Stack uses direct API, not those platforms |
+| Bedrock updated to Opus 4.8 in Claude Code (v2.1.207) | Same reason |
+| Deep research agent labels source hostnames (v2.1.207) | Claude Code UX; no Python stack change |
+| `/cd` directory suggestions (v2.1.206) | CLI UX; no code change |
+| `/commit-push-pr` auto-allow push remotes (v2.1.206) | Useful if using that skill; no code change |
+| Gateway support via `/login` (v2.1.206) | Not using an API gateway |
+| Auto mode blocks transcript tampering (v2.1.205) | Security hardening in Claude Code; attune hooks don't touch transcripts |
+| Built-in desktop browser (v2.1.205) | Potentially useful for attune-ops testing; nothing to change now |
+| Auto-update streams to disk, ~400 MB less memory (v2.1.205) | CLI improvement; no code change |
+| Grey ⏸ badge for manual permission mode (v2.1.203) | UI only |
+| Login expiry warning for background sessions (v2.1.203) | Informational; relevant context for Rec #1 |
+| MCP roots to additional working dirs (v2.1.203) | Passive improvement; no config change needed |
+
+---
+
+## Sources checked
+
+- `platform.claude.com/docs/en/release-notes/api` (through July 10, 2026)
+- `github.com/anthropics/claude-code/blob/main/CHANGELOG.md`
+  (v2.1.203–v2.1.207, July 7–11, 2026)
+- `releasebot.io/updates/anthropic/claude-code` (July 2026)
+- `www.anthropic.com/news` (no new model announcements July 7-13)
+- Grep: `managed-agents-2026-04-01`, `agent-memory`, `memory_stores` in
+  `src/attune/` — confirmed no Managed Agents memory API usage
+- `uv.lock` — confirmed `anthropic==0.116.0` already installed
+- Prior report: `weekly-reports/2026-07-06.md`


### PR DESCRIPTION
# Anthropic Ecosystem Weekly — 2026-07-13

## Summary

Quiet week on the API side — one developer convenience feature (API key
expiration in Console) and four Claude Code releases (v2.1.203–v2.1.207).
No new models, no pricing changes, no breaking API changes. The four
HIGH/MEDIUM carry-overs from July 6 remain the primary action items.

---

## Recommendations

**1. Set an expiry + rotation reminder on the ANTHROPIC_API_KEY (LOW)**

The July 8 Console update lets you set a lifetime on new API keys (preset or
custom; email notification fires 7 days before expiry for keys with ≥7-day
lifetime). Existing keys are unaffected, but the next time you rotate
`ANTHROPIC_API_KEY` — whether by choice or forced rotation — set a 90-day
expiry and add a calendar reminder. Scheduled routines (including this report
agent) fail silently when the key expires; the email-before-expiry feature
eliminates the "routine stopped working for no apparent reason" failure mode.

- **Applies to:** `~/.attune/anthropic.env`, `.github/` secrets for CI
- **Urgency:** Low — existing key unaffected; action on next rotation.
- **Alternative:** Workload Identity Federation (GA since May 4) replaces
  static keys entirely. More setup, but no expiry to track.

---

**2. Run `/doctor` in the next interactive session (LOW)**

v2.1.206 upgraded `/doctor` from a basic health check to a full diagnostic
and repair tool. It now inspects CLAUDE.md content and proposes trimming
derivable sections. The session-start hook is showing `.help` as 1 incomplete.
`/doctor` may fix or explain it without manual debugging.

- **Applies to:** `.claude/CLAUDE.md`, `.help/` freshness state
- **Urgency:** Low — cosmetic for now, but CLAUDE.md is growing (24 KB
  with the full lessons corpus) and trimming derivable content reduces
  cold-start token cost.

---

## Carry-overs

| # | First raised | Recommendation | Status |
|---|---|---|---|
| July-6 Rec #1 | 2026-07-06 | Fix `_OPUS_NO_SAMPLING_RE` regex for Sonnet 5 — test generation broken | **Open (HIGH)** |
| July-6 Rec #2 | 2026-07-06 | Handle `stop_reason: "refusal"` in `AnthropicProvider.generate()` | **Open (HIGH)** |
| July-6 Rec #3 | 2026-07-06 | Bump `max_tokens=8192` in MODEL_REGISTRY for Sonnet 5 / Opus 4.8 | Open (MEDIUM) |
| July-6 Rec #4 | 2026-07-06 | Audit `max_tokens` call sites for adaptive thinking on Sonnet 5 | Open (MEDIUM) |
| July-6 Rec #5 | 2026-07-06 | Update intro pricing in MODEL_REGISTRY (Sonnet 5 $2/$10 → expires Aug 31) | Open (LOW, 49 days) |
| June-29 Rec #1 | 2026-06-29 | Set `CLAUDE_CODE_MCP_TOOL_IDLE_TIMEOUT` for long-running MCP tools | Open |
| June-29 Rec #2 | 2026-06-29 | Verify hook matchers for hyphenated MCP server names | Open (low) |
| June-29 Rec #3 | 2026-06-29 | `autoMode.classifyAllShell` awareness | Open (low) |
| June-22 Rec #1 | 2026-06-22 | Adjust release workflows for destructive git blocking | Open (medium) |
| June-22 Rec #2 | 2026-06-22 | Investigate prompt caching on `_CITATION_BASE_URL` | Open |
| June-22 Rec #3 | 2026-06-22 | `Tool(param:value)` permission rules for cost control | Open (low) |
| June-22 Rec #4 | 2026-06-22 | Set `CLAUDE_CLIENT_PRESENCE_FILE` for scheduled runs | Open (low) |
| June-8 Rec #4 | 2026-06-08 | Stop hooks `additionalContext` for session-stash | Open (low) |
| May-25 #2 | 2026-05-25 | `attune-ops`: switch to `claude agents --json` | Open (12 weeks) |
| May-25 #3 | 2026-05-25 | Cache diagnostics for attune-author polish | **Close** — 10 weeks, no reported pain |
| May-25 #4 | 2026-05-25 | Update plugin docs `/simplify` → `/code-review` | **Do it or close** — one-liner, 10 weeks stale |
| May-11 #6 | 2026-05-11 | 1-hour cache TTL for attune-author polish | **Close** — 13 weeks |
| May-11 #7 | 2026-05-11 | Surface `api_error_status` from `ResultMessage` | **Close** — 13 weeks |

The May-11 items are 13 weeks old with no reported impact. Close them in the
next interactive session unless something specifically broke.

---

## Watch list

- **Sonnet 5 intro pricing expires August 31 (49 days).** The capable tier
  goes from $2/$10 to $3/$15 per MTok on September 1. Benchmark Haiku 4.5
  for any workflows where Sonnet 5 is cost overkill — doing it now gives you
  two weeks of real data before the price resets.
- **Opus 4.7 fast mode removal July 24 (11 days).** Not in the stack
  (confirmed by grep). No action, but if routing ever adds Opus 4.7 fast
  mode, the deadline has passed.
- **Opus 4.1 retirement August 5.** Not in the stack. No action.
- **`agent-memory-2026-07-22` header becomes mandatory for Managed Agents
  memory on July 22 (9 days).** The stack doesn't use the Managed Agents
  memory API (confirmed: no `managed-agents-2026-04-01` in `src/`). The
  stack is already on SDK 0.116.0, which sends the new header automatically.
  No action needed.

---

## No-ops

| Item | Why skipped |
|---|---|
| CMEK content preservation doc update (July 10) | Enterprise/compliance only; no API behavior change |
| API key expiration (July 8) | Existing keys unaffected; actioned as Rec #1 above |
| Claude Code terminal freeze fix (v2.1.207) | CLI quality-of-life; no code change needed |
| Auto mode on Bedrock/Vertex/Foundry (v2.1.207) | Stack uses direct API, not those platforms |
| Bedrock updated to Opus 4.8 in Claude Code (v2.1.207) | Same reason |
| Deep research agent labels source hostnames (v2.1.207) | Claude Code UX; no Python stack change |
| `/cd` directory suggestions (v2.1.206) | CLI UX; no code change |
| `/commit-push-pr` auto-allow push remotes (v2.1.206) | Useful if using that skill; no code change |
| Gateway support via `/login` (v2.1.206) | Not using an API gateway |
| Auto mode blocks transcript tampering (v2.1.205) | Security hardening in Claude Code; attune hooks don't touch transcripts |
| Built-in desktop browser (v2.1.205) | Potentially useful for attune-ops testing; nothing to change now |
| Auto-update streams to disk, ~400 MB less memory (v2.1.205) | CLI improvement; no code change |
| Grey ⏸ badge for manual permission mode (v2.1.203) | UI only |
| Login expiry warning for background sessions (v2.1.203) | Informational; relevant context for Rec #1 |
| MCP roots to additional working dirs (v2.1.203) | Passive improvement; no config change needed |

---

## Sources checked

- `platform.claude.com/docs/en/release-notes/api` (through July 10, 2026)
- `github.com/anthropics/claude-code/blob/main/CHANGELOG.md`
  (v2.1.203–v2.1.207, July 7–11, 2026)
- `releasebot.io/updates/anthropic/claude-code` (July 2026)
- `www.anthropic.com/news` (no new model announcements July 7-13)
- Grep: `managed-agents-2026-04-01`, `agent-memory`, `memory_stores` in
  `src/attune/` — confirmed no Managed Agents memory API usage
- `uv.lock` — confirmed `anthropic==0.116.0` already installed
- Prior report: `weekly-reports/2026-07-06.md`

---
_Generated by [Claude Code](https://claude.ai/code/session_01EaHQeEjNPX5JKSNep6c2yJ)_