### PR TITLE
fix(hooks): sentinel session keys fail open — no more shared unknown bucket

### DIFF
--- a/.claude/lessons.md
+++ b/.claude/lessons.md
@@ -14871,3 +14871,23 @@ def ", start_idx + 1)` for module-
   `TestSessionEnvIsolation` failed exactly that way). The
   trap-battery fixtures are zsh-heavy by design, so phase-2+
   additions will re-hit this unless guarded.
+
+- **RESOLUTION (2026-07-13, evening) of the sentinel-collapse lesson's
+  mechanism claim: live headless payloads on CC 2.1.144 DO carry
+  session_id (and transcript_path) — verified by a real `claude -p`
+  probe with a payload-dumping hook on SessionStart, UserPromptSubmit,
+  and PreToolUse. The "headless payloads carry NO session_id" claim
+  almost certainly came from DIRECT hook invocations with synthetic
+  payloads (the very diagnostic the lesson warns poisons the bucket).**
+  The shared-"unknown"-bucket hazard itself was real and is now fixed
+  fail-open: `_state.resolve_session_key(payload)` (session_id →
+  transcript stem → None) feeds every sentinel writer (jit_recall,
+  lesson_recall, compact_warning), and a None key means NO sentinel —
+  surface again rather than share a machine-wide bucket. Two durable
+  points: (a) hook payload shape claims must be verified with a LIVE
+  session probe (a ~$0.02 `claude -p` with a dump-hook plugin settles
+  it), never with synthetic stdin payloads; (b) ppid is NOT a usable
+  session key — each hook invocation gets a fresh parent (probe showed
+  three different ppids in one session). Benchmark note: per-run
+  `ATTUNE_AI_SENTINEL_DIR` isolation stays right for hygiene (virgin
+  gates per run, nothing written to the real ~/.attune).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Recall/warning sentinels no longer collapse into a shared bucket
+  when a hook payload lacks `session_id`**: jit_recall, lesson_recall,
+  and compact_warning keyed their surface-once sentinels on a literal
+  `unknown` fallback, so any no-id invocation joined one machine-wide
+  bucket — the first fire suppressed that rule/lesson/warning for
+  every such session for the 7-day TTL. Session identity now resolves
+  via `session_id`, then the transcript filename stem (which is the
+  session uuid), and with no identity at all the hooks fail open
+  (surface again, write nothing). Live-probe note: current Claude
+  Code supplies `session_id` in headless payloads, so real `claude
+  -p` sessions dedup correctly; the shared bucket bit synthetic and
+  legacy payloads.
+
 - **SDK-gate no longer silences hooks in headless `claude -p`
   sessions**: Claude Code stamps `CLAUDE_CODE_ENTRYPOINT=sdk-cli`
   into every headless session (verified on 2.1.144), so the

--- a/plugin/hooks/_state.py
+++ b/plugin/hooks/_state.py
@@ -1105,17 +1105,42 @@ def _sentinel_dir() -> Path:
     return Path.home() / ".attune"
 
 
-def session_sentinel_path(session_id: str | None) -> Path:
+def resolve_session_key(payload: dict) -> str | None:
+    """Best session identity a hook payload offers, or ``None``.
+
+    ``session_id`` when present; else the transcript filename stem
+    (which IS the session uuid). ``None`` means "no session identity"
+    — sentinel writers must fail OPEN (surface again, write nothing)
+    rather than share an ``unknown`` bucket across sessions, where
+    the first fire anywhere suppresses the item machine-wide for the
+    sentinel TTL (the 2026-07-13 headless-collapse bug).
+    """
+    session_id = payload.get("session_id")
+    if session_id:
+        return str(session_id)
+    transcript = payload.get("transcript_path")
+    if transcript:
+        stem = Path(str(transcript)).stem
+        if stem:
+            return stem
+    return None
+
+
+def session_sentinel_path(session_key: str | None) -> Path | None:
     """Path to the once-per-session compact-warning sentinel.
 
-    Uses a sanitized session id so the path stays inside the
-    sentinel dir even with weird inputs.
+    Uses a sanitized session key so the path stays inside the
+    sentinel dir even with weird inputs. Returns ``None`` when there
+    is no session identity — a shared fallback name would collapse
+    every no-id session into one machine-wide bucket (see
+    :func:`resolve_session_key`); callers fail open instead.
     """
-    base = _sentinel_dir()
-    safe = "unknown"
-    if session_id:
-        safe = re.sub(r"[^A-Za-z0-9_-]", "_", session_id)[:64] or "unknown"
-    return base / f".compact-warned-{safe}"
+    if not session_key:
+        return None
+    safe = re.sub(r"[^A-Za-z0-9_-]", "_", session_key)[:64]
+    if not safe:
+        return None
+    return _sentinel_dir() / f".compact-warned-{safe}"
 
 
 def prune_stale_sentinels(now: float | None = None) -> int:

--- a/plugin/hooks/compact_warning.py
+++ b/plugin/hooks/compact_warning.py
@@ -38,6 +38,7 @@ from _resume_prompt import build_resume_prompt  # noqa: E402
 from _state import (  # noqa: E402
     discover_specs,
     git_state,
+    resolve_session_key,
     session_sentinel_path,
     workspace_roots,
 )
@@ -87,18 +88,21 @@ def main() -> int:
         threshold = _threshold()
         if util < threshold:
             return 0
-        sentinel = session_sentinel_path(payload.get("session_id"))
-        if sentinel.exists():
-            return 0  # already warned this session
-        # Write the sentinel BEFORE the print so a re-fire mid-print
-        # can't double-emit the warning.
-        try:
-            sentinel.parent.mkdir(parents=True, exist_ok=True)
-            sentinel.write_text(f"{util:.4f}\n", encoding="utf-8")
-        except OSError:
-            # If we can't write the sentinel, skip the warning to
-            # avoid spamming on every Stop event.
-            return 0
+        # transcript_path is present here (early-returned above), so
+        # the key always resolves; None-handling is defensive only.
+        sentinel = session_sentinel_path(resolve_session_key(payload))
+        if sentinel is not None:
+            if sentinel.exists():
+                return 0  # already warned this session
+            # Write the sentinel BEFORE the print so a re-fire
+            # mid-print can't double-emit the warning.
+            try:
+                sentinel.parent.mkdir(parents=True, exist_ok=True)
+                sentinel.write_text(f"{util:.4f}\n", encoding="utf-8")
+            except OSError:
+                # If we can't write the sentinel, skip the warning to
+                # avoid spamming on every Stop event.
+                return 0
 
         cwd = Path(payload.get("cwd") or Path.cwd())
         roots = workspace_roots(cwd=cwd)

--- a/plugin/hooks/jit_recall.py
+++ b/plugin/hooks/jit_recall.py
@@ -53,10 +53,11 @@ if _HOOKS_DIR not in sys.path:
 
 try:
     from _recall_map import RECALL_MAP
-    from _state import _sentinel_dir  # type: ignore[attr-defined]
+    from _state import _sentinel_dir, resolve_session_key  # type: ignore[attr-defined]
 except Exception:  # noqa: BLE001 — hook must never crash a tool call
     RECALL_MAP = {}  # type: ignore[assignment]
     _sentinel_dir = None  # type: ignore[assignment]
+    resolve_session_key = None  # type: ignore[assignment]
 
 try:
     from _memory_telemetry import log_memory_event
@@ -110,10 +111,13 @@ def _safe(fragment: str | None, fallback: str) -> str:
     return re.sub(r"[^A-Za-z0-9_-]", "_", fragment)[:64] or fallback
 
 
-def _sentinel_path(session_id: str | None, rule_id: str) -> Path | None:
-    if _sentinel_dir is None:
+def _sentinel_path(session_key: str | None, rule_id: str) -> Path | None:
+    # No session identity -> no sentinel: fail OPEN (surface again)
+    # rather than share an "unknown" bucket across sessions, where the
+    # first fire suppresses the rule machine-wide for the TTL.
+    if _sentinel_dir is None or not session_key:
         return None
-    name = f"{_SENTINEL_PREFIX}{_safe(session_id, 'unknown')}-{_safe(rule_id, 'rule')}"
+    name = f"{_SENTINEL_PREFIX}{_safe(session_key, 'unknown')}-{_safe(rule_id, 'rule')}"
     return _sentinel_dir() / name
 
 
@@ -150,7 +154,11 @@ def main() -> int:
         if not rules:
             return 0
 
-        session_id = payload.get("session_id")
+        session_key = (
+            resolve_session_key(payload)
+            if resolve_session_key is not None
+            else payload.get("session_id")
+        )
         tool_input = payload.get("tool_input") or {}
         tool_input_text = json.dumps(tool_input)
         # Raw (un-JSON-escaped) string fields, for regex shapes that
@@ -171,7 +179,7 @@ def main() -> int:
                         continue
                 except re.error:
                     continue  # bad pattern never blocks the call (R4)
-            sentinel = _sentinel_path(session_id, rule["rule_id"])
+            sentinel = _sentinel_path(session_key, rule["rule_id"])
             if sentinel is not None and sentinel.exists():
                 continue
             fresh.append(rule)
@@ -205,7 +213,7 @@ def main() -> int:
         # whether the matching failure still occurred after the fire.
         log_memory_event(
             "jit_recall",
-            session_id=session_id,
+            session_id=session_key,
             tool=tool_name,
             rules=[rule["rule_id"] for rule in fresh],
             injected_chars=len(context),
@@ -213,7 +221,7 @@ def main() -> int:
 
         # Sentinels AFTER the emit so a mid-work crash retries next fire.
         for rule in fresh:
-            sentinel = _sentinel_path(session_id, rule["rule_id"])
+            sentinel = _sentinel_path(session_key, rule["rule_id"])
             if sentinel is None:
                 continue
             try:

--- a/plugin/hooks/lesson_recall.py
+++ b/plugin/hooks/lesson_recall.py
@@ -46,9 +46,10 @@ if _HOOKS_DIR not in sys.path:
     sys.path.insert(0, _HOOKS_DIR)
 
 try:
-    from _state import _sentinel_dir  # type: ignore[attr-defined]
+    from _state import _sentinel_dir, resolve_session_key  # type: ignore[attr-defined]
 except Exception:  # noqa: BLE001 — hook must never crash a prompt
     _sentinel_dir = None  # type: ignore[assignment]
+    resolve_session_key = None  # type: ignore[assignment]
 
 _SENTINEL_PREFIX = ".lesson-recalled-"
 _SENTINEL_TTL_SECONDS = 7 * 24 * 3600  # match the jit-recall TTL
@@ -79,10 +80,13 @@ def _safe(fragment: str | None, fallback: str) -> str:
     return re.sub(r"[^A-Za-z0-9_-]", "_", fragment)[:64] or fallback
 
 
-def _sentinel_path(session_id: str | None, lesson_id: str) -> Path | None:
-    if _sentinel_dir is None:
+def _sentinel_path(session_key: str | None, lesson_id: str) -> Path | None:
+    # No session identity -> no sentinel: fail OPEN (surface again)
+    # rather than share an "unknown" bucket across sessions, where the
+    # first fire suppresses the lesson machine-wide for the TTL.
+    if _sentinel_dir is None or not session_key:
         return None
-    name = f"{_SENTINEL_PREFIX}{_safe(session_id, 'unknown')}-{_safe(lesson_id, 'lesson')}"
+    name = f"{_SENTINEL_PREFIX}{_safe(session_key, 'unknown')}-{_safe(lesson_id, 'lesson')}"
     return _sentinel_dir() / name
 
 
@@ -135,11 +139,15 @@ def main() -> int:
         if not hits:
             return 0
 
-        session_id = payload.get("session_id")
+        session_key = (
+            resolve_session_key(payload)
+            if resolve_session_key is not None
+            else payload.get("session_id")
+        )
         fresh = []
         for hit in hits:
             lesson_id = Path(hit.entry.metadata.get("parent_path", hit.entry.path)).stem
-            sentinel = _sentinel_path(session_id, lesson_id)
+            sentinel = _sentinel_path(session_key, lesson_id)
             if sentinel is not None and sentinel.exists():
                 continue
             fresh.append((hit, lesson_id))
@@ -169,7 +177,7 @@ def main() -> int:
 
         # Sentinels AFTER the emit so a mid-work crash retries next fire.
         for _hit, lesson_id in fresh:
-            sentinel = _sentinel_path(session_id, lesson_id)
+            sentinel = _sentinel_path(session_key, lesson_id)
             if sentinel is None:
                 continue
             try:

--- a/tests/unit/hooks/test_jit_recall.py
+++ b/tests/unit/hooks/test_jit_recall.py
@@ -448,6 +448,35 @@ def test_sentinel_written_after_emit(jit_mod, monkeypatch, capsys, tmp_path):
     assert sentinels[0].name.startswith(".jit-recalled-sess-1-")
 
 
+def test_missing_session_id_dedups_via_transcript_stem(jit_mod, monkeypatch, capsys, tmp_path):
+    """A payload without session_id but with transcript_path still
+    dedups per session — the transcript stem IS the session uuid."""
+    payload = _payload()
+    del payload["session_id"]
+    payload["transcript_path"] = "/tmp/projects/x/abcd-1234.jsonl"
+    _, out1 = _run(jit_mod, monkeypatch, capsys, payload)
+    _, out2 = _run(jit_mod, monkeypatch, capsys, payload)
+    assert out1 != ""
+    assert out2 == ""  # suppressed within the same (transcript) session
+    names = [p.name for p in (tmp_path / "sentinels").iterdir()]
+    assert names and all("abcd-1234" in n for n in names)
+
+
+def test_no_identity_fails_open_and_writes_no_sentinel(jit_mod, monkeypatch, capsys, tmp_path):
+    """No session_id AND no transcript_path: surface every time, write
+    NOTHING — never a shared 'unknown' bucket where the first fire
+    suppresses the rule machine-wide for the TTL (the 2026-07-13
+    headless-collapse regression guard)."""
+    payload = _payload()
+    del payload["session_id"]
+    _, out1 = _run(jit_mod, monkeypatch, capsys, payload)
+    _, out2 = _run(jit_mod, monkeypatch, capsys, payload)
+    assert out1 != "" and out2 != ""  # fail-open: fires both times
+    base = tmp_path / "sentinels"
+    leftover = [p.name for p in base.iterdir()] if base.is_dir() else []
+    assert leftover == []
+
+
 def test_prune_removes_only_stale_jit_sentinels(jit_mod, tmp_path):
     base = tmp_path / "sentinels"
     base.mkdir(parents=True, exist_ok=True)

--- a/tests/unit/hooks/test_lesson_recall.py
+++ b/tests/unit/hooks/test_lesson_recall.py
@@ -175,6 +175,20 @@ def test_sentinel_written_after_emit(hook_mod, monkeypatch, capsys, tmp_path):
     assert all(s.name.startswith(".lesson-recalled-sess-1-") for s in sentinels)
 
 
+def test_no_identity_fails_open_and_writes_no_sentinel(hook_mod, monkeypatch, capsys, tmp_path):
+    """No session_id and no transcript_path: surface every time, write
+    NOTHING — never a shared 'unknown' bucket (the 2026-07-13
+    headless-collapse regression guard)."""
+    payload = _payload(MATCHING_PROMPT)
+    del payload["session_id"]
+    _, out1 = _run(hook_mod, monkeypatch, capsys, payload)
+    _, out2 = _run(hook_mod, monkeypatch, capsys, payload)
+    assert out1 != "" and out2 != ""  # fail-open: fires both times
+    base = tmp_path / "sentinels"
+    leftover = [p.name for p in base.iterdir()] if base.is_dir() else []
+    assert leftover == []
+
+
 def test_child_hit_sentinels_on_parent_lesson(hook_mod, monkeypatch, capsys, tmp_path):
     """A child-doc hit must gate on the PARENT lesson id, so the same
     mega-lesson isn't re-surfaced via a different child."""

--- a/tests/unit/hooks/test_session_continuity_state.py
+++ b/tests/unit/hooks/test_session_continuity_state.py
@@ -503,12 +503,32 @@ class TestSessionSentinelPath:
         assert path.parent == tmp_path
         assert ".." not in path.name
 
-    def test_unknown_session_id(
+    def test_no_session_key_returns_none(
         self, tmp_path: Path, state_mod, monkeypatch: pytest.MonkeyPatch
     ) -> None:
+        """No identity -> None, never a shared 'unknown' bucket (the
+        2026-07-13 headless-collapse regression guard)."""
         monkeypatch.setenv("ATTUNE_AI_SENTINEL_DIR", str(tmp_path))
-        path = state_mod.session_sentinel_path(None)
-        assert path.name == ".compact-warned-unknown"
+        assert state_mod.session_sentinel_path(None) is None
+        assert state_mod.session_sentinel_path("") is None
+
+
+# ── resolve_session_key ──────────────────────────────────────
+
+
+class TestResolveSessionKey:
+    def test_session_id_wins(self, state_mod) -> None:
+        payload = {"session_id": "abc", "transcript_path": "/x/y.jsonl"}
+        assert state_mod.resolve_session_key(payload) == "abc"
+
+    def test_transcript_stem_fallback(self, state_mod) -> None:
+        """The transcript filename stem IS the session uuid."""
+        payload = {"transcript_path": "/p/fdf0adc1-4322.jsonl"}
+        assert state_mod.resolve_session_key(payload) == "fdf0adc1-4322"
+
+    def test_no_identity_is_none(self, state_mod) -> None:
+        assert state_mod.resolve_session_key({}) is None
+        assert state_mod.resolve_session_key({"session_id": "", "transcript_path": ""}) is None
 
 
 # ── prune_stale_sentinels ────────────────────────────────────


### PR DESCRIPTION
## What

Three hooks keyed their surface-once sentinels on a literal `unknown` fallback when the payload lacked `session_id` — **jit_recall** (`.jit-recalled-unknown-<rule>`), **lesson_recall** (`.lesson-recalled-unknown-<lesson>`), and **compact_warning** (`.compact-warned-unknown`). Every no-id invocation joined one machine-wide bucket in the real `~/.attune`: the first fire suppressed that rule/lesson/warning for ALL such sessions for the 7-day TTL. This is the sentinel-collapse bug from the trap-battery forensics (task chip), which stacks with the sdk-cli gate exemption (#1352) for headless users.

## Premise correction (live probe receipt)

Before designing the fix I ran a real headless `claude -p` session (CC 2.1.144, scrubbed env, ~$0.02) with a payload-dumping probe plugin. Finding: **headless payloads DO carry `session_id` + `transcript_path`** on SessionStart, UserPromptSubmit, and PreToolUse — the "headless payloads carry NO session_id" claim came from synthetic direct invocations (the very diagnostic the lesson warns poisons the bucket). Also: `ppid` differs per hook invocation (three different values in one session), killing that candidate key. Recorded as a dated resolution in `.claude/lessons.md`.

So live headless sessions dedup correctly today; the shared bucket bites synthetic/legacy payloads — still worth closing, and the fix also stops diagnostic invocations from poisoning the real `~/.attune`.

## The fix

New `_state.resolve_session_key(payload)`: `session_id` → transcript filename stem (which IS the session uuid) → `None`. All three sentinel writers consume it, and a `None` key now means **no sentinel — fail open**: surface again (bounded noise) rather than suppress machine-wide (silent memory loss). `session_sentinel_path` returns `None` on a falsy key instead of `.compact-warned-unknown`.

## Tests

- jit: no-session_id-with-transcript dedups via stem; no-identity fires every time and writes **zero** files (regression guard).
- lesson_recall: same no-identity fail-open guard.
- `_state`: `resolve_session_key` precedence + `session_sentinel_path(None) is None` (replaces the old `unknown`-name assertion).
- 256 pass across the four affected suites + plugin suite.

## Follow-up (flagged, not in this PR)

`plugin/hooks/_state.py` is vendored into the 4 layer repos (attune-rag/gui/help/author) with sha-manifest drift guards — they need a `make sync-hooks` re-vendor in their own PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
