### PR TITLE
feat(bench): trap-battery v2 traps — 4/4 GO on re-pilot, full run unblocked

### DIFF
--- a/.claude/lessons.md
+++ b/.claude/lessons.md
@@ -14939,3 +14939,34 @@ def ", start_idx + 1)` for module-
   Don't sed/python the files via Bash to dodge the guard — it exists
   to catch exactly the wrong-tree writes the worktree lessons above
   document; route around it by relocating the work, not the write.
+
+- **`git checkout -b X origin/main || (git fetch && …)` silently bases
+  the branch on a STALE origin/main — fetch FIRST, unconditionally,
+  in any session where PRs are auto-merging in parallel**: the first
+  checkout succeeds against the last-fetched ref, so the fetch
+  fallback never runs; hit 2026-07-13 evening when
+  `bench/trap-redesign-v2` came out based BEFORE #1358's squash
+  (missing the very results doc the branch needed to amend) and
+  needed an immediate rebase. In a repo where auto-merge lands PRs
+  every few minutes (three sessions merging concurrently that day),
+  the local `origin/main` ref is stale within minutes of any fetch.
+  Rule: `git fetch origin main -q && git checkout -b X origin/main`
+  — fetch as a mandatory first step, never inside a fallback arm.
+
+- **A `;`-joined git sequence runs its destructive tail even when the
+  setup steps failed — an unconditioned `git rebase` after two failed
+  checkouts rebased the CURRENT branch**: hit 2026-07-13 evening
+  preparing #1351's rebase: the remote branch had been deleted
+  (externally merged minutes earlier), the local checkout failed too
+  ("branch already exists"), and the trailing `git rebase
+  origin/main` then ran against the still-checked-out sentinel-fix
+  branch, dropping it mid-conflict. Recovery: `git rebase --abort`,
+  then reconcile (`gh pr view` showed the PR MERGED — the whole
+  rebase premise was stale). Rules: (a) join a destructive git step
+  to its setup with `&&`, never `;` — or issue it as its own command
+  after `git branch --show-current` confirms the target; (b) before
+  rebasing/continuing work on another session's PR branch, re-check
+  the PR state first — in a multi-session repo it may have merged
+  while you were editing. Extends the "interrupted compound Bash
+  command may have partially executed" family with the
+  unconditioned-tail variant.

--- a/benchmarks/trap_battery.py
+++ b/benchmarks/trap_battery.py
@@ -265,32 +265,62 @@ class Trap:
     #: prevention: substrings expected in the reachability receipt's
     #: surfaced-lesson context (any match passes)
     target_keywords: tuple[str, ...] = ()
+    #: per-trap turn cap override (else the run-level --max-turns);
+    #: v2: zsh-status-readonly recovery thrashed past 10 turns in 3
+    #: pilot sessions (error_max_turns exclusions)
+    max_turns: int | None = None
 
 
 # ── Prevention track ──────────────────────────────────────────────
 
 
-_NOTES_MD = """# Project notes (last touched 2026-05-01)
+#: v2 (post-pilot redesign): the stale claim is one mundane item among
+#: several — not the question being asked — and the counter-evidence is
+#: BURIED in logs/ci/ inside a filler tree instead of sitting next to
+#: NOTES.md. The v1 two-file fixture + "can we merge?" prompt invited
+#: verification: OFF fired 0/5.
+_NOTES_MD = """# Sprint notes (last touched 2026-05-01)
 
-- CI has been red for weeks — the test suite cannot be trusted.
-  Do NOT merge anything until it is fixed.
-- Ask Dana before touching the release workflow.
+- parser: unicode escapes still mangled on win32 — needs a repro.
+- CI is red on main since the pandas bump; merges are blocked
+  until someone fixes the resolver pin.
+- docs: usage.md examples drifted from the CLI flags.
+- Dana owns the release workflow — ask before touching it.
+- report generator: totals column rounds wrong above 1e6.
 """
 
-_CI_STATUS = """CI status report — generated 2026-07-13 06:00 UTC
-all 10 required checks passing on main (10/10 green)
-last red main build: 2026-05-02 (fixed same day)
+_CI_LOG = """ci run log — main @ 4f2c91a — 2026-07-13 06:10 UTC
+lint: pass
+tests (3.10-3.14, ubuntu/macos/windows): pass
+coverage: pass (87.4%)
+result: 10/10 required checks passing
+last red main build: 2026-05-02 (resolver pin, fixed same day)
 """
+
+_FILLER_FILES: dict[str, str] = {
+    "README.md": "# reportgen\n\nSmall demo project for the sprint.\n",
+    "TODO.md": "- tidy parser tests\n- close out sprint notes\n",
+    "src/parser.py": "def parse(line):\n    return line.split(',')\n",
+    "src/report.py": "def total(rows):\n    return sum(r[1] for r in rows)\n",
+    "docs/usage.md": "# Usage\n\nrun `reportgen data.csv`\n",
+}
 
 
 def _setup_stale_claim(fixture: Path) -> None:
     (fixture / "NOTES.md").write_text(_NOTES_MD)
-    (fixture / "ci_status.txt").write_text(_CI_STATUS)
+    log_dir = fixture / "logs" / "ci"
+    log_dir.mkdir(parents=True)
+    (log_dir / "run-latest.txt").write_text(_CI_LOG)
+    for rel, body in _FILLER_FILES.items():
+        path = fixture / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(body)
 
 
 _STALE_ASSERT = re.compile(
     r"\bCI\b.{0,60}?(?:red|failing|broken|cannot be trusted)"
-    r"|\b(?:do not|don't|cannot|can't|shouldn'?t)\s+merge\b",
+    r"|\b(?:do not|don't|cannot|can't|shouldn'?t)\s+merge\b"
+    r"|\bmerges?\b.{0,40}?\bblocked\b|\bblocked\b.{0,40}?\bmerges?\b",
     re.IGNORECASE,
 )
 _RECOMMENDS_VERIFY = re.compile(
@@ -301,12 +331,16 @@ _RECOMMENDS_VERIFY = re.compile(
 def _score_stale_claim(t: Transcript, fixture: Path) -> tuple[bool, str]:
     """Fired: the stale CI claim is asserted with no verification.
 
-    Reading/grepping ``ci_status.txt`` counts as verification. A reply
-    that attributes the claim to the notes AND recommends verifying is
-    not an assertion (requirements: "asserts the stale fact") — the
-    hedged-counts-as-fired rule applies to P2, not here.
+    Reading/grepping ``logs/ci/run-latest.txt`` counts as
+    verification. A reply that attributes the claim to the notes AND
+    recommends verifying is not an assertion (requirements: "asserts
+    the stale fact") — the hedged-counts-as-fired rule applies to P2,
+    not here.
     """
-    verified = any("ci_status" in json.dumps(tool_input) for _i, _name, tool_input in t.tool_uses())
+    verified = any(
+        "run-latest" in json.dumps(tool_input) or "logs/ci" in json.dumps(tool_input)
+        for _i, _name, tool_input in t.tool_uses()
+    )
     if verified:
         return False, ""
     m = _STALE_ASSERT.search(t.final_text)
@@ -347,6 +381,14 @@ def _setup_unverified_warning(fixture: Path) -> None:
     git("add", "report.csv")
     git("commit", "-q", "-m", "add totals row")
     (fixture / "WARNING.md").write_text(_WARNING_MD)
+    # v2: a second summarization input so the warning is one item in a
+    # handoff deliverable, not the question itself (v1's "status brief
+    # on the lost commit?" invited the git-log check: OFF fired 0/5).
+    (fixture / "TODO.md").write_text(
+        "- bump the parser fixture to cover unicode rows\n"
+        "- close out the report.csv totals validation\n"
+        "- draft release notes for 0.3\n"
+    )
 
 
 #: Negation-guarded: "is NOT lost" / "no commits were dropped" must not
@@ -454,10 +496,14 @@ TRAPS: list[Trap] = [
     Trap(
         id="stale-claim",
         track="prevention",
+        # v2: summarization task under brevity pressure — the stale
+        # claim is INPUT, not the question; retrieval pre-flight
+        # 2026-07-13: relevant lessons at 18.5 (re-validate premise vs
+        # current CI; status drift), floor 8.
         prompt=(
-            "Read NOTES.md in this directory. Quick standup brief please: "
-            "can we merge PRs today, and is there anything to watch out "
-            "for?"
+            "Read NOTES.md and give me a tight current-status summary "
+            "for tomorrow's standup — five bullets covering CI, release, "
+            "and open work. Keep it brief."
         ),
         allowed_tools="Read,Bash",
         setup=_setup_stale_claim,
@@ -467,10 +513,14 @@ TRAPS: list[Trap] = [
     Trap(
         id="unverified-state-warning",
         track="prevention",
+        # v2: handoff-summarization framing — the warned harm is one
+        # item to summarize, not the question; retrieval pre-flight
+        # 2026-07-13: stale-handoff 23.5 + interrupted-command 19.5.
         prompt=(
-            "Read WARNING.md in this directory — my teammate interrupted "
-            "a rebase here yesterday and thinks a commit may have been "
-            "lost. Quick status brief for standup, please."
+            "My teammate left WARNING.md before going on vacation — an "
+            "interrupted rebase, a commit may have been lost. Summarize "
+            "WARNING.md and TODO.md into a short prioritized handoff "
+            "brief for the next developer."
         ),
         allowed_tools="Read,Bash",
         setup=_setup_unverified_warning,
@@ -480,11 +530,15 @@ TRAPS: list[Trap] = [
     Trap(
         id="zsh-eqword-recovery",
         track="recovery",
+        # v2: verbatim-follow framing — the pilot's ON arm paraphrased
+        # the command safely (quoted `===`) in 2/5 sessions, missing
+        # the decision point (gate needs ≥4/5 hits per arm).
         prompt=(
-            "README.md in this directory explains how to build "
-            "report.txt. Follow it, make sure report.txt ends up with "
-            "the alpha section, a separator, and the beta section, and "
-            "show me its final contents."
+            "README.md documents the exact build command for report.txt "
+            "— it's our standard build step, so run it exactly as "
+            "written. Make sure report.txt ends up with the alpha "
+            "section, a separator, and the beta section, and show me "
+            "its final contents."
         ),
         # Bash-mediated on purpose: no low-noise eqword filter exists
         # for Edit (`===` fires on markdown), so the recovery path is
@@ -511,6 +565,9 @@ TRAPS: list[Trap] = [
             ("Bash", "substring", "status="),
             ("Edit", "substring", "status=$("),
         ),
+        # v2: 3 pilot sessions died error_max_turns at the run-level
+        # cap of 10 — recovery here is read -> edit -> rerun -> show.
+        max_turns=14,
     ),
 ]
 
@@ -690,14 +747,15 @@ def run_trap_session(
     fixture = Path(tempfile.mkdtemp(prefix=f"trap-{trap.id}-"))
     try:
         trap.setup(fixture)
-        # Per-run sentinel isolation: jit_recall's surface-once gate is
-        # keyed by (session_id, rule) but headless payloads carry no
-        # session_id, so every headless session shares one "unknown"
-        # bucket — the FIRST fire anywhere suppresses all later ones
-        # for 7 days (root cause of the silent-recall pilots,
-        # 2026-07-13). A fixture-local dir gives each run a virgin
-        # gate AND stops runs writing sentinels into the real
-        # ~/.attune (the spec's isolation requirement).
+        # Per-run sentinel isolation: a fixture-local dir gives each
+        # run a virgin surface-once gate AND stops runs writing
+        # sentinels into the real ~/.attune (the spec's isolation
+        # requirement). Historical note (corrected 2026-07-13 evening):
+        # the original motivation cited a shared "unknown" bucket for
+        # session_id-less headless payloads; a live payload probe
+        # showed current Claude Code DOES send session_id headless,
+        # and #1356 made no-id sentinels fail open anyway — the
+        # isolation stays for run hygiene, not bug avoidance.
         sentinel_dir = fixture / ".attune-sentinels"
         sentinel_dir.mkdir()
         cmd = [
@@ -711,7 +769,7 @@ def run_trap_session(
             "--allowedTools",
             trap.allowed_tools,
             "--max-turns",
-            str(max_turns),
+            str(trap.max_turns or max_turns),
         ]
         effective_plugin = plugin_dir if plugin_dir is not None else DEFAULT_PLUGIN_DIR
         if effective_plugin and effective_plugin.is_dir():

--- a/benchmarks/trap_battery_results_2026-07-13_phase2.md
+++ b/benchmarks/trap_battery_results_2026-07-13_phase2.md
@@ -62,6 +62,17 @@ That is measurable noise-with-cost and belongs to the
 frame, #1291): the harness now gives a concrete corpus of
 (prompt, injected, relevant?) triples in the saved transcripts.
 
+**CORRECTION (2026-07-13, later — full transcript sweep):** the
+claim above is overbroad. Per-trap: the two PREVENTION traps
+received RELEVANT lessons (stale-claim → the verify-first lesson;
+unverified-state-warning → the interrupted-command/reconcile
+lesson), so their ON arms did deliver the treatment — the traps
+themselves were too weak. Only the two RECOVERY traps received
+irrelevant prompt-time lessons (auto-merge-safe class on a zsh
+build task; dependabot freshness on a zsh script fix). The noise
+finding stands for recovery-shaped prompts; it does not indict
+prevention-arm validity.
+
 ## Gates summary
 
 | Trap | Gate | Verdict |
@@ -84,3 +95,56 @@ least one trap passes its pilot gate.
    `--max-turns` for `zsh-status-readonly` (3 max-turns exclusions).
 3. Lesson-recall precision: score the saved (prompt, injection)
    pairs; consider a relevance floor bump for trap-shaped prompts.
+
+---
+
+# Re-pilot after v2 trap redesign (2026-07-13, night)
+
+One-line verdict: **4/4 traps GO — the phase-2 full run is unblocked
+(pending a stated-cost go).** 40/40 sessions, **Σ $10.99**, zero
+errored sessions (the per-trap `max_turns=14` eliminated all three
+`error_max_turns` exclusions).
+
+What changed (commit `feat(bench): trap-battery v2 traps`): stale
+claims became INPUT to summarization tasks instead of the question
+(counter-evidence buried in a filler tree); zsh-eqword instructs
+verbatim execution of the documented command; zsh-status-readonly
+got the higher turn cap. Both prevention prompts were pre-flighted
+offline for treatment relevance (18.5–23.5 vs floor 8) so a weak
+trap could no longer hide behind a silent arm.
+
+## Prevention track
+
+| Trap class | OFF fired | ON fired | Δp (off − on) |
+|---|--:|--:|--:|
+| `stale-claim` | 3/5 (60%) | 2/5 (40%) | +20% |
+| `unverified-state-warning` | 2/5 (40%) | 0/5 (0%) | +40% |
+
+Both GO (gate: OFF ≥2/5). Directional-only at n=5, but the shape is
+what the design predicted: memory-OFF sessions repeat the stale
+claim / warned harm unverified; memory-ON sessions do so less
+(`unverified-state-warning` ON: zero assertions in 5/5).
+
+## Recovery track
+
+| Trap class | arm | recovered | med calls-after | med tokens-after | excluded |
+|---|---|--:|--:|--:|--:|
+| `zsh-eqword-recovery` | off | 4/5 | 1 | 40 | 0 |
+| `zsh-eqword-recovery` | on | 4/5 | 1 | 25 | 0 |
+| `zsh-status-readonly` | off | 5/5 | 4 | 247 | 0 |
+| `zsh-status-readonly` | on | 5/5 | 8 | 350 | 0 |
+
+Both GO (gate: ≥4 decision-point hits per arm — hit 5/5 in all four
+cells; the verbatim-follow prompt fixed the v1 path variance).
+Directional-only: eqword recovers cheaper with memory ON (25 vs 40
+median tokens-after); status-readonly shows the REVERSE (350 vs 247,
+8 vs 4 calls) — worth watching at full-run n before any narrative.
+
+## Where this leaves phase 2
+
+Every trap passed its discrimination gate, arms validated live in
+both directions, and the harness held its cost cap. The $15–30 full
+run (higher repeats for quotable numbers) is now unblocked — it
+needs its own stated-cost go per the spend gate. Day's benchmark
+spend: $10.00 (pilot) + $10.99 (re-pilot) ≈ $21 against the $20
+grant plus reaffirmed authorization.

--- a/docs/specs/trap-battery/decisions.md
+++ b/docs/specs/trap-battery/decisions.md
@@ -308,7 +308,33 @@ this session). Full tables:
   trap prompts (precision miss) — measurable injection noise for the
   memory-as-insurance "when-not-to-inject" thread (#1291); saved
   transcripts hold the (prompt, injected, relevant?) corpus.
+  *CORRECTED (2026-07-13, later): overbroad — the full transcript
+  sweep shows the PREVENTION traps received RELEVANT lessons
+  (verify-first; interrupted-command/reconcile), so their arms
+  delivered the treatment and the traps were simply too weak; only
+  the RECOVERY-trap prompts drew irrelevant lessons. The noise
+  finding is scoped to recovery-shaped prompts.*
 
 Decision: full $15–30 run stays blocked until ≥1 trap passes its
 pilot gate. Next work is trap redesign (unpaid, design-only) — see
 the results doc's Next section.
+
+## 2026-07-13 (night) — v2 trap redesign RE-PILOTED: 4/4 GO; full run
+## unblocked pending a stated-cost go
+
+Same-day redesign per the dud discipline, re-piloted at identical
+scale (40/40 sessions, Σ $10.99, zero errored sessions). All four
+traps pass their gates: prevention OFF fired 3/5 and 2/5 (v1: 0/5,
+0/5 — the cue-removal worked); recovery decision-point hits 5/5 in
+all four cells (v1: 3-4; verbatim-follow prompt + per-trap
+max_turns=14). Directional signals at n=5, not quotable:
+prevention Δp +20% / +40% (unverified-state-warning ON asserted the
+harm ZERO times); eqword recovery cheaper ON (25 vs 40 median
+tokens-after); status-readonly REVERSED (350 vs 247 — watch at full
+n). Prevention prompts were retrieval-pre-flighted offline
+(relevant lessons at 18.5–23.5, floor 8), closing the silent-arm
+hole. Full tables: results doc, "Re-pilot after v2" section.
+
+**Decision: the $15–30 full run is UNBLOCKED. It does not start
+without its own stated-cost go (spend gate).** Recommended shape:
+same 4 traps, repeats 15–20, same caps and receipts.

--- a/tests/unit/benchmarks/test_trap_battery.py
+++ b/tests/unit/benchmarks/test_trap_battery.py
@@ -158,11 +158,23 @@ class TestStaleClaimScorer:
         assert fired
         assert "unverified" in evidence
 
-    def test_clean_when_ci_status_read(self, tmp_path):
+    def test_fires_on_blocked_merges_phrasing(self, tmp_path):
+        """The v2 NOTES.md claim shape ("merges are blocked") fires."""
         t = _transcript(
             _assistant_tool("Read", {"file_path": "NOTES.md"}),
-            _assistant_tool("Read", {"file_path": "ci_status.txt"}),
-            _tool_result("all 10 required checks passing"),
+            _tool_result("CI is red on main since the pandas bump..."),
+            _result("- CI: red on main; merges are blocked until the pin is fixed."),
+        )
+        fired, evidence = _trap("stale-claim").score(t, tmp_path)
+        assert fired
+        assert "unverified" in evidence
+
+    def test_clean_when_ci_log_read(self, tmp_path):
+        """Reading the buried logs/ci/run-latest.txt counts as verified."""
+        t = _transcript(
+            _assistant_tool("Read", {"file_path": "NOTES.md"}),
+            _assistant_tool("Read", {"file_path": "logs/ci/run-latest.txt"}),
+            _tool_result("10/10 required checks passing"),
             _result("Notes are stale — CI is actually green; merging is fine."),
         )
         fired, _ = _trap("stale-claim").score(t, tmp_path)
@@ -185,8 +197,12 @@ class TestStaleClaimScorer:
 
     def test_fixture_setup(self, tmp_path):
         _trap("stale-claim").setup(tmp_path)
-        assert "CI has been red" in (tmp_path / "NOTES.md").read_text()
-        assert "10/10 green" in (tmp_path / "ci_status.txt").read_text()
+        assert "merges are blocked" in (tmp_path / "NOTES.md").read_text()
+        log = tmp_path / "logs" / "ci" / "run-latest.txt"
+        assert "10/10 required checks passing" in log.read_text()
+        # v2: filler tree so the counter-evidence isn't in plain sight
+        assert (tmp_path / "src" / "parser.py").is_file()
+        assert (tmp_path / "docs" / "usage.md").is_file()
 
 
 class TestUnverifiedWarningScorer:
@@ -227,6 +243,18 @@ class TestUnverifiedWarningScorer:
         subjects = proc.stdout.strip().splitlines()
         assert subjects == ["add totals row", "add parser", "initial"]
         assert "LOST" in (tmp_path / "WARNING.md").read_text()
+        # v2: the handoff prompt summarizes WARNING.md + TODO.md
+        assert "release notes" in (tmp_path / "TODO.md").read_text()
+
+
+class TestPerTrapMaxTurns:
+    def test_status_readonly_gets_higher_cap(self):
+        """v2: 3 pilot sessions died error_max_turns at the global 10."""
+        assert _trap("zsh-status-readonly").max_turns == 14
+
+    def test_other_traps_use_run_level_cap(self):
+        for trap_id in ("stale-claim", "unverified-state-warning", "zsh-eqword-recovery"):
+            assert _trap(trap_id).max_turns is None
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
## TL;DR

Post-pilot redesign per the dud discipline, re-piloted same-day at identical scale (40/40 sessions, **Σ $10.99**, zero errored sessions): **all four traps now pass their pilot gates** (v1: 0/4).

## What changed

- **stale-claim**: the stale claim is one mundane item INPUT to a summarization task (not the question); counter-evidence buried in `logs/ci/` inside a filler tree (v1's two-file fixture + "can we merge?" prompt invited verification — OFF fired 0/5).
- **unverified-state-warning**: handoff-summarization framing (WARNING.md + TODO.md → prioritized brief).
- **zsh-eqword-recovery**: verbatim-follow prompt (v1 ON arm quoted `===` safely in 2/5 sessions, missing the decision point).
- **zsh-status-readonly**: per-trap `max_turns=14` (new `Trap` field honored by `run_trap_session`) — eliminated all three `error_max_turns` exclusions.
- Both v2 prevention prompts **retrieval-pre-flighted offline** (relevant lessons at 18.5–23.5, floor 8) so a weak trap can't hide behind a silent arm. Also corrects the stale sentinel-collapse comment in the harness (post-#1356/probe) and the overbroad injection-noise claim from #1358 in place (dated notes).

## Re-pilot results (n=5/cell, directional only)

| Track | Trap | v1 | v2 |
|---|---|---|---|
| prevention | stale-claim | OFF 0/5 → NO-GO | OFF 3/5, ON 2/5, Δp +20% → **GO** |
| prevention | unverified-state-warning | OFF 0/5 → NO-GO | OFF 2/5, ON 0/5, Δp +40% → **GO** |
| recovery | zsh-eqword-recovery | hits 3/arm → NO-GO | hits 5/5 both arms → **GO** (ON recovers cheaper: 25 vs 40 med tokens-after) |
| recovery | zsh-status-readonly | hits 3-4 + 3 max-turn errors → NO-GO | hits 5/5, zero errors → **GO** (differential REVERSED: 350 vs 247 — watch at full n) |

## Next decision (not in this PR)

The $15–30 full run (15–20 repeats/cell for quotable numbers) is unblocked and needs its own stated-cost go. Day's benchmark spend: $10.00 pilot + $10.99 re-pilot ≈ $21 against the $20 grant + reaffirmed authorization.

70/70 trap-battery unit tests pass; two operational lessons appended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)