### PR TITLE
feat(hooks): spec-audit archive-ready flag — terminal but top-level >7d

### DIFF
--- a/.claude/lessons.md
+++ b/.claude/lessons.md
@@ -14970,3 +14970,23 @@ def ", start_idx + 1)` for module-
   while you were editing. Extends the "interrupted compound Bash
   command may have partially executed" family with the
   unconditioned-tail variant.
+
+- **A multi-dimension sign-off (triage matrix, release gate) CAN go
+  out as ONE batched AskUserQuestion form — set
+  `metadata.source: "elicit-form"` to pass the one-question-per-turn
+  guard**: the `ask_question_format_guard.py` hook blocks any
+  AskUserQuestion with >1 question ("ask ONE actionable question per
+  turn"), but its §4 escape hatch accepts a batch when the questions
+  are independent, non-branching dimensions of a single decision —
+  opt in via `metadata.source` (e.g. `elicit-form`). Hit 2026-07-14
+  presenting the spec-backlog triage sign-off (archive/merge go +
+  kill list + commit list + recurrence build = 4 independent
+  dimensions of one ratification): the unbatched call was blocked;
+  the same call with the metadata opt-in went through and Patrick
+  answered all four in one turn. Judgment line: use the batch ONLY
+  when no answer changes another question's meaning (true
+  independence); sequential/branching decisions still go one per
+  turn. Pairs with the question-shape rule (recommendation first,
+  '(Recommended)' suffix) which applies per-question inside the
+  batch, and with `feedback_surface_forks_as_forms` (Patrick wants
+  forks AS forms, not prose).

--- a/plugin/hooks/spec_audit.py
+++ b/plugin/hooks/spec_audit.py
@@ -37,11 +37,13 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import subprocess
 import sys
 import time
 import traceback
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from pathlib import Path
 
 # Force utf-8 on stdout/stderr — the table uses ⚠ and an em-dash rule
@@ -56,8 +58,10 @@ if _HOOKS_DIR not in sys.path:
     sys.path.insert(0, _HOOKS_DIR)
 
 from _state import (  # noqa: E402 — sys.path bootstrap above
+    _TERMINAL_VERDICTS,
     PrRef,
     _is_in_flight,
+    _leading_verdict,
     _resolve_entry,
     discover_specs,
     extract_pr_refs,
@@ -97,6 +101,43 @@ def _max_gh_calls() -> int:
 
 _MAX_GH_CALLS = _max_gh_calls()
 _GH_TIMEOUT_SECONDS = 6.0
+
+# ── archive-ready detection (2026-07-14 triage R1) ────────────
+#
+# Three manual backlog triages in 25 days (48→27, 33→23, 56→22) showed
+# terminal specs accumulate top-level at ~1/day and only move when a
+# human schedules an excavation. A terminal-status spec that is still
+# top-level (the audit never sees archive/ — discover_specs walks one
+# level and archive dirs carry no phase files) past a grace window is
+# flagged "archive-ready". Warn-only: never affects --strict.
+_STATUS_DATE = re.compile(r"\((\d{4}-\d{2}-\d{2})")
+
+
+def _archive_grace_days() -> float:
+    try:
+        return float(os.environ.get("ATTUNE_SPEC_ARCHIVE_GRACE_DAYS", "7"))
+    except ValueError:
+        return 7.0
+
+
+def _terminal_since(status: str, mtime: float) -> float:
+    """Epoch seconds a spec has been terminal since.
+
+    Prefers the ISO date conventionally written right after the verdict
+    (``complete (2026-07-03) — …``); falls back to the spec's most
+    recent file mtime, so an undated terminal spec still ages out of
+    the grace window once it stops being touched.
+    """
+    match = _STATUS_DATE.search(status)
+    if match:
+        try:
+            parsed = datetime.strptime(match.group(1), "%Y-%m-%d")
+            return parsed.replace(tzinfo=timezone.utc).timestamp()
+        except ValueError:
+            pass
+    return mtime
+
+
 # All three phase files are scanned for citations, not just the
 # highest-priority one — a requirements.md often carries the approval
 # trail ("shipped in #N") even when tasks.md exists.
@@ -258,6 +299,9 @@ class AuditResult:
     signal: str = "deliverables"
     cache_key: str = ""  # "<layer>/<slug>" — the drift-cache key
     root: str = ""  # workspace root the spec lives under
+    # archive-ready (triage R1) — terminal status but still top-level
+    # past the grace window. Warn-only; never feeds --strict.
+    archive_ready: bool = False
 
 
 def _root_for(spec_path: Path, roots: list[Path]) -> str:
@@ -277,6 +321,7 @@ def audit_specs(
     *,
     pr_links: bool = False,
     resolver: _PrResolver | None = None,
+    now: float | None = None,
 ) -> list[AuditResult]:
     """Classify every discovered spec (terminal included) into a row.
 
@@ -292,6 +337,9 @@ def audit_specs(
     """
     if roots is None:
         roots = workspace_roots()
+    if now is None:
+        now = time.time()
+    grace_seconds = _archive_grace_days() * 86400.0
     results: list[AuditResult] = []
     for spec in discover_specs(roots, include_terminal=True):
         total = len(spec.deliverables)
@@ -320,6 +368,14 @@ def audit_specs(
             except Exception:  # noqa: BLE001 — one bad spec must not abort the audit
                 merged_prs = ()
             drifted = bool(merged_prs)
+        # archive-ready (triage R1): terminal verdict + still top-level
+        # (archive/ is invisible to discover_specs) past the grace window.
+        terminal = (
+            _leading_verdict(spec.effective_status or spec.status or "") in _TERMINAL_VERDICTS
+        )
+        archive_ready = (
+            terminal and (now - _terminal_since(spec.status or "", spec.mtime)) >= grace_seconds
+        )
         results.append(
             AuditResult(
                 slug=spec.slug,
@@ -334,6 +390,7 @@ def audit_specs(
                 signal="pr-links" if checked else "deliverables",
                 cache_key=f"{spec.layer}/{spec.slug}",
                 root=_root_for(spec.path, roots),
+                archive_ready=archive_ready,
             )
         )
     return results
@@ -378,12 +435,14 @@ def write_drift_cache(results: list[AuditResult], roots: list[Path]) -> list[Pat
 def format_json(results: list[AuditResult], resolver: _PrResolver | None = None) -> str:
     """Machine-readable audit payload for the tracking-issue upsert."""
     drifted = sorted(r.cache_key for r in results if r.drifted)
+    archive_ready = sorted(r.cache_key for r in results if r.archive_ready)
     payload = {
         "generated_at": time.time(),
         "counts": {
             "specs": len(results),
             "drifted": len(drifted),
             "suspected_stale": sum(1 for r in results if r.staleness == "suspected-stale"),
+            "archive_ready": len(archive_ready),
         },
         # attune-ai#1314: a capped or failure-ridden run means "refs went
         # unchecked" — consumers (the weekly issue upsert, humans) must
@@ -394,6 +453,7 @@ def format_json(results: list[AuditResult], resolver: _PrResolver | None = None)
             "capped": bool(resolver.capped) if resolver else False,
         },
         "drifted": drifted,
+        "archive_ready": archive_ready,
         "specs": {
             r.cache_key: {
                 "layer": r.layer,
@@ -404,6 +464,7 @@ def format_json(results: list[AuditResult], resolver: _PrResolver | None = None)
                 "drifted": r.drifted,
                 "prs": list(r.merged_prs),
                 "signal": r.signal,
+                "archive_ready": r.archive_ready,
             }
             for r in results
         },
@@ -479,6 +540,12 @@ def format_report(results: list[AuditResult]) -> str:
         out.append(
             f"⚠ {len(stale)} spec(s) have shipped deliverables but a "
             "non-terminal status — verify & update."
+        )
+    ready = sorted(r.slug for r in results if r.archive_ready)
+    if ready:
+        out.append(
+            f"⚠ {len(ready)} terminal spec(s) past the archive grace "
+            "window but still top-level — archive-ready: " + ", ".join(ready)
         )
     if not drifted and not stale:
         out.append("✓ No drifted or suspected-stale specs.")

--- a/tests/unit/hooks/test_spec_audit.py
+++ b/tests/unit/hooks/test_spec_audit.py
@@ -1287,3 +1287,89 @@ class TestOrientWorktreeAlarm:
         monkeypatch.setattr("sys.stdin", _io.StringIO(_json.dumps({"cwd": str(repo)})))
         assert orient_mod.main() == 0
         assert "uncommitted in worktree" not in capsys.readouterr().out
+
+
+# ── archive-ready detection (triage R1, 2026-07-14) ──────────
+
+
+def _epoch(day: str) -> float:
+    """UTC midnight of ``YYYY-MM-DD`` as epoch seconds."""
+    from datetime import datetime, timezone
+
+    return datetime.strptime(day, "%Y-%m-%d").replace(tzinfo=timezone.utc).timestamp()
+
+
+class TestArchiveReady:
+    def test_dated_terminal_past_grace_flags(self, audit_mod, audit_tree) -> None:
+        # done-spec is "complete (2026-06-17)" — 14 days before ``now``.
+        rows = {r.slug: r for r in audit_mod.audit_specs([audit_tree], now=_epoch("2026-07-01"))}
+        assert rows["done-spec"].archive_ready is True
+
+    def test_dated_terminal_within_grace_not_flagged(self, audit_mod, audit_tree) -> None:
+        rows = {r.slug: r for r in audit_mod.audit_specs([audit_tree], now=_epoch("2026-06-20"))}
+        assert rows["done-spec"].archive_ready is False
+
+    def test_non_terminal_never_flags(self, audit_mod, audit_tree) -> None:
+        # approved specs, however old, are not archive candidates.
+        rows = {r.slug: r for r in audit_mod.audit_specs([audit_tree], now=_epoch("2027-01-01"))}
+        assert rows["shipped-spec"].archive_ready is False
+        assert rows["pending-spec"].archive_ready is False
+
+    def test_parked_and_living_never_flag(self, audit_mod, tmp_path) -> None:
+        _audit_spec_file(
+            tmp_path / "specs" / "parked-spec",
+            status="parked (2026-01-01)",
+            deliverables=[],
+        )
+        _audit_spec_file(
+            tmp_path / "specs" / "living-spec",
+            status="living (2026-01-01)",
+            deliverables=[],
+        )
+        rows = {r.slug: r for r in audit_mod.audit_specs([tmp_path], now=_epoch("2027-01-01"))}
+        assert rows["parked-spec"].archive_ready is False
+        assert rows["living-spec"].archive_ready is False
+
+    def test_undated_terminal_falls_back_to_mtime(self, audit_mod, tmp_path) -> None:
+        _audit_spec_file(tmp_path / "specs" / "undated", status="complete", deliverables=[])
+        # Fresh mtime + now ≈ mtime → inside the grace window.
+        fresh = {r.slug: r for r in audit_mod.audit_specs([tmp_path])}
+        assert fresh["undated"].archive_ready is False
+        # Same tree judged 8 days after the file was written → flagged.
+        later = _time.time() + 8 * 86400
+        aged = {r.slug: r for r in audit_mod.audit_specs([tmp_path], now=later)}
+        assert aged["undated"].archive_ready is True
+
+    def test_grace_env_override(self, audit_mod, audit_tree, monkeypatch) -> None:
+        # A 60-day grace swallows the 14-day-old completion date.
+        monkeypatch.setenv("ATTUNE_SPEC_ARCHIVE_GRACE_DAYS", "60")
+        rows = {r.slug: r for r in audit_mod.audit_specs([audit_tree], now=_epoch("2026-07-01"))}
+        assert rows["done-spec"].archive_ready is False
+
+    def test_terminal_since_prefers_status_date(self, audit_mod) -> None:
+        since = audit_mod._terminal_since("complete (2026-06-17) — shipped #1", 12345.0)
+        assert since == _epoch("2026-06-17")
+        assert audit_mod._terminal_since("complete — no date", 12345.0) == 12345.0
+
+    def test_json_payload_carries_archive_ready(self, audit_mod, audit_tree) -> None:
+        results = audit_mod.audit_specs([audit_tree], now=_epoch("2026-07-01"))
+        payload = _json.loads(audit_mod.format_json(results))
+        assert payload["counts"]["archive_ready"] == 1
+        assert payload["archive_ready"] == ["workspace/done-spec"]
+        assert payload["specs"]["workspace/done-spec"]["archive_ready"] is True
+
+    def test_report_footer_lists_ready_slugs(self, audit_mod, audit_tree) -> None:
+        report = audit_mod.format_report(
+            audit_mod.audit_specs([audit_tree], now=_epoch("2026-07-01"))
+        )
+        assert "archive-ready: done-spec" in report
+
+    def test_strict_ignores_archive_ready(self, audit_mod, tmp_path, monkeypatch) -> None:
+        # Only an old terminal spec — archive-ready but nothing stale/drifted.
+        _audit_spec_file(
+            tmp_path / "specs" / "old-done",
+            status="complete (2020-01-01)",
+            deliverables=[],
+        )
+        monkeypatch.setenv("ATTUNE_AI_WORKSPACE_ROOTS", str(tmp_path))
+        assert audit_mod.main(["--strict", "--offline"]) == 0


### PR DESCRIPTION
## Summary

Triage R1, approved by Patrick 2026-07-14 (recorded in [matrix-2026-07-14.md](https://github.com/Smart-AI-Memory/attune-ai/pull/1363/files) — companion PR #1363). Three manual backlog triages in 25 days (48→27, 33→23, 56→22) showed terminal specs accumulate top-level at ~1/day and only move when a human schedules an excavation. This makes the weekly spec-status audit surface them automatically.

- `audit_specs`: flags `archive_ready` when the leading status verdict is terminal AND the spec is still top-level (`archive/` is invisible to `discover_specs`) past a grace window — 7 days default, `ATTUNE_SPEC_ARCHIVE_GRACE_DAYS` to tune. Age from the ISO date in the status line, mtime fallback for undated statuses.
- `--json`: `counts.archive_ready` + `archive_ready` list + per-spec field (flows into the weekly tracking-issue upsert).
- Report: one warn footer naming ready slugs. **Warn-only — `--strict` unaffected.**

## Live receipt

Run against the pre-triage main tree, the flag reproduces tonight's 19-spec archive list exactly and additionally surfaces `attune-rag/rag-strengthening` — a real cross-repo find on first run.

## Test plan

- [x] 10 new tests: dated/undated terminals, grace boundary, env override, parked/living exempt, JSON + report surfaces, `--strict` unaffected
- [x] Full `test_spec_audit.py` suite: 167 passed
- [x] Pinned black/ruff pre-flighted
- [ ] CI matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)