### PR TITLE
feat(hooks): per-surfacing memory-injection records — feedback-signal step 1

### DIFF
--- a/benchmarks/trap_battery.py
+++ b/benchmarks/trap_battery.py
@@ -946,7 +946,10 @@ def aggregate_recovery(results: list[TrapRunResult]) -> dict[str, dict[str, Reco
 #: NOT echo hook additionalContext into events, so transcript markers
 #: are structurally blind; the telemetry log is ground truth (every
 #: jit_recall/lesson_recall fire appends a line — see
-#: plugin/hooks/_memory_telemetry.py).
+#: plugin/hooks/_memory_telemetry.py). CAVEAT: lesson_recall only
+#: gained telemetry 2026-07-14 (memory-recall-eval) — in the phase-2
+#: runs (2026-07-13/14) prompt-time fires appended NOTHING, so those
+#: runs' event counts undercount lesson_recall injections.
 MEMORY_EVENTS_LOG = Path.home() / ".attune" / "telemetry" / "memory_events.jsonl"
 
 

--- a/docs/specs/memory-recall-eval/decisions.md
+++ b/docs/specs/memory-recall-eval/decisions.md
@@ -187,3 +187,63 @@ trap-battery phase-2 redesign owns the measurement side
 (UserPromptSubmit-carried rules measure prevention; JIT-carried rules
 measure recovery only). No eval re-run scheduled against style rules
 until a carrying surface exists.
+
+## 2026-07-14 — Injection feedback signal, step 1: complete per-surfacing capture records
+
+**Context:** the recommit (2026-07-14 triage) points this spec at the
+memory-as-insurance feedback signal — label each injection acted-on /
+ignored / wrong so the noise denominator builds itself
+(`project_memory_as_insurance`). Prerequisite audit found the capture
+side incomplete; this entry records the design shipped to close it.
+
+**What the audit found (pre-change state):**
+
+- `plugin/hooks/lesson_recall.py` (prompt-time recall) emitted **no
+  telemetry at all** — it computed `lesson_id` + score per hit, then
+  discarded them. The largest hole: prompt-time surfacings were
+  invisible to any later analysis. Corollary:
+  `benchmarks/trap_battery.py`'s comment claiming "every
+  jit_recall/lesson_recall fire appends a line" was false — the
+  phase-2 runs (2026-07-13/14) undercounted prompt-time injections in
+  their telemetry receipts (caveat now recorded at the
+  `MEMORY_EVENTS_LOG` definition).
+- `jit_recall` logged `tool` + `rules` + size but no join key and no
+  record of WHICH gate (substring/regex/tool-keyed) fired each rule.
+- `session_recall` logged only an aggregate entry count — not which
+  findings were surfaced.
+- No event anywhere carries an `acted_on`/`ignored`/`wrong` verdict;
+  the only outcome signal is `memory_feedback` (stash deletion), which
+  covers stashed findings, not surfaced rules/lessons.
+
+**Design shipped (capture side):** every injection surface now writes
+a complete, joinable surfacing record to
+`~/.attune/telemetry/memory_events.jsonl`:
+
+- **`lesson_recall` (new event):** `lessons` (parallel `scores`),
+  `surfacing_id`, `injected_chars`/`est_tokens`.
+- **`jit_recall` (enriched):** adds `surfacing_id` and `triggers`
+  (parallel to `rules`; values `tool` | `substring` | `regex` |
+  `substring+regex`).
+- **`session_recall` (enriched):** adds `surfacing_id` and
+  `finding_ids` (ids of the findings actually rendered; id-less
+  records still count in `entries`).
+- **`surfacing_id`** (12-hex uuid per event) is the join key a later
+  verdict event references; per-item verdicts key on
+  `(surfacing_id, lesson_id|rule_id|finding_id)`.
+
+Receipts: unit suites green (125 tests across the four hook suites;
+the one failure is the pre-existing real-Ollama environmental flake,
+confirmed failing on the untouched baseline) + live subprocess
+round-trips of both hooks with an isolated `ATTUNE_HOME` showing the
+new records on disk.
+
+**Step 2 (scoped, not built — the verdict scorer):** the Stop hook
+(`plugin/hooks/session_stash.py`) already parses the transcript tail
+at end-of-session; it is the natural place to correlate the session's
+surfacing records against the transcript and emit a `memory_signal`
+verdict per surfacing (`acted_on` / `ignored` / `wrong`), reusing its
+Ollama-with-fallback pattern — with `unscored` (not a guessed
+heuristic label) when Ollama is unavailable, because a garbage label
+is worse than none. Plus an `ops/data.py` reader that turns verdicts
+into the noise denominator `estimate_intervention_signal`'s caption
+says is missing. Design pass owed before build.

--- a/docs/specs/memory-recall-eval/requirements.md
+++ b/docs/specs/memory-recall-eval/requirements.md
@@ -5,7 +5,7 @@
 > recalls curated memory correctly — before investing further in the
 > subsystem or deciding it needs work.
 
-**Status:** recommitted (2026-07-14 triage) — requirements drafted; next eval round is real work (memory-as-insurance feedback signal)
+**Status:** in progress — feedback-signal step 1 (per-surfacing capture records on all three injection surfaces) shipped 2026-07-14; step 2 (Stop-hook verdict scorer + noise-denominator reader) scoped in decisions.md, design pass owed
 **Owner:** Patrick + agent
 **Related:**
 

--- a/plugin/hooks/_memory_telemetry.py
+++ b/plugin/hooks/_memory_telemetry.py
@@ -10,7 +10,8 @@ same local-only JSONL style as ``usage.jsonl``.
 One event = one JSON line:
 
 - ``v`` / ``ts`` — schema version, UTC ISO-8601 timestamp.
-- ``event`` — ``session_recall`` | ``jit_recall`` | ``session_stash``.
+- ``event`` — ``session_recall`` | ``jit_recall`` | ``lesson_recall``
+  | ``session_stash``.
 - ``session_id`` — Claude Code session id (local file only; the
   opt-in usage ping reads ``usage*.jsonl`` and never this file).
 - ``injected_chars`` / ``est_tokens`` — size of the context the hook
@@ -88,7 +89,7 @@ def log_memory_event(event: str, session_id: str | None = None, **fields: object
 
     Args:
         event: Event name (``session_recall`` / ``jit_recall`` /
-            ``session_stash``).
+            ``lesson_recall`` / ``session_stash``).
         session_id: Claude Code session id, when the payload carried one.
         **fields: Event-specific data. An int ``injected_chars`` field
             gains a derived ``est_tokens`` sibling automatically.

--- a/plugin/hooks/jit_recall.py
+++ b/plugin/hooks/jit_recall.py
@@ -23,8 +23,10 @@ Tunables (env): ``ATTUNE_JIT_RECALL`` (set ``0`` to disable),
 ``ATTUNE_AI_SENTINEL_DIR`` (sentinel dir override, for tests).
 
 Each fire is logged to ``~/.attune/telemetry/memory_events.jsonl``
-(tool, rule ids, injected size; see ``_memory_telemetry``) so fire
-rate and context cost are measurable per session.
+(tool, rule ids, matched triggers, injected size, a ``surfacing_id``
+join key; see ``_memory_telemetry``) so fire rate and context cost are
+measurable per session and a later verdict pass can label each
+surfacing acted-on / ignored / wrong (memory-recall-eval spec).
 
 Exit 0 always — a crash or missing corpus degrades to silent no-op (R4).
 
@@ -39,6 +41,7 @@ import os
 import re
 import sys
 import time
+import uuid
 from pathlib import Path
 
 # Force utf-8 on stdout/stderr (Windows cp1252 would crash on em-dash,
@@ -165,6 +168,7 @@ def main() -> int:
         # contain backslashes — `\<` becomes `\\<` in the JSON dump.
         raw_input_text = " ".join(v for v in tool_input.values() if isinstance(v, str))
         fresh = []
+        triggers = []  # parallel to fresh: which gate matched, for telemetry
         for rule in rules:
             # Optional content filters (e.g. a Bash rule scoped to one
             # command shape) — without one a Bash-keyed rule would fire
@@ -183,6 +187,12 @@ def main() -> int:
             if sentinel is not None and sentinel.exists():
                 continue
             fresh.append(rule)
+            triggers.append(
+                "+".join(
+                    part for part, active in (("substring", needle), ("regex", pattern)) if active
+                )
+                or "tool"
+            )
         if not fresh:
             return 0
 
@@ -207,15 +217,18 @@ def main() -> int:
         )
         sys.stdout.flush()
 
-        # Telemetry: which rules surfaced, for which tool, and how much
-        # context they cost — the (tool, rules, ts) triple also lets a
-        # later analysis estimate prevented-failure rate by checking
-        # whether the matching failure still occurred after the fire.
+        # Telemetry: which rules surfaced, for which tool, via which
+        # trigger, and how much context they cost. The surfacing_id is
+        # the join key a later verdict pass (acted-on / ignored / wrong)
+        # references; triggers[i] says which gate fired rules[i]
+        # (memory-recall-eval spec, 2026-07-14).
         log_memory_event(
             "jit_recall",
             session_id=session_key,
+            surfacing_id=uuid.uuid4().hex[:12],
             tool=tool_name,
             rules=[rule["rule_id"] for rule in fresh],
+            triggers=triggers,
             injected_chars=len(context),
         )
 

--- a/plugin/hooks/lesson_recall.py
+++ b/plugin/hooks/lesson_recall.py
@@ -19,6 +19,11 @@ Noise controls (all from the design):
 Test/ops knob: ``ATTUNE_LESSONS_FILE`` pins the corpus file (default:
 walk up from the payload cwd via ``attune.lessons.find_lessons_file``).
 
+Each fire is logged to ``~/.attune/telemetry/memory_events.jsonl``
+(lesson ids, scores, injected size, a ``surfacing_id`` join key; see
+``_memory_telemetry``) so a later verdict pass can label each
+surfacing acted-on / ignored / wrong (memory-recall-eval spec).
+
 Exit 0 always — a crash, missing attune install, or missing corpus
 degrades to silent no-op.
 
@@ -33,6 +38,7 @@ import os
 import re
 import sys
 import time
+import uuid
 from pathlib import Path
 
 # Force utf-8 on stdout/stderr (Windows cp1252 would crash on em-dash,
@@ -50,6 +56,14 @@ try:
 except Exception:  # noqa: BLE001 — hook must never crash a prompt
     _sentinel_dir = None  # type: ignore[assignment]
     resolve_session_key = None  # type: ignore[assignment]
+
+try:
+    from _memory_telemetry import log_memory_event
+except Exception:  # noqa: BLE001 — telemetry is optional, never load-bearing
+
+    def log_memory_event(event: str, session_id: str | None = None, **fields: object) -> None:
+        return
+
 
 _SENTINEL_PREFIX = ".lesson-recalled-"
 _SENTINEL_TTL_SECONDS = 7 * 24 * 3600  # match the jit-recall TTL
@@ -163,17 +177,32 @@ def main() -> int:
             if len(body) > _BODY_EXCERPT_CHARS:
                 body = body[:_BODY_EXCERPT_CHARS] + "…"
             lines.append(f"- **{hit.entry.summary}**: {body}")
+        context = "\n".join(lines)
         sys.stdout.write(
             json.dumps(
                 {
                     "hookSpecificOutput": {
                         "hookEventName": "UserPromptSubmit",
-                        "additionalContext": "\n".join(lines),
+                        "additionalContext": context,
                     }
                 }
             )
         )
         sys.stdout.flush()
+
+        # Telemetry: which lessons surfaced, at what score, and how much
+        # context they cost. The surfacing_id is the join key a later
+        # verdict pass (acted-on / ignored / wrong) references — without
+        # this record, prompt-time recall is invisible to the noise
+        # denominator (memory-recall-eval spec, 2026-07-14).
+        log_memory_event(
+            "lesson_recall",
+            session_id=session_key,
+            surfacing_id=uuid.uuid4().hex[:12],
+            lessons=[lesson_id for _hit, lesson_id in fresh],
+            scores=[round(hit.score, 1) for hit, _lesson_id in fresh],
+            injected_chars=len(context),
+        )
 
         # Sentinels AFTER the emit so a mid-work crash retries next fire.
         for _hit, lesson_id in fresh:

--- a/plugin/hooks/session_recall.py
+++ b/plugin/hooks/session_recall.py
@@ -15,8 +15,10 @@ Tunables (env): ``ATTUNE_MEMORY_RECALL`` (set ``0`` to disable),
 ``ATTUNE_MEMORY_RECALL_TOPK`` (default 5).
 
 Each emission is logged to ``~/.attune/telemetry/memory_events.jsonl``
-(size + entry count; see ``_memory_telemetry``) so the layer's token
-cost is measured, not modeled.
+(size, entry count, surfaced finding ids, a ``surfacing_id`` join key;
+see ``_memory_telemetry``) so the layer's token cost is measured, not
+modeled, and a later verdict pass can label each surfacing acted-on /
+ignored / wrong (memory-recall-eval spec).
 
 Copyright 2026 Smart-AI-Memory
 Licensed under Apache 2.0
@@ -30,6 +32,7 @@ import re
 import subprocess
 import sys
 import traceback
+import uuid
 from pathlib import Path
 
 for _stream in (sys.stdout, sys.stderr):
@@ -158,14 +161,20 @@ def _type_of(topics: object) -> str:
     return "note"
 
 
-def _format(entries: list[dict]) -> str:
-    """Render the recalled findings as a compact markdown block."""
+def _format(entries: list[dict]) -> tuple[str, list[str]]:
+    """Render the recalled findings as a compact markdown block.
+
+    Returns the block plus one id per rendered finding ("" when the
+    record carries none), so the telemetry event can say WHICH findings
+    were surfaced, not just how many.
+    """
     lines = [
         "## Recalled memories",
         "",
         "Recent findings from this project (most recent first):",
         "",
     ]
+    rendered_ids: list[str] = []
     used = 0
     for e in entries:
         if not isinstance(e, dict):
@@ -178,9 +187,10 @@ def _format(entries: list[dict]) -> str:
         if used > _CONTENT_BUDGET:
             break
         lines.append(f"- [{_type_of(e.get('topics'))}] {content}")
+        rendered_ids.append(str(e.get("id") or ""))
     lines.append("")
     lines.append("_Pull more with `/recall <topic>`._")
-    return "\n".join(lines)
+    return "\n".join(lines), rendered_ids
 
 
 def main() -> int:
@@ -244,15 +254,21 @@ def main() -> int:
             if health:
                 print(health)
             return 0
-        block = _format(entries)
+        block, rendered_ids = _format(entries)
         # Only print if we actually rendered at least one finding line.
-        rendered = sum(1 for line in block.splitlines() if line.startswith("- ["))
-        if rendered:
+        if rendered_ids:
             print(block)
+            # finding_ids says WHICH findings were surfaced (id-less
+            # records are counted in `entries` but not listed); the
+            # surfacing_id is the join key a later verdict pass
+            # (acted-on / ignored / wrong) references
+            # (memory-recall-eval spec, 2026-07-14).
             log_memory_event(
                 "session_recall",
                 session_id=payload.get("session_id"),
-                entries=rendered,
+                surfacing_id=uuid.uuid4().hex[:12],
+                entries=len(rendered_ids),
+                finding_ids=[i for i in rendered_ids if i],
                 injected_chars=len(block),
                 reconciled_stale=len(stale_ids),
                 forgotten=forgotten,

--- a/tests/unit/hooks/test_memory_telemetry.py
+++ b/tests/unit/hooks/test_memory_telemetry.py
@@ -2,8 +2,8 @@
 
 Covers the helper's contract (JSONL shape, env gates, never-raises)
 and the integration points: a session_recall emission, a jit_recall
-fire, and a session_stash run each append one measurable event to
-``<ATTUNE_HOME>/telemetry/memory_events.jsonl``.
+fire, a lesson_recall fire, and a session_stash run each append one
+measurable event to ``<ATTUNE_HOME>/telemetry/memory_events.jsonl``.
 
 The hooks are standalone scripts; they're loaded via importlib (the
 ``test_session_memory_hooks.py`` pattern).
@@ -145,7 +145,7 @@ def _run(mod, monkeypatch, payload: dict) -> int:
 def test_session_recall_emission_logs_event(tmp_path, monkeypatch, capsys):
     monkeypatch.setenv("ATTUNE_HOME", str(tmp_path / ".attune"))
     mod = _load_module("session_recall")
-    entries = [{"text": "decided the widget uses tables", "topics": ["type:decision"]}]
+    entries = [{"id": "f-1", "text": "decided the widget uses tables", "topics": ["type:decision"]}]
 
     import attune.memory.session_stash as stash_pkg
 
@@ -162,6 +162,8 @@ def test_session_recall_emission_logs_event(tmp_path, monkeypatch, capsys):
     assert e["event"] == "session_recall"
     assert e["session_id"] == "sess-r"
     assert e["entries"] == 1
+    assert e["finding_ids"] == ["f-1"]
+    assert isinstance(e["surfacing_id"], str) and len(e["surfacing_id"]) == 12
     assert e["injected_chars"] > 0 and e["est_tokens"] > 0
 
 
@@ -187,6 +189,10 @@ def test_jit_recall_fire_logs_tool_and_rules(tmp_path, monkeypatch, capsys):
     assert e["session_id"] == "sess-j"
     assert e["tool"] == "AskUserQuestion"
     assert e["rules"] and all(isinstance(r, str) for r in e["rules"])
+    # triggers is parallel to rules: which gate fired each rule.
+    assert len(e["triggers"]) == len(e["rules"])
+    assert all(t in {"tool", "substring", "regex", "substring+regex"} for t in e["triggers"])
+    assert isinstance(e["surfacing_id"], str) and len(e["surfacing_id"]) == 12
     assert e["injected_chars"] > 0
 
 
@@ -202,6 +208,68 @@ def test_jit_recall_no_match_logs_nothing(tmp_path, monkeypatch):
         "tool_input": {},
     }
     assert _run(mod, monkeypatch, payload) == 0
+    assert _events(tmp_path) == []
+
+
+def test_lesson_recall_fire_logs_lessons_and_scores(tmp_path, monkeypatch, capsys):
+    """Prompt-time recall must leave a surfacing record — before
+    2026-07-14 it logged NOTHING (the memory-recall-eval gap: no
+    record, no noise denominator)."""
+    monkeypatch.setenv("ATTUNE_HOME", str(tmp_path / ".attune"))
+    monkeypatch.setenv("ATTUNE_AI_SENTINEL_DIR", str(tmp_path / "sentinels"))
+    lessons = tmp_path / "lessons.md"
+    lessons.write_text(
+        "## Lessons Learned\n\n"
+        "- **Squash merge tagging requires the merge SHA**: after a\n"
+        "  squash merge always tag the squash merge commit SHA, never\n"
+        "  the feature branch tip.\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("ATTUNE_LESSONS_FILE", str(lessons))
+    _load_module("_state")
+    mod = _load_module("lesson_recall")
+    payload = {
+        "hook_event_name": "UserPromptSubmit",
+        "prompt": "how do I tag the release after the squash merge lands",
+        "session_id": "sess-l",
+        "cwd": str(tmp_path),
+    }
+    rc = _run(mod, monkeypatch, payload)
+    assert rc == 0
+    assert "additionalContext" in capsys.readouterr().out
+
+    events = _events(tmp_path)
+    assert len(events) == 1
+    e = events[0]
+    assert e["event"] == "lesson_recall"
+    assert e["session_id"] == "sess-l"
+    assert e["lessons"] and all(isinstance(x, str) for x in e["lessons"])
+    # scores is parallel to lessons, every score at/above the floor.
+    assert len(e["scores"]) == len(e["lessons"])
+    assert all(s >= 8.0 for s in e["scores"])
+    assert isinstance(e["surfacing_id"], str) and len(e["surfacing_id"]) == 12
+    assert e["injected_chars"] > 0 and e["est_tokens"] > 0
+
+
+def test_lesson_recall_no_match_logs_nothing(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("ATTUNE_HOME", str(tmp_path / ".attune"))
+    monkeypatch.setenv("ATTUNE_AI_SENTINEL_DIR", str(tmp_path / "sentinels"))
+    lessons = tmp_path / "lessons.md"
+    lessons.write_text(
+        "## Lessons Learned\n\n- **Squash merge tagging**: tag the merge SHA.\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("ATTUNE_LESSONS_FILE", str(lessons))
+    _load_module("_state")
+    mod = _load_module("lesson_recall")
+    payload = {
+        "hook_event_name": "UserPromptSubmit",
+        "prompt": "please recolor the dashboard purple with sparkles",
+        "session_id": "sess-l2",
+        "cwd": str(tmp_path),
+    }
+    assert _run(mod, monkeypatch, payload) == 0
+    assert capsys.readouterr().out == ""
     assert _events(tmp_path) == []
 
 

--- a/tests/unit/hooks/test_session_memory_hooks.py
+++ b/tests/unit/hooks/test_session_memory_hooks.py
@@ -420,23 +420,29 @@ def test_type_of(recall_mod):
 
 
 def test_format_renders_typed_lines(recall_mod):
-    block = recall_mod._format(
+    block, rendered_ids = recall_mod._format(
         [
-            {"text": "dropped reviews to 0", "topics": ["type:decision"]},
+            {"id": "abc123", "text": "dropped reviews to 0", "topics": ["type:decision"]},
             {"text": "race in the runner", "topics": ["type:bug"]},
         ]
     )
     assert "## Recalled memories" in block
     assert "- [decision] dropped reviews to 0" in block
     assert "- [bug] race in the runner" in block
+    # One slot per rendered line; id-less records render as "".
+    assert rendered_ids == ["abc123", ""]
 
 
 def test_format_respects_budget(recall_mod, monkeypatch):
-    monkeypatch.setattr(recall_mod, "_CONTENT_BUDGET", 10)
-    block = recall_mod._format(
-        [{"text": "x" * 50, "topics": []}, {"text": "should not appear", "topics": []}]
+    monkeypatch.setattr(recall_mod, "_CONTENT_BUDGET", 60)
+    block, rendered_ids = recall_mod._format(
+        [
+            {"id": "kept", "text": "x" * 50, "topics": []},
+            {"id": "cut", "text": "should not appear", "topics": []},
+        ]
     )
     assert "should not appear" not in block
+    assert rendered_ids == ["kept"]  # over-budget entries yield no id either
 
 
 _HEALTHY = {"backend": "FileStashBackend", "fallback": True, "unreachable_upgrade": None}


### PR DESCRIPTION
## What

Feedback-signal **step 1** for the recommitted `memory-recall-eval` spec: every memory-injection surface now writes a complete, **joinable per-surfacing record** to `~/.attune/telemetry/memory_events.jsonl`.

Per the ratified memory-as-insurance frame, the highest-leverage memory work is a feedback signal on injections (surfaced item acted-on / ignored / wrong) so the noise denominator builds itself. That needs capture records first — and the audit found the capture side incomplete:

| Surface | Before | After |
|---|---|---|
| `lesson_recall` (prompt-time) | **no telemetry at all** — ids + scores computed, then discarded | new `lesson_recall` event: `lessons`, `scores`, `surfacing_id`, sizes |
| `jit_recall` (tool-time) | `tool` + `rules` + size | adds `surfacing_id` + `triggers` (which gate fired each rule: tool/substring/regex) |
| `session_recall` (SessionStart) | aggregate count only | adds `surfacing_id` + `finding_ids` (which findings rendered) |

`surfacing_id` (12-hex uuid per event) is the join key the step-2 verdict pass will reference; per-item verdicts key on `(surfacing_id, item_id)`.

Also: caveat comment on `benchmarks/trap_battery.py`'s `MEMORY_EVENTS_LOG` — its "every jit_recall/lesson_recall fire appends a line" claim was **false until this PR**, so the phase-2 runs (2026-07-13/14) undercounted prompt-time injections in their telemetry receipts.

## Receipts

- 4 hook suites: 124/125 green; the single failure (`test_extract_via_ollama_real_round_trip`) is a pre-existing real-Ollama environmental flake, confirmed failing on the untouched baseline.
- Live subprocess round-trips (isolated `ATTUNE_HOME`) of both hooks show the new records on disk — e.g. `{"event":"lesson_recall","lessons":["squash-merge-tagging-…"],"scores":[11.0],"surfacing_id":"37820a2ad2b1",…}`.
- Pinned black/ruff pre-flighted; all pre-commit hooks passed at commit.

## Not in this PR (step 2, scoped in the spec's decisions.md)

Stop-hook verdict scorer (`memory_signal` event: acted_on/ignored/wrong, Ollama-with-`unscored`-fallback) + the `ops/data.py` noise-denominator reader. Design pass owed before build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
