### PR TITLE
feat(telemetry): log unmatched help_lookup queries — FG1 Phase 2 (channel 1)

### DIFF
--- a/src/attune/mcp/server.py
+++ b/src/attune/mcp/server.py
@@ -924,7 +924,10 @@ class EmpathyMCPServer(MemoryHandlersMixin, WorkflowHandlersMixin):
         Emits a help-query telemetry event to
         ``~/.attune/telemetry/help_queries.jsonl`` on every call so
         usage of the help system can be measured against drift
-        maintenance cost. Disable with ``ATTUNE_HELP_TELEMETRY=0``.
+        maintenance cost. Queries that resolve no topic are also
+        appended to ``~/.attune/telemetry/help_unmatched.jsonl``
+        (FAQ-Generator channel 1). Disable both with
+        ``ATTUNE_HELP_TELEMETRY=0``.
 
         Supports four modes:
         - progressive: escalates across template types
@@ -954,7 +957,8 @@ class EmpathyMCPServer(MemoryHandlersMixin, WorkflowHandlersMixin):
             return result
         finally:
             duration_ms = (time.perf_counter() - started) * 1000
-            get_tracker().log(
+            tracker = get_tracker()
+            tracker.log(
                 source="help_lookup",
                 mode=mode,
                 topic=topic,
@@ -962,6 +966,25 @@ class EmpathyMCPServer(MemoryHandlersMixin, WorkflowHandlersMixin):
                 found=bool(result.get("success")) and "error" not in result,
                 duration_ms=duration_ms,
             )
+            if self._help_lookup_unmatched(mode, result):
+                tracker.log_unmatched(query=topic, mode=mode)
+
+    @staticmethod
+    def _help_lookup_unmatched(mode: str, result: dict[str, Any]) -> bool:
+        """True when a lookup completed but resolved no help topic.
+
+        This is FAQ-Generator channel 1 (real user questions with no
+        matching topic — see help-docs-single-source follow-ups FG1).
+        Exceptions (empty result) and unknown modes don't count. The
+        error prefixes are the not-found returns produced by
+        ``_handle_help_lookup_impl`` below.
+        """
+        if not result:
+            return False
+        if result.get("success"):
+            return mode == "search_tag" and result.get("count") == 0
+        error = str(result.get("error", ""))
+        return error.startswith(("Template not found", "No preamble for"))
 
     async def _handle_help_lookup_impl(
         self, args: dict[str, Any], topic: str, mode: str

--- a/src/attune/telemetry/help_tracker.py
+++ b/src/attune/telemetry/help_tracker.py
@@ -20,6 +20,20 @@ Event shape (JSONL, one event per line)::
         "duration_ms": 12.4
     }
 
+Unmatched queries — lookups that completed but resolved no help
+topic — are additionally appended to
+``~/.attune/telemetry/help_unmatched.jsonl``. This is channel 1 of
+the FAQ Generator (real user questions with no matching topic; see
+docs/specs/archive/help-docs-single-source/follow-ups.md FG1)::
+
+    {
+        "v": "1.0",
+        "ts": "2026-04-19T18:30:00.123456+00:00",
+        "source": "help_lookup",
+        "mode": "progressive",
+        "query": "how do I rotate api keys"
+    }
+
 Copyright 2025 Smart-AI-Memory
 Licensed under the Apache License, Version 2.0
 """
@@ -39,6 +53,7 @@ logger = logging.getLogger(__name__)
 _LOG_VERSION = "1.0"
 _DEFAULT_DIR = Path.home() / ".attune" / "telemetry"
 _DEFAULT_FILE = "help_queries.jsonl"
+_UNMATCHED_FILE = "help_unmatched.jsonl"
 
 
 def _enabled() -> bool:
@@ -57,6 +72,7 @@ class HelpTracker:
         self,
         log_dir: Path | None = None,
         filename: str = _DEFAULT_FILE,
+        unmatched_filename: str = _UNMATCHED_FILE,
     ):
         """Construct a tracker.
 
@@ -64,15 +80,23 @@ class HelpTracker:
             log_dir: Directory for telemetry files. Defaults to
                 ``~/.attune/telemetry/``.
             filename: JSONL filename within ``log_dir``.
+            unmatched_filename: JSONL filename for the unmatched-query
+                (FAQ channel-1) log within ``log_dir``.
         """
         self._dir = log_dir or _DEFAULT_DIR
         self._path = self._dir / filename
+        self._unmatched_path = self._dir / unmatched_filename
         self._lock = threading.Lock()
 
     @property
     def path(self) -> Path:
         """Path to the JSONL log file."""
         return self._path
+
+    @property
+    def unmatched_path(self) -> Path:
+        """Path to the unmatched-query JSONL log file."""
+        return self._unmatched_path
 
     def log(
         self,
@@ -114,10 +138,44 @@ class HelpTracker:
             event["duration_ms"] = round(duration_ms, 2)
         if metadata:
             event["metadata"] = metadata
+        self._append(self._path, event)
+
+    def log_unmatched(
+        self,
+        *,
+        query: str,
+        mode: str,
+        source: str = "help_lookup",
+    ) -> None:
+        """Append an unmatched query to the FAQ channel-1 log.
+
+        Called when a help lookup completed but resolved no topic —
+        the raw query is what the future FAQ Generator ranks by
+        frequency. No-ops silently if ``ATTUNE_HELP_TELEMETRY=0`` or
+        if the write fails.
+
+        Args:
+            query: The topic/query string that found no help topic.
+            mode: Lookup sub-mode (e.g., ``"progressive"``).
+            source: Call site, e.g., ``"help_lookup"``.
+        """
+        if not _enabled():
+            return
+        event = {
+            "v": _LOG_VERSION,
+            "ts": datetime.now(timezone.utc).isoformat(),
+            "source": source,
+            "mode": mode,
+            "query": query,
+        }
+        self._append(self._unmatched_path, event)
+
+    def _append(self, path: Path, event: dict[str, Any]) -> None:
+        """Append one event to a JSONL file; never raises."""
         try:
             with self._lock:
                 self._dir.mkdir(parents=True, exist_ok=True)
-                with self._path.open("a", encoding="utf-8") as fh:
+                with path.open("a", encoding="utf-8") as fh:
                     fh.write(json.dumps(event, ensure_ascii=False) + "\n")
         except OSError as err:
             logger.debug("help telemetry write failed: %s", err)

--- a/tests/unit/mcp/test_help_handlers.py
+++ b/tests/unit/mcp/test_help_handlers.py
@@ -657,3 +657,130 @@ class TestHandleHelpUpdate:
             result = await server._handle_help_update({})
         assert result["success"] is False
         assert "help_init" in result["error"]
+
+
+# ------------------------------------------------------------------
+# Unmatched-query logging (FAQ-Generator channel 1)
+# ------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestHelpLookupUnmatchedLogging:
+    """_handle_help_lookup appends unmatched queries to the channel-1 log."""
+
+    @pytest.fixture(autouse=True)
+    def _telemetry_on(self, monkeypatch: Any) -> None:
+        """Re-enable help telemetry — the global conftest disables it."""
+        monkeypatch.delenv("ATTUNE_HELP_TELEMETRY", raising=False)
+
+    def _tracker(self, tmp_path: Any) -> Any:
+        from attune.telemetry.help_tracker import HelpTracker
+
+        return HelpTracker(log_dir=tmp_path / "telemetry")
+
+    @staticmethod
+    def _events(tracker: Any) -> list[dict[str, Any]]:
+        import json
+
+        if not tracker.unmatched_path.exists():
+            return []
+        return [
+            json.loads(line)
+            for line in tracker.unmatched_path.read_text(encoding="utf-8").splitlines()
+            if line
+        ]
+
+    async def test_progressive_not_found_logs_unmatched(self, tmp_path: Any) -> None:
+        """A template miss appends the raw query to the unmatched log."""
+        server = _make_server(tmp_path)
+        tracker = self._tracker(tmp_path)
+        with (
+            patch(f"{_HELP_IMPORTS}.populate_progressive", return_value=None),
+            patch("attune.telemetry.help_tracker.get_tracker", return_value=tracker),
+        ):
+            await server._handle_help_lookup({"topic": "how do I frobnicate"})
+
+        events = self._events(tracker)
+        assert len(events) == 1
+        assert events[0]["query"] == "how do I frobnicate"
+        assert events[0]["mode"] == "progressive"
+        assert events[0]["source"] == "help_lookup"
+
+    async def test_preamble_not_found_logs_unmatched(self, tmp_path: Any) -> None:
+        """A preamble miss appends the raw query to the unmatched log."""
+        server = _make_server(tmp_path)
+        tracker = self._tracker(tmp_path)
+        with (
+            patch(f"{_HELP_IMPORTS}.get_preamble", return_value=None),
+            patch("attune.telemetry.help_tracker.get_tracker", return_value=tracker),
+        ):
+            await server._handle_help_lookup({"topic": "mystery", "mode": "preamble"})
+
+        events = self._events(tracker)
+        assert len(events) == 1
+        assert events[0]["query"] == "mystery"
+        assert events[0]["mode"] == "preamble"
+
+    async def test_search_tag_zero_hits_logs_unmatched(self, tmp_path: Any) -> None:
+        """A tag search with zero hits counts as unmatched."""
+        server = _make_server(tmp_path)
+        tracker = self._tracker(tmp_path)
+        with (
+            patch(f"{_HELP_IMPORTS}.search_by_tag", return_value=[]),
+            patch("attune.telemetry.help_tracker.get_tracker", return_value=tracker),
+        ):
+            await server._handle_help_lookup({"topic": "no-such-tag", "mode": "search_tag"})
+
+        events = self._events(tracker)
+        assert len(events) == 1
+        assert events[0]["query"] == "no-such-tag"
+
+    async def test_search_tag_with_hits_not_logged(self, tmp_path: Any) -> None:
+        """A tag search with hits is NOT unmatched."""
+        server = _make_server(tmp_path)
+        tracker = self._tracker(tmp_path)
+        with (
+            patch(f"{_HELP_IMPORTS}.search_by_tag", return_value=["tpl-1"]),
+            patch("attune.telemetry.help_tracker.get_tracker", return_value=tracker),
+        ):
+            await server._handle_help_lookup({"topic": "security", "mode": "search_tag"})
+
+        assert self._events(tracker) == []
+
+    async def test_found_progressive_not_logged(self, tmp_path: Any) -> None:
+        """A successful lookup is NOT unmatched."""
+        server = _make_server(tmp_path)
+        tracker = self._tracker(tmp_path)
+        with (
+            patch(f"{_HELP_IMPORTS}.populate_progressive", return_value=_FakePopulated()),
+            patch("attune.telemetry.help_tracker.get_tracker", return_value=tracker),
+        ):
+            await server._handle_help_lookup({"topic": "security"})
+
+        assert self._events(tracker) == []
+
+    async def test_unknown_mode_not_logged(self, tmp_path: Any) -> None:
+        """A caller bug (unknown mode) is NOT a channel-1 signal."""
+        server = _make_server(tmp_path)
+        tracker = self._tracker(tmp_path)
+        with patch("attune.telemetry.help_tracker.get_tracker", return_value=tracker):
+            await server._handle_help_lookup({"topic": "x", "mode": "bogus"})
+
+        assert self._events(tracker) == []
+
+    async def test_impl_exception_not_logged(self, tmp_path: Any) -> None:
+        """An error during lookup is NOT unmatched — only resolved misses."""
+        server = _make_server(tmp_path)
+        tracker = self._tracker(tmp_path)
+        with (
+            patch(
+                f"{_HELP_IMPORTS}.populate_progressive",
+                side_effect=RuntimeError("boom"),
+            ),
+            patch("attune.telemetry.help_tracker.get_tracker", return_value=tracker),
+            pytest.raises(RuntimeError),
+        ):
+            await server._handle_help_lookup({"topic": "x"})
+
+        assert self._events(tracker) == []

--- a/tests/unit/telemetry/test_help_tracker.py
+++ b/tests/unit/telemetry/test_help_tracker.py
@@ -117,3 +117,63 @@ def test_unicode_topics_round_trip(tmp_path, topic):
     )
 
     assert _read_events(tracker.path)[0]["topic"] == topic
+
+
+# ------------------------------------------------------------------
+# log_unmatched — FAQ-Generator channel 1
+# ------------------------------------------------------------------
+
+
+def test_log_unmatched_writes_channel1_event(tmp_path):
+    tracker = HelpTracker(log_dir=tmp_path)
+    tracker.log_unmatched(query="how do I rotate api keys", mode="progressive")
+
+    events = _read_events(tracker.unmatched_path)
+    assert len(events) == 1
+    assert events[0]["query"] == "how do I rotate api keys"
+    assert events[0]["mode"] == "progressive"
+    assert events[0]["source"] == "help_lookup"
+    assert events[0]["v"] == "1.0"
+    assert "ts" in events[0]
+
+
+def test_log_unmatched_goes_to_separate_file(tmp_path):
+    tracker = HelpTracker(log_dir=tmp_path)
+    tracker.log_unmatched(query="x", mode="progressive")
+
+    assert tracker.unmatched_path.name == "help_unmatched.jsonl"
+    assert not tracker.path.exists()
+
+
+def test_log_unmatched_appends(tmp_path):
+    tracker = HelpTracker(log_dir=tmp_path)
+    for query in ["a", "b", "c"]:
+        tracker.log_unmatched(query=query, mode="progressive")
+
+    events = _read_events(tracker.unmatched_path)
+    assert [e["query"] for e in events] == ["a", "b", "c"]
+
+
+def test_log_unmatched_honors_opt_out(tmp_path, monkeypatch):
+    monkeypatch.setenv("ATTUNE_HELP_TELEMETRY", "0")
+    tracker = HelpTracker(log_dir=tmp_path)
+    tracker.log_unmatched(query="x", mode="progressive")
+
+    assert not tracker.unmatched_path.exists()
+
+
+def test_log_unmatched_never_raises_on_write_error(tmp_path):
+    tracker = HelpTracker(log_dir=tmp_path / "nested")
+    # Replace the dir with a file so mkdir would fail
+    (tmp_path / "nested").write_text("block")
+
+    # Should not raise
+    tracker.log_unmatched(query="x", mode="progressive")
+
+
+@pytest.mark.parametrize("query", ["ñoño", "日本語", "🎉"])
+def test_log_unmatched_unicode_round_trips(tmp_path, query):
+    tracker = HelpTracker(log_dir=tmp_path)
+    tracker.log_unmatched(query=query, mode="progressive")
+
+    assert _read_events(tracker.unmatched_path)[0]["query"] == query


### PR DESCRIPTION
## What

FG1 Phase 2 (docs/specs/archive/help-docs-single-source/follow-ups.md): `help_lookup` queries that complete but resolve **no help topic** now append to a dedicated local log, `~/.attune/telemetry/help_unmatched.jsonl`, so channel-1 data (real user questions with no matching topic) starts accumulating for the future FAQ ranker. No LLM, no spec-dir change (freeze through 2026-07-27). Phase 1 (channel-4 seeds projection) is PR #1370.

## How

- **`telemetry/help_tracker.py`** — `HelpTracker.log_unmatched()` writes `{v, ts, source, mode, query}` to the new append-only JSONL. Same lock, same never-raise write, same `ATTUNE_HELP_TELEMETRY=0` opt-out as the existing query log (write logic factored into `_append()`).
- **`mcp/server.py`** — the existing telemetry block in `_handle_help_lookup` also calls `log_unmatched` when `_help_lookup_unmatched()` says the lookup *resolved* no topic: progressive template-not-found, preamble miss, or `search_tag` with zero hits. Exceptions and unknown-mode caller bugs are deliberately excluded — the general `help_queries.jsonl` `found=false` stream conflates errors with misses; channel 1 must stay clean for frequency ranking.

## Why a second file (vs. filtering `help_queries.jsonl`)

The general log's `found=false` includes handler exceptions and caller bugs, and its `topic` field serves a different consumer (usage-vs-drift measurement). A dedicated file gives the FAQ ranker a clean, self-describing input with zero re-filtering.

## Receipts

- 57 tests pass (`tests/unit/telemetry/test_help_tracker.py` + `tests/unit/mcp/test_help_handlers.py`): 8 new tracker tests (event shape, separate file, append, opt-out, never-raises on write error, unicode) + 7 new handler wiring tests (each unmatched / not-unmatched outcome, including the exception path).
- Non-mocked round-trip: real help engine + real tracker under a temp `HOME` — a nonsense query (`how do i frobnicate the widget`) produced `{"v": "1.0", "ts": "...", "source": "help_lookup", "mode": "progressive", "query": "how do i frobnicate the widget"}` in `help_unmatched.jsonl`.
- follow-ups.md untouched: open PR #1370 already re-scopes FG1 with this exact Phase-2 line ("log unmatched `help_lookup` queries locally, cheap, do soon") — editing the same region here would conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
