### PR TITLE
feat(authoring): projection drift gate + idempotent generated_at writes

### DIFF
--- a/.claude/lessons.md
+++ b/.claude/lessons.md
@@ -15044,3 +15044,45 @@ def ", start_idx + 1)` for module-
   that it prunes other ad-hoc installs. Durable fix would be
   adding the docs pins to the dev dependency-group like the #1350
   play did for the dev extra.
+
+- **A line-granular diff filter misclassifies multi-field lines —
+  reverting "timestamp-only" churn by dropping diff lines containing
+  `generated_at` silently reverted REAL `source_hash` updates that
+  share the same footer line**: 2026-07-14, FG1 Phase 1 (PR #1370).
+  After a full 27-feature projection run, a cleanup script kept only
+  files whose diff had "content lines" — defined as +/- lines NOT
+  containing `generated_at`. The `.help` frontmatter puts
+  `generated_at:` and `source_hash:` on separate lines (filter
+  correct), but the docs-page footer packs both into ONE line
+  (`<!-- attune-generated: source_hash=X … generated_at=D -->`), so
+  15 docs pages with legitimately-moved source_hash were reverted to
+  stale footers. Caught only because the projection drift gate built
+  the same day fired on the real corpus at birth. Rule: when
+  filtering diffs by "does the line contain field X", first check
+  whether X ever shares a line with load-bearing fields; match the
+  FIELD (regex-replace `generated_at=\S+` then compare), not the
+  line. Companion fix that retires the whole dance: make generators
+  idempotent (skip writes whose only delta is the stamp) so
+  timestamp churn never enters the diff.
+
+- **A freshness exemption is an enforcement HOLE unless something
+  else guards the surface — `status: manual` features were exempt
+  from LLM-staleness by design, so master→projection drift had NO
+  gate and sat invisible for 3 weeks**: #1059 edited the models /
+  spec-engine masters (archive-path fixes) without re-projection;
+  `help_status` showed "0 stale / 27 manual" the whole time because
+  manual features are deliberately outside the staleness check
+  (correct — they must never get LLM regen), and the pre-commit
+  regen hook is check-only. Found by accident when FG1's full
+  projection run touched every feature. Fix shipped: deterministic
+  `check_projection_drift()` as a unit test (dry-run re-render vs
+  committed files, stamps normalized) + tripwire tests proving it
+  fires. Generalization: whenever a surface is EXEMPTED from a
+  freshness/validation mechanism ("manual", "frozen", "skip"),
+  ask what ELSE enforces its invariant — an exemption with no
+  replacement gate is where multi-week silent drift lives. Pairs
+  with the "spec-named work-scope drifts from code reality" lesson
+  (same family: the FG1 starter said "the 3 hand-authored FAQs" but
+  ALL 27 features had frozen faq.md files — glob the actual property
+  before executing; the undercount surfaced a 159-Q/A content
+  decision that needed Patrick's call).

--- a/docs/architecture/code-quality.md
+++ b/docs/architecture/code-quality.md
@@ -156,4 +156,4 @@ contrast, drive `CodeReviewWorkflow` directly.
   `_SUBAGENT_NAMES`; a new pass is a new `AgentDefinition` plus a
   synthesis section in the task template in `code_review.py`.
 
-<!-- attune-generated: source_hash=3f9592fd884ddc994048dbdc80fa264339717c64b37d33385ef2e36088c41472 feature=code-quality kind=architecture generated_at=2026-06-23 -->
+<!-- attune-generated: source_hash=1cda16e2ee597c3fc3187497350da0cf77783f31c42c22e4652888adb60ca679 feature=code-quality kind=architecture generated_at=2026-07-14 -->

--- a/docs/architecture/elicitation-forms.md
+++ b/docs/architecture/elicitation-forms.md
@@ -117,4 +117,4 @@ per-type "rejects out-of-option" test is the cheap guard that catches a
 missed validation site. Prove it with a non-mocked round-trip — render,
 submit, collect — not just unit tests.
 
-<!-- attune-generated: source_hash=a92a686cbf5ee20f00434eb8333649a9fe60ca3b10acaec689f66904730ce1c4 feature=elicitation-forms kind=architecture generated_at=2026-06-30 -->
+<!-- attune-generated: source_hash=ea2a2694719d75bff1894657cfe5e0f5c96ae71719ae4d7f00ce7252b9e9798a feature=elicitation-forms kind=architecture generated_at=2026-07-14 -->

--- a/docs/architecture/memory.md
+++ b/docs/architecture/memory.md
@@ -133,4 +133,4 @@ tiers above.
 - **Manage at runtime:** use `MemoryControlPanel` to browse, export,
   and clear stored memory without code changes.
 
-<!-- attune-generated: source_hash=544951b28662066a703ef7be552af08e83ef52a5186e5ad71ad216119352938b feature=memory kind=architecture generated_at=2026-06-23 -->
+<!-- attune-generated: source_hash=cba94c001e0b9e2f41279e9caa28b69cdc1ff0b0c62ec76baa038dc0e48cb5b6 feature=memory kind=architecture generated_at=2026-07-14 -->

--- a/docs/architecture/models.md
+++ b/docs/architecture/models.md
@@ -115,4 +115,4 @@ given mode so you can compare before committing.
   `min_success_rate` to `AdaptiveModelRouter.get_best_model`, or read
   `get_routing_stats` to drive your own selection logic.
 
-<!-- attune-generated: source_hash=234b0cd90506b69d0850593ea98bea4fd5db520bc09a02ed86d749c76b692459 feature=models kind=architecture generated_at=2026-06-21 -->
+<!-- attune-generated: source_hash=52589e077700e250b69e496efaa9634a271c4f91bd520b4c07b4915347a04668 feature=models kind=architecture generated_at=2026-07-14 -->

--- a/docs/architecture/spec-engine.md
+++ b/docs/architecture/spec-engine.md
@@ -128,4 +128,4 @@ a list of interrupted runs you can pick back up.
   incomplete plans, then pass `plan_path` to `execute_with_approval()`
   to resume.
 
-<!-- attune-generated: source_hash=2dfc8acb0ee448c292e20dbc3f8299d64331d1f378bbf85cced4377b5dc2b5d1 feature=spec-engine kind=architecture generated_at=2026-06-21 -->
+<!-- attune-generated: source_hash=657458c4d06bb198d067760775b69a5c87288113feaddb9cdaf3df631c188617 feature=spec-engine kind=architecture generated_at=2026-07-14 -->

--- a/docs/how-to/code-quality.md
+++ b/docs/how-to/code-quality.md
@@ -169,4 +169,4 @@ re-exported from `attune.workflows`. `WorkflowResult` comes from
 | MCP tool | `code_review` — one required `path` argument; runs at standard depth (the handler does not pass `depth`) and validates the path against the workspace root. |
 | Python | `await CodeReviewWorkflow().execute(path=<p>, depth=<d>)`. |
 
-<!-- attune-generated: source_hash=3f9592fd884ddc994048dbdc80fa264339717c64b37d33385ef2e36088c41472 feature=code-quality kind=how-to generated_at=2026-06-23 -->
+<!-- attune-generated: source_hash=1cda16e2ee597c3fc3187497350da0cf77783f31c42c22e4652888adb60ca679 feature=code-quality kind=how-to generated_at=2026-07-14 -->

--- a/docs/how-to/elicitation-forms.md
+++ b/docs/how-to/elicitation-forms.md
@@ -144,4 +144,4 @@ three construct types `decision`, `pushback`, `progress` — ten in all.
 `elicitation_collect_response`, and `elicitation_ask` — the same model,
 exposed for agents that drive forms through the MCP server.
 
-<!-- attune-generated: source_hash=a92a686cbf5ee20f00434eb8333649a9fe60ca3b10acaec689f66904730ce1c4 feature=elicitation-forms kind=how-to generated_at=2026-06-30 -->
+<!-- attune-generated: source_hash=ea2a2694719d75bff1894657cfe5e0f5c96ae71719ae4d7f00ce7252b9e9798a feature=elicitation-forms kind=how-to generated_at=2026-07-14 -->

--- a/docs/how-to/memory.md
+++ b/docs/how-to/memory.md
@@ -201,4 +201,4 @@ satisfies the protocol.
 | Static context | `ClaudeMemoryLoader().load_all_memory()`. |
 | Runtime management | `MemoryControlPanel`. |
 
-<!-- attune-generated: source_hash=544951b28662066a703ef7be552af08e83ef52a5186e5ad71ad216119352938b feature=memory kind=how-to generated_at=2026-06-23 -->
+<!-- attune-generated: source_hash=cba94c001e0b9e2f41279e9caa28b69cdc1ff0b0c62ec76baa038dc0e48cb5b6 feature=memory kind=how-to generated_at=2026-07-14 -->

--- a/docs/how-to/models.md
+++ b/docs/how-to/models.md
@@ -223,4 +223,4 @@ namespaces are `attune auth` (authentication) and `attune provider`
 | `MockLLMExecutor` | A deterministic executor for tests; records calls in `call_history`. |
 | `AdaptiveModelRouter` | Picks a model from historical telemetry. `get_best_model(workflow, stage, ...)` returns a model id; `recommend_tier_upgrade(workflow, stage)` returns `(bool, reason)`. |
 
-<!-- attune-generated: source_hash=234b0cd90506b69d0850593ea98bea4fd5db520bc09a02ed86d749c76b692459 feature=models kind=how-to generated_at=2026-06-21 -->
+<!-- attune-generated: source_hash=52589e077700e250b69e496efaa9634a271c4f91bd520b4c07b4915347a04668 feature=models kind=how-to generated_at=2026-07-14 -->

--- a/docs/how-to/spec-engine.md
+++ b/docs/how-to/spec-engine.md
@@ -246,4 +246,4 @@ final summary:
 Pipeline complete: 4/5 tasks executed  total_cost: $0.016  duration: 18402ms
 ```
 
-<!-- attune-generated: source_hash=2dfc8acb0ee448c292e20dbc3f8299d64331d1f378bbf85cced4377b5dc2b5d1 feature=spec-engine kind=how-to generated_at=2026-06-21 -->
+<!-- attune-generated: source_hash=657458c4d06bb198d067760775b69a5c87288113feaddb9cdaf3df631c188617 feature=spec-engine kind=how-to generated_at=2026-07-14 -->

--- a/docs/reference/code-quality.md
+++ b/docs/reference/code-quality.md
@@ -54,4 +54,4 @@ re-exported from `attune.workflows`. `WorkflowResult` comes from
 | MCP tool | `code_review` — one required `path` argument; runs at standard depth (the handler does not pass `depth`) and validates the path against the workspace root. |
 | Python | `await CodeReviewWorkflow().execute(path=<p>, depth=<d>)`. |
 
-<!-- attune-generated: source_hash=3f9592fd884ddc994048dbdc80fa264339717c64b37d33385ef2e36088c41472 feature=code-quality kind=reference generated_at=2026-06-23 -->
+<!-- attune-generated: source_hash=1cda16e2ee597c3fc3187497350da0cf77783f31c42c22e4652888adb60ca679 feature=code-quality kind=reference generated_at=2026-07-14 -->

--- a/docs/reference/elicitation-forms.md
+++ b/docs/reference/elicitation-forms.md
@@ -37,4 +37,4 @@ three construct types `decision`, `pushback`, `progress` — ten in all.
 `elicitation_collect_response`, and `elicitation_ask` — the same model,
 exposed for agents that drive forms through the MCP server.
 
-<!-- attune-generated: source_hash=a92a686cbf5ee20f00434eb8333649a9fe60ca3b10acaec689f66904730ce1c4 feature=elicitation-forms kind=reference generated_at=2026-06-30 -->
+<!-- attune-generated: source_hash=ea2a2694719d75bff1894657cfe5e0f5c96ae71719ae4d7f00ce7252b9e9798a feature=elicitation-forms kind=reference generated_at=2026-07-14 -->

--- a/docs/reference/memory.md
+++ b/docs/reference/memory.md
@@ -73,4 +73,4 @@ satisfies the protocol.
 | Static context | `ClaudeMemoryLoader().load_all_memory()`. |
 | Runtime management | `MemoryControlPanel`. |
 
-<!-- attune-generated: source_hash=544951b28662066a703ef7be552af08e83ef52a5186e5ad71ad216119352938b feature=memory kind=reference generated_at=2026-06-23 -->
+<!-- attune-generated: source_hash=cba94c001e0b9e2f41279e9caa28b69cdc1ff0b0c62ec76baa038dc0e48cb5b6 feature=memory kind=reference generated_at=2026-07-14 -->

--- a/docs/reference/models.md
+++ b/docs/reference/models.md
@@ -68,4 +68,4 @@ namespaces are `attune auth` (authentication) and `attune provider`
 | `MockLLMExecutor` | A deterministic executor for tests; records calls in `call_history`. |
 | `AdaptiveModelRouter` | Picks a model from historical telemetry. `get_best_model(workflow, stage, ...)` returns a model id; `recommend_tier_upgrade(workflow, stage)` returns `(bool, reason)`. |
 
-<!-- attune-generated: source_hash=234b0cd90506b69d0850593ea98bea4fd5db520bc09a02ed86d749c76b692459 feature=models kind=reference generated_at=2026-06-21 -->
+<!-- attune-generated: source_hash=52589e077700e250b69e496efaa9634a271c4f91bd520b4c07b4915347a04668 feature=models kind=reference generated_at=2026-07-14 -->

--- a/docs/reference/spec-engine.md
+++ b/docs/reference/spec-engine.md
@@ -75,4 +75,4 @@ final summary:
 Pipeline complete: 4/5 tasks executed  total_cost: $0.016  duration: 18402ms
 ```
 
-<!-- attune-generated: source_hash=2dfc8acb0ee448c292e20dbc3f8299d64331d1f378bbf85cced4377b5dc2b5d1 feature=spec-engine kind=reference generated_at=2026-06-21 -->
+<!-- attune-generated: source_hash=657458c4d06bb198d067760775b69a5c87288113feaddb9cdaf3df631c188617 feature=spec-engine kind=reference generated_at=2026-07-14 -->

--- a/scripts/project_features.py
+++ b/scripts/project_features.py
@@ -102,7 +102,8 @@ def main(argv: list[str] | None = None) -> int:
     print(f"{verb} {len(result.outputs)} output(s) for {args.feature!r}:")
     for out in result.outputs:
         rel = out.path.relative_to(repo_root) if out.path.is_relative_to(repo_root) else out.path
-        print(f"  [{out.target}] {out.kind:<16} -> {rel}")
+        note = " (unchanged, skipped)" if out.path in result.unchanged else ""
+        print(f"  [{out.target}] {out.kind:<16} -> {rel}{note}")
 
     if result.skipped:
         print(f"skipped {len(result.skipped)}:")

--- a/src/attune/authoring/projector.py
+++ b/src/attune/authoring/projector.py
@@ -153,6 +153,10 @@ class ProjectionResult:
     skipped: list[str] = field(default_factory=list)
     warnings: list[str] = field(default_factory=list)
     outputs: list[ProjectedOutput] = field(default_factory=list)
+    #: Planned outputs whose on-disk file already matches modulo the
+    #: ``generated_at`` stamp — left untouched so re-projection is
+    #: idempotent (no timestamp churn in diffs).
+    unchanged: list[Path] = field(default_factory=list)
 
 
 # ---------------------------------------------------------------------------
@@ -296,10 +300,74 @@ def project_feature(
     if not dry_run:
         for out in result.outputs:
             out.path.parent.mkdir(parents=True, exist_ok=True)
+            if out.path.exists():
+                existing = out.path.read_text(encoding="utf-8")
+                if normalize_generated_stamps(existing) == normalize_generated_stamps(out.content):
+                    result.unchanged.append(out.path)
+                    continue
             out.path.write_text(out.content, encoding="utf-8")
             result.written.append(out.path)
 
     return result
+
+
+#: ``generated_at`` carriers in projected outputs: the ``.help`` YAML
+#: frontmatter line and the docs-page HTML-comment footer field.
+_FRONTMATTER_GENERATED_AT_RE = re.compile(r"^generated_at: .*$", re.M)
+_FOOTER_GENERATED_AT_RE = re.compile(r" generated_at=[^ >]+")
+
+
+def normalize_generated_stamps(text: str) -> str:
+    """Return ``text`` with every ``generated_at`` stamp neutralized.
+
+    Projection output is deterministic except for the render
+    timestamp. Comparing two renders through this normalizer answers
+    "same content?" — used by the idempotent write path (skip
+    rewriting a file whose only difference would be the timestamp)
+    and by the projection drift gate.
+    """
+    text = _FRONTMATTER_GENERATED_AT_RE.sub("generated_at: <stamp>", text)
+    return _FOOTER_GENERATED_AT_RE.sub(" generated_at=<stamp>", text)
+
+
+def check_projection_drift(
+    project_root: str | Path,
+    help_dir: str | Path,
+    masters_dir: str | Path | None = None,
+) -> list[str]:
+    """Compare a dry-run projection of every master against disk.
+
+    The drift gate for single-sourced features: re-renders each
+    ``<masters_dir>/*.md`` master in memory and diffs every planned
+    output against the committed file, ignoring ``generated_at``
+    stamps. Returns one finding per drifted output — empty means the
+    corpus is in lockstep with its masters (the guarantee `status:
+    manual` features otherwise lack, since they are exempt from the
+    LLM-freshness staleness check by design).
+
+    Findings name the master, the output path, and whether the file
+    is missing or differs, so the fix is always the one-liner
+    ``python scripts/project_features.py <feature>``.
+    """
+    project_root = Path(project_root)
+    help_dir = Path(help_dir)
+    masters = Path(masters_dir) if masters_dir else project_root / "content" / "features"
+    findings: list[str] = []
+    for master in sorted(masters.glob("*.md")):
+        result = project_feature(master, project_root, help_dir, dry_run=True)
+        for out in result.outputs:
+            rel = (
+                out.path.relative_to(project_root)
+                if out.path.is_relative_to(project_root)
+                else out.path
+            )
+            if not out.path.exists():
+                findings.append(f"{master.stem}: {rel} missing — re-run projection")
+                continue
+            on_disk = out.path.read_text(encoding="utf-8")
+            if normalize_generated_stamps(on_disk) != normalize_generated_stamps(out.content):
+                findings.append(f"{master.stem}: {rel} differs from its master — re-run projection")
+    return findings
 
 
 #: The two accepted seed-bullet shapes (FG1 Phase 1). Bold-Q is the

--- a/tests/unit/authoring/test_projection_drift.py
+++ b/tests/unit/authoring/test_projection_drift.py
@@ -1,0 +1,159 @@
+"""Projection drift gate — masters and projected outputs in lockstep.
+
+Single-sourced (``status: manual``) features are exempt from the
+LLM-freshness staleness check by design, which left master→projection
+drift unguarded: PR #1059 edited ``models.md`` / ``spec-engine.md``
+masters and their committed templates carried a stale ``source_hash``
+for three weeks, caught only by an unrelated full projection run.
+
+This suite is the enforcer for that class:
+
+- the **corpus gate** re-renders every real master in memory and
+  fails when any committed output differs (ignoring ``generated_at``
+  stamps) — the fix is always
+  ``python scripts/project_features.py <feature>`` in the same PR;
+- the **tripwire tests** prove the gate actually fires on a mutated
+  master and on a deleted output (verify-it-fires, not just
+  verify-it-passes);
+- the **idempotence tests** pin the no-churn write path: re-running
+  projection over an unchanged master rewrites nothing.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from attune.authoring.projector import (
+    check_projection_drift,
+    normalize_generated_stamps,
+    project_feature,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+MASTERS_DIR = REPO_ROOT / "content" / "features"
+
+
+# --- the corpus gate ---------------------------------------------------------
+
+
+def test_projected_outputs_match_their_masters():
+    # The drift gate proper: every committed projection output must
+    # match a fresh render of its master. A failure here means a
+    # master (or the projector) changed without re-projection — run
+    # `python scripts/project_features.py <feature>` (and
+    # `python scripts/sync_help_bundle.py`) in the same PR.
+    assert MASTERS_DIR.is_dir(), f"masters dir missing: {MASTERS_DIR}"
+    findings = check_projection_drift(REPO_ROOT, REPO_ROOT / ".help")
+    assert findings == [], "projection drift detected:\n" + "\n".join(findings)
+
+
+# --- tripwires: the gate must FIRE, not just pass ---------------------------
+
+
+def _seed_project(tmp_path: Path) -> Path:
+    """A minimal project with one master, fully projected to disk."""
+    masters = tmp_path / "content" / "features"
+    masters.mkdir(parents=True)
+    (masters / "feat.md").write_text(
+        "---\n"
+        "feature: feat\n"
+        "summary: A feature\n"
+        "---\n\n"
+        "## Overview\n\nthe overview\n\n"
+        "## Concepts\n\nthe concepts\n\n"
+        "## Notes & tips\n\nthe notes\n",
+        encoding="utf-8",
+    )
+    project_feature(masters / "feat.md", tmp_path, tmp_path / ".help", dry_run=False)
+    return masters / "feat.md"
+
+
+def test_gate_clean_after_projection(tmp_path):
+    _seed_project(tmp_path)
+    assert check_projection_drift(tmp_path, tmp_path / ".help") == []
+
+
+def test_gate_fires_on_master_edit(tmp_path):
+    master = _seed_project(tmp_path)
+    master.write_text(
+        master.read_text(encoding="utf-8").replace("the overview", "the EDITED overview"),
+        encoding="utf-8",
+    )
+
+    findings = check_projection_drift(tmp_path, tmp_path / ".help")
+
+    assert findings, "gate must fire when a master changes without re-projection"
+    assert any("differs from its master" in f for f in findings)
+    assert all("feat:" in f for f in findings)
+
+
+def test_gate_fires_on_missing_output(tmp_path):
+    _seed_project(tmp_path)
+    (tmp_path / ".help" / "templates" / "feat" / "concept.md").unlink()
+
+    findings = check_projection_drift(tmp_path, tmp_path / ".help")
+
+    assert any("missing" in f for f in findings)
+
+
+def test_gate_ignores_timestamp_only_difference(tmp_path):
+    # A re-render whose only difference is generated_at is NOT drift.
+    _seed_project(tmp_path)
+    concept = tmp_path / ".help" / "templates" / "feat" / "concept.md"
+    stamped = concept.read_text(encoding="utf-8")
+    concept.write_text(
+        stamped.replace(
+            stamped.splitlines()[5],  # the generated_at: line
+            "generated_at: 1999-01-01T00:00:00+00:00",
+        ),
+        encoding="utf-8",
+    )
+
+    assert check_projection_drift(tmp_path, tmp_path / ".help") == []
+
+
+# --- idempotent writes -------------------------------------------------------
+
+
+def test_reprojection_of_unchanged_master_writes_nothing(tmp_path):
+    master = _seed_project(tmp_path)
+
+    second = project_feature(master, tmp_path, tmp_path / ".help", dry_run=False)
+
+    assert second.written == []
+    assert sorted(second.unchanged) == sorted(o.path for o in second.outputs)
+
+
+def test_reprojection_preserves_original_timestamp(tmp_path):
+    master = _seed_project(tmp_path)
+    concept = tmp_path / ".help" / "templates" / "feat" / "concept.md"
+    before = concept.read_text(encoding="utf-8")
+
+    project_feature(master, tmp_path, tmp_path / ".help", dry_run=False)
+
+    assert concept.read_text(encoding="utf-8") == before
+
+
+def test_reprojection_after_master_edit_rewrites(tmp_path):
+    master = _seed_project(tmp_path)
+    master.write_text(
+        master.read_text(encoding="utf-8").replace("the overview", "the EDITED overview"),
+        encoding="utf-8",
+    )
+
+    result = project_feature(master, tmp_path, tmp_path / ".help", dry_run=False)
+
+    assert result.written  # content change -> real rewrite
+    assert check_projection_drift(tmp_path, tmp_path / ".help") == []
+
+
+# --- normalizer --------------------------------------------------------------
+
+
+def test_normalize_covers_frontmatter_and_footer_stamps():
+    fm = "generated_at: 2026-07-14T00:00:00+00:00\nbody\n"
+    footer = "<!-- attune-generated: source_hash=abc feature=f kind=k generated_at=2026-07-14 -->"
+    assert "2026-07-14" not in normalize_generated_stamps(fm)
+    assert "2026-07-14" not in normalize_generated_stamps(footer)
+    # Everything else is untouched.
+    assert "source_hash=abc" in normalize_generated_stamps(footer)


### PR DESCRIPTION
## Projection drift gate + idempotent generated_at writes

Follow-up to #1370's discovery: `models`/`spec-engine` templates
drifted silently for 3 weeks after #1059 edited their masters —
single-sourced (`status: manual`) features are exempt from the
LLM-freshness staleness check *by design*, so master→projection drift
had **no enforcer at all**.

### What changed

- **Idempotent writes**: `normalize_generated_stamps()` neutralizes
  the frontmatter `generated_at` line and the docs-footer field;
  `project_feature` now skips any output whose on-disk content matches
  modulo stamps (`result.unchanged`). Re-projecting an unchanged
  corpus rewrites **nothing** — the 301-file timestamp-churn class
  from #1370 is extinct at the source.
- **Drift gate**: `check_projection_drift()` dry-run re-renders every
  master and diffs against committed outputs (stamps ignored), one
  finding per file with the one-line fix. Runs as a normal unit test
  (`tests/unit/authoring/test_projection_drift.py`), so a master edit
  without re-projection now fails the PR.
- **Tripwire receipts**: tests prove the gate FIRES (mutated master,
  deleted output) and that timestamp-only differences do NOT trip it.

### The gate fired on the real corpus at birth

15 docs pages carried stale `source_hash` footers — an artifact of
#1370's churn-revert script, which misread one-line footer changes
(`source_hash` and `generated_at` share a line) as timestamp-only.
Repaired here via re-projection; verified footer-only (0 non-footer
lines changed). Lessons entry included.

666 authoring+help tests pass. Freeze-compatible: no tag, no new spec
dir.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
