### PR TITLE
fix(discovery-sweep): surface silently-failed sources (health-plan items 1+3)

### DIFF
--- a/src/attune/ops/sweep_results.py
+++ b/src/attune/ops/sweep_results.py
@@ -184,8 +184,10 @@ def persist_result(scope_path: str, sweep_result: dict[str, Any], config: Config
         with os.fdopen(fd, "w", encoding="utf-8") as f:
             json.dump(sweep_result, f, indent=2)
         os.replace(tmp_name, target)
-    except Exception:
-        # Best-effort cleanup if the rename never happened.
+    except Exception:  # noqa: BLE001
+        # INTENTIONAL: cleanup-and-reraise, not a mask — the broad
+        # catch exists only so the temp file never leaks, and the
+        # bare `raise` preserves the original exception unchanged.
         try:
             os.unlink(tmp_name)
         except OSError:

--- a/src/attune/workflows/discovery_sweep/llm_source_base.py
+++ b/src/attune/workflows/discovery_sweep/llm_source_base.py
@@ -358,6 +358,45 @@ def cap_hit_finding_if_bound(
     )
 
 
+def workflow_unsuccessful_finding(
+    source_name: str,
+    path: str,
+    result: object,
+) -> Finding:
+    """Marker for a clean WorkflowResult whose ``success`` came back False.
+
+    Shared by every LLM source adapter (previously mirrored per-file
+    with a detail line that only read ``final_output`` — empty on most
+    failures, rendering the useless "(no detail returned)"). Prefers
+    the structured ``error`` / ``error_type`` fields so the question
+    entry names the actual failure.
+
+    Tagged ``source-failure`` so verification rule 0 routes it to the
+    ``questions`` bucket and the engine counts the source as failed
+    when it produced nothing else.
+    """
+    error = getattr(result, "error", None)
+    error_type = getattr(result, "error_type", None)
+    final_output = getattr(result, "final_output", "") or ""
+    detail = str(error or final_output or "(no detail returned)")
+    if error_type:
+        detail = f"[{error_type}] {detail}"
+    return Finding(
+        source=source_name,
+        severity="info",
+        title=f"{source_name} returned an unsuccessful result for {path}",
+        description=(
+            "Wrapped workflow completed without raising but reported "
+            f"success=False. Detail: {detail[:300]}"
+        ),
+        file=path,
+        line=None,
+        evidence=None,
+        confidence=1.0,
+        tags=("source-failure",),
+    )
+
+
 class LLMSource:
     """Optional marker base for LLM-backed FindingSource adapters.
 

--- a/src/attune/workflows/discovery_sweep/sources/bug_predict.py
+++ b/src/attune/workflows/discovery_sweep/sources/bug_predict.py
@@ -28,6 +28,7 @@ from ..llm_source_base import (
     budget_too_small_finding,
     cap_hit_finding_if_bound,
     findings_from_workflow_result,
+    workflow_unsuccessful_finding,
 )
 from ..workflow import Finding
 
@@ -98,7 +99,7 @@ class BugPredictSource(LLMSource):
             self._record_cost(result)
 
             if not getattr(result, "success", False):
-                findings.append(_workflow_unsuccessful_finding(self.name, path, result))
+                findings.append(workflow_unsuccessful_finding(self.name, path, result))
                 continue
 
             findings.extend(findings_from_workflow_result(result, self.name))
@@ -138,29 +139,6 @@ def _path_failed_finding(source_name: str, path: str, exc: BaseException) -> Fin
         description=(
             f"Wrapped workflow raised {type(exc).__name__}: {exc}. "
             f"Other paths (if any) were still attempted."
-        ),
-        file=path,
-        line=None,
-        evidence=None,
-        confidence=1.0,
-        tags=("source-failure",),
-    )
-
-
-def _workflow_unsuccessful_finding(
-    source_name: str,
-    path: str,
-    result: object,
-) -> Finding:
-    """Marker for a clean WorkflowResult whose ``success`` came back False."""
-    detail = getattr(result, "final_output", "") or "(no detail returned)"
-    return Finding(
-        source=source_name,
-        severity="info",
-        title=f"{source_name} returned an unsuccessful result for {path}",
-        description=(
-            "Wrapped workflow completed without raising but reported "
-            f"success=False. Detail: {detail[:200]}"
         ),
         file=path,
         line=None,

--- a/src/attune/workflows/discovery_sweep/sources/dependency_check.py
+++ b/src/attune/workflows/discovery_sweep/sources/dependency_check.py
@@ -34,6 +34,7 @@ from ..llm_source_base import (
     budget_too_small_finding,
     cap_hit_finding_if_bound,
     findings_from_workflow_result,
+    workflow_unsuccessful_finding,
 )
 from ..workflow import Finding
 
@@ -107,7 +108,7 @@ class DependencyCheckSource(LLMSource):
             self._record_cost(result)
 
             if not getattr(result, "success", False):
-                findings.append(_workflow_unsuccessful_finding(self.name, path, result))
+                findings.append(workflow_unsuccessful_finding(self.name, path, result))
                 continue
 
             findings.extend(findings_from_workflow_result(result, self.name))
@@ -147,29 +148,6 @@ def _path_failed_finding(source_name: str, path: str, exc: BaseException) -> Fin
         description=(
             f"Wrapped workflow raised {type(exc).__name__}: {exc}. "
             f"Other paths (if any) were still attempted."
-        ),
-        file=path,
-        line=None,
-        evidence=None,
-        confidence=1.0,
-        tags=("source-failure",),
-    )
-
-
-def _workflow_unsuccessful_finding(
-    source_name: str,
-    path: str,
-    result: object,
-) -> Finding:
-    """Marker for a clean WorkflowResult whose ``success`` came back False."""
-    detail = getattr(result, "final_output", "") or "(no detail returned)"
-    return Finding(
-        source=source_name,
-        severity="info",
-        title=f"{source_name} returned an unsuccessful result for {path}",
-        description=(
-            "Wrapped workflow completed without raising but reported "
-            f"success=False. Detail: {detail[:200]}"
         ),
         file=path,
         line=None,

--- a/src/attune/workflows/discovery_sweep/sources/doc_audit.py
+++ b/src/attune/workflows/discovery_sweep/sources/doc_audit.py
@@ -34,6 +34,7 @@ from ..llm_source_base import (
     budget_too_small_finding,
     cap_hit_finding_if_bound,
     findings_from_workflow_result,
+    workflow_unsuccessful_finding,
 )
 from ..workflow import Finding
 
@@ -106,7 +107,7 @@ class DocAuditSource(LLMSource):
             self._record_cost(result)
 
             if not getattr(result, "success", False):
-                findings.append(_workflow_unsuccessful_finding(self.name, path, result))
+                findings.append(workflow_unsuccessful_finding(self.name, path, result))
                 continue
 
             findings.extend(findings_from_workflow_result(result, self.name))
@@ -146,29 +147,6 @@ def _path_failed_finding(source_name: str, path: str, exc: BaseException) -> Fin
         description=(
             f"Wrapped workflow raised {type(exc).__name__}: {exc}. "
             f"Other paths (if any) were still attempted."
-        ),
-        file=path,
-        line=None,
-        evidence=None,
-        confidence=1.0,
-        tags=("source-failure",),
-    )
-
-
-def _workflow_unsuccessful_finding(
-    source_name: str,
-    path: str,
-    result: object,
-) -> Finding:
-    """Marker for a clean WorkflowResult whose ``success`` came back False."""
-    detail = getattr(result, "final_output", "") or "(no detail returned)"
-    return Finding(
-        source=source_name,
-        severity="info",
-        title=f"{source_name} returned an unsuccessful result for {path}",
-        description=(
-            "Wrapped workflow completed without raising but reported "
-            f"success=False. Detail: {detail[:200]}"
         ),
         file=path,
         line=None,

--- a/src/attune/workflows/discovery_sweep/sources/perf_audit.py
+++ b/src/attune/workflows/discovery_sweep/sources/perf_audit.py
@@ -33,6 +33,7 @@ from ..llm_source_base import (
     budget_too_small_finding,
     cap_hit_finding_if_bound,
     findings_from_workflow_result,
+    workflow_unsuccessful_finding,
 )
 from ..workflow import Finding
 
@@ -105,7 +106,7 @@ class PerfAuditSource(LLMSource):
             self._record_cost(result)
 
             if not getattr(result, "success", False):
-                findings.append(_workflow_unsuccessful_finding(self.name, path, result))
+                findings.append(workflow_unsuccessful_finding(self.name, path, result))
                 continue
 
             findings.extend(findings_from_workflow_result(result, self.name))
@@ -145,29 +146,6 @@ def _path_failed_finding(source_name: str, path: str, exc: BaseException) -> Fin
         description=(
             f"Wrapped workflow raised {type(exc).__name__}: {exc}. "
             f"Other paths (if any) were still attempted."
-        ),
-        file=path,
-        line=None,
-        evidence=None,
-        confidence=1.0,
-        tags=("source-failure",),
-    )
-
-
-def _workflow_unsuccessful_finding(
-    source_name: str,
-    path: str,
-    result: object,
-) -> Finding:
-    """Marker for a clean WorkflowResult whose ``success`` came back False."""
-    detail = getattr(result, "final_output", "") or "(no detail returned)"
-    return Finding(
-        source=source_name,
-        severity="info",
-        title=f"{source_name} returned an unsuccessful result for {path}",
-        description=(
-            "Wrapped workflow completed without raising but reported "
-            f"success=False. Detail: {detail[:200]}"
         ),
         file=path,
         line=None,

--- a/src/attune/workflows/discovery_sweep/sources/security_audit.py
+++ b/src/attune/workflows/discovery_sweep/sources/security_audit.py
@@ -34,6 +34,7 @@ from ..llm_source_base import (
     budget_too_small_finding,
     cap_hit_finding_if_bound,
     findings_from_workflow_result,
+    workflow_unsuccessful_finding,
 )
 from ..workflow import Finding
 
@@ -107,7 +108,7 @@ class SecurityAuditSource(LLMSource):
             self._record_cost(result)
 
             if not getattr(result, "success", False):
-                findings.append(_workflow_unsuccessful_finding(self.name, path, result))
+                findings.append(workflow_unsuccessful_finding(self.name, path, result))
                 continue
 
             findings.extend(findings_from_workflow_result(result, self.name))
@@ -147,29 +148,6 @@ def _path_failed_finding(source_name: str, path: str, exc: BaseException) -> Fin
         description=(
             f"Wrapped workflow raised {type(exc).__name__}: {exc}. "
             f"Other paths (if any) were still attempted."
-        ),
-        file=path,
-        line=None,
-        evidence=None,
-        confidence=1.0,
-        tags=("source-failure",),
-    )
-
-
-def _workflow_unsuccessful_finding(
-    source_name: str,
-    path: str,
-    result: object,
-) -> Finding:
-    """Marker for a clean WorkflowResult whose ``success`` came back False."""
-    detail = getattr(result, "final_output", "") or "(no detail returned)"
-    return Finding(
-        source=source_name,
-        severity="info",
-        title=f"{source_name} returned an unsuccessful result for {path}",
-        description=(
-            "Wrapped workflow completed without raising but reported "
-            f"success=False. Detail: {detail[:200]}"
         ),
         file=path,
         line=None,

--- a/src/attune/workflows/discovery_sweep/sources/test_audit.py
+++ b/src/attune/workflows/discovery_sweep/sources/test_audit.py
@@ -35,6 +35,7 @@ from ..llm_source_base import (
     budget_too_small_finding,
     cap_hit_finding_if_bound,
     findings_from_workflow_result,
+    workflow_unsuccessful_finding,
 )
 from ..workflow import Finding
 
@@ -107,7 +108,7 @@ class TestAuditSource(LLMSource):
             self._record_cost(result)
 
             if not getattr(result, "success", False):
-                findings.append(_workflow_unsuccessful_finding(self.name, path, result))
+                findings.append(workflow_unsuccessful_finding(self.name, path, result))
                 continue
 
             findings.extend(findings_from_workflow_result(result, self.name))
@@ -147,29 +148,6 @@ def _path_failed_finding(source_name: str, path: str, exc: BaseException) -> Fin
         description=(
             f"Wrapped workflow raised {type(exc).__name__}: {exc}. "
             f"Other paths (if any) were still attempted."
-        ),
-        file=path,
-        line=None,
-        evidence=None,
-        confidence=1.0,
-        tags=("source-failure",),
-    )
-
-
-def _workflow_unsuccessful_finding(
-    source_name: str,
-    path: str,
-    result: object,
-) -> Finding:
-    """Marker for a clean WorkflowResult whose ``success`` came back False."""
-    detail = getattr(result, "final_output", "") or "(no detail returned)"
-    return Finding(
-        source=source_name,
-        severity="info",
-        title=f"{source_name} returned an unsuccessful result for {path}",
-        description=(
-            "Wrapped workflow completed without raising but reported "
-            f"success=False. Detail: {detail[:200]}"
         ),
         file=path,
         line=None,

--- a/src/attune/workflows/discovery_sweep/verification.py
+++ b/src/attune/workflows/discovery_sweep/verification.py
@@ -147,6 +147,13 @@ def route(finding: Finding, all_findings: list[Finding]) -> Decision:
 
     Rule order (first non-None wins):
 
+    0. **Source failure marker.** Tagged ``source-failure`` →
+       ``Questions(SOURCE_FAILED)``. These are health signals about
+       the sweep itself, not code findings — they must stay visible
+       regardless of severity or file. Without this rule an ``info``
+       marker WITH a file fell through to rule 2 and was silently
+       buried in ``rejected`` (the 2026-07-14 6-of-7-dead-sources
+       sweep that still rendered as clean).
     1. **Location required.** No ``file`` and not tagged
        ``file-level`` → ``Questions(LOCATION_MISSING)``.
     2. **Severity threshold.** Below ``medium`` →
@@ -160,6 +167,16 @@ def route(finding: Finding, all_findings: list[Finding]) -> Decision:
 
     A finding that survives all five lands in ``Queue``.
     """
+    # 0. source failure markers surface as questions, never rejected
+    if "source-failure" in finding.tags:
+        return Questions(
+            reason=REASON_SOURCE_FAILED,
+            next_step=(
+                f"Run `attune workflow run discovery-sweep --path X "
+                f"--source {finding.source}` to reproduce."
+            ),
+        )
+
     # 1. location required
     if finding.file is None and "file-level" not in finding.tags:
         return Questions(

--- a/src/attune/workflows/discovery_sweep/workflow.py
+++ b/src/attune/workflows/discovery_sweep/workflow.py
@@ -277,6 +277,14 @@ def _render_markdown(result: SweepResult, *, verbose: bool = False) -> str:
     """
     colored = _should_color()
     out: list[str] = []
+    if result.metadata.failures:
+        n_failed = len(result.metadata.failures)
+        n_sources = len(result.metadata.sources)
+        out.append(
+            f"⚠ PARTIAL SWEEP: {n_failed} of {n_sources} source(s) failed "
+            f"({', '.join(result.metadata.failures)}) — findings below "
+            f"may be incomplete.\n"
+        )
     out.append(f"## Queue ({len(result.queue)} findings)\n")
     if result.queue:
         for f in result.queue:
@@ -608,8 +616,25 @@ class DiscoverySweepWorkflow(BaseWorkflow):
         if ds_stdout.is_emission_enabled():
             ds_stdout.emit_final_line(_render_json(sweep))
 
+        # A sweep where source failures are a strict majority is a
+        # failed sweep, not a clean one with quiet footnotes (NFR-1
+        # says failures must not ABORT the sweep — it never promised
+        # they render as success). At half or fewer failed, success
+        # stays True with the failures named in metadata + the
+        # markdown banner.
+        n_failed = len(sweep.metadata.failures)
+        sweep_ok = n_failed * 2 <= len(sources)
+
         return WorkflowResult(
-            success=True,
+            success=sweep_ok,
+            error=(
+                None
+                if sweep_ok
+                else (
+                    f"{n_failed} of {len(sources)} sources failed: "
+                    f"{', '.join(sweep.metadata.failures)}"
+                )
+            ),
             stages=[
                 WorkflowStage(
                     name="sweep",
@@ -682,6 +707,13 @@ class DiscoverySweepWorkflow(BaseWorkflow):
                 questions.append(_failure_to_question(source_name, payload))
                 continue
             all_findings.extend(payload)
+            # A source whose EVERY finding is a failure marker produced
+            # nothing usable — count it as failed alongside crashed
+            # sources so metadata.failures (and the caller's success
+            # flag) reflect reality. Before this, six dead LLM sources
+            # rendered as a clean sweep (2026-07-14 health report).
+            if payload and all("source-failure" in f.tags for f in payload):
+                failures.append(f"{source_name}: returned only failure markers")
 
         queue: list[Finding] = []
         rejected: list[RejectedFinding] = []

--- a/tests/unit/workflows/discovery_sweep/test_engine.py
+++ b/tests/unit/workflows/discovery_sweep/test_engine.py
@@ -108,6 +108,99 @@ class TestExecuteHappyPath:
         assert "## Rejected" in res.final_output
 
 
+def _failure_marker(source: str) -> Finding:
+    """The shape every LLM source emits when its wrapped workflow
+    reports success=False (see llm_source_base.workflow_unsuccessful_
+    finding) — info severity, file set, tagged source-failure."""
+    return _finding(
+        source=source,
+        severity="info",
+        title=f"{source} returned an unsuccessful result for src/",
+        file="src/",
+        line=None,
+        confidence=1.0,
+        tags=("source-failure",),
+    )
+
+
+class TestSourceFailureSurfacing:
+    """Regression suite for the 2026-07-14 silent-failure class: six of
+    seven sources returned only success=False markers, which routing
+    buried in ``rejected`` while the sweep rendered success=True with
+    no failures named (docs/reports/library-health-2026-07-14.md,
+    finding 1)."""
+
+    def test_majority_dead_sources_fail_the_sweep(self) -> None:
+        # The live 6-of-7 scenario: one healthy pattern source, six
+        # sources that produced nothing but failure markers.
+        healthy = FakeSource(name="pattern-scan", is_llm=False, findings=[_finding()])
+        dead = [
+            FakeSource(name=n, findings=[_failure_marker(n)])
+            for n in (
+                "bug-predict",
+                "security-audit",
+                "dependency-check",
+                "perf-audit",
+                "doc-audit",
+                "test-audit",
+            )
+        ]
+        wf = DiscoverySweepWorkflow()
+        res = asyncio.run(wf.execute(path="src/", sources=[healthy, *dead]))
+        sweep: SweepResult = res.metadata["sweep"]
+
+        # The sweep is FAILED, and says why.
+        assert res.success is False
+        assert res.error is not None
+        assert "6 of 7 sources failed" in res.error
+        # Every dead source is named in metadata.failures.
+        assert len(sweep.metadata.failures) == 6
+        assert all("returned only failure markers" in f for f in sweep.metadata.failures)
+        # Failure markers surface as questions — never buried in rejected.
+        assert sum(q.reason == "SOURCE_FAILED" for q in sweep.questions) == 6
+        assert not any(
+            "source-failure" in r.finding.tags for r in sweep.rejected
+        ), "failure markers must never land in the rejected bucket"
+        # The healthy source's finding still flows to the queue.
+        assert len(sweep.queue) == 1
+
+    def test_minority_failures_keep_success_but_are_named(self) -> None:
+        healthy = [FakeSource(name=f"ok-{i}", findings=[_finding()]) for i in range(3)]
+        dead = FakeSource(name="doc-audit", findings=[_failure_marker("doc-audit")])
+        wf = DiscoverySweepWorkflow()
+        res = asyncio.run(wf.execute(path="src/", sources=[*healthy, dead]))
+        sweep: SweepResult = res.metadata["sweep"]
+
+        assert res.success is True
+        assert sweep.metadata.failures == ["doc-audit: returned only failure markers"]
+
+    def test_markdown_banner_names_partial_sweep(self) -> None:
+        healthy = [FakeSource(name=f"ok-{i}", findings=[_finding()]) for i in range(3)]
+        dead = FakeSource(name="doc-audit", findings=[_failure_marker("doc-audit")])
+        wf = DiscoverySweepWorkflow()
+        res = asyncio.run(wf.execute(path="src/", sources=[*healthy, dead]))
+
+        assert "PARTIAL SWEEP: 1 of 4 source(s) failed" in res.final_output
+        assert "doc-audit" in res.final_output
+
+    def test_healthy_source_with_incidental_failure_marker_not_counted(self) -> None:
+        # A source that produced real findings PLUS one failure marker
+        # (e.g. one path of several failed) is degraded, not dead — it
+        # must not count toward the failure majority.
+        mixed = FakeSource(
+            name="doc-audit",
+            findings=[_finding(source="doc-audit"), _failure_marker("doc-audit")],
+        )
+        wf = DiscoverySweepWorkflow()
+        res = asyncio.run(wf.execute(path="src/", sources=[mixed]))
+        sweep: SweepResult = res.metadata["sweep"]
+
+        assert res.success is True
+        assert sweep.metadata.failures == []
+        # The marker itself still surfaces as a question.
+        assert any(q.reason == "SOURCE_FAILED" for q in sweep.questions)
+
+
 class TestBudgetAllocation:
     def test_per_source_budget_splits_across_llm_only(self) -> None:
         # Two LLM sources with default multiplier=1.0; one non-LLM


### PR DESCRIPTION
## Dead sources can no longer render as a clean sweep

Executes plan items 1+3 of [docs/reports/library-health-2026-07-14.md](https://github.com/Smart-AI-Memory/attune-ai/blob/main/docs/reports/library-health-2026-07-14.md)
(pending #1373). Live-found: 6 of 7 audit sources returned
success=False markers that verification buried in the rejected
bucket — the sweep rendered `success: true`, $0 spent, 'Here's what
I found'. Same class as #1152, applied at the sweep level.

### Changes
- **verification rule 0**: `source-failure`-tagged findings route to
  Questions(SOURCE_FAILED) — sweep-health signals stay visible, never
  buried by the severity threshold.
- **engine**: sources returning only failure markers count into
  `metadata.failures`; `success` flips False on a strict-majority
  failure (half or fewer stays True — the existing 1-of-2 NFR-1 test
  encodes that); `error` names the failed sources; markdown leads
  with a PARTIAL SWEEP banner. MCP tool inherits the honest flag.
- **shared helper**: `workflow_unsuccessful_finding` replaces six
  mirrored copies; detail prefers structured `error`/`error_type`
  over the usually-empty `final_output` ('(no detail returned)').
- **false positive recorded**: `ops/sweep_results.py:187` broad
  except is cleanup-and-reraise — marked INTENTIONAL, not 'fixed'.
- **regression suite**: the live 6-of-7 scenario + minority-failure +
  banner + degraded-but-alive-source cases.

Root cause of WHY wrapped SDK workflows fail nested inside a Claude
Code session stays open (sdk-teardown-exit-guard spec) — this PR
makes the failure loud and diagnosable instead of invisible.

Receipts: 229 discovery-sweep tests + 1,549 workflows+ops tests pass;
pinned black/ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)