### PR TITLE
chore(health): plan groundwork — characterization pins, TODO triage, spec-status fixes

### DIFF
--- a/docs/specs/elicitation-form-surface/design.md
+++ b/docs/specs/elicitation-form-surface/design.md
@@ -1,5 +1,7 @@
 # Elicitation Form Surface — Design (v1)
 
+**Status:** v1 shipped (verified 2026-07-14); v2+ status tracked in [requirements.md](requirements.md)
+
 Design for the [requirements](requirements.md), post-Phase 0. Surface
 decision is [decisions.md](decisions.md) **D4**: AskUserQuestion-first,
 elicitation rejected, widget deferred. v1 = a declarative-form artifact

--- a/docs/specs/windows-exit139-segfault/requirements.md
+++ b/docs/specs/windows-exit139-segfault/requirements.md
@@ -1,0 +1,12 @@
+# windows-exit139-segfault — requirements stub
+
+**Status:** open — fixable hypothesis confirmed (2026-07-06); fix plan drafted, not yet landed
+
+This spec's substance lives in [README.md](README.md) (class
+signature, capture log, hypothesis, and fix plan — split from
+[ci-runner-hang](../archive/ci-runner-hang/) per its 5th-capture
+tripwire). This stub exists so the SessionStart spec-orientation
+parser — which reads only `tasks.md` / `design.md` /
+`requirements.md`, in that priority order — surfaces the spec's
+status instead of skipping the directory entirely. Keep the status
+line above in sync with README.md's.

--- a/src/attune/orchestration/_strategies/__init__.py
+++ b/src/attune/orchestration/_strategies/__init__.py
@@ -16,7 +16,7 @@ This package provides modular organization of execution strategies:
 - base: ExecutionStrategy ABC
 - core_strategies: Sequential, Parallel, Debate, Teaching, Refinement, Adaptive
 - conditional_strategies: Conditional, MultiConditional, Nested, NestedSequential
-- advanced: ToolEnhanced, PromptCached, etc. (TODO)
+- advanced: ToolEnhanced, PromptCached, etc.
 
 Copyright 2025 Smart-AI-Memory
 Licensed under the Apache License, Version 2.0

--- a/tests/unit/ops/test_data_characterization.py
+++ b/tests/unit/ops/test_data_characterization.py
@@ -1,0 +1,580 @@
+"""Characterization tests for the two D-grade functions in ``ops/data.py``.
+
+Pins the CURRENT behavior of :func:`attune.ops.data.read_telemetry_summary`
+(radon D22, ~line 825) and :func:`attune.ops.data.spend_alarm` (radon D23,
+~line 1221) so a later decomposition refactor has a behavior-preservation
+receipt. These tests document what the code DOES today, quirks included —
+they are not aspirational, and several of them exist specifically to pin a
+surprising-but-intentional (or surprising-and-accidental) branch so a
+refactor can't silently change it.
+
+Some branch families are already covered by ``test_telemetry_summary.py``
+(the ts/timestamp field-name regression) and ``test_spend_alarm.py`` (the
+z-score / flat-multiplier / ceiling / source-precedence verdict shapes).
+This file does not try to avoid all overlap with those — it is meant to
+stand alone as a single characterization suite for the two functions —
+but it focuses new coverage on branches those files don't already pin:
+missing/unreadable files, malformed JSON, field-fallback edge cases
+(``None`` vs missing, empty-string falsy fallback, last-line-wins
+ordering), the workflow-registry canonical filter (success/failure/cap),
+and the spend-alarm threshold *boundaries*, custom overrides, and the
+``min_baseline_days`` guard against a ``statistics.stdev`` crash on a
+single-point baseline.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import date
+
+import pytest
+
+from attune.ops import data
+from attune.ops.config import Config
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_jsonl(path, lines: list[str]) -> None:
+    """Write raw lines (already-serialized or intentionally malformed)."""
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _write_events(path, events: list[dict]) -> None:
+    path.write_text("\n".join(json.dumps(e) for e in events) + "\n", encoding="utf-8")
+
+
+def _config(tmp_path) -> Config:
+    """Build an ops Config rooted in ``tmp_path`` (mirrors test_telemetry_summary.py)."""
+    home = tmp_path / "attune_home"
+    (home / "telemetry").mkdir(parents=True)
+    return Config(
+        project_root=tmp_path,
+        attune_home=home,
+        allow_run=False,
+        specs_roots=(),
+    )
+
+
+# Frozen "today" for read_telemetry_summary fixtures (matches
+# test_telemetry_summary.py's convention so events dated 2026-05-14 stay
+# inside the default 7-day recent-days window).
+_TELEMETRY_TODAY = date(2026, 5, 14)
+
+# Frozen "today" for spend_alarm fixtures (matches test_spend_alarm.py's
+# convention).
+_SPEND_TODAY = date(2026, 6, 20)
+
+
+# ===========================================================================
+# read_telemetry_summary
+# ===========================================================================
+
+
+def test_read_telemetry_summary_happy_path_full_shape(tmp_path):
+    """Main happy path: multiple workflows, multiple days, savings — pins
+    the exact TelemetrySummary shape (rounding, sort order, last_event_at)."""
+    cfg = _config(tmp_path)
+    import attune.ops.data as _data_mod
+    from attune.ops.data import WorkflowEntry
+
+    canonical = [
+        WorkflowEntry(name="code-review", description="", stages=1, tier_map={}),
+        WorkflowEntry(name="security-audit", description="", stages=1, tier_map={}),
+    ]
+
+    def _fake_list_workflows() -> list[WorkflowEntry]:
+        return canonical
+
+    _data_mod.list_workflows = _fake_list_workflows  # type: ignore[assignment]
+    try:
+        _write_events(
+            cfg.telemetry_path,
+            [
+                {
+                    "workflow": "code-review",
+                    "ts": "2026-05-14T09:00:00+00:00",
+                    "total_cost": 1.5,
+                    "savings": 0.5,
+                },
+                {
+                    "workflow": "code-review",
+                    "ts": "2026-05-14T10:00:00+00:00",
+                    "total_cost": 0.5,
+                },
+                {
+                    "workflow": "security-audit",
+                    "ts": "2026-05-13T08:00:00+00:00",
+                    "total_cost": 3.0,
+                    "savings": 1.0,
+                },
+            ],
+        )
+
+        summary = data.read_telemetry_summary(cfg, today=_TELEMETRY_TODAY)
+    finally:
+        del _data_mod.list_workflows
+
+    assert summary == data.TelemetrySummary(
+        total_requests=3,
+        total_cost=5.0,
+        total_savings=1.5,
+        by_workflow=[("security-audit", 1, 3.0), ("code-review", 2, 2.0)],
+        by_day=[("2026-05-13", 1, 3.0), ("2026-05-14", 2, 2.0)],
+        last_event_at="2026-05-13T08:00:00+00:00",
+    )
+
+
+def test_read_telemetry_summary_missing_file_returns_zeroed_summary(tmp_path):
+    """No ``usage.jsonl`` at all -> the early-return zeroed summary, not an
+    exception (the panel must render on a fresh install)."""
+    cfg = _config(tmp_path)
+    summary = data.read_telemetry_summary(cfg, today=_TELEMETRY_TODAY)
+    assert summary == data.TelemetrySummary(0, 0.0, 0.0, [], [], None)
+
+
+def test_read_telemetry_summary_unreadable_file_returns_zeroed_summary(tmp_path):
+    """A path that exists but can't be opened as a file (here: it's a
+    directory) hits the ``except OSError`` branch, not an unhandled crash."""
+    cfg = _config(tmp_path)
+    cfg.telemetry_path.mkdir()  # usage.jsonl is a directory, not a file
+    summary = data.read_telemetry_summary(cfg, today=_TELEMETRY_TODAY)
+    assert summary == data.TelemetrySummary(0, 0.0, 0.0, [], [], None)
+
+
+def test_read_telemetry_summary_blank_and_malformed_lines_are_skipped(tmp_path):
+    """Blank lines and lines that don't parse as JSON are silently
+    dropped — they don't count toward ``total_requests`` at all."""
+    cfg = _config(tmp_path)
+    _write_jsonl(
+        cfg.telemetry_path,
+        [
+            json.dumps({"ts": "2026-05-14T09:00:00+00:00", "workflow": "a", "total_cost": 0.01}),
+            "",  # blank line
+            "not valid json {{{",  # malformed
+            json.dumps({"ts": "2026-05-14T10:00:00+00:00", "workflow": "a", "total_cost": 0.02}),
+        ],
+    )
+    summary = data.read_telemetry_summary(cfg, today=_TELEMETRY_TODAY)
+    assert summary.total_requests == 2
+    assert summary.total_cost == pytest.approx(0.03)
+    assert summary.by_day == [("2026-05-14", 2, 0.03)]
+
+
+def test_read_telemetry_summary_cost_field_fallback_chain(tmp_path):
+    """``total_cost`` wins; falls back to ``cost``; falls back to 0.0 when
+    neither is present. Quirk: an EXPLICIT ``total_cost: null`` does NOT
+    fall through to ``cost`` — ``dict.get(key, default)`` only applies the
+    default when the key is absent, not when its value is ``None``, so
+    ``None or 0.0`` short-circuits to 0.0 even though ``cost`` has a value."""
+    cfg = _config(tmp_path)
+    _write_events(
+        cfg.telemetry_path,
+        [
+            {"ts": "2026-05-14T09:00:00+00:00", "workflow": "a", "total_cost": 1.0},
+            {"ts": "2026-05-14T09:01:00+00:00", "workflow": "a", "cost": 2.0},
+            {"ts": "2026-05-14T09:02:00+00:00", "workflow": "a"},
+            {
+                "ts": "2026-05-14T09:03:00+00:00",
+                "workflow": "a",
+                "total_cost": None,
+                "cost": 5.0,
+            },
+        ],
+    )
+    summary = data.read_telemetry_summary(cfg, today=_TELEMETRY_TODAY)
+    assert summary.total_requests == 4
+    # 1.0 (total_cost) + 2.0 (cost fallback) + 0.0 (neither) + 0.0 (null
+    # total_cost does NOT fall back to cost=5.0) == 3.0, not 8.0.
+    assert summary.total_cost == pytest.approx(3.0)
+
+
+def test_read_telemetry_summary_workflow_field_fallback_chain(tmp_path):
+    """``workflow`` wins; falls back to ``event_type``; falls back to
+    ``"unknown"``. Quirk: an EMPTY-STRING ``workflow`` is falsy under the
+    ``or`` chain, so it also falls through to ``event_type`` rather than
+    being kept as the literal empty string."""
+    cfg = _config(tmp_path)
+    import attune.ops.data as _data_mod
+
+    # Force the "show everything" fallback by making the registry lookup
+    # raise, so this test isolates the workflow-name resolution logic from
+    # the canonical-filter logic (covered separately below).
+    def _raise():
+        raise RuntimeError("registry unavailable")
+
+    _data_mod.list_workflows = _raise  # type: ignore[assignment]
+    try:
+        _write_events(
+            cfg.telemetry_path,
+            [
+                {
+                    "ts": "2026-05-14T09:00:00+00:00",
+                    "workflow": "code-review",
+                    "total_cost": 1.0,
+                },
+                {
+                    "ts": "2026-05-14T09:01:00+00:00",
+                    "event_type": "audit_run",
+                    "total_cost": 2.0,
+                },
+                {"ts": "2026-05-14T09:02:00+00:00", "total_cost": 3.0},
+                {
+                    "ts": "2026-05-14T09:03:00+00:00",
+                    "workflow": "",
+                    "event_type": "fallback-name",
+                    "total_cost": 4.0,
+                },
+            ],
+        )
+        summary = data.read_telemetry_summary(cfg, today=_TELEMETRY_TODAY)
+    finally:
+        del _data_mod.list_workflows
+
+    by_cost = {row[0]: row[2] for row in summary.by_workflow}
+    assert by_cost == {
+        "code-review": 1.0,
+        "audit_run": 2.0,
+        "unknown": 3.0,
+        "fallback-name": 4.0,
+    }
+
+
+def test_read_telemetry_summary_ts_missing_entirely_still_counts_in_totals(tmp_path):
+    """An event with neither ``ts`` nor ``timestamp`` still counts toward
+    ``total_requests``/``total_cost`` but contributes nothing to ``by_day``
+    and does not move ``last_event_at`` (the empty-string ts is falsy)."""
+    cfg = _config(tmp_path)
+    _write_events(
+        cfg.telemetry_path,
+        [
+            {"ts": "2026-05-14T09:00:00+00:00", "workflow": "a", "total_cost": 0.01},
+            {"timestamp": "2026-05-14T10:00:00+00:00", "workflow": "a", "total_cost": 0.02},
+            {"workflow": "a", "total_cost": 0.03},  # neither field
+        ],
+    )
+    summary = data.read_telemetry_summary(cfg, today=_TELEMETRY_TODAY)
+    assert summary.total_requests == 3
+    assert summary.total_cost == pytest.approx(0.06)
+    assert summary.by_day == [("2026-05-14", 2, 0.03)]
+    # last_event_at is "frozen" at the last event that HAD a truthy ts —
+    # the trailing no-ts event does not reset it to None.
+    assert summary.last_event_at == "2026-05-14T10:00:00+00:00"
+
+
+def test_read_telemetry_summary_last_event_at_is_last_line_not_max_timestamp(tmp_path):
+    """QUIRK: ``last_event_at`` tracks file/iteration order, not
+    chronological order. An event with an EARLIER timestamp that appears
+    LATER in the file wins over an event with a later timestamp that
+    appears earlier."""
+    cfg = _config(tmp_path)
+    _write_events(
+        cfg.telemetry_path,
+        [
+            {"ts": "2026-05-14T09:00:00+00:00", "workflow": "a", "total_cost": 1.0},
+            {"ts": "2026-05-10T09:00:00+00:00", "workflow": "a", "total_cost": 1.0},
+        ],
+    )
+    summary = data.read_telemetry_summary(cfg, today=_TELEMETRY_TODAY)
+    assert summary.last_event_at == "2026-05-10T09:00:00+00:00"
+
+
+def test_read_telemetry_summary_by_day_window_excludes_old_days_but_totals_include_them(
+    tmp_path,
+):
+    """``recent_days`` (default 7) trims ``by_day`` to a rolling window, but
+    ``total_requests``/``total_cost`` are NOT windowed — they're an
+    all-time sum over the whole file."""
+    cfg = _config(tmp_path)
+    _write_events(
+        cfg.telemetry_path,
+        [
+            # Outside the 7-day window relative to 2026-05-14 (cutoff is
+            # 2026-05-07; this is 13 days before "today").
+            {"ts": "2026-05-01T09:00:00+00:00", "workflow": "a", "total_cost": 5.0},
+            {"ts": "2026-05-14T09:00:00+00:00", "workflow": "a", "total_cost": 2.0},
+        ],
+    )
+    summary = data.read_telemetry_summary(cfg, today=_TELEMETRY_TODAY)
+    assert summary.total_requests == 2
+    assert summary.total_cost == pytest.approx(7.0)
+    assert summary.by_day == [("2026-05-14", 1, 2.0)]
+
+
+def test_read_telemetry_summary_canonical_filter_excludes_unregistered_workflows(tmp_path):
+    """When the workflow registry resolves, ``by_workflow`` only surfaces
+    canonical (currently-registered) workflow names — a stale test-fixture
+    or removed-workflow name is dropped from the rollup, though it still
+    counts toward the file-wide totals."""
+    cfg = _config(tmp_path)
+    import attune.ops.data as _data_mod
+    from attune.ops.data import WorkflowEntry
+
+    def _fake_list_workflows():
+        return [WorkflowEntry(name="code-review", description="", stages=1, tier_map={})]
+
+    _data_mod.list_workflows = _fake_list_workflows  # type: ignore[assignment]
+    try:
+        _write_events(
+            cfg.telemetry_path,
+            [
+                {
+                    "ts": "2026-05-14T09:00:00+00:00",
+                    "workflow": "code-review",
+                    "total_cost": 1.0,
+                },
+                {
+                    "ts": "2026-05-14T09:01:00+00:00",
+                    "workflow": "old-stub",
+                    "total_cost": 2.0,
+                },
+            ],
+        )
+        summary = data.read_telemetry_summary(cfg, today=_TELEMETRY_TODAY)
+    finally:
+        del _data_mod.list_workflows
+
+    assert summary.total_requests == 2
+    assert summary.total_cost == pytest.approx(3.0)  # unfiltered total
+    assert summary.by_workflow == [("code-review", 1, 1.0)]  # old-stub dropped
+
+
+def test_read_telemetry_summary_registry_failure_falls_back_to_show_everything(tmp_path):
+    """INTENTIONAL fallback: if introspecting the workflow registry raises,
+    the canonical filter is disabled entirely (``canonical_names = None``)
+    rather than hiding all data behind a broken registry call."""
+    cfg = _config(tmp_path)
+    import attune.ops.data as _data_mod
+
+    def _raise():
+        raise RuntimeError("registry unavailable")
+
+    _data_mod.list_workflows = _raise  # type: ignore[assignment]
+    try:
+        _write_events(
+            cfg.telemetry_path,
+            [
+                {
+                    "ts": "2026-05-14T09:00:00+00:00",
+                    "workflow": "not-a-real-workflow",
+                    "total_cost": 1.0,
+                }
+            ],
+        )
+        summary = data.read_telemetry_summary(cfg, today=_TELEMETRY_TODAY)
+    finally:
+        del _data_mod.list_workflows
+
+    assert summary.by_workflow == [("not-a-real-workflow", 1, 1.0)]
+
+
+def test_read_telemetry_summary_by_workflow_caps_at_top_20(tmp_path):
+    """``by_workflow`` is capped at the top 20 by cost (``heapq.nlargest``),
+    dropping the lowest spenders when more than 20 distinct workflows have
+    events, and returns them sorted descending by cost."""
+    cfg = _config(tmp_path)
+    import attune.ops.data as _data_mod
+
+    def _raise():
+        raise RuntimeError("registry unavailable")  # show-everything fallback
+
+    _data_mod.list_workflows = _raise  # type: ignore[assignment]
+    try:
+        events = [
+            {
+                "ts": "2026-05-14T09:00:00+00:00",
+                "workflow": f"w{i:02d}",
+                "total_cost": float(i),
+            }
+            for i in range(1, 23)  # w01..w22, costs 1.0..22.0
+        ]
+        _write_events(cfg.telemetry_path, events)
+        summary = data.read_telemetry_summary(cfg, today=_TELEMETRY_TODAY)
+    finally:
+        del _data_mod.list_workflows
+
+    assert len(summary.by_workflow) == 20
+    names = {row[0] for row in summary.by_workflow}
+    assert "w01" not in names  # lowest two dropped
+    assert "w02" not in names
+    assert summary.by_workflow[0] == ("w22", 1, 22.0)  # sorted descending by cost
+
+
+# ===========================================================================
+# spend_alarm
+# ===========================================================================
+
+
+def test_spend_alarm_happy_path_full_shape_ok_day():
+    """Main happy path: a mild day within a varied baseline — pins the
+    exact SpendAlarm shape, including the verbatim ``detail`` text and the
+    default source's CI-blindness suffix."""
+    daily = {
+        "2026-06-17": 4.0,
+        "2026-06-18": 6.0,
+        "2026-06-19": 5.0,
+        "2026-06-20": 6.5,
+    }
+    alarm = data.spend_alarm(daily, today=_SPEND_TODAY)
+    assert alarm == data.SpendAlarm(
+        level="ok",
+        triggered_by=(),
+        today_cost=6.5,
+        baseline_mean=5.0,
+        baseline_days=3,
+        method="zscore",
+        z_score=1.5,
+        month_to_date=21.5,
+        monthly_ceiling=350.0,
+        ceiling_pct=6.1,
+        source="local",
+        detail="today $6.50 within normal range (local telemetry only — CI spend not counted)",
+    )
+
+
+def test_spend_alarm_zscore_boundary_exact_threshold_alarms():
+    """z_score == z_threshold (the ``>=`` boundary) alarms — the trigger is
+    inclusive of the threshold, not strictly-greater."""
+    daily = {
+        "2026-06-17": 4.0,
+        "2026-06-18": 6.0,
+        "2026-06-19": 5.0,
+        "2026-06-20": 8.0,  # (8.0 - 5.0) / 1.0 == 3.0 exactly
+    }
+    alarm = data.spend_alarm(daily, today=_SPEND_TODAY)
+    assert alarm.z_score == 3.0
+    assert alarm.level == "alarm"
+    assert "daily_anomaly" in alarm.triggered_by
+
+
+def test_spend_alarm_zscore_boundary_just_below_threshold_is_ok():
+    """z_score just under z_threshold does not alarm."""
+    daily = {
+        "2026-06-17": 4.0,
+        "2026-06-18": 6.0,
+        "2026-06-19": 5.0,
+        "2026-06-20": 7.99,  # z == 2.99
+    }
+    alarm = data.spend_alarm(daily, today=_SPEND_TODAY)
+    assert alarm.z_score == 2.99
+    assert alarm.level == "ok"
+    assert alarm.triggered_by == ()
+
+
+def test_spend_alarm_flat_multiplier_boundary_exact_ratio_is_ok():
+    """QUIRK: the flat-history multiplier check uses strict ``>``, so
+    today's spend exactly equal to ``baseline_mean * flat_multiplier``
+    does NOT alarm — it must exceed the ratio, not merely meet it."""
+    daily = {
+        "2026-06-17": 5.0,
+        "2026-06-18": 5.0,
+        "2026-06-19": 5.0,
+        "2026-06-20": 15.0,  # exactly 3x the flat $5/day baseline
+    }
+    alarm = data.spend_alarm(daily, today=_SPEND_TODAY)
+    assert alarm.method == "multiplier"
+    assert alarm.level == "ok"
+    assert alarm.triggered_by == ()
+
+
+def test_spend_alarm_ceiling_boundary_exact_fraction_alarms():
+    """month_to_date exactly at ``ceiling_fraction`` of the ceiling alarms
+    (the ``>=`` boundary, same inclusive convention as the z-score check)."""
+    daily = {"2026-06-20": 1.0}
+    alarm = data.spend_alarm(
+        daily,
+        today=_SPEND_TODAY,
+        monthly_ceiling=350.0,
+        ceiling_fraction=0.8,
+        month_to_date=280.0,  # exactly 350 * 0.8
+    )
+    assert alarm.ceiling_pct == 80.0
+    assert alarm.level == "alarm"
+    assert "ceiling" in alarm.triggered_by
+
+
+def test_spend_alarm_both_triggers_fire_together():
+    """Daily-anomaly and ceiling triggers are independent and can both fire
+    on the same verdict; ``detail`` joins both explanations with '; '."""
+    daily = {
+        "2026-06-17": 4.0,
+        "2026-06-18": 6.0,
+        "2026-06-19": 5.0,
+        "2026-06-20": 8.0,  # z == 3.0, alarms
+    }
+    alarm = data.spend_alarm(
+        daily,
+        today=_SPEND_TODAY,
+        monthly_ceiling=350.0,
+        month_to_date=300.0,  # 300/350 ~= 85.7% >= 80%, alarms
+    )
+    assert alarm.level == "alarm"
+    assert set(alarm.triggered_by) == {"daily_anomaly", "ceiling"}
+    assert "; " in alarm.detail
+
+
+def test_spend_alarm_zero_monthly_ceiling_disables_ceiling_check():
+    """A ``monthly_ceiling`` of 0 (or negative) makes ``ceiling_pct`` 0.0
+    and never trips the ceiling trigger, regardless of month-to-date."""
+    daily = {"2026-06-20": 1.0}
+    alarm = data.spend_alarm(daily, today=_SPEND_TODAY, monthly_ceiling=0.0, month_to_date=1000.0)
+    assert alarm.ceiling_pct == 0.0
+    assert "ceiling" not in alarm.triggered_by
+
+
+def test_spend_alarm_min_baseline_days_one_avoids_stdev_crash_on_single_point():
+    """QUIRK / defensive guard: ``statistics.stdev`` requires >= 2 data
+    points and raises on a single value. When ``min_baseline_days`` is
+    lowered to 1, a 1-day baseline enters the anomaly branch but the code
+    guards with ``stdev = ... if baseline_days >= 2 else 0.0`` so it takes
+    the flat-multiplier path instead of crashing."""
+    daily = {"2026-06-19": 5.0, "2026-06-20": 20.0}  # single baseline day
+    alarm = data.spend_alarm(daily, today=_SPEND_TODAY, min_baseline_days=1)
+    assert alarm.baseline_days == 1
+    assert alarm.method == "multiplier"
+    assert alarm.level == "alarm"  # 20.0 > 5.0 * 3.0 flat multiplier
+
+
+def test_spend_alarm_missing_today_key_defaults_to_zero_cost():
+    """``daily`` with no entry for today's date yields ``today_cost == 0.0``
+    rather than a KeyError, and a below-baseline "today" is not an
+    anomaly (z_score negative, no trigger)."""
+    daily = {"2026-06-17": 5.0, "2026-06-18": 6.0, "2026-06-19": 4.0}  # no 06-20
+    alarm = data.spend_alarm(daily, today=_SPEND_TODAY)
+    assert alarm.today_cost == 0.0
+    assert alarm.z_score == -5.0
+    assert alarm.level == "ok"
+    assert alarm.triggered_by == ()
+
+
+def test_spend_alarm_custom_z_threshold_overrides_default():
+    """A caller-supplied ``z_threshold`` changes the trigger point: the
+    same z_score of 1.5 is 'ok' at the default 3.0 bar but 'alarm' at a
+    custom 1.0 bar."""
+    daily = {
+        "2026-06-17": 4.0,
+        "2026-06-18": 6.0,
+        "2026-06-19": 5.0,
+        "2026-06-20": 6.5,  # z == 1.5
+    }
+    default_alarm = data.spend_alarm(daily, today=_SPEND_TODAY)
+    assert default_alarm.level == "ok"
+
+    strict_alarm = data.spend_alarm(daily, today=_SPEND_TODAY, z_threshold=1.0)
+    assert strict_alarm.z_score == 1.5
+    assert strict_alarm.level == "alarm"
+    assert "daily_anomaly" in strict_alarm.triggered_by
+
+
+def test_spend_alarm_rounding_of_verdict_fields():
+    """``today_cost``/``month_to_date`` round to 4 decimals and
+    ``ceiling_pct`` rounds to 1 decimal, regardless of input precision."""
+    daily = {"2026-06-20": 1.23456789}
+    alarm = data.spend_alarm(
+        daily, today=_SPEND_TODAY, monthly_ceiling=350.0, month_to_date=12.3456789
+    )
+    assert alarm.today_cost == 1.2346
+    assert alarm.month_to_date == 12.3457
+    assert alarm.ceiling_pct == round(12.3456789 / 350.0 * 100, 1)

--- a/tests/unit/ops/test_data_characterization.py
+++ b/tests/unit/ops/test_data_characterization.py
@@ -73,7 +73,7 @@ _SPEND_TODAY = date(2026, 6, 20)
 # ===========================================================================
 
 
-def test_read_telemetry_summary_happy_path_full_shape(tmp_path):
+def test_read_telemetry_summary_happy_path_full_shape(tmp_path, monkeypatch):
     """Main happy path: multiple workflows, multiple days, savings — pins
     the exact TelemetrySummary shape (rounding, sort order, last_event_at)."""
     cfg = _config(tmp_path)
@@ -88,34 +88,31 @@ def test_read_telemetry_summary_happy_path_full_shape(tmp_path):
     def _fake_list_workflows() -> list[WorkflowEntry]:
         return canonical
 
-    _data_mod.list_workflows = _fake_list_workflows  # type: ignore[assignment]
-    try:
-        _write_events(
-            cfg.telemetry_path,
-            [
-                {
-                    "workflow": "code-review",
-                    "ts": "2026-05-14T09:00:00+00:00",
-                    "total_cost": 1.5,
-                    "savings": 0.5,
-                },
-                {
-                    "workflow": "code-review",
-                    "ts": "2026-05-14T10:00:00+00:00",
-                    "total_cost": 0.5,
-                },
-                {
-                    "workflow": "security-audit",
-                    "ts": "2026-05-13T08:00:00+00:00",
-                    "total_cost": 3.0,
-                    "savings": 1.0,
-                },
-            ],
-        )
+    monkeypatch.setattr(_data_mod, "list_workflows", _fake_list_workflows)
+    _write_events(
+        cfg.telemetry_path,
+        [
+            {
+                "workflow": "code-review",
+                "ts": "2026-05-14T09:00:00+00:00",
+                "total_cost": 1.5,
+                "savings": 0.5,
+            },
+            {
+                "workflow": "code-review",
+                "ts": "2026-05-14T10:00:00+00:00",
+                "total_cost": 0.5,
+            },
+            {
+                "workflow": "security-audit",
+                "ts": "2026-05-13T08:00:00+00:00",
+                "total_cost": 3.0,
+                "savings": 1.0,
+            },
+        ],
+    )
 
-        summary = data.read_telemetry_summary(cfg, today=_TELEMETRY_TODAY)
-    finally:
-        del _data_mod.list_workflows
+    summary = data.read_telemetry_summary(cfg, today=_TELEMETRY_TODAY)
 
     assert summary == data.TelemetrySummary(
         total_requests=3,
@@ -191,7 +188,7 @@ def test_read_telemetry_summary_cost_field_fallback_chain(tmp_path):
     assert summary.total_cost == pytest.approx(3.0)
 
 
-def test_read_telemetry_summary_workflow_field_fallback_chain(tmp_path):
+def test_read_telemetry_summary_workflow_field_fallback_chain(tmp_path, monkeypatch):
     """``workflow`` wins; falls back to ``event_type``; falls back to
     ``"unknown"``. Quirk: an EMPTY-STRING ``workflow`` is falsy under the
     ``or`` chain, so it also falls through to ``event_type`` rather than
@@ -205,33 +202,30 @@ def test_read_telemetry_summary_workflow_field_fallback_chain(tmp_path):
     def _raise():
         raise RuntimeError("registry unavailable")
 
-    _data_mod.list_workflows = _raise  # type: ignore[assignment]
-    try:
-        _write_events(
-            cfg.telemetry_path,
-            [
-                {
-                    "ts": "2026-05-14T09:00:00+00:00",
-                    "workflow": "code-review",
-                    "total_cost": 1.0,
-                },
-                {
-                    "ts": "2026-05-14T09:01:00+00:00",
-                    "event_type": "audit_run",
-                    "total_cost": 2.0,
-                },
-                {"ts": "2026-05-14T09:02:00+00:00", "total_cost": 3.0},
-                {
-                    "ts": "2026-05-14T09:03:00+00:00",
-                    "workflow": "",
-                    "event_type": "fallback-name",
-                    "total_cost": 4.0,
-                },
-            ],
-        )
-        summary = data.read_telemetry_summary(cfg, today=_TELEMETRY_TODAY)
-    finally:
-        del _data_mod.list_workflows
+    monkeypatch.setattr(_data_mod, "list_workflows", _raise)
+    _write_events(
+        cfg.telemetry_path,
+        [
+            {
+                "ts": "2026-05-14T09:00:00+00:00",
+                "workflow": "code-review",
+                "total_cost": 1.0,
+            },
+            {
+                "ts": "2026-05-14T09:01:00+00:00",
+                "event_type": "audit_run",
+                "total_cost": 2.0,
+            },
+            {"ts": "2026-05-14T09:02:00+00:00", "total_cost": 3.0},
+            {
+                "ts": "2026-05-14T09:03:00+00:00",
+                "workflow": "",
+                "event_type": "fallback-name",
+                "total_cost": 4.0,
+            },
+        ],
+    )
+    summary = data.read_telemetry_summary(cfg, today=_TELEMETRY_TODAY)
 
     by_cost = {row[0]: row[2] for row in summary.by_workflow}
     assert by_cost == {
@@ -303,7 +297,9 @@ def test_read_telemetry_summary_by_day_window_excludes_old_days_but_totals_inclu
     assert summary.by_day == [("2026-05-14", 1, 2.0)]
 
 
-def test_read_telemetry_summary_canonical_filter_excludes_unregistered_workflows(tmp_path):
+def test_read_telemetry_summary_canonical_filter_excludes_unregistered_workflows(
+    tmp_path, monkeypatch
+):
     """When the workflow registry resolves, ``by_workflow`` only surfaces
     canonical (currently-registered) workflow names — a stale test-fixture
     or removed-workflow name is dropped from the rollup, though it still
@@ -315,33 +311,32 @@ def test_read_telemetry_summary_canonical_filter_excludes_unregistered_workflows
     def _fake_list_workflows():
         return [WorkflowEntry(name="code-review", description="", stages=1, tier_map={})]
 
-    _data_mod.list_workflows = _fake_list_workflows  # type: ignore[assignment]
-    try:
-        _write_events(
-            cfg.telemetry_path,
-            [
-                {
-                    "ts": "2026-05-14T09:00:00+00:00",
-                    "workflow": "code-review",
-                    "total_cost": 1.0,
-                },
-                {
-                    "ts": "2026-05-14T09:01:00+00:00",
-                    "workflow": "old-stub",
-                    "total_cost": 2.0,
-                },
-            ],
-        )
-        summary = data.read_telemetry_summary(cfg, today=_TELEMETRY_TODAY)
-    finally:
-        del _data_mod.list_workflows
+    monkeypatch.setattr(_data_mod, "list_workflows", _fake_list_workflows)
+    _write_events(
+        cfg.telemetry_path,
+        [
+            {
+                "ts": "2026-05-14T09:00:00+00:00",
+                "workflow": "code-review",
+                "total_cost": 1.0,
+            },
+            {
+                "ts": "2026-05-14T09:01:00+00:00",
+                "workflow": "old-stub",
+                "total_cost": 2.0,
+            },
+        ],
+    )
+    summary = data.read_telemetry_summary(cfg, today=_TELEMETRY_TODAY)
 
     assert summary.total_requests == 2
     assert summary.total_cost == pytest.approx(3.0)  # unfiltered total
     assert summary.by_workflow == [("code-review", 1, 1.0)]  # old-stub dropped
 
 
-def test_read_telemetry_summary_registry_failure_falls_back_to_show_everything(tmp_path):
+def test_read_telemetry_summary_registry_failure_falls_back_to_show_everything(
+    tmp_path, monkeypatch
+):
     """INTENTIONAL fallback: if introspecting the workflow registry raises,
     the canonical filter is disabled entirely (``canonical_names = None``)
     rather than hiding all data behind a broken registry call."""
@@ -351,26 +346,23 @@ def test_read_telemetry_summary_registry_failure_falls_back_to_show_everything(t
     def _raise():
         raise RuntimeError("registry unavailable")
 
-    _data_mod.list_workflows = _raise  # type: ignore[assignment]
-    try:
-        _write_events(
-            cfg.telemetry_path,
-            [
-                {
-                    "ts": "2026-05-14T09:00:00+00:00",
-                    "workflow": "not-a-real-workflow",
-                    "total_cost": 1.0,
-                }
-            ],
-        )
-        summary = data.read_telemetry_summary(cfg, today=_TELEMETRY_TODAY)
-    finally:
-        del _data_mod.list_workflows
+    monkeypatch.setattr(_data_mod, "list_workflows", _raise)
+    _write_events(
+        cfg.telemetry_path,
+        [
+            {
+                "ts": "2026-05-14T09:00:00+00:00",
+                "workflow": "not-a-real-workflow",
+                "total_cost": 1.0,
+            }
+        ],
+    )
+    summary = data.read_telemetry_summary(cfg, today=_TELEMETRY_TODAY)
 
     assert summary.by_workflow == [("not-a-real-workflow", 1, 1.0)]
 
 
-def test_read_telemetry_summary_by_workflow_caps_at_top_20(tmp_path):
+def test_read_telemetry_summary_by_workflow_caps_at_top_20(tmp_path, monkeypatch):
     """``by_workflow`` is capped at the top 20 by cost (``heapq.nlargest``),
     dropping the lowest spenders when more than 20 distinct workflows have
     events, and returns them sorted descending by cost."""
@@ -380,20 +372,17 @@ def test_read_telemetry_summary_by_workflow_caps_at_top_20(tmp_path):
     def _raise():
         raise RuntimeError("registry unavailable")  # show-everything fallback
 
-    _data_mod.list_workflows = _raise  # type: ignore[assignment]
-    try:
-        events = [
-            {
-                "ts": "2026-05-14T09:00:00+00:00",
-                "workflow": f"w{i:02d}",
-                "total_cost": float(i),
-            }
-            for i in range(1, 23)  # w01..w22, costs 1.0..22.0
-        ]
-        _write_events(cfg.telemetry_path, events)
-        summary = data.read_telemetry_summary(cfg, today=_TELEMETRY_TODAY)
-    finally:
-        del _data_mod.list_workflows
+    monkeypatch.setattr(_data_mod, "list_workflows", _raise)
+    events = [
+        {
+            "ts": "2026-05-14T09:00:00+00:00",
+            "workflow": f"w{i:02d}",
+            "total_cost": float(i),
+        }
+        for i in range(1, 23)  # w01..w22, costs 1.0..22.0
+    ]
+    _write_events(cfg.telemetry_path, events)
+    summary = data.read_telemetry_summary(cfg, today=_TELEMETRY_TODAY)
 
     assert len(summary.by_workflow) == 20
     names = {row[0] for row in summary.by_workflow}

--- a/tests/unit/telemetry/test_recommend_tier_characterization.py
+++ b/tests/unit/telemetry/test_recommend_tier_characterization.py
@@ -1,0 +1,363 @@
+"""Characterization tests for FeedbackLoop.recommend_tier (complexity D23).
+
+Pins the CURRENT behavior of ``recommend_tier`` in
+``src/attune/telemetry/feedback_loop.py`` (~line 337) so a later
+table-driven refactor can prove behavior preservation.
+
+Branches already pinned by ``tests/unit/telemetry/test_feedback_loop.py``
+(TestFeedbackLoop / TestFeedbackLoopBranches) are NOT duplicated here:
+
+- no feedback data at all, ``current_tier`` explicitly given
+  (``test_recommend_tier_no_data``)
+- insufficient samples, ``current_stats`` present but below
+  ``MIN_SAMPLES`` (``test_recommend_tier_insufficient_samples``)
+- low quality on "cheap" -> recommend "capable"
+  (``test_recommend_tier_upgrade_on_low_quality``)
+- acceptable quality on "cheap" -> maintain
+  (``test_recommend_tier_maintain_on_acceptable_quality``)
+- low quality on "premium" -> stays "premium"
+  (``test_recommend_tier_already_premium``, weak on confidence)
+- low quality on "capable" -> recommend "premium"
+  (``test_recommend_tier_capable_low_quality_upgrades_to_premium``)
+- ``current_tier=None`` inferred from history, at least reaching the
+  branch (``test_recommend_tier_no_current_tier_inferred_from_history``,
+  weak assertion)
+- ``ModelTier`` enum -> ``.value`` conversion for ``current_tier``
+  (``test_recommend_tier_model_tier_enum``, weak assertion)
+
+This file covers the remaining/under-asserted branches: the
+``current_tier=None`` empty-store path, the "current tier has zero
+stats" path, the history-inference fallback-to-"cheap" path (forced,
+since it is not reachable through the real store), all four
+"excellent quality" downgrade/keep combinations for premium and
+capable, the "excellent quality but tier is cheap" exemption, and the
+numeric boundaries the code compares against (``QUALITY_THRESHOLD``
+0.7, the 0.9 "excellent" cutoff, the 0.85 downgrade-target cutoff,
+``MIN_SAMPLES`` 10, and the confidence formula's 0.0-1.0 clamp).
+
+Stats are injected directly via a ``get_quality_stats`` replacement
+(and, where needed, ``get_feedback_history``) rather than seeded
+through ``record_feedback``, so exact floating-point boundary values
+(0.7, 0.85, 0.9) are hit precisely instead of depending on averaging
+arithmetic.
+
+Copyright 2025 Smart-AI-Memory
+Licensed under the Apache License, Version 2.0
+"""
+
+from datetime import datetime, timezone
+
+from attune.telemetry.feedback_loop import FeedbackEntry, FeedbackLoop, QualityStats
+
+
+def _stats(tier: str, avg: float, count: int = 15, trend: float = 0.0) -> QualityStats:
+    """Build a QualityStats with a precise, hardcoded avg_quality."""
+    return QualityStats(
+        workflow_name="wf",
+        stage_name="stage",
+        tier=tier,
+        avg_quality=avg,
+        min_quality=avg,
+        max_quality=avg,
+        sample_count=count,
+        recent_trend=trend,
+    )
+
+
+def _stats_provider(stats_map: dict):
+    """Return a get_quality_stats replacement keyed by the `tier` kwarg.
+
+    recommend_tier always calls ``self.get_quality_stats(workflow_name,
+    stage_name, tier=tier)`` with tier in {"cheap", "capable", "premium"},
+    so keying on that kwarg is sufficient to control stats_by_tier
+    deterministically.
+    """
+
+    def _get(workflow_name, stage_name, tier=None):
+        return stats_map.get(tier)
+
+    return _get
+
+
+class TestNoDataAndZeroStatsPaths:
+    """stats_by_tier empty, or current_tier has no entry in it at all."""
+
+    def test_no_feedback_data_and_current_tier_none(self):
+        """stats_by_tier empty + current_tier=None -> 'unknown'/'cheap'.
+
+        Distinct from the already-pinned ``test_recommend_tier_no_data``,
+        which passes an explicit current_tier="cheap".
+        """
+        loop = FeedbackLoop()
+        loop.get_quality_stats = _stats_provider({})
+
+        rec = loop.recommend_tier("wf", "stage", current_tier=None)
+
+        assert rec.current_tier == "unknown"
+        assert rec.recommended_tier == "cheap"
+        assert rec.confidence == 0.0
+        assert "No feedback data" in rec.reason
+        assert rec.stats == {}
+
+    def test_current_stats_none_reports_zero_samples(self):
+        """current_tier has no key in stats_by_tier at all (not just too
+        few samples) -> 'Insufficient data ... have 0'."""
+        loop = FeedbackLoop()
+        loop.get_quality_stats = _stats_provider({"cheap": _stats("cheap", 0.8)})
+
+        rec = loop.recommend_tier("wf", "stage", current_tier="premium")
+
+        assert rec.current_tier == "premium"
+        assert rec.recommended_tier == "premium"
+        assert rec.confidence == 0.0
+        assert "Insufficient data" in rec.reason
+        assert "have 0" in rec.reason
+
+
+class TestCurrentTierNoneInference:
+    """current_tier=None -> inferred from the most recent history entry."""
+
+    def test_inferred_from_history_when_available(self):
+        """History lookup returns an entry -> its tier becomes current_tier,
+        and the recommendation still runs end to end (strengthens the
+        existing weak assertion in test_feedback_loop.py)."""
+        loop = FeedbackLoop()
+        loop.get_quality_stats = _stats_provider({"capable": _stats("capable", 0.8)})
+        entry = FeedbackEntry(
+            feedback_id="fb1",
+            workflow_name="wf",
+            stage_name="stage",
+            tier="capable",
+            quality_score=0.8,
+            timestamp=datetime.now(timezone.utc),
+        )
+        loop.get_feedback_history = lambda workflow_name, stage_name, tier=None, limit=100: [
+            entry,
+        ]
+
+        rec = loop.recommend_tier("wf", "stage", current_tier=None)
+
+        assert rec.current_tier == "capable"
+        assert rec.recommended_tier == "capable"
+        assert "Acceptable quality" in rec.reason
+
+    def test_history_lookup_empty_defaults_to_cheap(self):
+        """current_tier=None and the unfiltered history probe returns
+        nothing (line ~379's else branch) -> defaults to "cheap".
+
+        Not reachable through the real store in normal operation: if
+        stats_by_tier is non-empty, at least one entry must be visible
+        to the unfiltered (tier=None) history query too. Forced here via
+        a get_feedback_history replacement to pin the documented
+        fallback, then flows into the "current tier has zero stats"
+        branch (mirrors test_current_stats_none_reports_zero_samples).
+        """
+        loop = FeedbackLoop()
+        loop.get_quality_stats = _stats_provider({"capable": _stats("capable", 0.8)})
+        loop.get_feedback_history = lambda workflow_name, stage_name, tier=None, limit=100: []
+
+        rec = loop.recommend_tier("wf", "stage", current_tier=None)
+
+        assert rec.current_tier == "cheap"
+        assert rec.recommended_tier == "cheap"
+        assert rec.confidence == 0.0
+        assert "Insufficient data" in rec.reason
+        assert "have 0" in rec.reason
+
+
+class TestSampleCountBoundaries:
+    """MIN_SAMPLES (10) threshold and the confidence formula's clamp."""
+
+    def test_insufficient_at_min_samples_minus_one(self):
+        """sample_count=9 (MIN_SAMPLES - 1) -> still insufficient."""
+        loop = FeedbackLoop()
+        loop.get_quality_stats = _stats_provider({"cheap": _stats("cheap", 0.8, count=9)})
+
+        rec = loop.recommend_tier("wf", "stage", current_tier="cheap")
+
+        assert rec.confidence == 0.0
+        assert "Insufficient data" in rec.reason
+        assert "have 9" in rec.reason
+
+    def test_sufficient_at_exact_min_samples(self):
+        """sample_count=10 (== MIN_SAMPLES) -> no longer insufficient;
+        confidence = min(10 / 20, 1.0) = 0.5."""
+        loop = FeedbackLoop()
+        loop.get_quality_stats = _stats_provider({"cheap": _stats("cheap", 0.8, count=10)})
+
+        rec = loop.recommend_tier("wf", "stage", current_tier="cheap")
+
+        assert "Insufficient data" not in rec.reason
+        assert rec.recommended_tier == "cheap"
+        assert rec.confidence == 0.5
+
+    def test_confidence_saturates_at_double_min_samples(self):
+        """sample_count=20 (== MIN_SAMPLES * 2) -> confidence hits 1.0."""
+        loop = FeedbackLoop()
+        loop.get_quality_stats = _stats_provider({"cheap": _stats("cheap", 0.8, count=20)})
+
+        rec = loop.recommend_tier("wf", "stage", current_tier="cheap")
+
+        assert rec.confidence == 1.0
+
+    def test_confidence_capped_above_double_min_samples(self):
+        """sample_count=50 -> confidence stays clamped at 1.0, not 2.5."""
+        loop = FeedbackLoop()
+        loop.get_quality_stats = _stats_provider({"cheap": _stats("cheap", 0.8, count=50)})
+
+        rec = loop.recommend_tier("wf", "stage", current_tier="cheap")
+
+        assert rec.confidence == 1.0
+
+    def test_low_quality_premium_confidence_forced_to_one(self):
+        """The 'already premium, low quality' branch overrides confidence
+        to 1.0 regardless of sample_count, distinct from the normal
+        formula (sample_count=15 would otherwise give confidence 0.75).
+        """
+        loop = FeedbackLoop()
+        loop.get_quality_stats = _stats_provider({"premium": _stats("premium", 0.3, count=15)})
+
+        rec = loop.recommend_tier("wf", "stage", current_tier="premium")
+
+        assert rec.confidence == 1.0
+        assert "Already using premium" in rec.reason
+
+
+class TestQualityThresholdBoundaries:
+    """The 0.7 (low-quality) and 0.9 (excellent-quality) cutoffs."""
+
+    def test_quality_exactly_at_threshold_is_not_low(self):
+        """avg_quality == QUALITY_THRESHOLD (0.7) exactly is NOT < 0.7,
+        so it falls into the acceptable/maintain branch, not upgrade."""
+        loop = FeedbackLoop()
+        loop.get_quality_stats = _stats_provider({"cheap": _stats("cheap", 0.7)})
+
+        rec = loop.recommend_tier("wf", "stage", current_tier="cheap")
+
+        assert rec.recommended_tier == "cheap"
+        assert "Acceptable quality" in rec.reason
+
+    def test_quality_just_below_threshold_triggers_upgrade(self):
+        """avg_quality just under 0.7 triggers the low-quality branch."""
+        loop = FeedbackLoop()
+        loop.get_quality_stats = _stats_provider(
+            {"cheap": _stats("cheap", 0.6999999999999998)},
+        )
+
+        rec = loop.recommend_tier("wf", "stage", current_tier="cheap")
+
+        assert rec.recommended_tier == "capable"
+        assert "Low quality" in rec.reason
+
+    def test_quality_exactly_at_0_9_is_not_excellent(self):
+        """avg_quality == 0.9 exactly is NOT > 0.9, so a non-cheap tier
+        stays on the acceptable/maintain branch rather than the
+        excellent-quality downgrade/keep branch. Uses "capable" (not
+        "cheap") so the cheap-tier exemption doesn't also mask this."""
+        loop = FeedbackLoop()
+        loop.get_quality_stats = _stats_provider({"capable": _stats("capable", 0.9)})
+
+        rec = loop.recommend_tier("wf", "stage", current_tier="capable")
+
+        assert rec.recommended_tier == "capable"
+        assert "Acceptable quality" in rec.reason
+        assert "Excellent" not in rec.reason
+
+    def test_excellent_quality_on_cheap_tier_is_still_acceptable(self):
+        """avg_quality > 0.9 on the "cheap" tier is exempted from the
+        excellent-quality branch by `current_tier != "cheap"` and falls
+        through to the plain acceptable/maintain branch instead."""
+        loop = FeedbackLoop()
+        loop.get_quality_stats = _stats_provider({"cheap": _stats("cheap", 0.99)})
+
+        rec = loop.recommend_tier("wf", "stage", current_tier="cheap")
+
+        assert rec.recommended_tier == "cheap"
+        assert "Acceptable quality" in rec.reason
+        assert "Excellent" not in rec.reason
+
+
+class TestExcellentQualityCapableTier:
+    """avg_quality > 0.9 with current_tier="capable" (downgrade target: cheap)."""
+
+    def test_downgrades_to_cheap_when_cheap_stats_are_good(self):
+        loop = FeedbackLoop()
+        loop.get_quality_stats = _stats_provider(
+            {
+                "capable": _stats("capable", 0.95),
+                "cheap": _stats("cheap", 0.9),
+            },
+        )
+
+        rec = loop.recommend_tier("wf", "stage", current_tier="capable")
+
+        assert rec.recommended_tier == "cheap"
+        assert "downgrade to save cost" in rec.reason
+
+    def test_keeps_capable_when_cheap_stats_missing(self):
+        loop = FeedbackLoop()
+        loop.get_quality_stats = _stats_provider({"capable": _stats("capable", 0.95)})
+
+        rec = loop.recommend_tier("wf", "stage", current_tier="capable")
+
+        assert rec.recommended_tier == "capable"
+        assert "keep capable tier" in rec.reason
+
+    def test_keeps_capable_when_cheap_quality_at_0_85_boundary(self):
+        """cheap avg_quality == 0.85 exactly is NOT > 0.85, so no
+        downgrade -- keeps capable."""
+        loop = FeedbackLoop()
+        loop.get_quality_stats = _stats_provider(
+            {
+                "capable": _stats("capable", 0.95),
+                "cheap": _stats("cheap", 0.85),
+            },
+        )
+
+        rec = loop.recommend_tier("wf", "stage", current_tier="capable")
+
+        assert rec.recommended_tier == "capable"
+        assert "keep capable tier" in rec.reason
+
+
+class TestExcellentQualityPremiumTier:
+    """avg_quality > 0.9 with current_tier="premium" (downgrade target: capable)."""
+
+    def test_downgrades_to_capable_when_capable_stats_are_good(self):
+        loop = FeedbackLoop()
+        loop.get_quality_stats = _stats_provider(
+            {
+                "premium": _stats("premium", 0.95),
+                "capable": _stats("capable", 0.9),
+            },
+        )
+
+        rec = loop.recommend_tier("wf", "stage", current_tier="premium")
+
+        assert rec.recommended_tier == "capable"
+        assert "downgrade to save cost" in rec.reason
+
+    def test_keeps_premium_when_capable_stats_missing(self):
+        loop = FeedbackLoop()
+        loop.get_quality_stats = _stats_provider({"premium": _stats("premium", 0.95)})
+
+        rec = loop.recommend_tier("wf", "stage", current_tier="premium")
+
+        assert rec.recommended_tier == "premium"
+        assert "keep premium for consistency" in rec.reason
+
+    def test_keeps_premium_when_capable_quality_at_0_85_boundary(self):
+        """capable avg_quality == 0.85 exactly is NOT > 0.85, so no
+        downgrade -- keeps premium."""
+        loop = FeedbackLoop()
+        loop.get_quality_stats = _stats_provider(
+            {
+                "premium": _stats("premium", 0.95),
+                "capable": _stats("capable", 0.85),
+            },
+        )
+
+        rec = loop.recommend_tier("wf", "stage", current_tier="premium")
+
+        assert rec.recommended_tier == "premium"
+        assert "keep premium for consistency" in rec.reason


### PR DESCRIPTION
## Health-plan items 6+7 complete, items 2+5 pinned

Second PR of the plan execution (after #1374). Subordinate-model
inventories ran in parallel; every claim was centrally re-verified
before applying.

### Item 6 — TODO triage (done, and the metric was wrong)
Full classification of all 28 markers: **27 are false positives** —
scanner regexes, LLM prompt text, generated-scaffold placeholders,
severity-table keys. One genuine stale marker deleted ('(TODO)' on
the advanced strategies docstring line — ToolEnhanced/PromptCached
ship and are registered). The health report's '28 TODOs — watch'
signal was itself noise; correction going to #1373.

### Item 7 — spec-status (mostly already done; 2 real fixes)
20/22 active specs already had correct parser-readable status lines
(the 07-13/14 truth-sweep PRs). Fixed the two that didn't:
- elicitation-form-surface: parser reads design.md, which had no
  status line — added one pointing at requirements.md for v2+.
- windows-exit139-segfault: README-only dir was invisible to the
  parser — thin requirements.md stub carries the status.

**Receipt:** `discover_specs` returns full one-line statuses for
both. **New finding:** the '(unknown)' orientation noise is
`spec_audit.py`'s *staleness* column — no spec declares
`## Deliverables`, so the drift classifier is toothless repo-wide.
Left as a flagged follow-up, not papered over.
**Patrick's call needed:** `product-direction-review` has no
requirements/design/tasks.md by genre (assessment log, not a build
spec) — parser-invisible by design, or want a stub?

### Items 2+5 prep — behavior pinned before refactoring
- 23 characterization tests for `ops/data.py`'s two D-grade
  functions (branch families, boundaries, quirks documented).
- 19 characterization tests for `FeedbackLoop.recommend_tier`
  (threshold boundaries, confidence clamp; one provably-dead branch
  documented for removal).

Landing these first means the upcoming decomposition PRs prove
behavior preservation against main, not against themselves.

763 affected-suite tests pass (1 pre-existing environmental Ollama
failure per today's lesson).

🤖 Generated with [Claude Code](https://claude.com/claude-code)