### PR TITLE
refactor(health): decompose the pinned D-grade functions (plan items 2+5)

### DIFF
--- a/src/attune/ops/data.py
+++ b/src/attune/ops/data.py
@@ -822,6 +822,38 @@ def sparkline_points(values: list[float], *, width: int = 240, height: int = 40)
     return " ".join(points)
 
 
+def _parse_usage_event(line: str) -> tuple[float, float, str, str] | None:
+    """Parse one ``usage.jsonl`` line into ``(cost, savings, workflow, ts)``.
+
+    Returns ``None`` for blank or non-JSON lines (silently skipped —
+    they must not count toward totals). Field fallbacks, all pinned by
+    ``test_data_characterization.py``:
+
+    - cost: ``total_cost`` → ``cost`` → 0.0 (an explicit ``null``
+      total_cost does NOT fall through to ``cost`` — dict.get only
+      defaults on a MISSING key).
+    - workflow: ``workflow`` → ``event_type`` → ``"unknown"`` (an
+      empty-string workflow is falsy and falls through).
+    - ts: ``usage.jsonl`` events use the ``ts`` key (v1.0 schema in
+      UsageTracker._format_entry); ``timestamp`` is the legacy
+      fallback for rotated archives that predate the rename. Without
+      it every event silently misses the by_day bucketing and Home's
+      KPI tiles read zero.
+    """
+    line = line.strip()
+    if not line:
+        return None
+    try:
+        event: dict[str, Any] = json.loads(line)
+    except json.JSONDecodeError:
+        return None
+    cost = float(event.get("total_cost", event.get("cost", 0.0)) or 0.0)
+    savings = float(event.get("savings", 0.0) or 0.0)
+    workflow = str(event.get("workflow") or event.get("event_type") or "unknown")
+    ts = str(event.get("ts") or event.get("timestamp") or "")
+    return cost, savings, workflow, ts
+
+
 def read_telemetry_summary(
     config: Config,
     *,
@@ -854,23 +886,10 @@ def read_telemetry_summary(
     try:
         with path.open("r", encoding="utf-8") as f:
             for line in f:
-                line = line.strip()
-                if not line:
+                parsed = _parse_usage_event(line)
+                if parsed is None:
                     continue
-                try:
-                    event: dict[str, Any] = json.loads(line)
-                except json.JSONDecodeError:
-                    continue
-
-                cost = float(event.get("total_cost", event.get("cost", 0.0)) or 0.0)
-                savings = float(event.get("savings", 0.0) or 0.0)
-                workflow = str(event.get("workflow") or event.get("event_type") or "unknown")
-                # ``usage.jsonl`` events use the ``ts`` key (v1.0 schema in
-                # UsageTracker._format_entry); ``timestamp`` is kept as a
-                # legacy fallback for any rotated archives that predate the
-                # rename. Without this fallback every event silently misses
-                # the by_day bucketing and Home's KPI tiles read zero.
-                ts = str(event.get("ts") or event.get("timestamp") or "")
+                cost, savings, workflow, ts = parsed
 
                 total_requests += 1
                 total_cost += cost
@@ -1218,6 +1237,55 @@ class SpendAlarm:
     detail: str  # one-line human explanation
 
 
+def _daily_anomaly_check(
+    baseline: list[float],
+    baseline_mean: float,
+    today_cost: float,
+    *,
+    z_threshold: float,
+    flat_multiplier: float,
+) -> tuple[str, float | None, str | None]:
+    """The daily-anomaly trigger: ``(method, z_score, detail)``.
+
+    ``detail`` is non-None exactly when the trigger fires. With
+    variance in the baseline the method is ``"zscore"`` (flag at
+    ``z >= z_threshold``, inclusive); a flat baseline (stdev == 0)
+    falls back to ``"multiplier"`` (flag on STRICTLY exceeding
+    ``baseline_mean * flat_multiplier`` — the spec's explicit rule for
+    the variance-free $1,200-night case). ``baseline_mean`` arrives
+    pre-rounded (4dp) and is used as-is so the z-score matches the
+    reported baseline, while stdev is computed from the raw values —
+    both pinned by ``test_data_characterization.py``.
+
+    Callers gate on ``min_baseline_days`` before calling; the
+    ``len < 2`` guard here only prevents ``statistics.stdev`` from
+    raising when that gate is configured down to 1.
+    """
+    stdev = statistics.stdev(baseline) if len(baseline) >= 2 else 0.0
+    if stdev > 0:
+        z_score = round((today_cost - baseline_mean) / stdev, 2)
+        if z_score >= z_threshold:
+            return (
+                "zscore",
+                z_score,
+                f"today ${today_cost:.2f} is {z_score:.1f}σ above the "
+                f"${baseline_mean:.2f}/day baseline",
+            )
+        return "zscore", z_score, None
+
+    # Flat history: baseline_mean > 0 here (baseline keeps non-zero
+    # days only), so the ratio is finite; the inf arm is pure defense.
+    if today_cost > baseline_mean * flat_multiplier:
+        ratio = today_cost / baseline_mean if baseline_mean else float("inf")
+        return (
+            "multiplier",
+            None,
+            f"today ${today_cost:.2f} is {ratio:.1f}x the flat "
+            f"${baseline_mean:.2f}/day baseline (no variance)",
+        )
+    return "multiplier", None, None
+
+
 def spend_alarm(
     daily: dict[str, float],
     *,
@@ -1302,27 +1370,16 @@ def spend_alarm(
     detail_parts: list[str] = []
 
     if baseline_days >= min_baseline_days:
-        stdev = statistics.stdev(baseline) if baseline_days >= 2 else 0.0
-        if stdev > 0:
-            method = "zscore"
-            z_score = round((today_cost - baseline_mean) / stdev, 2)
-            if z_score >= z_threshold:
-                triggers.append("daily_anomaly")
-                detail_parts.append(
-                    f"today ${today_cost:.2f} is {z_score:.1f}σ above the "
-                    f"${baseline_mean:.2f}/day baseline"
-                )
-        else:
-            # Flat history: no variance -> multiplier fallback (the
-            # explicit spec rule). baseline_mean > 0 here (non-zero days).
-            method = "multiplier"
-            if today_cost > baseline_mean * flat_multiplier:
-                triggers.append("daily_anomaly")
-                ratio = today_cost / baseline_mean if baseline_mean else float("inf")
-                detail_parts.append(
-                    f"today ${today_cost:.2f} is {ratio:.1f}x the flat "
-                    f"${baseline_mean:.2f}/day baseline (no variance)"
-                )
+        method, z_score, anomaly_detail = _daily_anomaly_check(
+            baseline,
+            baseline_mean,
+            today_cost,
+            z_threshold=z_threshold,
+            flat_multiplier=flat_multiplier,
+        )
+        if anomaly_detail is not None:
+            triggers.append("daily_anomaly")
+            detail_parts.append(anomaly_detail)
 
     if ceiling_hit:
         triggers.append("ceiling")

--- a/src/attune/telemetry/feedback_loop.py
+++ b/src/attune/telemetry/feedback_loop.py
@@ -140,6 +140,15 @@ class FeedbackLoop:
     FEEDBACK_TTL = 604800  # 7 days
     MIN_SAMPLES = 10
     QUALITY_THRESHOLD = 0.7
+    #: Above this, a non-cheap tier is a downgrade candidate.
+    EXCELLENT_QUALITY = 0.9
+    #: A downgrade only fires when the target tier's own history
+    #: proves it holds quality above this bar.
+    DOWNGRADE_TARGET_QUALITY = 0.85
+
+    #: The tier ladder is linear, so each verdict direction is one map.
+    _UPGRADE_PATH = {"cheap": "capable", "capable": "premium"}
+    _DOWNGRADE_PATH = {"premium": "capable", "capable": "cheap"}
 
     def __init__(self, memory=None) -> None:
         """Initialise the feedback loop.
@@ -392,43 +401,14 @@ class FeedbackLoop:
                 stats=stats_by_tier,
             )
 
-        avg_quality = current_stats.avg_quality
-        confidence = min(current_stats.sample_count / (self.MIN_SAMPLES * 2), 1.0)
-
-        if avg_quality < self.QUALITY_THRESHOLD:
-            if current_tier == "cheap":
-                recommended = "capable"
-                reason = f"Low quality ({avg_quality:.2f}) - upgrade for better results"
-            elif current_tier == "capable":
-                recommended = "premium"
-                reason = f"Low quality ({avg_quality:.2f}) - upgrade to premium tier"
-            else:
-                recommended = "premium"
-                reason = f"Already using premium tier (quality: {avg_quality:.2f})"
-                confidence = 1.0
-        elif avg_quality > 0.9 and current_tier != "cheap":
-            if current_tier == "premium":
-                capable_stats = stats_by_tier.get("capable")
-                if capable_stats and capable_stats.avg_quality > 0.85:
-                    recommended = "capable"
-                    reason = f"Excellent quality ({avg_quality:.2f}) - downgrade to save cost"
-                else:
-                    recommended = "premium"
-                    reason = f"Excellent quality ({avg_quality:.2f}) - keep premium for consistency"
-            elif current_tier == "capable":
-                cheap_stats = stats_by_tier.get("cheap")
-                if cheap_stats and cheap_stats.avg_quality > 0.85:
-                    recommended = "cheap"
-                    reason = f"Excellent quality ({avg_quality:.2f}) - downgrade to save cost"
-                else:
-                    recommended = "capable"
-                    reason = f"Excellent quality ({avg_quality:.2f}) - keep capable tier"
-            else:
-                recommended = current_tier
-                reason = f"Excellent quality ({avg_quality:.2f}) - maintain current tier"
-        else:
-            recommended = current_tier
-            reason = f"Acceptable quality ({avg_quality:.2f}) - maintain current tier"
+        recommended, reason, confidence_override = self._tier_verdict(
+            current_tier, current_stats.avg_quality, stats_by_tier
+        )
+        confidence = (
+            confidence_override
+            if confidence_override is not None
+            else min(current_stats.sample_count / (self.MIN_SAMPLES * 2), 1.0)
+        )
 
         return TierRecommendation(
             current_tier=current_tier,
@@ -437,6 +417,51 @@ class FeedbackLoop:
             reason=reason,
             stats=stats_by_tier,
         )
+
+    def _tier_verdict(
+        self,
+        current_tier: str,
+        avg_quality: float,
+        stats_by_tier: dict,
+    ) -> tuple[str, str, float | None]:
+        """Resolve (recommended_tier, reason, confidence_override).
+
+        The verdict for a tier with sufficient samples, in three
+        quality bands:
+
+        - below ``QUALITY_THRESHOLD``: climb ``_UPGRADE_PATH`` one
+          rung; at the top (premium) stay put with confidence forced
+          to 1.0 — there is nothing to upgrade to.
+        - above ``EXCELLENT_QUALITY`` on a downgradable tier: step
+          down ``_DOWNGRADE_PATH`` one rung only when the target
+          tier's own history proves it holds quality above
+          ``DOWNGRADE_TARGET_QUALITY``; otherwise keep the tier.
+        - otherwise: acceptable — keep the current tier.
+
+        A ``None`` confidence override means the caller applies the
+        standard sample-count formula.
+        """
+        if avg_quality < self.QUALITY_THRESHOLD:
+            upgraded = self._UPGRADE_PATH.get(current_tier)
+            if upgraded is None:
+                reason = f"Already using premium tier (quality: {avg_quality:.2f})"
+                return "premium", reason, 1.0
+            direction = "for better results" if current_tier == "cheap" else "to premium tier"
+            return upgraded, f"Low quality ({avg_quality:.2f}) - upgrade {direction}", None
+
+        if avg_quality > self.EXCELLENT_QUALITY and current_tier in self._DOWNGRADE_PATH:
+            target = self._DOWNGRADE_PATH[current_tier]
+            target_stats = stats_by_tier.get(target)
+            if target_stats and target_stats.avg_quality > self.DOWNGRADE_TARGET_QUALITY:
+                reason = f"Excellent quality ({avg_quality:.2f}) - downgrade to save cost"
+                return target, reason, None
+            keep = (
+                "keep premium for consistency" if current_tier == "premium" else "keep capable tier"
+            )
+            return current_tier, f"Excellent quality ({avg_quality:.2f}) - {keep}", None
+
+        reason = f"Acceptable quality ({avg_quality:.2f}) - maintain current tier"
+        return current_tier, reason, None
 
     def get_underperforming_stages(
         self,


### PR DESCRIPTION
## Items 2+5 of the health plan — refactors proven against their pins

Third execution PR (after #1374, #1375). Every cut is proven
behavior-preserving by the characterization suites #1375 landed
first — the pins ran green against main before AND after the cuts.

| Function | Before | After |
|----------|--------|-------|
| `FeedbackLoop.recommend_tier` | D (23) | C (13) + B (9) table-driven `_tier_verdict` |
| `ops/data.spend_alarm` | D (23) | C (19), anomaly block → `_daily_anomaly_check` |
| `ops/data.read_telemetry_summary` | D (22) | C (15), parsing → `_parse_usage_event` |

Quirk semantics preserved and now documented at the seams (rounded
mean vs raw stdev, inclusive/strict trigger boundaries, the
null-total_cost no-fallthrough). One provably-dead branch dropped
(recommend_tier's excellent-band else — `stats_by_tier` keys are
exactly the three tier literals).

**Scope note:** the refreshed scoreboard corrected the D-count from
3 to 30 (the first measurement was truncated) — these three were
picked before that correction and remain the right ops/telemetry
targets; the newly-surfaced worst blocks (`form_from_dict` F87,
`_control_html` F84 in elicitation) are separate future targets.

Receipts: 510 telemetry+characterization tests green; full ops suite
1343/1343 serial; pinned black/ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)