### PR TITLE
docs(rules): delegation receipts — declared at launch, verified centrally

### DIFF
--- a/.claude/rules/attune/decision-routine.md
+++ b/.claude/rules/attune/decision-routine.md
@@ -140,6 +140,25 @@ Stage 2 review is the worked consumer.
 
 ---
 
+## Delegation receipts (ratified 2026-07-14)
+
+No subagent lane launches without its **receipt type declared in
+the launch prompt**, and the orchestrator **re-runs the receipts
+centrally** before shipping — a lane's self-report is never the
+receipt. Types (name one or more per lane): **suite** (named tests
+run SERIALLY, exact tail returned — xdist masks pollution),
+**behavioral** (byte-compare/golden output, wall-clock fields
+normalized), **live-fire** (the artifact demonstrably runs),
+**metric** (the motivating number re-measured from the FULL
+stream, never a truncated listing), **evidence-chain** (per-claim
+verification for deletions). A lane that stalls gets its mechanics
+taken over, not re-trusted. Origin + full taxonomy: the
+`feedback_receipt_declared_delegation` global memory; born from the
+2026-07-14 health-loop day, where both failures were claims
+standing in for receipts and both bug-catches were receipts.
+
+---
+
 ## Acting on a terse "go"
 
 Two gates fire before executing a `go` / `do it` / `y` (full rule in


### PR DESCRIPTION
## The day's working-agreement, formalized

Patrick-ratified 2026-07-14: **no subagent lane launches without its
receipt type declared up front**, and the orchestrator re-runs
receipts centrally — never trusting self-reports.

Receipt taxonomy: **suite** (serial, exact tail) · **behavioral**
(byte-compare, clocks normalized) · **live-fire** (it demonstrably
runs) · **metric** (re-measured from the full stream) ·
**evidence-chain** (per-claim verification).

Dual-homed by design: the canonical agreement lives in the global
cross-repo memory (loaded every session); this section makes it fire
at planning time inside attune-ai, next to the concerns palette.
Deliberately NOT a hook — receipt adequacy is a judgment call, and
judgment rules make noisy mechanical gates (guardrail when-NOT-to
criteria).

Receipts for the receipts rule: residency budget guard 4/4 green;
memory lint 0 violations across the global corpus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)