### PR TITLE
test(quality): batch-2 characterization pins — _workflow_response, _validate_recommendation, cmd_workflow_run

### DIFF
--- a/tests/unit/cli_commands/test_workflow_commands.py
+++ b/tests/unit/cli_commands/test_workflow_commands.py
@@ -532,6 +532,46 @@ class TestCmdWorkflowRunTarget:
         assert "target" not in call_kwargs
 
 
+class TestCmdWorkflowRunDiscoveryFlags:
+    """Characterization pins (D-block batch 2): the discovery-sweep
+    flags map into input_data exactly as today — set only when truthy,
+    absent otherwise."""
+
+    @staticmethod
+    def _run_tracking(args_kwargs: dict) -> dict:
+        call_kwargs: dict = {}
+
+        class TrackingWorkflow:
+            """Tracking."""
+
+            def execute(self, **kwargs):
+                call_kwargs.update(kwargs)
+                return {"status": "ok"}
+
+        with patch("attune.workflows.get_workflow", return_value=TrackingWorkflow):
+            from attune.cli_commands.workflow_commands import cmd_workflow_run
+
+            assert cmd_workflow_run(_make_args(**args_kwargs)) == 0
+        return call_kwargs
+
+    def test_verbose_flag_sets_input_key(self, capsys):
+        call_kwargs = self._run_tracking({"verbose": True})
+        assert call_kwargs["verbose"] is True
+
+    def test_source_flag_sets_input_key(self, capsys):
+        call_kwargs = self._run_tracking({"source": "git"})
+        assert call_kwargs["source"] == "git"
+
+    def test_depth_flag_sets_input_key(self, capsys):
+        call_kwargs = self._run_tracking({"depth": "quick"})
+        assert call_kwargs["depth"] == "quick"
+
+    def test_absent_flags_omit_keys(self, capsys):
+        call_kwargs = self._run_tracking({})
+        for key in ("verbose", "no_llm", "source", "depth", "output_format"):
+            assert key not in call_kwargs
+
+
 class TestCmdWorkflowRunSyncExecution:
     """Tests for synchronous workflow execution."""
 

--- a/tests/unit/mcp/handlers/test_workflow_response.py
+++ b/tests/unit/mcp/handlers/test_workflow_response.py
@@ -222,6 +222,67 @@ class TestWorkflowResponseReport:
 
         assert sorted(out["findings"]) == ["a.md outdated", "b.md 404"]
 
+    def test_report_response_exact_key_set(self):
+        """Characterization pin (D-block batch 2): the report-path
+        response carries exactly these keys — the refactor cut must
+        not add, drop, or rename any."""
+        result = _make_result(final_output=_make_report().to_dict())
+        out = _workflow_response(result, score="health_score")
+
+        assert set(out.keys()) == {
+            "success",
+            "summary_markdown",
+            "report",
+            "score",
+            "findings",
+            "panel_html",
+            "cost",
+        }
+
+    def test_cost_zero_when_cost_report_absent(self):
+        result = _make_result(final_output={"x": 1})
+        result.cost_report = None
+        out = _workflow_response(result)
+
+        assert out["cost"] == 0.0
+
+
+class TestMetadataFindingsEdges:
+    """Characterization pins (D-block batch 2) for the metadata-findings
+    fallback: each input shape must keep its exact current handling."""
+
+    @staticmethod
+    def _empty_report_result(metadata):
+        report = WorkflowReport(title="Doc audit", summary="ok", score=90)
+        return _make_result(final_output=report.to_dict(), metadata=metadata)
+
+    def test_none_metadata_yields_empty_findings(self):
+        result = self._empty_report_result(metadata={})
+        result.metadata = None
+        out = _workflow_response(result)
+
+        assert out["findings"] == []
+
+    def test_list_metadata_findings_used_verbatim(self):
+        result = self._empty_report_result(metadata={"findings": ["a", "b"]})
+        out = _workflow_response(result)
+
+        assert out["findings"] == ["a", "b"]
+
+    def test_non_list_values_in_findings_dict_skipped(self):
+        result = self._empty_report_result(
+            metadata={"findings": {"good": ["kept"], "bad": "skipped-not-a-list"}}
+        )
+        out = _workflow_response(result)
+
+        assert out["findings"] == ["kept"]
+
+    def test_non_dict_non_list_findings_value_yields_empty(self):
+        result = self._empty_report_result(metadata={"findings": "prose"})
+        out = _workflow_response(result)
+
+        assert out["findings"] == []
+
 
 # ==================================================================
 # _workflow_response — errored runs surface the real reason

--- a/tests/unit/ops/test_recommendations.py
+++ b/tests/unit/ops/test_recommendations.py
@@ -164,6 +164,122 @@ def test_validate_rejects_open_url_file_scheme(svc: RunnerService) -> None:
 
 
 # ----------------------------------------------------------------------
+# _validate_recommendation — characterization pins (D-block batch 2).
+# Exact-shape assertions: the refactor cut must not add, drop, or
+# rename response keys, and every coercion below must survive verbatim.
+# ----------------------------------------------------------------------
+
+
+def test_validate_exact_shape_minimal_next_workflow(svc: RunnerService) -> None:
+    out = svc._validate_recommendation({"kind": "next-workflow", "name": "code-review"})
+    assert out == {"kind": "next-workflow", "name": "code-review"}
+
+
+def test_validate_exact_shape_open_url_with_label_and_severity(svc: RunnerService) -> None:
+    out = svc._validate_recommendation(
+        {
+            "kind": "open-url",
+            "url": "https://example.com",
+            "label": "Docs",
+            "severity": "High",
+            "extra": "dropped",
+        }
+    )
+    assert out == {
+        "kind": "open-url",
+        "label": "Docs",
+        "severity": "high",
+        "url": "https://example.com",
+    }
+
+
+def test_validate_label_truncated_to_200(svc: RunnerService) -> None:
+    out = svc._validate_recommendation(
+        {"kind": "next-workflow", "name": "code-review", "label": "x" * 300}
+    )
+    assert out is not None
+    assert out["label"] == "x" * 200
+
+
+def test_validate_non_str_label_dropped(svc: RunnerService) -> None:
+    out = svc._validate_recommendation(
+        {"kind": "next-workflow", "name": "code-review", "label": 42}
+    )
+    assert out == {"kind": "next-workflow", "name": "code-review"}
+
+
+def test_validate_severity_lowercased_and_truncated(svc: RunnerService) -> None:
+    out = svc._validate_recommendation(
+        {"kind": "next-workflow", "name": "code-review", "severity": "URGENT" * 10}
+    )
+    assert out is not None
+    assert out["severity"] == ("urgent" * 10)[:20]
+
+
+def test_validate_non_str_severity_dropped(svc: RunnerService) -> None:
+    out = svc._validate_recommendation(
+        {"kind": "next-workflow", "name": "code-review", "severity": 3}
+    )
+    assert out == {"kind": "next-workflow", "name": "code-review"}
+
+
+@pytest.mark.parametrize("name", [None, "", 42], ids=["missing", "empty", "non-str"])
+def test_validate_rejects_bad_next_workflow_name(svc: RunnerService, name: object) -> None:
+    payload: dict[str, object] = {"kind": "next-workflow"}
+    if name is not None:
+        payload["name"] = name
+    assert svc._validate_recommendation(payload) is None
+
+
+def test_validate_rejects_args_not_an_object(svc: RunnerService) -> None:
+    out = svc._validate_recommendation(
+        {"kind": "next-workflow", "name": "code-review", "args": "src/"}
+    )
+    assert out is None
+
+
+def test_validate_args_without_path_omits_args_key(svc: RunnerService) -> None:
+    # Unknown args keys are dropped; an args dict that sanitizes to
+    # empty produces NO "args" key at all (not an empty dict).
+    out = svc._validate_recommendation(
+        {"kind": "next-workflow", "name": "code-review", "args": {"depth": "quick"}}
+    )
+    assert out == {"kind": "next-workflow", "name": "code-review"}
+
+
+@pytest.mark.parametrize("bad_path", ["", 42], ids=["empty", "non-str"])
+def test_validate_rejects_bad_args_path(svc: RunnerService, bad_path: object) -> None:
+    out = svc._validate_recommendation(
+        {"kind": "next-workflow", "name": "code-review", "args": {"path": bad_path}}
+    )
+    assert out is None
+
+
+def test_validate_path_passes_through_without_project_root() -> None:
+    # project_root=None disables path validation (test-fixture wiring);
+    # the raw string passes through unvalidated and unresolved.
+    svc = RunnerService(project_root=None)
+    out = svc._validate_recommendation(
+        {"kind": "next-workflow", "name": "code-review", "args": {"path": "src/anything"}}
+    )
+    assert out == {
+        "kind": "next-workflow",
+        "name": "code-review",
+        "args": {"path": "src/anything"},
+    }
+
+
+def test_validate_accepts_open_url_plain_http(svc: RunnerService) -> None:
+    out = svc._validate_recommendation({"kind": "open-url", "url": "http://localhost:8765/x"})
+    assert out == {"kind": "open-url", "url": "http://localhost:8765/x"}
+
+
+def test_validate_rejects_non_str_url(svc: RunnerService) -> None:
+    assert svc._validate_recommendation({"kind": "open-url", "url": 7}) is None
+    assert svc._validate_recommendation({"kind": "open-url"}) is None
+
+
+# ----------------------------------------------------------------------
 # RunnerService.handle_stdout_line — marker parsing
 # ----------------------------------------------------------------------
 


### PR DESCRIPTION
## What

Pins half of Batch 2 (churn-hot infra) from the paydown plan in `docs/reports/d-block-triage-2026-07-14.md` — characterization tests that make the follow-up cuts for `_workflow_response` (D26), `RunnerService._validate_recommendation` (D24), and `cmd_workflow_run` (D21) provable behavior preservation.

Existing coverage was already dense (23 pins on `_workflow_response`, 17 on the recommendation channel, ~40 on `cmd_workflow_run`), so this PR fills only the measured gaps:

- **`mcp/workflow_handlers`** — exact response **key-set** pin for the report path (the exact-dict-equality trap the triage doc flags), `cost=0.0` when `cost_report` is None, and the `_metadata_findings` fallback edges (None metadata, list findings verbatim, non-list dict values skipped, non-dict/non-list value → `[]`).
- **`ops/runner._validate_recommendation`** — exact-shape pins for both kinds, label/severity coercion (truncate 200/20, lowercase, non-str dropped), bad-name/bad-args/bad-path rejections, empty-sanitized args omits the key, `project_root=None` passthrough, plain-http accepted.
- **`cli_commands/cmd_workflow_run`** — discovery-flag mapping (`verbose`/`source`/`depth` set when truthy, absent otherwise).

## Receipts

- Branch-coverage measured before/after: all three target blocks now **100% line+branch covered** by their suites; remaining module gaps are neighboring handlers/executor paths outside the cut scope.
- Serial full-affected-suite run (`mcp/handlers`, `ops`, `cli_commands`, `cli`): **1919 passed**. The single failure is the pre-existing live-network test `test_analyze_png_returns_analysis` (real API call; account credit balance too low — skips in keyless CI).
- No production code changes; cuts PR follows once this and #1383 merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
