### PR TITLE
fix(ops): health-report link uses as_posix() — repairs Windows CI lanes

### DIFF
--- a/src/attune/ops/health_snapshot.py
+++ b/src/attune/ops/health_snapshot.py
@@ -384,10 +384,13 @@ def latest_llm_report(project_root: Path) -> str | None:
     if not candidates:
         return None
     latest = candidates[-1]
+    # as_posix(): the value is rendered as a repo-relative link/URL, so
+    # it must use forward slashes on every platform (Windows str() gives
+    # backslashes — broke all 5 windows CI lanes on 2026-07-14).
     try:
-        return str(latest.relative_to(project_root))
+        return latest.relative_to(project_root).as_posix()
     except ValueError:
-        return str(latest)
+        return latest.as_posix()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/ops/test_health_snapshot.py
+++ b/tests/unit/ops/test_health_snapshot.py
@@ -466,6 +466,22 @@ class TestLatestLlmReport:
     def test_no_reports_dir_returns_none(self, tmp_path: Path) -> None:
         assert hs.latest_llm_report(tmp_path) is None
 
+    def test_not_relative_falls_back_to_absolute_posix(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The defensive ValueError fallback still yields forward slashes."""
+        reports = tmp_path / "docs" / "reports"
+        reports.mkdir(parents=True)
+        (reports / "library-health-2026-07-14.md").write_text("x", encoding="utf-8")
+
+        def _boom(self: Path, *args: object, **kwargs: object) -> Path:
+            raise ValueError("not in the subpath")
+
+        monkeypatch.setattr(Path, "relative_to", _boom)
+        result = hs.latest_llm_report(tmp_path)
+        assert result == (reports / "library-health-2026-07-14.md").as_posix()
+        assert "\\" not in result
+
     def test_empty_reports_dir_returns_none(self, tmp_path: Path) -> None:
         (tmp_path / "docs" / "reports").mkdir(parents=True)
         assert hs.latest_llm_report(tmp_path) is None


### PR DESCRIPTION
## What

`latest_llm_report()` returned `str(Path.relative_to(...))` — backslashes on Windows — while the Health tab renders it as a repo-relative link and its tests assert `docs/reports/...`. Every `windows-latest` lane on main has been red since #1379 merged (run 29372404185 on `2ff37ddea`), and every PR since inherits the failure (first seen on #1383's matrix tonight).

One-line fix: `.as_posix()` on both return paths.

## Receipts

- `tests/unit/ops/test_health_snapshot.py` + `test_health_library_route.py`: 71 passed serially (the two lanes' failing tests included).
- Pre-existing on main, not introduced by any open PR — see the main-branch run linked above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)