### PR TITLE
refactor(quality): batch-2 cuts — _workflow_response D26→A4, _validate_recommendation D24→B9, cmd_workflow_run D21→B8

### DIFF
--- a/.claude/lessons.md
+++ b/.claude/lessons.md
@@ -15184,3 +15184,55 @@ def ", start_idx + 1)` for module-
   behavior-preservation receipt, strip or pin every wall-clock,
   random, or run-id field; a "difference" in one of those is
   harness noise that erodes trust in the real signal.
+
+- **A handoff that names a "known bug" without its MECHANISM is a
+  broken pointer once the session that knew it is deleted — starters
+  must carry the repro one-liner, not just the label**: 2026-07-14
+  evening, `next_session_starter.md` said "fix the known
+  `cmd_workflow_run` exit-0-on-failure bug"; Patrick had deleted the
+  prior session as cleanup, and NO surviving artifact (triage doc,
+  lessons, reports) recorded what the bug actually was — transcript
+  searches came up empty and the mechanism had to be re-derived from
+  scratch (~30 min: it was the spend-gate `ACTION_BLOCK` branch
+  returning `EXIT_SUCCESS`; the ops daemon pre-authorizes but still
+  BLOCKS on an exhausted envelope, so refused runs rendered green).
+  Deleting old sessions is fine — that's what handoffs are for — but
+  the contract is on the WRITER: any "known bug / known issue" line
+  in a starter or plan doc must include the one-line mechanism and,
+  ideally, the repro command. Rule of thumb: write the starter as if
+  every transcript will be gone by morning.
+
+- **ALL Windows lanes failing on your PR while ubuntu/macos are green
+  → check MAIN's latest tests.yml run BEFORE diagnosing your diff**:
+  2026-07-14, PR #1383 (exit-code fix, platform-neutral) showed 5/5
+  windows-latest failures; `gh run list --workflow=tests.yml
+  --branch=main --limit 3` showed main itself red on the same lanes
+  since #1379 merged the day before (the "admin-merge before Windows
+  lanes finish" lesson recurring — #1379's own matrix never went
+  green on Windows). The 30-second main-branch check redirected the
+  whole diagnosis from "what did my diff break" to a one-line
+  pre-existing hotfix (#1385). The bug class itself:
+  `str(Path.relative_to(root))` yields BACKSLASHES on Windows — any
+  repo-relative path destined for a URL/link/doc must use
+  `.as_posix()` (health tab's `latest_llm_report`). Recovery order
+  when main is the culprit: hotfix PR first, then
+  `gh pr update-branch` the blocked PRs so their matrices rerun green
+  — don't merge them over the inherited red even though Windows lanes
+  aren't required checks.
+
+- **The /tmp coverage recipe is for MEASURING one module's coverage,
+  not for verifying suites — cwd-dependent tests fail en masse from
+  /tmp and the failures are pure artifact**: 2026-07-14, running four
+  suites together under `cd /tmp && coverage run … -m pytest <abs
+  paths>` produced 102 failures (e.g. `test_specs_routes`,
+  spec/report readers that resolve `docs/…` relative to cwd); the
+  identical serial run from the worktree: 1919 passed, 1 unrelated
+  live-network failure. The recipe (from the worktree-coverage
+  lesson) stays correct for its purpose — targeted `--source=<mod>`
+  measurement where the module's own tests don't read cwd — but the
+  VERIFICATION run that gates a push must execute from the repo root.
+  Corollary: a live-network test (`test_analyze_png_returns_analysis`)
+  runs and spends real API money whenever `ANTHROPIC_API_KEY` is in
+  the shell env — deselect it for local full-suite runs (CI is
+  keyless and skips it); it failed "credit balance too low" and was
+  the session's tell that the API account was out of credits.

--- a/src/attune/cli_commands/workflow_commands.py
+++ b/src/attune/cli_commands/workflow_commands.py
@@ -78,14 +78,11 @@ def cmd_workflow_info(args: Namespace) -> int:
 def cmd_workflow_run(args: Namespace) -> int:
     """Execute a workflow."""
     import os
-    import sys
 
     from attune.cli_commands._exit_codes import (
         EXIT_CLI_ERROR,
-        EXIT_SUCCESS,
         run_workflow_with_exit_code,
     )
-    from attune.security.path_validation import _validate_file_path
     from attune.workflows import get_workflow
 
     name = args.name
@@ -106,93 +103,24 @@ def cmd_workflow_run(args: Namespace) -> int:
         print(f"❌ Workflow not found: {name}")
         return EXIT_CLI_ERROR
 
-    # Parse input if provided
-    input_data = {}
-    if args.input:
-        try:
-            input_data = json.loads(args.input)
-        except json.JSONDecodeError as e:
-            print(f"❌ Invalid JSON input: {e}")
-            return EXIT_CLI_ERROR
+    input_data, input_error = _build_input_data(args)
+    if input_error is not None:
+        return input_error
 
-    # Add common options with validation
-    if args.path:
-        try:
-            # Validate path to prevent path traversal attacks
-            validated_path = _validate_file_path(args.path)
-            input_data["path"] = str(validated_path)
-        except ValueError as e:
-            print(f"❌ Invalid path: {e}")
-            return EXIT_CLI_ERROR
-    if args.target:
-        input_data["target"] = args.target
-
-    # Discovery-sweep flags (no-op for workflows that don't accept them
-    # since execute() takes **kwargs — extra keys are dropped silently).
-    if getattr(args, "verbose", False):
-        input_data["verbose"] = True
-    if getattr(args, "no_llm", False):
-        input_data["no_llm"] = True
-    if getattr(args, "source", None):
-        input_data["source"] = args.source
-    if getattr(args, "depth", None):
-        input_data["depth"] = args.depth
-    if getattr(args, "json", False):
-        # Let workflows that honor it render their own JSON via
-        # ``final_output`` rather than the generic ``json.dumps(result)``
-        # at the bottom of this function (which produces awkward output
-        # for nested dataclasses).
-        input_data["output_format"] = "json"
-
-    # Auth pre-flight (setup-friction F1/F4) — BEFORE the spend gate,
-    # so a machine with no auth path at all gets one clean sentence
-    # instead of (a) a spend warning about dollars it cannot spend,
-    # then (b) an SDK traceback. Only blocks when NEITHER auth path
-    # exists: no ANTHROPIC_API_KEY and no `claude` CLI. A present-but-
-    # unauthenticated CLI can't be verified cheaply, so it proceeds
-    # (that failure is handled by SdkSubprocessError messaging).
+    record_cost = False
     if not getattr(args, "no_llm", False):
+        # Auth pre-flight (setup-friction F1/F4) — BEFORE the spend
+        # gate, so a machine with no auth path at all gets one clean
+        # sentence instead of (a) a spend warning about dollars it
+        # cannot spend, then (b) an SDK traceback.
         preflight_error = _auth_preflight()
         if preflight_error:
             print(preflight_error)
             return EXIT_CLI_ERROR
 
-    # Spend gate (collaboration-gates Phase 1) — guard the first
-    # billable run of the session. Free/local runs never reach it
-    # (R8): a ``--no-llm`` run makes no billable call. The gate's own
-    # off switch (``ATTUNE_SPEND_GATE=off`` / ``ATTUNE_MAX_BUDGET_USD=0``)
-    # short-circuits to proceed. ``record_cost`` stays False unless an
-    # enforced (non-disabled) envelope is in play, so the off path and
-    # ``--no-llm`` never touch the envelope store.
-    record_cost = False
-    if not getattr(args, "no_llm", False):
-        from attune.gates.spend_gate import (
-            ACTION_BLOCK,
-            ACTION_CONFIRM,
-            evaluate_spend_gate,
-        )
-
-        depth = input_data.get("depth", "standard")
-        interactive = sys.stdin.isatty() and sys.stdout.isatty()
-        decision = evaluate_spend_gate(name, depth, interactive=interactive)
-
-        if decision.action == ACTION_BLOCK:
-            # A blocked run is a refusal, not a success: the workflow
-            # never executed, so exiting 0 would render it green on
-            # every exit-code consumer (ops dashboard chips, CI steps,
-            # shell scripts). Same class as the auth pre-flight above —
-            # a CLI-level stop before execute() — so it shares
-            # EXIT_CLI_ERROR (3).
-            _print_spend_block(decision)
-            return EXIT_CLI_ERROR
-        if decision.action == ACTION_CONFIRM:
-            if not _confirm_spend(decision):
-                print("Skipped — no workflow run, no charge.")
-                return EXIT_SUCCESS
-            _authorize_envelope(decision)
-        # Record actual cost into the envelope only when the gate is
-        # enforced (a real dollar-capped window), never on the off path.
-        record_cost = not decision.envelope.disabled
+        gate_exit, record_cost = _spend_gate_check(name, input_data.get("depth", "standard"))
+        if gate_exit is not None:
+            return gate_exit
 
     print(f"\n🚀 Running workflow: {name}\n")
 
@@ -211,6 +139,96 @@ def cmd_workflow_run(args: Namespace) -> int:
         ),
         on_result=_record_envelope_cost if record_cost else None,
     )
+
+
+def _build_input_data(args: Namespace) -> tuple[dict, int | None]:
+    """Assemble the ``execute()`` kwargs from the CLI arguments.
+
+    Returns ``(input_data, None)`` on success, or ``(input_data,
+    exit_code)`` when a CLI-level input error (bad JSON, bad path) was
+    already printed and the caller should return that code.
+    """
+    from attune.cli_commands._exit_codes import EXIT_CLI_ERROR
+    from attune.security.path_validation import _validate_file_path
+
+    input_data: dict = {}
+    if args.input:
+        try:
+            input_data = json.loads(args.input)
+        except json.JSONDecodeError as e:
+            print(f"❌ Invalid JSON input: {e}")
+            return input_data, EXIT_CLI_ERROR
+
+    # Add common options with validation
+    if args.path:
+        try:
+            # Validate path to prevent path traversal attacks
+            validated_path = _validate_file_path(args.path)
+            input_data["path"] = str(validated_path)
+        except ValueError as e:
+            print(f"❌ Invalid path: {e}")
+            return input_data, EXIT_CLI_ERROR
+    if args.target:
+        input_data["target"] = args.target
+
+    # Discovery-sweep flags (no-op for workflows that don't accept them
+    # since execute() takes **kwargs — extra keys are dropped silently).
+    if getattr(args, "verbose", False):
+        input_data["verbose"] = True
+    if getattr(args, "no_llm", False):
+        input_data["no_llm"] = True
+    if getattr(args, "source", None):
+        input_data["source"] = args.source
+    if getattr(args, "depth", None):
+        input_data["depth"] = args.depth
+    if getattr(args, "json", False):
+        # Let workflows that honor it render their own JSON via
+        # ``final_output`` rather than the generic ``json.dumps(result)``
+        # printed by the exit-code layer (which produces awkward output
+        # for nested dataclasses).
+        input_data["output_format"] = "json"
+    return input_data, None
+
+
+def _spend_gate_check(name: str, depth: str) -> tuple[int | None, bool]:
+    """Run the spend gate (collaboration-gates Phase 1) for one run.
+
+    Guards the first billable run of the session. Free/local runs never
+    reach it (R8): a ``--no-llm`` run makes no billable call. The
+    gate's own off switch (``ATTUNE_SPEND_GATE=off`` /
+    ``ATTUNE_MAX_BUDGET_USD=0``) short-circuits to proceed.
+
+    Returns ``(exit_code, record_cost)``: a non-``None`` exit code means
+    the caller returns it without running the workflow (block → 3 so a
+    refused run is never green on exit-code consumers like the ops
+    dashboard chips; interactive decline → 0, an explicit user choice).
+    ``record_cost`` is True only when an enforced (non-disabled)
+    envelope is in play, so the off path never touches the envelope
+    store.
+    """
+    import sys
+
+    from attune.cli_commands._exit_codes import EXIT_CLI_ERROR, EXIT_SUCCESS
+    from attune.gates.spend_gate import (
+        ACTION_BLOCK,
+        ACTION_CONFIRM,
+        evaluate_spend_gate,
+    )
+
+    interactive = sys.stdin.isatty() and sys.stdout.isatty()
+    decision = evaluate_spend_gate(name, depth, interactive=interactive)
+
+    if decision.action == ACTION_BLOCK:
+        _print_spend_block(decision)
+        return EXIT_CLI_ERROR, False
+    if decision.action == ACTION_CONFIRM:
+        if not _confirm_spend(decision):
+            print("Skipped — no workflow run, no charge.")
+            return EXIT_SUCCESS, False
+        _authorize_envelope(decision)
+    # Record actual cost into the envelope only when the gate is
+    # enforced (a real dollar-capped window), never on the off path.
+    return None, not decision.envelope.disabled
 
 
 def _auth_preflight() -> str | None:

--- a/src/attune/mcp/workflow_handlers.py
+++ b/src/attune/mcp/workflow_handlers.py
@@ -42,6 +42,102 @@ def _metadata_findings(result: Any) -> list[Any]:
     return []
 
 
+def _pick_source(source: Any) -> tuple[Any, Any]:
+    """Unpack a field-pick ``source`` into ``(src_key, default)``."""
+    return source if isinstance(source, tuple) else (source, None)
+
+
+def _report_fields(result: Any, fo: Any, raw_output: bool, field_picks: dict) -> dict[str, Any]:
+    """Response fields for a serialized-WorkflowReport final_output.
+
+    Carries the rendered summary markdown verbatim (``summary_markdown``),
+    the report JSON (``report``), and the back-compat ``score`` /
+    ``findings`` fields restored from the report (metadata findings as
+    fallback). Findings-like picks (``findings``/``predictions``/
+    ``checks``) resolve to the report findings; score-like picks
+    (``score``, ``*_score`` — either side of the mapping) to the report
+    score; everything else to its default.
+    """
+    from attune.config import resolve_show_cost
+    from attune.voice.report_renderer import render_safe
+    from attune.workflows.output import WorkflowReport
+
+    # Universal rich panel for mcp__visualize__show_widget — renders
+    # the report's sections (findings / category-bullets / next-steps)
+    # for EVERY SDK-native workflow at once (spec
+    # analysis-workflow-output-widgets D4). Display-only, injection-safe.
+    from attune.workflows.report_panel import report_to_panel_html
+
+    report = WorkflowReport.from_dict(fo)
+    findings = [f.to_dict() for f in report.findings] or _metadata_findings(result)
+    fields: dict[str, Any] = {
+        "summary_markdown": render_safe(
+            report,
+            disclosure="summary",
+            show_cost=resolve_show_cost(),
+        ),
+        "report": fo,
+        "score": report.score,
+        "findings": findings,
+        "panel_html": report_to_panel_html(fo, succeeded=bool(getattr(result, "success", True))),
+    }
+    if raw_output:
+        fields["output"] = fields["summary_markdown"]
+    for key, source in field_picks.items():
+        src_key, default = _pick_source(source)
+        if key in _FINDINGS_KEYS or src_key in _FINDINGS_KEYS:
+            fields[key] = findings
+        elif _is_score_key(key) or _is_score_key(src_key):
+            fields[key] = report.score
+        else:
+            fields[key] = default
+    return fields
+
+
+def _legacy_fields(fo: Any, raw_output: bool, field_picks: dict) -> dict[str, Any]:
+    """Response fields for a legacy flat-dict final_output — each pick
+    is ``final_output.get(source)``, exactly the field-picking the
+    handlers did before the report path existed."""
+    fo_dict = fo if isinstance(fo, dict) else {}
+    fields: dict[str, Any] = {}
+    for key, source in field_picks.items():
+        src_key, default = _pick_source(source)
+        fields[key] = fo_dict.get(src_key, default)
+    if raw_output:
+        fields["output"] = fo
+    return fields
+
+
+def _error_fields(result: Any) -> dict[str, Any]:
+    """Surface the real failure reason of an errored run.
+
+    Without this, an errored run is indistinguishable from a clean
+    empty result (success=false, findings=[], cost=0) — the
+    swallowed-error trap (see removing-dead-code.md "fake-success
+    signature"). The canonical signal is result.error; SDK-native runs
+    leave that None and carry the message in metadata instead
+    (is_error + raw_result_text), e.g. an auth failure surfacing as
+    "Invalid API key". Only str messages are accepted so a mocked
+    result never injects a spurious key.
+    """
+    meta = getattr(result, "metadata", None) or {}
+    if not (result.success is False or meta.get("is_error")):
+        return {}
+    candidates = (
+        getattr(result, "error", None),
+        meta.get("raw_result_text") if meta.get("is_error") else None,
+        meta.get("errors"),
+    )
+    error_msg = next((c for c in candidates if isinstance(c, str) and c.strip()), None)
+    if error_msg is None:
+        return {}
+    fields: dict[str, Any] = {"error": error_msg}
+    error_type = getattr(result, "error_type", None)
+    if isinstance(error_type, str):
+        fields["error_type"] = error_type
+    return fields
+
+
 def _workflow_response(
     result: Any,
     *,
@@ -52,18 +148,10 @@ def _workflow_response(
     """Build an MCP response dict from a WorkflowResult.
 
     Two shapes, decided by what ``result.final_output`` carries
-    (workflow-result-formatting spec, T5):
-
-    - **Serialized WorkflowReport**: the response carries the rendered
-      summary markdown verbatim (``summary_markdown``), the report JSON
-      (``report``), and the back-compat ``score`` / ``findings`` fields
-      restored from the report (metadata findings as fallback).
-      Findings-like picks (``findings``/``predictions``/``checks``)
-      resolve to the report findings; score-like picks (``score``,
-      ``*_score`` — either side of the mapping) to the report score;
-      everything else to its default.
-    - **Legacy flat dict**: each pick is ``final_output.get(source)``,
-      exactly the field-picking the handlers did before.
+    (workflow-result-formatting spec, T5): a serialized WorkflowReport
+    (:func:`_report_fields`) or a legacy flat dict
+    (:func:`_legacy_fields`). Errored runs additionally carry the real
+    failure reason (:func:`_error_fields`).
 
     Args:
         result: WorkflowResult returned by a workflow ``execute()``.
@@ -83,73 +171,16 @@ def _workflow_response(
     fo = result.final_output
 
     if WorkflowReport.is_report_dict(fo):
-        from attune.config import resolve_show_cost
-        from attune.voice.report_renderer import render_safe
-
-        report = WorkflowReport.from_dict(fo)
-        findings = [f.to_dict() for f in report.findings] or _metadata_findings(result)
-        response["summary_markdown"] = render_safe(
-            report,
-            disclosure="summary",
-            show_cost=resolve_show_cost(),
-        )
-        response["report"] = fo
-        response["score"] = report.score
-        response["findings"] = findings
-        # Universal rich panel for mcp__visualize__show_widget — renders
-        # the report's sections (findings / category-bullets / next-steps)
-        # for EVERY SDK-native workflow at once (spec
-        # analysis-workflow-output-widgets D4). Display-only, injection-safe.
-        from attune.workflows.report_panel import report_to_panel_html
-
-        response["panel_html"] = report_to_panel_html(
-            fo, succeeded=bool(getattr(result, "success", True))
-        )
-        if raw_output:
-            response["output"] = response["summary_markdown"]
-        for key, source in field_picks.items():
-            src_key, default = source if isinstance(source, tuple) else (source, None)
-            if key in _FINDINGS_KEYS or src_key in _FINDINGS_KEYS:
-                response[key] = findings
-            elif _is_score_key(key) or _is_score_key(src_key):
-                response[key] = report.score
-            else:
-                response[key] = default
+        response.update(_report_fields(result, fo, raw_output, field_picks))
     else:
-        fo_dict = fo if isinstance(fo, dict) else {}
-        for key, source in field_picks.items():
-            src_key, default = source if isinstance(source, tuple) else (source, None)
-            response[key] = fo_dict.get(src_key, default)
-        if raw_output:
-            response["output"] = fo
+        response.update(_legacy_fields(fo, raw_output, field_picks))
 
     cost_report = getattr(result, "cost_report", None)
     response["cost"] = cost_report.total_cost if cost_report is not None else 0.0
     if include_provider:
         response["provider"] = result.provider
 
-    # Surface the real failure reason. Without this, an errored run is
-    # indistinguishable from a clean empty result (success=false,
-    # findings=[], cost=0) — the swallowed-error trap (see
-    # removing-dead-code.md "fake-success signature"). The canonical
-    # signal is result.error; SDK-native runs leave that None and carry
-    # the message in metadata instead (is_error + raw_result_text), e.g.
-    # an auth failure surfacing as "Invalid API key". Only str messages
-    # are accepted so a mocked result never injects a spurious key.
-    meta = getattr(result, "metadata", None) or {}
-    if result.success is False or meta.get("is_error"):
-        candidates = (
-            getattr(result, "error", None),
-            meta.get("raw_result_text") if meta.get("is_error") else None,
-            meta.get("errors"),
-        )
-        error_msg = next((c for c in candidates if isinstance(c, str) and c.strip()), None)
-        if error_msg is not None:
-            response["error"] = error_msg
-            error_type = getattr(result, "error_type", None)
-            if isinstance(error_type, str):
-                response["error_type"] = error_type
-
+    response.update(_error_fields(result))
     return response
 
 

--- a/src/attune/ops/runner.py
+++ b/src/attune/ops/runner.py
@@ -430,51 +430,67 @@ class RunnerService:
             sanitized["severity"] = payload["severity"].lower()[:20]
 
         if kind == "next-workflow":
-            name = payload.get("name")
-            if not isinstance(name, str) or not name:
-                logger.warning("recommendation rejected: next-workflow name missing")
+            return self._validate_next_workflow_rec(payload, sanitized)
+        return self._validate_open_url_rec(payload, sanitized)
+
+    def _validate_next_workflow_rec(
+        self, payload: dict[str, object], sanitized: dict[str, object]
+    ) -> dict[str, object] | None:
+        """Finish validating a ``next-workflow`` recommendation."""
+        name = payload.get("name")
+        if not isinstance(name, str) or not name:
+            logger.warning("recommendation rejected: next-workflow name missing")
+            return None
+        # Verify against the live registry. Cheap: ~25 entries, no I/O.
+        from attune.ops import data as _data
+
+        valid_names = {w.name for w in _data.list_workflows()}
+        if name not in valid_names:
+            logger.warning("recommendation rejected: unknown workflow %r", name)
+            return None
+        sanitized["name"] = name
+
+        args = payload.get("args")
+        if args is not None and not isinstance(args, dict):
+            logger.warning("recommendation rejected: args not an object")
+            return None
+        if isinstance(args, dict) and "path" in args:
+            validated_path = self._validate_rec_path(args["path"])
+            if validated_path is None:
                 return None
-            # Verify against the live registry. Cheap: ~25 entries, no I/O.
-            from attune.ops import data as _data
+            sanitized["args"] = {"path": validated_path}
+        return sanitized
 
-            valid_names = {w.name for w in _data.list_workflows()}
-            if name not in valid_names:
-                logger.warning("recommendation rejected: unknown workflow %r", name)
-                return None
-            sanitized["name"] = name
+    def _validate_rec_path(self, raw_path: object) -> str | None:
+        """Validate a recommendation ``args.path`` value.
 
-            args = payload.get("args")
-            if args is not None and not isinstance(args, dict):
-                logger.warning("recommendation rejected: args not an object")
-                return None
-            if isinstance(args, dict):
-                sanitized_args: dict[str, object] = {}
-                if "path" in args:
-                    raw_path = args["path"]
-                    if not isinstance(raw_path, str) or not raw_path:
-                        logger.warning("recommendation rejected: bad args.path")
-                        return None
-                    if self._project_root is not None:
-                        from attune.security.path_validation import _validate_file_path
+        Returns the validated path string, or ``None`` (after a warning
+        log) when it is rejected. ``project_root=None`` disables
+        validation — the raw string passes through (test-fixture
+        wiring; production server.py always supplies a root).
+        """
+        if not isinstance(raw_path, str) or not raw_path:
+            logger.warning("recommendation rejected: bad args.path")
+            return None
+        if self._project_root is None:
+            return raw_path
+        from attune.security.path_validation import _validate_file_path
 
-                        try:
-                            validated = _validate_file_path(
-                                raw_path, allowed_dir=str(self._project_root)
-                            )
-                        except ValueError as exc:
-                            logger.warning(
-                                "recommendation rejected: args.path failed validation (%s)",
-                                exc,
-                            )
-                            return None
-                        sanitized_args["path"] = str(validated)
-                    else:
-                        sanitized_args["path"] = raw_path
-                if sanitized_args:
-                    sanitized["args"] = sanitized_args
-            return sanitized
+        try:
+            validated = _validate_file_path(raw_path, allowed_dir=str(self._project_root))
+        except ValueError as exc:
+            logger.warning(
+                "recommendation rejected: args.path failed validation (%s)",
+                exc,
+            )
+            return None
+        return str(validated)
 
-        # kind == "open-url"
+    @staticmethod
+    def _validate_open_url_rec(
+        payload: dict[str, object], sanitized: dict[str, object]
+    ) -> dict[str, object] | None:
+        """Finish validating an ``open-url`` recommendation."""
         url = payload.get("url")
         if not isinstance(url, str) or not url.startswith(_VALID_URL_SCHEMES):
             logger.warning("recommendation rejected: bad open-url url %r", url)

--- a/tests/unit/quality/test_complexity_ratchet.py
+++ b/tests/unit/quality/test_complexity_ratchet.py
@@ -41,15 +41,12 @@ D_THRESHOLD = 21
 ALLOWLISTED_D_BLOCKS: frozenset[str] = frozenset(
     {
         "authoring/fact_check/python_refs.py::check",
-        "cli_commands/workflow_commands.py::cmd_workflow_run",
-        "mcp/workflow_handlers.py::_workflow_response",
         "memory/mixins/backend_init_mixin.py::BackendInitMixin._initialize_backends",
         "memory/security/query.py::AuditQueryMixin",
         "memory/security/query.py::AuditQueryMixin.query",
         "memory/security/query.py::_apply_custom_filters",
         "meta_workflows/cli_commands/workflow_commands.py::run_workflow",
         "models/empathy_executor.py::EmpathyLLMExecutor.run",
-        "ops/runner.py::RunnerService._validate_recommendation",
         "ops/spec_lifecycle.py::derive_lifecycle",
         "project_index/dependency_analysis.py::DependencyAnalysisMixin._build_summary",
         "project_index/index.py::ProjectIndex.refresh_incremental",


### PR DESCRIPTION
## What

Cuts half of Batch 2 (churn-hot infra) from `docs/reports/d-block-triage-2026-07-14.md` — pure stage extraction, proven behavior-preserving by the #1384 pins plus pre-existing suites, on top of the #1383 exit-code fix:

| Block | Before | After | Extracted stages |
|---|---|---|---|
| `mcp/workflow_handlers.py::_workflow_response` | D26 | **A4** | `_report_fields` (B9), `_legacy_fields` (A4), `_error_fields` (B10), `_pick_source` (A2) |
| `ops/runner.py::RunnerService._validate_recommendation` | D24 | **B9** | `_validate_next_workflow_rec` (B10), `_validate_open_url_rec` (A3), `_validate_rec_path` (A5) |
| `cli_commands/workflow_commands.py::cmd_workflow_run` | D21 | **B8** | `_build_input_data` (C11), `_spend_gate_check` (A5) |

Ratchet allowlist entries for all three **deleted** (ledger 22 → 19; batch-2 REFACTOR targets done). Also carries 3 session lessons in `.claude/lessons.md`.

## Receipts

- Serial full-affected-suite run on this exact branch (fresh off main with #1383/#1384/#1385 merged): **1991 passed** — quality ratchet, mcp/handlers, ops, cli_commands, cli, gates, voice_wiring, including the live-network test (account credits reloaded).
- The batch-2 pins (#1384) assert exact response key-sets and exact sanitized shapes, so key drift or coercion drift in these cuts would fail loudly.
- radon: no D-or-worse blocks remain in the three touched modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
