### PR TITLE
test(quality): batch-3 characterization pins — format_doc_gen_report, _build_summary, _extract_from_workflow_result

### DIFF
--- a/docs/reports/d-block-triage-2026-07-14.md
+++ b/docs/reports/d-block-triage-2026-07-14.md
@@ -25,7 +25,10 @@ land. Patrick approved Batch 1 + the two verified deletions
 | 4 | `workflows/documentation_orchestrator.py::DocumentationOrchestrator.execute` | D22 | 2 live integration points, prior #685 bug |
 | 4 | `models/empathy_executor.py::EmpathyLLMExecutor.run` | D22 | ALIVE (3 subsystems) — doc-fiction lesson confirmed again |
 
-## ACCEPT (12) — live, stable, tested; refactoring is gold-plating
+## ACCEPT (13) — live, stable, tested; refactoring is gold-plating
+
+(+1 on 2026-07-15: `refresh_incremental` promoted from DELETE-hold —
+see item 3 below.)
 
 `format_secure_release_report` D28 (1 contained caller, 0 churn),
 `HelpMaintenanceWorkflow.execute` D25, `TestMaintenanceWorkflow.
@@ -60,6 +63,13 @@ these aren't changing.
    (possibly forward-looking watch-mode API). NOT approved — hold
    for a should-this-exist decision when project_index is next
    touched.
+   **DECIDED 2026-07-15 (batch 3, Patrick): reclassified as ACCEPT.**
+   Re-verified: zero production callers (both ProjectIndex consumers
+   use full `refresh()`), but it is a tested, documented public
+   method on a published package with ~zero churn since v4.8.0 and
+   no watch-mode subsystem yet. Fits the ACCEPT rationale (complexity
+   is a tax on change; it isn't changing). Allowlist entry stays,
+   ACCEPT count 12 → 13.
 
 ## Paydown plan of record (Patrick-approved 2026-07-14 evening)
 
@@ -90,6 +100,10 @@ compatible.
   Parallel pin agents (similar section-builder shapes), one cut
   pass. Natural moment for the held `refresh_incremental`
   should-this-exist decision (sibling file).
+  *(Scope correction 2026-07-15: `_section_html` is an ACCEPT-table
+  entry — its mention here contradicted the triage table, which is
+  the authority. Batch 3 executes the three REFACTOR-table blocks
+  only.)*
 - **Batch 4 — workflow executes** (1 session, 3 small PRs):
   `RagCodeGenWorkflow.execute` D24,
   `DocumentationOrchestrator.execute` D22,
@@ -109,5 +123,6 @@ Post-freeze checkpoint: re-check the 12 ACCEPT rationales against
 fresh churn data once — an ACCEPT that starts churning is promoted
 to REFACTOR.
 
-Trajectory: 27 → 22 (in flight) → ~13 (batches 2+3) → 12
-all-ACCEPT (batch 4).
+Trajectory: 27 → 22 (in flight) → ~13 (batches 2+3) → 13
+all-ACCEPT (batch 4; 13 not 12 after the refresh_incremental
+ACCEPT, 2026-07-15).

--- a/tests/unit/project_index/test_dependency_analysis_summary.py
+++ b/tests/unit/project_index/test_dependency_analysis_summary.py
@@ -1,0 +1,434 @@
+"""Characterization pins for DependencyAnalysisMixin._build_summary.
+
+Pins the CURRENT exact aggregation behavior (project_index/
+dependency_analysis.py) so a follow-up refactor of the radon-F48
+method can be proven behavior-preserving. Records are built
+in-memory; the real ProjectScanner (which carries the mixin and a
+real IndexConfig) runs the real method — no mocks.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under Apache 2.0
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from attune.project_index.models import (
+    FileCategory,
+    FileRecord,
+    ProjectSummary,
+    TestRequirement,
+)
+from attune.project_index.scanner import ProjectScanner
+
+
+def _rec(path: str, **kw) -> FileRecord:
+    return FileRecord(path=path, name=path.split("/")[-1], **kw)
+
+
+@pytest.fixture()
+def scanner(tmp_path) -> ProjectScanner:
+    """Real analyzer carrying the mixin, with the default IndexConfig."""
+    return ProjectScanner(project_root=str(tmp_path))
+
+
+def test_config_defaults_assumed_by_these_pins(scanner: ProjectScanner) -> None:
+    """The pins below depend on the default high-impact threshold."""
+    assert scanner.config.high_impact_threshold == 5.0
+
+
+class TestEmptyRecords:
+    def test_empty_records_leaves_all_defaults_untouched(self, scanner: ProjectScanner) -> None:
+        summary = scanner._build_summary([])
+
+        assert isinstance(summary, ProjectSummary)
+        # Counts
+        assert summary.total_files == 0
+        assert summary.source_files == 0
+        assert summary.test_files == 0
+        assert summary.config_files == 0
+        assert summary.doc_files == 0
+        # Testing health
+        assert summary.files_requiring_tests == 0
+        assert summary.files_with_tests == 0
+        assert summary.files_without_tests == 0
+        assert summary.test_coverage_avg == 0.0
+        assert summary.total_test_count == 0
+        # Staleness (guards: untouched)
+        assert summary.stale_file_count == 0
+        assert summary.avg_staleness_days == 0.0
+        assert summary.most_stale_files == []
+        # Code metrics (guards: untouched)
+        assert summary.total_lines_of_code == 0
+        assert summary.total_lines_of_test == 0
+        assert summary.test_to_code_ratio == 0.0
+        assert summary.avg_complexity == 0.0
+        # Quality (guards: untouched)
+        assert summary.files_with_docstrings_pct == 0.0
+        assert summary.files_with_type_hints_pct == 0.0
+        assert summary.total_lint_issues == 0
+        # Impact / attention
+        assert summary.high_impact_files == []
+        assert summary.critical_untested_files == []
+        assert summary.files_needing_attention == 0
+        assert summary.top_attention_files == []
+
+
+class TestRichMixedRecords:
+    """One rich fixture, every aggregation pinned to exact values."""
+
+    @pytest.fixture()
+    def records(self) -> list[FileRecord]:
+        return [
+            _rec(
+                "src/s1.py",
+                category=FileCategory.SOURCE,
+                test_requirement=TestRequirement.REQUIRED,
+                tests_exist=True,
+                # test_count on a non-TEST record must NOT be summed:
+                test_count=99,
+                coverage_percent=80.0,
+                lines_of_code=100,
+                complexity_score=10.0,
+                has_docstrings=True,
+                has_type_hints=True,
+                lint_issues=2,
+                impact_score=20.0,
+            ),
+            _rec(
+                "src/s2.py",
+                category=FileCategory.SOURCE,
+                test_requirement=TestRequirement.REQUIRED,
+                tests_exist=False,
+                coverage_percent=40.0,
+                is_stale=True,
+                staleness_days=30,
+                lines_of_code=200,
+                complexity_score=6.0,
+                has_type_hints=True,
+                lint_issues=1,
+                impact_score=12.0,
+                needs_attention=True,
+            ),
+            _rec(
+                "src/s3.py",
+                category=FileCategory.SOURCE,
+                test_requirement=TestRequirement.REQUIRED,
+                tests_exist=False,
+                coverage_percent=0.0,  # excluded from coverage avg
+                is_stale=True,
+                staleness_days=5,
+                lines_of_code=50,
+                complexity_score=2.0,
+                has_docstrings=True,
+                impact_score=4.0,  # below high_impact_threshold
+                needs_attention=True,
+            ),
+            _rec(
+                "src/s4.py",
+                category=FileCategory.SOURCE,
+                test_requirement=TestRequirement.OPTIONAL,
+                tests_exist=False,
+                lines_of_code=150,
+                complexity_score=4.0,
+                lint_issues=3,
+                impact_score=7.0,  # high impact but OPTIONAL -> not critical
+            ),
+            _rec(
+                "src/s5.py",
+                category=FileCategory.SOURCE,
+                test_requirement=TestRequirement.REQUIRED,
+                tests_exist=False,
+                lines_of_code=80,
+                complexity_score=3.0,
+                has_docstrings=True,
+                has_type_hints=True,
+                lint_issues=1,
+                impact_score=6.0,
+                needs_attention=True,
+            ),
+            _rec(
+                "tests/test_s1.py",
+                category=FileCategory.TEST,
+                test_requirement=TestRequirement.NOT_APPLICABLE,
+                test_count=12,
+                lines_of_code=60,
+                impact_score=1.0,
+            ),
+            _rec(
+                "tests/test_s2.py",
+                category=FileCategory.TEST,
+                test_requirement=TestRequirement.NOT_APPLICABLE,
+                test_count=8,
+                lines_of_code=40,
+                impact_score=0.5,
+            ),
+            _rec(
+                "pyproject.toml",
+                category=FileCategory.CONFIG,
+                test_requirement=TestRequirement.NOT_APPLICABLE,
+                lines_of_code=30,  # non-source LOC must not count
+            ),
+            _rec(
+                "README.md",
+                category=FileCategory.DOCS,
+                test_requirement=TestRequirement.NOT_APPLICABLE,
+                lines_of_code=25,  # non-source LOC must not count
+            ),
+        ]
+
+    @pytest.fixture()
+    def summary(self, scanner: ProjectScanner, records: list[FileRecord]) -> ProjectSummary:
+        return scanner._build_summary(records)
+
+    def test_category_counts(self, summary: ProjectSummary) -> None:
+        assert summary.total_files == 9
+        assert summary.source_files == 5
+        assert summary.test_files == 2
+        assert summary.config_files == 1
+        assert summary.doc_files == 1
+
+    def test_testing_health(self, summary: ProjectSummary) -> None:
+        assert summary.files_requiring_tests == 4  # s1, s2, s3, s5
+        assert summary.files_with_tests == 1  # s1 only
+        assert summary.files_without_tests == 3  # derived difference
+        # Only TEST-category records contribute; s1's test_count=99 ignored.
+        assert summary.total_test_count == 20
+
+    def test_coverage_average_only_over_covered_records(self, summary: ProjectSummary) -> None:
+        # s1 (80.0) and s2 (40.0); s3's 0.0 excluded from the denominator.
+        assert summary.test_coverage_avg == 60.0
+
+    def test_staleness_aggregation_and_ordering(self, summary: ProjectSummary) -> None:
+        assert summary.stale_file_count == 2
+        assert summary.avg_staleness_days == 17.5  # (30 + 5) / 2
+        assert summary.most_stale_files == ["src/s2.py", "src/s3.py"]
+
+    def test_lines_of_code_totals_and_ratio(self, summary: ProjectSummary) -> None:
+        # Source LOC only (100+200+50+150+80); config/docs LOC excluded.
+        assert summary.total_lines_of_code == 580
+        assert summary.total_lines_of_test == 100  # 60 + 40
+        assert summary.test_to_code_ratio == 100 / 580
+
+    def test_avg_complexity_over_source_records(self, summary: ProjectSummary) -> None:
+        assert summary.avg_complexity == 5.0  # (10+6+2+4+3) / 5
+
+    def test_quality_percentages_and_lint_total(self, summary: ProjectSummary) -> None:
+        assert summary.files_with_docstrings_pct == 60.0  # s1, s3, s5 of 5
+        assert summary.files_with_type_hints_pct == 60.0  # s1, s2, s5 of 5
+        assert summary.total_lint_issues == 7  # 2+1+0+3+1 (all records)
+
+    def test_high_impact_files_filtered_and_ordered(self, summary: ProjectSummary) -> None:
+        # Top-10 by impact then filtered >= 5.0; s3 (4.0) is IN the top-10
+        # but excluded by the threshold filter.
+        assert summary.high_impact_files == [
+            "src/s1.py",
+            "src/s2.py",
+            "src/s4.py",
+            "src/s5.py",
+        ]
+
+    def test_critical_untested_files(self, summary: ProjectSummary) -> None:
+        # High impact + no tests + REQUIRED, ordered by impact desc.
+        # s1 excluded (has tests), s4 excluded (OPTIONAL), s3 (below threshold).
+        assert summary.critical_untested_files == ["src/s2.py", "src/s5.py"]
+
+    def test_attention_count_and_top_files(self, summary: ProjectSummary) -> None:
+        assert summary.files_needing_attention == 3
+        # Ordered by impact_score desc: s2 (12), s5 (6), s3 (4).
+        assert summary.top_attention_files == ["src/s2.py", "src/s5.py", "src/s3.py"]
+
+
+class TestGuardBranches:
+    def test_coverage_avg_untouched_when_no_covered_records(self, scanner: ProjectScanner) -> None:
+        records = [
+            _rec("src/a.py", category=FileCategory.SOURCE, coverage_percent=0.0),
+            _rec("src/b.py", category=FileCategory.SOURCE, coverage_percent=0.0),
+        ]
+        summary = scanner._build_summary(records)
+        assert summary.test_coverage_avg == 0.0
+
+    def test_staleness_untouched_when_no_stale_records(self, scanner: ProjectScanner) -> None:
+        records = [
+            _rec(
+                "src/a.py",
+                category=FileCategory.SOURCE,
+                is_stale=False,
+                staleness_days=99,  # ignored: not flagged stale
+            ),
+        ]
+        summary = scanner._build_summary(records)
+        assert summary.stale_file_count == 0
+        assert summary.avg_staleness_days == 0.0
+        assert summary.most_stale_files == []
+
+    def test_most_stale_files_top_five_by_staleness_days(self, scanner: ProjectScanner) -> None:
+        records = [
+            _rec(
+                f"src/f{i}.py",
+                category=FileCategory.SOURCE,
+                is_stale=True,
+                staleness_days=days,
+            )
+            for i, days in enumerate([3, 40, 7, 25, 12, 31, 1])
+        ]
+        summary = scanner._build_summary(records)
+        assert summary.stale_file_count == 7
+        assert summary.avg_staleness_days == (3 + 40 + 7 + 25 + 12 + 31 + 1) / 7
+        # Exactly 5, descending by staleness_days: 40, 31, 25, 12, 7.
+        assert summary.most_stale_files == [
+            "src/f1.py",
+            "src/f5.py",
+            "src/f3.py",
+            "src/f4.py",
+            "src/f2.py",
+        ]
+
+    def test_ratio_and_metrics_untouched_when_no_source_loc(self, scanner: ProjectScanner) -> None:
+        # TEST-only records: total_lines_of_code == 0 -> the ratio,
+        # avg_complexity, and quality percentages all stay at defaults
+        # even though test lines exist.
+        records = [
+            _rec(
+                "tests/test_x.py",
+                category=FileCategory.TEST,
+                lines_of_code=500,
+                complexity_score=9.0,
+                has_docstrings=True,
+                has_type_hints=True,
+                lint_issues=4,
+            ),
+        ]
+        summary = scanner._build_summary(records)
+        assert summary.total_lines_of_code == 0
+        assert summary.total_lines_of_test == 500
+        assert summary.test_to_code_ratio == 0.0
+        assert summary.avg_complexity == 0.0
+        assert summary.files_with_docstrings_pct == 0.0
+        assert summary.files_with_type_hints_pct == 0.0
+        # total_lint_issues sums ALL records (no source guard).
+        assert summary.total_lint_issues == 4
+
+    def test_source_with_zero_loc_still_gets_complexity_and_quality(
+        self, scanner: ProjectScanner
+    ) -> None:
+        # source_records non-empty but total LOC 0: ratio guard holds,
+        # avg_complexity and percentages DO compute.
+        records = [
+            _rec(
+                "src/empty.py",
+                category=FileCategory.SOURCE,
+                lines_of_code=0,
+                complexity_score=3.0,
+                has_docstrings=True,
+            ),
+            _rec("tests/test_empty.py", category=FileCategory.TEST, lines_of_code=10),
+        ]
+        summary = scanner._build_summary(records)
+        assert summary.total_lines_of_code == 0
+        assert summary.total_lines_of_test == 10
+        assert summary.test_to_code_ratio == 0.0  # guard: unchanged
+        assert summary.avg_complexity == 3.0
+        assert summary.files_with_docstrings_pct == 100.0
+        assert summary.files_with_type_hints_pct == 0.0
+
+
+class TestTopTenCaps:
+    def test_high_impact_capped_at_ten_descending(self, scanner: ProjectScanner) -> None:
+        # 12 records all above threshold -> only the top 10, descending.
+        records = [
+            _rec(
+                f"src/m{i:02d}.py",
+                category=FileCategory.SOURCE,
+                impact_score=float(20 - i),  # 20, 19, ..., 9
+            )
+            for i in range(12)
+        ]
+        summary = scanner._build_summary(records)
+        assert summary.high_impact_files == [f"src/m{i:02d}.py" for i in range(10)]
+
+    def test_critical_untested_capped_at_ten_descending(self, scanner: ProjectScanner) -> None:
+        records = [
+            _rec(
+                f"src/c{i:02d}.py",
+                category=FileCategory.SOURCE,
+                test_requirement=TestRequirement.REQUIRED,
+                tests_exist=False,
+                impact_score=float(30 - i),  # 30, 29, ..., 19
+            )
+            for i in range(12)
+        ]
+        summary = scanner._build_summary(records)
+        assert summary.critical_untested_files == [f"src/c{i:02d}.py" for i in range(10)]
+
+    def test_attention_count_uncapped_but_top_files_capped_at_ten(
+        self, scanner: ProjectScanner
+    ) -> None:
+        records = [
+            _rec(
+                f"src/a{i:02d}.py",
+                category=FileCategory.SOURCE,
+                needs_attention=True,
+                impact_score=float(12 - i),  # 12, 11, ..., 1
+            )
+            for i in range(12)
+        ]
+        summary = scanner._build_summary(records)
+        assert summary.files_needing_attention == 12
+        assert summary.top_attention_files == [f"src/a{i:02d}.py" for i in range(10)]
+
+
+class TestCriticalUntestedExclusions:
+    def test_each_exclusion_reason(self, scanner: ProjectScanner) -> None:
+        records = [
+            # Included: high impact, no tests, REQUIRED.
+            _rec(
+                "src/critical.py",
+                category=FileCategory.SOURCE,
+                test_requirement=TestRequirement.REQUIRED,
+                tests_exist=False,
+                impact_score=10.0,
+            ),
+            # Excluded: has tests.
+            _rec(
+                "src/tested.py",
+                category=FileCategory.SOURCE,
+                test_requirement=TestRequirement.REQUIRED,
+                tests_exist=True,
+                impact_score=11.0,
+            ),
+            # Excluded: not REQUIRED.
+            _rec(
+                "src/optional.py",
+                category=FileCategory.SOURCE,
+                test_requirement=TestRequirement.OPTIONAL,
+                tests_exist=False,
+                impact_score=12.0,
+            ),
+            # Excluded: below high_impact_threshold.
+            _rec(
+                "src/low.py",
+                category=FileCategory.SOURCE,
+                test_requirement=TestRequirement.REQUIRED,
+                tests_exist=False,
+                impact_score=4.9,
+            ),
+        ]
+        summary = scanner._build_summary(records)
+        assert summary.critical_untested_files == ["src/critical.py"]
+
+    def test_threshold_boundary_is_inclusive(self, scanner: ProjectScanner) -> None:
+        # impact_score == threshold (5.0) counts as high impact (>=).
+        records = [
+            _rec(
+                "src/edge.py",
+                category=FileCategory.SOURCE,
+                test_requirement=TestRequirement.REQUIRED,
+                tests_exist=False,
+                impact_score=5.0,
+            ),
+        ]
+        summary = scanner._build_summary(records)
+        assert summary.high_impact_files == ["src/edge.py"]
+        assert summary.critical_untested_files == ["src/edge.py"]

--- a/tests/unit/voice/test_formatter.py
+++ b/tests/unit/voice/test_formatter.py
@@ -9,6 +9,7 @@ from unittest.mock import patch
 from attune.voice import personality
 from attune.voice.formatter import (
     _extract_from_dict,
+    _extract_from_workflow_result,
     _extract_result_data,
     format_error,
     format_mcp_response,
@@ -652,3 +653,234 @@ class TestReportDisclosureAndDedup:
         output = format_output("release-prep", result)
         assert personality.HEADER_COST in output
         assert "$0.0042" in output
+
+
+# ---------------------------------------------------------------------------
+# CHARACTERIZATION PINS — _extract_from_workflow_result (radon D23)
+#
+# These tests pin the CURRENT behavior of the function exactly, tuple by
+# tuple, so a follow-up complexity-reduction refactor can be proven
+# behavior-preserving. Do not "fix" surprising behavior here (e.g. the
+# heading-without-items fallback output) — update a pin only alongside an
+# intentional, reviewed behavior change.
+# ---------------------------------------------------------------------------
+
+
+class TestExtractFromWorkflowResultCharacterization:
+    """Exact-tuple behavior pins for _extract_from_workflow_result."""
+
+    # Default _make_result cost_report: $0.0042 / 58% savings / 1500ms.
+    DEFAULT_COST_LINE = "$0.0042 (saved 58% vs premium) | 1.5s"
+
+    def _report_dict(self):
+        """Minimal serialized WorkflowReport, as final_output carries it."""
+        from attune.workflows.output import ProseSection, WorkflowReport
+
+        return WorkflowReport(
+            title="Code review",
+            summary="3 issues found.",
+            score=88,
+            sections=[
+                ProseSection(title="Overview", tier="essential", text="Solid."),
+            ],
+        ).to_dict()
+
+    def _bare_result(
+        self,
+        *,
+        final_output=None,
+        summary=None,
+        metadata=None,
+        success=True,
+        error=None,
+        cost_report=None,
+    ) -> WorkflowResult:
+        """WorkflowResult with NO default cost_report/final_output filling."""
+        now = datetime.now(timezone.utc)
+        return WorkflowResult(
+            success=success,
+            stages=[],
+            final_output=final_output,
+            cost_report=cost_report,
+            started_at=now,
+            completed_at=now,
+            total_duration_ms=1500,
+            error=error,
+            metadata=metadata or {},
+            summary=summary,
+        )
+
+    # -- report-dict final_output (rendered path) ------------------------
+
+    def test_pin_report_dict_renders_score_and_suppresses_cost_line(self):
+        """Rendered report: score from report, cost_line None despite cost_report."""
+        result = _make_result(final_output=self._report_dict())
+        with patch("attune.config.resolve_show_cost", return_value=False):
+            success, score, text, cost_line, error = _extract_from_workflow_result(result)
+        assert (success, score, cost_line, error) == (True, 88, None, None)
+        assert "# Code review" in text
+
+    def test_pin_render_failure_degrades_to_legacy_dict_fields(self):
+        """render_safe raising falls back to formatted_report/score from the dict."""
+        fo = self._report_dict()
+        fo["formatted_report"] = "legacy fallback text long enough to dodge the sparse fallback"
+        result = _make_result(final_output=fo)
+        with (
+            patch("attune.config.resolve_show_cost", return_value=False),
+            patch(
+                "attune.voice.report_renderer.render_safe",
+                side_effect=RuntimeError("boom"),
+            ),
+        ):
+            out = _extract_from_workflow_result(result)
+        assert out == (
+            True,
+            88,
+            "legacy fallback text long enough to dodge the sparse fallback",
+            self.DEFAULT_COST_LINE,
+            None,
+        )
+
+    # -- legacy dict / str / bespoke object paths ------------------------
+
+    def test_pin_legacy_dict_without_report(self):
+        """Plain dict final_output: formatted_report/score picked, cost line built."""
+        result = _make_result(final_output={"formatted_report": "x" * 60, "score": 70})
+        out = _extract_from_workflow_result(result)
+        assert out == (True, 70, "x" * 60, self.DEFAULT_COST_LINE, None)
+
+    def test_pin_str_final_output_passthrough(self):
+        """String final_output passes through untouched, score stays None."""
+        text = "## Findings\n\n- one\n- two\n- three, padding to clear fifty chars"
+        result = _make_result(final_output=text)
+        out = _extract_from_workflow_result(result)
+        assert out == (True, None, text, self.DEFAULT_COST_LINE, None)
+
+    def test_pin_unmigrated_object_banner_skips_sparse_fallback(self):
+        """Bespoke object: banner text is authoritative (rendered=True)."""
+
+        @dataclass
+        class FakeThing:
+            approved: bool = True
+
+        result = _make_result(final_output=FakeThing())
+        result.summary = "should not appear"
+        result.metadata = {"findings": {"security_issues": ["nope"]}}
+        success, score, text, cost_line, error = _extract_from_workflow_result(result)
+        assert text == (
+            "⚠ Renderer not yet migrated for FakeThing. Raw fields:\n\n  approved: True"
+        )
+        assert "## Security Issues" not in text
+        assert (success, score, cost_line, error) == (
+            True,
+            None,
+            self.DEFAULT_COST_LINE,
+            None,
+        )
+
+    # -- sparse fallback: summary + metadata findings --------------------
+
+    def test_pin_sparse_fallback_summary_only(self):
+        """No final_output: report_text becomes the bare summary."""
+        result = self._bare_result(summary="Run finished.")
+        out = _extract_from_workflow_result(result)
+        assert out == (True, None, "Run finished.", None, None)
+
+    def test_pin_sparse_fallback_summary_plus_findings_lists(self):
+        """Findings dict: '## Title Cased' headings + '- item' lines, exact join."""
+        result = self._bare_result(
+            summary="Scan done.",
+            metadata={
+                "findings": {
+                    "security_issues": ["issue a", "issue b"],
+                    "code_smells": ["smell c"],
+                },
+            },
+        )
+        out = _extract_from_workflow_result(result)
+        expected_text = (
+            "Scan done.\n"
+            "\n## Security Issues\n"
+            "- issue a\n"
+            "- issue b\n"
+            "\n## Code Smells\n"
+            "- smell c"
+        )
+        assert out == (True, None, expected_text, None, None)
+
+    def test_pin_sparse_fallback_non_list_findings_value_emits_heading_only(self):
+        """Non-list category value: heading still emitted, items silently skipped."""
+        result = self._bare_result(metadata={"findings": {"raw_stats": {"n": 3}}})
+        out = _extract_from_workflow_result(result)
+        assert out == (True, None, "\n## Raw Stats", None, None)
+
+    def test_pin_sparse_fallback_non_dict_findings_ignored(self):
+        """findings that is not a dict contributes nothing — report_text stays None."""
+        result = self._bare_result(metadata={"findings": ["not", "a", "dict"]})
+        out = _extract_from_workflow_result(result)
+        assert out == (True, None, None, None, None)
+
+    def test_pin_empty_fallback_parts_leave_short_report_text_unchanged(self):
+        """No summary/findings: a short report_text survives untouched."""
+        result = self._bare_result(final_output={"formatted_report": "tiny"})
+        out = _extract_from_workflow_result(result)
+        assert out == (True, None, "tiny", None, None)
+
+    def test_pin_sparse_fallback_replaces_short_report_text(self):
+        """Fallback REPLACES (not appends to) a sub-50-char report_text."""
+        result = self._bare_result(
+            final_output={"formatted_report": "short"},
+            summary="The summary wins.",
+        )
+        out = _extract_from_workflow_result(result)
+        assert out == (True, None, "The summary wins.", None, None)
+
+    # -- cost line variants ----------------------------------------------
+
+    def test_pin_cost_line_with_savings(self):
+        """savings_percent > 0: two-part cost line plus duration."""
+        result = _make_result(final_output={"formatted_report": "x" * 60})
+        _, _, _, cost_line, _ = _extract_from_workflow_result(result)
+        assert cost_line == "$0.0042 (saved 58% vs premium) | 1.5s"
+
+    def test_pin_cost_line_without_savings_segment(self):
+        """savings_percent == 0: no '(saved ...)' segment, just cost | duration."""
+        result = _make_result(
+            final_output={"formatted_report": "x" * 60},
+            cost_report=CostReport(
+                total_cost=0.01,
+                baseline_cost=0.01,
+                savings=0.0,
+                savings_percent=0.0,
+            ),
+        )
+        out = _extract_from_workflow_result(result)
+        assert out == (True, None, "x" * 60, "$0.0100 | 1.5s", None)
+
+    def test_pin_none_cost_report_yields_none_cost_line(self):
+        """cost_report None: cost_line is None, everything else unaffected."""
+        result = self._bare_result(final_output={"formatted_report": "x" * 60})
+        out = _extract_from_workflow_result(result)
+        assert out == (True, None, "x" * 60, None, None)
+
+    # -- error_msg gating --------------------------------------------------
+
+    def test_pin_error_surfaces_only_on_failure(self):
+        """result.error becomes error_msg only when success is False."""
+        result = self._bare_result(
+            success=False,
+            error="boom",
+            final_output={"formatted_report": "x" * 60},
+        )
+        out = _extract_from_workflow_result(result)
+        assert out == (False, None, "x" * 60, None, "boom")
+
+    def test_pin_error_masked_on_success(self):
+        """A populated result.error is dropped when success is True."""
+        result = self._bare_result(
+            success=True,
+            error="ignored",
+            final_output={"formatted_report": "x" * 60},
+        )
+        out = _extract_from_workflow_result(result)
+        assert out == (True, None, "x" * 60, None, None)

--- a/tests/unit/workflows/test_doc_gen_report_formatter.py
+++ b/tests/unit/workflows/test_doc_gen_report_formatter.py
@@ -1,0 +1,403 @@
+"""Characterization tests (behavior pins) for format_doc_gen_report.
+
+These tests pin the CURRENT exact behavior of
+``attune.workflows.document_gen.report_formatter.format_doc_gen_report``
+before a complexity refactor (radon D29). Do not "fix" expected output
+here without a deliberate behavior change — the refactor must be
+provably behavior-preserving against these pins.
+
+The function is pure (dict in, str out) — no fixtures or patching.
+"""
+
+from attune.workflows.document_gen.report_formatter import format_doc_gen_report
+
+EQ = "=" * 60
+DASH = "-" * 60
+
+
+# ---------------------------------------------------------------------------
+# Full-output pins (exact ==)
+# ---------------------------------------------------------------------------
+
+EXPECTED_MINIMAL = """\
+============================================================
+DOCUMENTATION GENERATION REPORT
+============================================================
+
+Document Type: General
+Target Audience: Developers
+
+------------------------------------------------------------
+STATISTICS
+------------------------------------------------------------
+Word Count: 0
+Section Count: ~0
+
+============================================================
+Generated using unknown tier model
+============================================================"""
+
+
+def test_minimal_inputs_full_pin() -> None:
+    """Empty dicts: defaults everywhere, only header/stats/footer emitted."""
+    out = format_doc_gen_report({}, {})
+    assert out == EXPECTED_MINIMAL
+
+
+RICH_OUTLINE = """\
+1. Introduction
+   - overview
+2. Usage
+   - basics
+3. Advanced
+   - tips
+4. FAQ
+   - common
+5. Appendix
+   - extras
+6. Glossary
+   - terms"""
+
+RICH_DOCUMENT = """\
+## Intro
+Alpha beta gamma.
+
+## Usage
+Delta epsilon."""
+
+EXPECTED_RICH = """\
+============================================================
+DOCUMENTATION GENERATION REPORT
+============================================================
+
+Document Type: Api Reference
+Target Audience: End Users
+
+------------------------------------------------------------
+DOCUMENT OUTLINE
+------------------------------------------------------------
+1. Introduction
+   - overview
+2. Usage
+   - basics
+3. Advanced
+   - tips
+4. FAQ
+   - common
+5. Appendix
+   - extras
+...
+
+------------------------------------------------------------
+GENERATED DOCUMENTATION
+------------------------------------------------------------
+
+## Intro
+Alpha beta gamma.
+
+## Usage
+Delta epsilon.
+
+------------------------------------------------------------
+STATISTICS
+------------------------------------------------------------
+Word Count: 9
+Section Count: ~2
+Generation Mode: Chunked (2/4 chunks completed)
+Polish Mode: Chunked (3 sections)
+Estimated Cost: $1.50
+
+------------------------------------------------------------
+FILE EXPORT
+------------------------------------------------------------
+Documentation saved to: /tmp/out.md
+Report saved to: /tmp/report.md
+
+Full documentation is available in the exported file.
+
+------------------------------------------------------------
+⚠️  WARNING
+------------------------------------------------------------
+Cost limit reached
+
+------------------------------------------------------------
+SCOPE NOTICE
+------------------------------------------------------------
+⚠️  DOCUMENTATION MAY BE INCOMPLETE
+   Planned sections: 6
+   Generated sections: 2
+
+To generate missing sections, re-run with section_focus:
+   workflow = DocumentGenerationWorkflow(
+       section_focus=["Testing Guide", "API Reference"]
+   )
+
+============================================================
+Generated using capable tier model
+============================================================"""
+
+
+def test_rich_inputs_full_pin() -> None:
+    """Every optional section active at once, pinned end to end.
+
+    Exercises: underscore->title transforms, >10-line outline
+    truncation ("..."), document section, chunked+stopped_early stats,
+    polish_chunked, cost line, export with report_path, input warning,
+    scope notice with planned-sections sub-branch, explicit model tier.
+    """
+    result = {
+        "doc_type": "api_reference",
+        "audience": "end_users",
+        "document": RICH_DOCUMENT,
+        "accumulated_cost": 1.5,
+        "polish_chunked": True,
+        "polish_chunks": 3,
+        "export_path": "/tmp/out.md",
+        "report_path": "/tmp/report.md",
+        "model_tier_used": "capable",
+    }
+    input_data = {
+        "outline": RICH_OUTLINE,
+        "chunked": True,
+        "chunk_count": 4,
+        "chunks_completed": 2,
+        "stopped_early": True,
+        "warning": "Cost limit reached",
+    }
+    out = format_doc_gen_report(result, input_data)
+    assert out == EXPECTED_RICH
+
+
+# ---------------------------------------------------------------------------
+# Header
+# ---------------------------------------------------------------------------
+
+
+def test_header_underscore_title_transform() -> None:
+    out = format_doc_gen_report({"doc_type": "user_guide", "audience": "new_team_members"}, {})
+    assert "Document Type: User Guide" in out
+    assert "Target Audience: New Team Members" in out
+
+
+# ---------------------------------------------------------------------------
+# Outline
+# ---------------------------------------------------------------------------
+
+
+def test_outline_short_no_truncation_marker() -> None:
+    """Outline of exactly 10 lines shows fully, no '...' line."""
+    outline = "\n".join(f"line {i}" for i in range(10))
+    out = format_doc_gen_report({}, {"outline": outline})
+    assert "DOCUMENT OUTLINE" in out
+    assert "line 9" in out
+    assert "\n...\n" not in out
+
+
+def test_outline_eleven_lines_truncated_with_ellipsis() -> None:
+    outline = "\n".join(f"line {i}" for i in range(11))
+    out = format_doc_gen_report({}, {"outline": outline})
+    assert "line 9" in out
+    assert "line 10" not in out
+    assert "\n...\n" in out
+
+
+# ---------------------------------------------------------------------------
+# Statistics / chunking
+# ---------------------------------------------------------------------------
+
+
+def test_chunked_without_stopped_early() -> None:
+    out = format_doc_gen_report({}, {"chunked": True, "chunk_count": 4})
+    assert "Generation Mode: Chunked (4 chunks)" in out
+    assert "chunks completed" not in out
+
+
+def test_chunks_completed_defaults_to_chunk_count() -> None:
+    """Without chunks_completed, stopped_early reports N/N completed."""
+    out = format_doc_gen_report({}, {"chunked": True, "chunk_count": 3, "stopped_early": True})
+    assert "Generation Mode: Chunked (3/3 chunks completed)" in out
+
+
+def test_not_chunked_omits_generation_mode() -> None:
+    out = format_doc_gen_report({}, {"chunk_count": 5})
+    assert "Generation Mode" not in out
+
+
+def test_polish_chunked_defaults_polish_chunks_to_zero() -> None:
+    out = format_doc_gen_report({"polish_chunked": True}, {})
+    assert "Polish Mode: Chunked (0 sections)" in out
+
+
+def test_zero_cost_omits_cost_line() -> None:
+    out = format_doc_gen_report({"accumulated_cost": 0}, {})
+    assert "Estimated Cost" not in out
+
+
+def test_positive_cost_formatted_two_decimals() -> None:
+    out = format_doc_gen_report({"accumulated_cost": 0.005}, {})
+    assert "Estimated Cost: $0.01" in out
+
+
+def test_word_and_section_counts_from_document() -> None:
+    """word count is whitespace-split tokens (## markers count as words);
+    section count is raw '##' substring occurrences."""
+    out = format_doc_gen_report({"document": "## A\none two\n## B\nthree"}, {})
+    assert "Word Count: 7" in out
+    assert "Section Count: ~2" in out
+    assert "GENERATED DOCUMENTATION" in out
+
+
+# ---------------------------------------------------------------------------
+# Export
+# ---------------------------------------------------------------------------
+
+
+def test_export_path_without_report_path() -> None:
+    out = format_doc_gen_report({"export_path": "/tmp/doc.md"}, {})
+    assert "FILE EXPORT" in out
+    assert "Documentation saved to: /tmp/doc.md" in out
+    assert "Report saved to:" not in out
+    assert "Full documentation is available in the exported file." in out
+
+
+def test_no_export_path_omits_export_section() -> None:
+    out = format_doc_gen_report({"report_path": "/tmp/r.md"}, {})
+    # report_path alone is ignored — export section keyed on export_path
+    assert "FILE EXPORT" not in out
+    assert "Report saved to:" not in out
+
+
+# ---------------------------------------------------------------------------
+# Warnings
+# ---------------------------------------------------------------------------
+
+
+def test_warning_from_result() -> None:
+    out = format_doc_gen_report({"warning": "result-side warning"}, {})
+    assert "⚠️  WARNING" in out
+    assert "result-side warning" in out
+
+
+def test_input_warning_takes_precedence_over_result() -> None:
+    out = format_doc_gen_report({"warning": "from result"}, {"warning": "from input"})
+    assert "from input" in out
+    assert "from result" not in out
+
+
+def test_empty_input_warning_falls_back_to_result() -> None:
+    """Falsy input warning ('' ) falls through the `or` to result's."""
+    out = format_doc_gen_report({"warning": "from result"}, {"warning": ""})
+    assert "from result" in out
+
+
+def test_stopped_early_without_warning_default_message() -> None:
+    out = format_doc_gen_report({}, {"stopped_early": True})
+    assert "⚠️  WARNING" in out
+    assert "Generation stopped early due to cost or error limits." in out
+
+
+def test_stopped_early_with_warning_no_default_message() -> None:
+    out = format_doc_gen_report({}, {"stopped_early": True, "warning": "budget hit"})
+    assert "budget hit" in out
+    assert "Generation stopped early due to cost or error limits." not in out
+
+
+def test_no_warning_no_warning_section() -> None:
+    out = format_doc_gen_report({}, {})
+    assert "WARNING" not in out
+
+
+# ---------------------------------------------------------------------------
+# Truncation indicators -> SCOPE NOTICE
+# ---------------------------------------------------------------------------
+
+
+def test_truncation_trailing_ellipsis() -> None:
+    out = format_doc_gen_report({"document": "Some words trailing off..."}, {})
+    assert "SCOPE NOTICE" in out
+    assert "⚠️  DOCUMENTATION MAY BE INCOMPLETE" in out
+    # no outline -> planned_sections == 0 -> counts sub-branch skipped
+    assert "Planned sections:" not in out
+    assert "Generated sections:" not in out
+    assert 'section_focus=["Testing Guide", "API Reference"]' in out
+
+
+def test_truncation_trailing_dash() -> None:
+    out = format_doc_gen_report({"document": "A sentence cut mid -"}, {})
+    assert "SCOPE NOTICE" in out
+
+
+def test_truncation_unclosed_code_fence() -> None:
+    out = format_doc_gen_report({"document": "Intro text\n```python\nx = 1\nstill open"}, {})
+    assert "SCOPE NOTICE" in out
+
+
+def test_even_code_fences_not_truncated() -> None:
+    out = format_doc_gen_report({"document": "Intro\n```py\nx = 1\n```\nAll closed here"}, {})
+    assert "SCOPE NOTICE" not in out
+
+
+def test_truncation_continuation_phrase_case_insensitive() -> None:
+    out = format_doc_gen_report({"document": "Chapter one. To Be Continued in the sequel"}, {})
+    assert "SCOPE NOTICE" in out
+
+
+def test_clean_document_no_scope_notice() -> None:
+    out = format_doc_gen_report({"document": "## Alpha\nAll good here"}, {})
+    assert "SCOPE NOTICE" not in out
+
+
+# ---------------------------------------------------------------------------
+# Planned-sections regex + scope-notice threshold
+# ---------------------------------------------------------------------------
+
+
+def test_planned_sections_regex_counting() -> None:
+    """Only stripped lines matching r'^(\\d+)\\.\\s+([A-Za-z].*)' count.
+
+    '2) Skip' (paren), 'A. Skip' (letter), '3. 42skip' (digit after
+    number) are NOT counted; indented and multi-digit numbered lines ARE.
+    """
+    outline = "\n".join(
+        [
+            "1. Introduction",
+            "2) Skip paren style",
+            "A. Skip letter style",
+            "3. 42skip digit-first title",
+            "  4. Indented counted",
+            "10. Ten counted",
+        ]
+    )
+    # No document -> section_count 0 < planned - 1 -> scope notice fires
+    out = format_doc_gen_report({}, {"outline": outline})
+    assert "SCOPE NOTICE" in out
+    assert "   Planned sections: 3" in out
+    assert "   Generated sections: 0" in out
+
+
+def test_no_scope_notice_when_sections_meet_plan() -> None:
+    """section_count == planned - 1 is tolerated (strict < in the check).
+
+    Note: the second disjunct `planned_sections > section_count + 1` is
+    mathematically equivalent to the planned-sections half of
+    is_truncated, so it never fires independently — pinned as-is.
+    """
+    outline = "1. Alpha\n2. Beta"
+    out = format_doc_gen_report({"document": "## Alpha\nwords only here"}, {"outline": outline})
+    # planned=2, section_count=1: 1 < 1 is False and 2 > 2 is False
+    assert "SCOPE NOTICE" not in out
+
+
+# ---------------------------------------------------------------------------
+# Footer
+# ---------------------------------------------------------------------------
+
+
+def test_footer_model_tier_default_unknown() -> None:
+    out = format_doc_gen_report({}, {})
+    assert out.endswith(f"Generated using unknown tier model\n{EQ}")
+
+
+def test_footer_model_tier_explicit() -> None:
+    out = format_doc_gen_report({"model_tier_used": "premium"}, {})
+    assert "Generated using premium tier model" in out


### PR DESCRIPTION
## What

Pins half of Batch 3 (formatters + the last F) from `docs/reports/d-block-triage-2026-07-14.md` — characterization tests making the follow-up cuts for `format_doc_gen_report` (D29), `DependencyAnalysisMixin._build_summary` (**F48, the last F on the ledger**), and `_extract_from_workflow_result` (D23) provable behavior preservation. Three parallel pin lanes, all receipts re-run centrally.

- **`format_doc_gen_report`** — was **1% covered**; now **100% line+branch**. 30 pins including two full golden-output exact matches. Lane finding for the cut: the scope-notice disjunct (`planned > sections+1`) is mathematically redundant with `is_truncated` — pinned as current behavior.
- **`_build_summary`** — 22 pins through the real `ProjectScanner` + default `IndexConfig`: empty-record defaults, exact aggregates, every guard branch, top-N orderings (heapq tie-order deliberately unpinned — distinct keys only — so an equivalent `sorted()[:n]` refactor can't false-fail).
- **`_extract_from_workflow_result`** — 16 exact-tuple pins covering the previously-unpinned metadata-findings fallback loop and zero-savings cost line; zero uncovered lines remain inside the target.

Also records two triage-doc updates: **`refresh_incremental` DELETE-hold → ACCEPT** (Patrick decided 2026-07-15; zero production callers but tested/documented public API with ~zero churn — ledger keeps the entry, ACCEPT 12→13), and the batch-3 **scope correction** (`_section_html` is an ACCEPT-table entry; the plan paragraph contradicted the table).

## Receipts (central, not lane self-reports)

- 117 tests across the three pin files: serial pass.
- 270-test project_index + voice + formatter sweep: serial pass.
- Branch coverage measured before/after: all three target functions fully covered; remaining module gaps are outside the cut scope.
- No production code changes; cuts PR follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
