### PR TITLE
fix(llm): refusal check on all Anthropic calls + fable adaptive-thinking headroom

### DIFF
--- a/src/attune/llm/fable_call.py
+++ b/src/attune/llm/fable_call.py
@@ -13,7 +13,11 @@ before anyone debugs the payload.
 Call sites swap ``client.messages.create(...)`` for
 ``create_with_fable(client, model=model, **kwargs)`` (or the async
 twin) and change nothing else: non-fable models take the exact
-pre-tier code path, byte-identical payload, no refusal check.
+pre-tier payload (no beta namespace, no ``extra_body`` fallbacks,
+no retention-hinted 400), but a ``stop_reason == "refusal"`` still
+raises :class:`~attune.model_tiers.ModelRefusalError` regardless of
+tier — a refusal is a verdict on any model, not just fable's
+server-side fallback chain.
 
 Response-consuming note for call sites: fable responses can lead with
 a thinking block that has no ``.text`` — read the first TEXT block,
@@ -33,6 +37,22 @@ _RETENTION_HINT = (
     "claude-fable-5 requires >=30-day org data retention - check the "
     "org's retention configuration before debugging the payload."
 )
+
+#: Fable is adaptive-thinking-by-default with no opt-out (even
+#: ``{"type": "disabled"}`` is a 400), and thinking output counts toward
+#: ``max_tokens`` — so a low caller cap (1024, 3000) can be eaten by the
+#: thinking block, truncating the answer. Mirror the explicit-thinking
+#: guard in ``providers/anthropic.py``: when the cap is at or below this
+#: headroom, grow it so the answer keeps its requested room. Caps already
+#: above the headroom are the caller's deliberate budget — untouched.
+#: (Fable's max output is 128K, so the grown cap is always in range.)
+_ADAPTIVE_THINKING_HEADROOM = 10_000
+
+
+def _grow_max_tokens_for_adaptive(kwargs: dict[str, Any]) -> None:
+    max_tokens = kwargs.get("max_tokens")
+    if isinstance(max_tokens, int) and max_tokens <= _ADAPTIVE_THINKING_HEADROOM:
+        kwargs["max_tokens"] = _ADAPTIVE_THINKING_HEADROOM + max_tokens
 
 
 def _refusal(model: str, response: Any) -> ModelRefusalError:
@@ -67,13 +87,17 @@ def _hinted_400(exc: Exception) -> Exception:
 def create_with_fable(client: Any, *, model: str, **kwargs: Any) -> Any:
     """Send one Messages request, routing fable models via the beta API.
 
-    Returns the raw SDK response. Raises ModelRefusalError when a fable
-    call's whole fallback chain refused; re-raises a fable 400 with the
-    retention hint appended (original chained as ``__cause__``).
+    Returns the raw SDK response. Raises ModelRefusalError on any
+    ``stop_reason == "refusal"``, fable or not; re-raises a fable 400
+    with the retention hint appended (original chained as ``__cause__``).
     """
     extras = fable_extras(model)
     if not extras:
-        return client.messages.create(model=model, **kwargs)
+        response = client.messages.create(model=model, **kwargs)
+        if getattr(response, "stop_reason", None) == "refusal":
+            raise _refusal(model, response)
+        return response
+    _grow_max_tokens_for_adaptive(kwargs)
     try:
         response = client.beta.messages.create(model=model, **kwargs, **extras)
     except Exception as exc:
@@ -89,7 +113,11 @@ async def acreate_with_fable(client: Any, *, model: str, **kwargs: Any) -> Any:
     """Async twin of :func:`create_with_fable` (AsyncAnthropic clients)."""
     extras = fable_extras(model)
     if not extras:
-        return await client.messages.create(model=model, **kwargs)
+        response = await client.messages.create(model=model, **kwargs)
+        if getattr(response, "stop_reason", None) == "refusal":
+            raise _refusal(model, response)
+        return response
+    _grow_max_tokens_for_adaptive(kwargs)
     try:
         response = await client.beta.messages.create(model=model, **kwargs, **extras)
     except Exception as exc:

--- a/tests/unit/llm/test_fable_call.py
+++ b/tests/unit/llm/test_fable_call.py
@@ -13,7 +13,12 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from attune.llm.fable_call import _RETENTION_HINT, acreate_with_fable, create_with_fable
+from attune.llm.fable_call import (
+    _ADAPTIVE_THINKING_HEADROOM,
+    _RETENTION_HINT,
+    acreate_with_fable,
+    create_with_fable,
+)
 from attune.model_tiers import ModelRefusalError
 
 FABLE = "claude-fable-5"
@@ -81,11 +86,15 @@ class TestSync:
             create_with_fable(client, model=FABLE, max_tokens=64)
         assert excinfo.value.category == "c"
 
-    def test_non_fable_refusal_stop_reason_not_checked(self):
+    def test_non_fable_refusal_also_raises(self):
         client = MagicMock()
-        client.messages.create.return_value = _response("t", stop_reason="refusal")
-        resp = create_with_fable(client, model=OPUS, max_tokens=64)
-        assert resp.content[0].text == "t"
+        refusal = _response("t", stop_reason="refusal")
+        refusal.stop_details = SimpleNamespace(category="harmful", explanation="no")
+        client.messages.create.return_value = refusal
+        with pytest.raises(ModelRefusalError) as excinfo:
+            create_with_fable(client, model=OPUS, max_tokens=64)
+        assert excinfo.value.category == "harmful"
+        client.beta.messages.create.assert_not_called()
 
     def test_fable_400_carries_retention_hint_same_type(self):
         client = MagicMock()
@@ -117,6 +126,26 @@ class TestSync:
             create_with_fable(client, model=OPUS, max_tokens=64)
         assert _RETENTION_HINT not in str(excinfo.value)
 
+    def test_fable_low_max_tokens_grows_for_adaptive_thinking(self):
+        client = MagicMock()
+        client.beta.messages.create.return_value = _response()
+        create_with_fable(client, model=FABLE, max_tokens=1024)
+        sent = client.beta.messages.create.call_args.kwargs["max_tokens"]
+        assert sent == _ADAPTIVE_THINKING_HEADROOM + 1024
+
+    def test_fable_large_max_tokens_untouched(self):
+        client = MagicMock()
+        client.beta.messages.create.return_value = _response()
+        create_with_fable(client, model=FABLE, max_tokens=_ADAPTIVE_THINKING_HEADROOM + 1)
+        sent = client.beta.messages.create.call_args.kwargs["max_tokens"]
+        assert sent == _ADAPTIVE_THINKING_HEADROOM + 1
+
+    def test_non_fable_max_tokens_never_grows(self):
+        client = MagicMock()
+        client.messages.create.return_value = _response()
+        create_with_fable(client, model=OPUS, max_tokens=64)
+        assert client.messages.create.call_args.kwargs["max_tokens"] == 64
+
 
 class TestAsync:
     @pytest.mark.asyncio
@@ -146,6 +175,16 @@ class TestAsync:
         with pytest.raises(ModelRefusalError) as excinfo:
             await acreate_with_fable(client, model=FABLE, max_tokens=64)
         assert excinfo.value.category is None
+
+    @pytest.mark.asyncio
+    async def test_non_fable_refusal_also_raises(self):
+        client = MagicMock()
+        refusal = _response("t", stop_reason="refusal")
+        refusal.stop_details = None
+        client.messages.create = AsyncMock(return_value=refusal)
+        with pytest.raises(ModelRefusalError):
+            await acreate_with_fable(client, model=OPUS, max_tokens=64)
+        client.beta.messages.create.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_fable_400_carries_retention_hint(self):


### PR DESCRIPTION
Two `fable_call.py` correctness fixes from the weekly-report carry-over sweep (July-6 Rec #2 and the fable half of Rec #4):

## 1. Refusal check on all Anthropic calls

`stop_reason == "refusal"` now raises `ModelRefusalError` on **non-fable** calls too. Previously only the fable/beta path checked, so a refusal on Sonnet/Opus silently returned as a normal truncated `LLMResponse` (`finish_reason="refusal"`, partial content). Every call site (curator, release base_agent, meta_workflows llm_execution, AnthropicProvider) already catches `ModelRefusalError` — zero call-site changes.

## 2. Fable adaptive-thinking max_tokens headroom

Fable is adaptive-thinking-by-default with no opt-out (even `{"type": "disabled"}` is a 400), and thinking output counts toward `max_tokens` — so a low caller cap could have its answer eaten by the thinking block (`base_agent.py` calls with `max_tokens=1024`; code_review 3000; bug_predict 2000). Fable-routed calls now grow caps ≤ 10k by a 10k headroom, mirroring the explicit-thinking guard in `providers/anthropic.py`. Caps above the headroom are the caller's deliberate budget and stay untouched.

## Receipts

- `tests/unit/llm/test_fable_call.py`: 17/17 (5 new: non-fable refusal sync+async, low-cap growth, large-cap untouched, non-fable never grows)
- Serial call-site sweep (`curator` + `agents/release` + `meta_workflows` + `llm`): **709 passed**
- Pinned pre-commit black/ruff clean pre-staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)
