### PR TITLE
chore(rules): move Markdown Formatting to a path-scoped JIT rule

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -43,28 +43,6 @@ Use `/hub-name` to access organized workflows:
 
 ---
 
-## Markdown Formatting
-
-All `.md` files should follow these rules:
-
-- Start every `.md` file with a single `#` (h1) heading
-- Heading levels must increment by one (don't skip from
-  `#` to `###`)
-- Put a single space after `#` in headings
-- Surround headings with blank lines (one above, one below)
-- Surround fenced code blocks (```) with blank lines
-- Surround lists with blank lines
-- Use `-` (dash) for unordered list markers, not `*` or `+`
-- No trailing whitespace on lines
-- No hard tabs — use spaces
-- No multiple consecutive blank lines
-- End files with a single trailing newline
-- Keep lines under 80 characters (except tables and URLs)
-- Do not manually pad or align table cells with extra
-  spaces — tables are exempt from trailing space rules
-
----
-
 ## Code Simplification
 
 After writing or modifying code, review it for unnecessary

--- a/.claude/rules/attune/INDEX.md
+++ b/.claude/rules/attune/INDEX.md
@@ -42,6 +42,9 @@ They do NOT fire when only WRITING a new file — pull manually then:
 - **Elicitation constructs (decision/pushback/progress forms)** →
   `communication-grammar.md` — the construct family + how to add
   the next member.
+- **Writing/editing any `.md` file** → `markdown-formatting.md` —
+  heading/list/table formatting rules; migrated 2026-07-15 from
+  the always-loaded CLAUDE.md.
 
 Resident (full bodies load every session): `decision-routine.md`,
 `xml-enhanced-prompts.md`, `output-formatting.md`. Budget enforced

--- a/.claude/rules/attune/markdown-formatting.md
+++ b/.claude/rules/attune/markdown-formatting.md
@@ -1,0 +1,30 @@
+---
+paths:
+  - "**/*.md"
+---
+
+# Markdown Formatting
+
+**Migrated:** 2026-07-15 (from `.claude/CLAUDE.md`, via `/doctor`
+lazy-loading check) — task-specific, only relevant when authoring
+or editing `.md` files.
+
+---
+
+All `.md` files should follow these rules:
+
+- Start every `.md` file with a single `#` (h1) heading
+- Heading levels must increment by one (don't skip from
+  `#` to `###`)
+- Put a single space after `#` in headings
+- Surround headings with blank lines (one above, one below)
+- Surround fenced code blocks (```) with blank lines
+- Surround lists with blank lines
+- Use `-` (dash) for unordered list markers, not `*` or `+`
+- No trailing whitespace on lines
+- No hard tabs — use spaces
+- No multiple consecutive blank lines
+- End files with a single trailing newline
+- Keep lines under 80 characters (except tables and URLs)
+- Do not manually pad or align table cells with extra
+  spaces — tables are exempt from trailing space rules


### PR DESCRIPTION
`/doctor` lazy-loading pass (2026-07-15): the **Markdown Formatting** section of `.claude/CLAUDE.md` only matters when authoring or editing `.md` files, so it moves to a path-scoped rule:

- New: `.claude/rules/attune/markdown-formatting.md` with `paths: "**/*.md"` frontmatter — loads only when working with markdown files
- `.claude/CLAUDE.md`: section removed (~500 chars off the always-resident budget, every session)
- `.claude/rules/attune/INDEX.md`: trip-wire entry added

Rules content is verbatim — no formatting rule changed. Continues the rules-corpus-jit residency work (#1236).

Receipts: `tests/unit/rules/` + `tests/unit/lessons/` — 30 passed (residency budget + core-mirror drift guards green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
