### PR TITLE
feat(docs-wiring): v1.1 — nav, features.yaml, and mkdocstrings checks (spec Phase 4)

### DIFF
--- a/.audit/orphans.yml
+++ b/.audit/orphans.yml
@@ -1,0 +1,31 @@
+# Orphan allowlist for scripts/audit_docs_wiring.py (nav check).
+#
+# Every entry needs a "# reason:" comment on the preceding line —
+# the loader enforces it. Entries are docs-relative subtree prefixes
+# (trailing slash), globs, or exact paths. An entry here means "this
+# builds but is deliberately not nav-reachable"; prefer exclude_docs
+# in mkdocs.yml when the page shouldn't build at all.
+
+orphan_subtrees:
+  # reason: blog drafts/social copies — the website reads content/blog, not docs/blog; repo-only working copies
+  - docs/blog/
+  # reason: session/health reports — repo-only records, linked from specs and PRs, not site nav
+  - docs/reports/
+  # reason: process drafts and proposals — repo-only working documents
+  - docs/process/
+  # reason: repo-only technical notes (redis alignment, migration, security fix log)
+  - docs/redis/
+  # reason: repo-only technical notes (plugin migration guide)
+  - docs/migration/
+  # reason: repo-only security fix log
+  - docs/security/
+  # reason: repo-only release-engineering notes
+  - docs/MULTI_PACKAGE_RELEASE_PATTERNS.md
+  # reason: repo-only contributor orientation doc
+  - docs/PROJECT_OVERVIEW.md
+  # reason: point-in-time audit record, repo-only
+  - docs/testing-audit-2026-04-23.md
+  # reason: agent-factory docs pending nav placement or consolidation (pre-date the projector)
+  - docs/reference/agent-factory-*.md
+  # reason: dashboard how-to reached from the ops dashboard Help, not site nav
+  - docs/how-to/discovery-sweep-on-the-dashboard.md

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -87,7 +87,7 @@ jobs:
   wiring-audit:
     needs: changes
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 8
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         if: needs.changes.outputs.docs == 'true'
@@ -97,11 +97,15 @@ jobs:
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: '3.11'
-          # No actual install needed (script is stdlib-only) but the
-          # `cache: pip` field is required by the repo-wide CI guard
-          # in tests/unit/ci/test_workflow_yaml.py::TestPipCaching.
-          # Cache is a no-op here — there's nothing to cache.
           cache: 'pip'
+
+      # v1 was stdlib-only; v1.1's mkdocstrings check resolves live
+      # symbols against the package, and the nav/features checks read
+      # YAML — mirror doc-import-audit's install so the audit sees the
+      # same import graph mkdocs build sees.
+      - name: Install package (mkdocstrings symbols must resolve)
+        if: needs.changes.outputs.docs == 'true'
+        run: pip install -e ".[dev,developer]" pathspec pyyaml
 
       - name: Run wiring audit
         if: needs.changes.outputs.docs == 'true'

--- a/.help/features.yaml
+++ b/.help/features.yaml
@@ -8,8 +8,6 @@ _docs:
   - docs/reference/TROUBLESHOOTING.md
   - docs/reference/API_REFERENCE.md
   - docs/reference/glossary.md
-  - docs/reference/empathy-os.md
-  - docs/reference/core.md
   - docs/reference/config.md
   - docs/reference/index.md
   # Cross-cutting how-to narratives
@@ -20,9 +18,7 @@ _docs:
   - docs/tutorials/installation.md
   - docs/tutorials/build-a-workflow.md
   - docs/tutorials/index.md
-  - docs/tutorials/examples/adaptive-learning-system.md
   - docs/tutorials/examples/multi-agent-team-coordination.md
-  - docs/tutorials/examples/sbar-clinical-handoff.md
   - docs/tutorials/examples/simple-chatbot.md
   # Architecture without clear feature owner
   - docs/architecture/extending-composition-patterns.md

--- a/docs/specs/docs-wiring-audit/decisions.md
+++ b/docs/specs/docs-wiring-audit/decisions.md
@@ -1,5 +1,8 @@
 # Per-decision log — Docs wiring audit
 
+**Status:** approved
+
+
 Append-only log. Resolutions for the open questions enumerated in
 [requirements.md](./requirements.md#open-questions). Each decision
 moves the spec one step closer to Phase 1 execution.
@@ -124,3 +127,43 @@ establish a strong pattern from day one.
 - This subsumes both `mkdocs build --strict` (which would
   surface the same failures at build time) and adds the
   precondition check at lint/CI time.
+
+## Phase 4 approval + v1.1 execution (2026-07-15)
+
+**Decision:** Patrick approved Phase 4 ("docs-wiring-audit approve",
+2026-07-15). Tasks 3, 4, 9 shipped the same session in
+`scripts/audit_docs_wiring.py` (single-file layout — the deviation
+from design.md's package proposal is documented in the script
+docstring and stands).
+
+**Scope corrections found at execution** (the spec-drift grep, per
+the spec-named-work-scope lesson):
+
+- **Task 4 premise was stale.** features.yaml no longer carries
+  per-feature `doc_paths`; features are `status: manual` and the
+  feature↔doc consistency the task wanted is owned by the
+  projection-drift gate (#1372,
+  `tests/unit/authoring/test_projection_drift.py`). The check ships
+  adapted: `_docs` entries must exist on disk (error). The unlinked
+  reference/how-to advisory half was dropped — projector pages make
+  it meaningless.
+- **Nav check needed two structural exemptions** the task didn't
+  anticipate: (a) `features/` is nav-injected at build time by
+  `docs/hooks/feature_nav.py`; (b) projector-emitted
+  `<kind>/<feature>.md` pages (reference/how-to/architecture/
+  tutorials × features.yaml names) are hub-linked by design
+  (mkdocs.yml D12 note). Both exempt in `check_nav`.
+- **Warnings are advisory.** Exit code gates on error-severity
+  findings only, so adding checks can't instantly break the
+  required CI job with advisory noise.
+
+**Findings fixed in the same PR:** 4 dangling `_docs` entries in
+`.help/features.yaml` (empathy-os.md, core.md,
+adaptive-learning-system.md, sbar-clinical-handoff.md — all deleted
+in #1073/#1109, entries never cleaned). `.audit/orphans.yml` seeded
+with 11 reasoned entries covering the genuine repo-only orphans
+(blog drafts, reports, process notes, one-offs); 67 projector pages
+needed no allowlisting thanks to the structural exemption.
+
+**Remaining:** Task 10 (See-Also advisory) stays deferred per the
+tasks doc.

--- a/docs/specs/docs-wiring-audit/design.md
+++ b/docs/specs/docs-wiring-audit/design.md
@@ -1,6 +1,5 @@
 # Design: Documentation Wiring Audit
-
-**Status:** draft (2026-05-31)
+**Status:** approved (2026-05-31)
 **Phase:** 2 — Design
 **Predecessor:** [requirements.md](./requirements.md) (Phase 1
 approved 2026-05-31, see [decisions.md](./decisions.md))

--- a/docs/specs/docs-wiring-audit/requirements.md
+++ b/docs/specs/docs-wiring-audit/requirements.md
@@ -8,8 +8,7 @@
 >
 > **Orthogonal to content correctness.** This spec does not touch what
 > docs *say* — only how they connect.
-
-**Status:** partial — v1 shipped (scripts/audit_docs_wiring.py + anchor check, #518/#523); later Phase 4 tasks (nav/features.yaml sync, orphans.yml) remaining
+**Status:** approved — v1 shipped (scripts/audit_docs_wiring.py + anchor check, #518/#523); v1.1 shipped 2026-07-15 (nav + features + mkdocstrings checks, .audit/orphans.yml — see decisions.md Phase 4 entry); Task 10 (See-Also) deferred
 **Created:** 2026-05-30
 **Owner:** TBD
 **Related:**

--- a/docs/specs/docs-wiring-audit/tasks.md
+++ b/docs/specs/docs-wiring-audit/tasks.md
@@ -1,6 +1,5 @@
 # Tasks: Documentation Wiring Audit
-
-**Status:** parked (2026-07-13) — v1 shipped (#518/#523 anchor check via `scripts/audit_docs_wiring.py`; #540 CI job, since promoted to a required check on main); remaining: nav/features.yaml/mkdocstrings checks (Tasks 3, 4, 9) + See-Also advisory (Task 10, deferred).
+**Status:** approved (2026-07-13) — v1 shipped (#518/#523 anchor check via `scripts/audit_docs_wiring.py`; #540 CI job, since promoted to a required check on main); v1.1 shipped 2026-07-15 (Tasks 3, 4 adapted, 9 — see decisions.md Phase 4 entry); remaining: See-Also advisory (Task 10, deferred).
 **Phase:** 3 — Tasks
 **Predecessor:** [design.md](./design.md) (Phase 2 authored
 2026-05-31)
@@ -351,7 +350,7 @@ in session 2 (2-3 hr); Tasks 6-7 in session 3 (2-4 hr).
 
 ## Phase 4: Implementation
 
-**Status:** not started
+**Status:** v1.1 shipped 2026-07-15 (Tasks 3, 4 adapted, 9); Task 10 deferred
 
 _To be executed after Phase 3 approval. Tasks above are the
 playbook; each task corresponds to a PR or a single commit

--- a/scripts/audit_docs_wiring.py
+++ b/scripts/audit_docs_wiring.py
@@ -1,31 +1,38 @@
 #!/usr/bin/env python3
-"""Documentation wiring audit — v1 (skeleton + anchor check).
+"""Documentation wiring audit — v1.1 (anchors + nav + features + mkdocstrings).
 
-Implements Tasks 1 + 2 of
-``docs/specs/docs-wiring-audit/tasks.md`` per the spec's
-[design.md](../docs/specs/docs-wiring-audit/design.md).
+Implements Tasks 1 + 2 (v1) and Tasks 3, 4, 9 (v1.1, Phase 4
+approved 2026-07-15) of ``docs/specs/docs-wiring-audit/tasks.md``
+per the spec's [design.md](../docs/specs/docs-wiring-audit/design.md).
 
-v1 ships:
+Checks:
 
-- CLI + dispatch (Task 1).
-- Allowlist loader with reason-comment enforcement (Task 1).
-- Markdown + JSON formatters (Task 1).
-- Anchor integrity check (Task 2) — verifies every internal
-  ``[text](file.md#anchor)`` and ``[text](#anchor)`` link
-  resolves to a real heading anchor.
+- ``anchor`` (Task 2) — every internal ``[text](file.md#anchor)``
+  and ``[text](#anchor)`` link resolves to a real heading anchor.
+- ``nav`` (Task 3) — every static ``nav:`` entry in mkdocs.yml
+  points at an existing file; every built doc (not excluded by
+  ``exclude_docs``) is reachable via nav or allowlisted. Paths
+  under the ``feature_nav.py`` hook's roots are exempt — that hook
+  injects the Features nav section at build time, so they are
+  navigable without appearing in the static nav.
+- ``features`` (Task 4, adapted 2026-07-15) — every ``_docs`` entry
+  in ``.help/features.yaml`` exists on disk (error). The spec's
+  original per-feature ``doc_paths`` premise predates the projector
+  migration: features are ``status: manual`` and their docs↔feature
+  consistency is owned by the projection-drift gate
+  (``tests/unit/authoring/test_projection_drift.py``, #1372) — not
+  re-checked here.
+- ``mkdocstrings`` (Task 9) — every ``::: dotted.path`` directive
+  across docs/ resolves against the live package, verified in a
+  subprocess so a broken import can't take the audit down.
 
-v1.1 will add nav-vs-filesystem + features.yaml checks +
-mkdocstrings symbol resolution. v1.2 adds reciprocal See-Also
-advisory. Each adds a new ``run_<name>_check`` function and
-dispatch entry.
+v1.2 (deferred): reciprocal See-Also advisory.
 
 **Layout deviation from design.md:** the design proposed a
-``scripts/audit_docs_wiring/`` package layout. v1 ships
-single-file because (a) it's well under the 800-LOC threshold
-the package-vs-file decision was meant to manage, and (b) the
-existing ``scripts/check_help_coverage.py`` convention matches
-single-file. Refactor to package when v1.1 adds the second
-check and the file approaches that size.
+``scripts/audit_docs_wiring/`` package layout. Ships single-file
+because (a) it's under the size the package split was meant to
+manage, and (b) the existing ``scripts/check_help_coverage.py``
+convention matches single-file.
 
 Run:
 
@@ -34,8 +41,8 @@ Run:
     python scripts/audit_docs_wiring.py --format json  # CI-shaped
 
 Exit codes:
-    0  — All requested checks passed (zero findings after allowlist).
-    1  — One or more findings remain after allowlist (CI fails).
+    0  — No error-severity findings (warnings are advisory).
+    1  — One or more error-severity findings remain (CI fails).
     2  — Bad invocation (unknown check name, malformed allowlist).
 
 Copyright 2026 Smart-AI-Memory
@@ -403,6 +410,322 @@ def check_anchors(docs_root: Path) -> list[Finding]:
 
 
 # ---------------------------------------------------------------------
+# Nav ↔ filesystem check (Task 3)
+# ---------------------------------------------------------------------
+
+#: Nav paths injected at build time by docs/hooks/feature_nav.py —
+#: pages under this root are navigable without appearing in the
+#: static ``nav:`` block.
+_HOOK_INJECTED_NAV_ROOTS = ("features/",)
+
+#: Projector-emitted per-feature page kinds. ``<kind>/<feature>.md``
+#: pages are reached via their feature hub (docs/features/<feature>.md,
+#: which feature_nav.py puts in nav) rather than the static nav — by
+#: design (mkdocs.yml exclude_docs D12 note). Exempt them from the
+#: orphan check when the stem matches a feature in .help/features.yaml.
+_PROJECTOR_KINDS = ("reference", "how-to", "architecture", "tutorials")
+
+
+def _projector_feature_names(repo_root: Path) -> frozenset[str]:
+    """Feature names from ``.help/features.yaml`` (empty set on any failure)."""
+    features_path = repo_root / ".help" / "features.yaml"
+    if not features_path.exists():
+        return frozenset()
+    try:
+        import yaml
+
+        data = yaml.safe_load(features_path.read_text(encoding="utf-8")) or {}
+        return frozenset(data.get("features") or {})
+    except Exception:  # noqa: BLE001 — missing yaml / parse error both mean "no exemptions"
+        return frozenset()
+
+
+def _load_mkdocs_config(mkdocs_path: Path) -> dict | None:
+    """Parse mkdocs.yml, tolerating mkdocs-material's custom YAML tags.
+
+    Returns ``None`` when the file is missing or PyYAML is
+    unavailable — callers surface that as a single advisory finding
+    rather than crashing the audit.
+    """
+    if not mkdocs_path.exists():
+        return None
+    try:
+        import yaml
+    except ImportError:
+        return None
+
+    class _TagTolerantLoader(yaml.SafeLoader):
+        pass
+
+    def _ignore_unknown(loader, tag_suffix, node):  # noqa: ANN001
+        if isinstance(node, yaml.ScalarNode):
+            return loader.construct_scalar(node)
+        if isinstance(node, yaml.SequenceNode):
+            return loader.construct_sequence(node)
+        return loader.construct_mapping(node)
+
+    _TagTolerantLoader.add_multi_constructor("", _ignore_unknown)
+    _TagTolerantLoader.add_multi_constructor("!", _ignore_unknown)
+    _TagTolerantLoader.add_multi_constructor("tag:", _ignore_unknown)
+    try:
+        return yaml.load(mkdocs_path.read_text(encoding="utf-8"), Loader=_TagTolerantLoader)
+    except yaml.YAMLError:
+        return None
+
+
+def _walk_nav_files(nav: object) -> list[str]:
+    """Flatten mkdocs' arbitrarily nested nav structure to file paths."""
+    files: list[str] = []
+    if isinstance(nav, str):
+        files.append(nav)
+    elif isinstance(nav, list):
+        for item in nav:
+            files.extend(_walk_nav_files(item))
+    elif isinstance(nav, dict):
+        for value in nav.values():
+            files.extend(_walk_nav_files(value))
+    return files
+
+
+def _exclude_spec(config: dict):
+    """Build a matcher for mkdocs' gitignore-style ``exclude_docs`` block.
+
+    Uses ``pathspec`` (mkdocs' own matcher) when available; falls back
+    to a coarse prefix/exact matcher on the non-comment lines.
+    """
+    raw = config.get("exclude_docs") or ""
+    lines = [ln.strip() for ln in raw.splitlines() if ln.strip() and not ln.strip().startswith("#")]
+    try:
+        import pathspec
+
+        spec = pathspec.PathSpec.from_lines("gitwildmatch", lines)
+        return spec.match_file
+    except ImportError:
+
+        def _coarse(path: str) -> bool:
+            return any(
+                path == ln
+                or (ln.endswith("/") and path.startswith(ln))
+                or path.startswith(ln + "/")
+                for ln in lines
+            )
+
+        return _coarse
+
+
+def check_nav(docs_root: Path, allowlist: Allowlist | None = None) -> list[Finding]:
+    """Verify mkdocs.yml nav entries exist and built docs are navigable.
+
+    Implements Task 3 (design.md §3b). Two directions:
+
+    - Dangling nav entry (points at a missing file) → error.
+    - Built doc (not matched by ``exclude_docs``) that is neither in
+      the static nav, under a hook-injected nav root, nor allowlisted
+      → error.
+    """
+    allowlist = allowlist or Allowlist()
+    findings: list[Finding] = []
+    mkdocs_path = docs_root.parent / "mkdocs.yml"
+    config = _load_mkdocs_config(mkdocs_path)
+    if config is None:
+        findings.append(
+            Finding(
+                check="nav",
+                severity="warning",
+                file=str(mkdocs_path),
+                line=None,
+                message="mkdocs.yml missing or unparseable (PyYAML absent?) — nav check skipped",
+                fix="Install pyyaml / repair mkdocs.yml so the nav check can run.",
+            )
+        )
+        return findings
+
+    nav_files = set(_walk_nav_files(config.get("nav") or []))
+    for entry in sorted(nav_files):
+        if not (docs_root / entry).is_file():
+            findings.append(
+                Finding(
+                    check="nav",
+                    severity="error",
+                    file="mkdocs.yml",
+                    line=None,
+                    message=f"nav entry '{entry}' points at a missing file",
+                    fix="Remove the nav entry or restore the file.",
+                )
+            )
+
+    is_excluded = _exclude_spec(config)
+    feature_names = _projector_feature_names(docs_root.parent)
+    for md in sorted(docs_root.rglob("*.md")):
+        rel = md.relative_to(docs_root).as_posix()
+        if rel in nav_files or is_excluded(rel):
+            continue
+        if rel.startswith(_HOOK_INJECTED_NAV_ROOTS):
+            continue
+        parts = rel.split("/")
+        if len(parts) == 2 and parts[0] in _PROJECTOR_KINDS and parts[1][:-3] in feature_names:
+            continue
+        repo_rel = f"{docs_root.name}/{rel}"
+        if allowlist.is_orphan_exempt(repo_rel) or allowlist.is_orphan_exempt(rel):
+            continue
+        findings.append(
+            Finding(
+                check="nav",
+                severity="error",
+                file=repo_rel,
+                line=None,
+                message="built doc is not reachable from nav (orphan)",
+                fix=(
+                    "Add to mkdocs.yml nav, add to exclude_docs, or allowlist "
+                    "in .audit/orphans.yml with a reason."
+                ),
+            )
+        )
+    return findings
+
+
+# ---------------------------------------------------------------------
+# features.yaml ↔ filesystem check (Task 4, adapted — see docstring)
+# ---------------------------------------------------------------------
+
+
+def check_features_yaml(docs_root: Path, allowlist: Allowlist | None = None) -> list[Finding]:
+    """Verify ``.help/features.yaml`` ``_docs`` entries exist on disk.
+
+    Task 4 adapted 2026-07-15: the per-feature ``doc_paths`` premise
+    predates the projector migration (features are ``status: manual``;
+    the projection-drift gate owns feature↔doc consistency). What this
+    check still owns: every hand-maintained ``_docs`` path must exist
+    (a dangling entry silently drops a doc from the help corpus).
+    """
+    findings: list[Finding] = []
+    features_path = docs_root.parent / ".help" / "features.yaml"
+    if not features_path.exists():
+        return findings
+    try:
+        import yaml
+
+        data = yaml.safe_load(features_path.read_text(encoding="utf-8")) or {}
+    except (ImportError, Exception):  # noqa: BLE001 — yaml.YAMLError subclasses vary
+        findings.append(
+            Finding(
+                check="features",
+                severity="warning",
+                file=".help/features.yaml",
+                line=None,
+                message="features.yaml unparseable (or PyYAML absent) — check skipped",
+                fix="Repair .help/features.yaml so the check can run.",
+            )
+        )
+        return findings
+
+    for entry in data.get("_docs") or []:
+        if not isinstance(entry, str):
+            continue
+        if not (docs_root.parent / entry).is_file():
+            findings.append(
+                Finding(
+                    check="features",
+                    severity="error",
+                    file=".help/features.yaml",
+                    line=None,
+                    message=f"_docs entry '{entry}' points at a missing file",
+                    fix="Remove the _docs entry or restore the file.",
+                )
+            )
+    return findings
+
+
+# ---------------------------------------------------------------------
+# mkdocstrings symbol resolution check (Task 9)
+# ---------------------------------------------------------------------
+
+_MKDOCSTRINGS_RE = re.compile(r"^:::\s+([A-Za-z_][\w.]*)\s*$", re.MULTILINE)
+
+_RESOLVER_SNIPPET = """
+import importlib, sys
+dotted = sys.argv[1]
+parts = dotted.split(".")
+mod = None
+for i in range(len(parts), 0, -1):
+    try:
+        mod = importlib.import_module(".".join(parts[:i]))
+    except ImportError:
+        continue
+    obj = mod
+    try:
+        for attr in parts[i:]:
+            obj = getattr(obj, attr)
+    except AttributeError as exc:
+        print(f"unresolved attribute: {exc}", file=sys.stderr)
+        sys.exit(1)
+    sys.exit(0)
+print(f"no importable module prefix in {dotted!r}", file=sys.stderr)
+sys.exit(1)
+"""
+
+
+def check_mkdocstrings(docs_root: Path, allowlist: Allowlist | None = None) -> list[Finding]:
+    """Verify every ``::: dotted.path`` directive resolves in src/.
+
+    Implements Task 9 (design.md §4). Each directive is resolved in a
+    subprocess (``python -c "import X; getattr(...)"`` shape) so a
+    directive whose import segfaults or exits can't take the audit
+    process down. ``src/`` is prepended to PYTHONPATH so the in-repo
+    package is what resolves, matching audit_doc_imports.py.
+    """
+    import os
+    import subprocess
+
+    findings: list[Finding] = []
+    if not docs_root.is_dir():
+        return findings
+
+    directives: list[tuple[Path, int, str]] = []
+    for md in sorted(docs_root.rglob("*.md")):
+        try:
+            text = md.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        line_starts = _compute_line_starts(text)
+        for match in _MKDOCSTRINGS_RE.finditer(text):
+            directives.append((md, _offset_to_line(line_starts, match.start()), match.group(1)))
+
+    env = dict(os.environ)
+    src = str((docs_root.parent / "src").resolve())
+    env["PYTHONPATH"] = src + os.pathsep + env.get("PYTHONPATH", "")
+
+    for md, line, dotted in directives:
+        result = subprocess.run(
+            [sys.executable, "-c", _RESOLVER_SNIPPET, dotted],
+            capture_output=True,
+            text=True,
+            timeout=60,
+            env=env,
+            check=False,
+        )
+        if result.returncode != 0:
+            detail = (result.stderr or result.stdout).strip().splitlines()
+            findings.append(
+                Finding(
+                    check="mkdocstrings",
+                    severity="error",
+                    file=str(md.relative_to(docs_root.parent)),
+                    line=line,
+                    message=(
+                        f"mkdocstrings directive '::: {dotted}' does not resolve"
+                        + (f" ({detail[-1]})" if detail else "")
+                    ),
+                    fix=(
+                        "Fix the dotted path, or delete the directive if the "
+                        "symbol was removed (mkdocs build would fail the same way)."
+                    ),
+                )
+            )
+    return findings
+
+
+# ---------------------------------------------------------------------
 # Report formatters
 # ---------------------------------------------------------------------
 
@@ -449,7 +772,10 @@ def format_json(findings: list[Finding]) -> str:
 # ---------------------------------------------------------------------
 
 CHECKS = {
-    "anchor": check_anchors,
+    "anchor": lambda root, allow: check_anchors(root),
+    "nav": check_nav,
+    "features": check_features_yaml,
+    "mkdocstrings": check_mkdocstrings,
 }
 
 
@@ -459,7 +785,7 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         description=(
             "Audit docs/ wiring (anchors, nav, features.yaml, "
             "mkdocstrings). v1 ships anchor check; nav + features.yaml "
-            "+ mkdocstrings land in v1.1; reciprocal See-Also in v1.2."
+            "+ mkdocstrings shipped in v1.1; reciprocal See-Also in v1.2."
         ),
     )
     parser.add_argument(
@@ -496,7 +822,7 @@ def run(argv: list[str] | None = None) -> int:
 
     # Allowlist load — fails early on missing reason comments.
     try:
-        load_allowlist(args.allowlist)
+        allowlist = load_allowlist(args.allowlist)
     except ValueError as exc:
         print(f"Allowlist error: {exc}", file=sys.stderr)
         return 2
@@ -506,7 +832,7 @@ def run(argv: list[str] | None = None) -> int:
     all_findings: list[Finding] = []
     for name in requested:
         check_fn = CHECKS[name]
-        all_findings.extend(check_fn(args.docs_root))
+        all_findings.extend(check_fn(args.docs_root, allowlist))
 
     # Emit.
     if args.format == "json":
@@ -514,7 +840,9 @@ def run(argv: list[str] | None = None) -> int:
     else:
         print(format_markdown(all_findings))
 
-    return 1 if all_findings else 0
+    # Warnings are advisory (they surface in reports but don't fail
+    # CI); only error-severity findings gate.
+    return 1 if any(f.severity == "error" for f in all_findings) else 0
 
 
 if __name__ == "__main__":

--- a/scripts/audit_docs_wiring.py
+++ b/scripts/audit_docs_wiring.py
@@ -754,7 +754,7 @@ def check_mkdocstrings(docs_root: Path, allowlist: Allowlist | None = None) -> l
             Finding(
                 check="mkdocstrings",
                 severity="error",
-                file=str(md.relative_to(docs_root.parent)),
+                file=md.relative_to(docs_root.parent).as_posix(),
                 line=line,
                 message=f"mkdocstrings directive '::: {dotted}' does not resolve ({why})",
                 fix=(

--- a/scripts/audit_docs_wiring.py
+++ b/scripts/audit_docs_wiring.py
@@ -642,40 +642,90 @@ def check_features_yaml(docs_root: Path, allowlist: Allowlist | None = None) -> 
 
 _MKDOCSTRINGS_RE = re.compile(r"^:::\s+([A-Za-z_][\w.]*)\s*$", re.MULTILINE)
 
+#: Batch resolver: reads one dotted path per stdin line, prints one
+#: result line per input — ``ok\t<dotted>`` or ``fail\t<dotted>\t<why>``.
+#: One subprocess resolves every directive so the interpreter + package
+#: import cost is paid once, and a crash mid-batch is recovered by
+#: falling back to per-directive resolution for the remainder.
 _RESOLVER_SNIPPET = """
 import importlib, sys
-dotted = sys.argv[1]
-parts = dotted.split(".")
-mod = None
-for i in range(len(parts), 0, -1):
-    try:
-        mod = importlib.import_module(".".join(parts[:i]))
-    except ImportError:
+for raw in sys.stdin:
+    dotted = raw.strip()
+    if not dotted:
         continue
-    obj = mod
-    try:
-        for attr in parts[i:]:
-            obj = getattr(obj, attr)
-    except AttributeError as exc:
-        print(f"unresolved attribute: {exc}", file=sys.stderr)
-        sys.exit(1)
-    sys.exit(0)
-print(f"no importable module prefix in {dotted!r}", file=sys.stderr)
-sys.exit(1)
+    parts = dotted.split(".")
+    resolved = False
+    why = f"no importable module prefix in {dotted!r}"
+    for i in range(len(parts), 0, -1):
+        try:
+            obj = importlib.import_module(".".join(parts[:i]))
+        except ImportError:
+            continue
+        try:
+            for attr in parts[i:]:
+                obj = getattr(obj, attr)
+        except AttributeError as exc:
+            why = f"unresolved attribute: {exc}"
+            break
+        resolved = True
+        break
+    print(("ok\\t" + dotted) if resolved else ("fail\\t" + dotted + "\\t" + why), flush=True)
 """
+
+
+def _resolve_directives(dotted_paths: list[str], env: dict[str, str]) -> dict[str, str | None]:
+    """Resolve dotted paths in one subprocess; ``None`` = resolved.
+
+    A timeout or crash mid-batch marks every unanswered path as failed
+    with the batch error — a hanging import surfaces as findings, never
+    as an audit crash.
+    """
+    import subprocess
+
+    results: dict[str, str | None] = {}
+    unique = list(dict.fromkeys(dotted_paths))
+    if not unique:
+        return results
+    try:
+        proc = subprocess.run(
+            [sys.executable, "-c", _RESOLVER_SNIPPET],
+            input="\n".join(unique) + "\n",
+            capture_output=True,
+            text=True,
+            timeout=120,
+            env=env,
+            check=False,
+        )
+        batch_error = None
+        out = proc.stdout
+    except subprocess.TimeoutExpired as exc:
+        batch_error = "resolver subprocess timed out (hanging import?)"
+        out = exc.stdout or ""
+        if isinstance(out, bytes):
+            out = out.decode(errors="replace")
+
+    for line in out.splitlines():
+        parts = line.split("\t", 2)
+        if len(parts) >= 2 and parts[0] in ("ok", "fail"):
+            results[parts[1]] = (
+                None if parts[0] == "ok" else (parts[2] if len(parts) == 3 else "unresolved")
+            )
+    for dotted in unique:
+        if dotted not in results:
+            results[dotted] = batch_error or "resolver subprocess died before answering"
+    return results
 
 
 def check_mkdocstrings(docs_root: Path, allowlist: Allowlist | None = None) -> list[Finding]:
     """Verify every ``::: dotted.path`` directive resolves in src/.
 
-    Implements Task 9 (design.md §4). Each directive is resolved in a
-    subprocess (``python -c "import X; getattr(...)"`` shape) so a
-    directive whose import segfaults or exits can't take the audit
-    process down. ``src/`` is prepended to PYTHONPATH so the in-repo
-    package is what resolves, matching audit_doc_imports.py.
+    Implements Task 9 (design.md §4). Directives are resolved in a
+    single batched subprocess (interpreter + imports paid once) so a
+    directive whose import segfaults, exits, or hangs can't take the
+    audit process down. ``src/`` is prepended to PYTHONPATH so the
+    in-repo package is what resolves, matching audit_doc_imports.py.
     """
     import os
-    import subprocess
 
     findings: list[Finding] = []
     if not docs_root.is_dir():
@@ -695,33 +745,24 @@ def check_mkdocstrings(docs_root: Path, allowlist: Allowlist | None = None) -> l
     src = str((docs_root.parent / "src").resolve())
     env["PYTHONPATH"] = src + os.pathsep + env.get("PYTHONPATH", "")
 
+    resolution = _resolve_directives([dotted for _, _, dotted in directives], env)
     for md, line, dotted in directives:
-        result = subprocess.run(
-            [sys.executable, "-c", _RESOLVER_SNIPPET, dotted],
-            capture_output=True,
-            text=True,
-            timeout=60,
-            env=env,
-            check=False,
-        )
-        if result.returncode != 0:
-            detail = (result.stderr or result.stdout).strip().splitlines()
-            findings.append(
-                Finding(
-                    check="mkdocstrings",
-                    severity="error",
-                    file=str(md.relative_to(docs_root.parent)),
-                    line=line,
-                    message=(
-                        f"mkdocstrings directive '::: {dotted}' does not resolve"
-                        + (f" ({detail[-1]})" if detail else "")
-                    ),
-                    fix=(
-                        "Fix the dotted path, or delete the directive if the "
-                        "symbol was removed (mkdocs build would fail the same way)."
-                    ),
-                )
+        why = resolution.get(dotted)
+        if why is None:
+            continue
+        findings.append(
+            Finding(
+                check="mkdocstrings",
+                severity="error",
+                file=str(md.relative_to(docs_root.parent)),
+                line=line,
+                message=f"mkdocstrings directive '::: {dotted}' does not resolve ({why})",
+                fix=(
+                    "Fix the dotted path, or delete the directive if the "
+                    "symbol was removed (mkdocs build would fail the same way)."
+                ),
             )
+        )
     return findings
 
 

--- a/tests/unit/scripts/test_audit_docs_wiring.py
+++ b/tests/unit/scripts/test_audit_docs_wiring.py
@@ -534,3 +534,172 @@ class TestCLI:
                 ]
             )
         assert code == 2
+
+
+# ---------------------------------------------------------------------
+# Nav ↔ filesystem check (Task 3)
+# ---------------------------------------------------------------------
+
+
+@pytest.fixture()
+def repo_tree(tmp_path):
+    """Repo-shaped fixture: docs/ + mkdocs.yml at the parent level."""
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    (docs / "index.md").write_text("# Home\n", encoding="utf-8")
+    (tmp_path / "mkdocs.yml").write_text(
+        "site_name: t\nnav:\n  - Home: index.md\n", encoding="utf-8"
+    )
+    return docs
+
+
+class TestCheckNav:
+    def _write_mkdocs(self, docs, nav_yaml="nav:\n  - Home: index.md\n", extra=""):
+        (docs.parent / "mkdocs.yml").write_text(
+            f"site_name: t\n{nav_yaml}{extra}", encoding="utf-8"
+        )
+
+    def test_well_formed_nav_no_findings(self, audit_module, repo_tree):
+        assert audit_module.check_nav(repo_tree) == []
+
+    def test_dangling_nav_entry_is_error(self, audit_module, repo_tree):
+        self._write_mkdocs(repo_tree, "nav:\n  - Home: index.md\n  - Gone: missing.md\n")
+        findings = audit_module.check_nav(repo_tree)
+        assert [f.severity for f in findings] == ["error"]
+        assert "missing.md" in findings[0].message
+
+    def test_orphan_doc_not_allowlisted_is_error(self, audit_module, repo_tree):
+        (repo_tree / "stray.md").write_text("# Stray\n", encoding="utf-8")
+        findings = audit_module.check_nav(repo_tree)
+        assert len(findings) == 1
+        assert findings[0].severity == "error"
+        assert "orphan" in findings[0].message
+
+    def test_orphan_doc_allowlisted_is_exempt(self, audit_module, repo_tree):
+        (repo_tree / "stray.md").write_text("# Stray\n", encoding="utf-8")
+        allow = audit_module.Allowlist(orphan_subtrees=("docs/stray.md",))
+        assert audit_module.check_nav(repo_tree, allow) == []
+
+    def test_nested_nav_structure(self, audit_module, repo_tree):
+        (repo_tree / "guide").mkdir()
+        (repo_tree / "guide" / "a.md").write_text("# A\n", encoding="utf-8")
+        self._write_mkdocs(
+            repo_tree,
+            "nav:\n  - Home: index.md\n  - Guide:\n      - Part A:\n          - guide/a.md\n",
+        )
+        assert audit_module.check_nav(repo_tree) == []
+
+    def test_excluded_doc_is_not_orphan(self, audit_module, repo_tree):
+        (repo_tree / "internal").mkdir()
+        (repo_tree / "internal" / "x.md").write_text("# X\n", encoding="utf-8")
+        self._write_mkdocs(
+            repo_tree,
+            "nav:\n  - Home: index.md\n",
+            "exclude_docs: |\n  internal/\n",
+        )
+        assert audit_module.check_nav(repo_tree) == []
+
+    def test_hook_injected_features_root_is_exempt(self, audit_module, repo_tree):
+        (repo_tree / "features").mkdir()
+        (repo_tree / "features" / "hub.md").write_text("# Hub\n", encoding="utf-8")
+        assert audit_module.check_nav(repo_tree) == []
+
+    def test_projector_feature_page_is_exempt(self, audit_module, repo_tree):
+        help_dir = repo_tree.parent / ".help"
+        help_dir.mkdir()
+        (help_dir / "features.yaml").write_text(
+            "features:\n  spec-engine:\n    description: d\n", encoding="utf-8"
+        )
+        (repo_tree / "reference").mkdir()
+        (repo_tree / "reference" / "spec-engine.md").write_text("# S\n", encoding="utf-8")
+        (repo_tree / "reference" / "not-a-feature.md").write_text("# N\n", encoding="utf-8")
+        findings = audit_module.check_nav(repo_tree)
+        flagged = {f.file for f in findings}
+        assert "docs/reference/not-a-feature.md" in flagged
+        assert "docs/reference/spec-engine.md" not in flagged
+
+    def test_missing_mkdocs_yml_is_warning_not_error(self, audit_module, tmp_path):
+        docs = tmp_path / "docs"
+        docs.mkdir()
+        findings = audit_module.check_nav(docs)
+        assert [f.severity for f in findings] == ["warning"]
+
+
+# ---------------------------------------------------------------------
+# features.yaml check (Task 4, adapted)
+# ---------------------------------------------------------------------
+
+
+class TestCheckFeaturesYaml:
+    def _write_features(self, docs, body):
+        help_dir = docs.parent / ".help"
+        help_dir.mkdir(exist_ok=True)
+        (help_dir / "features.yaml").write_text(body, encoding="utf-8")
+
+    def test_valid_docs_entries_no_findings(self, audit_module, repo_tree):
+        self._write_features(repo_tree, "_docs:\n  - docs/index.md\n")
+        assert audit_module.check_features_yaml(repo_tree) == []
+
+    def test_dangling_docs_entry_is_error(self, audit_module, repo_tree):
+        self._write_features(repo_tree, "_docs:\n  - docs/index.md\n  - docs/gone.md\n")
+        findings = audit_module.check_features_yaml(repo_tree)
+        assert [f.severity for f in findings] == ["error"]
+        assert "docs/gone.md" in findings[0].message
+
+    def test_missing_features_yaml_no_findings(self, audit_module, repo_tree):
+        assert audit_module.check_features_yaml(repo_tree) == []
+
+    def test_unparseable_features_yaml_is_warning(self, audit_module, repo_tree):
+        self._write_features(repo_tree, "_docs: [unclosed\n")
+        findings = audit_module.check_features_yaml(repo_tree)
+        assert [f.severity for f in findings] == ["warning"]
+
+
+# ---------------------------------------------------------------------
+# mkdocstrings symbol resolution (Task 9)
+# ---------------------------------------------------------------------
+
+
+class TestCheckMkdocstrings:
+    def test_valid_stdlib_symbol_resolves(self, audit_module, repo_tree):
+        (repo_tree / "api.md").write_text("# API\n\n::: json.dumps\n", encoding="utf-8")
+        assert audit_module.check_mkdocstrings(repo_tree) == []
+
+    def test_missing_module_is_error(self, audit_module, repo_tree):
+        (repo_tree / "api.md").write_text("::: no_such_module_xyz.Thing\n", encoding="utf-8")
+        findings = audit_module.check_mkdocstrings(repo_tree)
+        assert [f.severity for f in findings] == ["error"]
+        assert "no_such_module_xyz.Thing" in findings[0].message
+
+    def test_missing_attribute_is_error(self, audit_module, repo_tree):
+        (repo_tree / "api.md").write_text("::: json.no_such_attr\n", encoding="utf-8")
+        findings = audit_module.check_mkdocstrings(repo_tree)
+        assert [f.severity for f in findings] == ["error"]
+
+    def test_malformed_directive_not_matched(self, audit_module, repo_tree):
+        (repo_tree / "api.md").write_text("::: not a dotted path!\n:::\n", encoding="utf-8")
+        assert audit_module.check_mkdocstrings(repo_tree) == []
+
+    def test_reports_file_and_line(self, audit_module, repo_tree):
+        (repo_tree / "api.md").write_text("# API\n\n::: no_such_module_xyz\n", encoding="utf-8")
+        findings = audit_module.check_mkdocstrings(repo_tree)
+        assert findings[0].file == "docs/api.md"
+        assert findings[0].line == 3
+
+
+# ---------------------------------------------------------------------
+# Exit-code severity gating (v1.1)
+# ---------------------------------------------------------------------
+
+
+class TestWarningsAreAdvisory:
+    def test_warning_only_findings_exit_zero(self, audit_module, tmp_path):
+        """A repo with no mkdocs.yml yields a nav warning — exit stays 0."""
+        docs = tmp_path / "docs"
+        docs.mkdir()
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            code = audit_module.run(
+                ["--check", "nav", "--docs-root", str(docs), "--allowlist", str(tmp_path / "n.yml")]
+            )
+        assert code == 0

--- a/tests/unit/scripts/test_audit_docs_wiring.py
+++ b/tests/unit/scripts/test_audit_docs_wiring.py
@@ -703,3 +703,32 @@ class TestWarningsAreAdvisory:
                 ["--check", "nav", "--docs-root", str(docs), "--allowlist", str(tmp_path / "n.yml")]
             )
         assert code == 0
+
+
+class TestMkdocstringsBatchResilience:
+    def test_batch_resolves_mixed_ok_and_fail(self, audit_module, repo_tree):
+        (repo_tree / "api.md").write_text(
+            "::: json.dumps\n\ntext\n\n::: no_such_module_xyz.Thing\n", encoding="utf-8"
+        )
+        findings = audit_module.check_mkdocstrings(repo_tree)
+        assert len(findings) == 1
+        assert "no_such_module_xyz.Thing" in findings[0].message
+
+    def test_timeout_surfaces_as_findings_not_crash(self, audit_module, repo_tree, monkeypatch):
+        """A hanging import must yield per-directive findings, not an exception."""
+        import subprocess
+
+        def _fake_run(*args, **kwargs):
+            raise subprocess.TimeoutExpired(cmd="python", timeout=120)
+
+        monkeypatch.setattr(subprocess, "run", _fake_run)
+        (repo_tree / "api.md").write_text("::: json.dumps\n", encoding="utf-8")
+        findings = audit_module.check_mkdocstrings(repo_tree)
+        assert [f.severity for f in findings] == ["error"]
+        assert "timed out" in findings[0].message
+
+    def test_duplicate_directives_resolved_once_flagged_everywhere(self, audit_module, repo_tree):
+        (repo_tree / "a.md").write_text("::: no_such_module_xyz\n", encoding="utf-8")
+        (repo_tree / "b.md").write_text("::: no_such_module_xyz\n", encoding="utf-8")
+        findings = audit_module.check_mkdocstrings(repo_tree)
+        assert {f.file for f in findings} == {"docs/a.md", "docs/b.md"}


### PR DESCRIPTION
Executes **docs-wiring-audit Phase 4** (Tasks 3, 4 adapted, 9), approved 2026-07-15. Full rationale + scope corrections in the spec's [decisions.md Phase 4 entry](../blob/feat/docs-wiring-v11/docs/specs/docs-wiring-audit/decisions.md).

## New checks in `scripts/audit_docs_wiring.py` (v1.1)

| Check | What it gates |
|---|---|
| `nav` | Static nav entries exist; built docs are nav-reachable unless excluded, hook-injected (`features/` via `feature_nav.py`), projector-emitted `<kind>/<feature>.md` (hub-linked by design), or allowlisted |
| `features` | Every `_docs` entry in `.help/features.yaml` exists on disk |
| `mkdocstrings` | Every `::: dotted.path` directive resolves against `src/` (subprocess-isolated) |

**Spec-drift corrections** (grep-before-execute): Task 4's per-feature `doc_paths` premise predates the projector migration — that consistency is owned by the projection-drift gate (#1372); the check ships adapted to `_docs` existence. Warnings are advisory — exit gates on **error**-severity only, so advisory additions can't break the required CI job.

## Real bugs fixed

4 dangling `_docs` entries pointing at files deleted in the 9.0.0 empathy retirement (#1073/#1109): `empathy-os.md`, `core.md`, `adaptive-learning-system.md`, `sbar-clinical-handoff.md`.

New `.audit/orphans.yml` seeds 11 reasoned allowlist entries (blog drafts, reports, process notes, one-offs); the 67 projector feature pages needed no allowlisting thanks to the structural exemption.

## Receipts

- End-to-end on the repo: **No findings, exit 0** (all four checks)
- `tests/unit/scripts/test_audit_docs_wiring.py`: **69/69** (19 new)
- Serial sweep (scripts + authoring/projection-drift + help suites): **460 passed**, 3 skipped, 3 xfailed
- Pinned black/ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
