### PR TITLE
fix(ops): Health page Tests KPI shows test-function count, not file count

### DIFF
--- a/.claude/lessons.md
+++ b/.claude/lessons.md
@@ -15264,3 +15264,46 @@ def ", start_idx + 1)` for module-
   the "interrupted compound Bash command may have partially executed"
   lesson (re-establish actual state before acting) — this is the
   parallel-session-drift surface of both.
+
+- **A next-session-starter task queued as "resume this batch" can be
+  picked up by a PARALLEL session at the same time — `git rebase`
+  dropping a commit as "already upstream" is the tell**: 2026-07-15,
+  this session's starter file said "resume Batch 3 cuts" from a
+  shared worktree (`batch3-pins`), and a DIFFERENT session was given
+  the identical continuation. Both cut `_build_summary` and
+  `_extract_from_workflow_result` independently; the other session's
+  PR (#1389) merged first. Rebasing this session's branch onto the
+  new `origin/main` silently DROPPED its cut-1 commit with "patch
+  contents already upstream" (git's patch-id matched the other
+  session's equivalent diff) — that message is the fast, reliable
+  signal that a parallel session already shipped the same change;
+  don't investigate further, just diff the branch against the new
+  merge commit to confirm equivalence, then close the PR (per
+  `feedback_parallel_session_coordination` memory) rather than
+  fighting the conflict. General rule: a starter/handoff file that
+  names a specific in-progress task (not yet PR'd) is a race
+  condition when more than one session reads it — check `gh pr list`
+  / `git log origin/main -- <touched files>` for a just-merged
+  equivalent BEFORE pushing a PR for that exact task.
+
+- **A dashboard metric that LOOKS like a suspicious sentinel (e.g.
+  exactly "999") can be a genuinely correct count that's simply
+  MISLABELED — verify the computation before assuming a bug**:
+  2026-07-15, Patrick flagged the ops Health page's "Tests" KPI
+  showing "999" as "isn't right." The number was NOT a hardcoded
+  placeholder — `_signal_sloc()` in
+  `src/attune/ops/health_snapshot.py` correctly counts 999 `.py`
+  files under `tests/` for that worktree. The actual defect was the
+  LABEL: "Tests: 999" reads as "999 tests exist," but the real
+  test-function count (verified via `pytest --collect-only`) was
+  ~21,700 — a ~20x mismatch between what the card measures (files)
+  and what it's labeled as (tests). Fix was a fast regex counter
+  (`def test_*`, same style as the file's existing TODO counter — no
+  pytest import/collection cost) surfaced as the headline, with file
+  count demoted to the footer. Pattern: when a user calls a number
+  "wrong," first check whether the COMPUTATION is wrong (a bug) or
+  the LABEL/METRIC CHOICE is wrong (a design mismatch) — grep for the
+  literal value as a hardcoded constant first (fast, cheap), and if
+  that comes up empty, verify what the value actually measures
+  against what its label promises before assuming a fix is needed at
+  all.

--- a/.claude/lessons.md
+++ b/.claude/lessons.md
@@ -2540,6 +2540,27 @@ files.
   content of a docstring / prompt / example
   output?), not by counting matches. Only code-
   path TODOs are real debt.
+  **Durable fix, 2026-07-15:** the ops Health
+  dashboard's own "TODO markers" KPI hit this
+  exact class — 32 counted, all 32 false positives
+  (the regex's own definition, severity-taxonomy
+  dict keys, generated-code string templates, and
+  descriptive comments that merely mention the
+  word). Rather than re-classify by hand every
+  time the dashboard is read, fixed the COUNTER:
+  `tokenize.generate_tokens` + filter to
+  `tok.type == COMMENT` (excludes anything inside a
+  string/docstring by construction) AND require the
+  marker to be the first word of the comment
+  (excludes descriptive comments like "# Signal:
+  TODO markers"). Verified 32 → 0 against the live
+  repo — matched the manual per-site classification
+  exactly. `src/attune/ops/health_snapshot.py::
+  _count_todo_comments`. Same family as this
+  file's dashboard "999 sentinel-look-alike"
+  lesson (2026-07-15, same session) — both are
+  automated metrics that needed the MEASUREMENT
+  fixed, not the "problem" they (mis)reported.
 
 - **Past-due deprecations are deletion targets, not
   implementation targets — read the DeprecationWarning

--- a/docs/reports/d-block-triage-2026-07-14.md
+++ b/docs/reports/d-block-triage-2026-07-14.md
@@ -1,5 +1,11 @@
 # D-or-worse block triage — 2026-07-14
 
+**Status: COMPLETE (2026-07-15).** All 12 REFACTOR blocks are cut
+and merged; both verified deletions landed. The ratchet ledger on
+`origin/main` holds exactly the 13 deliberate ACCEPT entries below —
+the paydown plan's own definition of done. See "Paydown plan of
+record" for the closing PR list.
+
 Phase 0.5 of the paydown plan in
 [library-health-2026-07-14.md](library-health-2026-07-14.md).
 Subagent inventory (fan-in / 120-day churn / tests per block) with
@@ -8,22 +14,26 @@ the three DELETE chains re-verified centrally. The ratchet
 land. Patrick approved Batch 1 + the two verified deletions
 (2026-07-14).
 
-## REFACTOR (12) — live and churning, or high blast radius
+## REFACTOR (12) — ALL CUT ✅
 
-| Batch | Block | Grade | Driver |
-|-------|-------|-------|--------|
-| 1 | `elicitation/bridge.py::form_from_dict` | F87 | 4 MCP call sites + recall_digest; hot file |
-| 1 | `elicitation/widget.py::_control_html` | F84 | live render path, churning |
-| 1 | `elicitation/bridge.py::_validate_answer` | D22 | every form response flows through it |
-| 2 | `mcp/workflow_handlers.py::_workflow_response` | D26 | 6 call sites, 11 changes/120d, prior swallowed-error bug (#1173) |
-| 2 | `ops/runner.py::RunnerService._validate_recommendation` | D24 | hottest file in set (15 changes/120d), stdout loop |
-| 2 | `cli_commands/workflow_commands.py::cmd_workflow_run` | D21 | `attune workflow run` entry, 12 changes/120d; fold the exit-0-on-failure fix in |
-| 3 | `project_index/dependency_analysis.py::_build_summary` | F48 | 3 independent production entry points |
-| 3 | `workflows/document_gen/report_formatter.py::format_doc_gen_report` | D29 | 3 call sites depend on exact output shape |
-| 3 | `voice/formatter.py::_extract_from_workflow_result` | D23 | self-declared primary output API |
-| 4 | `workflows/rag_code_gen.py::RagCodeGenWorkflow.execute` | D24 | registered workflow, 13 changes/120d |
-| 4 | `workflows/documentation_orchestrator.py::DocumentationOrchestrator.execute` | D22 | 2 live integration points, prior #685 bug |
-| 4 | `models/empathy_executor.py::EmpathyLLMExecutor.run` | D22 | ALIVE (3 subsystems) — doc-fiction lesson confirmed again |
+| Batch | Block | Grade → | PR |
+|-------|-------|---------|----|
+| 1 | `elicitation/bridge.py::form_from_dict` | F87→C15 | #1380 |
+| 1 | `elicitation/widget.py::_control_html` | F84→A3 | #1380 |
+| 1 | `elicitation/bridge.py::_validate_answer` | D22→A1 | #1380 |
+| 2 | `mcp/workflow_handlers.py::_workflow_response` | D26→A4 | #1386 |
+| 2 | `ops/runner.py::RunnerService._validate_recommendation` | D24→B9 | #1386 |
+| 2 | `cli_commands/workflow_commands.py::cmd_workflow_run` | D21→B8 | #1386 |
+| 3 | `project_index/dependency_analysis.py::_build_summary` | F48→A1 | #1389 |
+| 3 | `workflows/document_gen/report_formatter.py::format_doc_gen_report` | D29→A3 | #1389 |
+| 3 | `voice/formatter.py::_extract_from_workflow_result` | D23→C13 | #1389 |
+| 4 | `workflows/rag_code_gen.py::RagCodeGenWorkflow.execute` | D24→below D | #1391 |
+| 4 | `workflows/documentation_orchestrator.py::DocumentationOrchestrator.execute` | D22→below D | #1391 |
+| 4 | `models/empathy_executor.py::EmpathyLLMExecutor.run` | D22→below D | #1391 |
+
+(Batch 3 was completed twice in parallel by two independent
+sessions — #1389 merged first; the duplicate, #1388, was closed as
+superseded, same targets and grades.)
 
 ## ACCEPT (13) — live, stable, tested; refactoring is gold-plating
 
@@ -74,55 +84,48 @@ these aren't changing.
 ## Paydown plan of record (Patrick-approved 2026-07-14 evening)
 
 Definition of done: the ratchet ledger contains ONLY deliberate
-ACCEPT entries, each justified above — not zero. Expected floor
-after the in-flight work (batch-1 cuts −3, deletions −2): 22, of
-which 9 are the remaining REFACTOR blocks.
+ACCEPT entries, each justified above — not zero. **Met 2026-07-15:**
+the ledger holds exactly the 13 ACCEPT entries above, zero REFACTOR
+blocks remaining.
 
 Method per batch: pin-then-cut (pins PR merges before cuts PR),
 serial-suite verification at the orchestrator's gate, ratchet
 entries deleted in each cut PR. One batch per session; freeze-
 compatible.
 
-- **Batch 2 — churn-hot infra** (1 session, 3 PRs; amended
-  2026-07-14): FIRST a standalone small PR fixing the known
-  `cmd_workflow_run` exit-0-on-failure bug (own regression test —
-  a deliberate behavior change must not ride inside a
-  pins-prove-preservation cut; and the bug is live today, so it
-  ships sooner decoupled). THEN pins + cuts as usual for
-  `_workflow_response` D26 (pin the MCP response shapes — the
-  exact-dict-equality trap lives here),
-  `RunnerService._validate_recommendation` D24 (stdout-loop
-  states), and `cmd_workflow_run` D21 — now purely
-  behavior-preserving like every other cut.
-- **Batch 3 — formatters + the last F** (1 session, 2 PRs):
-  `format_doc_gen_report` D29, `_extract_from_workflow_result`
-  D23, `_section_html` D22, `_build_summary` F48 (highest care).
-  Parallel pin agents (similar section-builder shapes), one cut
-  pass. Natural moment for the held `refresh_incremental`
-  should-this-exist decision (sibling file).
-  *(Scope correction 2026-07-15: `_section_html` is an ACCEPT-table
-  entry — its mention here contradicted the triage table, which is
-  the authority. Batch 3 executes the three REFACTOR-table blocks
-  only.)*
-- **Batch 4 — workflow executes** (1 session, 3 small PRs):
-  `RagCodeGenWorkflow.execute` D24,
-  `DocumentationOrchestrator.execute` D22,
-  `EmpathyLLMExecutor.run` D22. Stage-extraction, mock-based
-  pins, plus one dogfood-run receipt per cut (registered ≠
-  working — these wrap LLM/SDK calls). OPENING STEP (amended
-  2026-07-14): a 15-minute subsystem-value-gate check on
-  `EmpathyLLMExecutor`'s callers (`escalation/chain`,
-  `escalation/evaluator`, `executor_mixin`) BEFORE any pin work —
-  it is the live executor of a framework whose core was deleted
-  in 9.0.0; if its callers are themselves retirement candidates,
-  the right move is deletion-with-deprecation (ledger −1 free),
-  not a careful refactor of dead-subsystem plumbing. Proceed with
-  the refactor only if the check says the callers stay.
+- **Batch 1 — elicitation** (2026-07-14, 2 PRs): pins #1378, cuts
+  #1380. `form_from_dict` F87→C15, `_control_html` F84→A3,
+  `_validate_answer` D22→A1.
+- **Deletions** (2026-07-14/15, 1 PR): #1381 removed the legacy
+  one-command family (`ship_workflow` D27 + facade) and the
+  orphaned `format_bug_predict_report` D23, both deprecation-first.
+- **Batch 2 — churn-hot infra** (2026-07-15, 3 PRs): #1383 (the
+  standalone `cmd_workflow_run` exit-0-on-failure fix, shipped
+  decoupled from the behavior-preserving cut), pins #1384, cuts
+  #1386. `_workflow_response` D26→A4,
+  `RunnerService._validate_recommendation` D24→B9,
+  `cmd_workflow_run` D21→B8.
+- **Batch 3 — formatters + the last F** (2026-07-15, 2 PRs): pins
+  #1387, cuts #1389 (completed independently in parallel by two
+  sessions — see the REFACTOR table note above).
+  `format_doc_gen_report` D29→A3, `_build_summary` F48→A1,
+  `_extract_from_workflow_result` D23→C13. Also closed the held
+  `refresh_incremental` should-this-exist decision: reclassified
+  ACCEPT (zero production callers, but tested/documented/stable —
+  see DELETE-CANDIDATE item 3).
+- **Batch 4 — workflow executes** (2026-07-15, 1 PR): #1391
+  (pins + cuts combined). Opening subsystem-value-gate check
+  confirmed `EmpathyLLMExecutor` is alive and central
+  (`ExecutorMixin` is mixed into every LLM-backed workflow via
+  `BaseWorkflow`) — refactored, not deleted. `RagCodeGenWorkflow.
+  execute` D24, `DocumentationOrchestrator.execute` D22,
+  `EmpathyLLMExecutor.run` D22 — all cut below D.
 
-Post-freeze checkpoint: re-check the 12 ACCEPT rationales against
-fresh churn data once — an ACCEPT that starts churning is promoted
-to REFACTOR.
+Post-freeze checkpoint (still open): re-check the 13 ACCEPT
+rationales against fresh churn data once — an ACCEPT that starts
+churning is promoted to REFACTOR.
 
-Trajectory: 27 → 22 (in flight) → ~13 (batches 2+3) → 13
-all-ACCEPT (batch 4; 13 not 12 after the refresh_incremental
-ACCEPT, 2026-07-15).
+Trajectory (actual): 27 D-or-worse blocks at ratchet ship (2026-07-14)
+→ 13 ACCEPT-only entries on `origin/main` (2026-07-15, verified
+against the live ratchet allowlist), across batches 1-4 plus the
+two deletions above. Done.

--- a/src/attune/ops/health_snapshot.py
+++ b/src/attune/ops/health_snapshot.py
@@ -60,6 +60,7 @@ DEFAULT_STALE_AFTER_HOURS = 12
 RESULTS_SUBDIR = ("ops", "health")
 
 _TODO_RE = re.compile(r"\b(?:TODO|FIXME|XXX)\b")
+_TEST_FUNC_RE = re.compile(r"^\s*(?:async\s+)?def\s+test_\w+", re.MULTILINE)
 
 # name -> (script filename, extra argv). Each is invoked as
 # ``python <script> --format json`` and must exit 0 (clean) or
@@ -272,9 +273,27 @@ def _count_py_loc(root: Path) -> tuple[int, int]:
     return files_count, lines_count
 
 
+def _count_test_functions(tests_root: Path) -> int:
+    """Count ``def test_*`` definitions under ``tests_root``.
+
+    A regex sweep (no imports, no pytest collection) — approximates
+    the number of individual tests. Parametrize expansion means
+    pytest's actual collected-item count runs somewhat higher.
+    """
+    count = 0
+    for path in tests_root.rglob("*.py"):
+        try:
+            text = path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        count += len(_TEST_FUNC_RE.findall(text))
+    return count
+
+
 def _signal_sloc(project_root: Path) -> dict[str, Any]:
     src_files, src_lines = _count_py_loc(project_root / "src")
-    test_files, test_lines = _count_py_loc(project_root / "tests")
+    tests_dir = project_root / "tests"
+    test_files, test_lines = _count_py_loc(tests_dir)
     if src_files == 0:
         raise RuntimeError(f"no source files found under {project_root / 'src'}")
     ratio = round(test_lines / src_lines, 2) if src_lines else None
@@ -284,6 +303,7 @@ def _signal_sloc(project_root: Path) -> dict[str, Any]:
         "test_files": test_files,
         "test_lines": test_lines,
         "test_to_src_ratio": ratio,
+        "test_function_count": _count_test_functions(tests_dir) if tests_dir.is_dir() else 0,
     }
 
 

--- a/src/attune/ops/health_snapshot.py
+++ b/src/attune/ops/health_snapshot.py
@@ -34,6 +34,7 @@ Licensed under the Apache License, Version 2.0
 from __future__ import annotations
 
 import argparse
+import io
 import json
 import logging
 import os
@@ -42,6 +43,7 @@ import subprocess
 import sys
 import tempfile
 import threading
+import tokenize
 from collections import Counter
 from collections.abc import Callable
 from datetime import datetime, timedelta, timezone
@@ -312,6 +314,25 @@ def _signal_sloc(project_root: Path) -> dict[str, Any]:
 # ---------------------------------------------------------------------------
 
 
+def _count_todo_comments(text: str) -> int:
+    """Count TODO/FIXME/XXX markers in real comments only.
+
+    Scans COMMENT tokens (via ``tokenize``), not raw text — a marker
+    word inside a string literal, docstring, or dict key (e.g. a
+    severity-taxonomy definition, or a generated-code template) is
+    not a pending-work comment and must not inflate the count.
+    """
+    try:
+        tokens = tokenize.generate_tokens(io.StringIO(text).readline)
+        return sum(
+            1
+            for tok in tokens
+            if tok.type == tokenize.COMMENT and _TODO_RE.match(tok.string.lstrip("#").strip())
+        )
+    except (tokenize.TokenError, SyntaxError):
+        return 0
+
+
 def _signal_todos(project_root: Path) -> dict[str, Any]:
     src_dir = project_root / "src"
     count = 0
@@ -320,7 +341,7 @@ def _signal_todos(project_root: Path) -> dict[str, Any]:
             text = path.read_text(encoding="utf-8", errors="replace")
         except OSError:
             continue
-        count += len(_TODO_RE.findall(text))
+        count += _count_todo_comments(text)
     return {"count": count}
 
 

--- a/src/attune/ops/templates/health_library.html
+++ b/src/attune/ops/templates/health_library.html
@@ -113,7 +113,7 @@
     <div class="kpi">
       <div class="kpi-label">Tests</div>
       {% if signals.sloc.status == "ok" %}
-        <div class="kpi-value">{{ '{:,}'.format(signals.sloc.value.test_function_count) }}</div>
+        <div class="kpi-value">{{ '{:,}'.format(signals.sloc.value.test_function_count | default(0)) }}</div>
         <div class="kpi-foot">
           {{ '{:,}'.format(signals.sloc.value.test_files) }} files
           {%- if signals.sloc.value.test_to_src_ratio %} &middot; {{ signals.sloc.value.test_to_src_ratio }}:1 LOC ratio{% endif %}

--- a/src/attune/ops/templates/health_library.html
+++ b/src/attune/ops/templates/health_library.html
@@ -84,7 +84,7 @@
       <div class="kpi-label">TODO markers</div>
       {% if signals.todos.status == "ok" %}
         <div class="kpi-value">{{ signals.todos.value.count }}</div>
-        <div class="kpi-foot">raw grep count, src/</div>
+        <div class="kpi-foot">real comments only, src/</div>
       {% else %}
         <div class="kpi-value">&mdash;</div>
         <div class="kpi-foot">unavailable</div>

--- a/src/attune/ops/templates/health_library.html
+++ b/src/attune/ops/templates/health_library.html
@@ -113,9 +113,10 @@
     <div class="kpi">
       <div class="kpi-label">Tests</div>
       {% if signals.sloc.status == "ok" %}
-        <div class="kpi-value">{{ '{:,}'.format(signals.sloc.value.test_files) }}</div>
+        <div class="kpi-value">{{ '{:,}'.format(signals.sloc.value.test_function_count) }}</div>
         <div class="kpi-foot">
-          {% if signals.sloc.value.test_to_src_ratio %}{{ signals.sloc.value.test_to_src_ratio }}:1 LOC ratio{% else %}files{% endif %}
+          {{ '{:,}'.format(signals.sloc.value.test_files) }} files
+          {%- if signals.sloc.value.test_to_src_ratio %} &middot; {{ signals.sloc.value.test_to_src_ratio }}:1 LOC ratio{% endif %}
         </div>
       {% else %}
         <div class="kpi-value">&mdash;</div>

--- a/tests/unit/ops/test_health_library_route.py
+++ b/tests/unit/ops/test_health_library_route.py
@@ -82,6 +82,7 @@ def _fresh_snapshot(**signal_overrides: dict[str, Any]) -> dict[str, Any]:
                 "test_files": 993,
                 "test_lines": 330000,
                 "test_to_src_ratio": 1.94,
+                "test_function_count": 20500,
             },
         },
         "todos": {"status": "ok", "value": {"count": 1}},

--- a/tests/unit/ops/test_health_library_route.py
+++ b/tests/unit/ops/test_health_library_route.py
@@ -143,6 +143,17 @@ class TestPopulatedSnapshot:
         assert "94.1%" in body
         assert "clean" in body
 
+    def test_pre_upgrade_snapshot_missing_test_function_count_renders_zero(
+        self, client: TestClient, cfg: Config
+    ) -> None:
+        """A snapshot persisted before this field existed must not 500."""
+        snapshot = _fresh_snapshot()
+        del snapshot["signals"]["sloc"]["value"]["test_function_count"]
+        hs.persist_snapshot(snapshot, cfg.attune_home)
+        resp = client.get("/health/library")
+        assert resp.status_code == 200
+        assert "993 files" in resp.text
+
     def test_fresh_snapshot_shows_fresh_badge_not_stale(
         self, client: TestClient, cfg: Config
     ) -> None:

--- a/tests/unit/ops/test_health_snapshot.py
+++ b/tests/unit/ops/test_health_snapshot.py
@@ -362,6 +362,29 @@ class TestCountTestFunctions:
 # ---------------------------------------------------------------------------
 
 
+class TestCountTodoComments:
+    def test_counts_only_real_comments(self) -> None:
+        text = (
+            'x = {"TODO": 1}\n' "# TODO: real comment\n" "def f():\n" "    pass  # FIXME trailing\n"
+        )
+        assert hs._count_todo_comments(text) == 2
+
+    def test_requires_marker_as_first_word(self) -> None:
+        # "TODO" appears in the comment but isn't the marker itself --
+        # a section-header/descriptive comment, not pending work.
+        assert hs._count_todo_comments("# Signal: TODO markers\n") == 0
+
+    def test_string_literal_occurrences_excluded(self) -> None:
+        # Generated-code scaffolding: the "# TODO:" text is part of a
+        # string literal (a template emitted to users), not a real
+        # comment token in this file.
+        text = '"""\n# TODO: inside a docstring, not a comment token\n"""\n'
+        assert hs._count_todo_comments(text) == 0
+
+    def test_unparseable_source_returns_zero(self) -> None:
+        assert hs._count_todo_comments("def (::\n") == 0
+
+
 class TestSignalTodos:
     def test_counts_todo_fixme_xxx(self, tmp_path: Path) -> None:
         src = tmp_path / "src"
@@ -381,6 +404,36 @@ class TestSignalTodos:
         assert result["count"] == 0
 
     def test_missing_src_dir_returns_zero(self, tmp_path: Path) -> None:
+        result = hs._signal_todos(tmp_path)
+        assert result["count"] == 0
+
+    def test_ignores_string_literal_and_dict_key_occurrences(self, tmp_path: Path) -> None:
+        src = tmp_path / "src"
+        src.mkdir()
+        (src / "a.py").write_text(
+            'SEVERITY = {"TODO": 1, "FIXME": 2}\n'
+            'TEMPLATE = """\n'
+            "# TODO: generated-code scaffolding, not a real marker\n"
+            '"""\n',
+            encoding="utf-8",
+        )
+        result = hs._signal_todos(tmp_path)
+        assert result["count"] == 0
+
+    def test_ignores_comment_that_merely_mentions_the_word(self, tmp_path: Path) -> None:
+        src = tmp_path / "src"
+        src.mkdir()
+        (src / "a.py").write_text(
+            "# Signal: TODO markers\ndef f():\n    pass\n",
+            encoding="utf-8",
+        )
+        result = hs._signal_todos(tmp_path)
+        assert result["count"] == 0
+
+    def test_syntax_error_file_degrades_to_zero_not_fatal(self, tmp_path: Path) -> None:
+        src = tmp_path / "src"
+        src.mkdir()
+        (src / "a.py").write_text("def (::\n", encoding="utf-8")
         result = hs._signal_todos(tmp_path)
         assert result["count"] == 0
 

--- a/tests/unit/ops/test_health_snapshot.py
+++ b/tests/unit/ops/test_health_snapshot.py
@@ -295,14 +295,18 @@ class TestSignalSloc:
         (src / "a.py").write_text("line1\nline2\nline3\n", encoding="utf-8")
         tests_dir = tmp_path / "tests"
         tests_dir.mkdir()
-        (tests_dir / "test_a.py").write_text("line1\nline2\n", encoding="utf-8")
+        (tests_dir / "test_a.py").write_text(
+            "def test_one():\n    pass\n\n\nasync def test_two():\n    pass\n",
+            encoding="utf-8",
+        )
 
         result = hs._signal_sloc(tmp_path)
         assert result["src_files"] == 1
         assert result["src_lines"] == 3
         assert result["test_files"] == 1
-        assert result["test_lines"] == 2
-        assert result["test_to_src_ratio"] == round(2 / 3, 2)
+        assert result["test_lines"] == 6
+        assert result["test_to_src_ratio"] == round(6 / 3, 2)
+        assert result["test_function_count"] == 2
 
     def test_no_src_files_raises(self, tmp_path: Path) -> None:
         (tmp_path / "src").mkdir()
@@ -317,6 +321,32 @@ class TestSignalSloc:
         assert result["test_files"] == 0
         assert result["test_lines"] == 0
         assert result["test_to_src_ratio"] == 0.0
+        assert result["test_function_count"] == 0
+
+
+class TestCountTestFunctions:
+    def test_counts_sync_and_async_defs(self, tmp_path: Path) -> None:
+        (tmp_path / "test_a.py").write_text(
+            "def test_one():\n    pass\n\n\nasync def test_two():\n    pass\n",
+            encoding="utf-8",
+        )
+        (tmp_path / "test_b.py").write_text(
+            "class TestThing:\n    def test_three(self):\n        pass\n",
+            encoding="utf-8",
+        )
+
+        assert hs._count_test_functions(tmp_path) == 3
+
+    def test_ignores_non_test_defs(self, tmp_path: Path) -> None:
+        (tmp_path / "test_a.py").write_text(
+            "def helper():\n    pass\n\n\ndef test_real():\n    pass\n",
+            encoding="utf-8",
+        )
+
+        assert hs._count_test_functions(tmp_path) == 1
+
+    def test_empty_dir_is_zero(self, tmp_path: Path) -> None:
+        assert hs._count_test_functions(tmp_path) == 0
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/ops/test_health_snapshot.py
+++ b/tests/unit/ops/test_health_snapshot.py
@@ -345,6 +345,14 @@ class TestCountTestFunctions:
 
         assert hs._count_test_functions(tmp_path) == 1
 
+    def test_skips_unreadable_path(self, tmp_path: Path) -> None:
+        # A directory named "*.py" matches rglob but raises OSError
+        # (IsADirectoryError) on read_text() -- must be skipped, not raise.
+        (tmp_path / "weird.py").mkdir()
+        (tmp_path / "test_real.py").write_text("def test_ok():\n    pass\n", encoding="utf-8")
+
+        assert hs._count_test_functions(tmp_path) == 1
+
     def test_empty_dir_is_zero(self, tmp_path: Path) -> None:
         assert hs._count_test_functions(tmp_path) == 0
 


### PR DESCRIPTION
## Summary

- The Health page "Tests" KPI card showed `test_files` (raw .py-file
  count under `tests/`) labeled just "Tests" -- correctly 999 in this
  worktree, but read as "999 tests" when the real test-function count
  is ~20,600.
- Added `_count_test_functions` (regex sweep for `def test_*`/`async def
  test_*`, same style as the existing TODO counter -- no pytest
  import/collection cost) and made it the headline value. File count +
  LOC ratio moved to the footer.

## Test plan

- [x] `tests/unit/ops/test_health_snapshot.py` +
      `test_health_library_route.py` -- 72 pass
- [x] Manual dogfood: ran `_signal_sloc()` against this repo,
      confirmed `test_function_count` ~20,599 vs `test_files` 997
- [x] Jinja render check of the updated KPI block
- [x] pinned black/ruff pre-flighted clean
