### PR TITLE
fix(quality): coverage baseline misreports spec_from_file_location-loaded modules

### DIFF
--- a/.claude/lessons.md
+++ b/.claude/lessons.md
@@ -15351,3 +15351,40 @@ def ", start_idx + 1)` for module-
   delete-safety via content-diff (not is-ancestor), and before
   treating any residual diff as lost work, check whether it's just
   the framework-docs bot's regen racing ahead of your branch tip.
+
+- **A module loaded via `importlib.util.spec_from_file_location`
+  under a synthetic module name is INVISIBLE to
+  `--cov=<dotted.module>` — it shows 0% even when thoroughly
+  tested; use a path-based `--cov=<dir>` to see the real number**:
+  2026-07-15, the `scripts/qa_coverage_baseline.sh` whole-repo run
+  (Tier-2 backlog vetting) ranked `config.py` (180 missed) and
+  several `hooks/scripts/*.py` files (`worktree_path_guard.py` 101
+  missed, `starter_reconciler.py` 183 missed) at 0% — both are
+  deliberately loaded outside the normal package import graph
+  (`attune/config/__init__.py` loads the sibling `config.py` file
+  via `spec_from_file_location("attune_config_legacy", ...)` for
+  backward-compat re-export; hook-script tests load their target
+  the same way under names like `"_worktree_path_guard"`, so the
+  script can run standalone without pulling in the full `attune`
+  package). `pytest-cov`'s `--cov=<dotted.module>` internally does
+  `importlib.import_module(pkg)` to resolve what to instrument/
+  report — since that import never happens under the expected
+  name, it warns "Module X was never imported" and reports 0%,
+  even though 22+ real behavioral tests exist and pass. Re-running
+  with a **path-based** `--cov=src/attune/hooks/scripts` (a
+  directory, not a dotted name) correctly attributed coverage:
+  `worktree_path_guard.py` 93%, `starter_reconciler.py` 95%,
+  `config.py` 98% (via `--cov=src/attune`, its parent dir). This
+  full-suite path-scoped rerun also surfaced the ONE genuine gap
+  hiding in the noise: `hooks/scripts/_bootstrap.py` (24 lines,
+  truly 0%, confirmed under both measurement methods). Rule: before
+  writing tests for a QA-baseline "0%" module that already has a
+  test file (per the playbook's own step 2), check whether it's
+  loaded via `spec_from_file_location`/`runpy` under a synthetic
+  name — if so, re-measure with `--cov=<containing-dir>` before
+  trusting the number. Same family as the existing "worktree
+  coverage reports 0%" gotcha in the QA playbook, but a DIFFERENT
+  root cause (import-graph bypass, not the worktree-vs-main
+  editable-MAPPING mismatch) — both produce the same misleading
+  symptom, so diagnose which one you're looking at before assuming
+  either fix applies.

--- a/.claude/lessons.md
+++ b/.claude/lessons.md
@@ -14363,6 +14363,15 @@ def ", start_idx + 1)` for module-
   QA-baseline "a module here is a HYPOTHESIS" reminder: when a module
   is at *exactly* 0% (not partial), suspect a whole-module import guard
   and grep the gating dep BEFORE committing effort.
+  **Addendum 2026-07-16:** the mechanism for WHY it even reappears —
+  `progress_server.py` is ALSO deliberately in `pyproject.toml`'s
+  coverage `omit` list, but `scripts/qa_coverage_baseline.sh`'s
+  `--cov-config=/dev/null` (needed to work around the worktree-path
+  MAPPING bug) discards the whole rcfile, omit entries included, so
+  genuinely-excluded modules resurrect as fake "gaps" in ANY baseline
+  run. Being on the `omit` list is not protection from this specific
+  script; `grep <file> pyproject.toml` before trusting a baseline
+  "0%" as new work, independent of the optional-dep check above.
 
 <!-- from 87ac6f655 docs(lessons): subprocess check=False + parse-stdout masks a crash as "empty/clean" -->
 

--- a/docs/specs/test-quality-program/omit-audit.md
+++ b/docs/specs/test-quality-program/omit-audit.md
@@ -72,10 +72,22 @@ import or a call-time dependency, not an import barrier.
 servers), `project_index/scanner_parallel.py` (multiprocessing),
 `project_index/index.py` (integration-tested), all `__init__.py` /
 `__main__.py` package/entry stubs, `*_example.py`, deprecated
-`agent_factory/*` adapters, and `config.py` (import-shadowed). Hook
-scripts (`hooks/scripts/*.py`) are tagged "standalone / not importable
-via pytest" — **needs a second pass** to confirm (some may import and
-be partially coverable).
+`agent_factory/*` adapters, and `config.py` (import-shadowed).
+
+**Second pass done (2026-07-16):** hook scripts and `config.py` ARE
+well-covered — the reason they read 0% in whole-repo baselines is a
+measurement artifact, not an absence of tests. Both are loaded via
+`importlib.util.spec_from_file_location` under a synthetic module
+name (bypassing normal package import, by design — `config.py` for
+legacy re-export, hook scripts so they run standalone without the
+full `attune` package). `--cov=<dotted.module>` requires that exact
+import to happen and never sees them; a path-scoped `--cov=<dir>`
+does. Real numbers: `config.py` 98%, `worktree_path_guard.py` 93%,
+`starter_reconciler.py` 95%. The one genuine gap in this class:
+`hooks/scripts/_bootstrap.py` (24 lines, confirmed 0% under both
+measurement methods). See `.claude/lessons.md` "coverage baseline
+misreports spec_from_file_location-loaded modules" and the fix in
+`scripts/qa_coverage_baseline.sh`.
 
 ---
 

--- a/docs/specs/test-quality-program/qa-batch-playbook.md
+++ b/docs/specs/test-quality-program/qa-batch-playbook.md
@@ -99,16 +99,49 @@ Re-verify if anything looks off:
 - **Worktree coverage reports 0% by default.** The rcfile
   `source` filter can't map the worktree path to the package via
   the main-pointing editable MAPPING. Measure with the MAIN
-  venv's python + an absolute `PYTHONPATH` + `--cov-config=/dev/null`:
+  venv's python + an absolute `PYTHONPATH` + `--cov-config=/dev/null`
+  + a **path**, not a dotted module name, for `--cov` (see the next
+  gotcha for why):
 
   ```bash
   ANTHROPIC_API_KEY="" PYTHONPATH="<wt>/src" <main-venv>/bin/python \
     -m pytest <wt>/tests/path/to/test_<mod>.py \
-    --cov=attune.<mod> --cov-config=/dev/null \
+    --cov="<wt>/src/attune/<mod-path>" --cov-config=/dev/null \
     --cov-report=term-missing -o addopts= -p no:xdist
   ```
 
   (The baseline script already does this for the whole-suite run.)
+
+- **A module loaded via `spec_from_file_location` under a synthetic
+  name is invisible to `--cov=<dotted.module>`, even when
+  thoroughly tested.** `config.py` (legacy-compat re-export) and
+  every `hooks/scripts/*.py` test load their target this way, so
+  `--cov=attune.config` / `--cov=attune.hooks.scripts.X` reports 0%
+  regardless of real coverage — `pytest-cov` needs that exact
+  dotted name imported to find what to report. A **directory**
+  path (`--cov=<wt>/src/attune/hooks/scripts`) tracks by executed
+  file location instead and gives the real number — verified
+  identical to the dotted form for normally-imported modules, so
+  it's a strict superset, not a tradeoff. Real numbers once fixed:
+  `config.py` 98%, `worktree_path_guard.py` 93%,
+  `starter_reconciler.py` 95%. `scripts/qa_coverage_baseline.sh`
+  now does this automatically (converts the dotted `$PACKAGE` arg
+  to a path before invoking `--cov`).
+
+- **A whole-repo baseline can resurrect a module that's
+  DELIBERATELY in `pyproject.toml`'s coverage `omit` list.** The
+  baseline's `--cov-config=/dev/null` (needed for the worktree-path
+  gotcha above) also discards the `omit` entries, so genuinely
+  excluded dead-or-untestable code reappears as a fake "gap." Hit
+  with `workflows/progress_server.py` (142 missed, 0%) — already
+  flagged not-a-real-gap in this doc's Tier 4 and in `decisions.md`
+  (2026-06-14); confirming it's also genuinely dead code (no
+  `websockets` dependency declared, so it can never actually import
+  the live path — always raises at construction) took a few
+  minutes that a first glance at Tier 4 above would have saved.
+  Before treating a baseline "0%" as new work, check whether it's
+  already in the `omit` list (`grep <file> pyproject.toml`) and
+  whether this doc's Tier 4 already settled it.
 
 - **Keyless ALWAYS: `ANTHROPIC_API_KEY=""` (empty, not unset).**
   An UNSET key lets `load_dotenv` inject the real one and the run

--- a/scripts/qa_coverage_baseline.sh
+++ b/scripts/qa_coverage_baseline.sh
@@ -13,6 +13,20 @@
 # code is measured, and --cov-config=/dev/null to bypass the rcfile
 # source-mapping that otherwise reports 0% from a worktree.
 #
+# --cov is given a DIRECTORY PATH, not the dotted package name. A dotted
+# `--cov=attune.foo` requires coverage to `importlib.import_module` that
+# exact name to find what to instrument/report -- any module loaded via
+# `importlib.util.spec_from_file_location` under a different name (e.g.
+# config.py's legacy-compat loader, or a hooks/scripts/*.py test loading
+# its target standalone) is invisible to it and silently reports 0% even
+# when thoroughly tested (verified 2026-07-15: config.py showed 0%/98%,
+# worktree_path_guard.py 0%/93%, starter_reconciler.py 0%/95% dotted vs
+# path-scoped). Path-based --cov tracks by executed file location, not
+# import name, and gives IDENTICAL numbers to the dotted form for
+# normally-imported modules -- it is a strict superset fix, not a
+# tradeoff. See .claude/lessons.md "coverage baseline misreports
+# spec_from_file_location-loaded modules".
+#
 # Usage:
 #   bash scripts/qa_coverage_baseline.sh [package] [threshold] [out_file]
 #
@@ -30,6 +44,7 @@ PACKAGE="${1:-attune.memory}"
 THRESHOLD="${2:-80}"
 
 WT_ROOT="$(git rev-parse --show-toplevel)"
+PACKAGE_PATH="$WT_ROOT/src/$(echo "$PACKAGE" | tr '.' '/')"
 
 # Locate a python with all extras: prefer the MAIN checkout's venv (a
 # worktree venv is usually synced with only dev/developer extras).
@@ -58,7 +73,7 @@ set +e
 ANTHROPIC_API_KEY="" PYTHONPATH="$WT_ROOT/src" "$PY" -m pytest "$WT_ROOT/tests" \
   --ignore="$WT_ROOT/tests/integration" \
   -o addopts="" \
-  --cov="$PACKAGE" --cov-config=/dev/null \
+  --cov="$PACKAGE_PATH" --cov-config=/dev/null \
   --cov-report=term-missing \
   -n auto -q -p no:cacheprovider >"$OUT_FILE" 2>&1
 RC=$?


### PR DESCRIPTION
## Summary

- `scripts/qa_coverage_baseline.sh` now scopes `--cov` to a directory
  path instead of a dotted module name. `--cov=<dotted.module>`
  requires that exact import to happen to attribute coverage; any
  module loaded via `importlib.util.spec_from_file_location` under a
  synthetic name (config.py's legacy-compat loader, every
  hooks/scripts/*.py test) is invisible to it and silently reports 0%
  despite thorough real tests. Path-based `--cov` tracks by executed
  file location instead -- verified identical numbers for
  normally-imported modules (no regression) and correct numbers for
  the previously-blind ones: `config.py` 98%, `worktree_path_guard.py`
  93%, `starter_reconciler.py` 95%.
- Folded in a related finding from the same investigation:
  `workflows/progress_server.py` (142 missed/0% in a whole-repo
  baseline) is a THIRD false-positive class -- it's deliberately in
  `pyproject.toml`'s coverage `omit` list (the baseline's
  `--cov-config=/dev/null` discards omit entries too), already
  recorded not-a-real-gap in `decisions.md` (2026-06-14), and
  confirmed genuinely dead code (no `websockets` dependency declared,
  so it can never actually reach the live code path).
- Closed the `omit-audit.md` "needs a second pass" open item on hook
  scripts/config.py, and added both false-positive classes to the QA
  playbook's Gotchas section.
- New lesson banked in `.claude/lessons.md`.

## Test plan

- [x] `tests/unit/lessons/`, `tests/unit/rules/` -- 30 pass
      (lessons drift-guard + core-mirror)
- [x] `bash -n scripts/qa_coverage_baseline.sh` -- syntax OK
- [x] Manually verified path-based vs dotted `--cov` give IDENTICAL
      numbers for a normally-imported module (`claude_memory.py`,
      96% both ways) -- confirms the fix is a strict superset, not a
      tradeoff
- [x] Manually verified the fix surfaces real coverage for the
      previously-blind modules: `config.py` 98%, `worktree_path_guard.py`
      93%, `starter_reconciler.py` 95%
- A full whole-repo dry-run of the fixed script hit a known,
  separately-tracked xdist/asyncio-teardown hang (unrelated to this
  change -- occurred near 97% completion during async subprocess
  cleanup); killed and relied on the targeted verifications above
  instead, consistent with how the script is invoked per-package in
  normal use anyway.
