### PR TITLE
test(meta_workflows): cover agent_commands.py CLI -- ~11% -> 99%

### DIFF
--- a/docs/COVERAGE_BUG_LOG.md
+++ b/docs/COVERAGE_BUG_LOG.md
@@ -1,3 +1,42 @@
+## 2026-07-16 — meta_workflows/cli_commands/agent_commands.py (QA, Opus 4.8)
+
+`meta_workflows/cli_commands/agent_commands.py` (`create_agent`,
+`create_team`), **~11% → 99%** (net-new
+`tests/unit/meta_workflows/test_agent_commands.py`, 18 tests). No prior
+test file anywhere imported this module.
+
+- **Bug (crash), class 1 — `create-agent` crashes on EVERY successful
+  invocation, both interactive and quick mode.** The command's final two
+  lines split a Rich markup `[dim]...[/dim]` span across two separate
+  `console.print()` calls:
+
+  ```python
+  console.print(f"\n[dim]Agent tier '{tier}' will cost approximately:")
+  console.print(f"   {costs.get(tier, costs['capable'])} per execution[/dim]\n")
+  ```
+
+  Rich parses markup independently per `console.print()` call — there is
+  no cross-call tag state — so the second call's lone `[/dim]` has no
+  matching open tag and raises `rich.errors.MarkupError: closing tag
+  '[/dim]' at position N doesn't match any open tag`. Typer's `CliRunner`
+  (and a real terminal) surfaces this as exit code 1 with an unhandled
+  exception, AFTER the JSON spec panel and any `--output` file save have
+  already completed — so the command's core work (spec construction,
+  file save) succeeds, but the process always exits non-zero and never
+  prints its final cost-estimate line. `create-team`'s analogous final
+  line (`console.print(f"...{...}[/dim]\n")`) is a single call and does
+  **not** share this bug — confirmed via manual and automated testing
+  that `create-team` exits 0 cleanly. This means every `attune-ai` user
+  who has ever run `create-agent` (interactive or quick mode, any tier)
+  has hit this crash — there is no successful invocation path. Likely
+  fix: merge the two `console.print()` calls into one, or move the
+  closing `[/dim]` onto the first call. **Not fixed here** — kept this
+  PR test-only per the qa-batch-playbook cadence; tests assert the
+  crash's exact `MarkupError` and message as the current real behavior.
+  Filed as a follow-up for a dedicated one-line hotfix PR.
+
+---
+
 ## 2026-06-13 — test isolation: worktree_path_guard `_sdk_gate` import (Opus 4.8)
 
 `tests/unit/hooks/test_worktree_path_guard.py`, **test-infra / isolation

--- a/tests/unit/meta_workflows/test_agent_commands.py
+++ b/tests/unit/meta_workflows/test_agent_commands.py
@@ -1,0 +1,400 @@
+"""Unit tests for attune.meta_workflows.cli_commands.agent_commands.
+
+Covers create_agent and create_team CLI commands.
+Uses Typer's CliRunner with the app declared in cli_commands/__init__.py,
+mirroring the pattern in test_workflow_commands.py.
+
+KNOWN PRODUCTION BUG (documented, not fixed, by design -- see
+docs/COVERAGE_BUG_LOG.md): `create_agent`'s final two lines split a Rich
+markup `[dim]...[/dim]` span across two separate `console.print()` calls:
+
+    console.print(f"\\n[dim]Agent tier '{tier}' will cost approximately:")
+    console.print(f"   {costs.get(tier, costs['capable'])} per execution[/dim]\\n")
+
+Rich parses markup independently per `console.print()` call, so the second
+call's lone `[/dim]` has no matching open tag and raises
+`rich.errors.MarkupError`. This means `create-agent` crashes on EVERY
+successful invocation (both interactive and quick mode) -- it has never
+completed cleanly. `create-team`'s analogous final line is a single
+`console.print()` call and does not share this bug. Tests below assert
+the command's REAL (buggy) behavior: exit_code == 1 with a MarkupError,
+after all prior output (including the JSON spec and any file save) has
+already been emitted.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from rich.errors import MarkupError
+from typer.testing import CliRunner
+
+from attune.meta_workflows.cli_commands import meta_workflow_app
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+def _run(runner, args, input_text=None):
+    return runner.invoke(meta_workflow_app, args, input=input_text)
+
+
+def _assert_crashes_on_cost_display(result):
+    """Shared assertion for the known create-agent MarkupError crash."""
+    assert result.exit_code == 1
+    assert isinstance(result.exception, MarkupError)
+    assert "closing tag" in str(result.exception)
+    assert "[/dim]" in str(result.exception)
+
+
+# ---------------------------------------------------------------------------
+# create_agent -- quick mode validation
+# ---------------------------------------------------------------------------
+
+
+class TestCreateAgentQuickModeValidation:
+    def test_missing_both_name_and_role(self, runner):
+        result = _run(runner, ["create-agent", "-q"])
+        assert result.exit_code == 1
+        assert isinstance(result.exception, SystemExit)
+        assert "--name and --role required in quick mode" in result.output
+        assert "Use --interactive for guided creation" in result.output
+        assert "Agent Specification Created" not in result.output
+
+    def test_missing_role_only(self, runner):
+        result = _run(runner, ["create-agent", "-q", "-n", "X"])
+        assert result.exit_code == 1
+        assert "--name and --role required in quick mode" in result.output
+
+    def test_missing_name_only(self, runner):
+        result = _run(runner, ["create-agent", "-q", "-r", "Y"])
+        assert result.exit_code == 1
+        assert "--name and --role required in quick mode" in result.output
+
+
+# ---------------------------------------------------------------------------
+# create_agent -- quick mode success (crashes on cost display -- see module
+# docstring). Coverage of the tier/cost dict branches is still exercised:
+# the f-string evaluates costs.get(...) before console.print() raises.
+# ---------------------------------------------------------------------------
+
+
+class TestCreateAgentQuickModeSuccess:
+    def test_default_tier_builds_expected_spec(self, runner):
+        result = _run(runner, ["create-agent", "-q", "-n", "Foo", "-r", "Do the thing"])
+        _assert_crashes_on_cost_display(result)
+        assert "Agent Specification Created" in result.output
+        assert '"name": "Foo"' in result.output
+        assert '"role": "Do the thing"' in result.output
+        assert '"tier": "capable"' in result.output
+        assert '"tools": []' in result.output
+        assert '"success_criteria": "Task completed successfully"' in result.output
+        assert '"base_template": "generic"' in result.output
+        assert "Next Steps:" in result.output
+        assert "Agent tier 'capable' will cost approximately:" in result.output
+
+    def test_cheap_tier(self, runner):
+        result = _run(runner, ["create-agent", "-q", "-n", "CheapBot", "-r", "role", "-t", "cheap"])
+        _assert_crashes_on_cost_display(result)
+        assert '"tier": "cheap"' in result.output
+        assert "Agent tier 'cheap' will cost approximately:" in result.output
+
+    def test_premium_tier(self, runner):
+        result = _run(
+            runner, ["create-agent", "-q", "-n", "PremBot", "-r", "role", "-t", "premium"]
+        )
+        _assert_crashes_on_cost_display(result)
+        assert '"tier": "premium"' in result.output
+        assert "Agent tier 'premium' will cost approximately:" in result.output
+
+    def test_unknown_tier_falls_back_to_capable_cost_lookup(self, runner):
+        """costs.get(tier, costs['capable']) fallback branch for an
+        unrecognized tier string -- the tier itself is stored as-is
+        (unvalidated), only the cost lookup falls back."""
+        result = _run(runner, ["create-agent", "-q", "-n", "UnkBot", "-r", "role", "-t", "turbo"])
+        _assert_crashes_on_cost_display(result)
+        assert '"tier": "turbo"' in result.output
+        assert "Agent tier 'turbo' will cost approximately:" in result.output
+
+    def test_output_file_is_saved_despite_downstream_crash(self, runner, tmp_path):
+        out_path = tmp_path / "spec.json"
+        result = _run(
+            runner,
+            [
+                "create-agent",
+                "-q",
+                "-n",
+                "Saver",
+                "-r",
+                "Save role",
+                "-o",
+                str(out_path),
+            ],
+        )
+        _assert_crashes_on_cost_display(result)
+        assert out_path.exists()
+        saved = json.loads(out_path.read_text())
+        assert saved == {
+            "name": "Saver",
+            "role": "Save role",
+            "tier": "capable",
+            "tools": [],
+            "success_criteria": "Task completed successfully",
+            "base_template": "generic",
+        }
+        assert "Saved to:" in result.output
+        # Rich soft-wraps long paths across lines at the terminal width;
+        # strip newlines before checking the full path is present.
+        assert str(out_path) in result.output.replace("\n", "")
+
+
+# ---------------------------------------------------------------------------
+# create_agent -- interactive mode
+# ---------------------------------------------------------------------------
+
+
+class TestCreateAgentInteractive:
+    def test_default_name_derived_from_purpose(self, runner):
+        """No --name given: name = purpose.split()[0].title() + 'Agent'.
+        Also covers tasks/tools comma-split-and-strip."""
+        answers = (
+            "\n".join(
+                [
+                    "fix bugs fast",  # purpose
+                    "write tests, review code",  # tasks
+                    "cheap",  # tier
+                    "file_read, code_exec",  # tools
+                    "all bugs fixed",  # success
+                ]
+            )
+            + "\n"
+        )
+        result = _run(runner, ["create-agent"], answers)
+        _assert_crashes_on_cost_display(result)
+        assert '"name": "FixAgent"' in result.output
+        assert '"role": "fix bugs fast"' in result.output
+        assert '"tasks": [' in result.output
+        assert '"write tests",' in result.output
+        assert '"review code"' in result.output
+        assert '"tier": "cheap"' in result.output
+        assert '"tools": [' in result.output
+        assert '"file_read",' in result.output
+        assert '"code_exec"' in result.output
+        assert '"success_criteria": "all bugs fixed"' in result.output
+
+    def test_cli_name_preserved_and_cli_tier_overwritten_by_prompt(self, runner):
+        """When --name is passed, the interactive branch keeps it (does NOT
+        derive from purpose). But --tier is unconditionally overwritten by
+        the tier prompt regardless of the CLI value -- a blank tier answer
+        falls back to the prompt's own default ('capable'), not the
+        --tier CLI value ('premium'). Also covers the 'none' tools default
+        (blank input) -> tools == []."""
+        answers = (
+            "\n".join(
+                [
+                    "some purpose text",  # purpose
+                    "task1, task2",  # tasks
+                    "",  # tier blank -> prompt default "capable"
+                    "",  # tools blank -> prompt default "none" -> []
+                    "success crit",  # success
+                ]
+            )
+            + "\n"
+        )
+        result = _run(
+            runner,
+            ["create-agent", "--name", "CustomBot", "--tier", "premium"],
+            answers,
+        )
+        _assert_crashes_on_cost_display(result)
+        assert '"name": "CustomBot"' in result.output
+        assert '"tier": "capable"' in result.output
+        assert '"premium"' not in result.output
+        assert '"tools": []' in result.output
+
+
+# ---------------------------------------------------------------------------
+# create_team -- quick mode validation
+# ---------------------------------------------------------------------------
+
+
+class TestCreateTeamQuickModeValidation:
+    def test_missing_both_name_and_goal(self, runner):
+        result = _run(runner, ["create-team", "-q"])
+        assert result.exit_code == 1
+        assert isinstance(result.exception, SystemExit)
+        assert "--name and --goal required in quick mode" in result.output
+        assert "Use --interactive for guided creation" in result.output
+        assert "Agent Team Template Created" not in result.output
+
+    def test_missing_goal_only(self, runner):
+        result = _run(runner, ["create-team", "-q", "-n", "X"])
+        assert result.exit_code == 1
+        assert "--name and --goal required in quick mode" in result.output
+
+    def test_missing_name_only(self, runner):
+        result = _run(runner, ["create-team", "-q", "-g", "Y"])
+        assert result.exit_code == 1
+        assert "--name and --goal required in quick mode" in result.output
+
+
+# ---------------------------------------------------------------------------
+# create_team -- quick mode success (no crash -- create_team's final print
+# is a single console.print() call, so its [dim]...[/dim] span is matched).
+# ---------------------------------------------------------------------------
+
+
+class TestCreateTeamQuickModeSuccess:
+    def test_builds_fixed_three_agent_team(self, runner):
+        result = _run(runner, ["create-team", "-q", "-n", "T1", "-g", "ship it"])
+        assert result.exit_code == 0
+        assert result.exception is None
+        assert "Agent Team Template Created" in result.output
+        assert '"id": "t1"' in result.output
+        assert '"name": "T1"' in result.output
+        assert '"description": "ship it"' in result.output
+        assert '"collaboration_pattern": "sequential"' in result.output
+        assert '"role": "Analyst"' in result.output
+        assert '"purpose": "Analyze requirements"' in result.output
+        assert '"role": "Executor"' in result.output
+        assert '"role": "Validator"' in result.output
+        assert '"min": 0.03' in result.output
+        assert '"max": 0.45' in result.output
+        assert "Estimated cost: $0.03 - $0.45 per execution" in result.output
+        assert "empathy meta-workflow run t1" in result.output
+
+    def test_output_file_is_saved(self, runner, tmp_path):
+        out_path = tmp_path / "team.json"
+        result = _run(
+            runner,
+            ["create-team", "-q", "-n", "T2", "-g", "ship it", "-o", str(out_path)],
+        )
+        assert result.exit_code == 0
+        assert out_path.exists()
+        saved = json.loads(out_path.read_text())
+        assert saved["id"] == "t2"
+        assert saved["name"] == "T2"
+        assert saved["description"] == "ship it"
+        assert len(saved["agents"]) == 3
+        assert saved["estimated_cost_range"] == {"min": 0.03, "max": 0.45}
+        assert "Saved to:" in result.output
+        # Rich soft-wraps long paths across lines at the terminal width;
+        # strip newlines before checking the full path is present.
+        assert str(out_path) in result.output.replace("\n", "")
+
+
+# ---------------------------------------------------------------------------
+# create_team -- interactive mode
+# ---------------------------------------------------------------------------
+
+
+class TestCreateTeamInteractive:
+    def test_single_agent_all_explicit(self, runner):
+        answers = (
+            "\n".join(
+                [
+                    "ship a release",  # goal
+                    "1",  # agent_count
+                    "Analyst",  # agent1 role
+                    "analyze requirements",  # agent1 purpose
+                    "cheap",  # agent1 tier
+                    "parallel",  # collaboration pattern
+                    "Ship Team",  # team name
+                ]
+            )
+            + "\n"
+        )
+        result = _run(runner, ["create-team"], answers)
+        assert result.exit_code == 0
+        assert '"id": "ship-team"' in result.output
+        assert '"name": "Ship Team"' in result.output
+        assert '"description": "ship a release"' in result.output
+        assert '"collaboration_pattern": "parallel"' in result.output
+        assert '"role": "Analyst"' in result.output
+        assert '"purpose": "analyze requirements"' in result.output
+        assert '"tier": "cheap"' in result.output
+        assert '"min": 0.01' in result.output
+        assert '"max": 0.15' in result.output
+        assert "Estimated cost: $0.01 - $0.15 per execution" in result.output
+
+    def test_cli_goal_overwritten_and_blank_answers_use_defaults(self, runner):
+        """The goal prompt ALWAYS overwrites any --goal CLI value (unlike
+        create_agent's name, there is no `if not goal` guard). Blank
+        answers for tier/pattern/name fall through to their prompt
+        defaults ('capable', 'sequential', and the goal-derived name)."""
+        answers = (
+            "\n".join(
+                [
+                    "prepare release notes",  # goal (overwrites --goal below)
+                    "1",  # agent_count
+                    "Reviewer",  # role
+                    "review the notes",  # purpose
+                    "",  # tier blank -> default "capable"
+                    "",  # pattern blank -> default "sequential"
+                    "",  # name blank -> default "PrepareTeam"
+                ]
+            )
+            + "\n"
+        )
+        result = _run(
+            runner,
+            ["create-team", "--goal", "ignored goal case"],
+            answers,
+        )
+        assert result.exit_code == 0
+        assert '"description": "prepare release notes"' in result.output
+        assert "ignored goal case" not in result.output
+        assert '"tier": "capable"' in result.output
+        assert '"collaboration_pattern": "sequential"' in result.output
+        assert '"name": "PrepareTeam"' in result.output
+        assert '"id": "prepareteam"' in result.output
+
+    def test_multiple_agents_loop_preserves_order(self, runner):
+        answers = (
+            "\n".join(
+                [
+                    "build a bot",  # goal
+                    "2",  # agent_count
+                    "Builder",  # agent1 role
+                    "build the thing",  # agent1 purpose
+                    "capable",  # agent1 tier
+                    "Tester",  # agent2 role
+                    "test the thing",  # agent2 purpose
+                    "cheap",  # agent2 tier
+                    "sequential",  # pattern
+                    "Bot Squad",  # name
+                ]
+            )
+            + "\n"
+        )
+        result = _run(runner, ["create-team"], answers)
+        assert result.exit_code == 0
+        assert '"id": "bot-squad"' in result.output
+
+        # Extract agents from the printed JSON panel for an exact structural
+        # assertion (order matters -- Builder must precede Tester). Rich
+        # draws box-drawing border chars ("│") at the start/end of each
+        # panel line; strip them before parsing back to JSON.
+        start = result.output.index("{")
+        end = result.output.rindex("}") + 1
+        raw_lines = result.output[start:end].splitlines()
+        json_text = "\n".join(line.strip(" │") for line in raw_lines)
+        data = json.loads(json_text)
+        assert data["agents"] == [
+            {
+                "role": "Builder",
+                "purpose": "build the thing",
+                "tier": "capable",
+                "base_template": "generic",
+            },
+            {
+                "role": "Tester",
+                "purpose": "test the thing",
+                "tier": "cheap",
+                "base_template": "generic",
+            },
+        ]
+        assert data["estimated_cost_range"] == {"min": 0.02, "max": 0.3}


### PR DESCRIPTION
## Summary

- Adds `tests/unit/meta_workflows/test_agent_commands.py` (18 tests, net-new) for `create_agent` and `create_team` in `src/attune/meta_workflows/cli_commands/agent_commands.py` -- previously untested by any file anywhere in `tests/`.
- Coverage on `agent_commands.py`: **~11% -> 99%** (98 statements, 1 miss -- the `if __name__ == "__main__":` boilerplate on line 319). Measured via `--cov=<path-to-package-dir>` per the worktree-coverage gotcha in `docs/specs/test-quality-program/qa-batch-playbook.md`.
- Covers: interactive Socratic flows for both commands (prompt sequencing, defaults, per-agent loop for `create-team`), quick-mode success and validation-error paths, the tier/cost dict branches (including an unrecognized-tier fallback), `--output` file saves, and precedence behavior (e.g. `create_team`'s `goal` prompt always overwrites a CLI `--goal`, while `create_agent`'s CLI `--name` is preserved but `--tier` is overwritten by the prompt).

### Bug found (documented, not fixed -- test-only PR)

Found and logged in `docs/COVERAGE_BUG_LOG.md`: **`create_agent` crashes with `rich.errors.MarkupError` on every successful invocation** (interactive and quick mode, any tier). Its final two `console.print()` calls split a single `[dim]...[/dim]` markup span across two separate calls; Rich parses markup independently per call, so the trailing `[/dim]` has no matching open tag. The command's core work (spec construction, `--output` file save) completes first, then the process crashes and exits 1 instead of printing its final cost-estimate line. `create-team`'s analogous line is a single call and does not share this bug (verified: exits 0 cleanly).

Tests assert this actual (buggy) behavior -- exit code 1 with the specific `MarkupError` -- rather than mocking around it, per the test-quality-program's "behavioral, not implementation-coupled" bar. Kept this PR test-only (no source change) per the qa-batch-playbook's one-net-new-file-per-PR cadence; a one-line fix (merge the two prints, or move the closing tag) is flagged as a follow-up.

## Test plan

- [x] `pytest tests/unit/meta_workflows/test_agent_commands.py -v` -- 18/18 passed
- [x] Coverage measured with `--cov=<abs-path>/src/attune/meta_workflows/cli_commands --cov-config=/dev/null` -- `agent_commands.py` at 99%
- [x] Pre-flighted pinned `black` and `ruff` on the new test file -- both clean
- [ ] CI (not waited on per instructions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)