### PR TITLE
test(meta_workflows): strengthen mapping/fallback assertions in CLI coverage tests

### DIFF
--- a/tests/unit/meta_workflows/test_config_commands.py
+++ b/tests/unit/meta_workflows/test_config_commands.py
@@ -95,6 +95,9 @@ class TestSuggestDefaultsCmd:
             result = runner.invoke(meta_workflow_app, ["suggest-defaults", template.template_id])
         assert result.exit_code == 0
         assert "mystery_q" in result.output
+        # The suggested value must still render alongside the raw-id fallback,
+        # else a regression dropping the value column would go unnoticed.
+        assert "value_x" in result.output
 
     def test_suggestion_list_value_joined_with_commas(self, runner):
         """Lines 91-93: list value -> joined with ', '."""
@@ -244,4 +247,8 @@ class TestShowMigrationGuide:
         result = runner.invoke(meta_workflow_app, ["migrate", crew_name])
         assert result.exit_code == 0
         assert f"Migrating: {crew_name}" in result.output
-        assert f"attune workflow run {template_id}" in result.output
+        # Pin the template_id field specifically: it is rendered ONLY by the
+        # "Try it now:" line. The bare "attune workflow run {id}" form also
+        # comes from info['new_usage'], so asserting that would pass even if
+        # template_id were corrupted while new_usage stayed correct.
+        assert f"Try it now: attune workflow run {template_id}" in result.output

--- a/tests/unit/meta_workflows/test_memory_commands.py
+++ b/tests/unit/meta_workflows/test_memory_commands.py
@@ -160,7 +160,10 @@ class TestSearchMemory:
             result = runner.invoke(meta_workflow_app, ["search-memory", "q"])
 
         assert result.exit_code == 0
-        assert "N/A" in result.output
+        # Three fields (id/type/classification) each fall back to 'N/A'; a bare
+        # "N/A" in output would be satisfied by a single default, so require all
+        # three to prove each field independently fell back.
+        assert result.output.count("N/A") >= 3
 
     def test_import_error_exits_1(self, runner):
         """ImportError while acquiring UnifiedMemory -> exit 1, specific message."""

--- a/tests/unit/meta_workflows/test_template_commands.py
+++ b/tests/unit/meta_workflows/test_template_commands.py
@@ -193,6 +193,8 @@ class TestListTemplates:
         # Header count reflects list_templates(), even though "ghost" never renders.
         assert "Available Templates (2 total)" in result.output
         assert "Real Template" in result.output
+        # The unloadable template must be skipped, not rendered as a ghost panel.
+        assert "ghost" not in result.output
 
     def test_registry_error_exits_1(self, runner):
         with patch(REGISTRY, side_effect=RuntimeError("storage unavailable")):


### PR DESCRIPTION
## What

Follow-up to today's CLI-coverage batch (#1398–#1402). A phase-2 review found four assertions that raised coverage but under-verified behavior — each could pass even with a real regression. Tightened them.

| Test | Before | After |
|------|--------|-------|
| `test_all_known_crews_map_to_correct_template` | asserted `attune workflow run {template_id}` — also rendered from `info['new_usage']`, so a corrupted `template_id` still passed | asserts the `Try it now:` line, the **sole** render site of the `template_id` field |
| `test_suggestion_unknown_question_id_falls_back_to_raw_id` | only asserted the raw-id fallback | also asserts the suggested value (`value_x`) renders |
| `test_missing_pattern_fields_default_to_na` | `"N/A" in output` — satisfied by one field | `count("N/A") >= 3` — proves id/type/classification each fell back |
| `test_skips_unloadable_template_silently` | only asserted the real template renders | also asserts the unloadable `ghost` template is **not** rendered |

## Verification

- All 60 tests across the three files pass.
- `black --check` and `ruff` clean.
- No SUT changes — test-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
