### PR TITLE
fix(ops): attune ops --port default honors the PORT env var

### DIFF
--- a/src/attune/ops/cli.py
+++ b/src/attune/ops/cli.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import os
 import sys
 import webbrowser
 from pathlib import Path
@@ -22,8 +23,8 @@ def add_subparser(subparsers: argparse._SubParsersAction) -> None:
     parser.add_argument(
         "--port",
         type=int,
-        default=8765,
-        help="Port (default: 8765)",
+        default=int(os.environ.get("PORT") or 8765),
+        help="Port (default: $PORT env var if set, else 8765)",
     )
     parser.add_argument(
         "--project-root",

--- a/tests/unit/ops/test_cli.py
+++ b/tests/unit/ops/test_cli.py
@@ -54,7 +54,11 @@ def _make_parser() -> argparse.ArgumentParser:
 
 
 class TestAddSubparser:
-    def test_defaults(self) -> None:
+    def test_defaults(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Port default reads $PORT; delenv so 8765 is deterministic
+        # regardless of the caller's environment (e.g. a Cowork
+        # preview manager that exports PORT).
+        monkeypatch.delenv("PORT", raising=False)
         parser = _make_parser()
         args = parser.parse_args(["ops"])
         assert args.host == "127.0.0.1"
@@ -71,6 +75,21 @@ class TestAddSubparser:
         args = parser.parse_args(["ops", "--port", "9000"])
         assert args.port == 9000
         assert isinstance(args.port, int)
+
+    def test_port_defaults_to_env_var_when_set(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # A process manager (Cowork preview, container) that exports
+        # PORT gets honored without passing --port explicitly.
+        monkeypatch.setenv("PORT", "8010")
+        parser = _make_parser()
+        args = parser.parse_args(["ops"])
+        assert args.port == 8010
+        assert isinstance(args.port, int)
+
+    def test_explicit_port_flag_overrides_env_var(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("PORT", "8010")
+        parser = _make_parser()
+        args = parser.parse_args(["ops", "--port", "9000"])
+        assert args.port == 9000
 
     def test_project_root_coerced_to_path(self, tmp_path: Path) -> None:
         parser = _make_parser()


### PR DESCRIPTION
## What

`attune ops --port` defaulted to a hardcoded `8765`, ignoring the `PORT` environment variable that process managers export to assign a free port. When 8765 is already occupied (e.g. a stale `attune.ops` from another worktree), the Cowork preview manager's `autoPort` mode can't place the server — because the CLI never consults the port it was handed, so it re-binds 8765 and collides.

## Change

- `src/attune/ops/cli.py`: `--port` default now reads `PORT` (falling back to `8765` when unset). An explicit `--port` still overrides. One-line, backward-compatible.

## Why this matters

With this on `main`, the editable install picks up the PORT-aware default, so `.claude/launch.json` can use `"autoPort": true` with no `--port` flag and the preview manager places the dashboard on whatever port is free — no more manual port juggling when 8765 is taken.

## Tests

- `test_port_defaults_to_env_var_when_set` — `PORT=8010` → `args.port == 8010`
- `test_explicit_port_flag_overrides_env_var` — `--port 9000` beats `PORT=8010`
- `test_defaults` — now clears `PORT` so the 8765 default is deterministic

25/25 in `tests/unit/ops/test_cli.py` pass; black/ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
