### PR TITLE
docs(process): record book decisions + V7 form-template requirements draft

### DIFF
--- a/docs/process/BOOK_OUTLINE.md
+++ b/docs/process/BOOK_OUTLINE.md
@@ -27,13 +27,20 @@ metaphor/chapter conversations land somewhere.
   quantitative only as demonstrated results, never promised
   multipliers.
 
-## Proposed structure (UNRATIFIED — redline me)
+## Structure (RATIFIED 2026-07-16)
+
+Ratified as proposed by Patrick 2026-07-16 (decision form,
+11:55 session). Ordering within parts stays open.
 
 - **Part I — The discipline.** Grown from the article's real
   spine (§1 premise/vibe-coding counter-thesis · §2 mutual
   contract incl. autonomous mode · §3 pacing · §4 artifact
   discipline · §5 memory discipline · §6 multi-agent coordination
   · §7 verification · §8 24-hour case study).
+  **Part-I mode (RATIFIED 2026-07-16):** book chapters CITE the
+  live article as canon — no absorbed second master; the
+  published, pipeline-guarded article stays the single source
+  until a publisher requires embedded text.
 - **Part II — The craft.** The sculptor chapter (marble = data,
   the chisel never chooses the statue, sculpt-once-cast-many);
   artifact altitude in depth; the communication grammar as a
@@ -79,9 +86,12 @@ metaphor/chapter conversations land somewhere.
 - Chapter ratification, title, and ordering are Patrick's
   decisions — record them here with dates when made.
 
-## Open decisions (Patrick)
+## Decisions record (Patrick)
 
-1. Working title.
-2. Ratify/redline the three-part structure.
-3. Whether Part I reuses the article's sections directly (expand
-   in place) or the book chapters cite the article as canon.
+1. **Working title — DEFERRED (2026-07-16).** Internal handle
+   stays "the dev-with-AI book"; revisit once Part II/III prose
+   exists. No downstream dependency.
+2. **Three-part structure — RATIFIED as proposed (2026-07-16).**
+   See the Structure section above.
+3. **Part-I mode — cite the article as canon (2026-07-16).**
+   Recorded inline in the Structure section.

--- a/docs/specs/elicitation-form-surface/v7-requirements.md
+++ b/docs/specs/elicitation-form-surface/v7-requirements.md
@@ -1,0 +1,105 @@
+# Elicitation Form Surface — V7 Requirements: form-template library
+
+**Status:** draft (2026-07-16) — awaiting Patrick approval.
+**Freeze:** design-only until 2026-07-28; no code before the freeze
+lifts. V6 (MCP Apps adapter, `v6-requirements.md`) is queued for the
+same window — see Sequencing below.
+**Source:** Patrick's idea, discussed 2026-07-16 ("sculpt a form
+once, cast per fork") — the sculptor clause applied to the grammar's
+own artifacts.
+
+## The idea — sculpt once, cast per fork
+
+Every form today is hand-built per invocation: a skill or session
+assembles a dict and calls `form_from_dict`. Recurring fork classes —
+release-gate sign-off, session contract, triage matrix — get
+re-sculpted from scratch each time, with drift between castings.
+
+V7 adds a **template library**: a recurring form is persisted once as
+a named JSON template, and later invocations load it with per-use
+slot values. The value frame is **comparability**: reused forms make
+answers comparable across sessions — a sign-off form asked from the
+same template turns its responses into a time series, a dataset.
+
+## What already exists — reuse, do not rebuild
+
+- `form_from_dict` (`bridge.py:366`) — validates a plain-dict form
+  definition and returns a `FormSchema`. The template loader is a
+  thin wrapper over this; validation stays in the one seam.
+- `FormSchema` / `FormQuestion` (`meta_workflows/models.py`) — plain
+  dataclasses, already round-trippable through serializable dicts.
+- `FormResponse` (`models.py`) — carries `template_id`, so responses
+  already have the join key the comparability frame needs.
+- The four constructs (intake / decision / pushback / progress) and
+  their render paths — templates are instances of the existing
+  grammar, not a new member.
+
+## The gap — code-verified 2026-07-16
+
+No form-template persistence exists anywhere in `src/attune`:
+`grep -rn "form_from_template"` → zero hits; every `FormSchema` is
+built ad hoc via `form_from_dict` or direct construction. There is no
+store, no loader, no catalog.
+
+## Requirements
+
+- **R1 — template store.** A directory of JSON template files, one
+  per recurring fork class (e.g. `release-gate-signoff.json`,
+  `session-contract.json`, `triage-matrix.json`). Each file is
+  exactly the dict shape `form_from_dict` already accepts, plus a
+  `slots` declaration for per-use substitution points.
+- **R2 — loader.** `form_from_template(name, slots)` (~10 lines):
+  read the JSON, substitute slot values, delegate to `form_from_dict`.
+  No new QuestionType, no validator changes — malformed templates
+  fail through the existing `FormValidationError` path (R4 upheld).
+- **R3 — slot substitution.** Slots are named placeholders in string
+  fields (title, question text, options). Missing or extra slot
+  values are definition errors, reported through the same
+  every-problem-listed error style `form_from_dict` uses.
+- **R4 — catalog surface.** The `elicit` skill documents the
+  available templates (name, construct, purpose, slots) so a session
+  reaches for a template before hand-building.
+- **R5 — promote-on-repeat discipline.** A form earns templatehood on
+  its SECOND recurrence — same rule as lessons. No speculative
+  templates; the library ships with only templates whose fork class
+  has already recurred (candidates at draft time: release-gate
+  sign-off, session contract — confirm recurrence before seeding).
+
+## Acceptance criteria — receipts, not registration
+
+- **AC-1 — round-trip receipt.** A template loaded via
+  `form_from_template`, rendered on a live surface, answered by a
+  human, validated through `collect_form_response`. Receipt =
+  response id (D15/D16/V5 pattern).
+- **AC-2 — comparability receipt.** The same template asked in two
+  distinct sessions, with the two `FormResponse` records joinable on
+  `template_id` — the time-series claim demonstrated, not asserted.
+- **AC-3 — validation parity.** A deliberately malformed template
+  (bad type, duplicate id, missing slot) fails with the same
+  every-problem-listed `FormValidationError` a hand-built dict gets.
+
+## Out of scope
+
+- New QuestionTypes, validator changes, or render changes — zero.
+- Template versioning/migration — revisit when a template actually
+  changes shape after collecting responses.
+- Auto-promotion tooling (detecting the second recurrence
+  mechanically) — the discipline is manual until the library proves
+  itself.
+
+## Sequencing vs V6 (same post-freeze window)
+
+Recommend **V7 before V6**: V7 is pure-local plumbing (no API, no
+host dependency, dogfoodable same-day) and its templates give V6's
+MCP Apps round-trip receipts (AC-1/AC-2 there) realistic payloads to
+render. V6's ChatGPT-host receipt has external dependencies (host
+support, dev-mode access) that can slip without blocking V7 value.
+
+## Tasks (for review)
+
+1. Template store directory + 1-2 seed templates (recurrence
+   confirmed per R5).
+2. `form_from_template` loader + slot substitution + tests
+   (including AC-3 malformed-template cases).
+3. `elicit` skill catalog section (R4).
+4. Dogfood: live round-trip for AC-1, second-session ask for AC-2.


### PR DESCRIPTION
## What

Follow-up to #1407 (the 9:32→11:55 session handoff):

1. **Book decisions recorded in `BOOK_OUTLINE.md`** — resolved by Patrick 2026-07-16 via decision forms, one at a time:
   - Three-part structure **RATIFIED as proposed** (I discipline / II craft / III legible systems); ordering within parts stays open.
   - **Part-I mode:** book chapters **cite the live discipline article as canon** — no absorbed second 10.8k-word master.
   - **Working title: DEFERRED** — internal handle stays "the dev-with-AI book"; revisit once Part II/III prose exists.

2. **`v7-requirements.md`** (elicitation-form-surface) — the form-template library ("sculpt a form once, cast per fork") firmed into a spec draft, awaiting Patrick approval:
   - Gap code-verified: no `form_from_template` anywhere; every form hand-built via `form_from_dict`.
   - Template store (JSON per recurring fork class) + ~10-line loader delegating to the existing `form_from_dict` seam; zero new QuestionType, zero validator changes.
   - Promote-on-repeat discipline (templatehood on SECOND recurrence), comparability receipts (AC-2: same template across two sessions, responses joinable on `template_id`).
   - Sequencing: **V7 before V6** post-freeze (2026-07-28) — V7 is pure-local/dogfoodable and feeds V6's round-trip receipts realistic payloads.

Docs-only; no code (elicitation design freeze until 2026-07-28 respected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)