### PR TITLE
feat(widgets): render a panel for prose-only analysis workflows (Family-B)

### DIFF
--- a/docs/specs/archive/analysis-workflow-output-widgets/requirements.md
+++ b/docs/specs/archive/analysis-workflow-output-widgets/requirements.md
@@ -1,6 +1,16 @@
 # Analysis-Workflow Output Widgets — requirements
 
-**Status:** merged (2026-07-14) — into discovery-sweep-rich-surface (D4 re-scope: only discovery-sweep is structured)
+**Status:** merged (2026-07-14) — into discovery-sweep-rich-surface.
+**Superseded note (2026-07-16):** the D4 "only discovery-sweep is
+structured" framing is stale. A UNIVERSAL `report_to_panel_html`
+(`workflows/report_panel.py`) now attaches `panel_html` to EVERY
+analysis workflow whose run yields parseable findings (security-audit,
+perf-audit, bug-predict, code-review, doc-gen, refactor-plan,
+smart-test, code-quality, dependency-check, test-audit, deep-review);
+discovery-sweep keeps its dedicated board. The remaining "Family-B"
+gap — prose-only runs (no parseable findings) — was closed by
+`markdown_to_panel_html`, so those now render a styled panel too rather
+than raw markdown.
 **Kickoff:** `/spec` widget form, response `resp-20260628-143856`
 (goal = formalize the program; workflows = all 7; shared_renderer = yes;
 "parallel acceptable").

--- a/src/attune/mcp/workflow_handlers.py
+++ b/src/attune/mcp/workflow_handlers.py
@@ -174,6 +174,14 @@ def _workflow_response(
         response.update(_report_fields(result, fo, raw_output, field_picks))
     else:
         response.update(_legacy_fields(fo, raw_output, field_picks))
+        # Family-B: a prose-only run (no parseable findings) leaves
+        # final_output as the raw markdown string. Give it a styled panel
+        # too, so prose workflows (deep-review, test-audit, refactor-plan,
+        # dependency-check, code-review) aren't stuck with raw markdown.
+        if isinstance(fo, str) and fo.strip():
+            from attune.workflows.report_panel import markdown_to_panel_html
+
+            response["panel_html"] = markdown_to_panel_html(fo, succeeded=result.success)
 
     cost_report = getattr(result, "cost_report", None)
     response["cost"] = cost_report.total_cost if cost_report is not None else 0.0

--- a/src/attune/workflows/report_panel.py
+++ b/src/attune/workflows/report_panel.py
@@ -100,7 +100,7 @@ def _section_html(section: dict[str, Any]) -> str:
     if kind == "list":
         items = section.get("items") or []
         lis = (
-            "".join(f"<li>{_highlight(i)}</li>" for i in items) or '<li class="rp-empty">none</li>'
+            "".join(f"<li>{_md_inline(i)}</li>" for i in items) or '<li class="rp-empty">none</li>'
         )
         return _wrap(len(items), f'<ul class="rp-list">{lis}</ul>')
 
@@ -111,7 +111,7 @@ def _section_html(section: dict[str, Any]) -> str:
             text = a.get("text") if isinstance(a, dict) else str(a)
             cmd = a.get("command") if isinstance(a, dict) else None
             cmd_html = f' <code class="rp-cmd">{esc(cmd)}</code>' if cmd else ""
-            lis += f"<li>{_highlight(text)}{cmd_html}</li>"
+            lis += f"<li>{_md_inline(text)}{cmd_html}</li>"
         lis = lis or '<li class="rp-empty">none</li>'
         return _wrap(len(items), f'<ul class="rp-list">{lis}</ul>')
 
@@ -120,7 +120,7 @@ def _section_html(section: dict[str, Any]) -> str:
     # the analysis-workflow path today, but keeps the panel robust.
     items = section.get("items") or []
     if items:
-        lis = "".join(f"<li>{_highlight(i)}</li>" for i in items)
+        lis = "".join(f"<li>{_md_inline(i)}</li>" for i in items)
         return _wrap(len(items), f'<ul class="rp-list">{lis}</ul>')
     text = section.get("text") or section.get("body") or ""
     return _wrap(0, f'<div class="rp-prose">{esc(text)}</div>')

--- a/src/attune/workflows/report_panel.py
+++ b/src/attune/workflows/report_panel.py
@@ -177,6 +177,109 @@ def report_to_panel_html(report: dict[str, Any], succeeded: bool = True, message
     )
 
 
+# ------------------------------------------------------------------
+# Family-B: prose-only workflows (deep-review, test-audit,
+# refactor-plan, dependency-check, code-review) yield no parseable
+# findings, so their final_output stays raw markdown text rather than
+# a WorkflowReport. Render that prose as a panel too — same chrome and
+# injection-safety contract — instead of dumping raw markdown.
+# ------------------------------------------------------------------
+
+_MD_H_RE = re.compile(r"^(#{1,6})\s+(.*)$")
+_MD_BULLET_RE = re.compile(r"^\s*[-*+]\s+(.*)$")
+_MD_NUM_RE = re.compile(r"^\s*\d+[.)]\s+(.*)$")
+_MD_BOLD_RE = re.compile(r"\*\*(.+?)\*\*")
+_MD_CODE_RE = re.compile(r"`([^`]+)`")
+
+
+def _md_inline(text: Any) -> str:
+    """Escape a line, then apply safe inline markdown plus shared accents.
+
+    Runs ``_highlight`` first (``esc`` + CWE / ``file:line`` accents), so the
+    bold/code regexes only ever wrap already-escaped text — a raw ``<script>``
+    in the source can never survive as markup. Injection-safe by construction.
+    """
+    t = _highlight(text)
+    t = _MD_BOLD_RE.sub(r"<strong>\1</strong>", t)
+    t = _MD_CODE_RE.sub(r'<code class="rp-cmd">\1</code>', t)
+    return t
+
+
+def markdown_to_panel_html(
+    markdown: str, title: str = "", succeeded: bool = True, message: str = ""
+) -> str:
+    """Render a prose markdown string as a panel for ``show_widget``.
+
+    Supports a lightweight subset — ATX headings (``#``..``######``),
+    bullet / numbered lists, paragraphs, inline ``**bold**`` and
+    ``` `code` ```. Unknown syntax degrades to escaped text, never raw HTML.
+
+    Args:
+        markdown: The raw agent markdown (an analysis workflow's
+            ``final_output`` when no findings parsed).
+        title: Optional panel heading.
+        succeeded: ``False`` renders an explicit "did not complete" state —
+            never a false all-clear (the security-dashboard lesson, #1152).
+        message: Optional caption above the panel.
+
+    Returns:
+        Self-contained HTML for ``mcp__visualize__show_widget``.
+    """
+    caption = f'<p class="rp-msg">{esc(message)}</p>' if message else ""
+
+    if not succeeded:
+        return (
+            '<div id="rp-panel">'
+            + _STYLE
+            + caption
+            + '<div class="rp-fail">⚠ Workflow did not complete — no results '
+            + "to show. This is NOT a clean result; check the run/auth "
+            + "status and re-run.</div></div>"
+        )
+
+    head = f'<div class="rp-head"><span class="rp-title">{esc(title)}</span></div>' if title else ""
+
+    blocks: list[str] = []
+    para: list[str] = []
+    items: list[str] = []
+
+    def flush_para() -> None:
+        if para:
+            blocks.append(f'<p class="rp-md-p">{"<br>".join(_md_inline(x) for x in para)}</p>')
+            para.clear()
+
+    def flush_list() -> None:
+        if items:
+            lis = "".join(f"<li>{i}</li>" for i in items)
+            blocks.append(f'<ul class="rp-list">{lis}</ul>')
+            items.clear()
+
+    for line in (markdown or "").splitlines():
+        h = _MD_H_RE.match(line)
+        b = _MD_BULLET_RE.match(line) or _MD_NUM_RE.match(line)
+        if h:
+            flush_para()
+            flush_list()
+            level = min(len(h.group(1)), 6)
+            blocks.append(f'<div class="rp-md-h rp-md-h{level}">{_md_inline(h.group(2))}</div>')
+        elif b:
+            flush_para()
+            items.append(_md_inline(b.group(1)))
+        elif not line.strip():
+            flush_para()
+            flush_list()
+        else:
+            flush_list()
+            para.append(line)
+    flush_para()
+    flush_list()
+
+    body = "".join(blocks) or '<div class="rp-empty">no content</div>'
+    return (
+        '<div id="rp-panel">' + _STYLE + caption + head + f'<div class="rp-md">{body}</div></div>'
+    )
+
+
 _STYLE = """<style>
 #rp-panel { display:block; width:100%; padding:1rem 0;
   color:var(--text-primary); line-height:1.45; font-size:14px; }
@@ -219,4 +322,11 @@ _STYLE = """<style>
 #rp-panel .rp-prose { white-space:pre-wrap; color:var(--text-secondary); }
 #rp-panel .rp-empty { font-size:13px; color:var(--text-muted); font-style:italic; }
 #rp-panel .rp-fail { font-size:13.5px; font-weight:500; color:#e5484d; }
+#rp-panel .rp-md { color:var(--text-secondary); }
+#rp-panel .rp-md-p { margin:.5rem 0; }
+#rp-panel .rp-md-h { font-weight:600; color:var(--text-primary); margin:.9rem 0 .35rem; }
+#rp-panel .rp-md-h1, #rp-panel .rp-md-h2 { font-size:15px; }
+#rp-panel .rp-md-h3, #rp-panel .rp-md-h4,
+#rp-panel .rp-md-h5, #rp-panel .rp-md-h6 { font-size:13.5px; }
+#rp-panel .rp-md strong { color:var(--text-primary); }
 </style>"""

--- a/tests/unit/mcp/handlers/test_workflow_response.py
+++ b/tests/unit/mcp/handlers/test_workflow_response.py
@@ -143,6 +143,36 @@ class TestWorkflowResponseLegacy:
         assert out["approved"] is None
         assert out["recommendation"] is None
 
+    def test_prose_string_final_output_gets_panel(self):
+        # Family-B: a prose-only run (no parseable findings) leaves
+        # final_output a raw markdown string — it should still get a panel.
+        result = _make_result(final_output="# Review\n\nAll **good**.", total_cost=0.0)
+        out = _workflow_response(result, raw_output=True)
+
+        assert isinstance(out.get("panel_html"), str)
+        assert 'id="rp-panel"' in out["panel_html"]
+        assert "<strong>good</strong>" in out["panel_html"]
+        # raw markdown still passes through unchanged for back-compat
+        assert out["output"] == "# Review\n\nAll **good**."
+
+    def test_prose_panel_failed_run_not_a_false_all_clear(self):
+        result = _make_result(success=False, final_output="partial output", total_cost=0.0)
+        out = _workflow_response(result, raw_output=True)
+
+        assert "did not complete" in out["panel_html"]
+
+    def test_dict_final_output_gets_no_prose_panel(self):
+        result = _make_result(final_output={"coverage": 85})
+        out = _workflow_response(result, raw_output=True)
+
+        assert "panel_html" not in out
+
+    def test_empty_string_final_output_gets_no_panel(self):
+        result = _make_result(final_output="   ", total_cost=0.0)
+        out = _workflow_response(result, raw_output=True)
+
+        assert "panel_html" not in out
+
 
 # ==================================================================
 # _workflow_response — serialized WorkflowReport path

--- a/tests/unit/workflows/test_report_panel.py
+++ b/tests/unit/workflows/test_report_panel.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import pytest
 
 from attune.workflows.agent_sdk_adapter import AgentSDKResultAdapter as A
-from attune.workflows.report_panel import report_to_panel_html
+from attune.workflows.report_panel import markdown_to_panel_html, report_to_panel_html
 
 pytestmark = pytest.mark.unit
 
@@ -146,3 +146,52 @@ class TestInjectionSafety:
     def test_no_script_tag(self):
         html = report_to_panel_html(_report({"security": ["x"]}))
         assert "<script" not in html.lower()
+
+
+class TestMarkdownPanel:
+    """Family-B: prose-only workflows render markdown through a panel."""
+
+    def test_headings_lists_and_paragraphs_render(self):
+        md = "# Deep Review\n\nCode is fine.\n\n- item one\n- item two\n\n## Next\n1. do a thing"
+        html = markdown_to_panel_html(md, title="Deep Review")
+        assert 'id="rp-panel"' in html
+        # title head + both ATX headings become rp-md-h blocks
+        assert html.count("rp-md-h") >= 2
+        assert "Deep Review" in html and "Next" in html
+        # bullets AND the numbered item both become <li>
+        assert html.count("<li>") == 3
+        assert "item one" in html and "do a thing" in html
+        # a plain line becomes a paragraph
+        assert 'class="rp-md-p"' in html and "Code is fine." in html
+
+    def test_inline_bold_and_code(self):
+        html = markdown_to_panel_html("Overall **solid** work in `config.py`")
+        assert "<strong>solid</strong>" in html
+        assert '<code class="rp-cmd">config.py</code>' in html
+
+    def test_cwe_and_file_ref_accents_reused(self):
+        html = markdown_to_panel_html("- Hardcoded key in config.py:88 (CWE-798)")
+        assert 'class="rp-ref"' in html  # file:line accent
+        assert 'class="rp-cwe"' in html  # CWE accent
+
+    def test_escapes_html_never_emits_raw_markup(self):
+        html = markdown_to_panel_html("A `<script>alert(1)</script>` snippet")
+        assert "<script>" not in html
+        assert "&lt;script&gt;" in html
+
+    def test_no_script_tag(self):
+        assert "<script" not in markdown_to_panel_html("# H\n\ntext").lower()
+
+    def test_failure_state_never_a_false_all_clear(self):
+        html = markdown_to_panel_html("looks fine", succeeded=False)
+        assert "did not complete" in html
+        assert "NOT a clean result" in html
+
+    def test_empty_input_renders_placeholder_not_crash(self):
+        html = markdown_to_panel_html("")
+        assert 'id="rp-panel"' in html
+        assert "no content" in html
+
+    def test_message_caption_rendered(self):
+        html = markdown_to_panel_html("body", message="deep-review of src/")
+        assert "deep-review of src/" in html

--- a/tests/unit/workflows/test_report_panel.py
+++ b/tests/unit/workflows/test_report_panel.py
@@ -43,6 +43,15 @@ class TestCategoryBullets:
         assert "bare except" in html
         assert "<ul" in html
 
+    def test_list_bullets_render_inline_bold_and_code(self):
+        # text-tier bullets often carry markdown; render it, don't leave
+        # literal **asterisks** / `backticks` (the Family-B follow-up)
+        d = _report({"security": ["Use **parameterized** queries, never `eval`"]})
+        html = report_to_panel_html(d)
+        assert "<strong>parameterized</strong>" in html
+        assert '<code class="rp-cmd">eval</code>' in html
+        assert "**parameterized**" not in html
+
     def test_score_and_summary_in_header(self):
         html = report_to_panel_html(_report({"security": ["x"]}, summary="2 issues found."))
         assert "score 72/100" in html


### PR DESCRIPTION
## What

Closes the last "Family-B" gap in the analysis-workflow widget surface. Workflows whose run yields **no parseable findings** left `final_output` a raw markdown **string**, which fails `is_report_dict` → `_legacy_fields` → raw markdown, **no widget**. So prose-heavy workflows (deep-review, test-audit, refactor-plan, dependency-check, code-review) were the only ones without a `show_widget` panel.

## Changes

- **`workflows/report_panel.py`** — new `markdown_to_panel_html`: a lightweight, injection-safe renderer for ATX headings / bullet + numbered lists / paragraphs + inline `**bold**` and ``code``. Reuses the existing `esc` / `_highlight` / `_STYLE` chrome and the "did not complete" failure state (never a false all-clear — #1152 lesson).
- **`mcp/workflow_handlers.py`** — in `_workflow_response`, when the non-report `final_output` is a non-empty string, attach `panel_html`. Dict legacy outputs and empty strings are untouched.
- **Follow-up (second commit): text-tier bullets now render inline bold/code.** The `list`/`next-steps`/generic section renderers used `_highlight` (accents only), leaving literal `**asterisks**`; swapped to `_md_inline` so category-bullet output matches the prose panel. Finding cards keep `_highlight` (structured path).

Result: **every** analysis workflow gets a styled widget, and text-tier bullets no longer show raw markdown asterisks.

## Also

Reconciles the stale **"only discovery-sweep is structured"** status in the archived `analysis-workflow-output-widgets` spec.

## Injection safety

Every source string is `esc`'d first; the bold/code regexes run on already-escaped text, so a raw `<script>` can never survive as markup (tests cover this).

## Tests

- `TestMarkdownPanel` (8) + `test_list_bullets_render_inline_bold_and_code` + `_workflow_response` integration (4). Full `tests/unit/workflows/` + `tests/unit/mcp/handlers/` suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)