### PR TITLE
feat(widgets): clickable next-step buttons close the workflow→report loop

### DIFF
--- a/docs/specs/discovery-sweep-rich-surface/decisions.md
+++ b/docs/specs/discovery-sweep-rich-surface/decisions.md
@@ -54,9 +54,45 @@ without the audits multi-select the remaining open fields don't justify
 a form over the existing AskUserQuestion scoping — so the whole input
 surface waits for FR-3 rather than shipping a thin form now.
 
+## D4 — report-panel next-steps close the loop via `sendPrompt`; rich source, not the adapter's flat one
+
+**Date:** 2026-07-16 · **Status:** decided
+
+The report panel's `next-steps` actions became **clickable**: a next-step
+carrying a `command` renders a "run" button that posts the command back
+through the widget's global `sendPrompt`, so it becomes the user's next
+prompt — closing `workflow → report panel → pick a next step → next
+workflow`. Reuses the elicitation widget's return-path pattern (D8/S1
+there): the command lives in a `data-rp-command` attribute, read
+generically from the DOM, never interpolated into script. The single
+`<script>` is emitted **only** when the report has an actionable command;
+a report with no actions stays pure display, script-free.
+
+**Where the command comes from — the non-obvious half.** The
+`command` field existed on `output.NextAction` but no producer set it,
+and the adapter's text/structured extraction flattens every suggestion's
+`workflow_name` to the non-runnable `agent-followup`. The rich,
+project-aware names (`security-audit`, `test-gen`, …) come from
+`generate_suggestions()`, which runs in `execution_mixin` **after** the
+adapter already serialized the report — so the buttons were inert on the
+real path (the "registered ≠ working / dogfood the real path" trap;
+caught only by running the real producer, not the unit path). Fix: after
+`result.suggestions = generate_suggestions(...)`, refresh the report's
+next-steps section from those rich suggestions
+(`output.report_dict_with_next_steps`). Translation
+`workflow_name → slash command` reuses `cli_router`'s canonical map via
+the new `workflow_to_slash_command()` (no duplicate mapping).
+
+Same injection-safety contract as D2's board and D11's form. `agent-followup`
+resolves to `None` → renders as static text, not a button.
+
 ## Open
 
 - Phase 2: should `sources` filter live on the engine (`run`) as a
   plural `source_names`, or be resolved to an adapter list at the tool
   layer (engine unchanged)? Lean tool-layer (smaller engine surface;
   the engine already accepts an explicit `sources` adapter list).
+- Next-step buttons: cap/dedupe the rendered actions (`generate_suggestions`
+  can return several), and revisit the slash-command format for workflows
+  whose `_WORKFLOW_SKILL_MAP` entry is the generic `/workflows run <name>`
+  fallback — confirm each resolves to a real skill invocation.

--- a/src/attune/cli_router.py
+++ b/src/attune/cli_router.py
@@ -18,6 +18,50 @@ import yaml
 from attune.routing import SmartRouter
 from attune.security.path_validation import _validate_file_path
 
+#: Canonical ``workflow_name -> (skill, args)`` map. The single source of
+#: truth for translating a workflow name into a Claude Code skill
+#: invocation — used both by :meth:`HybridRouter._workflow_to_skill` and by
+#: :func:`workflow_to_slash_command` (the next-step button's re-run command).
+_WORKFLOW_SKILL_MAP: dict[str, tuple[str, str]] = {
+    "security-audit": ("workflows", "run security-audit"),
+    "bug-predict": ("workflows", "run bug-predict"),
+    "code-review": ("dev", "review"),
+    "test-gen": ("testing", "gen"),
+    "perf-audit": ("workflows", "run perf-audit"),
+    "commit": ("dev", "commit"),
+    "refactor": ("dev", "refactor"),
+    "simplify": ("workflows", "run simplify-code"),
+    "simplify-code": ("workflows", "run simplify-code"),
+    "debug": ("dev", "debug"),
+    "explain": ("docs", "explain"),
+    "plan": ("plan", ""),
+}
+
+#: Generic placeholder workflow names that have no concrete re-runnable
+#: command (a suggestion the engine could not tie to a real workflow).
+_NON_RUNNABLE_WORKFLOWS = frozenset({"agent-followup", ""})
+
+
+def workflow_to_slash_command(workflow: str) -> str | None:
+    """Translate a workflow name into a re-runnable Claude Code slash command.
+
+    Used by the report panel's next-step buttons: clicking one posts this
+    string through the widget's ``sendPrompt`` so it becomes the next
+    prompt, closing the workflow -> report -> next-step loop.
+
+    Args:
+        workflow: Workflow name from a suggestion (e.g. ``"security-audit"``).
+
+    Returns:
+        A slash command like ``"/workflows run security-audit"`` or
+        ``"/dev review"``, or ``None`` for a generic placeholder
+        (``"agent-followup"``) that names no concrete workflow.
+    """
+    if workflow in _NON_RUNNABLE_WORKFLOWS:
+        return None
+    skill, args = _WORKFLOW_SKILL_MAP.get(workflow, ("workflows", f"run {workflow}"))
+    return f"/{skill} {args}".rstrip() if args else f"/{skill}"
+
 
 @dataclass
 class RoutingPreference:
@@ -394,23 +438,7 @@ class HybridRouter:
             Tuple of (skill_name, args)
 
         """
-        # Workflow to skill mapping
-        workflow_map = {
-            "security-audit": ("workflows", "run security-audit"),
-            "bug-predict": ("workflows", "run bug-predict"),
-            "code-review": ("dev", "review"),
-            "test-gen": ("testing", "gen"),
-            "perf-audit": ("workflows", "run perf-audit"),
-            "commit": ("dev", "commit"),
-            "refactor": ("dev", "refactor"),
-            "simplify": ("workflows", "run simplify-code"),
-            "simplify-code": ("workflows", "run simplify-code"),
-            "debug": ("dev", "debug"),
-            "explain": ("docs", "explain"),
-            "plan": ("plan", ""),
-        }
-
-        return workflow_map.get(workflow, ("workflows", f"run {workflow}"))
+        return _WORKFLOW_SKILL_MAP.get(workflow, ("workflows", f"run {workflow}"))
 
     def learn_preference(self, keyword: str, skill: str, args: str = "") -> None:
         """Learn user's routing preference.

--- a/src/attune/workflows/agent_sdk_adapter.py
+++ b/src/attune/workflows/agent_sdk_adapter.py
@@ -32,11 +32,10 @@ from .output import (
     Finding,
     FindingsSection,
     ListSection,
-    NextStepsSection,
     Section,
     WorkflowReport,
+    next_steps_section_from_suggestions,
 )
-from .output import NextAction as ReportNextAction
 
 logger = logging.getLogger(__name__)
 
@@ -1675,14 +1674,15 @@ class AgentSDKResultAdapter:
                 ]
                 sections.append(ListSection(title=heading, tier="essential", items=str_items))
 
-        if suggestions:
-            sections.append(
-                NextStepsSection(
-                    title="Next steps",
-                    tier="essential",
-                    items=[ReportNextAction(text=s.description) for s in suggestions],
-                )
-            )
+        # Attach a re-runnable slash command to each suggestion so the report
+        # panel can render one-click next-step buttons (closes the
+        # workflow -> report -> next-step loop). The adapter's text-extracted
+        # suggestions flatten to the non-runnable ``agent-followup``, so these
+        # render as static text until the richer ``generate_suggestions``
+        # pipeline refreshes them post-execution (see execution_mixin).
+        next_steps = next_steps_section_from_suggestions(suggestions)
+        if next_steps is not None:
+            sections.append(next_steps)
 
         report_metadata: dict[str, object] = {"duration_s": duration_ms / 1000}
         if total_cost is not None:

--- a/src/attune/workflows/execution_mixin.py
+++ b/src/attune/workflows/execution_mixin.py
@@ -308,6 +308,17 @@ class ExecutionMixin:
             from .suggestions import generate_suggestions
 
             result.suggestions = generate_suggestions(self.name, result)
+            # Re-source the report panel's next-step buttons from these richer
+            # suggestions. The report in final_output was serialized earlier
+            # from the adapter's text-extracted suggestions (flattened to the
+            # non-runnable ``agent-followup``); this swaps in the real workflow
+            # commands so the next-step buttons become clickable and close the
+            # workflow -> report -> next-step loop.
+            from .output import report_dict_with_next_steps
+
+            result.final_output = report_dict_with_next_steps(
+                result.final_output, result.suggestions
+            )
         except Exception as e:  # noqa: BLE001
             # INTENTIONAL: Suggestions are optional -- never crash workflow
             logger.debug("Suggestion generation skipped: %s", e)

--- a/src/attune/workflows/output.py
+++ b/src/attune/workflows/output.py
@@ -324,3 +324,78 @@ class WorkflowReport:
     def is_report_dict(value: object) -> bool:
         """True if ``value`` is a serialized WorkflowReport (voice detection)."""
         return isinstance(value, dict) and value.get("_type") == "WorkflowReport"
+
+
+def next_steps_section_from_suggestions(
+    suggestions: list[object],
+) -> NextStepsSection | None:
+    """Build a ``NextStepsSection`` from suggestion objects, attaching a
+    re-runnable slash command to each.
+
+    The command turns the panel's next-step into a one-click "run" button that
+    posts the command back through ``sendPrompt`` — closing the
+    ``workflow -> report -> next-step -> next workflow`` loop. Each suggestion
+    is anything exposing ``description`` and ``workflow_name`` (a
+    ``attune.workflows.data_classes.NextAction``). The command is resolved via
+    :func:`attune.cli_router.workflow_to_slash_command`; a suggestion whose
+    ``workflow_name`` names no concrete workflow (``agent-followup``) gets a
+    ``None`` command and renders as static text, not a button.
+
+    Args:
+        suggestions: Suggestion objects to render as forward actions.
+
+    Returns:
+        A populated ``NextStepsSection``, or ``None`` when there are no
+        suggestions (the caller appends nothing).
+    """
+    if not suggestions:
+        return None
+    from attune.cli_router import workflow_to_slash_command
+
+    return NextStepsSection(
+        title="Next steps",
+        tier="essential",
+        items=[
+            NextAction(
+                text=str(getattr(s, "description", "") or ""),
+                command=workflow_to_slash_command(str(getattr(s, "workflow_name", "") or "")),
+            )
+            for s in suggestions
+        ],
+    )
+
+
+def report_dict_with_next_steps(report: object, suggestions: list[object]) -> object:
+    """Return ``report`` with its next-steps section rebuilt from ``suggestions``.
+
+    Applied after the richer, project-aware suggestion pipeline
+    (``generate_suggestions``) runs post-execution: the report inside
+    ``WorkflowResult.final_output`` was serialized earlier from the adapter's
+    text-extracted suggestions (which flatten to the non-runnable
+    ``agent-followup``), so its next-step buttons would be inert. This swaps in
+    the rich suggestions' real workflow commands.
+
+    Non-report values (raw markdown, prose) pass through untouched, as does a
+    report when ``suggestions`` is empty (its existing section is preserved).
+
+    Args:
+        report: ``WorkflowResult.final_output`` — a serialized report dict or
+            raw markdown.
+        suggestions: The rich suggestions to source next-step commands from.
+
+    Returns:
+        The report dict with its next-steps section replaced, or ``report``
+        unchanged when it is not a report dict or there is nothing to add.
+    """
+    if not suggestions or not WorkflowReport.is_report_dict(report):
+        return report
+    assert isinstance(report, dict)
+    section = next_steps_section_from_suggestions(suggestions)
+    if section is None:
+        return report
+    kept = [
+        s
+        for s in (report.get("sections") or [])
+        if not (isinstance(s, dict) and s.get("kind") == NextStepsSection.kind)
+    ]
+    return {**report, "sections": [*kept, section.to_dict()]}

--- a/src/attune/workflows/report_panel.py
+++ b/src/attune/workflows/report_panel.py
@@ -18,9 +18,21 @@ So ONE panel renders any of them — no per-finding-shape assumptions
 ``_workflow_response`` report path, it lights up every report workflow at
 once.
 
-Same injection-safety contract as the other widgets: display-only (no
-``<script>``), every report-derived string ``html.escape``d, CDS tokens,
-transparent background, no ``position: fixed``.
+``next-steps`` actions that carry a ``command`` render as **clickable**
+buttons: on click the widget posts the command back through the global
+``sendPrompt`` so it becomes the next prompt — closing the loop
+``workflow → report panel → pick a next step → next workflow``. This
+reuses the exact return-path pattern the elicitation widget proved
+(``attune.elicitation.widget``): the command lives in a ``data-``
+attribute and is read generically from the DOM — never interpolated into
+the script — so a malicious command string cannot inject markup or code.
+
+Same injection-safety contract as the other widgets: every
+report-derived string ``html.escape``d, CDS tokens, transparent
+background, no ``position: fixed``, and no report data in executable
+script. A single ``<script>`` is emitted ONLY when the report has at
+least one actionable next-step command; a report with no actions stays
+pure display, script-free.
 """
 
 from __future__ import annotations
@@ -110,10 +122,23 @@ def _section_html(section: dict[str, Any]) -> str:
         for a in items:
             text = a.get("text") if isinstance(a, dict) else str(a)
             cmd = a.get("command") if isinstance(a, dict) else None
-            cmd_html = f' <code class="rp-cmd">{esc(cmd)}</code>' if cmd else ""
-            lis += f"<li>{_md_inline(text)}{cmd_html}</li>"
+            if cmd:
+                # Clickable action — closes the loop. The command sits in
+                # ``data-rp-command`` (escaped for the attribute; read back
+                # verbatim via getAttribute) and is posted by _ACTION_SCRIPT
+                # through ``sendPrompt``. It degrades to readable text (the
+                # ``<code>``) when the surface has no ``sendPrompt``.
+                lis += (
+                    '<li><button type="button" class="rp-step" '
+                    f'data-rp-command="{esc(cmd)}">'
+                    '<span class="rp-step-run">run</span> '
+                    f'<span class="rp-step-text">{_md_inline(text)}</span> '
+                    f'<code class="rp-cmd">{esc(cmd)}</code></button></li>'
+                )
+            else:
+                lis += f'<li><span class="rp-step-static">{_md_inline(text)}</span></li>'
         lis = lis or '<li class="rp-empty">none</li>'
-        return _wrap(len(items), f'<ul class="rp-list">{lis}</ul>')
+        return _wrap(len(items), f'<ul class="rp-list rp-steps">{lis}</ul>')
 
     # Generic fallback for any other section kind (callout/prose/table):
     # render the title plus any string items, escaped. Never produced by
@@ -166,6 +191,14 @@ def report_to_panel_html(report: dict[str, Any], succeeded: bool = True, message
     if not sections_html:
         sections_html = '<div class="rp-empty">no findings reported</div>'
 
+    # The script is emitted ONLY when a next-step actually carries a
+    # command — a report with no actions stays pure display, script-free.
+    has_actions = any(
+        s.get("kind") == "next-steps"
+        and any(isinstance(a, dict) and a.get("command") for a in (s.get("items") or []))
+        for s in sections
+    )
+
     return (
         '<div id="rp-panel">'
         + _STYLE
@@ -173,6 +206,7 @@ def report_to_panel_html(report: dict[str, Any], succeeded: bool = True, message
         + f'<div class="rp-head"><span class="rp-title">{title}</span>{score_html}</div>'
         + summary_html
         + sections_html
+        + (_ACTION_SCRIPT if has_actions else "")
         + "</div>"
     )
 
@@ -329,4 +363,49 @@ _STYLE = """<style>
 #rp-panel .rp-md-h3, #rp-panel .rp-md-h4,
 #rp-panel .rp-md-h5, #rp-panel .rp-md-h6 { font-size:13.5px; }
 #rp-panel .rp-md strong { color:var(--text-primary); }
+#rp-panel .rp-steps { list-style:none; padding-left:0; }
+#rp-panel .rp-steps li { margin:.2rem 0; }
+#rp-panel .rp-step { display:flex; align-items:baseline; gap:.45rem; width:100%;
+  text-align:left; padding:.45rem .6rem; font-size:14px; color:var(--text-primary);
+  background:var(--surface-1); border:1px solid var(--border);
+  border-radius:var(--radius); cursor:pointer; font-family:inherit; }
+#rp-panel .rp-step:hover { border-color:var(--border-accent); }
+#rp-panel .rp-step-run { flex:0 0 auto; font-size:10.5px; font-weight:700;
+  text-transform:uppercase; letter-spacing:.04em; color:var(--text-accent);
+  border:1px solid var(--border-accent); border-radius:3px; padding:0 .35em; }
+#rp-panel .rp-step-text { flex:1 1 auto; }
+#rp-panel .rp-step .rp-cmd { flex:0 0 auto; }
+#rp-panel .rp-step-sent { opacity:.55; cursor:default; }
+#rp-panel .rp-step-sent .rp-step-run::after { content:" \\2713"; }
+#rp-panel .rp-step[data-rp-nopost] .rp-step-run { color:var(--text-muted);
+  border-color:var(--border); }
+#rp-panel .rp-step-static { color:var(--text-secondary); }
 </style>"""
+
+
+#: Injection-safe click handler. Reads each action's command from its
+#: ``data-rp-command`` attribute (never from interpolated report data) and
+#: posts it verbatim through the widget's global ``sendPrompt`` — the same
+#: return path the elicitation widget uses. Emitted by
+#: :func:`report_to_panel_html` only when the report has an actionable
+#: next-step. Degrades gracefully: with no ``sendPrompt`` the button tags
+#: itself ``data-rp-nopost`` and the command stays readable as text.
+_ACTION_SCRIPT = """<script>
+(function() {
+  var panel = document.getElementById('rp-panel');
+  if (!panel) return;
+  panel.querySelectorAll('button.rp-step[data-rp-command]').forEach(function(btn) {
+    btn.addEventListener('click', function() {
+      var cmd = btn.getAttribute('data-rp-command');
+      if (!cmd) return;
+      if (typeof sendPrompt === 'function') {
+        sendPrompt(cmd);
+        btn.classList.add('rp-step-sent');
+        btn.disabled = true;
+      } else {
+        btn.setAttribute('data-rp-nopost', '1');
+      }
+    });
+  });
+})();
+</script>"""

--- a/tests/unit/workflows/test_output_model.py
+++ b/tests/unit/workflows/test_output_model.py
@@ -20,7 +20,76 @@ from attune.workflows.output import (
     Section,
     TableSection,
     WorkflowReport,
+    next_steps_section_from_suggestions,
+    report_dict_with_next_steps,
 )
+
+
+class _Suggestion:
+    """Minimal stand-in for data_classes.NextAction (description + name)."""
+
+    def __init__(self, workflow_name: str, description: str) -> None:
+        self.workflow_name = workflow_name
+        self.description = description
+
+
+class TestNextStepsSectionFromSuggestions:
+    def test_real_workflow_gets_runnable_command(self) -> None:
+        section = next_steps_section_from_suggestions(
+            [_Suggestion("security-audit", "Re-run the audit")]
+        )
+        assert section is not None
+        assert section.items[0].command == "/workflows run security-audit"
+        assert section.items[0].text == "Re-run the audit"
+
+    def test_generic_followup_has_no_command(self) -> None:
+        section = next_steps_section_from_suggestions(
+            [_Suggestion("agent-followup", "Look into it")]
+        )
+        assert section is not None
+        assert section.items[0].command is None
+
+    def test_empty_returns_none(self) -> None:
+        assert next_steps_section_from_suggestions([]) is None
+
+
+class TestReportDictWithNextSteps:
+    def _report_with_flat_steps(self) -> dict:
+        rep = WorkflowReport(
+            title="X",
+            summary="s",
+            score=1,
+            metadata={},
+            sections=[
+                ListSection(title="security", tier="essential", items=["finding"]),
+                NextStepsSection(
+                    title="Next steps",
+                    tier="essential",
+                    items=[NextAction(text="stale flat step", command=None)],
+                ),
+            ],
+        )
+        return rep.to_dict()
+
+    def test_swaps_in_rich_commands_and_replaces_old_section(self) -> None:
+        out = report_dict_with_next_steps(
+            self._report_with_flat_steps(),
+            [_Suggestion("code-review", "Review the diff")],
+        )
+        steps = [s for s in out["sections"] if s["kind"] == "next-steps"]
+        assert len(steps) == 1  # replaced, not duplicated
+        assert steps[0]["items"][0]["command"] == "/dev review"
+        # the non-next-steps section is preserved
+        assert any(s["kind"] == "list" for s in out["sections"])
+
+    def test_non_report_passes_through(self) -> None:
+        assert (
+            report_dict_with_next_steps("raw markdown", [_Suggestion("x", "y")]) == "raw markdown"
+        )
+
+    def test_empty_suggestions_preserves_report_unchanged(self) -> None:
+        rep = self._report_with_flat_steps()
+        assert report_dict_with_next_steps(rep, []) is rep
 
 
 def _full_report() -> WorkflowReport:

--- a/tests/unit/workflows/test_report_panel.py
+++ b/tests/unit/workflows/test_report_panel.py
@@ -130,6 +130,73 @@ class TestNextSteps:
         assert "Rotate the leaked key" in html
 
 
+class TestNextStepActions:
+    """A next-step with a command renders a clickable button that posts the
+    command back via sendPrompt — closing the workflow -> report loop."""
+
+    def _with_suggestions(self, suggestions):
+        from attune.workflows.data_classes import NextAction
+
+        return _report(
+            {"security": ["x"]},
+            suggestions=[NextAction(**s) for s in suggestions],
+        )
+
+    def test_command_renders_clickable_button(self):
+        d = self._with_suggestions(
+            [
+                {
+                    "workflow_name": "security-audit",
+                    "description": "Re-run the audit",
+                    "reasoning": "r",
+                }
+            ]
+        )
+        html = report_to_panel_html(d)
+        assert 'class="rp-step"' in html
+        assert 'data-rp-command="/workflows run security-audit"' in html
+        assert "Re-run the audit" in html
+
+    def test_command_maps_via_router(self):
+        # code-review maps to /dev review, not the generic /workflows run
+        d = self._with_suggestions(
+            [{"workflow_name": "code-review", "description": "Review it", "reasoning": "r"}]
+        )
+        assert 'data-rp-command="/dev review"' in report_to_panel_html(d)
+
+    def test_generic_followup_has_no_button(self):
+        # agent-followup names no concrete workflow -> static text, no button
+        d = self._with_suggestions(
+            [{"workflow_name": "agent-followup", "description": "Look into it", "reasoning": "r"}]
+        )
+        html = report_to_panel_html(d)
+        assert "Look into it" in html
+        assert "rp-step-static" in html
+        assert 'class="rp-step"' not in html
+
+    def test_actionable_report_emits_one_sendprompt_script(self):
+        d = self._with_suggestions(
+            [{"workflow_name": "security-audit", "description": "Re-run", "reasoning": "r"}]
+        )
+        html = report_to_panel_html(d)
+        assert html.count("<script>") == 1
+        assert "sendPrompt" in html
+
+    def test_report_without_actions_stays_script_free(self):
+        # findings but no suggestions -> pure display, no script
+        html = report_to_panel_html(_report({"security": ["x"]}))
+        assert "<script" not in html.lower()
+
+    def test_malicious_workflow_name_escaped_in_attribute(self):
+        d = self._with_suggestions(
+            [{"workflow_name": 'evil" onclick="alert(1)', "description": "x", "reasoning": "r"}]
+        )
+        html = report_to_panel_html(d)
+        # the injected quote/handler must be entity-escaped, never live markup
+        assert 'onclick="alert(1)"' not in html
+        assert "&quot;" in html
+
+
 class TestFailureState:
     def test_failed_run_not_clean(self):
         d = _report({"security": ["x"]})


### PR DESCRIPTION
## What

Analysis-workflow report panels now render `next-steps` actions as clickable **RUN** buttons. Clicking one posts its command back through the widget's global `sendPrompt` — becoming the user's next prompt — which closes the loop:

`workflow → report panel → pick a next step → next workflow → new report`

This is the output-side half of the "forms and widgets" surface: the elicitation widget collects decisions (input), the report panel now hands back runnable next actions (output), both through the same `sendPrompt` return path and the same injection-safety contract.

## The non-obvious part (why this is more than a render tweak)

The `command` field already existed on `output.NextAction`, but **no producer set it**, and the adapter flattens every suggestion's `workflow_name` to the non-runnable `agent-followup`. The rich workflow names (`security-audit`, `test-gen`, …) come from `generate_suggestions()`, which runs in `execution_mixin` **after** the adapter already serialized the report — so the buttons were inert on the real path (classic "registered ≠ working"; caught only by dogfooding the real producer).

Fix: after `result.suggestions = generate_suggestions(...)`, `execution_mixin` refreshes the report's next-steps from those rich suggestions via `output.report_dict_with_next_steps`. The `workflow_name → slash command` translation reuses `cli_router`'s canonical map through the new `workflow_to_slash_command()` (no duplicate mapping).

## Changes

| File | Change |
|---|---|
| `workflows/report_panel.py` | Clickable next-step buttons; single `sendPrompt` script emitted only when an actionable command exists; CSS |
| `cli_router.py` | Extract `_WORKFLOW_SKILL_MAP` + new `workflow_to_slash_command()` |
| `workflows/output.py` | `next_steps_section_from_suggestions()` + `report_dict_with_next_steps()` |
| `workflows/agent_sdk_adapter.py` | Use the shared next-steps builder |
| `workflows/execution_mixin.py` | Re-source panel next-steps from the rich suggestion pipeline |
| tests | +13 (render, command mapping, injection, refresh, passthrough) |
| `docs/specs/discovery-sweep-rich-surface/decisions.md` | D4 |

## Verification

- **live-fire:** browser click on a real `report_to_panel_html` output fired `sendPrompt("/workflows run security-audit")` and marked the button `RUN ✓`.
- **behavioral:** dogfood proved *before* refresh → no buttons (inert), *after* refresh → real commands, old flat text replaced, exactly one next-steps section; non-report and empty-suggestion inputs pass through untouched.
- **injection-safe:** malicious `workflow_name`/`description` entity-escaped; only the single controlled IIFE survives.
- **suite:** 3323 passed across workflows + voice + mcp; 95 passed cli_router. No regressions.

## Scope

Output-side only. The V7 elicitation form surface (design freeze until 2026-07-28) is untouched.

## Follow-ups (noted in D4 "Open")

- Cap/dedupe rendered next-steps (`generate_suggestions` can return several).
- Confirm each `/workflows run <name>` fallback resolves to a real skill invocation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
