### PR TITLE
feat(elicitation): add canonical all-controls reference form

### DIFF
--- a/docs/specs/elicitation-form-surface/design.md
+++ b/docs/specs/elicitation-form-surface/design.md
@@ -109,3 +109,36 @@ a real round-trip, not a mock.
   or redirect (wizard step / `/spec` intake are alternatives).
 - **Rule-relaxation criteria** (§4) — the behavioral change; needs
   explicit OK, since it edits attune's Socratic question-shape habit.
+
+## 7. Reference form — every control type (freeze-safe V7 precursor)
+
+`attune.elicitation.reference_form` is the single code-verified example
+of a *complete* declarative form: exactly one field per `QuestionType`
+member (all ten — the four v1 controls, the three v2.1 rich controls,
+and the v3–v5 constructs), each with realistic values, paired with
+valid `EXAMPLE_ANSWERS`.
+
+```python
+from attune.elicitation import (
+    REFERENCE_FORM,
+    EXAMPLE_ANSWERS,
+    form_from_dict,
+    collect_form_response,
+)
+
+form = form_from_dict(REFERENCE_FORM)
+response = collect_form_response(form, EXAMPLE_ANSWERS)
+```
+
+It is a plain data constant — **not** a template-store entry or a
+`form_from_template` call. That mechanism is the V7 template library,
+design-frozen until 2026-07-28; this reference is the freeze-safe
+precursor that becomes V7's first stored template verbatim when the
+freeze lifts.
+
+`tests/unit/elicitation/test_reference_form.py` guards it: a
+completeness test fails CI if a new `QuestionType` is added without a
+field here, so the reference cannot silently fall behind the grammar.
+The same test proves the definition validates, the answers round-trip,
+a missing required answer is rejected (R4), and the form casts to all
+three surfaces (`widget` / `AskUserQuestion` / native elicitation).

--- a/src/attune/elicitation/__init__.py
+++ b/src/attune/elicitation/__init__.py
@@ -30,9 +30,12 @@ from attune.elicitation.bridge import (
     form_to_askuserquestion,
 )
 from attune.elicitation.elicitation_schema import form_to_elicitation_schema
+from attune.elicitation.reference_form import EXAMPLE_ANSWERS, REFERENCE_FORM
 from attune.elicitation.widget import WIDGET_RESPONSE_MARKER, form_to_widget_html
 
 __all__ = [
+    "EXAMPLE_ANSWERS",
+    "REFERENCE_FORM",
     "WIDGET_RESPONSE_MARKER",
     "FormValidationError",
     "collect_form_response",

--- a/src/attune/elicitation/reference_form.py
+++ b/src/attune/elicitation/reference_form.py
@@ -1,0 +1,152 @@
+"""Canonical reference form exercising every elicitation control type.
+
+This module is the single, code-verified example of a *complete*
+declarative form: one field per :class:`~attune.meta_workflows.models.QuestionType`
+member, each with realistic example values, plus a matching set of valid
+answers. It is deliberately a plain data constant — importable and
+copy-from-able today — not a template-store entry or a
+``form_from_template`` invocation. Those belong to the V7 template
+library, which is design-frozen until 2026-07-28; this reference is the
+freeze-safe precursor that becomes V7's first stored template verbatim
+once the freeze lifts.
+
+The paired :data:`REFERENCE_FORM` / :data:`EXAMPLE_ANSWERS` round-trip
+through the existing seams with no changes:
+
+    >>> from attune.elicitation import form_from_dict, collect_form_response
+    >>> form = form_from_dict(REFERENCE_FORM)
+    >>> response = collect_form_response(form, EXAMPLE_ANSWERS)
+    >>> response.responses["priority"]
+    'high'
+
+``tests/unit/elicitation/test_reference_form.py`` asserts the form stays
+complete: if a new ``QuestionType`` is added without a field here, CI
+fails — the reference cannot silently fall behind the grammar.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+#: A complete declarative form — exactly one field per control type.
+#: The scenario (a small "new feature intake") keeps the example
+#: coherent rather than a random grab-bag of controls.
+REFERENCE_FORM: dict[str, Any] = {
+    "title": "Reference form — every control type",
+    "description": "One field per elicitation control, with example values.",
+    "fields": [
+        {
+            # v1: free single-line text
+            "id": "feature_name",
+            "type": "text_input",
+            "text": "What is the feature called?",
+            "help_text": "A short human-readable name.",
+        },
+        {
+            # v1: pick exactly one
+            "id": "priority",
+            "type": "single_select",
+            "text": "How urgent is it?",
+            "options": ["low", "medium", "high"],
+        },
+        {
+            # v1: pick zero or more — batches N dimensions into one turn
+            "id": "concerns",
+            "type": "multi_select",
+            "text": "Which concerns apply?",
+            "options": ["impl", "test", "docs", "migration", "release-notes"],
+        },
+        {
+            # v1: yes / no
+            "id": "needs_migration",
+            "type": "boolean",
+            "text": "Does it require a data migration?",
+        },
+        {
+            # v2.1: bounded number
+            "id": "estimated_days",
+            "type": "number",
+            "text": "Estimated effort in days?",
+            "minimum": 0,
+            "maximum": 30,
+        },
+        {
+            # v2.1: ISO-8601 date
+            "id": "target_date",
+            "type": "date",
+            "text": "Target ship date?",
+        },
+        {
+            # v2.1: multi-line, length-bounded, optional
+            "id": "notes",
+            "type": "textarea",
+            "text": "Anything else to capture?",
+            "max_length": 500,
+            "required": False,
+        },
+        {
+            # v3: a recommended single-select with rationale + tradeoffs
+            "id": "rollout",
+            "type": "decision",
+            "text": "How should we roll it out?",
+            "options": [
+                "Ship behind a feature flag",
+                "Ship to everyone at once",
+                "Hold for the next release",
+            ],
+            "recommended": "Ship behind a feature flag",
+            "rationale": "A flag lets us dark-launch and roll back without a redeploy.",
+            "option_notes": {
+                "Ship behind a feature flag": "Safest — gated exposure, instant rollback.",
+                "Ship to everyone at once": "Fastest, but no kill switch if it regresses.",
+                "Hold for the next release": "Zero risk now, but delays the value.",
+            },
+        },
+        {
+            # v4: a pushback — the user's approach vs the agent's alternative
+            "id": "branch_strategy",
+            "type": "pushback",
+            "text": "You proposed a long-lived feature branch.",
+            "options": [
+                "Long-lived feature branch",
+                "Short stacked PRs off main",
+            ],
+            "user_position": "Long-lived feature branch",
+            "recommended": "Short stacked PRs off main",
+            "rationale": "Long-lived branches drift from main and make review a big-bang; "
+            "small stacked PRs stay mergeable and reviewable.",
+        },
+        {
+            # v5: a status report whose blocked items are a picker
+            "id": "blockers",
+            "type": "progress",
+            "text": "Which blocker should we tackle first?",
+            "options": ["Design sign-off", "Staging environment"],
+            "progress_items": [
+                {"label": "Requirements", "status": "done", "detail": "approved"},
+                {"label": "Prototype", "status": "in_flight", "detail": "in review"},
+                {"label": "Design sign-off", "status": "blocked", "detail": "awaiting design"},
+                {
+                    "label": "Staging environment",
+                    "status": "blocked",
+                    "detail": "infra ticket open",
+                },
+            ],
+        },
+    ],
+}
+
+#: Valid answers for every field in :data:`REFERENCE_FORM`. Round-trips
+#: through ``collect_form_response`` to a successful ``FormResponse``.
+EXAMPLE_ANSWERS: dict[str, Any] = {
+    "feature_name": "Dark mode toggle",
+    "priority": "high",
+    "concerns": ["impl", "test", "docs"],
+    "needs_migration": "No",
+    "estimated_days": 3,
+    "target_date": "2026-08-01",
+    "notes": "Ship behind a flag, measure, then widen.",
+    "rollout": "Ship behind a feature flag",
+    "branch_strategy": "Short stacked PRs off main",
+    "blockers": "Design sign-off",
+}

--- a/tests/unit/elicitation/test_reference_form.py
+++ b/tests/unit/elicitation/test_reference_form.py
@@ -1,0 +1,92 @@
+"""Tests for the canonical all-controls reference form.
+
+Guards two invariants:
+
+1. **Completeness** — the reference exercises *every* ``QuestionType``.
+   If a new control type is added to the grammar without a field in
+   ``REFERENCE_FORM``, ``test_reference_covers_every_control_type``
+   fails, so the reference cannot silently fall behind.
+2. **Round-trip** — the reference plus its example answers validate
+   through the real ``form_from_dict`` → ``collect_form_response`` seams
+   (no mocks), and a missing required answer is rejected (R4).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from attune.elicitation import (
+    EXAMPLE_ANSWERS,
+    REFERENCE_FORM,
+    FormValidationError,
+    collect_form_response,
+    form_from_dict,
+    form_to_askuserquestion,
+    form_to_elicitation_schema,
+    form_to_widget_html,
+)
+from attune.meta_workflows.models import QuestionType
+
+
+def test_reference_covers_every_control_type() -> None:
+    """The reference must contain exactly one field per QuestionType."""
+    field_types = {field["type"] for field in REFERENCE_FORM["fields"]}
+    all_types = {qtype.value for qtype in QuestionType}
+    assert field_types == all_types, (
+        "REFERENCE_FORM drifted from the grammar: "
+        f"missing {all_types - field_types}, extra {field_types - all_types}"
+    )
+
+
+def test_reference_form_definition_validates() -> None:
+    """form_from_dict accepts the reference and keeps every field."""
+    form = form_from_dict(REFERENCE_FORM)
+    assert len(form.questions) == len(REFERENCE_FORM["fields"])
+
+
+def test_example_answers_round_trip() -> None:
+    """Valid answers collect into a FormResponse with a join key."""
+    form = form_from_dict(REFERENCE_FORM)
+    response = collect_form_response(form, EXAMPLE_ANSWERS, template_id="reference-form")
+
+    assert response.template_id == "reference-form"
+    assert response.response_id  # auto-populated, non-empty
+    # Every field carrying an example answer round-trips.
+    for field_id in EXAMPLE_ANSWERS:
+        assert field_id in response.responses
+    assert response.responses["priority"] == "high"
+    assert response.responses["estimated_days"] == 3
+
+
+def test_missing_required_answer_is_rejected() -> None:
+    """R4: dropping a required answer names exactly that field."""
+    form = form_from_dict(REFERENCE_FORM)
+    answers = {k: v for k, v in EXAMPLE_ANSWERS.items() if k != "priority"}
+
+    with pytest.raises(FormValidationError) as exc_info:
+        collect_form_response(form, answers)
+
+    assert any("priority" in problem for problem in exc_info.value.problems)
+
+
+def test_optional_field_may_be_omitted() -> None:
+    """The optional textarea (notes) is not required to collect."""
+    form = form_from_dict(REFERENCE_FORM)
+    answers = {k: v for k, v in EXAMPLE_ANSWERS.items() if k != "notes"}
+
+    response = collect_form_response(form, answers)
+    assert "notes" not in response.responses
+
+
+def test_reference_casts_to_every_surface() -> None:
+    """All three renderers accept the reference without raising."""
+    form = form_from_dict(REFERENCE_FORM)
+
+    html = form_to_widget_html(form)
+    assert isinstance(html, str) and html
+
+    batches = form_to_askuserquestion(form)
+    assert isinstance(batches, list) and batches
+
+    # Native elicitation schema (non-rendering on CC, but must not raise).
+    form_to_elicitation_schema(form)


### PR DESCRIPTION
## What

Adds `attune.elicitation.reference_form` — the single code-verified,
importable example of a *complete* declarative form: exactly one field
per `QuestionType` (all ten controls — v1, v2.1 rich, and the v3–v5
constructs), paired with valid `EXAMPLE_ANSWERS`.

```python
from attune.elicitation import REFERENCE_FORM, EXAMPLE_ANSWERS, form_from_dict, collect_form_response

form = form_from_dict(REFERENCE_FORM)
response = collect_form_response(form, EXAMPLE_ANSWERS)
```

## Why

A canonical "all controls, with examples" reference you can copy from,
and a **CI-enforced completeness invariant**: the drift test fails if a
new `QuestionType` is added without a field here, so the reference can
never silently fall behind the grammar.

## Freeze-safe

This is a plain data constant — **not** `form_from_template` or a
template store. The V7 template library stays design-frozen until
2026-07-28; this reference is the freeze-safe precursor that becomes
V7's first stored template verbatim when the freeze lifts.

## Files

- `src/attune/elicitation/reference_form.py` — `REFERENCE_FORM` + `EXAMPLE_ANSWERS`
- `src/attune/elicitation/__init__.py` — exports both
- `tests/unit/elicitation/test_reference_form.py` — completeness guard + round-trip + R4 rejection + all-three-surface cast
- `docs/specs/elicitation-form-surface/design.md` — §7 documenting the reference

## Verification

- 6 new tests + full 220-test elicitation suite pass locally
- Pinned black + ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
