### PR TITLE
perf(elicitation): emit only the CSS a form's controls use

### DIFF
--- a/src/attune/elicitation/widget.py
+++ b/src/attune/elicitation/widget.py
@@ -377,6 +377,133 @@ def _field_html(q: FormQuestion) -> str:
     )
 
 
+#: The form CSS, split by control family. Every form emits ``_CSS_BASE``;
+#: each field pulls in only the family its control renders with, so a form
+#: never ships styles for controls it lacks (a number+date form omits the
+#: cards/progress rules — ~60% of the block). See :func:`_needed_css`.
+_CSS_BASE = """#attune-elicit-form { display:block; width:100%; padding:1rem 0;
+  color:var(--text-primary); line-height:1.5; }
+#attune-elicit-form .sr-only { position:absolute; width:1px; height:1px;
+  overflow:hidden; clip:rect(0 0 0 0); }
+#attune-elicit-form h3 { font-size:18px; font-weight:500; margin:0 0 .25rem; }
+#attune-elicit-form .ae-msg { margin:0 0 .5rem; color:var(--text-secondary); }
+#attune-elicit-form .ae-desc { margin:0 0 1rem; color:var(--text-muted);
+  font-size:15px; }
+#attune-elicit-form .ae-field { margin:0 0 1rem; }
+#attune-elicit-form .ae-label { display:block; font-weight:500;
+  margin:0 0 .35rem; }
+#attune-elicit-form .ae-req { color:var(--text-accent); margin-left:2px; }
+#attune-elicit-form .ae-help { font-size:13px; color:var(--text-muted);
+  margin:0 0 .35rem; }
+#attune-elicit-form .ae-submit { margin-top:.5rem; padding:.55rem 1.1rem;
+  font-size:15px; font-weight:500; cursor:pointer; color:var(--text-primary);
+  background:var(--bg-accent); border:1px solid var(--border-accent);
+  border-radius:var(--radius); }
+#attune-elicit-form .ae-submit:disabled { opacity:.6; cursor:default; }
+#attune-elicit-form .ae-error { margin-top:.5rem; font-size:14px;
+  color:var(--text-accent); }
+"""
+
+#: INPUT — text_input, textarea, number, date, boolean, non-list single_select.
+_CSS_INPUT = """#attune-elicit-form .ae-input { width:100%; box-sizing:border-box;
+  padding:.5rem .6rem; font-size:15px; color:var(--text-primary);
+  background:var(--surface-1); border:1px solid var(--border);
+  border-radius:var(--radius); }
+#attune-elicit-form .ae-textarea { resize:vertical; min-height:3.5rem; }
+"""
+
+#: CHECKS — non-list multi_select (checkbox rows).
+_CSS_CHECKS = """#attune-elicit-form .ae-checks { display:flex; flex-direction:column;
+  gap:.35rem; }
+#attune-elicit-form .ae-check { display:flex; align-items:center; gap:.5rem;
+  font-weight:400; }
+"""
+
+#: LIST — any select rendered with ``list_style``.
+_CSS_LIST = """#attune-elicit-form .ae-list { margin:0; padding-left:1.6rem;
+  display:flex; flex-direction:column; gap:.3rem; }
+#attune-elicit-form .ae-list-item label { display:inline-flex;
+  align-items:baseline; gap:.45rem; cursor:pointer; font-weight:400; }
+"""
+
+#: CARDS — decision / pushback option cards + the rationale callout (also
+#: reused by the progress blocked-picker).
+_CSS_CARDS = """#attune-elicit-form .ae-cards { display:flex; flex-direction:column; gap:.5rem; }
+#attune-elicit-form .ae-card { position:relative; display:flex;
+  flex-direction:column; gap:.15rem; padding:.6rem 1.9rem .6rem .75rem;
+  border:1px solid var(--border); border-radius:var(--radius); cursor:pointer; }
+#attune-elicit-form .ae-card:hover { border-color:var(--text-muted); }
+#attune-elicit-form .ae-card-rec { border-color:var(--border-accent); }
+#attune-elicit-form .ae-card input { position:absolute; top:.7rem; right:.6rem; }
+#attune-elicit-form .ae-card-title { font-weight:500; }
+#attune-elicit-form .ae-card-note { font-size:13px; color:var(--text-muted); }
+#attune-elicit-form .ae-rec-badge { font-size:11px; font-weight:600;
+  text-transform:uppercase; letter-spacing:.03em; color:var(--text-accent); }
+#attune-elicit-form .ae-yours-tag { font-size:11px; font-weight:600;
+  text-transform:uppercase; letter-spacing:.03em; color:var(--text-muted); }
+#attune-elicit-form .ae-rationale { margin:.6rem 0 0; padding:.4rem 0 .4rem .75rem;
+  font-size:13px; color:var(--text-secondary);
+  border-left:2px solid var(--border-accent); }
+#attune-elicit-form .ae-rationale-h { display:block; font-weight:600;
+  font-size:11px; text-transform:uppercase; letter-spacing:.03em;
+  color:var(--text-accent); margin-bottom:.15rem; }
+"""
+
+#: PROGRESS — the done/in_flight/blocked status rows (pulls CARDS too).
+_CSS_PROGRESS = """#attune-elicit-form .ae-progress { display:flex; flex-direction:column; gap:.5rem; }
+#attune-elicit-form .ae-prog-rows { display:flex; flex-direction:column; gap:.25rem; }
+#attune-elicit-form .ae-prog-row { display:flex; align-items:baseline; gap:.5rem;
+  font-size:14px; color:var(--text-secondary); }
+#attune-elicit-form .ae-prog-icon { flex:none; font-weight:700; width:1.1em;
+  text-align:center; }
+#attune-elicit-form .ae-prog-done .ae-prog-icon { color:var(--text-success,#3fb950); }
+#attune-elicit-form .ae-prog-in_flight .ae-prog-icon { color:var(--text-accent); }
+#attune-elicit-form .ae-prog-blocked { color:var(--text-accent); }
+#attune-elicit-form .ae-prog-detail { font-size:13px; color:var(--text-muted); }
+#attune-elicit-form .ae-prog-label { color:var(--text-primary); }
+#attune-elicit-form .ae-prog-done .ae-prog-label { text-decoration:line-through;
+  color:var(--text-muted); }
+#attune-elicit-form .ae-prog-blocked-h { font-size:11px; font-weight:600;
+  text-transform:uppercase; letter-spacing:.03em; color:var(--text-accent); }
+#attune-elicit-form .ae-prog-tag { flex:none; font-size:10px; font-weight:600;
+  text-transform:uppercase; letter-spacing:.04em; color:var(--text-muted);
+  border:1px solid var(--border); border-radius:3px; padding:0 .3em; }
+#attune-elicit-form .ae-card .ae-prog-tag { align-self:flex-start; }
+#attune-elicit-form .ae-card .ae-prog-icon { margin-right:.15rem; }
+"""
+
+#: Named family blocks in cascade-emission order (BASE is always first).
+_CSS_FAMILIES: list[tuple[str, str]] = [
+    ("INPUT", _CSS_INPUT),
+    ("CHECKS", _CSS_CHECKS),
+    ("LIST", _CSS_LIST),
+    ("CARDS", _CSS_CARDS),
+    ("PROGRESS", _CSS_PROGRESS),
+]
+
+
+def _families_for(question: FormQuestion) -> set[str]:
+    """Return the CSS families one question's control renders with."""
+    qtype = question.type
+    if qtype == QuestionType.PROGRESS:
+        return {"CARDS", "PROGRESS"}  # blocked picker reuses the cards
+    if qtype in (QuestionType.DECISION, QuestionType.PUSHBACK):
+        return {"CARDS"}
+    if qtype == QuestionType.MULTI_SELECT:
+        return {"LIST"} if question.list_style else {"CHECKS"}
+    if qtype == QuestionType.SINGLE_SELECT:
+        return {"LIST"} if question.list_style else {"INPUT"}
+    return {"INPUT"}  # boolean, number, date, textarea, text_input, fallback
+
+
+def _needed_css(form: FormSchema) -> str:
+    """Return BASE plus only the family CSS the form's controls use."""
+    used: set[str] = set()
+    for question in form.questions:
+        used |= _families_for(question)
+    return _CSS_BASE + "".join(css for name, css in _CSS_FAMILIES if name in used)
+
+
 def form_to_widget_html(form: FormSchema, message: str = "") -> str:
     """Render a declarative form as an inline ``show_widget`` HTML form.
 
@@ -408,80 +535,7 @@ def form_to_widget_html(form: FormSchema, message: str = "") -> str:
     return f"""<h2 class="sr-only">{_esc(form.title)} — interactive form</h2>
 <form id="attune-elicit-form" data-form-title="{_esc(form.title)}">
 <style>
-#attune-elicit-form {{ display:block; width:100%; padding:1rem 0;
-  color:var(--text-primary); line-height:1.5; }}
-#attune-elicit-form .sr-only {{ position:absolute; width:1px; height:1px;
-  overflow:hidden; clip:rect(0 0 0 0); }}
-#attune-elicit-form h3 {{ font-size:18px; font-weight:500; margin:0 0 .25rem; }}
-#attune-elicit-form .ae-msg {{ margin:0 0 .5rem; color:var(--text-secondary); }}
-#attune-elicit-form .ae-desc {{ margin:0 0 1rem; color:var(--text-muted);
-  font-size:15px; }}
-#attune-elicit-form .ae-field {{ margin:0 0 1rem; }}
-#attune-elicit-form .ae-label {{ display:block; font-weight:500;
-  margin:0 0 .35rem; }}
-#attune-elicit-form .ae-req {{ color:var(--text-accent); margin-left:2px; }}
-#attune-elicit-form .ae-help {{ font-size:13px; color:var(--text-muted);
-  margin:0 0 .35rem; }}
-#attune-elicit-form .ae-input {{ width:100%; box-sizing:border-box;
-  padding:.5rem .6rem; font-size:15px; color:var(--text-primary);
-  background:var(--surface-1); border:1px solid var(--border);
-  border-radius:var(--radius); }}
-#attune-elicit-form .ae-textarea {{ resize:vertical; min-height:3.5rem; }}
-#attune-elicit-form .ae-checks {{ display:flex; flex-direction:column;
-  gap:.35rem; }}
-#attune-elicit-form .ae-check {{ display:flex; align-items:center; gap:.5rem;
-  font-weight:400; }}
-#attune-elicit-form .ae-list {{ margin:0; padding-left:1.6rem;
-  display:flex; flex-direction:column; gap:.3rem; }}
-#attune-elicit-form .ae-list-item label {{ display:inline-flex;
-  align-items:baseline; gap:.45rem; cursor:pointer; font-weight:400; }}
-#attune-elicit-form .ae-cards {{ display:flex; flex-direction:column; gap:.5rem; }}
-#attune-elicit-form .ae-card {{ position:relative; display:flex;
-  flex-direction:column; gap:.15rem; padding:.6rem 1.9rem .6rem .75rem;
-  border:1px solid var(--border); border-radius:var(--radius); cursor:pointer; }}
-#attune-elicit-form .ae-card:hover {{ border-color:var(--text-muted); }}
-#attune-elicit-form .ae-card-rec {{ border-color:var(--border-accent); }}
-#attune-elicit-form .ae-card input {{ position:absolute; top:.7rem; right:.6rem; }}
-#attune-elicit-form .ae-card-title {{ font-weight:500; }}
-#attune-elicit-form .ae-card-note {{ font-size:13px; color:var(--text-muted); }}
-#attune-elicit-form .ae-rec-badge {{ font-size:11px; font-weight:600;
-  text-transform:uppercase; letter-spacing:.03em; color:var(--text-accent); }}
-#attune-elicit-form .ae-yours-tag {{ font-size:11px; font-weight:600;
-  text-transform:uppercase; letter-spacing:.03em; color:var(--text-muted); }}
-#attune-elicit-form .ae-rationale {{ margin:.6rem 0 0; padding:.4rem 0 .4rem .75rem;
-  font-size:13px; color:var(--text-secondary);
-  border-left:2px solid var(--border-accent); }}
-#attune-elicit-form .ae-rationale-h {{ display:block; font-weight:600;
-  font-size:11px; text-transform:uppercase; letter-spacing:.03em;
-  color:var(--text-accent); margin-bottom:.15rem; }}
-#attune-elicit-form .ae-progress {{ display:flex; flex-direction:column; gap:.5rem; }}
-#attune-elicit-form .ae-prog-rows {{ display:flex; flex-direction:column; gap:.25rem; }}
-#attune-elicit-form .ae-prog-row {{ display:flex; align-items:baseline; gap:.5rem;
-  font-size:14px; color:var(--text-secondary); }}
-#attune-elicit-form .ae-prog-icon {{ flex:none; font-weight:700; width:1.1em;
-  text-align:center; }}
-#attune-elicit-form .ae-prog-done .ae-prog-icon {{ color:var(--text-success,#3fb950); }}
-#attune-elicit-form .ae-prog-in_flight .ae-prog-icon {{ color:var(--text-accent); }}
-#attune-elicit-form .ae-prog-blocked {{ color:var(--text-accent); }}
-#attune-elicit-form .ae-prog-detail {{ font-size:13px; color:var(--text-muted); }}
-#attune-elicit-form .ae-prog-label {{ color:var(--text-primary); }}
-#attune-elicit-form .ae-prog-done .ae-prog-label {{ text-decoration:line-through;
-  color:var(--text-muted); }}
-#attune-elicit-form .ae-prog-blocked-h {{ font-size:11px; font-weight:600;
-  text-transform:uppercase; letter-spacing:.03em; color:var(--text-accent); }}
-#attune-elicit-form .ae-prog-tag {{ flex:none; font-size:10px; font-weight:600;
-  text-transform:uppercase; letter-spacing:.04em; color:var(--text-muted);
-  border:1px solid var(--border); border-radius:3px; padding:0 .3em; }}
-#attune-elicit-form .ae-card .ae-prog-tag {{ align-self:flex-start; }}
-#attune-elicit-form .ae-card .ae-prog-icon {{ margin-right:.15rem; }}
-#attune-elicit-form .ae-submit {{ margin-top:.5rem; padding:.55rem 1.1rem;
-  font-size:15px; font-weight:500; cursor:pointer; color:var(--text-primary);
-  background:var(--bg-accent); border:1px solid var(--border-accent);
-  border-radius:var(--radius); }}
-#attune-elicit-form .ae-submit:disabled {{ opacity:.6; cursor:default; }}
-#attune-elicit-form .ae-error {{ margin-top:.5rem; font-size:14px;
-  color:var(--text-accent); }}
-</style>
+{_needed_css(form)}</style>
 <h3>{_esc(form.title)}</h3>
 {intro}{desc}
 {fields}

--- a/tests/unit/elicitation/test_widget_css_families.py
+++ b/tests/unit/elicitation/test_widget_css_families.py
@@ -1,0 +1,148 @@
+"""Tests for per-control CSS family emission in ``form_to_widget_html``.
+
+The widget ships CSS only for the control families a form actually uses
+(``_needed_css``). The load-bearing invariant is **coverage**: every
+class a control renders must have a matching selector in the emitted
+``<style>``. ``test_every_control_types_classes_are_styled`` renders each
+control branch and asserts no class is left unstyled — so a new control
+(or a family-mapping slip) that drops a needed rule fails CI instead of
+shipping an unstyled form.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from attune.elicitation import form_from_dict, form_to_widget_html
+from attune.elicitation.widget import _CSS_FAMILIES, _families_for
+from attune.meta_workflows.models import QuestionType
+
+_CLASS_RE = re.compile(r'class="([^"]*)"')
+
+#: One minimal valid form per render branch (keyed by a readable label).
+_FORMS: dict[str, dict] = {
+    "text_input": {"id": "t", "type": "text_input", "text": "t"},
+    "textarea": {"id": "t", "type": "textarea", "text": "t"},
+    "number": {"id": "n", "type": "number", "text": "n", "minimum": 0},
+    "date": {"id": "d", "type": "date", "text": "d"},
+    "boolean": {"id": "b", "type": "boolean", "text": "b"},
+    "single_select": {"id": "s", "type": "single_select", "text": "s", "options": ["a", "b"]},
+    "single_select_list": {
+        "id": "s",
+        "type": "single_select",
+        "text": "s",
+        "options": ["a", "b"],
+        "list_style": "unordered",
+    },
+    "multi_select": {"id": "m", "type": "multi_select", "text": "m", "options": ["a", "b"]},
+    "multi_select_list": {
+        "id": "m",
+        "type": "multi_select",
+        "text": "m",
+        "options": ["a", "b"],
+        "list_style": "ordered",
+    },
+    "decision": {
+        "id": "x",
+        "type": "decision",
+        "text": "x",
+        "options": ["a", "b"],
+        "recommended": "a",
+        "rationale": "why",
+    },
+    "pushback": {
+        "id": "x",
+        "type": "pushback",
+        "text": "x",
+        "options": ["a", "b"],
+        "user_position": "a",
+        "recommended": "b",
+    },
+    "progress": {
+        "id": "p",
+        "type": "progress",
+        "text": "p",
+        "options": ["X"],
+        "progress_items": [{"label": "D", "status": "done"}, {"label": "X", "status": "blocked"}],
+    },
+    "progress_report": {
+        "id": "p",
+        "type": "progress",
+        "text": "p",
+        "progress_style": "report",
+        "options": ["A"],
+        "progress_items": [{"label": "A", "status": "note"}],
+    },
+}
+
+
+def _split(html: str) -> tuple[str, str]:
+    """Return ``(style_block, body)`` — body is between </style> and <script>."""
+    style = html.split("<style>")[1].split("</style>")[0]
+    body = html.split("</style>")[1].split("<script>")[0]
+    return style, body
+
+
+def _emitted_classes(body: str) -> set[str]:
+    classes: set[str] = set()
+    for match in _CLASS_RE.finditer(body):
+        classes.update(match.group(1).split())
+    return {c for c in classes if c.startswith("ae-") or c == "sr-only"}
+
+
+def _is_styled(style: str, cls: str) -> bool:
+    return any(token in style for token in (f".{cls} ", f".{cls}{{", f".{cls}:"))
+
+
+@pytest.mark.parametrize("label", sorted(_FORMS))
+def test_every_control_types_classes_are_styled(label: str) -> None:
+    """No control may emit a class the trimmed CSS doesn't define."""
+    html = form_to_widget_html(form_from_dict({"title": "t", "fields": [_FORMS[label]]}))
+    style, body = _split(html)
+    unstyled = [c for c in _emitted_classes(body) if not _is_styled(style, c)]
+    assert not unstyled, f"{label}: classes with no CSS: {unstyled}"
+
+
+def test_base_shell_classes_always_present() -> None:
+    """Shell classes render for every form, whatever its controls."""
+    html = form_to_widget_html(
+        form_from_dict({"title": "t", "fields": [_FORMS["text_input"]]}), message="hi"
+    )
+    style, _ = _split(html)
+    for cls in ("sr-only", "ae-field", "ae-label", "ae-submit", "ae-error", "ae-msg"):
+        assert _is_styled(style, cls)
+
+
+def test_trimming_actually_drops_families() -> None:
+    """A plain form must ship less CSS than one using cards + progress."""
+    plain = form_to_widget_html(form_from_dict({"title": "t", "fields": [_FORMS["number"]]}))
+    rich = form_to_widget_html(form_from_dict({"title": "t", "fields": [_FORMS["progress"]]}))
+    assert len(_split(plain)[0]) < len(_split(rich)[0])
+    # The plain form carries no card or progress rules.
+    plain_style = _split(plain)[0]
+    assert "ae-card" not in plain_style
+    assert "ae-prog" not in plain_style
+
+
+def test_families_for_returns_known_names() -> None:
+    """Every QuestionType maps only to declared family names (drift guard).
+
+    A new control routed to a mistyped or missing family fails here before
+    it can ship an unstyled control.
+    """
+    known = {name for name, _ in _CSS_FAMILIES}
+    for qtype in QuestionType:
+        fields = {"id": "q", "type": qtype.value, "text": "q"}
+        # Give constructs/selects the extra keys form_from_dict requires.
+        if qtype in (QuestionType.SINGLE_SELECT, QuestionType.MULTI_SELECT):
+            fields["options"] = ["a", "b"]
+        elif qtype in (QuestionType.DECISION, QuestionType.PUSHBACK):
+            fields.update(options=["a", "b"], recommended="a")
+        elif qtype == QuestionType.PROGRESS:
+            fields.update(options=["X"], progress_items=[{"label": "X", "status": "blocked"}])
+        form = form_from_dict({"title": "t", "fields": [fields]})
+        families = _families_for(form.questions[0])
+        assert families, f"{qtype.value} maps to no family"
+        assert families <= known, f"{qtype.value} maps to unknown family: {families - known}"


### PR DESCRIPTION
## What

Splits the widget's form CSS into per-control families and emits only
the families a form uses. Before, every widget form shipped the entire
4,674-byte style block — including cards + progress rules a plain form
never renders.

## Why — measured

CSS-block reduction vs the always-emitted block:

| Form | CSS saved |
| --- | --- |
| number / date / boolean / select | ~68–70% |
| decision / pushback | ~46% |
| progress (needs cards + progress) | ~16% |
| all-controls reference form | ~5% (legitimately uses everything) |

The widget HTML round-trips through the model twice (render → show), and
output tokens are the latency-dominant half of a turn, so trimming the
re-emitted CSS is a direct latency + token win on every widget render.
This compounds with #1413: native-eligible forms now skip the widget
entirely, and the ones that remain carry only their own controls' CSS.

## Correctness guard

The risk with conditional CSS is dropping a rule a control needs.
`test_widget_css_families.py` renders **every** control branch and
asserts no emitted class lacks a matching selector — a new control (or a
family-mapping slip) fails CI rather than shipping an unstyled form.
Rendering is unchanged; the existing 19 widget tests pass untouched.

## Not in scope

CSS minification (a further ~7%) — deliberately skipped to keep the
emitted CSS human-readable for debugging.

## Verification

- 236 elicitation tests pass (incl. 16 new + the 19 pre-existing widget tests)
- Pinned black + ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
