### PR TITLE
perf(rules): serve 2 doc rules as jit_recall one-liners (POC)

### DIFF
--- a/.claude/rules-tail/attune/doc-fiction-triage.md
+++ b/.claude/rules-tail/attune/doc-fiction-triage.md
@@ -1,9 +1,3 @@
----
-paths:
-  - "docs/**"
-  - "content/**"
----
-
 # Doc-Fiction Triage — pre-flight checklist before a doc cleanup
 
 **Created:** 2026-06-26
@@ -16,7 +10,7 @@ the checklist that prevents them.
 Run this BEFORE deleting/rewriting any doc that references a "removed"
 symbol. It is the human/agent counterpart to the CI
 [doc-import-gate](./doc-import-gate.md) and pairs with
-[removing-dead-code](../../rules-tail/attune/removing-dead-code.md) (the delete-vs-rewrite
+[removing-dead-code](./removing-dead-code.md) (the delete-vs-rewrite
 decision once a symbol is confirmed dead).
 
 ---
@@ -118,8 +112,8 @@ a prior decision is found wrong, CORRECT it in place with a dated note
 
 ## Cross-references
 
-- [removing-dead-code.md](../../rules-tail/attune/removing-dead-code.md) — the
+- [removing-dead-code.md](./removing-dead-code.md) — the
   delete-vs-rewrite / should-it-exist gate (after §2 confirms dead).
 - [doc-import-gate.md](./doc-import-gate.md) — the CI enforcement of §3.
-- [website-content-accuracy.md](./website-content-accuracy.md) — verify
+- [website-content-accuracy.md](../../rules/attune/website-content-accuracy.md) — verify
   counts/claims against live code (the website counterpart).

--- a/.claude/rules-tail/attune/doc-import-gate.md
+++ b/.claude/rules-tail/attune/doc-import-gate.md
@@ -1,11 +1,3 @@
----
-paths:
-  - "docs/**"
-  - "content/**"
-  - "scripts/audit_doc_imports.py"
-  - ".github/workflows/docs.yml"
----
-
 # Doc-Import Gate — the FINAL guard against doc fiction
 
 **Created:** 2026-06-26

--- a/.claude/rules-tail/attune/removing-dead-code.md
+++ b/.claude/rules-tail/attune/removing-dead-code.md
@@ -80,7 +80,7 @@ generalize those, do not revive `SDKAgent`.)
 
 ## Cross-references
 
-- `.claude/rules/attune/doc-fiction-triage.md` — the pre-flight
+- `.claude/rules-tail/attune/doc-fiction-triage.md` — the pre-flight
   checklist for DOC cleanups: confirm a symbol is actually dead (and
   where its live form lives) BEFORE applying this delete-vs-rewrite gate.
 - `.claude/rules/attune/plugin-reference-validation.md` — the forward

--- a/.claude/rules/attune/INDEX.md
+++ b/.claude/rules/attune/INDEX.md
@@ -23,14 +23,18 @@ the one-liner here is the trip-wire, not the rule.
 - **Touching `os.walk` traversal code, or a scanner flags
   `dirs[:]`** → `os-walk-dirs-pattern.md` — `dirs[:] = [...]` is
   required in-place filtering, NOT a copy to "fix".
+- **Cleaning up docs that name a "removed" symbol** →
+  `doc-fiction-triage.md` (+ `doc-import-gate.md`, the CI gate,
+  and its `doc-import-skip` escape hatch) — a `jit_recall`
+  one-liner fires on Edit/Write touching `docs/` or `content/`;
+  Read the full body before acting (migrated off harness
+  path-scope 2026-07-16 — one body, deduped, not a doubled
+  full-body auto-load).
 
 ## Path-scoped rules (auto-load on READS of matching files only)
 
 They do NOT fire when only WRITING a new file — pull manually then:
 
-- **docs/content cleanup naming a "removed" symbol** →
-  `doc-fiction-triage.md` (+ `doc-import-gate.md` for the CI gate
-  and its `doc-import-skip` escape hatch).
 - **Authoring/reorganizing docs** → `documentation-patterns.md` —
   consolidate over scatter, delete + redirect, ~150-line guideline.
 - **Editing plugin commands/skills/hooks or MCP tools** →

--- a/plugin/hooks/_recall_map.py
+++ b/plugin/hooks/_recall_map.py
@@ -190,5 +190,32 @@ RECALL_MAP: dict[str, list[dict[str, str]]] = {
                 "`st`/`result` instead."
             ),
         },
+        # Migrated off harness path-scope (2026-07-16): these two doc rules
+        # used to auto-load their full ~1.3k-token bodies on any docs/content
+        # edit — and doubled in a dogfooding session (plugin installed in its
+        # own repo). Served here as deduped one-liners with a pointer; the
+        # full bodies live behind the INDEX in .claude/rules-tail/attune/.
+        {
+            "rule_id": "doc-fiction-triage",
+            "match_regex": r"(docs|content)/",
+            "text": (
+                "Doc-cleanup pre-flight: before deleting/rewriting docs that "
+                "name a 'removed' symbol, VERIFY it is actually gone from "
+                "src/ (a live symbol at a new path is not fiction), inventory "
+                "the FULL dead-symbol set, and scope to PUBLISHED surfaces. "
+                "Full checklist: .claude/rules-tail/attune/doc-fiction-triage.md"
+            ),
+        },
+        {
+            "rule_id": "doc-import-gate",
+            "match_regex": r"(docs|content)/",
+            "text": (
+                "Doc-import gate: a doc code-fence importing a REMOVED attune "
+                "symbol fails the doc-import-audit (served surfaces only). If "
+                "a fence shows old API on purpose, mark it "
+                "'<!-- doc-import-skip: reason -->'. Full body: "
+                ".claude/rules-tail/attune/doc-import-gate.md"
+            ),
+        },
     ],
 }


### PR DESCRIPTION
## What

POC (per the scope decision) migrating two path-scoped rules off the
harness full-body auto-load onto the `jit_recall` one-liner+pointer
pattern. Proves the pattern on the two rules that actually misfired
before committing the whole tier.

`doc-fiction-triage` and `doc-import-gate` carried `paths:` frontmatter,
so the harness auto-loaded their full ~1.3k-token bodies on any
docs/content edit — and **doubled** them in a dogfooding session (the
plugin installed in its own source repo loads each rule from two roots).
Both are about deleting/renaming a **removed** symbol, yet fired on
purely additive docs edits.

## Change

- Both rules moved to `.claude/rules-tail/attune/` (frontmatter
  stripped → harness no longer auto-loads them); inbound links repointed
- `INDEX.md` entry moved path-scoped → tail, noting the new jit trigger
- 2 `jit_recall` entries (Edit-keyed, `match_regex` on `docs/`\|`content/`)
  serve a ~50-token one-liner + a "Read the full body" pointer, deduped
  once per session

## Receipts

- **Dogfooded the live hook** (registered ≠ working): a `docs/` Edit
  fires both one-liners; a `src/` edit fires neither.
- **44 corpus tests pass** — residency budget + INDEX-coverage (moved
  files recognized as tail rules) + jit_recall structure (new entries
  satisfy the broad-tool content-filter requirement).
- **Link-clean** — no stale refs to the old paths outside history.

## Win

~1,344 + 1,272-token full-body auto-loads (doubled in dogfooding) →
two ~50-token one-liners + pointers, deduped per session.

## Caveat (for the full-migration decision)

`jit_recall` triggers on a content `match_regex`, not a path-glob — it
fires when `docs/` or `content/` appears anywhere in the edit input, not
strictly "editing a file under docs/." No broader than the old
`paths: docs/**` glob, but a looser match. This is the tradeoff to weigh
before migrating the rest of the tier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
