### PR TITLE
docs: ratify V7 form-template library (D20) + reconciler-blind-spot lesson

### DIFF
--- a/.claude/lessons.md
+++ b/.claude/lessons.md
@@ -15506,3 +15506,55 @@ def ", start_idx + 1)` for module-
   uncommitted working-tree edit for local dev is fine; a WIP BRANCH is
   what's blocked). Pairs with the existing worktree-path / editable-
   MAPPING lessons — same family, this is the cross-SIBLING-repo surface.
+
+- **A green `starter_reconciler` report is NOT "the starter is
+  accurate" — it proves PR/PyPI STATE, and says nothing about the
+  DECISION CONTENT the starter narrates; reconcile a "decision open"
+  thread against the decision's own record file**: 2026-07-17,
+  picking up `~/.attune/next_session_starter.md`. The
+  `starter_reconciler.py` SessionStart hook ran and reported clean
+  (`#1412 MERGED · #1413 MERGED · #1414 MERGED · #1415 MERGED · #1407
+  MERGED`, `PyPI attune-ai latest=10.4.1`) — every PR the starter
+  named was correctly resolved, and the starter's own "Pre-flight"
+  section confirmed them. That green is exactly what made the lead
+  thread dangerous: it read as blanket verification. But the starter's
+  §(1) said "Three decisions open (Patrick dismissed the first
+  form-pass — re-present, possibly one at a time)" for the book
+  outline, while `docs/process/BOOK_OUTLINE.md`'s "Decisions record"
+  showed **all three already decided** — working title DEFERRED,
+  3-part structure RATIFIED, Part-I mode CITE-the-article — recorded
+  in #1408 at **12:27 the same day**, ~11h before the starter was
+  written at 23:20. The 22:48 latency session had copied the older
+  9:32-session thread text forward verbatim without re-reading the
+  file it pointed at. Executing as written would have re-presented a
+  form Patrick had already answered — the precise "dismissed the first
+  form-pass" annoyance the starter was warning about, inflicted a
+  second time. **Why no probe caught it:** the reconciler's checks are
+  `gh pr view --json state` and a PyPI version read — both are
+  SHIPPING-state probes. The staleness lived in *document content
+  inside an already-merged file*, so #1408 being MERGED was
+  simultaneously true and the reason the thread was dead. There is no
+  PR-state query whose answer is "the decision this thread describes
+  was made." **Durable rules:** (1) a thread framed as "decision open
+  / awaiting approval / needs ratify" reconciles against **the
+  artifact that would record the decision** (`decisions.md`, a spec
+  `Status:` line, a "Decisions record" section) — one Read, not a `gh`
+  call; (2) `git log --format='%h %ad' --date=...` the starter's named
+  files and compare against the starter's own mtime (`stat -f '%Sm'`)
+  — a commit touching the thread's file AFTER the text was drafted but
+  BEFORE the starter was written is the tell that a copy-forward
+  skipped a reconcile; (3) treat automated reconciliation as covering
+  its stated surface ONLY, and say which surface — "PRs verified" ≠
+  "threads verified"; (4) when a stale thread is found, fix the
+  starter file itself in the same session (rewrite the section to
+  CLOSED with the date + recording commit), or the next session
+  inherits the same phantom. Extends "A next-session starter / TODO
+  handoff can be STALE ON ARRIVAL" (same family, second+ recurrence)
+  with the nuance that lesson's remedy misses: it says reconcile
+  against `git/gh/PyPI`, which is necessary but insufficient — a
+  decision-shaped thread needs a content Read, and the automation
+  built to enforce the original lesson can supply false confidence
+  precisely because it passes. Pairs with "Spec-named work-scope
+  drifts from code reality — grep the actual instances" (the code is
+  the contract) and "gated document goes silently unblocked" — all
+  three are prose-about-state rotting while the state moves.

--- a/docs/specs/elicitation-form-surface/decisions.md
+++ b/docs/specs/elicitation-form-surface/decisions.md
@@ -695,6 +695,44 @@ skill documents it; `tests/unit/elicitation/test_list_style.py` covers
 render + round-trip + definition validation (11 tests). Zero new
 `QuestionType`, zero answer-path change.
 
+## D20 — V7 form-template library RATIFIED as proposed; V7 sequences before V6
+
+**Date:** 2026-07-17 · **Status:** decided
+
+Patrick ratified [v7-requirements.md](v7-requirements.md) as drafted —
+R1–R5 and AC-1/AC-3 unchanged — including its recommended sequencing:
+**V7 before V6** in the post-freeze window. The 2026-07-28 design-only
+freeze is untouched by this ratification; no code lands before it lifts.
+
+**Why V7 leads:** V7 is pure-local plumbing (no API, no host
+dependency, dogfoodable same-day), and its templates hand V6's MCP Apps
+round-trip its realistic payloads. V6's ChatGPT-host receipt depends on
+external host support and dev-mode access that can slip — sequencing it
+second keeps that slip off V7's value.
+
+**What the ratified shape commits to:** a template store of plain JSON
+files in the dict shape `form_from_dict` already accepts (R1); a ~10-line
+`form_from_template(name, slots)` loader delegating to that one
+validation seam (R2) — so malformed templates fail through the existing
+`FormValidationError` path rather than a parallel one; slot substitution
+in string fields only (R3); an `elicit` catalog section (R4); and
+promote-on-repeat — a form earns templatehood on its SECOND recurrence,
+same rule as lessons (R5). Zero new `QuestionType`, zero validator or
+render change, consistent with the D19 finding that the grammar earns
+its keep by shrinking work rather than adding members.
+
+**Receipts, not registration:** AC-2 is the load-bearing one — the same
+template asked in two distinct sessions, the two `FormResponse` records
+joinable on `template_id`. That demonstrates the comparability claim
+instead of asserting it. `FormResponse` already carries `template_id`,
+so the join key exists before the feature does.
+
+**Worked examples available:** the 2026-07-16 latency session rendered
+two design-only template sketches — `session-contract` (all-scalar) and
+`triage-matrix` (list-valued slots plus a `for_each` expansion that
+needs `_substitute` to handle sole-value list slots). They bracket the
+difficulty range and belong in `design.md` when V7 designs.
+
 ## Open
 
 - **Confirm CC elicitation support** — low priority (elicitation is

--- a/docs/specs/elicitation-form-surface/v6-requirements.md
+++ b/docs/specs/elicitation-form-surface/v6-requirements.md
@@ -3,6 +3,10 @@
 **Status:** draft (2026-07-16) — awaiting Patrick approval.
 **Freeze:** design-only until 2026-07-28 (ratified with the
 standards-landscape sequence); no code before the freeze lifts.
+**Sequencing:** V7 (`v7-requirements.md`) was ratified 2026-07-17 and
+sequences BEFORE this doc in the same post-freeze window (D20 in
+[decisions.md](decisions.md)) — V7's templates supply this adapter's
+round-trip payloads. This doc's own approval remains open.
 **Source:** [v3-standards-landscape.md](v3-standards-landscape.md)
 (2026-07-13, 26-agent verified) — this doc is its "Recommended
 sequence" step 2 (+ step 1 as FR-4), phased as V6.

--- a/docs/specs/elicitation-form-surface/v7-requirements.md
+++ b/docs/specs/elicitation-form-surface/v7-requirements.md
@@ -1,9 +1,11 @@
 # Elicitation Form Surface — V7 Requirements: form-template library
 
-**Status:** draft (2026-07-16) — awaiting Patrick approval.
+**Status:** RATIFIED as proposed (2026-07-17, Patrick — D20 in
+[decisions.md](decisions.md)); requirements below are unchanged from
+the approved draft.
 **Freeze:** design-only until 2026-07-28; no code before the freeze
 lifts. V6 (MCP Apps adapter, `v6-requirements.md`) is queued for the
-same window — see Sequencing below.
+same window and sequences AFTER V7 (ratified — see Sequencing below).
 **Source:** Patrick's idea, discussed 2026-07-16 ("sculpt a form
 once, cast per fork") — the sculptor clause applied to the grammar's
 own artifacts.
@@ -89,10 +91,10 @@ store, no loader, no catalog.
 
 ## Sequencing vs V6 (same post-freeze window)
 
-Recommend **V7 before V6**: V7 is pure-local plumbing (no API, no
-host dependency, dogfoodable same-day) and its templates give V6's
-MCP Apps round-trip receipts (AC-1/AC-2 there) realistic payloads to
-render. V6's ChatGPT-host receipt has external dependencies (host
+**RATIFIED 2026-07-17: V7 before V6.** V7 is pure-local plumbing (no
+API, no host dependency, dogfoodable same-day) and its templates give
+V6's MCP Apps round-trip receipts (AC-1/AC-2 there) realistic payloads
+to render. V6's ChatGPT-host receipt has external dependencies (host
 support, dev-mode access) that can slip without blocking V7 value.
 
 ## Tasks (for review)


### PR DESCRIPTION
## What

Docs-only. Two commits, no code — the 2026-07-28 design-only freeze is untouched.

### 1. V7 form-template library — RATIFIED as proposed (`b45b8f652`)

Patrick ratified `v7-requirements.md` as drafted (2026-07-17): R1–R5 and
AC-1/AC-3 unchanged, including its recommended sequencing — **V7 before V6**.

- `decisions.md` — **D20** records the ratification, the V7-before-V6 rationale
  (V7 is pure-local plumbing and supplies V6's round-trip payloads; V6's
  ChatGPT-host receipt has slippable external deps), and the two worked
  template sketches (`session-contract`, `triage-matrix`) for `design.md`.
- `v7-requirements.md` — status `draft` → `RATIFIED`; Sequencing section marked ratified.
- `v6-requirements.md` — sequencing note only. **V6's own approval stays open** —
  Patrick ratified V7, not V6. Recorded from both sides so the ordering stays
  checkable rather than living only in V7's text.

### 2. Lesson: a green `starter_reconciler` proves PR state, not decision content (`ffcceb4c1`)

Earned this session. The starter's lead thread — "three book-outline decisions
open" — was already closed: all three were decided and recorded in #1408 at
12:27 the same day, ~11h before the starter was written at 23:20. A prior
session copied the older thread text forward without re-reading the file it
pointed at.

The reconciler hook ran and passed clean, and **that green is what made the dead
thread look live**: it correctly reported #1408 MERGED, and #1408 being merged
was simultaneously true and the reason the thread was dead. No PR-state query
answers "the decision this thread describes was already made."

Rule added: a thread framed as *decision-open / awaiting-ratify* reconciles
against the artifact that would **record** the decision (`decisions.md`, a spec
`Status:` line) — one Read, not a `gh` call. Filed as an extension of the
existing "STALE ON ARRIVAL" lesson (line 7981), whose remedy says reconcile
against `git/gh/PyPI` — necessary but insufficient here.

## Not in this PR

`~/.attune/next_session_starter.md` was also corrected (closed thread marked
CLOSED with its recording commit) so the next session doesn't inherit the
phantom. It lives outside the repo, so it isn't part of this diff.

## Receipts

- Pinned pre-commit hooks pre-flighted before staging; both commits verified
  landed via `git log` (no-error ≠ landed).
- No code paths touched — no test impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
