### PR TITLE
fix(packaging): complete the #1418 sweep — attune_redis, plugin/, pin, test, changelog

### DIFF
--- a/.agents/skills/memory-and-context/SKILL.md
+++ b/.agents/skills/memory-and-context/SKILL.md
@@ -289,7 +289,9 @@ features described in this skill work without Redis.
 **Upgrade:**
 
 ```bash
-pip install attune-ai[memory]
+# Redis client libraries ship with attune-ai core — nothing extra to
+# install; you only need a running Redis / Agent Memory Server.
+pip install attune-ai
 ```
 
 Zero configuration needed -- connects to

--- a/.agents/skills/rag-code-gen/SKILL.md
+++ b/.agents/skills/rag-code-gen/SKILL.md
@@ -4,7 +4,7 @@ description: "RAG-grounded code generation with source citations. Triggers on: g
 ---
 # RAG-grounded code generation
 
-Requires the `[rag]` extra (`pip install 'attune-ai[rag]'`).
+attune-rag ships with attune-ai core (`pip install attune-ai`).
 Grounds code generation in the attune-help template corpus
 so outputs cite real APIs, workflow names, and patterns
 instead of hallucinating them. Every output ends with a
@@ -72,7 +72,8 @@ another model.
 ## If the extra isn't installed
 
 The workflow returns a structured error pointing at
-`pip install 'attune-ai[rag]'`. No exception propagates.
+`pip install attune-rag` (a core dep — missing means a broken
+install). No exception propagates.
 
 ## See also
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- **The six empty placeholder extras (`[rag]`, `[memory]`, `[redis]`,
+  `[cache]`, `[agent-sdk]`, `[software]`) are deleted** (#1418; extras
+  menu 22 → 16). Each was a back-compat alias whose dependencies had
+  been promoted to core, so `pip install 'attune-ai[redis]'` etc. now
+  emits a pip "unknown extra" warning but still installs everything —
+  the deps ship with the base package. Update install scripts to plain
+  `pip install attune-ai` (or a real extra such as `[developer]`,
+  `[ops]`).
+
 ### Fixed
+
+- **Error messages no longer point at empty-alias extras as
+  remediations, and the interactive Redis installer no longer reports
+  fake success** (#1418 + follow-up). Previously, a broken `redis`
+  import prompted "Install now?" → ran `pip install attune-ai[redis]`
+  (a no-op that exits 0) → printed "✓ redis package installed" with
+  nothing installed. The installer now targets the real, version-pinned
+  package (`redis>=5.0.0,<9.0.0`) and verifies the import before
+  claiming success. All install hints across `attune` and the bundled
+  `attune_redis` plugin (MCP tool errors included) now name real
+  packages, and the extras-honesty guard scans every package that ships
+  in the wheel — not just `src/attune`.
 
 - **`attune workflow run` no longer exits 0 when the spend gate blocks
   the run.** A blocked run (non-interactive without

--- a/attune_redis/README.md
+++ b/attune_redis/README.md
@@ -11,15 +11,17 @@ search over long-term memory, and pub/sub coordination.
 
 ## Installation
 
-```bash
-pip install 'attune-ai[redis]'
-```
-
-Or as an extra of the core framework:
+Nothing extra to install — this plugin is **bundled in the attune-ai
+wheel**, and its dependencies (`redis`, `agent-memory-client`) are core
+attune-ai dependencies:
 
 ```bash
-pip install attune-ai[redis]
+pip install attune-ai
 ```
+
+(There is no standalone `attune-redis` package on PyPI, and the former
+`[redis]` extra was an empty alias, removed 2026-07-17. You only need a
+running Redis / Agent Memory Server to connect to.)
 
 ## Quick start
 

--- a/attune_redis/__init__.py
+++ b/attune_redis/__init__.py
@@ -5,7 +5,8 @@ Attune AI framework. Implements the MemoryBackend protocol
 via AMS working memory and adds semantic search via AMS
 long-term memory.
 
-Install: ``pip install attune-ai[redis]``
+Bundled with attune-ai — ``pip install attune-ai`` includes this plugin
+and its dependencies (redis, agent-memory-client are core deps).
 
 Copyright 2025-2026 Smart AI Memory, LLC
 Licensed under the Apache License, Version 2.0

--- a/attune_redis/mcp_tools.py
+++ b/attune_redis/mcp_tools.py
@@ -21,6 +21,18 @@ from typing import Any
 
 logger = logging.getLogger(__name__)
 
+# redis + agent-memory-client are CORE attune-ai dependencies, so an
+# ImportError here means a broken or partial environment — never a
+# missing extra. Do NOT point users at an extras install: the [redis]
+# extra was an empty alias (deleted 2026-07-17, #1418) and suggesting
+# it was the #758 no-op-remediation trap.
+_REDIS_MISSING_ERROR = (
+    "Redis client libraries are not importable. They ship with attune-ai "
+    "core, so this indicates a broken or partial install. "
+    "Fix: pip install --force-reinstall attune-ai  "
+    "(in a uv-managed dev checkout: uv sync)"
+)
+
 # =========================================================================
 # Tool definitions (JSON Schema)
 # =========================================================================
@@ -191,7 +203,7 @@ async def handle_redis_memory_store(server: Any, args: dict[str, Any]) -> dict[s
     except ImportError:
         return {
             "success": False,
-            "error": "Redis support not installed. Run: pip install 'attune-ai[redis]'",
+            "error": _REDIS_MISSING_ERROR,
         }
     except Exception as e:  # noqa: BLE001
         # INTENTIONAL: Graceful degradation for MCP tool errors
@@ -225,7 +237,7 @@ async def handle_redis_memory_retrieve(server: Any, args: dict[str, Any]) -> dic
     except ImportError:
         return {
             "success": False,
-            "error": "Redis support not installed. Run: pip install 'attune-ai[redis]'",
+            "error": _REDIS_MISSING_ERROR,
         }
     except Exception as e:  # noqa: BLE001
         # INTENTIONAL: Graceful degradation for MCP tool errors
@@ -259,7 +271,7 @@ async def handle_redis_memory_search(server: Any, args: dict[str, Any]) -> dict[
     except ImportError:
         return {
             "success": False,
-            "error": "Redis support not installed. Run: pip install 'attune-ai[redis]'",
+            "error": _REDIS_MISSING_ERROR,
         }
     except Exception as e:  # noqa: BLE001
         # INTENTIONAL: Graceful degradation for MCP tool errors
@@ -289,7 +301,7 @@ async def handle_redis_memory_promote(server: Any, args: dict[str, Any]) -> dict
     except ImportError:
         return {
             "success": False,
-            "error": "Redis support not installed. Run: pip install 'attune-ai[redis]'",
+            "error": _REDIS_MISSING_ERROR,
         }
     except Exception as e:  # noqa: BLE001
         # INTENTIONAL: Graceful degradation for MCP tool errors
@@ -323,7 +335,7 @@ async def handle_redis_memory_forget(server: Any, args: dict[str, Any]) -> dict[
     except ImportError:
         return {
             "success": False,
-            "error": "Redis support not installed. Run: pip install 'attune-ai[redis]'",
+            "error": _REDIS_MISSING_ERROR,
         }
     except Exception as e:  # noqa: BLE001
         # INTENTIONAL: Graceful degradation for MCP tool errors
@@ -354,7 +366,7 @@ async def handle_redis_health_check(server: Any, args: dict[str, Any]) -> dict[s
     except ImportError:
         return {
             "success": False,
-            "error": "Redis support not installed. Run: pip install 'attune-ai[redis]'",
+            "error": _REDIS_MISSING_ERROR,
         }
     except Exception as e:  # noqa: BLE001
         # INTENTIONAL: Graceful degradation for MCP tool errors

--- a/attune_redis/plugin.py
+++ b/attune_redis/plugin.py
@@ -88,8 +88,9 @@ class RedisPlugin(BasePlugin):
             logger.info("attune-redis: agent-memory-client available")
         except ImportError:
             logger.warning(
-                "attune-redis: agent-memory-client not installed. "
-                "Install with: pip install attune-ai[redis]"
+                "attune-redis: agent-memory-client not importable — it is a "
+                "core attune-ai dependency, so this means a broken or "
+                "partial install. Fix: pip install --force-reinstall attune-ai"
             )
 
 

--- a/attune_redis/tests/test_error_paths.py
+++ b/attune_redis/tests/test_error_paths.py
@@ -214,7 +214,10 @@ class TestMCPHandlerImportErrorPaths:
         ):
             result = await handle_redis_memory_retrieve(import_error_server, {"key": "k"})
         assert result["success"] is False
-        assert "not installed" in result["error"]
+        # New contract (#1420): the deps are core, so the error names a
+        # broken install and a remediation that can actually work.
+        assert "not importable" in result["error"]
+        assert "attune-ai[" not in result["error"]
 
     @pytest.mark.asyncio()
     async def test_search_import_error(self, import_error_server):
@@ -225,7 +228,10 @@ class TestMCPHandlerImportErrorPaths:
         ):
             result = await handle_redis_memory_search(import_error_server, {"query": "test"})
         assert result["success"] is False
-        assert "not installed" in result["error"]
+        # New contract (#1420): the deps are core, so the error names a
+        # broken install and a remediation that can actually work.
+        assert "not importable" in result["error"]
+        assert "attune-ai[" not in result["error"]
 
     @pytest.mark.asyncio()
     async def test_promote_import_error(self, import_error_server):
@@ -236,7 +242,10 @@ class TestMCPHandlerImportErrorPaths:
         ):
             result = await handle_redis_memory_promote(import_error_server, {})
         assert result["success"] is False
-        assert "not installed" in result["error"]
+        # New contract (#1420): the deps are core, so the error names a
+        # broken install and a remediation that can actually work.
+        assert "not importable" in result["error"]
+        assert "attune-ai[" not in result["error"]
 
     @pytest.mark.asyncio()
     async def test_health_check_import_error(self, import_error_server):
@@ -247,7 +256,10 @@ class TestMCPHandlerImportErrorPaths:
         ):
             result = await handle_redis_health_check(import_error_server, {})
         assert result["success"] is False
-        assert "not installed" in result["error"]
+        # New contract (#1420): the deps are core, so the error names a
+        # broken install and a remediation that can actually work.
+        assert "not importable" in result["error"]
+        assert "attune-ai[" not in result["error"]
 
 
 # =================================================================

--- a/attune_redis/tests/test_mcp_tools.py
+++ b/attune_redis/tests/test_mcp_tools.py
@@ -154,7 +154,7 @@ class TestHandleStore:
 
     @pytest.mark.asyncio()
     async def test_store_import_error(self):
-        """Store returns error when plugin not installed."""
+        """Store returns error when redis libs are not importable."""
         server = MagicMock(spec=[])
         del server._redis_backend
         with patch(
@@ -163,7 +163,10 @@ class TestHandleStore:
         ):
             result = await handle_redis_memory_store(server, {"key": "k", "value": "v"})
         assert result["success"] is False
-        assert "not installed" in result["error"]
+        # New contract (#1420): the deps are core, so the error names a
+        # broken install and a remediation that can actually work.
+        assert "not importable" in result["error"]
+        assert "attune-ai[" not in result["error"]
 
 
 class TestHandleRetrieve:

--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -94,13 +94,13 @@ Feature                        Status          Details
 ✅ Long-term memory (file-based) Available       Core feature (always available)
 ✅ File session storage         Available       Core feature (always available)
 ⚠️ Short-term memory (Redis-based) Missing Dependency Redis package not importable
-                                Install: pip install --force-reinstall redis
+                                Install: pip install --force-reinstall 'redis>=5.0.0,<9.0.0'
 ...
 
 💡 To enable Redis-enhanced features:
    1. Repair the redis package (it ships as a core
       dependency, so this means a broken install):
-      pip install --force-reinstall redis
+      pip install --force-reinstall 'redis>=5.0.0,<9.0.0'
 
    2. Install and start Redis server:
       • macOS: brew install redis && brew services start redis
@@ -362,7 +362,7 @@ missing extra.
 **Solution:**
 
 ```bash
-pip install --force-reinstall redis
+pip install --force-reinstall 'redis>=5.0.0,<9.0.0'
 ```
 
 ### "Redis server not running"
@@ -397,7 +397,7 @@ docker start attune-redis
 pip list | grep redis
 
 # If not installed, reinstall
-pip install --force-reinstall redis
+pip install --force-reinstall 'redis>=5.0.0,<9.0.0'
 ```
 
 ### Connection errors
@@ -511,7 +511,7 @@ try:
 except ImportError as e:
     print(e)  # "Short-term memory requires Redis.\n
               #  Status: Redis package not importable\n
-              #  Install: pip install --force-reinstall redis"
+              #  Install: pip install --force-reinstall 'redis>=5.0.0,<9.0.0'"
 ```
 
 **Recommended pattern:**

--- a/plugin/agents/setup-guide.md
+++ b/plugin/agents/setup-guide.md
@@ -42,10 +42,11 @@ Detect-and-adapt agent that checks for attune-ai prerequisites and guides setup.
      - Sub-millisecond lookups for shared state
      - Shared state persistence across sessions
 
-   - Offer the install command:
+   - The Python client libraries ship with attune-ai core — if they
+     are missing, the install is broken; offer the repair command:
 
      ```bash
-     pip install attune-ai[memory]
+     pip install --force-reinstall attune-ai
      ```
 
    - NEVER block on this step. Always allow the user to proceed without Redis.
@@ -88,7 +89,7 @@ After all detection steps complete, output a summary table showing the state of 
 | Component | Status | Action |
 | --------- | ------ | ------ |
 | attune-ai | vX.Y.Z installed | None needed |
-| Redis | Not detected | Optional -- run `pip install attune-ai[memory]` for multi-agent support |
+| Redis | Not detected | Optional -- client libraries ship with attune-ai; start a Redis server for multi-agent support |
 | MCP Server | Healthy (18 tools) | None needed |
 | Updates | Up to date | None needed |
 

--- a/plugin/help/generated/errors/claude-agent-sdk-is-now-a-core-dependency-of-attune-ai.md
+++ b/plugin/help/generated/errors/claude-agent-sdk-is-now-a-core-dependency-of-attune-ai.md
@@ -14,7 +14,7 @@ source: .claude/CLAUDE.md
 
 ## Root Cause
 
-As of v4.2.0, the Agent SDK is included in core dependencies. No need for `pip install 'attune-ai[agent-sdk]'` — a plain `pip install attune-ai` includes it. The `[agent-sdk]` extra is kept as an empty placeholder for backward compatibility.
+As of v4.2.0, the Agent SDK is included in core dependencies. No need for `pip install 'attune-ai[agent-sdk]'` — a plain `pip install attune-ai` includes it. (The former `[agent-sdk]` empty placeholder extra was removed 2026-07-17.)
 
 ## Resolution
 

--- a/plugin/help/generated/faqs/claude-agent-sdk-is-now-a-core-dependency-of-attune-ai.md
+++ b/plugin/help/generated/faqs/claude-agent-sdk-is-now-a-core-dependency-of-attune-ai.md
@@ -12,7 +12,7 @@ source: .claude/CLAUDE.md
 As of v4.2.0, the Agent SDK is included in core dependencies. No need for `pip install 'attune-ai[agent-sdk]'` — a plain `pip install attune-ai` includes it.
 
 ```
-pip install 'attune-ai[agent-sdk]'
+pip install attune-ai
 ```
 
 ## Related Topics

--- a/plugin/help/generated/notes/project-structure.md
+++ b/plugin/help/generated/notes/project-structure.md
@@ -26,7 +26,7 @@ src/attune/
 ├── telemetry/         # FeedbackLoop, UsageTracker (MemoryBackend protocol)
 └── cli_router.py      # Natural language command routing
 
-attune_redis/          # attune-redis plugin (pip install 'attune-ai[redis]')
+attune_redis/          # Redis plugin (bundled — ships with attune-ai)
 ```
 
 ## Related Topics

--- a/plugin/help/generated/references/skill-memory-and-context.md
+++ b/plugin/help/generated/references/skill-memory-and-context.md
@@ -289,7 +289,9 @@ features described in this skill work without Redis.
 **Upgrade:**
 
 ```bash
-pip install attune-ai[memory]
+# Redis client libraries ship with attune-ai core — nothing extra to
+# install; you only need a running Redis / Agent Memory Server.
+pip install attune-ai
 ```
 
 Zero configuration needed -- connects to

--- a/plugin/help/generated/references/skill-rag-code-gen.md
+++ b/plugin/help/generated/references/skill-rag-code-gen.md
@@ -75,7 +75,8 @@ another model.
 ## If the extra isn't installed
 
 The workflow returns a structured error pointing at
-`pip install 'attune-ai[rag]'`. No exception propagates.
+`pip install attune-rag` (a core dep — missing means a broken
+install). No exception propagates.
 
 ## See also
 

--- a/plugin/skills/memory-and-context/SKILL.md
+++ b/plugin/skills/memory-and-context/SKILL.md
@@ -292,7 +292,9 @@ features described in this skill work without Redis.
 **Upgrade:**
 
 ```bash
-pip install attune-ai[memory]
+# Redis client libraries ship with attune-ai core — nothing extra to
+# install; you only need a running Redis / Agent Memory Server.
+pip install attune-ai
 ```
 
 Zero configuration needed -- connects to

--- a/plugin/skills/rag-code-gen/SKILL.md
+++ b/plugin/skills/rag-code-gen/SKILL.md
@@ -6,7 +6,7 @@ argument-hint: "<what you want generated + any specifics>"
 
 # RAG-grounded code generation
 
-Requires the `[rag]` extra (`pip install 'attune-ai[rag]'`).
+attune-rag ships with attune-ai core (`pip install attune-ai`).
 Grounds code generation in the attune-help template corpus
 so outputs cite real APIs, workflow names, and patterns
 instead of hallucinating them. Every output ends with a
@@ -74,7 +74,8 @@ another model.
 ## If the extra isn't installed
 
 The workflow returns a structured error pointing at
-`pip install 'attune-ai[rag]'`. No exception propagates.
+`pip install attune-rag` (a core dep — missing means a broken
+install). No exception propagates.
 
 ## See also
 

--- a/src/attune/cli_commands/utility_commands.py
+++ b/src/attune/cli_commands/utility_commands.py
@@ -320,7 +320,7 @@ def cmd_features(args: Namespace) -> int:
         print("\n💡 To enable Redis-enhanced features:")
         print("   1. Repair the redis package (it ships as a core")
         print("      dependency, so this means a broken install):")
-        print("      pip install --force-reinstall redis")
+        print("      pip install --force-reinstall 'redis>=5.0.0,<9.0.0'")
         print("\n   2. Install and start Redis server:")
         print("      • macOS: brew install redis && brew services start redis")
         print("      • Linux: sudo apt install redis-server")

--- a/src/attune/memory/features.py
+++ b/src/attune/memory/features.py
@@ -146,7 +146,7 @@ class MemoryFeatures:
                     message="Redis package not importable (it ships as a "
                     "core dependency, so this usually means a broken or "
                     "partial install)",
-                    install_command="pip install --force-reinstall redis",
+                    install_command="pip install --force-reinstall 'redis>=5.0.0,<9.0.0'",
                 )
 
             if not MemoryFeatures.is_redis_running():
@@ -257,7 +257,7 @@ class MemoryFeatures:
                     message="Redis package not importable (it ships as a "
                     "core dependency, so this usually means a broken or "
                     "partial install)",
-                    install_command="pip install --force-reinstall redis",
+                    install_command="pip install --force-reinstall 'redis>=5.0.0,<9.0.0'",
                 )
             if not redis_server_running:
                 return FeatureInfo(

--- a/src/attune/memory/redis_auto_detect.py
+++ b/src/attune/memory/redis_auto_detect.py
@@ -234,7 +234,7 @@ class RedisAutoDetector:
         print("  persistent session memory in Attune AI.")
         print()
         print("  Install now?")
-        print("    pip install --force-reinstall redis")
+        print("    pip install --force-reinstall 'redis>=5.0.0,<9.0.0'")
         print()
 
         try:
@@ -246,7 +246,7 @@ class RedisAutoDetector:
         if response in ("d", "dont", "don't"):
             self._save_preference("install_declined", True)
             print("  Won't ask again. Enable later with:")
-            print("    pip install --force-reinstall redis")
+            print("    pip install --force-reinstall 'redis>=5.0.0,<9.0.0'")
             print("=" * 60)
             print()
             return False
@@ -272,14 +272,16 @@ class RedisAutoDetector:
                     "install",
                     "--quiet",
                     "--force-reinstall",
-                    "redis",
+                    # Same spec as pyproject's core dep — an unpinned
+                    # install could pull a redis major that violates it.
+                    "redis>=5.0.0,<9.0.0",
                 ],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
             )
         except subprocess.CalledProcessError as e:
             print(f"  ✗ Installation failed: {e}")
-            print("  Install manually: pip install --force-reinstall redis")
+            print("  Install manually: pip install --force-reinstall 'redis>=5.0.0,<9.0.0'")
             print("=" * 60)
             print()
             logger.error(f"Failed to install redis package: {e}")
@@ -296,8 +298,11 @@ class RedisAutoDetector:
         self._invalidate_cache()
         if not self._check_python_package():
             print("  ✗ pip reported success but redis is still not importable.")
-            print("    This usually means a broken environment rather than a")
-            print("    missing package. Try: pip install --force-reinstall redis")
+            print("    The install command was already retried, so don't re-run it —")
+            print("    this points at the environment itself. Diagnose with:")
+            print("      python -m pip check")
+            print("      python -c 'import redis'   (read the actual ImportError)")
+            print("    or rebuild the env: pip install --force-reinstall attune-ai")
             print("=" * 60)
             print()
             logger.error("redis still not importable after a successful pip install")

--- a/src/attune/telemetry/features.py
+++ b/src/attune/telemetry/features.py
@@ -95,7 +95,7 @@ class TelemetryFeatures:
                     message="Redis package not importable (it ships as a "
                     "core dependency, so this usually means a broken or "
                     "partial install)",
-                    install_command="pip install --force-reinstall redis",
+                    install_command="pip install --force-reinstall 'redis>=5.0.0,<9.0.0'",
                 )
 
             return FeatureInfo(
@@ -139,7 +139,7 @@ class TelemetryFeatures:
                 f"{feature_name} requires the redis package, which ships "
                 f"as a core attune-ai dependency — a failure here usually "
                 f"means a broken or partial install.\n"
-                f"Fix: pip install --force-reinstall redis\n"
+                f"Fix: pip install --force-reinstall 'redis>=5.0.0,<9.0.0'\n"
                 f"Redis server setup: https://redis.io/docs/install/",
             )
 

--- a/tests/unit/cli_commands/test_utility_commands.py
+++ b/tests/unit/cli_commands/test_utility_commands.py
@@ -918,7 +918,7 @@ class TestCmdFeatures:
         # Must name the `redis` package, not `attune-ai[redis]`: redis is a
         # core dep, so that extra was an empty alias and the suggestion was
         # a no-op that could not fix a missing import (the #758 trap).
-        assert "--force-reinstall redis" in captured.out
+        assert "--force-reinstall 'redis>=5.0.0,<9.0.0'" in captured.out
         assert "attune-ai[" not in captured.out
 
     def test_redis_available_and_running(
@@ -974,7 +974,7 @@ class TestCmdFeatures:
             name="Redis Memory",
             status="not_installed",
             message="Not available",
-            install_command="pip install --force-reinstall redis",
+            install_command="pip install --force-reinstall 'redis>=5.0.0,<9.0.0'",
         )
 
         mock_mem = MagicMock()
@@ -989,7 +989,7 @@ class TestCmdFeatures:
 
         captured = capsys.readouterr()
         assert "Install:" in captured.out
-        assert "--force-reinstall redis" in captured.out
+        assert "--force-reinstall 'redis>=5.0.0,<9.0.0'" in captured.out
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/memory/test_redis_auto_detect.py
+++ b/tests/unit/memory/test_redis_auto_detect.py
@@ -298,6 +298,57 @@ class TestRedisAutoDetector:
             result = detector._prompt_server_install()
         assert result is False
 
+    # ---- Package-install verification (#1418 fake-success regression) ----
+
+    def test_package_install_pip_success_but_import_fails(self, detector, capsys):
+        """pip exiting 0 must NOT produce a success claim when the import
+        still fails — the #1418 fake-success bug (a no-op install printed
+        '✓ redis package installed' and sent the user to debug the server)."""
+        with (
+            patch("builtins.input", return_value="y"),
+            patch("attune.memory.redis_auto_detect.subprocess.check_call", return_value=0),
+            patch.object(detector, "_check_python_package", return_value=False),
+        ):
+            result = detector._prompt_python_package()
+
+        out = capsys.readouterr().out
+        assert result is False
+        assert "✓ redis package installed" not in out
+        assert "still not importable" in out
+        # The remediation must not be the command that just ran (circular).
+        assert "pip check" in out or "attune-ai" in out
+
+    def test_package_install_success_verified_by_import(self, detector, capsys):
+        """The success claim appears only after the import re-check passes,
+        and the server flow continues."""
+        with (
+            patch("builtins.input", return_value="y"),
+            patch("attune.memory.redis_auto_detect.subprocess.check_call", return_value=0),
+            patch.object(detector, "_check_python_package", return_value=True),
+            patch.object(detector, "_check_server_reachable", return_value=True),
+        ):
+            result = detector._prompt_python_package()
+
+        assert result is True
+        assert "✓ redis package installed" in capsys.readouterr().out
+
+    def test_package_install_subprocess_targets_pinned_redis(self, detector):
+        """The pip invocation must target the real `redis` package with
+        pyproject's version pin — never the deleted [redis] extra (whose
+        no-op success created the fake-success bug), and never unpinned
+        (which could pull a major that violates the core constraint)."""
+        with (
+            patch("builtins.input", return_value="y"),
+            patch("attune.memory.redis_auto_detect.subprocess.check_call", return_value=0) as cc,
+            patch.object(detector, "_check_python_package", return_value=True),
+            patch.object(detector, "_check_server_reachable", return_value=True),
+        ):
+            detector._prompt_python_package()
+
+        args = cc.call_args[0][0]
+        assert "redis>=5.0.0,<9.0.0" in args
+        assert not any("attune-ai[" in a for a in args)
+
     # ---- Cache invalidation ----
 
     def test_invalidate_cache(self, detector):

--- a/tests/unit/test_extras_honesty.py
+++ b/tests/unit/test_extras_honesty.py
@@ -117,7 +117,19 @@ def _referenced_extras() -> dict[str, list[str]]:
     Comma combos like [memory,redis] expand to individual extras.
     """
     refs: dict[str, list[str]] = {}
-    files = (py for root in SCAN_ROOTS if root.is_dir() for py in sorted(root.rglob("*.py")))
+    # Skip test directories: they are excluded from the wheel
+    # (packages.find excludes tests*), and test code legitimately
+    # contains NEGATIVE examples — e.g. an assertion that an error
+    # message does NOT offer "attune-ai[" — which the hint regex would
+    # otherwise match as a garbage extra name. (That exact ouroboros
+    # broke CI when this guard first scanned attune_redis/tests.)
+    files = (
+        py
+        for root in SCAN_ROOTS
+        if root.is_dir()
+        for py in sorted(root.rglob("*.py"))
+        if "tests" not in py.relative_to(root).parts
+    )
     for py in files:
         for lineno, line in enumerate(py.read_text(encoding="utf-8").splitlines(), start=1):
             if line.strip().startswith("#"):

--- a/tests/unit/test_extras_honesty.py
+++ b/tests/unit/test_extras_honesty.py
@@ -34,7 +34,16 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 PYPROJECT = REPO_ROOT / "pyproject.toml"
-SRC_ROOT = REPO_ROOT / "src" / "attune"
+#: Every Python package that SHIPS IN THE WHEEL (packages.find scans
+#: both `src` and `.`). Scanning only src/attune left attune_redis's
+#: 6 MCP error hints invisible — the #758 trap survived #1418 there
+#: precisely because this list used to be one root. If a new bundled
+#: package is added, add it here.
+SCAN_ROOTS = [
+    REPO_ROOT / "src" / "attune",
+    REPO_ROOT / "attune_redis",
+    REPO_ROOT / "attune_software",
+]
 
 #: Empty extras that are allowed to exist — each must be a deliberate
 #: back-compat alias whose deps were promoted to core, documented by the
@@ -100,14 +109,16 @@ def _extras_with_dep_counts() -> dict[str, int]:
 
 
 def _referenced_extras() -> dict[str, list[str]]:
-    """{extra: [file:line, ...]} for every attune-ai[...] hint in src/.
+    """{extra: [file:line, ...]} for every attune-ai[...] hint in the
+    wheel's Python packages (see SCAN_ROOTS).
 
     Comment-only lines are skipped — a comment describing the pattern
     (doc_audit/checks.py does this) is not a user-facing install hint.
     Comma combos like [memory,redis] expand to individual extras.
     """
     refs: dict[str, list[str]] = {}
-    for py in sorted(SRC_ROOT.rglob("*.py")):
+    files = (py for root in SCAN_ROOTS if root.is_dir() for py in sorted(root.rglob("*.py")))
+    for py in files:
         for lineno, line in enumerate(py.read_text(encoding="utf-8").splitlines(), start=1):
             if line.strip().startswith("#"):
                 continue

--- a/tests/unit/test_utility_commands.py
+++ b/tests/unit/test_utility_commands.py
@@ -596,7 +596,7 @@ class TestCmdFeatures:
 
         captured = capsys.readouterr()
         assert "pip install" in captured.out
-        assert "--force-reinstall redis" in captured.out
+        assert "--force-reinstall 'redis>=5.0.0,<9.0.0'" in captured.out
 
     def test_features_redis_available_and_running(self, capsys: pytest.CaptureFixture) -> None:
         """Test cmd_features shows all-good when Redis is available and running."""
@@ -674,7 +674,7 @@ class TestCmdFeatures:
                 name="Short-term memory",
                 status=MemFeatureStatus.MISSING_DEPENDENCY,
                 message="Redis package not importable",
-                install_command="pip install --force-reinstall redis",
+                install_command="pip install --force-reinstall 'redis>=5.0.0,<9.0.0'",
             ),
         }
 
@@ -707,7 +707,7 @@ class TestCmdFeatures:
 
         captured = capsys.readouterr()
         assert "Install:" in captured.out
-        assert "--force-reinstall redis" in captured.out
+        assert "--force-reinstall 'redis>=5.0.0,<9.0.0'" in captured.out
 
     def test_features_shows_header(self, capsys: pytest.CaptureFixture) -> None:
         """Test cmd_features shows the FEATURE AVAILABILITY header."""
@@ -775,7 +775,7 @@ class TestCmdFeatures:
         else:
             short_term_status = MemFeatureStatus.MISSING_DEPENDENCY
             short_term_msg = "Redis package not importable"
-            short_term_install = "pip install --force-reinstall redis"
+            short_term_install = "pip install --force-reinstall 'redis>=5.0.0,<9.0.0'"
 
         return {
             "short_term": FeatureInfo(
@@ -815,6 +815,10 @@ class TestCmdFeatures:
                     if redis_available
                     else "Redis package not importable"
                 ),
-                install_command=None if redis_available else "pip install --force-reinstall redis",
+                install_command=(
+                    None
+                    if redis_available
+                    else "pip install --force-reinstall 'redis>=5.0.0,<9.0.0'"
+                ),
             ),
         }


### PR DESCRIPTION
## What

Completes #1418. A fresh-eyes review of that merged PR found five gaps;
this fixes all of them. 22 files, `fix(packaging)` risk profile.

## The headline finding

**The #758 trap #1418 claimed to eliminate was still live in shipped
code.** The sweep covered `src/`, `docs/`, `tests/` — but not
`attune_redis/` (ships in the wheel) or `plugin/` (shipped plugin
content). Eight more remediation sites pointed at deleted extras, six of
them MCP tool error responses:

```python
"error": "Redis support not installed. Run: pip install 'attune-ai[redis]'"
```

That extra no longer exists at all. All six now use one module constant
that names the real fix (the deps are core, so a failure means a broken
install). Also fixed: `plugin.py`'s ImportError warning,
`rag-code-gen/SKILL.md`'s flat claim that the workflow "Requires the
`[rag]` extra" (false since v3.x), `setup-guide.md`'s
`pip install attune-ai[memory]` remediation, the `attune_redis` README's
double extras-install instruction, and the mirrored generated-help
copies.

## The structural fix

The extras-honesty guard scanned only `src/attune` — so `attune_redis`
was structurally invisible to it. The "a guard's predicate defines its
blind spot" lesson applied to the fix itself. `SCAN_ROOTS` now covers
every package that ships in the wheel (`src/attune`, `attune_redis`,
`attune_software`).

**Receipt — the widened guard proven to fire, not assumed:** restoring
`origin/main`'s `mcp_tools.py` into the tree made the guard fail on all
6 sites, **plus a 7th (`plugin.py:92`) that the review's own
head-truncated grep had missed.** The encoded invariant caught what
eyeballing didn't — twice now.

## The other three findings

- **Unpinned remediation.** `pip install --force-reinstall redis` could
  someday pull redis 9.x past pyproject's `<9.0.0` constraint. All 14
  sites (the subprocess argument, printed hints, docs) now carry
  `'redis>=5.0.0,<9.0.0'`.
- **The fake-success fix had no test.** Three added:
  pip-exits-0-but-import-still-fails must NOT print the success banner
  (direct regression for the #1418 bug); success prints only after the
  import re-check; the subprocess must target the pinned real package
  and never an `attune-ai[...]` extra.
- **No CHANGELOG entry** for a user-visible packaging change.
  `[Unreleased]` now carries Removed (six extras, with the migration
  note) and Fixed (fake success + remediation hints).

Plus: the circular failure message ("try the command that just ran")
now points at `python -m pip check`, reading the actual ImportError, or
reinstalling attune-ai.

## Receipts

- **175 passed** serially across the 7 affected suites.
- Guard **proven to fire** against origin/main's `mcp_tools.py` before
  being trusted.
- Repo-wide residual references: **3, all deliberate** (one explanatory
  comment — the guard skips comments by design — and two historical
  "No need for X" FAQ lines).
- `attune_redis` imports verified; black/ruff pinned pre-flight clean.

## Out of scope, flagged

The session-start `[memory-drift]` hook advice still says
`uv sync --extra dev --extra developer --extra redis` — referencing the
deleted extra. That hook lives outside this repo (harness-side), so no
attune-ai PR can reach it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
