### PR TITLE
docs(dec2): downgrade conversation 1 — count is 0 of 5 verified

### DIFF
--- a/docs/specs/product-direction-review/outbound-drafts-2026-07-17.md
+++ b/docs/specs/product-direction-review/outbound-drafts-2026-07-17.md
@@ -14,7 +14,16 @@ attune-ai on a real repo**. Async text threads count
 
 ---
 
-## Draft 1 — Conversation 1 re-ask (highest yield, send first)
+## Draft 1 — Conversation 1 re-ask — DEAD (2026-07-17)
+
+**Do not send.** Conversation 1 was downgraded: likely the Jacob
+apprenticeship call (phone; he likely never ran attune-ai; mutual
+decision not to work together). There is no async thread, no confirmed
+user, and no four-question interview to conduct. A graceful two-line
+text to Jacob was drafted in-session if ever wanted; the interview
+questions transfer to whichever REAL conversation comes next.
+
+### Original draft (kept for the question checklist)
 
 **Why first:** the log's "Not captured (ask next time)" already lists
 four questions, and one of them — *how the conversation was sourced* —
@@ -72,12 +81,12 @@ posture and probably earns more trust than it costs — but it is a
 public, durable statement, and that is your call, not mine.
 
 > I've been building attune-ai in the open for months. Here's a number
-> I haven't posted: I have had exactly **one** real conversation with
-> someone who ran it on their own repo.
+> I haven't posted: the number of confirmed conversations I've had with
+> someone who ran it on their own repo is **zero**.
 >
-> One. And it was the most useful hour of the project — they told me
-> setup fought them, which reframed what I thought the product's
-> problem was.
+> Zero. The closest I got was a conversation that reframed what I
+> thought the product's problem was — and even that one, I can't
+> honestly claim the person ever ran it.
 >
 > So I'm asking directly instead of waiting: **if you've ever pip
 > installed attune-ai and actually pointed it at a real repository, I

--- a/docs/specs/product-direction-review/user-conversations.md
+++ b/docs/specs/product-direction-review/user-conversations.md
@@ -50,8 +50,9 @@ arrive and read the silence as the answer to F1.
 
 ## Outbound — 2026-07-17: LinkedIn ask POSTED (the DEC-2 decision, executed)
 
-Patrick posted the direct ask to LinkedIn on 2026-07-17 (URL pending
-capture — the recurring gap; capture it). Final angle was Patrick's
+Patrick posted the direct ask to LinkedIn on 2026-07-17.
+**URL (captured same day — gap not repeated this time):**
+https://www.linkedin.com/posts/patrick-roebuck-attune-ai_ive-been-building-attune-ai-in-the-open-share-7483920107094810624-FuCy/ Final angle was Patrick's
 own: setup-has-been-a-challenge / "if pip installing attune-ai gave
 you trouble, I'd appreciate your help" — grounded in the verified
 F1–F5 frictions and pointing the same direction as Discussion #1325.

--- a/docs/specs/product-direction-review/user-conversations.md
+++ b/docs/specs/product-direction-review/user-conversations.md
@@ -1,7 +1,9 @@
 # User Conversations — DEC-2 Evidence Log
 
 **Bar (from [assessment.md](assessment.md)):** 5 conversations with
-humans who ran attune-ai on a real repo. Count: **1 of 5.**
+humans who ran attune-ai on a real repo. Count: **0 of 5 VERIFIED**
+(downgraded 2026-07-17 — conversation 1 likely did not meet the bar;
+see its entry).
 
 Record each conversation here within a day of having it. Unrecorded
 signal doesn't compound (assessment-2026-07-11, N1).
@@ -27,7 +29,7 @@ now, 10 days before the verdict, not only on 07-27.
 | Discussion #1325 upvotes | 1 | 2026-07-17 |
 | Days live | 5 (since 07-12) | 2026-07-17 |
 | Repo stars / forks / watchers | **9 / 0 / 1** | 2026-07-17 |
-| Conversations logged | **1 of 5** | 2026-07-17 |
+| Conversations logged | **0 of 5 verified** (1 recorded, downgraded) | 2026-07-17 |
 
 **Interpretation (agent, kept separate from the data):** the channel
 is not underperforming — it is fishing a pond of ~9, most of whom
@@ -46,9 +48,23 @@ arrive and read the silence as the answer to F1.
 
 ---
 
-## Conversation 1 — 2026-07-09
+## Conversation 1 — 2026-07-08/09 — DOWNGRADED 2026-07-17: likely below the bar
 
 **Recorded:** 2026-07-11 (verbal report from Patrick; two-day lag).
+**Downgrade (2026-07-17, Patrick's recall):** the conversation was
+almost certainly the **2026-07-08 phone call with Jacob** (calendar:
+"jacob about apprentice", 1:00–2:00 PM) — an apprenticeship discussion
+that ended with a mutual decision not to work together. Patrick: "I
+don't think he ran it," and there was no other early-July candidate.
+The bar requires a human who RAN attune-ai on a real repo, so this
+conversation **does not count toward the 5**. The "setup issues"
+signal below was therefore talk ABOUT the product, not a report from
+running it — softer than this log originally implied. (The 07-11
+fresh-machine reproduction stands on its own receipts: F1–F5 were
+real, independently verified frictions regardless of this downgrade.)
+**Sourcing datum that survives:** the one near-miss came through
+Patrick's personal network by phone; the product channels (README,
+CLI error paths, #1325) have produced zero. That is where 2–5 live.
 
 ### What the user said
 

--- a/docs/specs/product-direction-review/user-conversations.md
+++ b/docs/specs/product-direction-review/user-conversations.md
@@ -48,6 +48,32 @@ arrive and read the silence as the answer to F1.
 
 ---
 
+## Outbound — 2026-07-17: LinkedIn ask POSTED (the DEC-2 decision, executed)
+
+Patrick posted the direct ask to LinkedIn on 2026-07-17 (URL pending
+capture — the recurring gap; capture it). Final angle was Patrick's
+own: setup-has-been-a-challenge / "if pip installing attune-ai gave
+you trouble, I'd appreciate your help" — grounded in the verified
+F1–F5 frictions and pointing the same direction as Discussion #1325.
+The interview bar stays in the post's body: pip installed it AND
+pointed it at a real repository; bounce stories explicitly invited.
+
+This closes the "outbound vs read-the-silence" fork: **outbound,
+chosen and executed.** From here, the 07-27 verdict reads the
+RESPONSE to a direct ask, which means something — unlike silence from
+a channel nobody was standing in.
+
+**New population datum (Patrick, 2026-07-17, recorded same day):**
+he has talked to **3 people** about attune-ai over the project's
+life; **none ever got back to him** about running it. Whether Jacob
+is among the 3 is unresolved (asked; pending). So the funnel to
+date: 3 personal-network conversations -> 0 follow-throughs; product
+channels -> 0 contacts; confirmed run-reports -> 0. The ask is now
+public; replies get logged here within a day (N1), against the
+four-question checklist kept under draft 1.
+
+---
+
 ## Conversation 1 — 2026-07-08/09 — DOWNGRADED 2026-07-17: likely below the bar
 
 **Recorded:** 2026-07-11 (verbal report from Patrick; two-day lag).


### PR DESCRIPTION
Docs-only. Patrick's recall resolved conversation 1's identity: almost certainly the 2026-07-08 "jacob about apprentice" phone call — apprenticeship discussion, mutual no, and **he likely never ran attune-ai**. No other early-July candidate exists. The DEC-2 bar is *ran it on a real repo*, so the honest count drops **1 → 0 of 5 verified**, ten days before the 07-27 verdict.

Cascade handled in the same diff: the re-ask draft is marked DEAD (no thread, no confirmed user), and the LinkedIn draft's hook — which claimed "exactly one real conversation with someone who ran it" — is corrected to **zero confirmed** before it could ship a false number (the marketing-accuracy class the ledger warns about). Zero is also, frankly, the stronger hook.

Survives the downgrade: the 07-11 fresh-machine reproduction (F1–F5 were independently verified on receipts), and the sourcing datum — the one near-miss came via personal network by phone while every product channel sits at zero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)