### PR TITLE
release: 10.5.0 — widget surface complete, elicitation reference form, honest packaging

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "Spec-driven development for Claude Code — take an idea through requirements, design, tasks, and gated execution with an approval loop. Plus 23 auto-triggering skills: security audits, code review, test generation, release prep.",
-    "version": "10.4.1"
+    "version": "10.5.0"
   },
   "plugins": [
     {
       "name": "attune-ai",
       "description": "Spec-driven development is the core workflow: /spec carries an idea through brainstorm, requirements, design, and task execution with quality gates and your approval at each stage. Backed by 23 auto-triggering skills — security audits, code reviews, test generation, bug prediction, and release preparation. For help content tools, also install attune-help and attune-author from this marketplace.",
       "source": "./plugin",
-      "version": "10.4.1",
+      "version": "10.5.0",
       "author": {
         "name": "Smart AI Memory",
         "email": "patrick.roebuck@smartaimemory.com"

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,4 +1,4 @@
-# Attune AI Framework v10.4.1
+# Attune AI Framework v10.5.0
 
 AI-powered developer workflows with cost optimization and multi-agent orchestration.
 
@@ -129,7 +129,7 @@ attune_redis/          # Redis plugin — BUNDLED, ships in the attune-ai
 
 ---
 
-**Version:** 10.4.1 | **License:** Apache 2.0 | **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)
+**Version:** 10.5.0 | **License:** Apache 2.0 | **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)
 
 ## Lessons — core
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,50 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [10.5.0] — 2026-07-17
+
+Feature release: the analysis-workflow widget surface is now complete
+(every workflow renders a rich panel, with clickable next steps), the
+elicitation form surface gained its canonical reference form and
+cheaper rendering paths, and the packaging surface was made honest —
+empty placeholder extras deleted and every install remediation now
+names a command that can actually fix the stated problem.
+
+### Added
+
+- **Every analysis workflow now renders a rich report panel** (#1409).
+  Prose-only runs (deep-review, test-audit, refactor-plan,
+  dependency-check, code-review without findings) previously fell back
+  to raw markdown with no widget; `markdown_to_panel_html` closes the
+  Family-B gap.
+- **Report panels render next-step actions as clickable RUN buttons**
+  (#1411). Clicking posts the command back as the next prompt, closing
+  the workflow → report → next-workflow loop.
+- **`attune.elicitation.reference_form`** (#1412) — the canonical,
+  code-verified example form: one field per QuestionType across all
+  ten controls, paired with valid `EXAMPLE_ANSWERS`; doubles as the
+  living spec for form authors.
+- **`needs_widget(form)`** (#1413) — deterministic routing predicate:
+  forms expressible with native controls skip the widget round-trip
+  entirely and go straight to the cheaper surface.
+
+### Changed
+
+- **Widget forms ship only the CSS their controls use** (#1414). The
+  style block is split into per-control families; typical forms emit
+  46–70% less CSS than the previous fixed 4.7 KB block.
+
+### Fixed (also in this release)
+
+- **`create-agent` no longer crashes rendering its cost-estimate
+  line** (#1403) — a Rich markup span split across two prints raised
+  `MarkupError` at the end of every successful create.
+- **`attune ops --port` honors the `PORT` env var** (#1405) — the
+  hardcoded 8765 default collided with occupied ports under process
+  managers using auto-port placement.
+- **Coverage baseline no longer misreports modules loaded via
+  `spec_from_file_location`** (#1397).
+
 ### Removed
 
 - **The six empty placeholder extras (`[rag]`, `[memory]`, `[redis]`,

--- a/docs/reference/API_REFERENCE.md
+++ b/docs/reference/API_REFERENCE.md
@@ -1,6 +1,6 @@
 # Attune AI API Reference
 
-**Version:** 10.4.1
+**Version:** 10.5.0
 **License:** Apache License 2.0
 **Copyright:** 2025-2026 Smart AI Memory, LLC
 
@@ -1152,5 +1152,5 @@ msg = format_error(
 
 ---
 
-**Version:** 10.4.1 | **License:** Apache 2.0
+**Version:** 10.5.0 | **License:** Apache 2.0
 **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)

--- a/docs/specs/usage-signals/decisions.md
+++ b/docs/specs/usage-signals/decisions.md
@@ -572,3 +572,16 @@ recorded interpretation in this file says otherwise. The DEC-7
 release-freeze window (2026-07-13 → 07-27, no tags) is the live
 experiment; its 07-27 interpretation supersedes this entry's
 "pending evidence" clause either way.
+
+## DEC-7 amendment — 2026-07-17: mid-window tag, reframed as the experiment's sharpest probe
+
+**Decided by Patrick 2026-07-17** (form pick: "Release now, AS the
+experiment"). The no-tags window (07-13 → 07-27) is amended: v10.5.0
+tags on 2026-07-17, deliberately, four days into the window — same day
+as the LinkedIn direct ask (URL in `product-direction-review/
+user-conversations.md`). Rationale: a tag whose download spike arrives
+with zero human responses alongside it is the cleanest CI-shadow
+evidence the experiment can produce — sharper than an undisturbed
+quiet window. The 07-27 interpretation must therefore read THREE
+series together: the download curve, the tag date, and the
+LinkedIn-response count. Not a violation; an instrumented probe.

--- a/plugin/.claude-plugin/marketplace.json
+++ b/plugin/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "Spec-driven development for Claude Code — /spec plans, reviews, and executes with quality gates; plus security audits, code reviews, test generation, and release prep from /attune.",
-    "version": "10.4.1"
+    "version": "10.5.0"
   },
   "plugins": [
     {
       "name": "attune-ai",
       "description": "Spec-driven development for Claude Code — /spec plans, reviews, and executes with quality gates; plus security audits, code reviews, test generation, and release prep from /attune.",
       "source": "./",
-      "version": "10.4.1",
+      "version": "10.5.0",
       "author": {
         "name": "Smart AI Memory",
         "email": "patrick.roebuck@smartaimemory.com"

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "attune-ai",
-  "version": "10.4.1",
+  "version": "10.5.0",
   "description": "Spec-driven development for Claude Code — /spec plans, reviews, and executes with quality gates; plus security audits, code reviews, test generation, and release prep from /attune.",
   "author": {
     "name": "Smart AI Memory",

--- a/plugin/core/__init__.py
+++ b/plugin/core/__init__.py
@@ -5,4 +5,4 @@ This module provides the core workflow functionality when the full
 attune-ai package is not installed via pip.
 """
 
-__version__ = "10.4.1"
+__version__ = "10.5.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "attune-ai"
-version = "10.4.1"
+version = "10.5.0"
 description = "AI-powered developer workflows for Claude with cost optimization, multi-agent orchestration, and workflow automation."
 readme = {file = "README.md", content-type = "text/markdown"}
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -299,7 +299,7 @@ wheels = [
 
 [[package]]
 name = "attune-ai"
-version = "10.4.1"
+version = "10.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "agent-memory-client" },

--- a/website/app/page.tsx
+++ b/website/app/page.tsx
@@ -58,7 +58,7 @@ export default function Home() {
             <div className="grid lg:grid-cols-2 gap-16 items-center">
               <div className="z-10">
                 <div className="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-[var(--surface-container-high)] text-[var(--primary)] text-xs font-bold tracking-widest mb-6 uppercase">
-                  <span>v10.4.1</span>
+                  <span>v10.5.0</span>
                   <span className="w-1 h-1 rounded-full bg-[var(--primary)]"></span>
                   <span className="opacity-80">Spec-driven development platform</span>
                 </div>

--- a/website/lib/features.ts
+++ b/website/lib/features.ts
@@ -32,7 +32,7 @@ export const PRODUCTS: Product[] = [
     id: "attune-ai",
     name: "Attune AI",
     pypiName: "attune-ai",
-    version: "10.4.1",
+    version: "10.5.0",
     tagline: "Generate, maintain, and serve help from your code",
     installCommand: "pip install attune-ai",
     marketplaceInstall:
@@ -101,7 +101,7 @@ export const PRODUCTS: Product[] = [
     id: "claude-code-plugin",
     name: "Claude Code Plugin",
     pypiName: "attune-ai",
-    version: "10.4.1",
+    version: "10.5.0",
     tagline: "Progressive help right in your terminal",
     installCommand:
       "claude plugin marketplace add Smart-AI-Memory/attune-ai",


### PR DESCRIPTION
Release prep for **10.5.0** (minor: features present; removals are non-breaking — empty extras pip-warn-but-install, legacy workflow family had zero live callers with a deprecation path).

- Version bumps via `scripts/bump_version.py` (all sites, self-validated)
- Changelog promoted with **8 previously-missing entries** folded in (#1409 #1411 #1412 #1413 #1414 #1403 #1405 #1397) — the v9.4.0-class completeness pass, run against `git log v10.4.1..origin/main`
- `uv.lock`: one-line diff (own version only)
- **DEC-7 amendment recorded** (usage-signals decisions): deliberate mid-window tag as the experiment's sharpest probe; 07-27 interpretation must read downloads + tag date + LinkedIn responses together
- Docs regen skipped this release (stale-only LLM polish; error-string churn risks whole-feature re-polish)

Post-merge: /attune-release-check → recall gate → content-in-SHA → tag from the merge SHA → publish approval → PyPI verification → reach snapshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)