### PR TITLE
docs: close DEC-8/Block 0 with the CI-run receipt; +1 lesson

### DIFF
--- a/.claude/lessons.md
+++ b/.claude/lessons.md
@@ -15854,3 +15854,18 @@ def ", start_idx + 1)` for module-
   time. History: rate-limiting also hit the 10.0.x and 10.2.0
   releases (release_state memory); it is the norm at tag time, not
   weather. Defer by default; don't burn the evening.
+
+- **"Auto-merge lane should take it" is a claim about an ARM state —
+  reconcile with `autoMergeRequest`, not the checks**: 2026-07-17
+  evening run. The starter said #1425 (docs-only, all green) would be
+  taken by the auto-merge lane; it sat OPEN for hours at
+  `mergeStateStatus: CLEAN` because `autoMergeRequest` was null —
+  auto-merge was never armed. Green checks + CLEAN prove MERGEABLE,
+  not MERGING. When a handoff says a PR will self-merge, the one-call
+  reconcile is `gh pr view <n> --json mergeStateStatus,autoMergeRequest`
+  — null autoMergeRequest on a CLEAN PR means arm it or merge it now.
+  Companion datum, same run: the pypistats IP-wide 429 penalty was
+  STILL active ~7+ hours after the morning's three attempts (first
+  request of the evening 429'd) — the #1425 lesson's "defer, don't
+  retry" horizon is hours, not the 15 minutes the error message
+  suggests; plan snapshot retries a day apart, not within a session.

--- a/docs/specs/product-direction-review/freeze-week-plan-2026-07-13.md
+++ b/docs/specs/product-direction-review/freeze-week-plan-2026-07-13.md
@@ -34,6 +34,17 @@ rationale.
 **Done when:** `ci_spend_gate.py` runs enforcing (not fail-open)
 on its next scheduled run; umbrella spec-audit CI green.
 
+**CLOSED 2026-07-17 — verified with the CI-run receipt.** The
+secret landed 2026-07-13 02:24 UTC; the next scheduled
+`integration-auth` run (29243098370, 2026-07-13 10:33 UTC) took
+the ENFORCING path — its gate step logged
+`ci_spend_gate: month-to-date spend $26.53 is under the $350.00
+ceiling — proceeding.` (not the fail-open warning). Secret-set ≠
+gate-working was the open doubt; the step log is the receipt.
+Note the third bullet (`ATTUNE_WORKSPACE_RO_TOKEN`) was closed
+separately as a phantom carry — never created, never needed
+(spec-audit CI uses the built-in `github.token`; see #1422).
+
 ## Block 1 — Watch the door (10 min/day, every day)
 
 - Check Discussion #1325; reply same-day to anything substantive.


### PR DESCRIPTION
## Summary

- **DEC-8/Block 0 formally closed** in [freeze-week-plan-2026-07-13.md](https://github.com/Smart-AI-Memory/attune-ai/blob/main/docs/specs/product-direction-review/freeze-week-plan-2026-07-13.md): the open doubt was "secret-set ≠ gate-working." Receipt: scheduled `integration-auth` run 29243098370 (2026-07-13 10:33 UTC, ~8h after the secret landed) logged the **enforcing** path — `month-to-date spend $26.53 is under the $350.00 ceiling — proceeding.` — not the fail-open warning. This is item 6 of the 07-14 assessment ("record it and stop carrying it").
- **+1 lesson** (evening run): a starter's "auto-merge lane will take it" reconciles against `autoMergeRequest` (#1425 sat CLEAN but never armed); pypistats 429 penalty observed persisting 7+ hours — snapshot retries belong a day apart.

Docs-only. The v10.5.0 reach snapshot itself is still 429-blocked (2 more probes tonight, both aborted correctly with exit 1) — carried to tomorrow morning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)