### PR TITLE
ci(reach-snapshot): persist-credentials false so the PAT push works

### DIFF
--- a/.github/workflows/reach-snapshot.yml
+++ b/.github/workflows/reach-snapshot.yml
@@ -27,6 +27,11 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # checkout's persisted GITHUB_TOKEN extraheader OVERRIDES the
+          # PAT embedded in the remote URL below — with contents: read
+          # the push then 403s as github-actions[bot] (run 29636107041).
+          persist-credentials: false
 
       - name: Capture snapshot (spaced requests, aborts on 429)
         env:


### PR DESCRIPTION
## Summary

The reach-snapshot workflow's first two dispatches failed differently:

- Run 29622463754 (00:09 UTC): instant 429 — pypistats-side throttling that night (falsified this morning: run 29636107041 captured all 5 packages from a runner IP).
- Run 29636107041 (07:39 UTC): capture SUCCEEDED, but the push 403'd as github-actions[bot] — actions/checkout persists the GITHUB_TOKEN auth extraheader, which overrides the ADMIN_MERGE_TOKEN embedded in the remote URL, and the workflow token is contents: read.

Fix: `persist-credentials: false` on the checkout step so the PAT remote URL actually authenticates the push.

## Validation

Run 29636274657 dispatched from THIS branch (workflow_dispatch honors the branch's workflow file) — if the fix works it ships today's snapshot PR itself via the auto-merge-safe lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
