### PR TITLE
feat(skills): project .claude/skills into the tracked .agents mirror

### DIFF
--- a/.agents/skills/agent/SKILL.md
+++ b/.agents/skills/agent/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: agent
+description: Create and manage custom AI agents and teams
+---
+# agent
+
+Create and manage custom AI agents and teams using
+the Attune Agent SDK.
+
+## Routes
+
+| Subcommand | Action |
+| ---------- | ------ |
+| `create` | Create a new agent |
+| `create-team` | Create a multi-agent team |
+| `run` | Run an existing agent |
+| `list` | List available agents |
+| `release-prep` | Run release prep agent team |
+
+## Usage
+
+```bash
+/agent                  # Ask what to do
+/agent create           # Create an agent
+/agent create-team      # Create a team
+/agent run              # Run an agent
+/agent list             # List agents
+/agent release-prep     # Run release prep team
+```
+
+## Behavior
+
+### create
+
+Use `AskUserQuestion` to understand:
+
+- What should the agent do?
+- What tier? (cheap, capable, premium)
+- What tools does it need?
+
+Then guide the user through agent definition using
+the SDK:
+
+```python
+from attune.agents.sdk import SDKAgent
+
+agent = SDKAgent(
+    agent_id="my-agent",
+    role="analyst",
+    tier="capable",
+)
+```
+
+### create-team
+
+Use `AskUserQuestion` to understand:
+
+- What's the team's goal?
+- How many agents?
+- What roles?
+
+Then guide through team creation:
+
+```python
+from attune.agents.sdk import SDKAgentTeam
+
+team = SDKAgentTeam(
+    team_id="my-team",
+    agents=[agent1, agent2],
+)
+```
+
+### run
+
+Use `AskUserQuestion`:
+
+- Which agent or team to run?
+- What input?
+
+Then execute the agent.
+
+### list
+
+Show available agents and teams from the registry.
+
+### release-prep
+
+Run the release preparation agent team:
+
+```bash
+uv run attune workflow run release-prep
+```

--- a/.agents/skills/attune/SKILL.md
+++ b/.agents/skills/attune/SKILL.md
@@ -1,0 +1,248 @@
+---
+name: attune
+description: AI-powered developer workflows with Socratic discovery
+---
+# attune
+
+Your AI-powered developer workflow assistant with Socratic discovery.
+
+**One command. Every workflow.**
+
+## How It Works
+
+Type `/attune` and I'll guide you through questions to find the right workflow.
+
+```bash
+/attune                              # Start Socratic discovery
+/attune "I need to fix a bug"        # Natural language
+/attune debug                        # Direct shortcut
+```
+
+## Fast-Path Detection
+
+When the user provides sufficient context inline,
+**skip scoping questions and execute directly**.
+This satisfies the Socratic requirement because the
+user's explicit args provide the scoping context.
+
+**Fast-path triggers (execute immediately):**
+
+- Specific subcommand + target path:
+  `/attune security-audit ./src`
+- Natural language with clear scope:
+  `/attune "review src/auth"`
+- Explicit `--auto` flag:
+  `/attune commit --auto`
+
+**Socratic flow (ask questions first):**
+
+- `/attune` (no args)
+- `/attune "fix something"` (vague)
+
+**Rule:** If input contains BOTH an action AND a target,
+proceed to execution. If either is missing or ambiguous,
+use `AskUserQuestion`.
+
+## Workflows by Goal
+
+### 🔧 Fix or Improve Something
+
+**Debugging:**
+
+- Investigate errors and exceptions
+- Trace execution flow
+- Identify root causes
+
+**Code Review:**
+
+- Quality and pattern analysis
+- Security review
+- Performance review
+
+**Refactoring:**
+
+- Improve structure and organization
+- Extract functions/classes
+- Simplify complex code
+
+### ✅ Validate My Work
+
+**Testing:**
+
+- Run test suites
+- Generate new tests
+
+**Coverage:**
+
+- Analyze test coverage
+- Identify gaps
+- Boost coverage
+
+**Security Audit:**
+
+- Vulnerability scanning
+- Dependency analysis
+- Code security review
+
+**Performance Audit:**
+
+- Identify bottlenecks
+- Memory analysis
+- Optimization recommendations
+
+### 🚀 Ship My Changes
+
+**Commit:**
+
+- Stage and commit changes
+- Generate commit messages
+- Follow conventional commits
+
+**Pull Request:**
+
+- Create PR with description
+- Review checklist
+- Link to issues
+
+**Release:**
+
+- Version bump
+- Changelog generation
+- Security pre-checks
+- Publish to registry
+
+### 📚 Understand or Document
+
+**Explain Code:**
+
+- Understand how code works
+- Trace through logic
+- Learn patterns used
+
+**Generate Docs:**
+
+- API documentation
+- README updates
+- Architecture docs
+
+**Feature Overview:**
+
+- High-level summaries
+- Component relationships
+- Usage examples
+
+## Quick Shortcuts
+
+| Shortcut | Action |
+| -------- | ------ |
+| `/attune debug` | Start debugging session |
+| `/attune review` | Code review |
+| `/attune refactor` | Refactoring session |
+| `/attune test` | Run tests |
+| `/attune coverage` | Coverage analysis |
+| `/attune security` | Security audit |
+| `/attune commit` | Create commit |
+| `/attune pr` | Create pull request |
+| `/attune release` | Prepare release |
+| `/attune docs` | Documentation |
+| `/attune explain` | Explain code |
+
+## Natural Language
+
+Just describe what you need:
+
+- "find security vulnerabilities"
+- "why is this test failing"
+- "generate tests for config.py"
+- "review my authentication code"
+- "prepare for release 2.0"
+- "explain how caching works"
+- "this function is too long"
+
+## CRITICAL: Socratic Discovery Before Execution
+
+**ALWAYS use `AskUserQuestion` to scope and confirm before executing any workflow. NEVER skip straight to running commands.**
+
+### Step 1: Understand the Goal
+
+If invoked without arguments (`/attune`), use `AskUserQuestion` to ask what the user is trying to accomplish.
+
+### Step 2: Scope the Work
+
+Once the goal is identified, use `AskUserQuestion` to narrow scope. Examples:
+
+- **Testing**: "What scope? Full suite, CLI tests only, quick smoke test, or coverage report?"
+- **Security audit**: "What target? src/, a specific module, or full project?"
+- **Code review**: "What focus? Quality, security, performance, or all?"
+- **Commit**: "Which files? All staged changes, specific files, or let me review first?"
+- **Release**: "What stage? Prep check, changelog update, or full publish?"
+
+### Step 3: Execute
+
+Only after scoping via `AskUserQuestion`, execute the appropriate CLI command.
+
+### Shortcut Routing
+
+When the user types a shortcut, **still ask a scoping question before executing**:
+
+| Input | CLI Command |
+| ----- | ----------- |
+| `/attune security` | `uv run attune workflow run security-audit` |
+| `/attune test` | `uv run pytest` |
+| `/attune coverage` | `uv run pytest --cov=src --cov-report=term-missing` |
+| `/attune perf` | `uv run attune workflow run perf-audit` |
+| `/attune review` | `uv run attune workflow run code-review` |
+| `/attune bug-predict` | `uv run attune workflow run bug-predict` |
+| `/attune test-gen` | `uv run attune workflow run test-gen` |
+| `/attune commit` | Use git to stage and commit changes |
+| `/attune pr` | Use gh to create a pull request |
+| `/attune release` | `uv run attune workflow run release-prep` |
+| `/attune debug` | Start interactive debugging session |
+| `/attune refactor` | Analyze code and suggest refactoring |
+| `/attune docs` | Generate documentation |
+| `/attune explain` | Read and explain the specified code |
+
+### Natural Language Routing (EXECUTE THESE)
+
+When the user provides natural language, map to the appropriate CLI command:
+
+| Pattern | CLI Command |
+| ------- | ----------- |
+| "security", "vulnerabilities", "audit" | `uv run attune workflow run security-audit` |
+| "test", "tests", "run tests" | `uv run pytest` |
+| "coverage", "test coverage" | `uv run pytest --cov=src --cov-report=term-missing` |
+| "generate tests", "write tests" | `uv run attune workflow run test-gen` |
+| "review", "code review" | `uv run attune workflow run code-review` |
+| "performance", "perf", "bottleneck" | `uv run attune workflow run perf-audit` |
+| "bugs", "predict bugs" | `uv run attune workflow run bug-predict` |
+| "release", "ship", "publish" | `uv run attune workflow run release-prep` |
+
+**IMPORTANT:** When arguments are provided, DO NOT just display documentation. Use `AskUserQuestion` to scope, THEN execute the CLI command.
+
+### CLI Reference
+
+```bash
+# Workflows
+uv run attune workflow run security-audit --path <target>
+uv run attune workflow run perf-audit --path <target>
+uv run attune workflow run bug-predict --path <target>
+uv run attune workflow run code-review --path <target>
+uv run attune workflow run test-gen --path <target>
+uv run attune workflow run release-prep
+
+# Testing
+uv run pytest
+uv run pytest --cov=src --cov-report=term-missing
+uv run pytest -k "test_name"
+
+# Telemetry
+uv run attune telemetry show
+```
+
+## Philosophy
+
+**Socratic over menus.** I ask "What are you trying to accomplish?" not "Which tool do you want?" This helps you think about your actual goal.
+
+**Teaching over telling.** I help you understand *why*, not just *what*.
+
+**Questions before actions.** ALWAYS use `AskUserQuestion` to guide users through decisions at every step — goal identification, scoping, and confirmation. Never assume scope or jump to execution. This is the #1 rule of the Attune workflow experience.

--- a/.agents/skills/brainstorm/SKILL.md
+++ b/.agents/skills/brainstorm/SKILL.md
@@ -1,0 +1,209 @@
+---
+name: brainstorm
+description: Guided brainstorming with structured discovery and plan output
+---
+# brainstorm
+
+Guided brainstorming that turns fuzzy thinking into concrete
+plans.
+
+**One conversation. Clear outcome.**
+
+## Routes
+
+| Shortcut | Behavior |
+| -------- | -------- |
+| `/brainstorm` | Full open discovery |
+| `/brainstorm "topic"` | Start with context pre-filled |
+| `/brainstorm plan` | Skip to goals/planning |
+
+Note: Brainstorm is conversational — not routed like
+other commands. There are no `###` behavior sections.
+The phases (Context, Problem, Goals, End State) flow
+naturally through the conversation.
+
+## How It Works
+
+Type `/brainstorm` and I'll think through the problem with
+you. We'll move through four natural phases and end with
+an artifact you can act on.
+
+```bash
+/brainstorm                        # Start open discovery
+/brainstorm "flaky CI tests"       # Start with context
+/brainstorm plan                   # Jump closer to planning
+```
+
+## Conversation Flow
+
+### Opening
+
+> I'll help you think this through. We'll explore the
+> problem, clarify goals, and end with a concrete plan
+> you can act on.
+>
+> What are you working on?
+
+### Phases
+
+The conversation moves through four phases. Show a
+breadcrumb for orientation. Use soft checkpoints when
+alignment is uncertain.
+
+**Breadcrumb format:**
+
+```
+Context > Problem > Goals > End State > Plan
+   done     here
+```
+
+| Phase | AI's Job | Advance when... |
+| ----- | -------- | --------------- |
+| Context | Listen, ask follow-ups, understand the situation | Situation is clear |
+| Problem | Mirror back understanding, challenge assumptions | Core issue is agreed on |
+| Goals | Distinguish must-haves from nice-to-haves | Success criteria defined |
+| End State | Make it concrete and testable | "Done" is unambiguous |
+
+### AI Behavior Rules
+
+**Three moves per turn — pick one:**
+
+1. **Mirror** — "So the core issue is X" (confirm
+   understanding)
+2. **Challenge** — "But is it actually Y?" (push deeper,
+   question assumptions)
+3. **Advance** — "OK, what does done look like?" (move to
+   next phase)
+
+**Transition rules:**
+
+- **Default:** Show breadcrumb, advance naturally
+- **When uncertain:** Soft checkpoint — "Here's what I'm
+  hearing... does that sound right?" Use this when:
+  - Answers are vague or contradictory
+  - Scope keeps shifting
+  - High-stakes decisions are involved
+- **Never** announce phase names or say "entering phase 3"
+- **Never** rush — stay in a phase until it has genuine
+  clarity
+
+**Conversation principles:**
+
+- Ask ONE question at a time (not a list of three)
+- Keep responses short — 2-4 sentences plus a question
+- Challenge at least once per session — don't just collect
+- Reference what the user said — "You mentioned X, but..."
+- If the user gives a one-word answer, dig deeper
+
+### Closing — User Chooses Output
+
+When the end state is clear, present the output options
+using `AskUserQuestion`:
+
+```yaml
+question: "We've got a clear picture. What would you like to do with it?"
+header: "Output"
+options:
+  - label: "Execute now"
+    description: "I'll start implementing the plan"
+  - label: "Save as plan"
+    description: "Write to .claude/plans/{topic}.md for later"
+  - label: "Export as task prompts"
+    description: "XML task specs for subagents or future sessions"
+  - label: "Just the summary"
+    description: "Keep it in this conversation"
+```
+
+**Plan file format** (when "Save as plan" is chosen):
+
+```markdown
+# {Topic Title}
+
+**Created:** {date}
+**Source:** /brainstorm session
+
+## Problem
+{1-2 sentence problem statement}
+
+## Goals
+- {Must-have 1}
+- {Must-have 2}
+- {Nice-to-have (marked as such)}
+
+## End State
+{Concrete description of what "done" looks like}
+
+## Approach
+1. {Step 1}
+2. {Step 2}
+3. {Step 3}
+
+## Next Steps
+- [ ] {First actionable item}
+- [ ] {Second actionable item}
+
+## Open Questions
+- {Anything unresolved}
+```
+
+Ensure `.claude/plans/` directory exists before writing.
+
+## CRITICAL: This Is a Conversation, Not a Form
+
+**ALWAYS use `AskUserQuestion` for each phase transition.
+NEVER dump all questions at once. NEVER skip to
+generating a plan without the full interactive flow.**
+
+The phases are invisible scaffolding. The user experiences
+a natural thinking conversation that happens to produce a
+structured result.
+
+**Do NOT:**
+
+- Ask multiple questions in one turn
+- Skip phases because the answer seems obvious
+- Generate a plan without going through all four phases
+- Announce "now we're in the Goals phase"
+- Accept vague answers without pushing for specifics
+
+**Do:**
+
+- Listen more than you talk
+- Challenge assumptions at least once
+- Use the user's own words when mirroring back
+- Keep each response to 2-4 sentences plus one question
+- Show the breadcrumb so the user knows where they are
+
+## Natural Language Detection
+
+Route to `/brainstorm` when the user says things like:
+
+- "I need to think through..."
+- "Help me figure out..."
+- "I'm not sure how to approach..."
+- "Let's brainstorm..."
+- "I have an idea about..."
+- "What if we..."
+- "How should I tackle..."
+
+## Shortcuts
+
+| Shortcut | Behavior |
+| -------- | -------- |
+| `/brainstorm` | Full open discovery |
+| `/brainstorm "topic"` | Start with context pre-filled |
+| `/brainstorm plan` | Lightweight — skip to goals/planning |
+
+## Philosophy
+
+**Thinking partner, not idea generator.** I help you
+clarify YOUR thinking, not replace it with mine.
+
+**Challenge over agreement.** A good brainstorm includes
+"but have you considered..." at least once.
+
+**Artifact over air.** Every session ends with something
+concrete — a plan, a summary, task specs, or execution.
+
+**Questions before answers.** The right question matters
+more than the right solution.

--- a/.agents/skills/commit-push-pr/SKILL.md
+++ b/.agents/skills/commit-push-pr/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: commit-push-pr
+description: Stage, commit, push, and create PR in one command
+---
+# commit-push-pr
+
+One-shot command to commit current work, push, and open a PR.
+
+## Context (pre-computed)
+
+```bash
+git status -u
+git diff --stat
+git log --oneline -5
+git branch --show-current
+```
+
+## Instructions
+
+1. Review the git status and diff above
+2. Stage all relevant changed files (exclude .env,
+   credentials, large binaries)
+3. Write a conventional commit message based on the
+   changes:
+   - `feat:` for new features
+   - `fix:` for bug fixes
+   - `docs:` for documentation
+   - `chore:` for maintenance
+   - `refactor:` for restructuring
+4. Commit with the message
+5. Push the current branch to origin (create remote
+   branch if needed with `-u`)
+6. Create a PR targeting main using `gh pr create`
+   with a summary and test plan
+7. Return the PR URL
+
+If on `main`, create a feature branch first based on
+the change type (e.g., `feat/description` or
+`fix/description`).

--- a/.agents/skills/deep-review/SKILL.md
+++ b/.agents/skills/deep-review/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: deep-review
+description: Multi-pass deep code review — security, quality, and test gaps
+---
+# deep-review
+
+Multi-pass code review that runs security, quality, and
+test gap analysis on a target. Uses subagents to keep
+context clean.
+
+## Context (pre-computed)
+
+```bash
+git diff --name-only main...HEAD 2>/dev/null || git diff --name-only HEAD~3 2>/dev/null
+```
+
+## Instructions
+
+Use `AskUserQuestion` to scope:
+
+- Which path or files to review?
+- Focus: security, quality, test gaps, or all three?
+
+Then run three passes using the Task tool with subagents:
+
+### Pass 1: Security
+
+```bash
+uv run attune workflow run security-audit --path <target>
+```
+
+### Pass 2: Quality
+
+```bash
+uv run attune workflow run code-review --path <target>
+```
+
+### Pass 3: Test Gaps
+
+Analyze which functions in the target lack test coverage
+by cross-referencing source files with test files.
+
+### Output
+
+Consolidate findings into a single summary table:
+
+| File | Issue | Severity | Category |
+|------|-------|----------|----------|
+
+Group by severity (high → medium → low). End with
+actionable recommendations.

--- a/.agents/skills/dev/SKILL.md
+++ b/.agents/skills/dev/SKILL.md
@@ -1,0 +1,160 @@
+---
+name: dev
+description: Developer tools (commits, reviews, refactoring)
+---
+# dev
+
+Developer tools for daily coding workflows.
+
+## Routes
+
+| Subcommand | Action |
+| ---------- | ------ |
+| `review` | Code review workflow |
+| `debug` | Debugging session |
+| `refactor` | Refactoring session |
+| `commit` | Stage and commit changes |
+| `pr` | Create a pull request |
+| `quality` | Code quality check |
+| `perf-audit` | Performance audit |
+
+## Usage
+
+```bash
+/dev                    # Ask what to do
+/dev review             # Code review
+/dev commit             # Stage and commit
+/dev debug              # Debug session
+/dev refactor           # Refactoring
+/dev pr                 # Create PR
+```
+
+## Fast-Path Detection
+
+When explicit args satisfy scoping, skip questions:
+
+- `/dev commit --auto` → stage all + commit
+- `/dev review ./src/auth` → review that path
+- `/dev commit` → ask what to stage
+- `/dev` → ask what to do
+
+**Rule:** If input contains BOTH an action AND a
+target (or `--auto` flag), proceed to execution.
+If either is missing, use `AskUserQuestion`.
+
+## Behavior
+
+### Plan Detection (all routes)
+
+Before starting scoping questions for any route,
+check for saved plans from `/plan`:
+
+1. Use `Glob` to check `.claude/plans/{route}-*.md`
+   for the current route (e.g., `refactor-*.md`
+   for `/dev refactor`)
+2. If matching plans exist, use `Read` to check
+   their **Status** field (skip `completed` plans)
+3. If no pending plans match, proceed normally
+   with the scoping flow below
+4. If multiple pending plans match, show a list
+   and let the user choose which one
+5. If a pending/in-progress plan is found, use
+   `AskUserQuestion` with these options:
+
+- **"Yes, use this plan"**: Read the plan file.
+  Update its **Status** to `in-progress`. Use
+  the plan's **Scope** and **Approach** sections
+  to drive execution. Do NOT re-ask scoping
+  questions.
+- **"No, start fresh"**: Proceed with the normal
+  `AskUserQuestion` scoping flow below.
+
+Example prompt:
+
+```yaml
+question: "I found a saved plan:
+  {plan-title} ({date}). Pick up where you
+  left off?"
+header: "Plan"
+options:
+  - label: "Yes, use this plan"
+    description: "Skip scoping — execute based
+      on the saved plan"
+  - label: "No, start fresh"
+    description: "Ignore the plan and scope
+      from scratch"
+```
+
+### review
+
+Use `AskUserQuestion` to scope:
+
+- Which files or path to review?
+- Focus area: quality, security, performance, or all?
+
+Then run:
+
+```bash
+uv run attune workflow run code-review --path <target>
+```
+
+### debug
+
+Use `AskUserQuestion` to understand:
+
+- What error or unexpected behavior?
+- Which file or area?
+
+Then investigate using Read, Grep, and Bash tools.
+
+### refactor
+
+Use `AskUserQuestion` to scope:
+
+- Which file or module?
+- What kind of refactoring? (extract, simplify, rename)
+
+Then use EnterPlanMode to plan the refactoring.
+
+### commit
+
+Use `AskUserQuestion` to confirm:
+
+- Which files to stage?
+- What kind of change? (feature, fix, refactor)
+
+Then use git to stage and commit with a conventional
+commit message.
+
+### pr
+
+Use `AskUserQuestion` to confirm:
+
+- Target branch?
+- PR description scope?
+
+Then use `gh pr create` to create the PR.
+
+### perf-audit
+
+Use `AskUserQuestion` to scope:
+
+- Which path to audit?
+
+Then run:
+
+```bash
+uv run attune workflow run perf-audit --path <target>
+```
+
+### quality
+
+Use `AskUserQuestion` to scope:
+
+- Which path to analyze?
+
+Then run:
+
+```bash
+uv run attune workflow run bug-predict --path <target>
+```

--- a/.agents/skills/docs/SKILL.md
+++ b/.agents/skills/docs/SKILL.md
@@ -1,0 +1,244 @@
+---
+name: docs
+description: Documentation generation and explanation
+---
+# docs
+
+Documentation generation, explanation, and accuracy auditing.
+
+## Routes
+
+| Subcommand | Action |
+| ---------- | ------ |
+| `audit` | Quick inline accuracy checks (10 checks) |
+| `audit-deep` | Full DocAuditWorkflow with auto-fix |
+| `explain` | Explain how code works |
+| `generate` | Generate documentation |
+| `readme` | Update README |
+| `changelog` | Generate changelog |
+| `overview` | High-level project overview |
+
+## Usage
+
+```bash
+/docs                   # Ask what to do
+/docs audit             # Verify doc accuracy
+/docs explain           # Explain code
+/docs generate          # Generate documentation
+/docs readme            # Update README
+/docs changelog         # Generate changelog
+```
+
+## Behavior
+
+### audit
+
+Cross-reference documentation claims against the actual
+codebase. Run all checks below and report a summary table
+with pass/fail per check and file:line references for any
+mismatches.
+
+#### 1. Test count
+
+Run:
+
+```bash
+pytest --collect-only -q 2>/dev/null | tail -1
+```
+
+Compare the collected/passing count against:
+
+- The static badge in README.md (the number in the
+  `img.shields.io/badge/tests-` URL)
+- Any "X+ tests" claims in README body text
+- Any test counts in CHANGELOG.md (current release only)
+
+Flag if the README count exceeds the actual count by
+more than 5%.
+
+#### 2. Workflow count
+
+Count entries under `[project.entry-points."attune.workflows"]`
+in `pyproject.toml`. Compare against any "N built-in" claims
+in README.md. Flag mismatches.
+
+#### 3. Skill count
+
+Count directories in `plugin/skills/` (each directory with
+a `SKILL.md` is one skill). Compare against:
+
+- README.md (any "N skills" claims)
+- CHANGELOG.md (current release section)
+- `.claude-plugin/marketplace.json`
+- `plugin/.claude-plugin/marketplace.json`
+
+Flag mismatches.
+
+#### 4. MCP tool count
+
+Count `@server.tool()` decorators or tool registrations in
+`src/attune/mcp/server.py`. Compare against any "N tools" or
+"N MCP tools" claims in README.md and plugin/README.md.
+Flag mismatches.
+
+#### 5. File line limits
+
+If README.md claims a maximum file size (e.g., "no file
+exceeds X lines"), verify by running:
+
+```bash
+find src/attune -name "*.py" -exec wc -l {} + \
+  | sort -rn | head -5
+```
+
+Flag any files that exceed the claimed limit.
+
+#### 6. Install extras
+
+Grep README.md and plugin/README.md for `attune-ai[` to
+find all referenced extras. Verify each extra name exists
+in `pyproject.toml` under `[project.optional-dependencies]`.
+Flag any extras that are referenced in docs but do not exist
+in pyproject.toml (e.g., `[redis]` when the actual extra is
+`[memory]`).
+
+#### 7. Stale command references
+
+Grep all `*.md` files for these removed/legacy patterns:
+
+- `empathy-memory` (removed in v2.6.2)
+- `empathy workflow` (renamed to `attune workflow`)
+- `empathy` as a CLI prefix (e.g., `empathy workflow`)
+
+Report file:line for each occurrence. Exclude CHANGELOG
+entries that document historical changes (those are
+intentionally referencing old names).
+
+#### 8. Version consistency
+
+Compare the version string across:
+
+- `pyproject.toml` (`version = "X.Y.Z"`)
+- `src/attune/__init__.py` (`__version__`)
+- `CHANGELOG.md` (latest `## [X.Y.Z]` heading)
+- `plugin/.claude-plugin/plugin.json`
+- `.claude-plugin/marketplace.json`
+- `plugin/.claude-plugin/marketplace.json`
+
+Flag any that do not match.
+
+#### 9. Cross-doc number consistency
+
+Check that the same metric uses the same number everywhere:
+
+- Cost savings percentages (README vs FAQ vs pitch docs)
+- Test counts (README badge vs README body vs CHANGELOG)
+- Skill counts (README vs CHANGELOG vs marketplace.json)
+- Tool counts (README vs plugin README)
+
+Flag any contradictions.
+
+#### 10. Documentation links
+
+For each markdown link in README.md that points to a local
+file (not a URL), verify the target file exists. Report
+broken links.
+
+#### Output format
+
+Present results as:
+
+```markdown
+## Doc Audit Results
+
+| # | Check | Status | Details |
+|---|-------|--------|---------|
+| 1 | Test count | PASS/FAIL | ... |
+| 2 | Workflow count | PASS/FAIL | ... |
+...
+
+### Issues Found
+
+- [README.md:76](README.md#L76): claims "14,000+ tests"
+  but actual count is 11,016
+...
+```
+
+### audit-deep
+
+Trigger the DocAuditWorkflow for a full documentation
+audit with automatic fixes. This is the autonomous
+pipeline with 4 stages:
+
+1. **Audit** — Run all 10 doc checks programmatically
+2. **Plan** — For each failing check, generate a fix plan
+3. **Execute** — Apply auto-fixable changes (counts,
+   versions, stale refs)
+4. **Verify** — Re-run checks, confirm score improved,
+   build MkDocs to verify
+
+Show audit results and fix plan for approval before
+the execute phase.
+
+```bash
+# Interactive mode (default)
+uv run attune workflow run doc-audit
+
+# With --batch flag for fire-and-forget
+uv run attune workflow run doc-audit --batch
+```
+
+Use `AskUserQuestion` before running:
+
+- Auto-fix safe changes? (default: yes)
+- Build MkDocs to verify? (default: yes)
+- Approve plan before executing?
+
+### explain
+
+Use `AskUserQuestion` to scope:
+
+- Which file, function, or module to explain?
+- What level of detail? (overview, deep dive, or
+  architecture)
+
+Then read the code and provide a clear explanation
+with context.
+
+### generate
+
+Use `AskUserQuestion` to scope:
+
+- What to document? (API, module, function)
+- Format? (docstrings, markdown, or both)
+
+Then generate documentation using the codebase.
+
+### readme
+
+Read the current README and project structure, then
+suggest or apply updates based on current state.
+
+### changelog
+
+Use git log to generate a changelog:
+
+```bash
+git log --oneline --since="last tag"
+```
+
+Format as a markdown changelog grouped by type
+(features, fixes, refactoring).
+
+### overview
+
+Use `AskUserQuestion` to scope:
+
+- Which scope? (full project, specific module,
+  or subsystem)
+- What audience? (new contributor, external user,
+  or architecture review)
+
+Then read the project structure and generate a
+high-level overview covering purpose, key modules,
+and how they connect.

--- a/.agents/skills/help/SKILL.md
+++ b/.agents/skills/help/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: help
+description: Help and navigation
+---
+# help
+
+Help navigating Attune AI workflows.
+
+## Behavior
+
+When invoked, show the user the available command
+hubs and how to access them:
+
+| Hub | What It Does | Try |
+| --- | ------------ | --- |
+| `/attune` | Socratic discovery — guides you to the right workflow | `/attune` |
+| `/dev` | Debug, review, commit, PR, refactor | `/dev` |
+| `/testing` | Run tests, coverage, generate tests | `/testing` |
+| `/plan` | Plan features, refactoring, architecture | `/plan` |
+| `/workflows` | Security audit, bug predict, perf audit | `/workflows` |
+| `/docs` | Generate docs, README, changelog | `/docs` |
+| `/release` | Release prep, security scan, publish | `/release` |
+| `/brainstorm` | Guided brainstorming sessions | `/brainstorm` |
+| `/agent` | Create and manage custom agents | `/agent` |
+| `/bulk` | Batch API processing (50% cost savings) | `/bulk` |
+| `/wizard` | Guided multi-step wizards | `/wizard` |
+| `/utilities` | Auth and provider management | `/utilities` |
+
+**Tip:** Not sure where to start? Try `/attune` —
+it will ask what you're trying to do and route you
+to the right place.
+
+For CLI usage, run:
+
+```bash
+uv run attune --help
+```

--- a/.agents/skills/pipeline/SKILL.md
+++ b/.agents/skills/pipeline/SKILL.md
@@ -1,0 +1,11 @@
+---
+name: pipeline
+description: "[Retired] Use /spec instead — spec-driven development with approval loop"
+---
+# pipeline (Retired)
+
+The `/pipeline` skill has been replaced by `/spec`.
+
+Type `/spec` to start spec-driven development —
+brainstorm, plan, review, and execute with quality
+gates and approval at every step.

--- a/.agents/skills/plan/SKILL.md
+++ b/.agents/skills/plan/SKILL.md
@@ -1,0 +1,170 @@
+---
+name: plan
+description: Development planning and architecture
+---
+# plan
+
+Development planning and architecture design.
+
+## Routes
+
+| Subcommand | Action |
+| ---------- | ------ |
+| `feature` | Plan a new feature |
+| `refactor` | Plan refactoring |
+| `architecture` | Architecture review |
+
+## Usage
+
+```bash
+/plan                   # Ask what to plan
+/plan feature           # Plan a feature
+/plan refactor          # Plan refactoring
+/plan architecture      # Architecture review
+```
+
+## Behavior
+
+All planning tasks use `EnterPlanMode` to create
+a structured plan for user approval before any
+implementation.
+
+**After every plan is approved**, follow the
+[Post-Plan Handoff](#post-plan-handoff) process.
+
+### feature
+
+Use `AskUserQuestion` to understand:
+
+- What feature? What problem does it solve?
+- What's the scope? Which files/modules?
+- Any constraints or preferences?
+
+Then use `EnterPlanMode` to design the implementation
+plan. After approval, follow Post-Plan Handoff.
+
+### refactor
+
+Use `AskUserQuestion` to understand:
+
+- What code needs refactoring?
+- What's the goal? (simplify, split, extract)
+- Any constraints?
+
+Then use `EnterPlanMode` to plan the refactoring.
+After approval, follow Post-Plan Handoff.
+
+### architecture
+
+Use `AskUserQuestion` to understand:
+
+- What system or subsystem to review?
+- Any specific concerns?
+
+Then analyze the codebase structure and provide
+architectural recommendations. If the review
+produces actionable changes, follow Post-Plan
+Handoff.
+
+## Post-Plan Handoff
+
+**This section applies to ALL routes after a plan
+is approved.**
+
+### Step 1: Save the plan
+
+Save the approved plan to `.claude/plans/` using
+the [Plan File Format](#plan-file-format) below.
+
+File naming convention:
+`{route}-{slug}-{YYYY-MM-DD}.md`
+
+Examples:
+
+- `refactor-auth-module-2026-02-22.md`
+- `feature-dark-mode-2026-02-22.md`
+
+Ensure `.claude/plans/` directory exists before
+writing.
+
+### Step 2: Offer execution
+
+Use `AskUserQuestion` to ask:
+
+```yaml
+question: "Plan saved to .claude/plans/{filename}.
+  Ready to execute?"
+header: "Next"
+options:
+  - label: "Execute now"
+    description: "Start implementing — I'll carry
+      the plan context forward so you won't need
+      to re-explain anything"
+  - label: "Save for later"
+    description: "Plan is saved — pick it up later
+      with /dev {route}"
+```
+
+### Step 3: Transition
+
+- **Execute now**: Transition into the corresponding
+  route with full plan context. Do NOT re-ask
+  scoping questions — the plan already contains
+  all needed context. Use this mapping:
+
+| Plan Route | Execute Via |
+| ---------- | ----------- |
+| `/plan feature` | `/dev` (implement directly) |
+| `/plan refactor` | `/dev refactor` |
+| `/plan architecture` | (analysis only — no auto-execute) |
+
+- **Save for later**: Confirm the file path and
+  end gracefully. Tell the user they can resume
+  with `/dev {route}` in a future session.
+
+## Plan File Format
+
+All saved plans MUST use this format:
+
+```markdown
+# {Title}
+
+**Created:** {YYYY-MM-DD}
+**Source:** /plan {route}
+**Route:** {route}
+**Status:** pending
+
+## Problem
+
+{1-2 sentence problem statement}
+
+## Goals
+
+- {Must-have 1}
+- {Must-have 2}
+- {Nice-to-have (marked as such)}
+
+## End State
+
+{Concrete description of what "done" looks like}
+
+## Scope
+
+- **Files:** {list of target files/directories}
+- **Type:** {refactor | feature | architecture}
+
+## Approach
+
+1. {Step 1 with specific file references}
+2. {Step 2}
+3. {Step 3}
+
+## Open Questions
+
+- {Anything unresolved}
+```
+
+The **Route** and **Status** fields are required
+for `/dev` plan detection. Update **Status** to
+`in-progress` when execution begins and `completed`
+when done.

--- a/.agents/skills/quick-test/SKILL.md
+++ b/.agents/skills/quick-test/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: quick-test
+description: Run tests on recently changed files
+---
+# quick-test
+
+Fast feedback loop — run tests related to recently
+changed files only.
+
+## Context (pre-computed)
+
+```bash
+git diff --name-only HEAD 2>/dev/null
+git diff --name-only --cached 2>/dev/null
+```
+
+## Instructions
+
+1. Look at the changed files from the context above
+2. For each changed `.py` file in `src/`, find the
+   corresponding test file:
+   - `src/attune/foo/bar.py` → `tests/unit/foo/test_bar.py`
+   - `src/attune/foo.py` → `tests/unit/test_foo.py`
+3. Run only those test files:
+
+```bash
+uv run pytest <test_files> -x -q --tb=short
+```
+
+4. If no matching test files exist, say so and offer
+   to generate them with `/testing gen`
+5. Report pass/fail summary

--- a/.agents/skills/release/SKILL.md
+++ b/.agents/skills/release/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: release
+description: Release preparation and publishing
+---
+# release
+
+Release preparation, validation, and publishing.
+
+## Routes
+
+| Subcommand | Action |
+| ---------- | ------ |
+| `prep` | Release readiness checks |
+| `security` | Pre-release security audit |
+| `health` | Code health check |
+| `publish` | Version bump and publish |
+
+## Usage
+
+```bash
+/release                # Ask what to do
+/release prep           # Release prep checks
+/release security       # Security audit
+/release health         # Health check
+/release publish        # Publish release
+```
+
+## Behavior
+
+### prep
+
+Run release preparation workflow:
+
+```bash
+uv run attune workflow run release-prep
+```
+
+This checks:
+
+- Test suite passes
+- No critical security issues
+- Documentation is current
+- Changelog is updated
+
+### security
+
+Run security audit focused on release readiness:
+
+```bash
+uv run attune workflow run security-audit --path src/
+```
+
+### health
+
+Run code health checks:
+
+- Test coverage
+- Lint status
+- Type check status
+- Dependency audit
+
+### publish
+
+Use `AskUserQuestion` to confirm:
+
+- Version bump type? (patch, minor, major)
+- Changelog reviewed?
+- All checks passing?
+
+Then guide through:
+
+1. Version bump in pyproject.toml
+2. Update CHANGELOG.md
+3. Create git tag
+4. Push and publish

--- a/.agents/skills/simplify/SKILL.md
+++ b/.agents/skills/simplify/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: simplify
+description: Run code simplification on a target path
+---
+# simplify
+
+Run the SimplifyCodeWorkflow on a target path to find and
+reduce unnecessary complexity.
+
+## Context (pre-computed)
+
+```bash
+git diff --name-only HEAD~1 2>/dev/null || echo "No recent commits"
+```
+
+## Instructions
+
+Use `AskUserQuestion` to scope:
+
+- Which path to simplify? (recently changed files,
+  specific module, or full src/)
+- Minimum complexity threshold? (default: 5)
+
+Then run:
+
+```bash
+uv run attune workflow run simplify-code --path <target>
+```
+
+Present results as a table of hotspots with file, function,
+complexity score, and suggested simplification.

--- a/.agents/skills/testing/SKILL.md
+++ b/.agents/skills/testing/SKILL.md
@@ -1,0 +1,176 @@
+---
+name: testing
+description: Test runner, generation, and coverage analysis
+---
+# testing
+
+Test runner, generation, and coverage analysis.
+
+**Default mode:** Module-level testing for daily development.
+Full suite reserved for release verification and deep audits.
+
+## Routes
+
+| Subcommand | Action |
+| ---------- | ------ |
+| `run` | Run tests (changed modules by default) |
+| `quick` | Run tests for recently changed files |
+| `coverage` | Coverage analysis (module or full) |
+| `gen` | Generate tests |
+| `generate` | Generate tests |
+| `audit` | Deep coverage audit (TestAuditWorkflow) |
+| `benchmark` | Run benchmarks |
+| `generate --batch` | Batch test generation |
+
+## Usage
+
+```bash
+/testing                # Ask what to do
+/testing run            # Run tests for changed modules
+/testing run --all      # Run full test suite
+/testing quick          # Run tests for changed files
+/testing coverage       # Module-level coverage
+/testing coverage --full # Full codebase coverage
+/testing audit          # Deep coverage audit workflow
+/testing gen            # Generate tests
+```
+
+## Fast-Path Detection
+
+When explicit args satisfy scoping, skip questions:
+
+- `/testing run --all` → full suite immediately
+- `/testing gen src/auth` → generate for that module
+- `/testing coverage --full` → full codebase coverage
+- `/testing run` → ask which tests
+- `/testing` → ask what to do
+
+**Rule:** If input contains BOTH an action AND a
+target (or `--all`/`--full` flag), proceed to
+execution. If either is missing, use
+`AskUserQuestion`.
+
+## Behavior
+
+### run
+
+Default behavior: detect changed files via `git diff` and
+run only their corresponding test files (module-level).
+
+Use `AskUserQuestion` to scope if no flags provided:
+
+- Changed modules only (default), specific directory, or
+  full suite?
+- Quick smoke test or thorough run?
+
+```bash
+# Default: changed modules only
+git diff --name-only HEAD | grep '\.py$'
+# Map source files to test files, then:
+uv run pytest <test_files> -q
+
+# With --all flag: full suite
+uv run pytest tests/unit/ -q
+
+# With --coverage flag: add coverage for changed modules
+uv run pytest <test_files> --cov=attune.<module> -q
+```
+
+### quick
+
+Detect changed files from `git diff` (staged + unstaged)
+and run their corresponding tests. No scoping questions.
+
+```bash
+git diff --name-only HEAD
+# Map each src/attune/foo/bar.py -> tests/unit/foo/test_bar.py
+uv run pytest <mapped_test_files> -x -q
+```
+
+### coverage
+
+Default: module-level coverage for changed files.
+
+Use `AskUserQuestion` to scope:
+
+- Which module? Or changed files only (default)?
+
+```bash
+# Default: changed modules
+uv run pytest <test_files> --cov=attune.<module> --cov-report=term-missing
+
+# With --full flag: full codebase coverage
+# Warning: This takes 5-10 minutes on large codebases
+uv run pytest tests/unit/ --cov=src/attune --cov-report=term-missing
+```
+
+### audit
+
+Trigger the TestAuditWorkflow for a deep coverage audit.
+This is the autonomous pipeline with 4 stages:
+
+1. **Audit** — Run pytest with coverage JSON, parse results,
+   produce prioritized module list
+2. **Plan** — Group modules into batches, generate XML task
+   prompts per batch
+3. **Execute** — Generate tests per batch (parallel)
+4. **Verify** — Run full suite, compare coverage before/after
+
+Show the plan for approval before the execute phase.
+
+```bash
+# Interactive mode (default)
+uv run attune workflow run test-audit
+
+# With --batch flag for fire-and-forget
+uv run attune workflow run test-audit --batch
+
+# Quick audit (audit + targeted run only, no generation)
+uv run attune workflow run test-audit --mode quick
+```
+
+Use `AskUserQuestion` before running:
+
+- Target coverage? (default: 90%)
+- Quick audit or full deep pipeline?
+- Approve plan before executing?
+
+### gen
+
+Use `AskUserQuestion` to scope:
+
+- Which file or function needs tests?
+- Unit tests, integration tests, or edge cases?
+
+Then run:
+
+```bash
+uv run attune workflow run test-gen --path <target>
+```
+
+### benchmark
+
+Use `AskUserQuestion` to scope:
+
+- Full benchmark suite, specific module, or function?
+- Compare against a baseline?
+
+Then run:
+
+```bash
+uv run pytest benchmarks/ --benchmark-only
+```
+
+### generate --batch
+
+Use `AskUserQuestion` to scope:
+
+- Which directory or module?
+- Test type? (unit, integration, or both)
+- Any exclusions?
+
+Then run:
+
+```bash
+uv run attune workflow run test-gen --path <target> --batch
+```

--- a/.agents/skills/utilities/SKILL.md
+++ b/.agents/skills/utilities/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: utilities
+description: Authentication and provider management
+---
+# utilities
+
+Authentication, subscription, and provider management utilities.
+
+## Routes
+
+| Subcommand | Action |
+| ---------- | ------ |
+| `subscription` | Show subscription/auth strategy status |
+| `show` | Show current provider configuration |
+| `set` | Set the active LLM provider |
+| `setup` | Configure auth strategy interactively |
+
+## Usage
+
+```bash
+/utilities                   # Ask what to do
+/utilities subscription      # Show subscription status
+/utilities show              # Show current provider
+/utilities set               # Set provider
+/utilities setup             # Configure auth strategy
+```
+
+Or use natural language: "subscription status", "auth", "provider",
+"show provider", "set provider", "what is my subscription".
+
+## Behavior
+
+### subscription
+
+Run the auth status command to show subscription tier and strategy:
+
+```bash
+uv run attune auth status
+```
+
+Display the subscription tier (FREE/PRO/MAX/ENTERPRISE), default auth
+mode, and module size thresholds.
+
+### show
+
+Run the provider show command:
+
+```bash
+uv run attune provider show
+```
+
+Display the current provider mode, primary provider,
+and available providers.
+
+### set
+
+Use `AskUserQuestion` to confirm:
+
+- Which provider? (anthropic, openai, hybrid)
+
+Then run:
+
+```bash
+uv run attune provider set <provider>
+```
+
+### setup
+
+Run the interactive auth strategy setup:
+
+```bash
+uv run attune auth setup
+```

--- a/.agents/skills/wizard/SKILL.md
+++ b/.agents/skills/wizard/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: wizard
+description: Guided multi-step wizards with XML task decomposition
+---
+# wizard
+
+Guided multi-step wizards with XML task decomposition
+for complex workflows.
+
+## Routes
+
+| Subcommand | Action |
+| ---------- | ------ |
+| `run debug` | Debug wizard |
+| `run test-gen` | Test generation wizard |
+| `run refactor` | Refactoring wizard |
+| `run security` | Security wizard |
+| `run release-prep` | Release prep wizard |
+| `create` | Create a custom wizard |
+| `list` | List available wizards |
+| `edit` | Edit a wizard |
+
+## Usage
+
+```bash
+/wizard                      # Ask what to do
+/wizard run debug            # Debug wizard
+/wizard run test-gen         # Test gen wizard
+/wizard run refactor         # Refactoring wizard
+/wizard run security         # Security wizard
+/wizard run release-prep     # Release prep wizard
+/wizard create               # Create custom wizard
+/wizard list                 # List wizards
+```
+
+## Behavior
+
+### run
+
+Handles all built-in wizards (`debug`, `test-gen`,
+`refactor`, `security`, `release-prep`). When invoked
+with a specific wizard (e.g., `/wizard run debug`),
+skip the wizard selection question.
+
+Use `AskUserQuestion` to scope:
+
+- Which wizard to run? (if not specified)
+- What target files or path?
+
+Then execute the wizard step-by-step, using
+`AskUserQuestion` at each decision point.
+
+### create
+
+Guide the user through wizard creation:
+
+1. Name and description
+2. Steps definition
+3. XML task templates
+4. Validation criteria
+
+### list
+
+Show available wizards with descriptions.
+
+### edit
+
+Use `AskUserQuestion`:
+
+- Which wizard to edit?
+- What to change?
+
+Then modify the wizard definition.
+
+## Built-in Wizards
+
+| Wizard | Description |
+| ------ | ----------- |
+| `debug` | Guided debugging session |
+| `test-gen` | Test generation with coverage goals |
+| `refactor` | Structured refactoring workflow |
+| `security` | Security audit and remediation |
+| `release-prep` | Release readiness checklist |

--- a/.agents/skills/workflows/SKILL.md
+++ b/.agents/skills/workflows/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: workflows
+description: AI-powered analysis workflows
+---
+# workflows
+
+AI-powered analysis workflows for security, bugs,
+and performance.
+
+## Routes
+
+| Subcommand | Action |
+| ---------- | ------ |
+| `run security-audit` | Security vulnerability scan |
+| `run bug-predict` | Bug prediction analysis |
+| `run perf-audit` | Performance audit |
+| `run code-review` | Code review workflow |
+
+| `list` | List available workflows |
+
+## Usage
+
+```bash
+/workflows                       # Ask which workflow
+/workflows run security-audit    # Security audit
+/workflows run bug-predict       # Bug prediction
+/workflows run perf-audit        # Performance audit
+/workflows list                  # List all workflows
+```
+
+## Fast-Path Detection
+
+When the user provides a workflow name AND a path,
+skip `AskUserQuestion` and execute directly:
+
+- `/workflows run security-audit ./src` → execute
+- `/workflows run bug-predict src/auth` → execute
+- `/workflows run security-audit` → ask for path
+- `/workflows` → ask which workflow
+
+**Rule:** If both workflow and target are provided,
+proceed to execution. If either is missing, use
+`AskUserQuestion`.
+
+## Behavior
+
+### run security-audit
+
+If a path argument was provided (e.g.,
+`/workflows run security-audit ./src`), skip
+`AskUserQuestion` and execute immediately.
+
+Otherwise, use `AskUserQuestion` to scope:
+
+- Which path? `src/`, specific module, or full project?
+
+Then run:
+
+```bash
+uv run attune workflow run security-audit --path <target>
+```
+
+### run bug-predict
+
+Use `AskUserQuestion` to scope:
+
+- Which path to scan?
+
+Then run:
+
+```bash
+uv run attune workflow run bug-predict --path <target>
+```
+
+### run perf-audit
+
+Use `AskUserQuestion` to scope:
+
+- Which path to audit?
+
+Then run:
+
+```bash
+uv run attune workflow run perf-audit --path <target>
+```
+
+### run code-review
+
+Use `AskUserQuestion` to scope:
+
+- Which path or files to review?
+- Focus area: quality, security, performance,
+  or all?
+
+Then run:
+
+```bash
+uv run attune workflow run code-review --path <target>
+```
+
+### list
+
+Run:
+
+```bash
+uv run attune workflow list
+```
+
+Display results in a table format.

--- a/scripts/sync_agents_skills.py
+++ b/scripts/sync_agents_skills.py
@@ -1,9 +1,17 @@
 #!/usr/bin/env python3
-"""Sync Claude Code plugin skills to agentskills.io-compliant format.
+"""Sync Claude Code skills to agentskills.io-compliant format.
 
-Reads SKILL.md files from plugin/skills/*/SKILL.md, strips Claude
-Code-specific frontmatter fields, validates naming rules, and writes
-to .agents/skills/<name>/SKILL.md.
+Reads SKILL.md files from plugin/skills/*/SKILL.md AND
+.claude/skills/*/SKILL.md, strips Claude Code-specific frontmatter
+fields, validates naming rules, and writes to
+.agents/skills/<name>/SKILL.md. On a name collision between the two
+sources, plugin/skills/ wins and the .claude/skills/ copy is skipped
+(reported as [SKIP]).
+
+The tracked .agents/skills/ tree is the one skill mirror other
+agents (e.g. Codex) read — keeping it complete stops Codex's init
+from regenerating its own mangled untracked copies of
+.claude/skills/ (see the 2026-07-18 lesson).
 
 Usage:
     python scripts/sync_agents_skills.py          # Generate files
@@ -257,18 +265,38 @@ def main(argv: list[str] | None = None) -> int:
     plugin_dir = repo_root / "plugin"
     output_root = repo_root / ".agents" / "skills"
 
-    skill_paths = discover_skills(plugin_dir)
-    if not skill_paths:
+    plugin_paths = discover_skills(plugin_dir)
+    if not plugin_paths:
         print("No SKILL.md files found in plugin/skills/")
         return 1
 
+    # Second source: repo-level user skills. Plugin skills shadow
+    # same-named .claude skills (the plugin copy is the product
+    # surface; the .claude copy is the repo-local variant).
+    claude_paths = discover_skills(repo_root / ".claude")
+    plugin_names = {p.parent.name for p in plugin_paths}
+
     mode = "Checking" if check else "Generating"
-    print(f"{mode} agentskills.io skills from {len(skill_paths)} sources\n")
+    total = len(plugin_paths) + len(claude_paths)
+    print(f"{mode} agentskills.io skills from {total} sources\n")
 
     successes = 0
     failures = 0
 
-    for skill_path in skill_paths:
+    for skill_path in plugin_paths:
+        ok, msg = sync_one(skill_path, output_root, check=check)
+        status = "  OK" if ok else "FAIL"
+        print(f"  [{status}] {msg}")
+        if ok:
+            successes += 1
+        else:
+            failures += 1
+
+    for skill_path in claude_paths:
+        name = skill_path.parent.name
+        if name in plugin_names:
+            print(f"  [SKIP] {name}: shadowed by plugin/skills/")
+            continue
         ok, msg = sync_one(skill_path, output_root, check=check)
         status = "  OK" if ok else "FAIL"
         print(f"  [{status}] {msg}")

--- a/tests/unit/plugins/test_sync_agents_skills.py
+++ b/tests/unit/plugins/test_sync_agents_skills.py
@@ -352,12 +352,31 @@ class TestDiscoverSkills:
 
 REPO_ROOT = Path(__file__).parents[3]
 PLUGIN_SKILLS = REPO_ROOT / "plugin" / "skills"
+CLAUDE_SKILLS = REPO_ROOT / ".claude" / "skills"
 AGENTS_SKILLS = REPO_ROOT / ".agents" / "skills"
+
+
+def _expected_sources() -> dict[str, Path]:
+    """Map mirror name -> source SKILL.md, applying shadowing.
+
+    plugin/skills/ wins a name collision; non-shadowed
+    .claude/skills/ entries fill in the rest. Mirrors the sync
+    script's source resolution.
+    """
+    sources: dict[str, Path] = {}
+    for root in (PLUGIN_SKILLS, CLAUDE_SKILLS):
+        for skill_dir in sorted(root.iterdir()):
+            skill_file = skill_dir / "SKILL.md"
+            if not skill_dir.is_dir() or not skill_file.exists():
+                continue
+            if skill_dir.name not in sources:
+                sources[skill_dir.name] = skill_file
+    return sources
 
 
 @pytest.mark.unit
 class TestAgentSkillsIntegration:
-    """Validate .agents/skills/ matches plugin/skills/."""
+    """Validate .agents/skills/ matches its two source roots."""
 
     def test_agents_skills_directory_exists(self) -> None:
         """Test that .agents/skills/ directory exists."""
@@ -366,37 +385,32 @@ class TestAgentSkillsIntegration:
         )
 
     def test_all_plugin_skills_synced(self) -> None:
-        """Test all plugin skills have .agents/ copies."""
-        plugin = {
-            d.name for d in PLUGIN_SKILLS.iterdir() if d.is_dir() and (d / "SKILL.md").exists()
-        }
+        """Test the mirror set equals plugin ∪ non-shadowed .claude."""
+        expected = set(_expected_sources())
         agents = {
             d.name for d in AGENTS_SKILLS.iterdir() if d.is_dir() and (d / "SKILL.md").exists()
         }
-        assert plugin == agents, f"Missing: {plugin - agents}. " f"Extra: {agents - plugin}"
+        assert expected == agents, f"Missing: {expected - agents}. " f"Extra: {agents - expected}"
 
     def test_skill_body_content_matches(self) -> None:
-        """Test .agents/ SKILL.md body matches plugin/ copies.
+        """Test .agents/ SKILL.md body matches its source copy.
 
         Frontmatter differs (Claude Code fields stripped), but
         the body content after the closing --- should match.
         """
-        for skill_dir in PLUGIN_SKILLS.iterdir():
-            if not skill_dir.is_dir():
-                continue
-            plugin_file = skill_dir / "SKILL.md"
-            agents_file = AGENTS_SKILLS / skill_dir.name / "SKILL.md"
-            if not plugin_file.exists() or not agents_file.exists():
+        for name, source_file in _expected_sources().items():
+            agents_file = AGENTS_SKILLS / name / "SKILL.md"
+            if not agents_file.exists():
                 continue
 
             def _body(path: Path) -> str:
                 parts = path.read_text(encoding="utf-8").split("---", 2)
                 return parts[2].strip() if len(parts) >= 3 else ""
 
-            plugin_body = _body(plugin_file)
+            source_body = _body(source_file)
             agents_body = _body(agents_file)
-            assert plugin_body == agents_body, (
-                f"{skill_dir.name}/SKILL.md body differs. "
+            assert source_body == agents_body, (
+                f"{name}/SKILL.md body differs from {source_file}. "
                 f"Run: python scripts/sync_agents_skills.py"
             )
 
@@ -406,16 +420,11 @@ class TestAgentSkillsIntegration:
         ``sync_one`` in check mode compares the full generated
         file (frontmatter *and* body) byte-for-byte. This guards
         against frontmatter drift -- e.g. a ``description`` edited
-        in plugin/skills/ but never re-synced -- which the
+        in a source SKILL.md but never re-synced -- which the
         body-only and dir-set checks above do not catch.
         """
-        for skill_dir in PLUGIN_SKILLS.iterdir():
-            if not skill_dir.is_dir():
-                continue
-            plugin_file = skill_dir / "SKILL.md"
-            if not plugin_file.exists():
-                continue
-            ok, msg = sync_one(plugin_file, AGENTS_SKILLS, check=True)
+        for _name, source_file in _expected_sources().items():
+            ok, msg = sync_one(source_file, AGENTS_SKILLS, check=True)
             assert ok, f"{msg}. Run: python scripts/sync_agents_skills.py"
 
     def test_no_claude_code_fields_in_agents(self) -> None:


### PR DESCRIPTION
## Summary

Points Codex's skill mirror at the tracked `.agents/skills/` tree, per Patrick's ask. Background: Codex's init was mirroring `.claude/skills/` into `.agents/skills/` itself as untracked strays with a naive `.claude`→`.Codex` string replace (fictional paths). With the repo's own projector owning the complete mirror, Codex finds correct tracked content already present.

- `sync_agents_skills.py` now reads BOTH `plugin/skills/` (24) and `.claude/skills/` (22); plugin wins name collisions — `bulk`, `catalog`, `coach`, `fix-test`, `smart-test` are shadowed and reported `[SKIP]`.
- 17 non-shadowed repo-level user skills land as tracked mirrors (41 total).
- Drift-guard tests updated to the union-with-shadowing rule via a shared `_expected_sources()` resolver; 33/33 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
