### PR TITLE
feat: project cross-provider collaboration contract

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -44,6 +44,30 @@ See `docs/reference/cli-reference.md`.
 - Keep provider-specific setup in adapters. The shared contract must
   still work when only one provider is available.
 
+### Artifact selection
+
+- Match the artifact to the work before non-trivial implementation and
+  name the selected tier in the session contract:
+  - **Inline edit** — trivial, one file, no ambiguity.
+  - **Structured one-shot** — single-session work framed by a goal,
+    constraints, and acceptance criteria.
+  - **XML task** — dependent work across three or more files, or work
+    that must be executable as a cold handoff.
+  - **Spec** — multi-session or multi-PR work, design ambiguity, or an
+    irreversible choice.
+- Escalate the artifact tier when ambiguity or dependencies grow; do
+  not add ceremony to work that still fits a smaller tier.
+
+### Verification receipts
+
+- Before implementation, name the claim and a probe that would fail if
+  the claim were false. Report the probe actually run and its result.
+- Treat unit tests as evidence only inside their tested boundaries.
+  Hooks, persistence, networking, packaging, and other external seams
+  require a non-mocked round trip through the real boundary.
+- “Configured,” “registered,” and “exited successfully” are not
+  working receipts. Prefer evidence of the user-visible behavior.
+
 ### Handoffs
 
 - For multi-step work, create or update a portable handoff from

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -22,6 +22,41 @@ See `docs/reference/cli-reference.md`.
 
 ---
 
+<!-- attune:collaboration:start -->
+
+## Cross-provider collaboration
+
+### Shared truth
+
+- Treat the current worktree, Git state, and relevant test results as
+  authoritative. Do not rely on hidden chat context for a handoff.
+- Preserve unrelated working-tree changes and do not touch another
+  agent's worktree.
+- Discover capabilities from the available tools, MCP server, and
+  tracked skills; do not rely on hard-coded capability counts.
+
+### Session protocol
+
+- State the goal, acceptance criteria, assumptions, and intended
+  verification before non-trivial implementation.
+- Prefer existing repository conventions and public interfaces before
+  adding a parallel mechanism.
+- Keep provider-specific setup in adapters. The shared contract must
+  still work when only one provider is available.
+
+### Handoffs
+
+- For multi-step work, create or update a portable handoff from
+  `templates/agent-handoff.md` in the branch or task's tracked work.
+- A receiving agent verifies the handoff against the current Git state
+  and tests before continuing; a handoff is context, not authority.
+- Record only concrete evidence: commands actually run, their results,
+  changed files, unresolved risks, and the next action.
+
+<!-- attune:collaboration:end -->
+
+---
+
 ## Command Hubs
 
 Use `/hub-name` to access organized workflows:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,30 @@ attune_redis/          # Redis plugin — bundled in the attune-ai wheel
 - Keep provider-specific setup in adapters. The shared contract must
   still work when only one provider is available.
 
+### Artifact selection
+
+- Match the artifact to the work before non-trivial implementation and
+  name the selected tier in the session contract:
+  - **Inline edit** — trivial, one file, no ambiguity.
+  - **Structured one-shot** — single-session work framed by a goal,
+    constraints, and acceptance criteria.
+  - **XML task** — dependent work across three or more files, or work
+    that must be executable as a cold handoff.
+  - **Spec** — multi-session or multi-PR work, design ambiguity, or an
+    irreversible choice.
+- Escalate the artifact tier when ambiguity or dependencies grow; do
+  not add ceremony to work that still fits a smaller tier.
+
+### Verification receipts
+
+- Before implementation, name the claim and a probe that would fail if
+  the claim were false. Report the probe actually run and its result.
+- Treat unit tests as evidence only inside their tested boundaries.
+  Hooks, persistence, networking, packaging, and other external seams
+  require a non-mocked round trip through the real boundary.
+- “Configured,” “registered,” and “exited successfully” are not
+  working receipts. Prefer evidence of the user-visible behavior.
+
 ### Handoffs
 
 - For multi-step work, create or update a portable handoff from

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,39 @@ src/attune/
 attune_redis/          # Redis plugin — bundled in the attune-ai wheel
 ```
 
+<!-- attune:collaboration:start -->
+
+## Cross-provider collaboration
+
+### Shared truth
+
+- Treat the current worktree, Git state, and relevant test results as
+  authoritative. Do not rely on hidden chat context for a handoff.
+- Preserve unrelated working-tree changes and do not touch another
+  agent's worktree.
+- Discover capabilities from the available tools, MCP server, and
+  tracked skills; do not rely on hard-coded capability counts.
+
+### Session protocol
+
+- State the goal, acceptance criteria, assumptions, and intended
+  verification before non-trivial implementation.
+- Prefer existing repository conventions and public interfaces before
+  adding a parallel mechanism.
+- Keep provider-specific setup in adapters. The shared contract must
+  still work when only one provider is available.
+
+### Handoffs
+
+- For multi-step work, create or update a portable handoff from
+  `templates/agent-handoff.md` in the branch or task's tracked work.
+- A receiving agent verifies the handoff against the current Git state
+  and tests before continuing; a handoff is context, not authority.
+- Record only concrete evidence: commands actually run, their results,
+  changed files, unresolved risks, and the next action.
+
+<!-- attune:collaboration:end -->
+
 ## Commands
 
 ```bash

--- a/content/collaboration/contract.md
+++ b/content/collaboration/contract.md
@@ -1,0 +1,70 @@
+# Cross-Provider Collaboration Contract
+
+This is the single source for the collaboration contract shared by
+Codex/ChatGPT tools and Claude in this repository. Edit this master,
+then run `python scripts/project_collaboration_contract.py`; do not
+hand-edit its projected blocks or the handoff template.
+
+## Shared contract
+
+### Shared truth
+
+- Treat the current worktree, Git state, and relevant test results as
+  authoritative. Do not rely on hidden chat context for a handoff.
+- Preserve unrelated working-tree changes and do not touch another
+  agent's worktree.
+- Discover capabilities from the available tools, MCP server, and
+  tracked skills; do not rely on hard-coded capability counts.
+
+### Session protocol
+
+- State the goal, acceptance criteria, assumptions, and intended
+  verification before non-trivial implementation.
+- Prefer existing repository conventions and public interfaces before
+  adding a parallel mechanism.
+- Keep provider-specific setup in adapters. The shared contract must
+  still work when only one provider is available.
+
+### Handoffs
+
+- For multi-step work, create or update a portable handoff from
+  `templates/agent-handoff.md` in the branch or task's tracked work.
+- A receiving agent verifies the handoff against the current Git state
+  and tests before continuing; a handoff is context, not authority.
+- Record only concrete evidence: commands actually run, their results,
+  changed files, unresolved risks, and the next action.
+
+## Portable handoff template
+
+# Agent work handoff
+
+## Goal
+
+<!-- What should be true when this work is complete? -->
+
+## Acceptance criteria
+
+<!-- Concrete conditions that demonstrate completion. -->
+
+## Scope and assumptions
+
+- Branch/worktree:
+- Provider/session:
+- Assumptions:
+
+## Current state
+
+- Status:
+- Changed files:
+- Decisions:
+- Risks or open questions:
+
+## Verification
+
+| Command | Result |
+| --- | --- |
+| <!-- command actually run --> | <!-- pass / fail / not run --> |
+
+## Next action
+
+<!-- One concrete, ordered action for the receiving agent. -->

--- a/content/collaboration/contract.md
+++ b/content/collaboration/contract.md
@@ -25,6 +25,30 @@ hand-edit its projected blocks or the handoff template.
 - Keep provider-specific setup in adapters. The shared contract must
   still work when only one provider is available.
 
+### Artifact selection
+
+- Match the artifact to the work before non-trivial implementation and
+  name the selected tier in the session contract:
+  - **Inline edit** — trivial, one file, no ambiguity.
+  - **Structured one-shot** — single-session work framed by a goal,
+    constraints, and acceptance criteria.
+  - **XML task** — dependent work across three or more files, or work
+    that must be executable as a cold handoff.
+  - **Spec** — multi-session or multi-PR work, design ambiguity, or an
+    irreversible choice.
+- Escalate the artifact tier when ambiguity or dependencies grow; do
+  not add ceremony to work that still fits a smaller tier.
+
+### Verification receipts
+
+- Before implementation, name the claim and a probe that would fail if
+  the claim were false. Report the probe actually run and its result.
+- Treat unit tests as evidence only inside their tested boundaries.
+  Hooks, persistence, networking, packaging, and other external seams
+  require a non-mocked round trip through the real boundary.
+- “Configured,” “registered,” and “exited successfully” are not
+  working receipts. Prefer evidence of the user-visible behavior.
+
 ### Handoffs
 
 - For multi-step work, create or update a portable handoff from
@@ -61,9 +85,9 @@ hand-edit its projected blocks or the handoff template.
 
 ## Verification
 
-| Command | Result |
-| --- | --- |
-| <!-- command actually run --> | <!-- pass / fail / not run --> |
+| Claim | Failure-sensitive probe | Result |
+| --- | --- | --- |
+| <!-- behavior claimed --> | <!-- command or live check actually run --> | <!-- pass / fail / not run --> |
 
 ## Next action
 

--- a/scripts/project_collaboration_contract.py
+++ b/scripts/project_collaboration_contract.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""Project the shared collaboration contract into its consumer surfaces.
+
+The master at ``content/collaboration/contract.md`` owns the common
+Codex/ChatGPT-tools/Claude operating contract. This script writes only
+between explicit markers in provider instruction files, leaving their
+provider-specific content untouched, and emits the portable handoff
+template. ``--check`` is the drift gate for CI and pre-commit use.
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass, field
+from pathlib import Path
+
+START_MARKER = "<!-- attune:collaboration:start -->"
+END_MARKER = "<!-- attune:collaboration:end -->"
+MASTER_PATH = Path("content/collaboration/contract.md")
+CONTRACT_HEADING = "Shared contract"
+HANDOFF_HEADING = "Portable handoff template"
+CONTRACT_TARGETS = (Path("AGENTS.md"), Path(".claude/CLAUDE.md"))
+HANDOFF_TARGET = Path("templates/agent-handoff.md")
+
+
+class ProjectionError(ValueError):
+    """Raised when the master or a marked target is malformed."""
+
+
+@dataclass
+class ProjectionResult:
+    """Paths changed, unchanged, or stale during one projection."""
+
+    written: list[Path] = field(default_factory=list)
+    unchanged: list[Path] = field(default_factory=list)
+    stale: list[Path] = field(default_factory=list)
+
+
+def _parse_sections(text: str) -> dict[str, str]:
+    """Return the two contract-level section bodies from a Markdown master.
+
+    The handoff template intentionally has its own H2 headings, so only
+    the two declared master headings delimit sections here.
+    """
+    sections: dict[str, str] = {}
+    current: str | None = None
+    lines: list[str] = []
+    for line in text.splitlines():
+        if line.startswith("## ") and line[3:].strip() in {CONTRACT_HEADING, HANDOFF_HEADING}:
+            if current is not None:
+                sections[current] = "\n".join(lines).strip()
+            current = line[3:].strip()
+            lines = []
+        elif current is not None:
+            lines.append(line)
+    if current is not None:
+        sections[current] = "\n".join(lines).strip()
+    return sections
+
+
+def _master_sections(root: Path) -> dict[str, str]:
+    """Read and validate the collaboration master under ``root``."""
+    path = root / MASTER_PATH
+    if not path.is_file():
+        raise ProjectionError(f"master missing: {MASTER_PATH}")
+    sections = _parse_sections(path.read_text(encoding="utf-8"))
+    missing = [
+        heading for heading in (CONTRACT_HEADING, HANDOFF_HEADING) if not sections.get(heading)
+    ]
+    if missing:
+        raise ProjectionError(f"master missing required section(s): {', '.join(missing)}")
+    return sections
+
+
+def _render_marked_block(contract: str) -> str:
+    """Return the provider-neutral contract inserted in instruction files."""
+    return "## Cross-provider collaboration\n\n" + contract.strip() + "\n"
+
+
+def _replace_marked_block(content: str, rendered: str, path: Path) -> str:
+    """Replace exactly one marker-delimited block while preserving all else."""
+    if content.count(START_MARKER) != 1 or content.count(END_MARKER) != 1:
+        raise ProjectionError(f"{path}: expected exactly one collaboration marker pair")
+    start = content.index(START_MARKER)
+    end = content.index(END_MARKER)
+    if end <= start:
+        raise ProjectionError(f"{path}: collaboration markers are out of order")
+    prefix = content[: start + len(START_MARKER)]
+    suffix = content[end:]
+    return prefix + "\n\n" + rendered.rstrip() + "\n\n" + suffix
+
+
+def project(root: Path, *, check: bool = False) -> ProjectionResult:
+    """Project the master under ``root`` and optionally only report drift."""
+    sections = _master_sections(root)
+    result = ProjectionResult()
+    rendered_contract = _render_marked_block(sections[CONTRACT_HEADING])
+
+    for relative_path in CONTRACT_TARGETS:
+        path = root / relative_path
+        if not path.is_file():
+            raise ProjectionError(f"target missing: {relative_path}")
+        current = path.read_text(encoding="utf-8")
+        expected = _replace_marked_block(current, rendered_contract, relative_path)
+        if current == expected:
+            result.unchanged.append(relative_path)
+        elif check:
+            result.stale.append(relative_path)
+        else:
+            path.write_text(expected, encoding="utf-8")
+            result.written.append(relative_path)
+
+    handoff_path = root / HANDOFF_TARGET
+    expected_handoff = sections[HANDOFF_HEADING].strip() + "\n"
+    current_handoff = handoff_path.read_text(encoding="utf-8") if handoff_path.is_file() else None
+    if current_handoff == expected_handoff:
+        result.unchanged.append(HANDOFF_TARGET)
+    elif check:
+        result.stale.append(HANDOFF_TARGET)
+    else:
+        handoff_path.parent.mkdir(parents=True, exist_ok=True)
+        handoff_path.write_text(expected_handoff, encoding="utf-8")
+        result.written.append(HANDOFF_TARGET)
+
+    return result
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run projection or report targets that have drifted from the master."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--check", action="store_true", help="report drift without writing")
+    args = parser.parse_args(argv)
+    root = Path(__file__).resolve().parent.parent
+    try:
+        result = project(root, check=args.check)
+    except ProjectionError as error:
+        print(f"error: {error}")
+        return 1
+
+    if result.stale:
+        print("collaboration projection drift:")
+        for path in result.stale:
+            print(f"  {path}")
+        return 1
+    for path in result.written:
+        print(f"wrote {path}")
+    for path in result.unchanged:
+        print(f"unchanged {path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/templates/agent-handoff.md
+++ b/templates/agent-handoff.md
@@ -23,9 +23,9 @@
 
 ## Verification
 
-| Command | Result |
-| --- | --- |
-| <!-- command actually run --> | <!-- pass / fail / not run --> |
+| Claim | Failure-sensitive probe | Result |
+| --- | --- | --- |
+| <!-- behavior claimed --> | <!-- command or live check actually run --> | <!-- pass / fail / not run --> |
 
 ## Next action
 

--- a/templates/agent-handoff.md
+++ b/templates/agent-handoff.md
@@ -1,0 +1,32 @@
+# Agent work handoff
+
+## Goal
+
+<!-- What should be true when this work is complete? -->
+
+## Acceptance criteria
+
+<!-- Concrete conditions that demonstrate completion. -->
+
+## Scope and assumptions
+
+- Branch/worktree:
+- Provider/session:
+- Assumptions:
+
+## Current state
+
+- Status:
+- Changed files:
+- Decisions:
+- Risks or open questions:
+
+## Verification
+
+| Command | Result |
+| --- | --- |
+| <!-- command actually run --> | <!-- pass / fail / not run --> |
+
+## Next action
+
+<!-- One concrete, ordered action for the receiving agent. -->

--- a/tests/unit/scripts/test_project_collaboration_contract.py
+++ b/tests/unit/scripts/test_project_collaboration_contract.py
@@ -46,6 +46,26 @@ def test_repo_projection_is_in_sync() -> None:
     assert result.stale == []
 
 
+def test_repo_projection_carries_artifact_tiers_and_verification_receipts() -> None:
+    contract = (REPO_ROOT / projector.MASTER_PATH).read_text(encoding="utf-8")
+    handoff = (REPO_ROOT / projector.HANDOFF_TARGET).read_text(encoding="utf-8")
+
+    for target in projector.CONTRACT_TARGETS:
+        projected = (REPO_ROOT / target).read_text(encoding="utf-8")
+        assert "### Artifact selection" in projected
+        assert "**Inline edit**" in projected
+        assert "**Structured one-shot**" in projected
+        assert "**XML task**" in projected
+        assert "**Spec**" in projected
+        assert "### Verification receipts" in projected
+        assert "require a non-mocked round trip" in projected
+        assert "working receipts" in projected
+
+    assert "### Artifact selection" in contract
+    assert "### Verification receipts" in contract
+    assert "| Claim | Failure-sensitive probe | Result |" in handoff
+
+
 def test_projects_contract_and_handoff_without_clobbering_provider_tail(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
 

--- a/tests/unit/scripts/test_project_collaboration_contract.py
+++ b/tests/unit/scripts/test_project_collaboration_contract.py
@@ -1,0 +1,102 @@
+"""Tests for the cross-provider collaboration contract projector."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCRIPT = REPO_ROOT / "scripts" / "project_collaboration_contract.py"
+spec = importlib.util.spec_from_file_location("project_collaboration_contract", SCRIPT)
+assert spec is not None and spec.loader is not None
+projector = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = projector
+spec.loader.exec_module(projector)
+
+
+def _seed_repo(tmp_path: Path) -> None:
+    master = tmp_path / "content" / "collaboration" / "contract.md"
+    master.parent.mkdir(parents=True)
+    master.write_text(
+        "# Contract\n\n"
+        "## Shared contract\n\n"
+        "Shared rule.\n\n"
+        "## Portable handoff template\n\n"
+        "# Handoff\n\n"
+        "## Goal\n\n"
+        "Describe it.\n",
+        encoding="utf-8",
+    )
+    for relative_path in projector.CONTRACT_TARGETS:
+        path = tmp_path / relative_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            "# Provider rules\n\n"
+            f"{projector.START_MARKER}\nold content\n{projector.END_MARKER}\n\n"
+            "Provider-specific tail.\n",
+            encoding="utf-8",
+        )
+
+
+def test_repo_projection_is_in_sync() -> None:
+    result = projector.project(REPO_ROOT, check=True)
+    assert result.stale == []
+
+
+def test_projects_contract_and_handoff_without_clobbering_provider_tail(tmp_path: Path) -> None:
+    _seed_repo(tmp_path)
+
+    result = projector.project(tmp_path)
+
+    assert set(result.written) == set(projector.CONTRACT_TARGETS) | {projector.HANDOFF_TARGET}
+    agents = (tmp_path / "AGENTS.md").read_text(encoding="utf-8")
+    assert "Shared rule." in agents
+    assert "Provider-specific tail." in agents
+    handoff = (tmp_path / projector.HANDOFF_TARGET).read_text(encoding="utf-8")
+    assert handoff.startswith("# Handoff")
+    assert "## Goal" in handoff
+
+
+def test_check_fires_when_master_changes_after_projection(tmp_path: Path) -> None:
+    _seed_repo(tmp_path)
+    projector.project(tmp_path)
+    master = tmp_path / projector.MASTER_PATH
+    master.write_text(
+        master.read_text(encoding="utf-8").replace("Shared rule.", "Changed rule."),
+        encoding="utf-8",
+    )
+
+    result = projector.project(tmp_path, check=True)
+
+    assert set(result.stale) == set(projector.CONTRACT_TARGETS)
+    assert projector.HANDOFF_TARGET not in result.stale
+
+
+def test_second_projection_is_idempotent(tmp_path: Path) -> None:
+    _seed_repo(tmp_path)
+    projector.project(tmp_path)
+
+    result = projector.project(tmp_path)
+
+    assert result.written == []
+    assert set(result.unchanged) == set(projector.CONTRACT_TARGETS) | {projector.HANDOFF_TARGET}
+
+
+def test_handoff_projection_preserves_nested_h2_sections(tmp_path: Path) -> None:
+    _seed_repo(tmp_path)
+
+    projector.project(tmp_path)
+
+    handoff = (tmp_path / projector.HANDOFF_TARGET).read_text(encoding="utf-8")
+    assert "## Goal" in handoff
+
+
+def test_rejects_target_without_exactly_one_marker_pair(tmp_path: Path) -> None:
+    _seed_repo(tmp_path)
+    (tmp_path / "AGENTS.md").write_text("# Missing markers\n", encoding="utf-8")
+
+    with pytest.raises(projector.ProjectionError, match="marker pair"):
+        projector.project(tmp_path)


### PR DESCRIPTION
## Summary
- add a single-source collaboration contract projected into AGENTS.md and .claude/CLAUDE.md
- add a portable evidence-based agent handoff template
- encode artifact-tier selection and failure-sensitive verification receipts
- add drift and content regression coverage for projector-owned outputs

## Verification
- `uv run pytest tests/unit/scripts/test_project_collaboration_contract.py -q` — 7 passed
- pinned Black pre-commit hook — passed
- `uv run ruff check tests/unit/scripts/test_project_collaboration_contract.py scripts/project_collaboration_contract.py` — passed
- `uv run python scripts/project_collaboration_contract.py --check` — all projections unchanged
- commit pre-commit suite — passed