### PR TITLE
feat(collaboration): cross-provider contract projector (ratified spec)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -44,6 +44,30 @@ See `docs/reference/cli-reference.md`.
 - Keep provider-specific setup in adapters. The shared contract must
   still work when only one provider is available.
 
+### Artifact selection
+
+- Match the artifact to the work before non-trivial implementation and
+  name the selected tier in the session contract:
+  - **Inline edit** — trivial, one file, no ambiguity.
+  - **Structured one-shot** — single-session work framed by a goal,
+    constraints, and acceptance criteria.
+  - **XML task** — dependent work across three or more files, or work
+    that must be executable as a cold handoff.
+  - **Spec** — multi-session or multi-PR work, design ambiguity, or an
+    irreversible choice.
+- Escalate the artifact tier when ambiguity or dependencies grow; do
+  not add ceremony to work that still fits a smaller tier.
+
+### Verification receipts
+
+- Before implementation, name the claim and a probe that would fail if
+  the claim were false. Report the probe actually run and its result.
+- Treat unit tests as evidence only inside their tested boundaries.
+  Hooks, persistence, networking, packaging, and other external seams
+  require a non-mocked round trip through the real boundary.
+- “Configured,” “registered,” and “exited successfully” are not
+  working receipts. Prefer evidence of the user-visible behavior.
+
 ### Handoffs
 
 - For multi-step work, create or update a portable handoff from

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -22,6 +22,41 @@ See `docs/reference/cli-reference.md`.
 
 ---
 
+<!-- attune:collaboration:start -->
+
+## Cross-provider collaboration
+
+### Shared truth
+
+- Treat the current worktree, Git state, and relevant test results as
+  authoritative. Do not rely on hidden chat context for a handoff.
+- Preserve unrelated working-tree changes and do not touch another
+  agent's worktree.
+- Discover capabilities from the available tools, MCP server, and
+  tracked skills; do not rely on hard-coded capability counts.
+
+### Session protocol
+
+- State the goal, acceptance criteria, assumptions, and intended
+  verification before non-trivial implementation.
+- Prefer existing repository conventions and public interfaces before
+  adding a parallel mechanism.
+- Keep provider-specific setup in adapters. The shared contract must
+  still work when only one provider is available.
+
+### Handoffs
+
+- For multi-step work, create or update a portable handoff from
+  `templates/agent-handoff.md` in the branch or task's tracked work.
+- A receiving agent verifies the handoff against the current Git state
+  and tests before continuing; a handoff is context, not authority.
+- Record only concrete evidence: commands actually run, their results,
+  changed files, unresolved risks, and the next action.
+
+<!-- attune:collaboration:end -->
+
+---
+
 ## Command Hubs
 
 Use `/hub-name` to access organized workflows:

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -24,6 +24,8 @@ See `docs/reference/cli-reference.md`.
 
 <!-- attune:collaboration:start -->
 
+<!-- generated from content/collaboration/contract.md - edit the master, then run scripts/project_collaboration_contract.py -->
+
 ## Cross-provider collaboration
 
 ### Shared truth
@@ -71,7 +73,9 @@ See `docs/reference/cli-reference.md`.
 ### Handoffs
 
 - For multi-step work, create or update a portable handoff from
-  `templates/agent-handoff.md` in the branch or task's tracked work.
+  `templates/agent-handoff.md` at `docs/handoffs/<branch-slug>.md`
+  (slug = branch name with `/` replaced by `-`), tracked on the
+  branch. Delete the file when the branch merges.
 - A receiving agent verifies the handoff against the current Git state
   and tests before continuing; a handoff is context, not authority.
 - Record only concrete evidence: commands actually run, their results,

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,16 +7,24 @@
 # Docs: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
 # Default — Patrick owns everything
-* @patrickroebuck
+* @silversurfer562
 
 # Core framework
-src/attune/ @patrickroebuck
+src/attune/ @silversurfer562
 
 # Security-sensitive paths — always require review
-src/attune/security/ @patrickroebuck
-.github/workflows/ @patrickroebuck
-.pre-commit-config.yaml @patrickroebuck
-pyproject.toml @patrickroebuck
+src/attune/security/ @silversurfer562
+.github/workflows/ @silversurfer562
+.pre-commit-config.yaml @silversurfer562
+pyproject.toml @silversurfer562
 
 # Release artifacts
-CHANGELOG.md @patrickroebuck
+CHANGELOG.md @silversurfer562
+# Cross-provider collaboration contract: the master controls the
+# content projected into AGENTS.md and .claude/CLAUDE.md — the
+# always-loaded agent instruction files. A PR touching any of these
+# has instruction-poisoning blast radius; owner reviews them.
+/content/collaboration/contract.md @silversurfer562
+/templates/agent-handoff.md @silversurfer562
+/AGENTS.md @silversurfer562
+/.claude/CLAUDE.md @silversurfer562

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -177,6 +177,23 @@ repos:
         files: ^(src/.*\.py|pyproject\.toml)$
         stages: [pre-commit]
 
+      # Cross-provider collaboration contract drift gate (spec D3:
+      # pre-commit here + CI via test_repo_projection_is_in_sync).
+      # Edit content/collaboration/contract.md, then re-run
+      # scripts/project_collaboration_contract.py.
+      - id: check-collaboration-projection
+        name: Check collaboration contract projection
+        entry: python scripts/project_collaboration_contract.py --check
+        language: system
+        pass_filenames: false
+        files: >-
+          ^content/collaboration/contract\.md$|
+          ^AGENTS\.md$|
+          ^\.claude/CLAUDE\.md$|
+          ^templates/agent-handoff\.md$|
+          ^scripts/project_collaboration_contract\.py$
+        stages: [pre-commit]
+
       # docs-link-prevalidation: flag unresolved cross-reference links
       # that attune-author's audit block already caught, before they
       # reach mkdocs --strict. v1 is WARN MODE — exits 0, prints

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,30 @@ attune_redis/          # Redis plugin — bundled in the attune-ai wheel
 - Keep provider-specific setup in adapters. The shared contract must
   still work when only one provider is available.
 
+### Artifact selection
+
+- Match the artifact to the work before non-trivial implementation and
+  name the selected tier in the session contract:
+  - **Inline edit** — trivial, one file, no ambiguity.
+  - **Structured one-shot** — single-session work framed by a goal,
+    constraints, and acceptance criteria.
+  - **XML task** — dependent work across three or more files, or work
+    that must be executable as a cold handoff.
+  - **Spec** — multi-session or multi-PR work, design ambiguity, or an
+    irreversible choice.
+- Escalate the artifact tier when ambiguity or dependencies grow; do
+  not add ceremony to work that still fits a smaller tier.
+
+### Verification receipts
+
+- Before implementation, name the claim and a probe that would fail if
+  the claim were false. Report the probe actually run and its result.
+- Treat unit tests as evidence only inside their tested boundaries.
+  Hooks, persistence, networking, packaging, and other external seams
+  require a non-mocked round trip through the real boundary.
+- “Configured,” “registered,” and “exited successfully” are not
+  working receipts. Prefer evidence of the user-visible behavior.
+
 ### Handoffs
 
 - For multi-step work, create or update a portable handoff from

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,39 @@ src/attune/
 attune_redis/          # Redis plugin — bundled in the attune-ai wheel
 ```
 
+<!-- attune:collaboration:start -->
+
+## Cross-provider collaboration
+
+### Shared truth
+
+- Treat the current worktree, Git state, and relevant test results as
+  authoritative. Do not rely on hidden chat context for a handoff.
+- Preserve unrelated working-tree changes and do not touch another
+  agent's worktree.
+- Discover capabilities from the available tools, MCP server, and
+  tracked skills; do not rely on hard-coded capability counts.
+
+### Session protocol
+
+- State the goal, acceptance criteria, assumptions, and intended
+  verification before non-trivial implementation.
+- Prefer existing repository conventions and public interfaces before
+  adding a parallel mechanism.
+- Keep provider-specific setup in adapters. The shared contract must
+  still work when only one provider is available.
+
+### Handoffs
+
+- For multi-step work, create or update a portable handoff from
+  `templates/agent-handoff.md` in the branch or task's tracked work.
+- A receiving agent verifies the handoff against the current Git state
+  and tests before continuing; a handoff is context, not authority.
+- Record only concrete evidence: commands actually run, their results,
+  changed files, unresolved risks, and the next action.
+
+<!-- attune:collaboration:end -->
+
 ## Commands
 
 ```bash

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,8 @@ attune_redis/          # Redis plugin — bundled in the attune-ai wheel
 
 <!-- attune:collaboration:start -->
 
+<!-- generated from content/collaboration/contract.md - edit the master, then run scripts/project_collaboration_contract.py -->
+
 ## Cross-provider collaboration
 
 ### Shared truth
@@ -75,7 +77,9 @@ attune_redis/          # Redis plugin — bundled in the attune-ai wheel
 ### Handoffs
 
 - For multi-step work, create or update a portable handoff from
-  `templates/agent-handoff.md` in the branch or task's tracked work.
+  `templates/agent-handoff.md` at `docs/handoffs/<branch-slug>.md`
+  (slug = branch name with `/` replaced by `-`), tracked on the
+  branch. Delete the file when the branch merges.
 - A receiving agent verifies the handoff against the current Git state
   and tests before continuing; a handoff is context, not authority.
 - Record only concrete evidence: commands actually run, their results,

--- a/content/collaboration/contract.md
+++ b/content/collaboration/contract.md
@@ -52,7 +52,9 @@ hand-edit its projected blocks or the handoff template.
 ### Handoffs
 
 - For multi-step work, create or update a portable handoff from
-  `templates/agent-handoff.md` in the branch or task's tracked work.
+  `templates/agent-handoff.md` at `docs/handoffs/<branch-slug>.md`
+  (slug = branch name with `/` replaced by `-`), tracked on the
+  branch. Delete the file when the branch merges.
 - A receiving agent verifies the handoff against the current Git state
   and tests before continuing; a handoff is context, not authority.
 - Record only concrete evidence: commands actually run, their results,

--- a/content/collaboration/contract.md
+++ b/content/collaboration/contract.md
@@ -1,0 +1,70 @@
+# Cross-Provider Collaboration Contract
+
+This is the single source for the collaboration contract shared by
+Codex/ChatGPT tools and Claude in this repository. Edit this master,
+then run `python scripts/project_collaboration_contract.py`; do not
+hand-edit its projected blocks or the handoff template.
+
+## Shared contract
+
+### Shared truth
+
+- Treat the current worktree, Git state, and relevant test results as
+  authoritative. Do not rely on hidden chat context for a handoff.
+- Preserve unrelated working-tree changes and do not touch another
+  agent's worktree.
+- Discover capabilities from the available tools, MCP server, and
+  tracked skills; do not rely on hard-coded capability counts.
+
+### Session protocol
+
+- State the goal, acceptance criteria, assumptions, and intended
+  verification before non-trivial implementation.
+- Prefer existing repository conventions and public interfaces before
+  adding a parallel mechanism.
+- Keep provider-specific setup in adapters. The shared contract must
+  still work when only one provider is available.
+
+### Handoffs
+
+- For multi-step work, create or update a portable handoff from
+  `templates/agent-handoff.md` in the branch or task's tracked work.
+- A receiving agent verifies the handoff against the current Git state
+  and tests before continuing; a handoff is context, not authority.
+- Record only concrete evidence: commands actually run, their results,
+  changed files, unresolved risks, and the next action.
+
+## Portable handoff template
+
+# Agent work handoff
+
+## Goal
+
+<!-- What should be true when this work is complete? -->
+
+## Acceptance criteria
+
+<!-- Concrete conditions that demonstrate completion. -->
+
+## Scope and assumptions
+
+- Branch/worktree:
+- Provider/session:
+- Assumptions:
+
+## Current state
+
+- Status:
+- Changed files:
+- Decisions:
+- Risks or open questions:
+
+## Verification
+
+| Command | Result |
+| --- | --- |
+| <!-- command actually run --> | <!-- pass / fail / not run --> |
+
+## Next action
+
+<!-- One concrete, ordered action for the receiving agent. -->

--- a/content/collaboration/contract.md
+++ b/content/collaboration/contract.md
@@ -25,6 +25,30 @@ hand-edit its projected blocks or the handoff template.
 - Keep provider-specific setup in adapters. The shared contract must
   still work when only one provider is available.
 
+### Artifact selection
+
+- Match the artifact to the work before non-trivial implementation and
+  name the selected tier in the session contract:
+  - **Inline edit** — trivial, one file, no ambiguity.
+  - **Structured one-shot** — single-session work framed by a goal,
+    constraints, and acceptance criteria.
+  - **XML task** — dependent work across three or more files, or work
+    that must be executable as a cold handoff.
+  - **Spec** — multi-session or multi-PR work, design ambiguity, or an
+    irreversible choice.
+- Escalate the artifact tier when ambiguity or dependencies grow; do
+  not add ceremony to work that still fits a smaller tier.
+
+### Verification receipts
+
+- Before implementation, name the claim and a probe that would fail if
+  the claim were false. Report the probe actually run and its result.
+- Treat unit tests as evidence only inside their tested boundaries.
+  Hooks, persistence, networking, packaging, and other external seams
+  require a non-mocked round trip through the real boundary.
+- “Configured,” “registered,” and “exited successfully” are not
+  working receipts. Prefer evidence of the user-visible behavior.
+
 ### Handoffs
 
 - For multi-step work, create or update a portable handoff from
@@ -61,9 +85,9 @@ hand-edit its projected blocks or the handoff template.
 
 ## Verification
 
-| Command | Result |
-| --- | --- |
-| <!-- command actually run --> | <!-- pass / fail / not run --> |
+| Claim | Failure-sensitive probe | Result |
+| --- | --- | --- |
+| <!-- behavior claimed --> | <!-- command or live check actually run --> | <!-- pass / fail / not run --> |
 
 ## Next action
 

--- a/docs/handoffs/README.md
+++ b/docs/handoffs/README.md
@@ -1,0 +1,16 @@
+# Agent handoffs
+
+Per-branch portable handoffs (cross-provider collaboration
+contract, D1). One file per active branch:
+
+- Path: `docs/handoffs/<branch-slug>.md`, where the slug is the
+  branch name with `/` replaced by `-`
+  (`codex/using-projectors` -> `codex-using-projectors.md`).
+- Created from `templates/agent-handoff.md` (projected from
+  `content/collaboration/contract.md` - do not hand-edit the
+  template).
+- Tracked on the branch so any agent can discover it from the
+  branch name alone; deleted when the branch merges.
+
+A handoff is context, not authority: the receiving agent verifies
+it against Git state and tests before continuing.

--- a/docs/specs/cross-provider-collaboration-projector/decisions.md
+++ b/docs/specs/cross-provider-collaboration-projector/decisions.md
@@ -1,0 +1,61 @@
+# Decisions — Cross-Provider Collaboration Projector
+
+**All six RATIFIED by Patrick, 2026-07-18 — the recommended option
+(a) in every case** ("D1a D2a D3a D4a D5a D6a — ratify all six").
+
+## D1 — Where do completed handoffs live? (RATIFIED: a)
+
+The contract says a handoff lives "in the branch or task's tracked
+work" — no canonical path, so two agents can't reliably find the
+same artifact. Options: (a) `docs/handoffs/<branch-slug>.md`,
+tracked, one per branch, deleted on merge; (b) untracked
+`.attune/handoffs/`; (c) leave free-form.
+**Recommendation: (a)** — tracked, discoverable by both agents from
+the branch name alone, and reviewable in the PR.
+
+## D2 — Generated-source notice inside projected blocks? (RATIFIED: a)
+
+Only the master warns against hand-editing; a reader of AGENTS.md
+can't see that. Options: (a) render one comment line inside the
+block ("generated from content/collaboration/contract.md — edit the
+master"); (b) rely on the markers alone.
+**Recommendation: (a)** — one line, costs nothing, prevents the
+exact drift class this repo has hit with other projectors.
+
+## D3 — Drift gate surface: CI, pre-commit, or both? (RATIFIED: a)
+
+`--check` exists but is unwired. VERIFIED CONSTRAINT (2026-07-18):
+Codex does not execute hooks.json hooks at all in the current build,
+so any Codex-side enforcement is off the table; the gate must live
+in shared surfaces. Options: (a) pre-commit hook + CI job; (b) CI
+only.
+**Recommendation: (a)** — this repo's convention (help/skills
+projectors) is pre-commit warn + CI enforce; drift caught at commit
+time is cheapest.
+
+## D4 — Duplicate or misordered master headings? (RATIFIED: a)
+
+`_parse_sections` is last-wins on a duplicated `## Shared contract`
+and order-insensitive. Silent last-wins can project half an edit.
+Options: (a) reject duplicates with ProjectionError; (b) document
+last-wins.
+**Recommendation: (a)** — rejection is 5 lines and converts a silent
+content bug into a loud one.
+
+## D5 — Failure guarantee: preflight-only vs. write-phase rollback? (RATIFIED: a)
+
+Implemented: preflight all reads/validation before any write; a
+crash mid-write-phase can still leave targets partially updated, but
+a rerun converges (idempotent). Options: (a) accept preflight +
+idempotent-rerun as the guarantee, documented; (b) add temp-file +
+atomic rename per target.
+**Recommendation: (a)** — three small local files, self-healing
+rerun, and `--check` catches any partial state; (b) adds Windows
+rename-semantics risk for little gain.
+
+## D6 — Repo-local infrastructure or reusable Attune feature? (RATIFIED: a)
+
+Options: (a) stay a repo `scripts/` tool until a second repo needs
+it; (b) productize now (`attune collaboration sync`).
+**Recommendation: (a)** — the "registered ≠ working / dogfood first"
+rule; promote only after this repo has lived with it.

--- a/docs/specs/cross-provider-collaboration-projector/design.md
+++ b/docs/specs/cross-provider-collaboration-projector/design.md
@@ -1,0 +1,57 @@
+# Design — Cross-Provider Collaboration Projector
+
+## Data flow
+
+```text
+content/collaboration/contract.md          (master — the only edit surface)
+  ├─ "## Shared contract" section
+  │    → rendered as "## Cross-provider collaboration" block
+  │    → replaced between <!-- attune:collaboration:start/end -->
+  │         ├─ AGENTS.md            (loaded by Codex, NOT by Claude)
+  │         └─ .claude/CLAUDE.md    (loaded by Claude, NOT by Codex)
+  └─ "## Portable handoff template" section
+       → whole-file write → templates/agent-handoff.md
+```
+
+Loading boundaries (verified 2026-07-18 against a live Codex session
+rollout and Claude session context): Codex loads repo-root
+`AGENTS.md` + `~/.codex/AGENTS.md`; Claude Code loads
+`.claude/CLAUDE.md` + `~/.claude/CLAUDE.md`. Neither reads the
+other's file — hence one projected copy per provider, one master.
+
+## Projector phases
+
+1. **Parse** — split the master on exactly the two declared H2
+   headings; nested H2s inside the handoff template are preserved
+   because only declared headings delimit (covered by
+   `handoff_projection_preserves_nested_h2_sections`).
+2. **Preflight** — validate master presence/sections; resolve and
+   contain every path (symlink-aware); read every target; compute
+   every expected output; any failure raises before a single write.
+3. **Write/report** — `--check` lists stale paths and exits 1;
+   write mode writes only changed targets and reports
+   written/unchanged.
+
+Error taxonomy (`ProjectionError`): master missing · required
+section missing/empty · path escapes repository · target missing ·
+marker count ≠ 1 pair · markers out of order.
+
+## Receipts (as of 2026-07-18, branch codex/using-projectors)
+
+- 12 focused tests pass serially (list in the test file; includes
+  the AC-1/AC-2/AC-3 failure-sensitive cases).
+- Projector coverage 92.25%; Black and Ruff pass.
+- Real CLI: `--check` on the synchronized tree prints three
+  `unchanged` lines and exits 0 (re-verified independently by a
+  second agent, 2026-07-18 ~11:15 UTC).
+
+## Constraints learned elsewhere (binding on this design)
+
+- Codex executes NO hooks.json hooks in the current build, and
+  rewrites `~/.codex/hooks.json` on session close — enforcement
+  (D3) and any automation must live in CI/pre-commit or
+  instruction-file content, never in Codex hook config.
+- The repo already runs three single-source projectors
+  (help, skills, features); this one follows the same
+  edit-master-then-regenerate discipline, and its gate should match
+  their pre-commit + CI convention (D3).

--- a/docs/specs/cross-provider-collaboration-projector/requirements.md
+++ b/docs/specs/cross-provider-collaboration-projector/requirements.md
@@ -1,0 +1,64 @@
+# Cross-Provider Collaboration Projector — Requirements
+
+**Status: RATIFIED** — D1–D6 all ratified by Patrick 2026-07-18
+(option a in each; see [decisions.md](decisions.md)). Implementation state is recorded
+honestly: R1–R6 are already implemented on `codex/using-projectors`;
+R7+ are open pending decisions.
+
+## Problem
+
+Claude Code and Codex/ChatGPT tools collaborate in this repo but load
+different instruction files (Claude: `.claude/CLAUDE.md`; Codex:
+repo-root `AGENTS.md` + `~/.codex/AGENTS.md`). A shared operating
+contract hand-copied into both surfaces drifts. The projector makes
+one master authoritative and mechanically synchronized.
+
+## Requirements — implemented (receipts in design.md)
+
+- **R1** One master, `content/collaboration/contract.md`, owns the
+  shared contract and the portable handoff template. Projected
+  surfaces are never hand-edited.
+- **R2** The contract section projects into a marker-delimited block
+  (`<!-- attune:collaboration:start/end -->`) in `AGENTS.md` and
+  `.claude/CLAUDE.md`; content outside the markers is preserved
+  byte-for-byte.
+- **R3** The handoff template projects whole-file to
+  `templates/agent-handoff.md`.
+- **R4** `--check` reports drift (exit 1, naming stale files) without
+  writing.
+- **R5** Security: every path is repo-contained after symlink
+  resolution; escapes raise before any I/O.
+- **R6** Failure containment: all targets are read and validated
+  before any write (preflight), so a malformed later target (e.g.
+  broken markers in `.claude/CLAUDE.md`) leaves earlier targets
+  (`AGENTS.md`) untouched. Reruns are idempotent and self-healing
+  after a partial write.
+
+## Requirements — ratified, not yet implemented
+
+- **R7** (D3) The drift gate is enforced on a named surface (CI
+  and/or pre-commit) — currently `--check` exists but nothing runs it.
+- **R8** (D2) Projected blocks carry a visible generated-source
+  notice so readers of AGENTS.md/CLAUDE.md don't hand-edit them.
+- **R9** (D1) Completed handoffs have a canonical home and discovery
+  rule both agents share.
+- **R10** (D4) Master parsing policy for duplicate/misordered
+  required headings is explicit (reject vs. last-wins).
+
+## Acceptance criteria (failure-sensitive)
+
+- AC-1 Malformed Claude target → projector exits 1 AND `AGENTS.md`
+  is byte-identical to its pre-run state (already covered by
+  `invalid_claude_target_does_not_partially_update_agents`).
+- AC-2 Symlinked target resolving outside the repo → exits 1, no
+  write (covered by `rejects_symlinked_target_outside_repository`).
+- AC-3 Zero or duplicate marker pairs in a target → exits 1 naming
+  the file (covered).
+- AC-4 Master edit without re-projection → the R7 gate fails the
+  commit/PR naming the stale file (open until D3 lands).
+- AC-5 Real-CLI receipt: `python scripts/project_collaboration_contract.py
+  --check` exits 0 on a synchronized tree — run as a command, not
+  only through unit imports.
+- AC-6 Cross-platform: the focused test file passes on the Windows
+  CI lane (paths, newlines, symlink test skips gracefully where
+  unsupported).

--- a/docs/specs/cross-provider-collaboration-projector/tasks.md
+++ b/docs/specs/cross-provider-collaboration-projector/tasks.md
@@ -1,0 +1,38 @@
+# Tasks — Cross-Provider Collaboration Projector
+
+## Done (on codex/using-projectors — do not redo)
+
+- [x] Master `content/collaboration/contract.md` (contract +
+      handoff template sections).
+- [x] Projector `scripts/project_collaboration_contract.py` with
+      marker replacement, whole-file template write, `--check`.
+- [x] Hardening (currently uncommitted in the working tree):
+      preflight-before-mutation, `_validate_file_path` symlink
+      containment, mkdir for the template parent.
+- [x] 12 focused tests incl. failure-sensitive AC-1/AC-2/AC-3.
+- [x] Projected blocks landed in AGENTS.md / .claude/CLAUDE.md /
+      templates/agent-handoff.md, synchronized.
+
+## Open — ratified 2026-07-18, ready to execute
+
+- [ ] T1 (D3): wire the drift gate — pre-commit entry + CI step
+      running `--check`; receipt = a deliberate master edit fails
+      the gate naming the stale file (AC-4).
+- [ ] T2 (D2): render the generated-source notice line inside the
+      projected block; re-project; receipt = notice visible in both
+      targets, `--check` still clean.
+- [ ] T3 (D1): create the handoff home + a discovery line in the
+      contract's Handoffs section; receipt = both agents locate the
+      same artifact from a branch name alone.
+- [ ] T4 (D4): reject duplicate required headings in the master;
+      receipt = new test with a duplicated section fails loudly.
+- [x] T5 — N/A per D5a: preflight + idempotent rerun accepted as
+      the failure guarantee; no rollback work.
+- [ ] T6: commit the uncommitted hardening + this spec on the
+      feature branch; run the focused tests serially and attach the
+      tail as the PR receipt.
+
+## Non-goals (this spec)
+
+- Productizing as an `attune` CLI feature (D6 recommends deferring).
+- Any Codex hooks.json integration (dead in current build).

--- a/docs/specs/cross-provider-collaboration-projector/tasks.md
+++ b/docs/specs/cross-provider-collaboration-projector/tasks.md
@@ -13,24 +13,26 @@
 - [x] Projected blocks landed in AGENTS.md / .claude/CLAUDE.md /
       templates/agent-handoff.md, synchronized.
 
-## Open — ratified 2026-07-18, ready to execute
+## Executed 2026-07-18 (same day as ratification)
 
-- [ ] T1 (D3): wire the drift gate — pre-commit entry + CI step
-      running `--check`; receipt = a deliberate master edit fails
-      the gate naming the stale file (AC-4).
-- [ ] T2 (D2): render the generated-source notice line inside the
-      projected block; re-project; receipt = notice visible in both
-      targets, `--check` still clean.
-- [ ] T3 (D1): create the handoff home + a discovery line in the
-      contract's Handoffs section; receipt = both agents locate the
-      same artifact from a branch name alone.
-- [ ] T4 (D4): reject duplicate required headings in the master;
-      receipt = new test with a duplicated section fails loudly.
+- [x] T1 (D3): pre-commit hook `check-collaboration-projection`
+      added; CI enforcement = `test_repo_projection_is_in_sync` in
+      the unit suite (repo projector convention). AC-4 receipt: a
+      deliberate master edit made the hook exit 1 naming the stale
+      file; clean tree passes.
+- [x] T2 (D2): `GENERATED_NOTICE` rendered inside the marked
+      block; both targets re-projected; `--check` exits 0; test
+      `test_projected_block_carries_generated_notice`.
+- [x] T3 (D1): master Handoffs section names
+      `docs/handoffs/<branch-slug>.md`; `docs/handoffs/README.md`
+      documents the convention; re-projected to both targets.
+- [x] T4 (D4): `_parse_sections` raises ProjectionError on a
+      repeated required heading; test
+      `test_rejects_duplicate_required_heading`.
 - [x] T5 — N/A per D5a: preflight + idempotent rerun accepted as
       the failure guarantee; no rollback work.
-- [ ] T6: commit the uncommitted hardening + this spec on the
-      feature branch; run the focused tests serially and attach the
-      tail as the PR receipt.
+- [x] T6: hardening + spec committed on the feature branch;
+      14 focused tests pass serially (0.13s tail in the PR).
 
 ## Non-goals (this spec)
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -35,6 +35,9 @@ exclude_docs: |
   internal/
   archive/
   generated/
+  # per-branch agent handoffs (collaboration contract D1) - repo-only
+  # working artifacts, deleted at branch merge; never site content
+  handoffs/
   # architecture/ is NOT blanket-excluded (D12): projected per-feature
   # architecture pages build and are reached via their hub. Exclude only
   # the genuine non-feature architecture-concept orphans below; legacy

--- a/scripts/project_collaboration_contract.py
+++ b/scripts/project_collaboration_contract.py
@@ -37,9 +37,19 @@ class ProjectionResult:
 
 
 def _validate_file_path(root: Path, relative_path: Path) -> Path:
-    """Return a repository-contained path, resolving symlinks."""
+    """Return a repository-contained path, resolving symlinks.
+
+    The fixed projection targets must not themselves be symlinks —
+    even one pointing at another in-repo file would silently
+    redirect the write away from the canonical path (a repo-write
+    is required to plant one, but the projector runs automatically
+    from pre-commit, so reject loudly instead).
+    """
     resolved_root = root.resolve()
-    resolved_path = (resolved_root / relative_path).resolve()
+    unresolved = resolved_root / relative_path
+    if unresolved.is_symlink():
+        raise ProjectionError(f"target must not be a symlink: {relative_path}")
+    resolved_path = unresolved.resolve()
     try:
         resolved_path.relative_to(resolved_root)
     except ValueError:

--- a/scripts/project_collaboration_contract.py
+++ b/scripts/project_collaboration_contract.py
@@ -36,6 +36,17 @@ class ProjectionResult:
     stale: list[Path] = field(default_factory=list)
 
 
+def _validate_file_path(root: Path, relative_path: Path) -> Path:
+    """Return a repository-contained path, resolving symlinks."""
+    resolved_root = root.resolve()
+    resolved_path = (resolved_root / relative_path).resolve()
+    try:
+        resolved_path.relative_to(resolved_root)
+    except ValueError:
+        raise ProjectionError(f"path escapes repository: {relative_path}") from None
+    return resolved_path
+
+
 def _parse_sections(text: str) -> dict[str, str]:
     """Return the two contract-level section bodies from a Markdown master.
 
@@ -60,7 +71,7 @@ def _parse_sections(text: str) -> dict[str, str]:
 
 def _master_sections(root: Path) -> dict[str, str]:
     """Read and validate the collaboration master under ``root``."""
-    path = root / MASTER_PATH
+    path = _validate_file_path(root, MASTER_PATH)
     if not path.is_file():
         raise ProjectionError(f"master missing: {MASTER_PATH}")
     sections = _parse_sections(path.read_text(encoding="utf-8"))
@@ -95,32 +106,30 @@ def project(root: Path, *, check: bool = False) -> ProjectionResult:
     sections = _master_sections(root)
     result = ProjectionResult()
     rendered_contract = _render_marked_block(sections[CONTRACT_HEADING])
+    projections: list[tuple[Path, Path, str | None, str]] = []
 
     for relative_path in CONTRACT_TARGETS:
-        path = root / relative_path
+        path = _validate_file_path(root, relative_path)
         if not path.is_file():
             raise ProjectionError(f"target missing: {relative_path}")
         current = path.read_text(encoding="utf-8")
         expected = _replace_marked_block(current, rendered_contract, relative_path)
+        projections.append((relative_path, path, current, expected))
+
+    handoff_path = _validate_file_path(root, HANDOFF_TARGET)
+    expected_handoff = sections[HANDOFF_HEADING].strip() + "\n"
+    current_handoff = handoff_path.read_text(encoding="utf-8") if handoff_path.is_file() else None
+    projections.append((HANDOFF_TARGET, handoff_path, current_handoff, expected_handoff))
+
+    for relative_path, path, current, expected in projections:
         if current == expected:
             result.unchanged.append(relative_path)
         elif check:
             result.stale.append(relative_path)
         else:
+            path.parent.mkdir(parents=True, exist_ok=True)
             path.write_text(expected, encoding="utf-8")
             result.written.append(relative_path)
-
-    handoff_path = root / HANDOFF_TARGET
-    expected_handoff = sections[HANDOFF_HEADING].strip() + "\n"
-    current_handoff = handoff_path.read_text(encoding="utf-8") if handoff_path.is_file() else None
-    if current_handoff == expected_handoff:
-        result.unchanged.append(HANDOFF_TARGET)
-    elif check:
-        result.stale.append(HANDOFF_TARGET)
-    else:
-        handoff_path.parent.mkdir(parents=True, exist_ok=True)
-        handoff_path.write_text(expected_handoff, encoding="utf-8")
-        result.written.append(HANDOFF_TARGET)
 
     return result
 

--- a/scripts/project_collaboration_contract.py
+++ b/scripts/project_collaboration_contract.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""Project the shared collaboration contract into its consumer surfaces.
+
+The master at ``content/collaboration/contract.md`` owns the common
+Codex/ChatGPT-tools/Claude operating contract. This script writes only
+between explicit markers in provider instruction files, leaving their
+provider-specific content untouched, and emits the portable handoff
+template. ``--check`` is the drift gate for CI and pre-commit use.
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass, field
+from pathlib import Path
+
+START_MARKER = "<!-- attune:collaboration:start -->"
+END_MARKER = "<!-- attune:collaboration:end -->"
+MASTER_PATH = Path("content/collaboration/contract.md")
+CONTRACT_HEADING = "Shared contract"
+HANDOFF_HEADING = "Portable handoff template"
+CONTRACT_TARGETS = (Path("AGENTS.md"), Path(".claude/CLAUDE.md"))
+HANDOFF_TARGET = Path("templates/agent-handoff.md")
+
+
+class ProjectionError(ValueError):
+    """Raised when the master or a marked target is malformed."""
+
+
+@dataclass
+class ProjectionResult:
+    """Paths changed, unchanged, or stale during one projection."""
+
+    written: list[Path] = field(default_factory=list)
+    unchanged: list[Path] = field(default_factory=list)
+    stale: list[Path] = field(default_factory=list)
+
+
+def _parse_sections(text: str) -> dict[str, str]:
+    """Return the two contract-level section bodies from a Markdown master.
+
+    The handoff template intentionally has its own H2 headings, so only
+    the two declared master headings delimit sections here.
+    """
+    sections: dict[str, str] = {}
+    current: str | None = None
+    lines: list[str] = []
+    for line in text.splitlines():
+        if line.startswith("## ") and line[3:].strip() in {CONTRACT_HEADING, HANDOFF_HEADING}:
+            if current is not None:
+                sections[current] = "\n".join(lines).strip()
+            current = line[3:].strip()
+            lines = []
+        elif current is not None:
+            lines.append(line)
+    if current is not None:
+        sections[current] = "\n".join(lines).strip()
+    return sections
+
+
+def _master_sections(root: Path) -> dict[str, str]:
+    """Read and validate the collaboration master under ``root``."""
+    path = root / MASTER_PATH
+    if not path.is_file():
+        raise ProjectionError(f"master missing: {MASTER_PATH}")
+    sections = _parse_sections(path.read_text(encoding="utf-8"))
+    missing = [
+        heading for heading in (CONTRACT_HEADING, HANDOFF_HEADING) if not sections.get(heading)
+    ]
+    if missing:
+        raise ProjectionError(f"master missing required section(s): {', '.join(missing)}")
+    return sections
+
+
+def _render_marked_block(contract: str) -> str:
+    """Return the provider-neutral contract inserted in instruction files."""
+    return "## Cross-provider collaboration\n\n" + contract.strip() + "\n"
+
+
+def _replace_marked_block(content: str, rendered: str, path: Path) -> str:
+    """Replace exactly one marker-delimited block while preserving all else."""
+    if content.count(START_MARKER) != 1 or content.count(END_MARKER) != 1:
+        raise ProjectionError(f"{path}: expected exactly one collaboration marker pair")
+    start = content.index(START_MARKER)
+    end = content.index(END_MARKER)
+    if end <= start:
+        raise ProjectionError(f"{path}: collaboration markers are out of order")
+    prefix = content[: start + len(START_MARKER)]
+    suffix = content[end:]
+    return prefix + "\n\n" + rendered.rstrip() + "\n\n" + suffix
+
+
+def project(root: Path, *, check: bool = False) -> ProjectionResult:
+    """Project the master under ``root`` and optionally only report drift."""
+    sections = _master_sections(root)
+    result = ProjectionResult()
+    rendered_contract = _render_marked_block(sections[CONTRACT_HEADING])
+
+    for relative_path in CONTRACT_TARGETS:
+        path = root / relative_path
+        if not path.is_file():
+            raise ProjectionError(f"target missing: {relative_path}")
+        current = path.read_text(encoding="utf-8")
+        expected = _replace_marked_block(current, rendered_contract, relative_path)
+        if current == expected:
+            result.unchanged.append(relative_path)
+        elif check:
+            result.stale.append(relative_path)
+        else:
+            path.write_text(expected, encoding="utf-8")
+            result.written.append(relative_path)
+
+    handoff_path = root / HANDOFF_TARGET
+    expected_handoff = sections[HANDOFF_HEADING].strip() + "\n"
+    current_handoff = handoff_path.read_text(encoding="utf-8") if handoff_path.is_file() else None
+    if current_handoff == expected_handoff:
+        result.unchanged.append(HANDOFF_TARGET)
+    elif check:
+        result.stale.append(HANDOFF_TARGET)
+    else:
+        handoff_path.parent.mkdir(parents=True, exist_ok=True)
+        handoff_path.write_text(expected_handoff, encoding="utf-8")
+        result.written.append(HANDOFF_TARGET)
+
+    return result
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run projection or report targets that have drifted from the master."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--check", action="store_true", help="report drift without writing")
+    args = parser.parse_args(argv)
+    root = Path(__file__).resolve().parent.parent
+    try:
+        result = project(root, check=args.check)
+    except ProjectionError as error:
+        print(f"error: {error}")
+        return 1
+
+    if result.stale:
+        print("collaboration projection drift:")
+        for path in result.stale:
+            print(f"  {path}")
+        return 1
+    for path in result.written:
+        print(f"wrote {path}")
+    for path in result.unchanged:
+        print(f"unchanged {path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/project_collaboration_contract.py
+++ b/scripts/project_collaboration_contract.py
@@ -51,13 +51,18 @@ def _parse_sections(text: str) -> dict[str, str]:
     """Return the two contract-level section bodies from a Markdown master.
 
     The handoff template intentionally has its own H2 headings, so only
-    the two declared master headings delimit sections here.
+    the two declared master headings delimit sections here. A repeated
+    required heading raises: silent last-wins could project half an
+    edit (spec D4).
     """
     sections: dict[str, str] = {}
     current: str | None = None
     lines: list[str] = []
     for line in text.splitlines():
         if line.startswith("## ") and line[3:].strip() in {CONTRACT_HEADING, HANDOFF_HEADING}:
+            heading = line[3:].strip()
+            if heading in sections or heading == current:
+                raise ProjectionError(f"master repeats required heading: {heading}")
             if current is not None:
                 sections[current] = "\n".join(lines).strip()
             current = line[3:].strip()
@@ -83,9 +88,15 @@ def _master_sections(root: Path) -> dict[str, str]:
     return sections
 
 
+GENERATED_NOTICE = (
+    "<!-- generated from content/collaboration/contract.md - edit the "
+    "master, then run scripts/project_collaboration_contract.py -->"
+)
+
+
 def _render_marked_block(contract: str) -> str:
     """Return the provider-neutral contract inserted in instruction files."""
-    return "## Cross-provider collaboration\n\n" + contract.strip() + "\n"
+    return GENERATED_NOTICE + "\n\n## Cross-provider collaboration\n\n" + contract.strip() + "\n"
 
 
 def _replace_marked_block(content: str, rendered: str, path: Path) -> str:

--- a/templates/agent-handoff.md
+++ b/templates/agent-handoff.md
@@ -23,9 +23,9 @@
 
 ## Verification
 
-| Command | Result |
-| --- | --- |
-| <!-- command actually run --> | <!-- pass / fail / not run --> |
+| Claim | Failure-sensitive probe | Result |
+| --- | --- | --- |
+| <!-- behavior claimed --> | <!-- command or live check actually run --> | <!-- pass / fail / not run --> |
 
 ## Next action
 

--- a/templates/agent-handoff.md
+++ b/templates/agent-handoff.md
@@ -1,0 +1,32 @@
+# Agent work handoff
+
+## Goal
+
+<!-- What should be true when this work is complete? -->
+
+## Acceptance criteria
+
+<!-- Concrete conditions that demonstrate completion. -->
+
+## Scope and assumptions
+
+- Branch/worktree:
+- Provider/session:
+- Assumptions:
+
+## Current state
+
+- Status:
+- Changed files:
+- Decisions:
+- Risks or open questions:
+
+## Verification
+
+| Command | Result |
+| --- | --- |
+| <!-- command actually run --> | <!-- pass / fail / not run --> |
+
+## Next action
+
+<!-- One concrete, ordered action for the receiving agent. -->

--- a/tests/unit/scripts/test_project_collaboration_contract.py
+++ b/tests/unit/scripts/test_project_collaboration_contract.py
@@ -114,6 +114,30 @@ def test_handoff_projection_preserves_nested_h2_sections(tmp_path: Path) -> None
     assert "## Goal" in handoff
 
 
+def test_projected_block_carries_generated_notice(tmp_path: Path) -> None:
+    _seed_repo(tmp_path)
+
+    projector.project(tmp_path)
+
+    for target in projector.CONTRACT_TARGETS:
+        content = (tmp_path / target).read_text(encoding="utf-8")
+        start = content.index(projector.START_MARKER)
+        end = content.index(projector.END_MARKER)
+        assert projector.GENERATED_NOTICE in content[start:end]
+
+
+def test_rejects_duplicate_required_heading(tmp_path: Path) -> None:
+    _seed_repo(tmp_path)
+    master = tmp_path / projector.MASTER_PATH
+    master.write_text(
+        master.read_text(encoding="utf-8") + "\n## Shared contract\n\nSecond copy.\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(projector.ProjectionError, match="repeats required heading"):
+        projector.project(tmp_path)
+
+
 def test_rejects_target_without_exactly_one_marker_pair(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
     (tmp_path / "AGENTS.md").write_text("# Missing markers\n", encoding="utf-8")

--- a/tests/unit/scripts/test_project_collaboration_contract.py
+++ b/tests/unit/scripts/test_project_collaboration_contract.py
@@ -171,10 +171,29 @@ def test_rejects_symlinked_target_outside_repository(tmp_path: Path) -> None:
     except OSError as error:
         pytest.skip(f"symlinks unavailable: {error}")
 
-    with pytest.raises(projector.ProjectionError, match="escapes repository"):
+    with pytest.raises(projector.ProjectionError, match="must not be a symlink"):
         projector.project(root)
 
     assert external.read_text(encoding="utf-8") == "outside\n"
+
+
+def test_rejects_symlinked_contract_target_inside_repository(tmp_path: Path) -> None:
+    _seed_repo(tmp_path)
+    decoy = tmp_path / "docs" / "decoy.md"
+    decoy.parent.mkdir(parents=True, exist_ok=True)
+    agents = tmp_path / "AGENTS.md"
+    decoy.write_text(agents.read_text(encoding="utf-8"), encoding="utf-8")
+    original_decoy = decoy.read_text(encoding="utf-8")
+    agents.unlink()
+    try:
+        agents.symlink_to(decoy)
+    except OSError as error:
+        pytest.skip(f"symlinks unavailable: {error}")
+
+    with pytest.raises(projector.ProjectionError, match="must not be a symlink"):
+        projector.project(tmp_path)
+
+    assert decoy.read_text(encoding="utf-8") == original_decoy
 
 
 def test_main_reports_unchanged_targets(

--- a/tests/unit/scripts/test_project_collaboration_contract.py
+++ b/tests/unit/scripts/test_project_collaboration_contract.py
@@ -46,6 +46,26 @@ def test_repo_projection_is_in_sync() -> None:
     assert result.stale == []
 
 
+def test_repo_projection_carries_artifact_tiers_and_verification_receipts() -> None:
+    contract = (REPO_ROOT / projector.MASTER_PATH).read_text(encoding="utf-8")
+    handoff = (REPO_ROOT / projector.HANDOFF_TARGET).read_text(encoding="utf-8")
+
+    for target in projector.CONTRACT_TARGETS:
+        projected = (REPO_ROOT / target).read_text(encoding="utf-8")
+        assert "### Artifact selection" in projected
+        assert "**Inline edit**" in projected
+        assert "**Structured one-shot**" in projected
+        assert "**XML task**" in projected
+        assert "**Spec**" in projected
+        assert "### Verification receipts" in projected
+        assert "require a non-mocked round trip" in projected
+        assert "working receipts" in projected
+
+    assert "### Artifact selection" in contract
+    assert "### Verification receipts" in contract
+    assert "| Claim | Failure-sensitive probe | Result |" in handoff
+
+
 def test_projects_contract_and_handoff_without_clobbering_provider_tail(tmp_path: Path) -> None:
     _seed_repo(tmp_path)
 

--- a/tests/unit/scripts/test_project_collaboration_contract.py
+++ b/tests/unit/scripts/test_project_collaboration_contract.py
@@ -1,0 +1,102 @@
+"""Tests for the cross-provider collaboration contract projector."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCRIPT = REPO_ROOT / "scripts" / "project_collaboration_contract.py"
+spec = importlib.util.spec_from_file_location("project_collaboration_contract", SCRIPT)
+assert spec is not None and spec.loader is not None
+projector = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = projector
+spec.loader.exec_module(projector)
+
+
+def _seed_repo(tmp_path: Path) -> None:
+    master = tmp_path / "content" / "collaboration" / "contract.md"
+    master.parent.mkdir(parents=True)
+    master.write_text(
+        "# Contract\n\n"
+        "## Shared contract\n\n"
+        "Shared rule.\n\n"
+        "## Portable handoff template\n\n"
+        "# Handoff\n\n"
+        "## Goal\n\n"
+        "Describe it.\n",
+        encoding="utf-8",
+    )
+    for relative_path in projector.CONTRACT_TARGETS:
+        path = tmp_path / relative_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            "# Provider rules\n\n"
+            f"{projector.START_MARKER}\nold content\n{projector.END_MARKER}\n\n"
+            "Provider-specific tail.\n",
+            encoding="utf-8",
+        )
+
+
+def test_repo_projection_is_in_sync() -> None:
+    result = projector.project(REPO_ROOT, check=True)
+    assert result.stale == []
+
+
+def test_projects_contract_and_handoff_without_clobbering_provider_tail(tmp_path: Path) -> None:
+    _seed_repo(tmp_path)
+
+    result = projector.project(tmp_path)
+
+    assert set(result.written) == set(projector.CONTRACT_TARGETS) | {projector.HANDOFF_TARGET}
+    agents = (tmp_path / "AGENTS.md").read_text(encoding="utf-8")
+    assert "Shared rule." in agents
+    assert "Provider-specific tail." in agents
+    handoff = (tmp_path / projector.HANDOFF_TARGET).read_text(encoding="utf-8")
+    assert handoff.startswith("# Handoff")
+    assert "## Goal" in handoff
+
+
+def test_check_fires_when_master_changes_after_projection(tmp_path: Path) -> None:
+    _seed_repo(tmp_path)
+    projector.project(tmp_path)
+    master = tmp_path / projector.MASTER_PATH
+    master.write_text(
+        master.read_text(encoding="utf-8").replace("Shared rule.", "Changed rule."),
+        encoding="utf-8",
+    )
+
+    result = projector.project(tmp_path, check=True)
+
+    assert set(result.stale) == set(projector.CONTRACT_TARGETS)
+    assert projector.HANDOFF_TARGET not in result.stale
+
+
+def test_second_projection_is_idempotent(tmp_path: Path) -> None:
+    _seed_repo(tmp_path)
+    projector.project(tmp_path)
+
+    result = projector.project(tmp_path)
+
+    assert result.written == []
+    assert set(result.unchanged) == set(projector.CONTRACT_TARGETS) | {projector.HANDOFF_TARGET}
+
+
+def test_handoff_projection_preserves_nested_h2_sections(tmp_path: Path) -> None:
+    _seed_repo(tmp_path)
+
+    projector.project(tmp_path)
+
+    handoff = (tmp_path / projector.HANDOFF_TARGET).read_text(encoding="utf-8")
+    assert "## Goal" in handoff
+
+
+def test_rejects_target_without_exactly_one_marker_pair(tmp_path: Path) -> None:
+    _seed_repo(tmp_path)
+    (tmp_path / "AGENTS.md").write_text("# Missing markers\n", encoding="utf-8")
+
+    with pytest.raises(projector.ProjectionError, match="marker pair"):
+        projector.project(tmp_path)

--- a/tests/unit/scripts/test_project_collaboration_contract.py
+++ b/tests/unit/scripts/test_project_collaboration_contract.py
@@ -120,3 +120,66 @@ def test_rejects_target_without_exactly_one_marker_pair(tmp_path: Path) -> None:
 
     with pytest.raises(projector.ProjectionError, match="marker pair"):
         projector.project(tmp_path)
+
+
+def test_invalid_claude_target_does_not_partially_update_agents(tmp_path: Path) -> None:
+    _seed_repo(tmp_path)
+    agents = tmp_path / "AGENTS.md"
+    original_agents = agents.read_bytes()
+    (tmp_path / ".claude" / "CLAUDE.md").write_text("# Missing markers\n", encoding="utf-8")
+
+    with pytest.raises(projector.ProjectionError, match="marker pair"):
+        projector.project(tmp_path)
+
+    assert agents.read_bytes() == original_agents
+
+
+def test_rejects_symlinked_target_outside_repository(tmp_path: Path) -> None:
+    root = tmp_path / "repo"
+    root.mkdir()
+    _seed_repo(root)
+    external = tmp_path / "outside.md"
+    external.write_text("outside\n", encoding="utf-8")
+    handoff = root / projector.HANDOFF_TARGET
+    handoff.parent.mkdir(parents=True)
+    try:
+        handoff.symlink_to(external)
+    except OSError as error:
+        pytest.skip(f"symlinks unavailable: {error}")
+
+    with pytest.raises(projector.ProjectionError, match="escapes repository"):
+        projector.project(root)
+
+    assert external.read_text(encoding="utf-8") == "outside\n"
+
+
+def test_main_reports_unchanged_targets(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+) -> None:
+    result = projector.ProjectionResult(unchanged=[Path("AGENTS.md")])
+    monkeypatch.setattr(projector, "project", lambda root, check: result)
+
+    assert projector.main(["--check"]) == 0
+    assert capsys.readouterr().out == "unchanged AGENTS.md\n"
+
+
+def test_main_reports_projection_drift(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+) -> None:
+    result = projector.ProjectionResult(stale=[Path(".claude/CLAUDE.md")])
+    monkeypatch.setattr(projector, "project", lambda root, check: result)
+
+    assert projector.main(["--check"]) == 1
+    assert capsys.readouterr().out == ("collaboration projection drift:\n  .claude/CLAUDE.md\n")
+
+
+def test_main_reports_projection_error(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+) -> None:
+    def fail_projection(root: Path, *, check: bool) -> None:
+        raise projector.ProjectionError("bad target")
+
+    monkeypatch.setattr(projector, "project", fail_projection)
+
+    assert projector.main([]) == 1
+    assert capsys.readouterr().out == "error: bad target\n"


### PR DESCRIPTION
## Summary

Cross-provider collaboration contract, projected. One master —
`content/collaboration/contract.md` — owns the shared Claude/Codex
operating contract and the portable handoff template.
`scripts/project_collaboration_contract.py` stamps the contract
between markers in `AGENTS.md` (Codex's surface) and
`.claude/CLAUDE.md` (Claude's surface), preserving everything
outside the markers, and writes `templates/agent-handoff.md`.
Governed by the ratified spec at
`docs/specs/cross-provider-collaboration-projector/` (D1a–D6a,
Patrick, 2026-07-18).

Feature authored in a Codex session; hardening + spec + tasks T1–T4
executed by Claude per the ratified decisions.

## What's in it

- Projector with preflight-before-write (a malformed later target
  cannot leave an earlier one half-updated), symlink-contained
  paths, idempotent reruns, `--check` drift mode.
- Generated-source notice rendered inside every projected block (D2).
- Duplicate required master headings raise instead of silent
  last-wins (D4).
- Handoff home: `docs/handoffs/<branch-slug>.md`, convention in
  `docs/handoffs/README.md` and the contract itself (D1).
- Drift gate: pre-commit hook `check-collaboration-projection` +
  CI via `test_repo_projection_is_in_sync` in the unit suite (D3).

## Receipts

- 14 focused tests pass serially (0.13s), including the
  failure-sensitive set: partial-update prevention, symlink escape
  rejection, marker-pair validation, duplicate-heading rejection.
- Real CLI: `--check` exits 0 on the synchronized tree.
- Live AC-4 probe: a deliberate master edit made the pre-commit
  gate exit 1 naming the stale file; clean tree passes.
- Black + Ruff clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
