### PR TITLE
docs(collaboration): migrate the shared agent core into the contract master

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -81,6 +81,67 @@ See `docs/reference/cli-reference.md`.
 - Record only concrete evidence: commands actually run, their results,
   changed files, unresolved risks, and the next action.
 
+### Critical code rules
+
+- NEVER use `eval()` or `exec()`.
+- ALWAYS validate file paths in file operations; security tests are
+  required for file-op code.
+- NEVER use bare `except:` — catch specific exceptions and log them
+  before handling.
+- Type hints and docstrings on all public APIs; minimum 80% test
+  coverage on changed code.
+- Simpler is better: flatten nested conditionals, inline one-use
+  helpers, prefer stdlib over custom abstractions.
+
+### Git and pre-commit
+
+- Commits are GPG-signed; `git pull` rebases.
+- Pre-commit auto-fix hooks modify staged files mid-commit.
+  Pre-flight the PINNED tools on your files BEFORE `git add`
+  (`uv run --with pre-commit pre-commit run black --files <f>`).
+- After every commit, verify it landed (`git log --oneline -1` +
+  `git status --short`) — hooks can skip a commit with exit 0.
+- If a hook reformats staged files, the fixes land unstaged —
+  `git add` again and retry.
+- A guard blocks commit messages containing literal `eval(` /
+  `exec(` — write the message to a file and `git commit -F <file>`.
+- `--no-verify` is forbidden. To skip ONE misbehaving hook:
+  `SKIP=<hook-id> git commit …`.
+- detect-secrets flags placeholder-looking strings; annotate false
+  positives with `# pragma: allowlist secret`.
+
+### Branch and worktree discipline
+
+- One branch per agent per task. Never commit to a branch another
+  agent has in flight.
+- One PR per feature surface: before opening a PR, check for an
+  existing or parallel PR touching the same files
+  (`gh pr list`, `git log origin/main -- <files>`).
+- Before every commit: `git branch --show-current` — confirm the
+  checkout you edited is on the branch you mean to ship.
+- Don't touch other agents' worktrees under `.claude/worktrees/`.
+
+### Single-source projections
+
+- `plugin/skills/*/SKILL.md` and `.claude/skills/*/SKILL.md` are
+  SOURCES for the tracked `.agents/skills/` mirror — after editing
+  a skill, run `python scripts/sync_agents_skills.py` and commit
+  both sides (a drift-guard test fails CI otherwise).
+- This contract's own projected blocks and
+  `templates/agent-handoff.md` are owned by
+  `scripts/project_collaboration_contract.py` — edit the master,
+  re-run the projector.
+- `.help/` and docs feature pages are projector-owned; edit the
+  source and re-project, never the generated output.
+
+### CI notes
+
+- Per-push/PR workflows run with `ANTHROPIC_API_KEY: ""` (empty,
+  keyless) by design — never wire the real secret into them. To
+  reproduce keyless CI locally use the empty string, not unset.
+- Windows matrix lanes are slow (~13 min) but real — path,
+  subprocess, and encoding changes must wait for them.
+
 <!-- attune:collaboration:end -->
 
 ---

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,9 +2,12 @@
 
 Project instructions for AI coding agents that do not read
 `.claude/` (Codex, etc.). Claude Code loads `.claude/CLAUDE.md`
-instead; the rules below are the shared, agent-agnostic core. If
-you change a rule here, check whether `.claude/CLAUDE.md` needs
-the same change.
+instead. The shared, agent-agnostic core lives in
+`content/collaboration/contract.md` and is projected into the
+marked block below (and into `.claude/CLAUDE.md`) — edit the
+master and re-run `scripts/project_collaboration_contract.py`,
+never the block. Content outside the block is Codex-facing
+orientation only.
 
 ## Overview
 
@@ -85,6 +88,67 @@ attune_redis/          # Redis plugin — bundled in the attune-ai wheel
 - Record only concrete evidence: commands actually run, their results,
   changed files, unresolved risks, and the next action.
 
+### Critical code rules
+
+- NEVER use `eval()` or `exec()`.
+- ALWAYS validate file paths in file operations; security tests are
+  required for file-op code.
+- NEVER use bare `except:` — catch specific exceptions and log them
+  before handling.
+- Type hints and docstrings on all public APIs; minimum 80% test
+  coverage on changed code.
+- Simpler is better: flatten nested conditionals, inline one-use
+  helpers, prefer stdlib over custom abstractions.
+
+### Git and pre-commit
+
+- Commits are GPG-signed; `git pull` rebases.
+- Pre-commit auto-fix hooks modify staged files mid-commit.
+  Pre-flight the PINNED tools on your files BEFORE `git add`
+  (`uv run --with pre-commit pre-commit run black --files <f>`).
+- After every commit, verify it landed (`git log --oneline -1` +
+  `git status --short`) — hooks can skip a commit with exit 0.
+- If a hook reformats staged files, the fixes land unstaged —
+  `git add` again and retry.
+- A guard blocks commit messages containing literal `eval(` /
+  `exec(` — write the message to a file and `git commit -F <file>`.
+- `--no-verify` is forbidden. To skip ONE misbehaving hook:
+  `SKIP=<hook-id> git commit …`.
+- detect-secrets flags placeholder-looking strings; annotate false
+  positives with `# pragma: allowlist secret`.
+
+### Branch and worktree discipline
+
+- One branch per agent per task. Never commit to a branch another
+  agent has in flight.
+- One PR per feature surface: before opening a PR, check for an
+  existing or parallel PR touching the same files
+  (`gh pr list`, `git log origin/main -- <files>`).
+- Before every commit: `git branch --show-current` — confirm the
+  checkout you edited is on the branch you mean to ship.
+- Don't touch other agents' worktrees under `.claude/worktrees/`.
+
+### Single-source projections
+
+- `plugin/skills/*/SKILL.md` and `.claude/skills/*/SKILL.md` are
+  SOURCES for the tracked `.agents/skills/` mirror — after editing
+  a skill, run `python scripts/sync_agents_skills.py` and commit
+  both sides (a drift-guard test fails CI otherwise).
+- This contract's own projected blocks and
+  `templates/agent-handoff.md` are owned by
+  `scripts/project_collaboration_contract.py` — edit the master,
+  re-run the projector.
+- `.help/` and docs feature pages are projector-owned; edit the
+  source and re-project, never the generated output.
+
+### CI notes
+
+- Per-push/PR workflows run with `ANTHROPIC_API_KEY: ""` (empty,
+  keyless) by design — never wire the real secret into them. To
+  reproduce keyless CI locally use the empty string, not unset.
+- Windows matrix lanes are slow (~13 min) but real — path,
+  subprocess, and encoding changes must wait for them.
+
 <!-- attune:collaboration:end -->
 
 ## Commands
@@ -96,69 +160,6 @@ uv run ruff check src/ tests/           # lint
 uv run --with pre-commit pre-commit run black --files <f>  # pinned format
 attune <command>                        # CLI (canonical entry)
 ```
-
-## Critical rules
-
-- NEVER use `eval()` or `exec()`.
-- ALWAYS validate file paths with `_validate_file_path()` in file
-  operations; security tests required for file-op code.
-- NEVER use bare `except:` — catch specific exceptions and log them
-  before handling.
-- Type hints and docstrings required on all public APIs (PEP 8).
-- Minimum 80% test coverage on changed code.
-- Simpler is better: flatten nested conditionals, inline one-use
-  helpers, prefer stdlib over custom abstractions. Three clear
-  lines beat one clever abstraction.
-
-## Git and pre-commit
-
-- Commits are GPG-signed; `git pull` rebases.
-- Pre-commit auto-fix hooks (black, ruff, detect-secrets) modify
-  staged files mid-commit. Pre-flight the PINNED tools on your
-  files BEFORE `git add` (command above) so hooks see clean files.
-- After every `git commit`, verify it landed: `git log --oneline
-  -1` + `git status --short`. Hooks can leave the commit skipped
-  with exit 0 and files re-staged.
-- If a hook reformats staged files, the fixes land UNSTAGED —
-  `git add` again and retry the commit.
-- A PreToolUse/pre-commit guard blocks commit messages containing
-  literal `eval(` / `exec(` — write the message to a file and use
-  `git commit -F <file>`.
-- `--no-verify` is forbidden. To skip ONE misbehaving hook:
-  `SKIP=<hook-id> git commit …` (runs all others).
-- detect-secrets flags placeholder-looking strings; annotate false
-  positives with `# pragma: allowlist secret`.
-
-## Branch and worktree discipline
-
-Multiple agents work this repo in parallel (Claude Code sessions
-use worktrees under `.claude/worktrees/<slug>/`).
-
-- One branch per agent per task. Never commit to a branch another
-  agent has in flight.
-- Before every commit: `git branch --show-current` — confirm the
-  checkout you edited is on the branch you mean to ship.
-- Don't touch other worktrees under `.claude/worktrees/` — they
-  may hold live sessions.
-
-## Single-source projections (don't hand-edit generated files)
-
-- `plugin/skills/*/SKILL.md` is the SOURCE for
-  `.agents/skills/<name>/SKILL.md`. After editing a skill, run
-  `python scripts/sync_agents_skills.py` and commit BOTH sides —
-  a drift-guard test fails CI otherwise.
-- `.help/` and docs feature pages are projector-owned
-  (`status: manual` pages excepted). Don't rewrite generated help
-  content by hand; edit the source and re-project.
-
-## CI notes
-
-- Per-push/PR workflows run with `ANTHROPIC_API_KEY: ""` (empty,
-  keyless) by design — never wire the real secret into them.
-- To reproduce keyless CI locally: `ANTHROPIC_API_KEY="" pytest …`
-  (empty string, not unset — dotenv re-injects unset vars).
-- The Windows matrix lanes are slow (~13 min) but real — path
-  handling, subprocess, and encoding changes must wait for them.
 
 ## Where agent-specific state lives
 

--- a/content/collaboration/contract.md
+++ b/content/collaboration/contract.md
@@ -60,6 +60,67 @@ hand-edit its projected blocks or the handoff template.
 - Record only concrete evidence: commands actually run, their results,
   changed files, unresolved risks, and the next action.
 
+### Critical code rules
+
+- NEVER use `eval()` or `exec()`.
+- ALWAYS validate file paths in file operations; security tests are
+  required for file-op code.
+- NEVER use bare `except:` — catch specific exceptions and log them
+  before handling.
+- Type hints and docstrings on all public APIs; minimum 80% test
+  coverage on changed code.
+- Simpler is better: flatten nested conditionals, inline one-use
+  helpers, prefer stdlib over custom abstractions.
+
+### Git and pre-commit
+
+- Commits are GPG-signed; `git pull` rebases.
+- Pre-commit auto-fix hooks modify staged files mid-commit.
+  Pre-flight the PINNED tools on your files BEFORE `git add`
+  (`uv run --with pre-commit pre-commit run black --files <f>`).
+- After every commit, verify it landed (`git log --oneline -1` +
+  `git status --short`) — hooks can skip a commit with exit 0.
+- If a hook reformats staged files, the fixes land unstaged —
+  `git add` again and retry.
+- A guard blocks commit messages containing literal `eval(` /
+  `exec(` — write the message to a file and `git commit -F <file>`.
+- `--no-verify` is forbidden. To skip ONE misbehaving hook:
+  `SKIP=<hook-id> git commit …`.
+- detect-secrets flags placeholder-looking strings; annotate false
+  positives with `# pragma: allowlist secret`.
+
+### Branch and worktree discipline
+
+- One branch per agent per task. Never commit to a branch another
+  agent has in flight.
+- One PR per feature surface: before opening a PR, check for an
+  existing or parallel PR touching the same files
+  (`gh pr list`, `git log origin/main -- <files>`).
+- Before every commit: `git branch --show-current` — confirm the
+  checkout you edited is on the branch you mean to ship.
+- Don't touch other agents' worktrees under `.claude/worktrees/`.
+
+### Single-source projections
+
+- `plugin/skills/*/SKILL.md` and `.claude/skills/*/SKILL.md` are
+  SOURCES for the tracked `.agents/skills/` mirror — after editing
+  a skill, run `python scripts/sync_agents_skills.py` and commit
+  both sides (a drift-guard test fails CI otherwise).
+- This contract's own projected blocks and
+  `templates/agent-handoff.md` are owned by
+  `scripts/project_collaboration_contract.py` — edit the master,
+  re-run the projector.
+- `.help/` and docs feature pages are projector-owned; edit the
+  source and re-project, never the generated output.
+
+### CI notes
+
+- Per-push/PR workflows run with `ANTHROPIC_API_KEY: ""` (empty,
+  keyless) by design — never wire the real secret into them. To
+  reproduce keyless CI locally use the empty string, not unset.
+- Windows matrix lanes are slow (~13 min) but real — path,
+  subprocess, and encoding changes must wait for them.
+
 ## Portable handoff template
 
 # Agent work handoff


### PR DESCRIPTION
## Summary

Migrates the agent-agnostic shared core out of AGENTS.md's hand-written sections into `content/collaboration/contract.md`, where the projector owns it. The five sections (critical code rules, git/pre-commit dance, branch/worktree discipline, single-source projections, CI notes) now live once and project into both AGENTS.md and .claude/CLAUDE.md. AGENTS.md is reduced to Codex orientation + the projected block; its header directs edits at the master.

**One addition beyond pure migration** (from today's #1434 parallel-PR incident): the discipline section gains *one PR per feature surface — check for a parallel PR before opening*. Strike it if unwanted.

CLAUDE.md keeps its richer hand-written sections by design (option 1, Patrick 2026-07-18): the projected block is the shared floor, CLAUDE.md's sections are the Claude-specific superset.

## Receipts

- Projector `--check` clean; 15 focused tests pass serially
- wiring-audit: no findings
- core-mirror + rules-residency guard tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
