### PR TITLE
test(resilience): platform-tolerant latency bound for Windows timer resolution

### DIFF
--- a/tests/unit/resilience/test_health.py
+++ b/tests/unit/resilience/test_health.py
@@ -215,7 +215,9 @@ class TestHealthCheckClass:
 
         result = await health.run_check("latency_check")
 
-        assert result.latency_ms >= 50
+        # Windows event-loop timers are coarse (~15.6ms), so a 50ms sleep
+        # can measure as low as ~35ms — use a platform-tolerant lower bound.
+        assert result.latency_ms >= 30
 
     @pytest.mark.asyncio
     async def test_run_all_checks(self, health):


### PR DESCRIPTION
## Summary

Fixes the flaky timing assertion that failed the `test (windows-latest, *)` lane on #1439 (run 29649026439) despite being unrelated to that PR's diff.

`TestHealthCheckClass::test_run_check_tracks_latency` registers an async check that does `await asyncio.sleep(0.05)` and asserted `result.latency_ms >= 50`. Windows event-loop timers use a coarse (~15.6ms) clock, so the measured latency can undershoot the sleep duration — the failing run measured 37.1ms.

## Change

- Relax the boundary-exact assertion to `latency_ms >= 30` with a comment naming the Windows timer-resolution slack. The test's intent (latency is tracked and reflects the sleep) is preserved.
- Audited the rest of `tests/unit/resilience/test_health.py` for sibling patterns: the parallel-execution test asserts `elapsed < 1.0` (already generous) and the timeout test has 20x margin (1s sleep vs 0.05s timeout) — no other boundary-exact wall-clock assertions.

## Verification

`uv run python -m pytest tests/unit/resilience/test_health.py -q` — 36 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
