### PR TITLE
feat(collaboration): Antigravity contract adapter (ratified) + provider-adapter specs

### DIFF
--- a/.agents/rules/collaboration-contract.md
+++ b/.agents/rules/collaboration-contract.md
@@ -1,0 +1,9 @@
+---
+trigger: always_on
+---
+
+The cross-provider collaboration contract for this repository applies
+to every agent session. Its full current text follows from the
+referenced file and is part of your operating instructions:
+
+@../../AGENTS.md

--- a/docs/specs/antigravity-adapter/decisions.md
+++ b/docs/specs/antigravity-adapter/decisions.md
@@ -1,0 +1,105 @@
+# Antigravity Adapter — Decisions
+
+## D1 — contract delivery: RATIFIED (a) — 2026-07-18, Patrick
+
+Live receipts, 2026-07-18, Antigravity app 2.3.1 + `agy` CLI 1.1.4
+(`~/.local/bin/agy`; authenticated silently with no browser flow — the OS-keyring path; the exact token source was not verified).
+All runs: `agy --add-dir <workspace> -p "<prompt>" --mode plan` from
+the workspace root. Every probe instructed "without using any tools;
+if not in loaded context reply NOT IN CONTEXT" so answers could only
+come from loaded context.
+
+### AC-1 — skills discovery: PASS (41/41)
+
+- Bare `agy -p` had NO workspace ("no active workspace set") and
+  listed only Antigravity's 10 built-in skills — `--add-dir` (or a
+  real project/IDE workspace) is REQUIRED for workspace skills.
+- With the workspace bound, the agent listed 40 of the repo's 41
+  `.agents/skills/` mirrors by name (attune-hub, spec,
+  security-audit, ...). Zero-work claim holds.
+- `verify` was absent from the first enumeration but a direct
+  probe ("is a workspace skill named 'verify' available?")
+  returned yes with its exact description — the omission was
+  single-run LLM listing slippage, not a discovery gap. Lesson
+  for receipt design: enumeration answers are lossy; probe
+  specific names when a count matters.
+
+### AC-2 — contract via rules: PASS, with two doc-vs-tool corrections
+
+1. **Control (no rule file): NOT IN CONTEXT** — Antigravity does
+   NOT natively read `AGENTS.md`. An adapter is required; the
+   spec's premise holds.
+2. **A bare markdown rule in `.agents/rules/` does NOT load.**
+   Sentinel token in the rule body → NOT IN CONTEXT. The docs'
+   Rules page never mentions file frontmatter (activation is "set
+   at the rule level" in the UI), but the file needs
+   `---\ntrigger: always_on\n---` frontmatter — with it, the
+   sentinel is returned. UNDOCUMENTED, verified against the tool.
+3. **`@/AGENTS.md` (docs' absolute-then-workspace form) did NOT
+   inline** — contract questions stayed NOT IN CONTEXT while the
+   sentinel in the same rule body succeeded. The RULES-FILE-
+   RELATIVE form `@../../AGENTS.md` DOES inline: the agent then
+   named the four artifact tiers (inline edit / structured
+   one-shot / XML task / spec) and quoted the Session protocol
+   bullet verbatim.
+4. **Fidelity bonus receipt**: the workspace was a worktree at
+   pre-#1439 base `ced32cd7e`, whose AGENTS.md predates the
+   preflight bullet — and the agent answered exactly that item
+   NOT IN CONTEXT while quoting the bullets that DO exist in that
+   file revision. The @-reference serves the live file content,
+   not cached or hallucinated text.
+
+### Resulting adapter (staged at `.agents/rules/collaboration-contract.md`)
+
+```markdown
+---
+trigger: always_on
+---
+
+The cross-provider collaboration contract for this repository applies
+to every agent session. Its full current text follows from the
+referenced file and is part of your operating instructions:
+
+@../../AGENTS.md
+```
+
+**RATIFIED (a)** (2026-07-18, Patrick, after receipts) — one 9-line tracked file, no
+new projection target, drift-free by construction (the reference
+inlines whatever the projector last wrote to AGENTS.md). Risks to
+carry into design: the `trigger:` frontmatter and the relative-path
+resolution are behaviors verified on agy 1.1.4 / app 2.3.1, not
+documented — pin both in a receipt-style test note and re-verify on
+CLI updates (the binary self-updates in the background).
+
+### D1b — adapter @-target: AGENTS.md, deliberately (reviewed)
+
+Considered referencing the provider-neutral master
+(`content/collaboration/contract.md`) instead. Kept `AGENTS.md`:
+its 1,902 chars outside the contract markers are generic repo
+orientation (Overview, Commands, agent-state locations) that
+benefits any agent, and the projector rewrites AGENTS.md on every
+contract change, so drift-freedom is identical. Revisit only if
+AGENTS.md accretes truly Codex-specific instructions.
+
+### Post-ff fidelity receipt (before/after pair)
+
+After fast-forwarding the worktree to current main (f3ecedc91,
+post-#1439), the previously-NOT IN CONTEXT probe now returns the
+preflight bullet verbatim: "python scripts/collaboration_preflight.py
+… read-only, uses cached Git refs, does not fetch, pull, switch
+branches, invoke uv, or create an environment," citing AGENTS.md.
+Same adapter, same probe, different file revision — the reference
+tracks the live projected content.
+
+## D2 — `.agents/` tracking: rules file joins the tracked adapter set
+
+`.agents/` is already tracked (skills mirror). The one rule file is
+hand-owned (like `.gemini/settings.json` in the sibling spec). No
+`.gitignore` change needed for Antigravity itself; decide separately
+if local Antigravity state dirs appear.
+
+## D3 — surface parity: CLI verified; IDE pending
+
+All receipts above are CLI (`agy` 1.1.4). The IDE (app 2.3.1)
+presumably shares the rules engine; verify once in the IDE before
+closing D3 (open the workspace, ask the same two questions).

--- a/docs/specs/antigravity-adapter/requirements.md
+++ b/docs/specs/antigravity-adapter/requirements.md
@@ -1,0 +1,119 @@
+# Antigravity Adapter — Requirements
+
+**Status: D1 RATIFIED (a)** — receipts passed and Patrick
+ratified option (a) same day (2026-07-18,
+app 2.3.1 + agy CLI 1.1.4; transcripts in
+[decisions.md](decisions.md)); D2 largely
+resolved by the receipts; D3 (IDE parity) still open. Two
+mechanisms differ from the live docs — rules need
+`trigger: always_on` frontmatter and only rules-file-relative
+`@`-paths inline — exactly the schema-drift class the
+gemini-projector spec predicted.
+
+Sibling of [gemini-projector](../gemini-projector/requirements.md)
+(PARKED 2026-07-18 — Google sunset the Gemini CLI free tier in
+favor of Antigravity; this spec is the surviving Google-surface
+adapter).
+
+## The headline finding (verified from live docs, not memory)
+
+**The repo already speaks half of Antigravity's convention.**
+Antigravity discovers workspace skills from
+`<workspace-root>/.agents/skills/<skill>/SKILL.md` (agentskills.io
+open standard) — exactly the tracked mirror this repo has shipped
+for months via `scripts/sync_agents_skills.py` (41 skills today).
+Skills integration is expected to be ZERO new work; AC-1 just
+proves it.
+
+Remaining surface is the collaboration CONTRACT, via Antigravity's
+workspace rules: markdown files in `.agents/rules/` at the git
+root (backward-compat `.agent/rules`), ≤12,000 chars each, with
+per-rule activation (Manual / Always On / Model Decision / Glob).
+Rules support `@filename` references to other files. Global rules
+live in `~/.gemini/GEMINI.md` — shared with Gemini CLI, user-owned,
+out of repo scope.
+
+## Design fork
+
+- **D1 — contract delivery into `.agents/rules/`.**
+  - **(a) Reference adapter (recommended if @-inlining verifies):**
+    a tiny tracked `.agents/rules/collaboration-contract.md`
+    (`trigger: always_on` frontmatter) whose body is essentially
+    `@../../AGENTS.md` plus one framing line (the path is
+    rules-file-relative; the docs' `@/AGENTS.md` form does not
+    inline — verified). No duplicated contract text, no new projection
+    target; drift-free by construction. Gated on verifying that
+    `@` references actually inline the target file's content into
+    agent context (AC-2), and on how activation mode is declared
+    in-file (frontmatter format is undocumented on the page —
+    inspect a UI-created rule file after install).
+  - **(b) Fourth projection target:** add
+    `.agents/rules/collaboration-contract.md` to the projector's
+    `CONTRACT_TARGETS` with the standard marker pair. The
+    projected block is 5,662 chars today — fits the 12,000-char
+    rule limit with ~50% headroom, but add a projector-side size
+    guard so growth past the limit fails `--check` loudly instead
+    of being silently truncated by the consumer.
+  - Pick (a) if AC-2 passes; (b) is the sturdy fallback and stays
+    mechanically drift-guarded either way.
+
+- **D2 — `.agents/rules/` tracked-vs-generated status.** `.agents/`
+  is already tracked (skills mirror). If D1=(a) the rule file is a
+  small hand-owned adapter (tracked, hand-edited, like
+  `.gemini/settings.json` in the sibling spec). If D1=(b) it is
+  projector-owned like AGENTS.md — never hand-edited, drift-gated.
+
+- **D3 — surface parity.** The Customizations docs sit under the
+  "Antigravity 2.0" platform section; verify with the installed
+  tool whether the CLI and IDE both honor workspace
+  `.agents/rules/` (expected) and whether rule activation
+  defaults differ between them.
+
+## Requirements
+
+- **R1** The shared contract reaches Antigravity agent context
+  mechanically (mechanism per D1); no hand-copied contract text.
+- **R2** The existing `.agents/skills/` mirror is consumed as-is —
+  no Antigravity-specific skill duplication. If Antigravity needs
+  frontmatter beyond the agentskills.io fields the mirror already
+  emits, extend `sync_agents_skills.py`, never hand-edit mirrors.
+- **R3** If D1=(b): the new target joins the projector's
+  preflight-all-then-write, `--check`, and test discipline, plus
+  the size guard (rule-limit headroom asserted in tests).
+- **R4** `collaboration_preflight.py` gains the D2-consistent
+  check; silent when Antigravity absent. Everything works with
+  Antigravity not installed (CI has no Antigravity).
+- **R5** Antigravity sessions follow the same branch/worktree
+  discipline; note its native "New Worktree Mode" in the adapter
+  docs as the preferred mode for this repo.
+- **R6** Global-level config (`~/.gemini/GEMINI.md`,
+  `~/.gemini/config/skills/`) stays user-owned and out of scope.
+
+## Acceptance criteria (failure-sensitive)
+
+- **AC-1 (skills, zero-work claim)** With the repo opened as an
+  Antigravity workspace, the agent's skill discovery lists the
+  mirrored skills (spot-check 3 by name, e.g. `attune-hub`,
+  `spec`, `security`). Fails → R2's extension path activates.
+- **AC-2 (gates D1)** A scratch `.agents/rules/` rule containing
+  an `@` reference demonstrably lands the referenced file's
+  CONTENT in agent context (agent quotes contract specifics it
+  was never shown directly). Record transcript in decisions.md.
+- **AC-3** If D1=(b): master edit without re-projection →
+  `--check` exits 1 naming the rules target; size guard fails
+  when the rendered block exceeds a safety threshold (e.g.
+  10,000 chars) below Antigravity's 12,000 limit.
+- **AC-4** Preflight + both projector checks exit 0 on a clean
+  tree with the adapter landed (real commands, not mocks).
+- **AC-5** Full keyless suite green on all OS lanes (Windows
+  receipts load-bearing for this script family — see #1439's
+  `as_posix()` lesson).
+
+## Out of scope
+
+- Antigravity plugins/hooks/sidecars/subagents integration
+  (separate evaluation; `attune-ai` is a Claude Code plugin — an
+  Antigravity plugin port is a product decision, not contract
+  plumbing).
+- Migrating any workflow off Claude Code / Codex / Gemini CLI.
+- The Antigravity SDK and 2.0 agent-manager surfaces.

--- a/docs/specs/gemini-projector/decisions.md
+++ b/docs/specs/gemini-projector/decisions.md
@@ -1,0 +1,70 @@
+# Gemini Projector Integration — Decisions
+
+## D1 — adapter shape (OPEN, receipt pending)
+
+**Candidate (a), config-only adapter, staged for the live test.**
+
+Verified against the installed CLI, not docs-from-memory
+(2026-07-18, `@google/gemini-cli` 0.51.0 via npm):
+
+- The legacy flat `contextFileName` settings key is STALE for this
+  version. The bundle reads `settings.context?.fileName` — the v2
+  nested schema. An adapter written from older docs
+  (`{"contextFileName": ...}`) would silently no-op.
+- Candidate adapter (now preserved as `settings.json.artifact`):
+  `{"context": {"fileName": ["GEMINI.md", "AGENTS.md"]}}` —
+  `GEMINI.md` kept first so a future native context file still
+  loads; `AGENTS.md` carries the projected contract block.
+
+### AC-1 experiment protocol (runs after one-time Google auth)
+
+1. **Control** — in a checkout WITHOUT `.gemini/settings.json`:
+   `gemini -p "According to your loaded project context, what
+   script must be run before non-trivial work, and what are the
+   four artifact tiers?"`
+   Expected: cannot answer from context (no GEMINI.md exists;
+   AGENTS.md not loaded by default).
+2. **Test** — same prompt in this worktree WITH the staged
+   settings. Expected: quotes `scripts/collaboration_preflight.py`
+   and the inline-edit / structured-one-shot / XML-task / spec
+   tiers from AGENTS.md's projected contract block.
+3. Paste both transcript excerpts below; ratify (a) on pass,
+   fall back to (b) on fail.
+
+### Receipt: BLOCKED BY PRODUCT SUNSET (2026-07-18)
+
+The free-tier OAuth path no longer exists. With valid shared
+credentials in `~/.gemini/` (from the Antigravity sign-in),
+`gemini -p` (CLI 0.51.0) fails hard:
+
+```
+IneligibleTierError: This client is no longer supported for
+Gemini Code Assist for individuals. To continue using Gemini,
+please migrate to the Antigravity suite of products:
+https://antigravity.google
+```
+
+Google has retired the standalone Gemini CLI's individual free
+tier in favor of Antigravity. Remaining paths for THIS spec:
+(a) GEMINI_API_KEY auth from AI Studio (API-quota billing;
+changes the premise from "free ambient CLI" to "keyed tool"), or
+(b) PARK this spec as superseded — the Antigravity adapter
+(../antigravity-adapter/, D1 RATIFIED, receipts green) already
+delivers the contract to Google's agent surface, and Antigravity
+shares `~/.gemini/GEMINI.md` for global rules.
+
+**RATIFIED (b) — parked as superseded (2026-07-18, Patrick).** The staged
+`.gemini/settings.json` adapter is kept in the spec dir as an
+artifact of record; do not track it at repo root unless (a) is
+chosen later.
+
+## D2 — `.gemini/` tracked-vs-ignored (OPEN)
+
+Depends on D1. If (a): proposed `.gitignore` entries
+`.gemini/*` + `!.gemini/settings.json`. If (b): `.gemini/`
+wholesale like `.codex/` (line 267).
+
+## D3 — preflight coverage (OPEN)
+
+Depends on D2. Extend `scripts/collaboration_preflight.py` with the
+D2-consistent ignore/tracked check; silent when Gemini absent.

--- a/docs/specs/gemini-projector/requirements.md
+++ b/docs/specs/gemini-projector/requirements.md
@@ -1,0 +1,126 @@
+# Gemini Projector Integration — Requirements
+
+**Status: PARKED — SUPERSEDED (ratified 2026-07-18, Patrick)** by
+[../antigravity-adapter/](../antigravity-adapter/requirements.md).
+Google retired the Gemini CLI's free individual tier the same day
+this spec was drafted (`IneligibleTierError` → "migrate to the
+Antigravity suite"); the Antigravity adapter (D1 RATIFIED,
+receipts green) now delivers the contract to Google's agent
+surface. Revive only if a keyed (GEMINI_API_KEY) Gemini CLI
+becomes worth the billing premise — see decisions.md. The
+candidate adapter is preserved at
+[settings.json.artifact](settings.json.artifact). Written against
+the projector as merged in #1439 (`dbfd8bb58`); re-verify claims
+about Gemini CLI behavior against the installed CLI before
+ratifying (the D1 fork turns entirely on a live receipt).
+
+## Problem
+
+The collaboration contract master
+(`content/collaboration/contract.md`) projects into the two current
+provider surfaces — `AGENTS.md` (Codex) and `.claude/CLAUDE.md`
+(Claude) — via `scripts/project_collaboration_contract.py`, with a
+`--check` drift gate and marker-delimited blocks. Gemini CLI loads
+neither file: its context surface is `GEMINI.md` (hierarchical:
+global `~/.gemini/GEMINI.md`, repo root, subdirectories), with
+workspace config in `.gemini/settings.json`. Adding Gemini as a
+third collaborating agent without a mechanical projection re-creates
+exactly the hand-copy drift the projector was built to kill.
+
+## Design fork (decide before any implementation)
+
+- **D1 — adapter shape.** Two candidate mechanisms:
+  - **(a) Config-only adapter (recommended if verified):** track a
+    minimal `.gemini/settings.json` that sets `contextFileName` to
+    include `AGENTS.md`, so Gemini reads the *existing* projected
+    surface. Zero new projection targets, zero new drift surface;
+    the projector is untouched. Requires a live receipt that the
+    installed Gemini CLI honors the setting from a workspace
+    `.gemini/settings.json` and loads repo-root `AGENTS.md` (AC-1).
+    Fits "simpler is better" and the contract's "provider-specific
+    setup stays in adapters" rule.
+  - **(b) Third projection target:** add `GEMINI.md` to
+    `CONTRACT_TARGETS` with the standard marker pair. Mechanical,
+    symmetric with the existing targets, but adds a tracked file
+    whose non-projected remainder needs an owner and content plan.
+  - Pick (a) unless the live receipt fails; fall back to (b).
+
+- **D2 — `.gemini/` tracked-vs-ignored split.** `.gitignore` line
+  267 ignores `.codex/` wholesale; `.gemini/` has no entry today.
+  Unlike `.codex/`, option (a) requires *one tracked file inside*
+  `.gemini/` (`settings.json`). Proposed: ignore `.gemini/*` except
+  `settings.json` (negation pattern), keeping caches/session state
+  out while versioning the adapter. If (b) wins D1, ignore
+  `.gemini/` wholesale like `.codex/`.
+
+- **D3 — preflight coverage.** `scripts/collaboration_preflight.py`
+  checks `.codex/` is ignored (`codex-ignore`). Extend with the
+  D2-consistent check: (a) `.gemini/settings.json` tracked + rest
+  ignored; (b) `.gemini/` ignored wholesale. Also decide whether a
+  missing-Gemini environment stays silent (Gemini not installed is
+  the common case; the contract must keep working when only one
+  provider is available).
+
+## Requirements
+
+- **R1** The shared contract reaches Gemini's loaded context
+  mechanically — no hand-copied contract text on any
+  Gemini-read surface. (Mechanism per D1.)
+- **R2** Provider-specific setup lives in the adapter
+  (`.gemini/settings.json` or the `GEMINI.md` non-projected
+  remainder), never in the contract master. The master stays
+  provider-neutral.
+- **R3** If D1=(b): `GEMINI.md` joins the projector's preflight-
+  all-targets-then-write discipline, `--check` names it on drift,
+  and the marker/notice conventions match the existing targets
+  byte-for-byte. Existing projector tests extend to the third
+  target (drift, malformed markers, symlink rejection, partial-
+  write containment).
+- **R4** The `.gitignore` and preflight changes land per D2/D3 in
+  the same PR as the adapter, with the preflight's read-only
+  receipt still passing.
+- **R5** Everything works with zero Gemini installed: no test,
+  hook, or preflight check may require the Gemini CLI. Live-CLI
+  receipts are recorded in this spec's decisions.md, not asserted
+  in CI.
+- **R6** A Gemini session follows the same branch/worktree
+  discipline as Codex/Claude (one branch per agent per task,
+  handoffs from `templates/agent-handoff.md`). If Gemini's tooling
+  can't create worktrees, document the constraint in the adapter,
+  don't weaken the contract.
+
+## Acceptance criteria (failure-sensitive)
+
+- **AC-1 (gates D1)** Live receipt: in a scratch worktree with the
+  candidate `.gemini/settings.json`, an actual Gemini CLI session
+  demonstrably loads the contract (e.g. it can quote the session
+  protocol from `AGENTS.md` without being shown the file). A
+  transcript excerpt goes in decisions.md. If this fails, D1=(b).
+- **AC-2** With the adapter landed, `python
+  scripts/project_collaboration_contract.py --check` and `python
+  scripts/collaboration_preflight.py` both exit 0 on a clean tree —
+  run as commands, not unit-mocked.
+- **AC-3** If D1=(b): editing the master without re-projecting
+  makes `--check` exit 1 naming `GEMINI.md`; the drift-gate test
+  suite covers it.
+- **AC-4** `git check-ignore` receipts match D2 exactly (probe
+  both a `.gemini/` scratch file AND `.gemini/settings.json`).
+- **AC-5** Full keyless test suite green on all OS lanes — the
+  projector's path-output lesson (#1439's `as_posix()` fix) says
+  Windows receipts are load-bearing for this script family.
+
+## Out of scope
+
+- Projecting into Gemini's *global* `~/.gemini/GEMINI.md` (user-
+  level config is the user's, not the repo's).
+- Any Gemini API/SDK integration in `src/attune` (this spec is
+  collaboration-contract plumbing only).
+- Retrofitting `.codex/` to the D2 negation pattern.
+- **Google Antigravity** — promoted to its own sibling spec the
+  same day (see
+  [../antigravity-adapter/requirements.md](../antigravity-adapter/requirements.md));
+  deferred here because it is a separate product from Gemini CLI
+  with its own context-loading mechanism (workspace rules in
+  `.agents/rules/`, skills from `.agents/skills/` — see the
+  sibling spec), and folding it in would double the verification
+  surface before this spec's D1 is ratified.

--- a/docs/specs/gemini-projector/settings.json.artifact
+++ b/docs/specs/gemini-projector/settings.json.artifact
@@ -1,0 +1,5 @@
+{
+  "context": {
+    "fileName": ["GEMINI.md", "AGENTS.md"]
+  }
+}


### PR DESCRIPTION
## What landed

- **`.agents/rules/collaboration-contract.md`** — the entire Antigravity adapter: a 9-line `trigger: always_on` rule inlining `AGENTS.md` via a rules-file-relative `@`-reference. Drift-free by construction (the reference serves whatever the projector last wrote). **D1 RATIFIED (a)**, 2026-07-18.
- **`docs/specs/antigravity-adapter/`** — requirements + decisions with full live receipts (agy CLI 1.1.4 / app 2.3.1): 41/41 workspace skills discovered natively from the existing `.agents/skills/` mirror; control run proving `AGENTS.md` is not loaded without the rule; the before/after fidelity pair (pre-#1439 revision honestly `NOT IN CONTEXT` → post-ff verbatim quote of the preflight bullet).
- **`docs/specs/gemini-projector/`** — PARKED as superseded: Google sunset the Gemini CLI individual free tier (`IneligibleTierError` → "migrate to the Antigravity suite") the same day the spec was drafted. Sunset evidence recorded; candidate `.gemini/settings.json` preserved as an artifact of record.

## Verified-undocumented behaviors (pinned as re-verify risks)

- Rules in `.agents/rules/` require `trigger: always_on` YAML frontmatter (docs never mention frontmatter).
- The docs' `@/path` form does not inline; rules-file-relative `@../../AGENTS.md` does.
- `agy` binds no workspace in bare `-p` mode — `--add-dir` required.

The `agy` binary self-updates in the background; both behaviors get re-verified on version change before trusting the adapter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)