### PR TITLE
fix(collaboration): mirror AGENTS.md into .agents/ for the Antigravity IDE (D3)

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -1,0 +1,177 @@
+# AGENTS.md — Attune AI
+
+Project instructions for AI coding agents that do not read
+`.claude/` (Codex, etc.). Claude Code loads `.claude/CLAUDE.md`
+instead. The shared, agent-agnostic core lives in
+`content/collaboration/contract.md` and is projected into the
+marked block below (and into `.claude/CLAUDE.md`) — edit the
+master and re-run `scripts/project_collaboration_contract.py`,
+never the block. Content outside the block is Codex-facing
+orientation only.
+
+## Overview
+
+Attune AI — AI-powered developer workflows with cost optimization
+and multi-agent orchestration. Python 3.10+, published on PyPI as
+`attune-ai`. Stack: pydantic, anthropic SDK / claude-agent-sdk,
+structlog, rich, typer.
+
+```text
+src/attune/
+├── agents/            # Release agents, state persistence, recovery
+├── workflows/         # AI-powered workflows (all SDK-native)
+├── models/            # Auth strategy and LLM providers
+├── meta_workflows/    # Intent detection, NL routing
+├── orchestration/     # Dynamic teams, workflow composition
+├── plugins/           # BasePlugin + register_mcp_tools() hook
+├── telemetry/         # FeedbackLoop, UsageTracker
+└── cli_router.py      # NL command routing
+attune_redis/          # Redis plugin — bundled in the attune-ai wheel
+```
+
+<!-- attune:collaboration:start -->
+
+<!-- generated from content/collaboration/contract.md - edit the master, then run scripts/project_collaboration_contract.py -->
+
+## Cross-provider collaboration
+
+### Shared truth
+
+- Treat the current worktree, Git state, and relevant test results as
+  authoritative. Do not rely on hidden chat context for a handoff.
+- Preserve unrelated working-tree changes and do not touch another
+  agent's worktree.
+- Discover capabilities from the available tools, MCP server, and
+  tracked skills; do not rely on hard-coded capability counts.
+
+### Session protocol
+
+- Before non-trivial work, run
+  `python scripts/collaboration_preflight.py`. It is read-only, uses
+  cached Git refs, and does not fetch, pull, switch branches, invoke
+  `uv`, or create an environment.
+- State the goal, acceptance criteria, assumptions, and intended
+  verification before non-trivial implementation.
+- Prefer existing repository conventions and public interfaces before
+  adding a parallel mechanism.
+- Keep provider-specific setup in adapters. The shared contract must
+  still work when only one provider is available.
+
+### Artifact selection
+
+- Match the artifact to the work before non-trivial implementation and
+  name the selected tier in the session contract:
+  - **Inline edit** — trivial, one file, no ambiguity.
+  - **Structured one-shot** — single-session work framed by a goal,
+    constraints, and acceptance criteria.
+  - **XML task** — dependent work across three or more files, or work
+    that must be executable as a cold handoff.
+  - **Spec** — multi-session or multi-PR work, design ambiguity, or an
+    irreversible choice.
+- Escalate the artifact tier when ambiguity or dependencies grow; do
+  not add ceremony to work that still fits a smaller tier.
+
+### Verification receipts
+
+- Before implementation, name the claim and a probe that would fail if
+  the claim were false. Report the probe actually run and its result.
+- Treat unit tests as evidence only inside their tested boundaries.
+  Hooks, persistence, networking, packaging, and other external seams
+  require a non-mocked round trip through the real boundary.
+- “Configured,” “registered,” and “exited successfully” are not
+  working receipts. Prefer evidence of the user-visible behavior.
+
+### Handoffs
+
+- For multi-step work, create or update a portable handoff from
+  `templates/agent-handoff.md` at `docs/handoffs/<branch-slug>.md`
+  (slug = branch name with `/` replaced by `-`), tracked on the
+  branch. Delete the file when the branch merges.
+- A receiving agent verifies the handoff against the current Git state
+  and tests before continuing; a handoff is context, not authority.
+- Record only concrete evidence: commands actually run, their results,
+  changed files, unresolved risks, and the next action.
+
+### Critical code rules
+
+- NEVER use `eval()` or `exec()`.
+- ALWAYS validate file paths in file operations; security tests are
+  required for file-op code.
+- NEVER use bare `except:` — catch specific exceptions and log them
+  before handling.
+- Type hints and docstrings on all public APIs; minimum 80% test
+  coverage on changed code.
+- Simpler is better: flatten nested conditionals, inline one-use
+  helpers, prefer stdlib over custom abstractions.
+
+### Git and pre-commit
+
+- Commits are GPG-signed; `git pull` rebases.
+- Pre-commit auto-fix hooks modify staged files mid-commit.
+  Pre-flight the PINNED tools on your files BEFORE `git add`
+  (`uv run --with pre-commit pre-commit run black --files <f>`).
+- After every commit, verify it landed (`git log --oneline -1` +
+  `git status --short`) — hooks can skip a commit with exit 0.
+- If a hook reformats staged files, the fixes land unstaged —
+  `git add` again and retry.
+- A guard blocks commit messages containing literal `eval(` /
+  `exec(` — write the message to a file and `git commit -F <file>`.
+- `--no-verify` is forbidden. To skip ONE misbehaving hook:
+  `SKIP=<hook-id> git commit …`.
+- detect-secrets flags placeholder-looking strings; annotate false
+  positives with `# pragma: allowlist secret`.
+
+### Branch and worktree discipline
+
+- One branch per agent per task. Never commit to a branch another
+  agent has in flight.
+- Before updating `main`, inspect its existing checkout. Pull only when
+  that checkout is on `main` and clean; otherwise fetch `origin/main`
+  separately and leave the current task worktree untouched.
+- One PR per feature surface: before opening a PR, check for an
+  existing or parallel PR touching the same files
+  (`gh pr list`, `git log origin/main -- <files>`).
+- Before every commit: `git branch --show-current` — confirm the
+  checkout you edited is on the branch you mean to ship.
+- Don't touch other agents' worktrees under `.claude/worktrees/`.
+
+### Single-source projections
+
+- `plugin/skills/*/SKILL.md` and `.claude/skills/*/SKILL.md` are
+  SOURCES for the tracked `.agents/skills/` mirror — after editing
+  a skill, run `python scripts/sync_agents_skills.py --write` and commit
+  both sides (a drift-guard test fails CI otherwise).
+- This contract's own projected blocks and
+  `templates/agent-handoff.md` are owned by
+  `scripts/project_collaboration_contract.py` — edit the master,
+  re-run the projector.
+- `.help/` and docs feature pages are projector-owned; edit the
+  source and re-project, never the generated output.
+
+### CI notes
+
+- Per-push/PR workflows run with `ANTHROPIC_API_KEY: ""` (empty,
+  keyless) by design — never wire the real secret into them. To
+  reproduce keyless CI locally use the empty string, not unset.
+- Windows matrix lanes are slow (~13 min) but real — path,
+  subprocess, and encoding changes must wait for them.
+
+<!-- attune:collaboration:end -->
+
+## Commands
+
+```bash
+uv sync --extra dev --extra developer   # environment
+uv run pytest tests/unit -q             # unit tests (fast lanes)
+uv run ruff check src/ tests/           # lint
+uv run --with pre-commit pre-commit run black --files <f>  # pinned format
+attune <command>                        # CLI (canonical entry)
+```
+
+## Where agent-specific state lives
+
+- `.claude/` — Claude Code's rules, lessons corpus, skills,
+  worktrees. Not loaded by other agents; don't edit ad hoc.
+- `.codex/` — Codex local config (gitignored).
+- `AGENTS.md` (this file) — tracked, shared rules for non-Claude
+  agents.

--- a/.claude/lessons.md
+++ b/.claude/lessons.md
@@ -16131,3 +16131,32 @@ def ", start_idx + 1)` for module-
   Diagnostic order for "is app X installed": lsregister dump
   FIRST when the cheap checks disagree with the user — the user
   is usually right about their own machine.
+
+- **Antigravity IDE vs CLI diverge on rules mechanics — the IDE
+  does NOT expand @-references, and AGENTS.md loads natively ONLY
+  from the workspace customization root `.agents/`**: 2026-07-18,
+  D3 parity check (app 2.3.1 vs agy CLI 1.1.4; receipts in
+  docs/specs/antigravity-adapter/decisions.md). The ratified
+  adapter (rule file inlining `@../../AGENTS.md`) passed all CLI
+  receipts but the IDE returned NOT IN CONTEXT for the contract.
+  The three-part discriminating probe (rule-body sentinel /
+  literal @-text / referenced-content item) localized it in one
+  round: sentinel present, `@../../AGENTS.md` quoted back as
+  LITERAL text, content absent — rule discovery+activation are
+  shared between surfaces, @-expansion is CLI-only. Asking the
+  IDE to enumerate its "customization roots" (its own system text
+  mentions them) yielded the fix: global `~/.gemini/config`,
+  workspace `.agents/` — so repo-root AGENTS.md is invisible to
+  the IDE but `.agents/AGENTS.md` loads natively. Fix shipped
+  (#1445): the contract projector emits `.agents/AGENTS.md` as a
+  byte-copy fourth target (created-if-missing, `--check`
+  drift-guarded; NOT a symlink — Windows checkouts + the
+  projector rejects symlinked targets). Durable rules: (1) never
+  extrapolate a receipt across provider surfaces that "presumably
+  share the engine" — agy and the IDE shipped different @-support
+  in the same product family; (2) when a context probe fails,
+  ladder it: body-sentinel → literal-reference-text →
+  referenced-content — one probe splits loads-at-all from
+  inlines-references; (3) an agent's own system text often names
+  its config surface (here "customization roots") — asking the
+  tool to enumerate them beats guessing paths from docs.

--- a/docs/specs/antigravity-adapter/decisions.md
+++ b/docs/specs/antigravity-adapter/decisions.md
@@ -98,8 +98,61 @@ hand-owned (like `.gemini/settings.json` in the sibling spec). No
 `.gitignore` change needed for Antigravity itself; decide separately
 if local Antigravity state dirs appear.
 
-## D3 — surface parity: CLI verified; IDE pending
+## D3 — surface parity: FAIL — IDE loads the rule but does NOT inline @-references
 
-All receipts above are CLI (`agy` 1.1.4). The IDE (app 2.3.1)
-presumably shares the rules engine; verify once in the IDE before
-closing D3 (open the workspace, ask the same two questions).
+Live receipt, 2026-07-18, Antigravity IDE (app 2.3.1), workspace
+`~/attune-ai` on `main` at `1e1889b59` (clean tree, adapter and
+contract verified present before the probe). Patrick ran the
+probes in the IDE agent panel; scored against that revision.
+
+1. **Contract probe (same as CLI AC-2): NOT IN CONTEXT.** The
+   preflight script and artifact tiers — verbatim-quotable in the
+   CLI receipts — did not load.
+2. **Discriminating three-part probe localized the break:**
+   - Rule BODY loads: the sentinel phrase "cross-provider
+     collaboration contract for this repository" was quoted back.
+     (So file discovery + activation work in the IDE too.)
+   - The `@../../AGENTS.md` reference was quoted back as LITERAL
+     TEXT — the IDE serves it un-expanded.
+   - `collaboration_preflight.py` (content that exists only in the
+     referenced AGENTS.md): NOT IN CONTEXT.
+
+Diagnosis: the CLI (`agy` 1.1.4) expands rules-file-relative
+@-references; the IDE (app 2.3.1) does not expand @-references at
+all. The adapter's zero-drift trick is CLI-only. Same family as
+the CLI's own `@/AGENTS.md` silent no-op (AC-2 item 3): @-form
+support is fragile and surface-specific across this product.
+
+Lead for the fix: the IDE's own loaded instructions contain
+"Append rules to the `AGENTS.md` file in one of the customization
+roots, depending on scope" — the IDE may support AGENTS.md
+NATIVELY from specific roots (workspace root evidently not among
+them, or not auto-loaded, since item 3 failed). Next probe: ask
+the IDE to enumerate its customization roots.
+
+Fix options:
+
+- (a) Probe the customization roots; if one is repo-reachable and
+  tracked, AGENTS.md lands there natively and the rule file stays
+  as-is for the CLI.
+- (b) Make the projector write the full contract block INTO
+  `.agents/rules/collaboration-contract.md` (new projection
+  target). Guaranteed on both surfaces; costs the by-construction
+  drift-freedom, regains it via the projector's `--check` gate.
+  Keep the @-reference line too — harmless where unsupported.
+
+### Customization-roots receipt → fix (a) selected (2026-07-18)
+
+IDE enumeration probe (quoting its loaded context): global root
+`/Users/patrickroebuck/.gemini/config`; workspace root `.agents`
+(relative to the workspace root). So `.agents/` IS the workspace
+customization root — which retro-explains the whole D3 result:
+the rule file loaded because it lives under `.agents/`, and
+repo-root `AGENTS.md` never loaded because it sits OUTSIDE the
+root and the @-bridge doesn't expand in the IDE.
+
+Fix (a): project `.agents/AGENTS.md` as a new fully-generated
+projector target (byte-copy of root `AGENTS.md`), so the IDE
+loads the contract natively from its customization root. Not a
+symlink — Windows checkouts. Rule file stays for the CLI.
+Re-probe in the IDE after landing to close D3.

--- a/scripts/project_collaboration_contract.py
+++ b/scripts/project_collaboration_contract.py
@@ -21,6 +21,12 @@ CONTRACT_HEADING = "Shared contract"
 HANDOFF_HEADING = "Portable handoff template"
 CONTRACT_TARGETS = (Path("AGENTS.md"), Path(".claude/CLAUDE.md"))
 HANDOFF_TARGET = Path("templates/agent-handoff.md")
+# The Antigravity IDE loads AGENTS.md only from its workspace
+# customization root (.agents/) and does not expand the rule file's
+# @-reference, so the root file is mirrored there byte-for-byte
+# (docs/specs/antigravity-adapter, D3). Not a symlink: Windows
+# checkouts, and the projector rejects symlinked targets.
+IDE_MIRROR_TARGET = Path(".agents/AGENTS.md")
 
 
 class ProjectionError(ValueError):
@@ -136,6 +142,15 @@ def project(root: Path, *, check: bool = False) -> ProjectionResult:
         current = path.read_text(encoding="utf-8")
         expected = _replace_marked_block(current, rendered_contract, relative_path)
         projections.append((relative_path, path, current, expected))
+
+    agents_expected = next(
+        expected
+        for relative_path, _, _, expected in projections
+        if relative_path == CONTRACT_TARGETS[0]
+    )
+    mirror_path = _validate_file_path(root, IDE_MIRROR_TARGET)
+    current_mirror = mirror_path.read_text(encoding="utf-8") if mirror_path.is_file() else None
+    projections.append((IDE_MIRROR_TARGET, mirror_path, current_mirror, agents_expected))
 
     handoff_path = _validate_file_path(root, HANDOFF_TARGET)
     expected_handoff = sections[HANDOFF_HEADING].strip() + "\n"

--- a/tests/unit/scripts/test_project_collaboration_contract.py
+++ b/tests/unit/scripts/test_project_collaboration_contract.py
@@ -71,7 +71,10 @@ def test_projects_contract_and_handoff_without_clobbering_provider_tail(tmp_path
 
     result = projector.project(tmp_path)
 
-    assert set(result.written) == set(projector.CONTRACT_TARGETS) | {projector.HANDOFF_TARGET}
+    assert set(result.written) == set(projector.CONTRACT_TARGETS) | {
+        projector.HANDOFF_TARGET,
+        projector.IDE_MIRROR_TARGET,
+    }
     agents = (tmp_path / "AGENTS.md").read_text(encoding="utf-8")
     assert "Shared rule." in agents
     assert "Provider-specific tail." in agents
@@ -91,7 +94,7 @@ def test_check_fires_when_master_changes_after_projection(tmp_path: Path) -> Non
 
     result = projector.project(tmp_path, check=True)
 
-    assert set(result.stale) == set(projector.CONTRACT_TARGETS)
+    assert set(result.stale) == set(projector.CONTRACT_TARGETS) | {projector.IDE_MIRROR_TARGET}
     assert projector.HANDOFF_TARGET not in result.stale
 
 
@@ -102,7 +105,36 @@ def test_second_projection_is_idempotent(tmp_path: Path) -> None:
     result = projector.project(tmp_path)
 
     assert result.written == []
-    assert set(result.unchanged) == set(projector.CONTRACT_TARGETS) | {projector.HANDOFF_TARGET}
+    assert set(result.unchanged) == set(projector.CONTRACT_TARGETS) | {
+        projector.HANDOFF_TARGET,
+        projector.IDE_MIRROR_TARGET,
+    }
+
+
+def test_ide_mirror_is_byte_copy_of_root_agents(tmp_path: Path) -> None:
+    _seed_repo(tmp_path)
+
+    projector.project(tmp_path)
+
+    root_agents = (tmp_path / "AGENTS.md").read_bytes()
+    mirror = (tmp_path / projector.IDE_MIRROR_TARGET).read_bytes()
+    assert mirror == root_agents
+
+
+def test_check_fires_when_root_agents_hand_content_changes(tmp_path: Path) -> None:
+    _seed_repo(tmp_path)
+    projector.project(tmp_path)
+    agents = tmp_path / "AGENTS.md"
+    agents.write_text(
+        agents.read_text(encoding="utf-8").replace(
+            "Provider-specific tail.", "Edited provider tail."
+        ),
+        encoding="utf-8",
+    )
+
+    result = projector.project(tmp_path, check=True)
+
+    assert projector.IDE_MIRROR_TARGET in result.stale
 
 
 def test_handoff_projection_preserves_nested_h2_sections(tmp_path: Path) -> None:


### PR DESCRIPTION
## What

The Antigravity IDE (app 2.3.1) never loaded the collaboration
contract: it reads `AGENTS.md` only from its workspace customization
root (`.agents/`), and — unlike `agy` CLI 1.1.4 — it does **not**
expand the rule file's `@../../AGENTS.md` reference.

Live receipt (D3 probe ladder, full transcript excerpts in the spec):

- Contract probe: **NOT IN CONTEXT** in the IDE (verbatim-quotable in
  the CLI receipts).
- Rule body sentinel: present → file discovery/activation works.
- `@../../AGENTS.md`: quoted back as **literal text** → no expansion.
- IDE customization-roots enumeration: global
  `~/.gemini/config`; workspace `.agents/` — root `AGENTS.md` sits
  outside it.

## Fix

`scripts/project_collaboration_contract.py` gains a fourth target:
`.agents/AGENTS.md`, a byte-copy of root `AGENTS.md` (created if
missing, drift-guarded by `--check` like every other projection).
Not a symlink: Windows checkouts, and the projector rejects
symlinked targets by design. The rule file stays — the @-reference
path is what works in the CLI.

## Receipts

- Projector run: `wrote .agents/AGENTS.md`; `--check` clean after.
- `cmp AGENTS.md .agents/AGENTS.md` → identical.
- Projector suite 17/17 (2 new tests: byte-copy invariant;
  `--check` fires when root AGENTS.md hand-content drifts).
- Neighboring guards 62/62 (preflight, skills-mirror sync, lessons
  core mirror); `sync_agents_skills.py` still 41 ok / 0 failed.
- D3 receipt + fix selection recorded in
  `docs/specs/antigravity-adapter/decisions.md`.

## After merge

Re-run the contract probe in the Antigravity IDE (workspace
`~/attune-ai` on updated main) — expected: preflight script +
four artifact tiers quoted; that receipt closes D3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
