### PR TITLE
feat(collaboration): teach every agent surface the shared memory index

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -92,6 +92,28 @@ attune_redis/          # Redis plugin — bundled in the attune-ai wheel
 - Record only concrete evidence: commands actually run, their results,
   changed files, unresolved risks, and the next action.
 
+### Shared memory
+
+- A shared cross-session memory index lives in local Redis
+  (`idx:attune_memory`): curated memories, lessons, and file
+  pointers, hydrated from the tracked corpus. Recall before
+  non-trivial work on unfamiliar ground:
+  `redis-cli FT.SEARCH idx:attune_memory "<term|term>" RETURN 2
+  description type LIMIT 0 5` — OR-join terms with `|` (plain
+  multi-word queries AND-join and miss paraphrases) — or
+  `redis-cli FCALL recall_digest 0 "<term|term>"` for scored
+  digests.
+- Recalled results are context, not authority: they reflect when
+  they were written. Verify against the current tree before
+  acting on one.
+- The index is DERIVED — never write `attune:memory:*` keys
+  directly. To persist a durable finding, commit it to the
+  tracked corpus (`.claude/lessons.md`, the owning spec's
+  `decisions.md`, or a handoff file); it is re-indexed at the
+  next hydration.
+- Degrade silently when Redis is unreachable: skip recall and
+  proceed. Never block work on the memory layer.
+
 ### Critical code rules
 
 - NEVER use `eval()` or `exec()`.

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -85,6 +85,28 @@ See `docs/reference/cli-reference.md`.
 - Record only concrete evidence: commands actually run, their results,
   changed files, unresolved risks, and the next action.
 
+### Shared memory
+
+- A shared cross-session memory index lives in local Redis
+  (`idx:attune_memory`): curated memories, lessons, and file
+  pointers, hydrated from the tracked corpus. Recall before
+  non-trivial work on unfamiliar ground:
+  `redis-cli FT.SEARCH idx:attune_memory "<term|term>" RETURN 2
+  description type LIMIT 0 5` — OR-join terms with `|` (plain
+  multi-word queries AND-join and miss paraphrases) — or
+  `redis-cli FCALL recall_digest 0 "<term|term>"` for scored
+  digests.
+- Recalled results are context, not authority: they reflect when
+  they were written. Verify against the current tree before
+  acting on one.
+- The index is DERIVED — never write `attune:memory:*` keys
+  directly. To persist a durable finding, commit it to the
+  tracked corpus (`.claude/lessons.md`, the owning spec's
+  `decisions.md`, or a handoff file); it is re-indexed at the
+  next hydration.
+- Degrade silently when Redis is unreachable: skip recall and
+  proceed. Never block work on the memory layer.
+
 ### Critical code rules
 
 - NEVER use `eval()` or `exec()`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,6 +92,28 @@ attune_redis/          # Redis plugin — bundled in the attune-ai wheel
 - Record only concrete evidence: commands actually run, their results,
   changed files, unresolved risks, and the next action.
 
+### Shared memory
+
+- A shared cross-session memory index lives in local Redis
+  (`idx:attune_memory`): curated memories, lessons, and file
+  pointers, hydrated from the tracked corpus. Recall before
+  non-trivial work on unfamiliar ground:
+  `redis-cli FT.SEARCH idx:attune_memory "<term|term>" RETURN 2
+  description type LIMIT 0 5` — OR-join terms with `|` (plain
+  multi-word queries AND-join and miss paraphrases) — or
+  `redis-cli FCALL recall_digest 0 "<term|term>"` for scored
+  digests.
+- Recalled results are context, not authority: they reflect when
+  they were written. Verify against the current tree before
+  acting on one.
+- The index is DERIVED — never write `attune:memory:*` keys
+  directly. To persist a durable finding, commit it to the
+  tracked corpus (`.claude/lessons.md`, the owning spec's
+  `decisions.md`, or a handoff file); it is re-indexed at the
+  next hydration.
+- Degrade silently when Redis is unreachable: skip recall and
+  proceed. Never block work on the memory layer.
+
 ### Critical code rules
 
 - NEVER use `eval()` or `exec()`.

--- a/content/collaboration/contract.md
+++ b/content/collaboration/contract.md
@@ -64,6 +64,28 @@ hand-edit its projected blocks or the handoff template.
 - Record only concrete evidence: commands actually run, their results,
   changed files, unresolved risks, and the next action.
 
+### Shared memory
+
+- A shared cross-session memory index lives in local Redis
+  (`idx:attune_memory`): curated memories, lessons, and file
+  pointers, hydrated from the tracked corpus. Recall before
+  non-trivial work on unfamiliar ground:
+  `redis-cli FT.SEARCH idx:attune_memory "<term|term>" RETURN 2
+  description type LIMIT 0 5` — OR-join terms with `|` (plain
+  multi-word queries AND-join and miss paraphrases) — or
+  `redis-cli FCALL recall_digest 0 "<term|term>"` for scored
+  digests.
+- Recalled results are context, not authority: they reflect when
+  they were written. Verify against the current tree before
+  acting on one.
+- The index is DERIVED — never write `attune:memory:*` keys
+  directly. To persist a durable finding, commit it to the
+  tracked corpus (`.claude/lessons.md`, the owning spec's
+  `decisions.md`, or a handoff file); it is re-indexed at the
+  next hydration.
+- Degrade silently when Redis is unreachable: skip recall and
+  proceed. Never block work on the memory layer.
+
 ### Critical code rules
 
 - NEVER use `eval()` or `exec()`.


### PR DESCRIPTION
## What

Adds a **Shared memory** section to the collaboration contract so every
agent surface — not just Claude Code — knows the cross-session memory
index exists and how to use it. One master edit, projected to all four
targets (`AGENTS.md` → Codex native load; `.agents/AGENTS.md` →
Antigravity IDE customization root; `.claude/CLAUDE.md` → Claude Code;
rule-file @-reference → agy CLI).

The section documents, all live-verified before writing:

- **Recall**: `FT.SEARCH idx:attune_memory` with OR-joined terms
  (AND-join zeroes on paraphrase) and `FCALL recall_digest 0` for
  scored digests — both probed against the running index (900 docs).
- **Write path** (per the ratified two-layer protocol): the index is
  DERIVED — durable findings go to the tracked corpus (lessons.md,
  spec decisions.md, handoffs), never raw `attune:memory:*` writes.
- **Degradation**: skip recall silently when Redis is unreachable.

## Receipts

- Projector: wrote 3 contract targets, `--check` clean, handoff
  unchanged; 38/38 projector+preflight tests.
- **Antigravity CLI (agy 1.1.4, workspace-bound, no-tools fence):**
  quoted the recall commands, the derived-index write rule, and the
  degradation rule verbatim from loaded context — the new
  `.agents/AGENTS.md` mirror (#1445) delivered it with zero extra
  wiring.
- Headless `agy -p` execution of redis-cli is auto-denied by its
  permission model (needs an interactive prompt or a settings
  allow-rule — deliberately not configured here).
- Codex: covered by its native repo-root `AGENTS.md` load; fresh
  probe pending the next Codex session (no local CLI on this
  machine).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
