### PR TITLE
feat(roundtable): Phase 0 substrate — board schema + Redis Functions

### DIFF
--- a/docs/specs/agent-round-table/decisions.md
+++ b/docs/specs/agent-round-table/decisions.md
@@ -79,6 +79,25 @@ overruling a unanimous member recommendation — with rationale the
 members lacked (the plugin-manifest consent mechanism) — is
 exactly the human-in-the-loop shape the table is designed around.
 
+## P0 substrate — SHIPPED (2026-07-18)
+
+`src/attune/roundtable/` (`board.py`): message schema
+(`BoardMessage`, `KINDS`), the `attune_roundtable` Redis Function
+library (`rt_post_message` / `rt_read_thread` / `rt_promote` —
+distinct library name from the hydration hook's `attune_memory`,
+so `FUNCTION LOAD REPLACE` never clobbers it), and the
+moderator-side `Board` client. Validation lives SERVER-SIDE in
+Lua per R2/AC-1.
+
+Receipts: 16 tests, run parallel AND serial against a REAL local
+Redis with the library loaded by the suite itself — AC-1 (five
+malformed shapes each rejected with `rt_post_message:` errors and
+ZERO partial writes: thread + meta keys both absent after), AC-6
+(TTL set on post), full post→read→promote round trip, promote
+marks meta + returns messages, missing-thread and
+missing-destination rejections. Keyless-CI lane covered by
+boundary-double tests (no Redis required).
+
 ## Seating receipts (2026-07-18)
 
 - Antigravity: contract probe answered verbatim from loaded

--- a/src/attune/roundtable/__init__.py
+++ b/src/attune/roundtable/__init__.py
@@ -1,0 +1,27 @@
+"""Agent round table — moderated multi-LLM deliberation substrate.
+
+Phase 0 of ``docs/specs/agent-round-table``: the board keyspace
+(``attune:roundtable:*``), the message schema, and the server-side
+Redis Functions (``rt_post_message`` / ``rt_read_thread`` /
+``rt_promote``) that make every board write atomic and
+schema-validated.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under Apache 2.0
+"""
+
+from attune.roundtable.board import (
+    KINDS,
+    THREAD_KEY_PREFIX,
+    THREAD_TTL_SECONDS,
+    Board,
+    BoardMessage,
+)
+
+__all__ = [
+    "KINDS",
+    "THREAD_KEY_PREFIX",
+    "THREAD_TTL_SECONDS",
+    "Board",
+    "BoardMessage",
+]

--- a/src/attune/roundtable/board.py
+++ b/src/attune/roundtable/board.py
@@ -1,0 +1,234 @@
+"""Round-table board: schema, Redis Functions, and the moderator client.
+
+The board is the short-term deliberation surface ratified in
+``docs/specs/agent-round-table``. Design constraints it implements:
+
+- **Moderator owns all I/O (R1)** — members never touch Redis; this
+  module is called only by the moderator (a live Claude Code session
+  in Phase 1).
+- **Schema-validated atomic writes (R2, AC-1)** — validation lives in
+  the server-side Lua function, so a malformed message is rejected by
+  Redis itself with no partial write, regardless of which client
+  posts it.
+- **Board keyspace only (R3)** — every key starts with
+  ``attune:roundtable:``; the derived ``attune:memory:*`` keyspace is
+  never written (collaboration contract, PR #1447).
+- **TTL'd working state (AC-6)** — threads expire (default 7 days);
+  durability comes from chair-approved promotion into tracked
+  artifacts, not from Redis.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under Apache 2.0
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass, field
+from typing import Any
+
+#: Message kinds the schema admits (requirements P0; R9 adds
+#: member-originated ``question``/``suggestion`` as first-class).
+KINDS: tuple[str, ...] = (
+    "question",
+    "position",
+    "synthesis",
+    "ruling",
+    "suggestion",
+    "halt",
+)
+
+#: Every board key lives under this prefix (R3).
+THREAD_KEY_PREFIX = "attune:roundtable:thread:"
+
+#: Default thread TTL — 7 days, refreshed on each post (AC-6).
+THREAD_TTL_SECONDS = 604_800
+
+#: Name of the Redis Function library this module owns. Distinct from
+#: the hydration hook's ``attune_memory`` library — FUNCTION LOAD
+#: REPLACE only replaces the same-named library, so the two never
+#: clobber each other.
+LIBRARY_NAME = "attune_roundtable"
+
+#: The server-side library. Validation is deliberately here, not in
+#: Python: AC-1 requires Redis itself to reject a malformed message
+#: atomically no matter what client sent it.
+LIBRARY_SOURCE = """#!lua name=attune_roundtable
+
+local KINDS = {
+  question = true, position = true, synthesis = true,
+  ruling = true, suggestion = true, halt = true,
+}
+
+local function validate(msg)
+  if type(msg) ~= 'table' then
+    return 'message must be a JSON object'
+  end
+  if type(msg.author) ~= 'string' or #msg.author == 0 then
+    return 'author is required'
+  end
+  if type(msg.kind) ~= 'string' or not KINDS[msg.kind] then
+    return 'kind is required and must be one of: ' ..
+      'question|position|synthesis|ruling|suggestion|halt'
+  end
+  if type(msg.body) ~= 'string' or #msg.body == 0 then
+    return 'body is required'
+  end
+  return nil
+end
+
+local function post_message(keys, args)
+  local msgs_key = keys[1]
+  local meta_key = msgs_key .. ':meta'
+  local ok, msg = pcall(cjson.decode, args[1])
+  if not ok then
+    return redis.error_reply('rt_post_message: body is not valid JSON')
+  end
+  local err = validate(msg)
+  if err then
+    return redis.error_reply('rt_post_message: ' .. err)
+  end
+  local ttl = tonumber(args[2]) or 604800
+  local t = redis.call('TIME')
+  msg.ts = t[1] .. '.' .. t[2]
+  msg.id = redis.call('HINCRBY', meta_key, 'seq', 1)
+  redis.call('RPUSH', msgs_key, cjson.encode(msg))
+  redis.call('EXPIRE', msgs_key, ttl)
+  redis.call('EXPIRE', meta_key, ttl)
+  return msg.id
+end
+
+local function read_thread(keys, args)
+  return redis.call('LRANGE', keys[1], 0, -1)
+end
+
+local function promote(keys, args)
+  local msgs_key = keys[1]
+  local meta_key = msgs_key .. ':meta'
+  if redis.call('EXISTS', msgs_key) == 0 then
+    return redis.error_reply('rt_promote: thread does not exist')
+  end
+  local destination = args[1]
+  if type(destination) ~= 'string' or #destination == 0 then
+    return redis.error_reply('rt_promote: destination is required')
+  end
+  local t = redis.call('TIME')
+  redis.call('HSET', meta_key, 'status', 'promoted',
+    'destination', destination, 'promoted_at', t[1])
+  return redis.call('LRANGE', msgs_key, 0, -1)
+end
+
+redis.register_function('rt_post_message', post_message)
+redis.register_function('rt_read_thread', read_thread)
+redis.register_function('rt_promote', promote)
+"""
+
+
+@dataclass
+class BoardMessage:
+    """One validated board message as stored in a thread.
+
+    ``id`` and ``ts`` are assigned server-side by ``rt_post_message``
+    (monotonic per-thread sequence; Redis server clock).
+    """
+
+    author: str
+    kind: str
+    body: str
+    id: int | None = None
+    ts: str | None = None
+    reply_to: int | None = None
+    extra: dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_json(cls, raw: str | bytes) -> BoardMessage:
+        """Parse a stored message; unknown fields are kept in ``extra``."""
+        if isinstance(raw, bytes):
+            raw = raw.decode("utf-8")
+        data = json.loads(raw)
+        known = {k: data.pop(k, None) for k in ("author", "kind", "body", "id", "ts", "reply_to")}
+        return cls(
+            author=str(known["author"]),
+            kind=str(known["kind"]),
+            body=str(known["body"]),
+            id=known["id"],
+            ts=None if known["ts"] is None else str(known["ts"]),
+            reply_to=known["reply_to"],
+            extra=data,
+        )
+
+
+class Board:
+    """Moderator-side client for the round-table board.
+
+    All methods call the server-side functions; nothing here bypasses
+    the schema validation they enforce.
+
+    Args:
+        client: A connected ``redis.Redis`` client. When None, one is
+            created from ``REDIS_URL`` (default
+            ``redis://127.0.0.1:6379/0``).
+        ttl_seconds: Thread TTL refreshed on every post.
+    """
+
+    def __init__(self, client: Any = None, ttl_seconds: int = THREAD_TTL_SECONDS) -> None:
+        if client is None:
+            import redis  # noqa: PLC0415 — optional dependency, import at use
+
+            url = os.environ.get("REDIS_URL", "redis://127.0.0.1:6379/0")
+            client = redis.Redis.from_url(url, decode_responses=True)
+        self.client = client
+        self.ttl_seconds = ttl_seconds
+
+    @staticmethod
+    def thread_key(thread: str) -> str:
+        """Return the messages key for a thread id (R3 keyspace)."""
+        if not thread or any(c.isspace() for c in thread):
+            raise ValueError(f"invalid thread id: {thread!r}")
+        return THREAD_KEY_PREFIX + thread
+
+    def ensure_functions(self) -> None:
+        """Idempotently load the ``attune_roundtable`` function library."""
+        self.client.function_load(LIBRARY_SOURCE, replace=True)
+
+    def post_message(
+        self,
+        thread: str,
+        author: str,
+        kind: str,
+        body: str,
+        reply_to: int | None = None,
+        **extra: Any,
+    ) -> int:
+        """Post one message; returns its server-assigned id.
+
+        Validation is server-side: a malformed message raises
+        ``redis.ResponseError`` and writes nothing (AC-1).
+        """
+        message: dict[str, Any] = {"author": author, "kind": kind, "body": body, **extra}
+        if reply_to is not None:
+            message["reply_to"] = reply_to
+        reply = self.client.fcall(
+            "rt_post_message",
+            1,
+            self.thread_key(thread),
+            json.dumps(message),
+            str(self.ttl_seconds),
+        )
+        return int(reply)
+
+    def read_thread(self, thread: str) -> list[BoardMessage]:
+        """Return all messages in a thread, oldest first."""
+        raw = self.client.fcall("rt_read_thread", 1, self.thread_key(thread))
+        return [BoardMessage.from_json(entry) for entry in raw or []]
+
+    def promote(self, thread: str, destination: str) -> list[BoardMessage]:
+        """Mark a thread promoted and return its messages for writing out.
+
+        The artifact write itself is the moderator's job (D2 routing;
+        chair approval per R4 happens before this is called). The
+        board only records that promotion happened and where.
+        """
+        raw = self.client.fcall("rt_promote", 1, self.thread_key(thread), destination)
+        return [BoardMessage.from_json(entry) for entry in raw or []]

--- a/tests/unit/roundtable/test_board.py
+++ b/tests/unit/roundtable/test_board.py
@@ -1,0 +1,196 @@
+"""Round-table board tests (agent-round-table Phase 0).
+
+Two layers, mirroring ``test_recall_digest.py``: message/key logic
+against a boundary double (runs in keyless CI, no Redis), and the
+non-mocked receipts against a REAL Redis with the library loaded by
+this suite itself — AC-1 (atomic rejection of malformed messages),
+AC-6 (TTL set), and the post→read→promote round trip. Real-Redis
+tests skip when localhost:6379 is unreachable.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+
+import pytest
+
+from attune.roundtable import (
+    KINDS,
+    THREAD_KEY_PREFIX,
+    Board,
+    BoardMessage,
+)
+
+
+class FakeRedisClient:
+    """Boundary double — records fcall/function_load invocations."""
+
+    def __init__(self, reply=None) -> None:
+        self.reply = reply
+        self.calls: list[tuple] = []
+        self.loaded: list[tuple] = []
+
+    def fcall(self, name, numkeys, *args):
+        self.calls.append((name, numkeys, *args))
+        return self.reply
+
+    def function_load(self, code, replace=False):
+        self.loaded.append((code, replace))
+        return "attune_roundtable"
+
+
+def _real_board_or_skip() -> Board:
+    """Return a Board on a real Redis with the library loaded, or skip."""
+    redis = pytest.importorskip("redis")
+    client = redis.Redis.from_url("redis://localhost:6379/0", decode_responses=True)
+    try:
+        client.ping()
+    except redis.RedisError:
+        pytest.skip("no reachable Redis on localhost:6379")
+    board = Board(client=client)
+    board.ensure_functions()
+    return board
+
+
+def _fresh_thread() -> str:
+    return "test-" + uuid.uuid4().hex[:12]
+
+
+class TestSchemaAndKeys:
+    def test_kinds_cover_spec_enum(self) -> None:
+        assert set(KINDS) == {
+            "question",
+            "position",
+            "synthesis",
+            "ruling",
+            "suggestion",
+            "halt",
+        }
+
+    def test_thread_key_uses_board_keyspace(self) -> None:
+        assert Board.thread_key("t1") == THREAD_KEY_PREFIX + "t1"
+        assert THREAD_KEY_PREFIX.startswith("attune:roundtable:")
+
+    @pytest.mark.parametrize("bad", ["", "has space", "tab\tid"])
+    def test_thread_key_rejects_invalid_ids(self, bad: str) -> None:
+        with pytest.raises(ValueError, match="invalid thread id"):
+            Board.thread_key(bad)
+
+    def test_message_from_json_keeps_unknown_fields_in_extra(self) -> None:
+        raw = json.dumps(
+            {
+                "author": "codex@s1",
+                "kind": "position",
+                "body": "b",
+                "id": 3,
+                "ts": "1.2",
+                "cost_usd": 0.01,
+            }
+        )
+        msg = BoardMessage.from_json(raw)
+        assert (msg.author, msg.kind, msg.id) == ("codex@s1", "position", 3)
+        assert msg.extra == {"cost_usd": 0.01}
+
+
+class TestBoardWithFakeClient:
+    """Client argument construction — runs everywhere, incl. keyless CI."""
+
+    def test_post_message_sends_schema_fields_and_ttl(self) -> None:
+        fake = FakeRedisClient(reply=1)
+        board = Board(client=fake, ttl_seconds=60)
+        msg_id = board.post_message("t1", author="claude@s1", kind="question", body="Q?")
+        assert msg_id == 1
+        name, numkeys, key, payload, ttl = fake.calls[0]
+        assert (name, numkeys, key, ttl) == ("rt_post_message", 1, THREAD_KEY_PREFIX + "t1", "60")
+        assert json.loads(payload) == {"author": "claude@s1", "kind": "question", "body": "Q?"}
+
+    def test_post_message_carries_reply_to_and_extra(self) -> None:
+        fake = FakeRedisClient(reply=2)
+        Board(client=fake).post_message(
+            "t1", author="agy@s2", kind="position", body="B", reply_to=1, round=2
+        )
+        payload = json.loads(fake.calls[0][3])
+        assert payload["reply_to"] == 1
+        assert payload["round"] == 2
+
+    def test_read_thread_parses_messages(self) -> None:
+        entries = [json.dumps({"author": "a", "kind": "position", "body": "b", "id": 1})]
+        board = Board(client=FakeRedisClient(reply=entries))
+        msgs = board.read_thread("t1")
+        assert len(msgs) == 1 and msgs[0].id == 1
+
+    def test_ensure_functions_loads_with_replace(self) -> None:
+        fake = FakeRedisClient()
+        Board(client=fake).ensure_functions()
+        code, replace = fake.loaded[0]
+        assert replace is True
+        assert code.startswith("#!lua name=attune_roundtable")
+
+
+class TestAgainstRealRedis:
+    """Non-mocked receipts — the library is loaded by this suite."""
+
+    def test_post_read_round_trip(self) -> None:
+        board = _real_board_or_skip()
+        thread = _fresh_thread()
+        id1 = board.post_message(thread, author="claude@s1", kind="question", body="Q?")
+        id2 = board.post_message(
+            thread, author="codex@s1", kind="position", body="A.", reply_to=id1
+        )
+        msgs = board.read_thread(thread)
+        assert [m.id for m in msgs] == [id1, id2]
+        assert msgs[0].ts is not None
+        assert msgs[1].reply_to == id1
+
+    def test_ac1_malformed_message_rejected_atomically(self) -> None:
+        """AC-1: server-side rejection, no partial write."""
+        redis = pytest.importorskip("redis")
+        board = _real_board_or_skip()
+        thread = _fresh_thread()
+        key = Board.thread_key(thread)
+
+        for bad_args in (
+            ("{not json", "60"),
+            (json.dumps({"kind": "position", "body": "no author"}), "60"),
+            (json.dumps({"author": "a", "body": "no kind"}), "60"),
+            (json.dumps({"author": "a", "kind": "not-a-kind", "body": "b"}), "60"),
+            (json.dumps({"author": "a", "kind": "position"}), "60"),
+        ):
+            with pytest.raises(redis.ResponseError, match="rt_post_message"):
+                board.client.fcall("rt_post_message", 1, key, *bad_args)
+
+        assert board.client.exists(key) == 0, "malformed post left a partial write"
+        assert board.client.exists(key + ":meta") == 0
+
+    def test_ac6_thread_ttl_is_set_and_refreshed(self) -> None:
+        board = _real_board_or_skip()
+        board.ttl_seconds = 120
+        thread = _fresh_thread()
+        board.post_message(thread, author="a@s", kind="question", body="q")
+        ttl = board.client.ttl(Board.thread_key(thread))
+        assert 0 < ttl <= 120
+
+    def test_promote_marks_meta_and_returns_messages(self) -> None:
+        board = _real_board_or_skip()
+        thread = _fresh_thread()
+        board.post_message(thread, author="a@s", kind="suggestion", body="do X")
+        msgs = board.promote(thread, "docs/reports/roundtable/test.md")
+        assert len(msgs) == 1 and msgs[0].body == "do X"
+        meta = board.client.hgetall(Board.thread_key(thread) + ":meta")
+        assert meta["status"] == "promoted"
+        assert meta["destination"] == "docs/reports/roundtable/test.md"
+
+    def test_promote_missing_thread_errors(self) -> None:
+        redis = pytest.importorskip("redis")
+        board = _real_board_or_skip()
+        with pytest.raises(redis.ResponseError, match="does not exist"):
+            board.promote(_fresh_thread(), "anywhere.md")
+
+    def test_promote_requires_destination(self) -> None:
+        redis = pytest.importorskip("redis")
+        board = _real_board_or_skip()
+        thread = _fresh_thread()
+        board.post_message(thread, author="a@s", kind="suggestion", body="x")
+        with pytest.raises(redis.ResponseError, match="destination"):
+            board.client.fcall("rt_promote", 1, Board.thread_key(thread), "")


### PR DESCRIPTION
Implements **agent-round-table Phase 0** ([spec](https://github.com/Smart-AI-Memory/attune-ai/blob/main/docs/specs/agent-round-table/requirements.md), merged in #1449).

## What

- `src/attune/roundtable/board.py`: message schema (`BoardMessage`, six-kind enum incl. member-originated `question`/`suggestion` per R9), the `attune_roundtable` Redis Function library (`rt_post_message` / `rt_read_thread` / `rt_promote`), and the moderator-side `Board` client.
- **Validation is server-side** (Lua): malformed messages are rejected by Redis atomically regardless of client — R2/AC-1 by construction, not convention.
- Keyspace `attune:roundtable:thread:*` only, TTL'd — the derived `attune:memory:*` keyspace is never written (R3, contract #1447). Library name is distinct from the hydration hook's `attune_memory` so `FUNCTION LOAD REPLACE` never clobbers it.

## Receipts

- 16 tests green, parallel AND serial.
- **AC-1 against real Redis**: five malformed shapes (bad JSON, missing author/kind/body, unknown kind) each rejected with named errors and **zero partial writes** (thread + meta keys both absent after).
- **AC-6**: TTL set and bounded on post.
- Full post→read→promote round trip; promote marks meta + returns messages; missing-thread and empty-destination rejections.
- Keyless CI covered by boundary-double tests (lanes have no Redis; real-Redis tests skip cleanly).

Next: Phase 1 — the `/roundtable` skill (moderated round-trip using the verified member recipes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)