### PR TITLE
feat(roundtable): Phases 1-3 — /roundtable skill, promotion gates, lesson lint, routines

### DIFF
--- a/.agents/skills/attune-hub/SKILL.md
+++ b/.agents/skills/attune-hub/SKILL.md
@@ -114,6 +114,7 @@ rule (a single turn can't bundle multiple ambiguous decisions). See
 | image-analysis | analyze this image, look at this screenshot, what's in this diagram, read this mockup |
 | elicit | scope this, discovery form, ask me everything at once, multi-select question |
 | author-feature | author a feature page, single-source doc, new feature master, draft docs without an api |
+| roundtable | roundtable, convene the table, ask the table, what do the other models think |
 
 ## MCP Server Not Running
 

--- a/.agents/skills/roundtable/SKILL.md
+++ b/.agents/skills/roundtable/SKILL.md
@@ -135,11 +135,12 @@ candidates. Read the thread back any time with:
 T="<slug>" python -c "import os, json; from attune.roundtable import Board; print(json.dumps([vars(m) for m in Board().read_thread(os.environ['T'])], ensure_ascii=False, default=str))"
 ```
 
-## Step 6 — Chair rules; promote (R4, R10, D2)
+## Step 6 — Chair rules; promote per item (R4, R10, D2)
 
-Ask the chair per item: promote, decline, or another round. Use
-`AskUserQuestion` (or an elicitation form) — never assume. On
-promotion:
+Present the promotion candidates as discrete items — each with its
+board message id — and ask the chair per item: promote, decline, or
+another round. Use `AskUserQuestion` with `multiSelect` (or an
+elicitation form) — never assume. On promotion:
 
 1. Recommend an artifact tier per the contract's artifact-selection
    table — inline edit / structured one-shot / XML task / spec —
@@ -147,14 +148,40 @@ promotion:
 2. Destination (D2): the owning spec's `decisions.md` when a spec
    exists; else `docs/reports/roundtable/<slug>.md`. The artifact
    records the thread id it came from.
-3. Write the artifact, then mark the thread:
+3. Write the artifact, then mark the thread, passing the
+   chair-approved message ids so the board records exactly what was
+   promoted (an unknown id rejects the whole call, no meta change):
 
 ```bash
-T="<slug>" D="docs/reports/roundtable/<slug>.md" python -c "import os; from attune.roundtable import Board; Board().promote(os.environ['T'], os.environ['D'])"
+T="<slug>" D="docs/reports/roundtable/<slug>.md" IDS="2,4" python -c "import os; from attune.roundtable import Board; Board().promote(os.environ['T'], os.environ['D'], item_ids=[int(i) for i in os.environ['IDS'].split(',')])"
 ```
 
 Post the chair's decision as a `ruling` message (author `chair`).
 Declined items get no file writes — `git status` stays clean.
+
+### The lesson lane (chair rulings, thread lessons-flow-001)
+
+When — and only when — a deliberation yields reusable cross-session
+knowledge (a verified gotcha, a rationale that will be asked again),
+draft a lesson candidate. Default is NO candidate; most threads
+produce none. Before presenting it to the chair, lint it — the gate
+is mechanical: no receipt AND no chair waiver → blocked:
+
+```bash
+TI="<title>" B="<body>" E="<evidence or empty>" T="<slug>" python -c "import os; from attune.roundtable import LessonCandidate; c=LessonCandidate(title=os.environ['TI'], body=os.environ['B'], evidence=os.environ['E'], thread=os.environ['T']); print(c.lint() or c.render())"
+```
+
+- `evidence` is a receipt from the real system (command run,
+  failure observed, fixing diff) — transcript consensus never
+  qualifies.
+- The chair may waive the receipt for a strong design rationale
+  (`waived=True`): the rendered entry then carries the visible
+  `unverified — design rationale (chair-waived)` tag and upgrades
+  to a normal entry when evidence lands. The waiver is the chair's,
+  per item — never self-granted.
+- Approved entries append to `.claude/lessons.md` (or the owning
+  spec's `decisions.md`); Redis re-derives at next hydration. The
+  table never touches the lessons corpus directly.
 
 Deliberation is TTL'd; only promoted content is durable. If the
 chair wants a raw thread kept past 7 days, promotion to a report is

--- a/.agents/skills/roundtable/SKILL.md
+++ b/.agents/skills/roundtable/SKILL.md
@@ -187,6 +187,25 @@ Deliberation is TTL'd; only promoted content is durable. If the
 chair wants a raw thread kept past 7 days, promotion to a report is
 the mechanism — say so rather than extending TTLs ad hoc.
 
+## Routines (P3 — headless table runs)
+
+A routine convenes the table on a recurring question with the same
+gates (R5 cap, R6 absent seats) and one extra: **a routine NEVER
+promotes (R8)** — its digest thread waits on the board for the
+chair. Manual-first is ratified: run it by hand, arm a schedule
+only after the chair reviews a proven run.
+
+```bash
+python -m attune.roundtable.routine clean-run            # real run
+python -m attune.roundtable.routine clean-run --dry-run  # checks + brief only, no board/LLM
+```
+
+Routine #1 is `clean-run` (the weekly health check): keyless check
+battery (collaboration preflight + unit suite) → seats deliberate
+the results → one synthesis pass → digest thread
+`routine-clean-run-<date>`. Review it with
+`/roundtable read <thread>`; promote per-item via Step 6.
+
 ## Arguments
 
 - `/roundtable <question>` — full deliberation (Steps 0–6).
@@ -194,3 +213,5 @@ the mechanism — say so rather than extending TTLs ad hoc.
   (Step 5's read snippet); no member invocations.
 - `/roundtable promote <thread>` — jump to Step 6 for a thread that
   already deliberated.
+- `/roundtable routine <name>` — run a registered routine (above)
+  and present its digest to the chair.

--- a/.agents/skills/roundtable/SKILL.md
+++ b/.agents/skills/roundtable/SKILL.md
@@ -1,0 +1,169 @@
+---
+name: roundtable
+description: "Convene the multi-LLM round table — Claude, Antigravity, and Codex deliberate a question; the user chairs promotion. Triggers on: roundtable, round table, convene the table, ask the table, what do the other models think, deliberate."
+---
+# Round Table
+
+**IMPORTANT: Start your response by telling the user:**
+
+> **Round table** — Convening the fixed roster (Claude, Antigravity,
+> Codex). You chair; I moderate. Up to 3 rounds.
+
+## What It Does
+
+A moderated deliberation (Phase 1 of
+`docs/specs/agent-round-table`): the user poses a question, each
+roster member answers headlessly and independently, the moderator
+(this session) posts every message to the Redis board, synthesizes,
+and presents the result. Only the chair — the user — promotes
+anything into a tracked artifact.
+
+Invariants (ratified — do not improvise around them):
+
+- **R1** Members are text-in/text-out. They never touch Redis,
+  files, or shell. All board I/O goes through the moderator via
+  the `Board` client (`attune.roundtable`).
+- **R3** Board state lives only under `attune:roundtable:*`
+  (TTL 7 days). Never write `attune:memory:*`.
+- **R4** Nothing reaches a tracked file without explicit per-item
+  chair approval. No auto-promotion, ever.
+- **D3** Hard ceiling: 3 rounds per question. Halt early when
+  positions converge or a round adds no information.
+
+## Step 0 — Intake and the spend gate
+
+Confirm the question with the user (one short exchange if it is
+ambiguous; skip if crisp). Derive a thread slug
+(`kebab-case`, e.g. `q-cache-invalidation-002`). Then state the
+plan — roster, expected rounds (usually 1) — and get an explicit
+go before invoking any member. That go is session-durable.
+
+If Redis is unreachable (`Board()` raises on first call): tell the
+chair. Offer to deliberate unrecorded (transcript stays in-session;
+promotion still writes artifacts) or abort. Never block silently.
+
+## Step 1 — Open the thread
+
+Write the question to a scratch file, then post it:
+
+```bash
+T="<slug>" A="chair" K="question" F="/tmp/rt-q.txt" python -c "import os; from attune.roundtable import Board; b=Board(); b.ensure_functions(); print(b.post_message(os.environ['T'], os.environ['A'], os.environ['K'], open(os.environ['F']).read()))"
+```
+
+## Step 2 — Brief the members (round 1)
+
+Write one brief per member to a scratch file. Brief template:
+
+```text
+You are one seat at a three-model round table (Claude, Antigravity,
+Codex). Answer independently; you cannot see the other seats this
+round. Reply with: (1) your POSITION on the question, concretely;
+(2) the main RISK of your own position; (3) optionally ONE follow-up
+question for the table. Text only — do not run tools, write files,
+or take actions. Question:
+
+<question text, plus any round-N context — see Step 4>
+```
+
+Invoke all three (verified recipes; run the two CLIs in parallel
+Bash calls, each with a timeout of ~180s):
+
+- **Claude seat** — Agent tool, `general-purpose`, context-free:
+  pass the brief verbatim as the prompt; its final text is the
+  reply.
+- **Antigravity** — reasoning-only plan mode (shell is auto-denied
+  headlessly, which is what R1 wants):
+
+```bash
+agy --add-dir "$PWD" -p "$(cat /tmp/rt-brief.txt)" --mode plan
+```
+
+- **Codex** — brief on stdin (the arg-prompt form blocks forever on
+  non-TTY stdin):
+
+```bash
+codex exec --skip-git-repo-check - < /tmp/rt-brief.txt
+```
+
+## Step 3 — Post positions with receipts
+
+For each member, write its reply to a scratch file and post it as a
+`position` authored by the provider, carrying the R7 receipt fields
+(and `round`):
+
+```bash
+T="<slug>" A="codex" F="/tmp/rt-codex.txt" DUR="41s" python -c "import os; from attune.roundtable import Board; b=Board(); print(b.post_message(os.environ['T'], os.environ['A'], 'position', open(os.environ['F']).read(), round=1, duration=os.environ['DUR']))"
+```
+
+Add token/cost figures as extra kwargs when the CLI reported them.
+
+**Absent seat (R6):** a member whose CLI is missing, unauthenticated,
+or times out never blocks the table. Post
+`kind='position'`, body `ABSENT — <reason>`, extra `absent=True`,
+and proceed. The table degrades to however many seats answered.
+
+**Member-originated items (R9):** if a reply contains a follow-up
+question or an unprompted suggestion, post it as its own message
+(`kind='question'` or `'suggestion'`, author = that provider,
+`reply_to` = the position's id). Origination grants no execution
+rights — triage it to the chair in Step 5.
+
+## Step 4 — Further rounds (bounded)
+
+Run another round only if member follow-up questions (R9) need
+answers or positions genuinely diverge on a decidable point. The
+round-N brief appends the prior round's positions (as plain text,
+attributed by seat) and the open follow-ups. Repeat Steps 2–3 with
+`round=N`.
+
+Halt early on convergence. At the ceiling (3 rounds) or any budget
+the chair set, stop and post the halt (R5):
+
+```bash
+T="<slug>" python -c "import os; from attune.roundtable import Board; Board().post_message(os.environ['T'], 'moderator', 'halt', 'round ceiling (3) reached')"
+```
+
+## Step 5 — Synthesize and present
+
+Post one `synthesis` message (author `moderator`): where seats
+agree, where they split and why, and the moderator's read. Then
+present to the chair: a compact per-seat position table, the
+synthesis, member-originated items needing triage, and promotion
+candidates. Read the thread back any time with:
+
+```bash
+T="<slug>" python -c "import os, json; from attune.roundtable import Board; print(json.dumps([vars(m) for m in Board().read_thread(os.environ['T'])], ensure_ascii=False, default=str))"
+```
+
+## Step 6 — Chair rules; promote (R4, R10, D2)
+
+Ask the chair per item: promote, decline, or another round. Use
+`AskUserQuestion` (or an elicitation form) — never assume. On
+promotion:
+
+1. Recommend an artifact tier per the contract's artifact-selection
+   table — inline edit / structured one-shot / XML task / spec —
+   sized to what the table produced. The chair ratifies the tier.
+2. Destination (D2): the owning spec's `decisions.md` when a spec
+   exists; else `docs/reports/roundtable/<slug>.md`. The artifact
+   records the thread id it came from.
+3. Write the artifact, then mark the thread:
+
+```bash
+T="<slug>" D="docs/reports/roundtable/<slug>.md" python -c "import os; from attune.roundtable import Board; Board().promote(os.environ['T'], os.environ['D'])"
+```
+
+Post the chair's decision as a `ruling` message (author `chair`).
+Declined items get no file writes — `git status` stays clean.
+
+Deliberation is TTL'd; only promoted content is durable. If the
+chair wants a raw thread kept past 7 days, promotion to a report is
+the mechanism — say so rather than extending TTLs ad hoc.
+
+## Arguments
+
+- `/roundtable <question>` — full deliberation (Steps 0–6).
+- `/roundtable read <thread>` — read and render an existing thread
+  (Step 5's read snippet); no member invocations.
+- `/roundtable promote <thread>` — jump to Step 6 for a thread that
+  already deliberated.

--- a/docs/specs/agent-round-table/decisions.md
+++ b/docs/specs/agent-round-table/decisions.md
@@ -187,3 +187,34 @@ moderator-pushback amendment accepted:
    before they reach the chair (antigravity's R9 origination,
    promoted). Mechanical rule the tag enables: no receipt AND no
    waiver tag → the candidate is blocked before presentation.
+
+## P2 promotion gates — SHIPPED (2026-07-18)
+
+- **Per-item promotion**: `rt_promote` accepts an optional JSON
+  array of chair-approved message ids, validated server-side
+  against the thread sequence — an unknown id rejects the whole
+  call with zero meta change; approved ids are recorded in meta as
+  `promoted_ids` (deduped, sorted). Omitting ids keeps the P1
+  whole-thread behavior. `Board.promote(thread, destination,
+  item_ids=...)`.
+- **Lesson lane** (`src/attune/roundtable/lessons.py`):
+  `LessonCandidate` (title/body/evidence/waived/thread) with the
+  ruled lint — no receipt AND no waiver → BLOCKED; evidence+waiver
+  flagged as contradictory; title/body curation bounds; origin
+  thread required (R10). `render()` refuses non-lint-clean drafts
+  and stamps waived entries with the visible
+  `unverified — design rationale (chair-waived)` tag.
+- **Skill Step 6** rewritten: per-item chair review
+  (multi-select), promoted ids passed to the board, lesson-lane
+  procedure with the lint gate run before any candidate reaches
+  the chair.
+
+Receipts: 31 roundtable tests green — per-item ids recorded /
+unknown-id atomic rejection / malformed-payload rejection /
+P1-behavior preserved, all against REAL Redis; 14 lint/render
+tests (blocking rule, waiver substitution, contradiction flag,
+render refusal). AC-3 approve-half exercised live on
+`lessons-flow-001` (this file is the destination; thread meta
+`status=promoted`); decline-half is procedural (skill: declined
+items get no writes) and enforced at the board by the
+unknown-id no-meta-change receipt.

--- a/docs/specs/agent-round-table/decisions.md
+++ b/docs/specs/agent-round-table/decisions.md
@@ -157,3 +157,33 @@ chair (unruled as of this writing): the evidence bar for lesson
 candidates (codex + claude convergent follow-up) and a pre-chair
 lint guardrail (antigravity). Promotion of the thread itself:
 chair's call, pending (R4).
+
+## Chair rulings — thread lessons-flow-001 (2026-07-18, Patrick)
+
+Promoted from `attune:roundtable:thread:lessons-flow-001` to this
+file (D2: the owning spec's decisions.md). Tier: direct decision
+record (R10 inline edit). Ruled via shorthand, with one
+moderator-pushback amendment accepted:
+
+1. **Lesson lane ratified (thread promoted here).** Lessons flow
+   via a **distinct lesson-promotion lane**: the moderator drafts
+   an atomic candidate only when a deliberation yields reusable
+   knowledge (default: no candidate); the chair
+   approves/edits/declines per item; approval writes the tracked
+   corpus; Redis re-derives at next hydration. No auto-append on
+   promotion; the table never touches the lessons corpus directly.
+2. **Evidence bar: (ii) + waiver tag.** Candidates carry receipts
+   from contact with the real system by default. The chair may
+   waive for a strong design rationale or defer until evidence
+   exists — but a waived-in lesson is recorded with an explicit
+   `unverified — design rationale (chair-waived)` marker and
+   upgrades to a normal entry when evidence lands. Transcript
+   consensus never self-qualifies; the waiver is the chair's, per
+   item. (Amendment accepted from moderator pushback: an untagged
+   waiver is invisible at retrieval time and reproduces the
+   dilution risk all three seats named.)
+3. **Pre-chair guardrail lint: accepted as a P2 task.** A check
+   enforcing lesson format + curation bar on drafted candidates
+   before they reach the chair (antigravity's R9 origination,
+   promoted). Mechanical rule the tag enables: no receipt AND no
+   waiver tag → the candidate is blocked before presentation.

--- a/docs/specs/agent-round-table/decisions.md
+++ b/docs/specs/agent-round-table/decisions.md
@@ -218,3 +218,42 @@ render refusal). AC-3 approve-half exercised live on
 `status=promoted`); decline-half is procedural (skill: declined
 items get no writes) and enforced at the board by the
 unknown-id no-meta-change receipt.
+
+## P3 forks ruled (2026-07-18, Patrick, batched form)
+
+The requirements' "§12 Clean-Run-Check" pointed at nothing — the
+live discipline article has §1–§8 only and no tracked doc defines
+the term (phantom-referent lesson applied: verified before
+building). The chair ruled all three P3 forks, taking each
+recommendation:
+
+1. **Routine #1 = clean-run health check**: keyless check battery
+   (collaboration preflight + unit suite) → seats deliberate the
+   results → digest thread for the chair. Requirements P3 text
+   updated to the ratified definition.
+2. **Manual-first scheduling**: `python -m
+   attune.roundtable.routine <name>` proves the loop by hand;
+   a weekly schedule is armed only after the chair reviews a
+   proven run. (D1's prove-before-automate precedent.)
+3. **Synthesis in unattended runs = one bounded `claude -p`
+   moderator pass**, inside the R5 cap (4 invocations/run:
+   3 seats + 1 synthesis).
+
+## P3 routines — SHIPPED (2026-07-18)
+
+`src/attune/roundtable/routine.py`: `RoutineSpec` (checks,
+question, `max_invocations`), the registered `clean-run` routine,
+seat recipes matching the verified roster invocations, keyless
+check runner (`ANTHROPIC_API_KEY=""` — empty, never unset), and
+`run_routine()` enforcing R5 (halt posted at the cap, single-halt
+semantics), R6 (absent seat → `absent=True` position, run
+completes), R8 (thread left unpromoted, always). `--dry-run` runs
+checks and prints the brief with zero board writes and zero LLM
+invocations.
+
+Receipts: 10 routine tests (real-Redis thread shape; fake seats)
+— full-run message shape, R8 unpromoted meta, check evidence in
+the question body, R6 absent-seat completion, AC-5 cap halt
+(seat N+1 not invoked, one halt message), dry-run
+touches-nothing, keyless env, brief substitution both recipe
+forms. 41 roundtable tests total.

--- a/docs/specs/agent-round-table/decisions.md
+++ b/docs/specs/agent-round-table/decisions.md
@@ -251,9 +251,38 @@ completes), R8 (thread left unpromoted, always). `--dry-run` runs
 checks and prints the brief with zero board writes and zero LLM
 invocations.
 
-Receipts: 10 routine tests (real-Redis thread shape; fake seats)
+Receipts: 12 routine tests (real-Redis thread shape; fake seats)
 — full-run message shape, R8 unpromoted meta, check evidence in
 the question body, R6 absent-seat completion, AC-5 cap halt
 (seat N+1 not invoked, one halt message), dry-run
-touches-nothing, keyless env, brief substitution both recipe
-forms. 41 roundtable tests total.
+touches-nothing, keyless check env, provider-clean seat env,
+synthesis-failure visibility, brief substitution both recipe
+forms. 43 roundtable tests total.
+
+## P3 manual proof runs — receipts (2026-07-18)
+
+Two live runs of `clean-run`, verified by READING the board
+threads (exit 0 proved nothing both times):
+
+- **Run 1** (`routine-clean-run-2026-07-18`): caught three real
+  defects. (a) Seats inherited `ANTHROPIC_API_KEY=""` → claude
+  CLI 401 (checks-correct env was seat-wrong); (b) a failed
+  synthesis was SILENT — digest-less run read as success; (c) the
+  keyless suite check caught genuine drift: the 25th skill broke
+  the website capability counts (features.ts + 3 pages, fixed
+  24→25 + roundtable added to the docs skill list). The routine
+  paid for itself on its first run.
+- **Run 2** (`routine-clean-run-20260718-1737`), after fixes:
+  both checks PASS (count fix verified end-to-end), antigravity
+  6s + codex 12s positions posted, synthesis failure now VISIBLE
+  as a halt naming the exit — and the claude seat still ABSENT:
+  the CLI's own stored OAuth token is REVOKED on this machine
+  (verified with a provider-clean env probe — not an env-
+  inheritance issue). R6 degradation worked exactly as specified
+  (AC-4, exercised live, unplanned).
+
+**Blocked on the chair:** full-roster proof + arming the weekly
+schedule wait on an interactive `claude login` re-auth (agent
+must not perform credential flows), then one rerun of
+`python -m attune.roundtable.routine clean-run`. Until then the
+routine runs as a two-seat table with a visible synthesis halt.

--- a/docs/specs/agent-round-table/decisions.md
+++ b/docs/specs/agent-round-table/decisions.md
@@ -131,3 +131,29 @@ boundary-double tests (no Redis required).
   complexity using our table with 4 types of responses" —
   bidirectional origination (R9) + promotion routed through the
   contract's four artifact tiers (R10).
+
+## P1 moderated round-trip — SHIPPED (2026-07-18)
+
+The `/roundtable` skill (`plugin/skills/roundtable/SKILL.md`,
+mirrored to `.agents/skills/` by the sync projector): intake +
+spend gate, thread open, member briefs via the verified headless
+recipes, positions posted with R7 receipts, R6 absent-seat
+degradation, R9 origination as `question`/`suggestion` messages,
+bounded rounds with early-halt (D3), synthesis, and chair-gated
+promotion with R10 tier recommendation and D2 destination routing.
+
+**AC-2 receipt — live dogfood, thread `lessons-flow-001`** (board
+`attune:roundtable:thread:lessons-flow-001`, TTL 7d from
+2026-07-18): question ("how do deliberations flow into the shared
+learning corpus?") → all 3 seats answered (claude 17s via
+subagent; antigravity 5s via `agy --mode plan`; codex 10s via
+`codex exec -`) → 3 `position` + 3 member-originated `question`
+messages + 1 `synthesis`, all server-side schema-validated, thread
+read back via `rt_read_thread`. Moderator halted after round 1 of
+3 on unanimous convergence: all seats picked (b) — a distinct
+lesson-promotion lane — and all three independently named
+review-fatigue/dilution as the risk. Open items triaged to the
+chair (unruled as of this writing): the evidence bar for lesson
+candidates (codex + claude convergent follow-up) and a pre-chair
+lint guardrail (antigravity). Promotion of the thread itself:
+chair's call, pending (R4).

--- a/docs/specs/agent-round-table/requirements.md
+++ b/docs/specs/agent-round-table/requirements.md
@@ -56,7 +56,10 @@ to make convening it cheap, monitored, and recorded.
   Bounded rounds.
 - **P2 — promotion gates.** Chair reviews thread; per-item
   approve/decline; approved items written to the destination
-  (D2) and the thread marked promoted.
+  (D2) and the thread marked promoted. Includes the
+  lesson-candidate lint (chair ruling, lessons-flow-001): drafted
+  lesson candidates are checked for format + curation bar before
+  presentation; no receipt AND no chair-waiver tag → blocked.
 - **P3 — routines.** Scheduled table runs (weekly §12
   Clean-Run-Check is the first candidate), budget-capped,
   results posted as a board digest; bridge to pipeline-learner

--- a/docs/specs/agent-round-table/requirements.md
+++ b/docs/specs/agent-round-table/requirements.md
@@ -60,10 +60,13 @@ to make convening it cheap, monitored, and recorded.
   lesson-candidate lint (chair ruling, lessons-flow-001): drafted
   lesson candidates are checked for format + curation bar before
   presentation; no receipt AND no chair-waiver tag → blocked.
-- **P3 — routines.** Scheduled table runs (weekly §12
-  Clean-Run-Check is the first candidate), budget-capped,
-  results posted as a board digest; bridge to pipeline-learner
-  (routines are canonicalized sequences).
+- **P3 — routines.** Scheduled table runs, budget-capped, results
+  posted as a board digest; bridge to pipeline-learner (routines
+  are canonicalized sequences). First routine: the weekly
+  **clean-run health check** (chair-defined 2026-07-18 — the
+  originating chat's "§12 Clean-Run-Check" shorthand resolved to
+  no tracked doc, so the chair defined it: keyless check battery →
+  seats deliberate the results → digest thread for the chair).
 
 ## Roster invocation recipes (verified live 2026-07-18)
 

--- a/plugin/skills/attune-hub/SKILL.md
+++ b/plugin/skills/attune-hub/SKILL.md
@@ -116,6 +116,7 @@ rule (a single turn can't bundle multiple ambiguous decisions). See
 | image-analysis | analyze this image, look at this screenshot, what's in this diagram, read this mockup |
 | elicit | scope this, discovery form, ask me everything at once, multi-select question |
 | author-feature | author a feature page, single-source doc, new feature master, draft docs without an api |
+| roundtable | roundtable, convene the table, ask the table, what do the other models think |
 
 ## MCP Server Not Running
 

--- a/plugin/skills/roundtable/SKILL.md
+++ b/plugin/skills/roundtable/SKILL.md
@@ -189,6 +189,25 @@ Deliberation is TTL'd; only promoted content is durable. If the
 chair wants a raw thread kept past 7 days, promotion to a report is
 the mechanism — say so rather than extending TTLs ad hoc.
 
+## Routines (P3 — headless table runs)
+
+A routine convenes the table on a recurring question with the same
+gates (R5 cap, R6 absent seats) and one extra: **a routine NEVER
+promotes (R8)** — its digest thread waits on the board for the
+chair. Manual-first is ratified: run it by hand, arm a schedule
+only after the chair reviews a proven run.
+
+```bash
+python -m attune.roundtable.routine clean-run            # real run
+python -m attune.roundtable.routine clean-run --dry-run  # checks + brief only, no board/LLM
+```
+
+Routine #1 is `clean-run` (the weekly health check): keyless check
+battery (collaboration preflight + unit suite) → seats deliberate
+the results → one synthesis pass → digest thread
+`routine-clean-run-<date>`. Review it with
+`/roundtable read <thread>`; promote per-item via Step 6.
+
 ## Arguments
 
 - `/roundtable <question>` — full deliberation (Steps 0–6).
@@ -196,3 +215,5 @@ the mechanism — say so rather than extending TTLs ad hoc.
   (Step 5's read snippet); no member invocations.
 - `/roundtable promote <thread>` — jump to Step 6 for a thread that
   already deliberated.
+- `/roundtable routine <name>` — run a registered routine (above)
+  and present its digest to the chair.

--- a/plugin/skills/roundtable/SKILL.md
+++ b/plugin/skills/roundtable/SKILL.md
@@ -1,0 +1,171 @@
+---
+name: roundtable
+description: "Convene the multi-LLM round table — Claude, Antigravity, and Codex deliberate a question; the user chairs promotion. Triggers on: roundtable, round table, convene the table, ask the table, what do the other models think, deliberate."
+argument-hint: "<question | read <thread> | promote <thread>>"
+---
+
+# Round Table
+
+**IMPORTANT: Start your response by telling the user:**
+
+> **Round table** — Convening the fixed roster (Claude, Antigravity,
+> Codex). You chair; I moderate. Up to 3 rounds.
+
+## What It Does
+
+A moderated deliberation (Phase 1 of
+`docs/specs/agent-round-table`): the user poses a question, each
+roster member answers headlessly and independently, the moderator
+(this session) posts every message to the Redis board, synthesizes,
+and presents the result. Only the chair — the user — promotes
+anything into a tracked artifact.
+
+Invariants (ratified — do not improvise around them):
+
+- **R1** Members are text-in/text-out. They never touch Redis,
+  files, or shell. All board I/O goes through the moderator via
+  the `Board` client (`attune.roundtable`).
+- **R3** Board state lives only under `attune:roundtable:*`
+  (TTL 7 days). Never write `attune:memory:*`.
+- **R4** Nothing reaches a tracked file without explicit per-item
+  chair approval. No auto-promotion, ever.
+- **D3** Hard ceiling: 3 rounds per question. Halt early when
+  positions converge or a round adds no information.
+
+## Step 0 — Intake and the spend gate
+
+Confirm the question with the user (one short exchange if it is
+ambiguous; skip if crisp). Derive a thread slug
+(`kebab-case`, e.g. `q-cache-invalidation-002`). Then state the
+plan — roster, expected rounds (usually 1) — and get an explicit
+go before invoking any member. That go is session-durable.
+
+If Redis is unreachable (`Board()` raises on first call): tell the
+chair. Offer to deliberate unrecorded (transcript stays in-session;
+promotion still writes artifacts) or abort. Never block silently.
+
+## Step 1 — Open the thread
+
+Write the question to a scratch file, then post it:
+
+```bash
+T="<slug>" A="chair" K="question" F="/tmp/rt-q.txt" python -c "import os; from attune.roundtable import Board; b=Board(); b.ensure_functions(); print(b.post_message(os.environ['T'], os.environ['A'], os.environ['K'], open(os.environ['F']).read()))"
+```
+
+## Step 2 — Brief the members (round 1)
+
+Write one brief per member to a scratch file. Brief template:
+
+```text
+You are one seat at a three-model round table (Claude, Antigravity,
+Codex). Answer independently; you cannot see the other seats this
+round. Reply with: (1) your POSITION on the question, concretely;
+(2) the main RISK of your own position; (3) optionally ONE follow-up
+question for the table. Text only — do not run tools, write files,
+or take actions. Question:
+
+<question text, plus any round-N context — see Step 4>
+```
+
+Invoke all three (verified recipes; run the two CLIs in parallel
+Bash calls, each with a timeout of ~180s):
+
+- **Claude seat** — Agent tool, `general-purpose`, context-free:
+  pass the brief verbatim as the prompt; its final text is the
+  reply.
+- **Antigravity** — reasoning-only plan mode (shell is auto-denied
+  headlessly, which is what R1 wants):
+
+```bash
+agy --add-dir "$PWD" -p "$(cat /tmp/rt-brief.txt)" --mode plan
+```
+
+- **Codex** — brief on stdin (the arg-prompt form blocks forever on
+  non-TTY stdin):
+
+```bash
+codex exec --skip-git-repo-check - < /tmp/rt-brief.txt
+```
+
+## Step 3 — Post positions with receipts
+
+For each member, write its reply to a scratch file and post it as a
+`position` authored by the provider, carrying the R7 receipt fields
+(and `round`):
+
+```bash
+T="<slug>" A="codex" F="/tmp/rt-codex.txt" DUR="41s" python -c "import os; from attune.roundtable import Board; b=Board(); print(b.post_message(os.environ['T'], os.environ['A'], 'position', open(os.environ['F']).read(), round=1, duration=os.environ['DUR']))"
+```
+
+Add token/cost figures as extra kwargs when the CLI reported them.
+
+**Absent seat (R6):** a member whose CLI is missing, unauthenticated,
+or times out never blocks the table. Post
+`kind='position'`, body `ABSENT — <reason>`, extra `absent=True`,
+and proceed. The table degrades to however many seats answered.
+
+**Member-originated items (R9):** if a reply contains a follow-up
+question or an unprompted suggestion, post it as its own message
+(`kind='question'` or `'suggestion'`, author = that provider,
+`reply_to` = the position's id). Origination grants no execution
+rights — triage it to the chair in Step 5.
+
+## Step 4 — Further rounds (bounded)
+
+Run another round only if member follow-up questions (R9) need
+answers or positions genuinely diverge on a decidable point. The
+round-N brief appends the prior round's positions (as plain text,
+attributed by seat) and the open follow-ups. Repeat Steps 2–3 with
+`round=N`.
+
+Halt early on convergence. At the ceiling (3 rounds) or any budget
+the chair set, stop and post the halt (R5):
+
+```bash
+T="<slug>" python -c "import os; from attune.roundtable import Board; Board().post_message(os.environ['T'], 'moderator', 'halt', 'round ceiling (3) reached')"
+```
+
+## Step 5 — Synthesize and present
+
+Post one `synthesis` message (author `moderator`): where seats
+agree, where they split and why, and the moderator's read. Then
+present to the chair: a compact per-seat position table, the
+synthesis, member-originated items needing triage, and promotion
+candidates. Read the thread back any time with:
+
+```bash
+T="<slug>" python -c "import os, json; from attune.roundtable import Board; print(json.dumps([vars(m) for m in Board().read_thread(os.environ['T'])], ensure_ascii=False, default=str))"
+```
+
+## Step 6 — Chair rules; promote (R4, R10, D2)
+
+Ask the chair per item: promote, decline, or another round. Use
+`AskUserQuestion` (or an elicitation form) — never assume. On
+promotion:
+
+1. Recommend an artifact tier per the contract's artifact-selection
+   table — inline edit / structured one-shot / XML task / spec —
+   sized to what the table produced. The chair ratifies the tier.
+2. Destination (D2): the owning spec's `decisions.md` when a spec
+   exists; else `docs/reports/roundtable/<slug>.md`. The artifact
+   records the thread id it came from.
+3. Write the artifact, then mark the thread:
+
+```bash
+T="<slug>" D="docs/reports/roundtable/<slug>.md" python -c "import os; from attune.roundtable import Board; Board().promote(os.environ['T'], os.environ['D'])"
+```
+
+Post the chair's decision as a `ruling` message (author `chair`).
+Declined items get no file writes — `git status` stays clean.
+
+Deliberation is TTL'd; only promoted content is durable. If the
+chair wants a raw thread kept past 7 days, promotion to a report is
+the mechanism — say so rather than extending TTLs ad hoc.
+
+## Arguments
+
+- `/roundtable <question>` — full deliberation (Steps 0–6).
+- `/roundtable read <thread>` — read and render an existing thread
+  (Step 5's read snippet); no member invocations.
+- `/roundtable promote <thread>` — jump to Step 6 for a thread that
+  already deliberated.

--- a/plugin/skills/roundtable/SKILL.md
+++ b/plugin/skills/roundtable/SKILL.md
@@ -137,11 +137,12 @@ candidates. Read the thread back any time with:
 T="<slug>" python -c "import os, json; from attune.roundtable import Board; print(json.dumps([vars(m) for m in Board().read_thread(os.environ['T'])], ensure_ascii=False, default=str))"
 ```
 
-## Step 6 — Chair rules; promote (R4, R10, D2)
+## Step 6 — Chair rules; promote per item (R4, R10, D2)
 
-Ask the chair per item: promote, decline, or another round. Use
-`AskUserQuestion` (or an elicitation form) — never assume. On
-promotion:
+Present the promotion candidates as discrete items — each with its
+board message id — and ask the chair per item: promote, decline, or
+another round. Use `AskUserQuestion` with `multiSelect` (or an
+elicitation form) — never assume. On promotion:
 
 1. Recommend an artifact tier per the contract's artifact-selection
    table — inline edit / structured one-shot / XML task / spec —
@@ -149,14 +150,40 @@ promotion:
 2. Destination (D2): the owning spec's `decisions.md` when a spec
    exists; else `docs/reports/roundtable/<slug>.md`. The artifact
    records the thread id it came from.
-3. Write the artifact, then mark the thread:
+3. Write the artifact, then mark the thread, passing the
+   chair-approved message ids so the board records exactly what was
+   promoted (an unknown id rejects the whole call, no meta change):
 
 ```bash
-T="<slug>" D="docs/reports/roundtable/<slug>.md" python -c "import os; from attune.roundtable import Board; Board().promote(os.environ['T'], os.environ['D'])"
+T="<slug>" D="docs/reports/roundtable/<slug>.md" IDS="2,4" python -c "import os; from attune.roundtable import Board; Board().promote(os.environ['T'], os.environ['D'], item_ids=[int(i) for i in os.environ['IDS'].split(',')])"
 ```
 
 Post the chair's decision as a `ruling` message (author `chair`).
 Declined items get no file writes — `git status` stays clean.
+
+### The lesson lane (chair rulings, thread lessons-flow-001)
+
+When — and only when — a deliberation yields reusable cross-session
+knowledge (a verified gotcha, a rationale that will be asked again),
+draft a lesson candidate. Default is NO candidate; most threads
+produce none. Before presenting it to the chair, lint it — the gate
+is mechanical: no receipt AND no chair waiver → blocked:
+
+```bash
+TI="<title>" B="<body>" E="<evidence or empty>" T="<slug>" python -c "import os; from attune.roundtable import LessonCandidate; c=LessonCandidate(title=os.environ['TI'], body=os.environ['B'], evidence=os.environ['E'], thread=os.environ['T']); print(c.lint() or c.render())"
+```
+
+- `evidence` is a receipt from the real system (command run,
+  failure observed, fixing diff) — transcript consensus never
+  qualifies.
+- The chair may waive the receipt for a strong design rationale
+  (`waived=True`): the rendered entry then carries the visible
+  `unverified — design rationale (chair-waived)` tag and upgrades
+  to a normal entry when evidence lands. The waiver is the chair's,
+  per item — never self-granted.
+- Approved entries append to `.claude/lessons.md` (or the owning
+  spec's `decisions.md`); Redis re-derives at next hydration. The
+  table never touches the lessons corpus directly.
 
 Deliberation is TTL'd; only promoted content is durable. If the
 chair wants a raw thread kept past 7 days, promotion to a report is

--- a/src/attune/roundtable/__init__.py
+++ b/src/attune/roundtable/__init__.py
@@ -17,11 +17,17 @@ from attune.roundtable.board import (
     Board,
     BoardMessage,
 )
+from attune.roundtable.lessons import (
+    WAIVER_TAG,
+    LessonCandidate,
+)
 
 __all__ = [
     "KINDS",
     "THREAD_KEY_PREFIX",
     "THREAD_TTL_SECONDS",
+    "WAIVER_TAG",
     "Board",
     "BoardMessage",
+    "LessonCandidate",
 ]

--- a/src/attune/roundtable/board.py
+++ b/src/attune/roundtable/board.py
@@ -113,6 +113,23 @@ local function promote(keys, args)
   if type(destination) ~= 'string' or #destination == 0 then
     return redis.error_reply('rt_promote: destination is required')
   end
+  local ids_json = args[2]
+  if ids_json ~= nil and #ids_json > 0 then
+    local ok, ids = pcall(cjson.decode, ids_json)
+    if not ok or type(ids) ~= 'table' or #ids == 0 then
+      return redis.error_reply(
+        'rt_promote: item ids must be a non-empty JSON array')
+    end
+    local seq = tonumber(redis.call('HGET', meta_key, 'seq')) or 0
+    for _, id in ipairs(ids) do
+      if type(id) ~= 'number' or id < 1 or id ~= math.floor(id)
+          or id > seq then
+        return redis.error_reply(
+          'rt_promote: unknown item id ' .. tostring(id))
+      end
+    end
+    redis.call('HSET', meta_key, 'promoted_ids', cjson.encode(ids))
+  end
   local t = redis.call('TIME')
   redis.call('HSET', meta_key, 'status', 'promoted',
     'destination', destination, 'promoted_at', t[1])
@@ -223,12 +240,30 @@ class Board:
         raw = self.client.fcall("rt_read_thread", 1, self.thread_key(thread))
         return [BoardMessage.from_json(entry) for entry in raw or []]
 
-    def promote(self, thread: str, destination: str) -> list[BoardMessage]:
+    def promote(
+        self,
+        thread: str,
+        destination: str,
+        item_ids: list[int] | None = None,
+    ) -> list[BoardMessage]:
         """Mark a thread promoted and return its messages for writing out.
 
         The artifact write itself is the moderator's job (D2 routing;
         chair approval per R4 happens before this is called). The
         board only records that promotion happened and where.
+
+        Args:
+            thread: Thread id.
+            destination: Tracked artifact path the content goes to.
+            item_ids: Chair-approved message ids (P2 per-item gates).
+                When given, they are validated server-side against the
+                thread's sequence and recorded in the thread meta as
+                ``promoted_ids``; an unknown id rejects the whole call
+                with no meta change. When omitted, the whole thread is
+                promoted (the P1 behavior).
         """
-        raw = self.client.fcall("rt_promote", 1, self.thread_key(thread), destination)
+        args: list[str] = [destination]
+        if item_ids:
+            args.append(json.dumps(sorted(set(item_ids))))
+        raw = self.client.fcall("rt_promote", 1, self.thread_key(thread), *args)
         return [BoardMessage.from_json(entry) for entry in raw or []]

--- a/src/attune/roundtable/lessons.py
+++ b/src/attune/roundtable/lessons.py
@@ -1,0 +1,103 @@
+"""Lesson-candidate lane: structure, lint, and rendering (P2).
+
+Implements the chair rulings on thread ``lessons-flow-001``
+(``docs/specs/agent-round-table/decisions.md``, 2026-07-18):
+
+- Lessons flow through a distinct promotion lane — the moderator
+  drafts an atomic candidate, the chair approves per item.
+- Candidates carry receipts from contact with the real system by
+  default; the chair may waive for a strong design rationale, and a
+  waived entry is visibly tagged as unverified.
+- The mechanical gate this module is: **no receipt AND no waiver
+  tag → blocked** before the candidate ever reaches the chair.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under Apache 2.0
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+#: The visible marker a chair-waived (receipt-less) lesson carries,
+#: verbatim from the ruling. Retrieval must be able to see which
+#: entries never touched the real system.
+WAIVER_TAG = "unverified — design rationale (chair-waived)"
+
+#: Curation-bar bounds: candidates are atomic, not essays. A draft
+#: that cannot fit is really several lessons, or a report.
+TITLE_MAX_CHARS = 100
+BODY_MAX_CHARS = 2000
+
+
+@dataclass
+class LessonCandidate:
+    """One drafted lesson awaiting the chair's per-item review.
+
+    Args:
+        title: One-line bolded summary (the corpus's scan surface).
+        body: The lesson itself — what to do or avoid, and why.
+        evidence: The receipt: commands run, failure observed, diff
+            that fixed it. Empty only when ``waived`` is True.
+        waived: Chair-granted waiver for a design rationale that has
+            not been exercised in code yet. Rendered with
+            :data:`WAIVER_TAG`.
+        thread: Board thread id the candidate came from (R10: the
+            artifact records its origin).
+    """
+
+    title: str
+    body: str
+    evidence: str = ""
+    waived: bool = False
+    thread: str = ""
+
+    def lint(self) -> list[str]:
+        """Return the list of curation-bar violations (empty = clean).
+
+        The blocking rule is the ruled one: a candidate with neither
+        evidence nor a chair waiver never reaches the chair.
+        """
+        problems: list[str] = []
+        title = self.title.strip()
+        body = self.body.strip()
+        if not title:
+            problems.append("title is required")
+        elif "\n" in title:
+            problems.append("title must be a single line")
+        elif len(title) > TITLE_MAX_CHARS:
+            problems.append(f"title exceeds {TITLE_MAX_CHARS} chars — not scannable")
+        if not body:
+            problems.append("body is required")
+        elif len(body) > BODY_MAX_CHARS:
+            problems.append(
+                f"body exceeds {BODY_MAX_CHARS} chars — split it or write a report instead"
+            )
+        if not self.evidence.strip() and not self.waived:
+            problems.append(
+                "BLOCKED: no receipt and no chair waiver — a candidate must "
+                "carry evidence from the real system or an explicit "
+                "chair-waived design rationale"
+            )
+        if self.evidence.strip() and self.waived:
+            problems.append("carries evidence AND a waiver tag — drop the waiver")
+        if not self.thread.strip():
+            problems.append("thread id is required — the artifact records its origin")
+        return problems
+
+    def render(self) -> str:
+        """Render the corpus-ready markdown entry.
+
+        Raises:
+            ValueError: If the candidate does not lint clean — only
+                chair-approvable drafts are renderable.
+        """
+        problems = self.lint()
+        if problems:
+            raise ValueError("candidate does not lint clean: " + "; ".join(problems))
+        tag = f" [{WAIVER_TAG}]" if self.waived else ""
+        lines = [f"- **{self.title.strip()}**{tag}: {self.body.strip()}"]
+        if self.evidence.strip():
+            lines.append(f"  Evidence: {self.evidence.strip()}")
+        lines.append(f"  (round-table thread {self.thread.strip()})")
+        return "\n".join(lines)

--- a/src/attune/roundtable/routine.py
+++ b/src/attune/roundtable/routine.py
@@ -103,14 +103,26 @@ BRIEF_PREAMBLE = (
 
 
 def run_command(
-    argv: Sequence[str], stdin_text: str | None = None, timeout: int = SEAT_TIMEOUT
+    argv: Sequence[str],
+    stdin_text: str | None = None,
+    timeout: int = SEAT_TIMEOUT,
+    strip_api_key: bool = False,
 ) -> tuple[int, str]:
     """Run one fixed-argv command keyless; return (exit code, output tail).
 
-    ``ANTHROPIC_API_KEY`` is set to the EMPTY string (CI-faithful
-    keyless: unset would let dotenv re-inject a real key downstream).
+    Two keyless modes, both deliberate:
+
+    - Checks (default): ``ANTHROPIC_API_KEY`` set to the EMPTY string
+      — CI-faithful (unset would let dotenv re-inject a real key
+      downstream).
+    - Seats (``strip_api_key=True``): the variable REMOVED — the
+      ``claude`` CLI 401s on an empty key instead of falling back to
+      subscription auth (live-run receipt, 2026-07-18), and members
+      should never inherit a real API key anyway (R1 hygiene).
     """
     env = {**os.environ, "ANTHROPIC_API_KEY": ""}
+    if strip_api_key:
+        env.pop("ANTHROPIC_API_KEY")
     try:
         proc = subprocess.run(  # nosec B603 — fixed argv, shell=False
             list(argv),
@@ -131,9 +143,9 @@ def run_command(
 def default_invoke_seat(recipe: Sequence[str], brief: str) -> tuple[int, str]:
     """Invoke one seat CLI with the brief substituted per its recipe."""
     if recipe[-1] == "-":
-        return run_command(recipe, stdin_text=brief)
+        return run_command(recipe, stdin_text=brief, strip_api_key=True)
     argv = [brief if part == "{brief}" else part for part in recipe]
-    return run_command(argv)
+    return run_command(argv, strip_api_key=True)
 
 
 def run_routine(
@@ -157,8 +169,10 @@ def run_routine(
         dry_run: Run checks and print the brief; skip the board and
             every LLM invocation.
     """
-    date = datetime.date.today().isoformat()
-    thread = f"routine-{spec.name}-{date}"
+    # Minute-resolution stamp: same-day reruns (fix-and-rerun is the
+    # normal proving loop) must not append into one shared thread.
+    stamp = datetime.datetime.now().strftime("%Y%m%d-%H%M")
+    thread = f"routine-{spec.name}-{stamp}"
 
     evidence: list[str] = []
     for label, argv in spec.checks:
@@ -218,6 +232,16 @@ def run_routine(
         code, digest = invoke_seat(("claude", "-p", "{brief}"), synthesis_brief)
         if code == 0 and digest.strip():
             board.post_message(thread, "moderator", "synthesis", digest, round=1)
+        else:
+            # Silence here would read as success — name the failure on
+            # the thread so the chair sees a digest-less run for what
+            # it is.
+            board.post_message(
+                thread,
+                "moderator",
+                "halt",
+                f"synthesis invocation failed (exit {code}): {digest[:200]}",
+            )
     elif positions and not halted:
         board.post_message(
             thread,

--- a/src/attune/roundtable/routine.py
+++ b/src/attune/roundtable/routine.py
@@ -1,0 +1,254 @@
+"""Round-table routines: scheduled/manual headless table runs (P3).
+
+A routine convenes the table on a recurring question — the first is
+the weekly **clean-run health check** (chair-ratified 2026-07-18,
+replacing the unresolvable "§12 Clean-Run-Check" shorthand): run the
+repo's keyless check battery, put the results to the seats, post a
+digest thread for the chair.
+
+Gates carried from the interactive loop (R8):
+
+- **R5** — a hard invocation cap; the run halts with a ``halt``
+  message when reached, never silently exceeds it.
+- **R6** — an unavailable seat is marked absent; the run completes.
+- **R8** — the runner NEVER promotes. The digest thread stays on the
+  board for the chair; promotion happens interactively
+  (``/roundtable promote <thread>``).
+
+Manual-first (chair-ratified): ``python -m attune.roundtable.routine
+clean-run``. Arm a schedule only after a proven manual run.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under Apache 2.0
+"""
+
+from __future__ import annotations
+
+import datetime
+import os
+import subprocess  # nosec B404 — fixed argv seat recipes, never shell=True
+import sys
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+
+from attune.roundtable.board import Board
+
+#: Per-check and per-seat wall-clock bounds (seconds).
+CHECK_TIMEOUT = 900
+SEAT_TIMEOUT = 300
+
+#: Output kept per check/seat before truncation — briefs stay bounded.
+TAIL_CHARS = 2000
+
+
+@dataclass
+class RoutineSpec:
+    """One routine: its checks, question framing, and caps.
+
+    Args:
+        name: Routine name; thread ids are ``routine-<name>-<date>``.
+        question: Question template put to the seats; check evidence
+            is appended by the runner.
+        checks: ``(label, argv)`` commands run keyless for evidence.
+        max_invocations: R5 cap on LLM invocations per run (seats +
+            synthesis together).
+    """
+
+    name: str
+    question: str
+    checks: Sequence[tuple[str, Sequence[str]]] = ()
+    max_invocations: int = 4
+
+
+#: Routine #1 — the weekly clean-run health check.
+CLEAN_RUN = RoutineSpec(
+    name="clean-run",
+    question=(
+        "Weekly clean-run health check. Below are the keyless check "
+        "results from the current tree. Deliberate: is the tree "
+        "healthy? Name anything that drifted or degraded, rank "
+        "anything needing action, and propose AT MOST one lesson "
+        "candidate — only if a durable, receipted gotcha surfaced."
+    ),
+    checks=(
+        # sys.executable, not bare "python": the check subprocess must
+        # run the interpreter this runner runs under (PATH's python may
+        # lack pytest entirely).
+        ("collaboration-preflight", (sys.executable, "scripts/collaboration_preflight.py")),
+        (
+            "keyless-unit-suite",
+            (sys.executable, "-m", "pytest", "tests/unit", "-q", "--timeout", "600"),
+        ),
+    ),
+)
+
+ROUTINES: dict[str, RoutineSpec] = {CLEAN_RUN.name: CLEAN_RUN}
+
+#: Seat recipes, verified live 2026-07-18 (requirements: roster
+#: invocation recipes). ``{brief}`` marks where the brief goes;
+#: ``"-"`` as the sole marker means "brief on stdin".
+SEAT_RECIPES: tuple[tuple[str, tuple[str, ...]], ...] = (
+    ("claude", ("claude", "-p", "{brief}")),
+    ("antigravity", ("agy", "--add-dir", ".", "-p", "{brief}", "--mode", "plan")),
+    ("codex", ("codex", "exec", "--skip-git-repo-check", "-")),
+)
+
+BRIEF_PREAMBLE = (
+    "You are one seat at a three-model round table (Claude, "
+    "Antigravity, Codex), convened by a scheduled routine. Answer "
+    "independently. Reply with: (1) your POSITION, concretely; (2) "
+    "the main RISK of your own position. Text only — do not run "
+    "tools, write files, or take actions.\n\nQuestion:\n\n"
+)
+
+
+def run_command(
+    argv: Sequence[str], stdin_text: str | None = None, timeout: int = SEAT_TIMEOUT
+) -> tuple[int, str]:
+    """Run one fixed-argv command keyless; return (exit code, output tail).
+
+    ``ANTHROPIC_API_KEY`` is set to the EMPTY string (CI-faithful
+    keyless: unset would let dotenv re-inject a real key downstream).
+    """
+    env = {**os.environ, "ANTHROPIC_API_KEY": ""}
+    try:
+        proc = subprocess.run(  # nosec B603 — fixed argv, shell=False
+            list(argv),
+            input=stdin_text,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            env=env,
+        )
+    except FileNotFoundError:
+        return 127, f"{argv[0]}: not found"
+    except subprocess.TimeoutExpired:
+        return 124, f"timed out after {timeout}s"
+    out = (proc.stdout + proc.stderr).strip()
+    return proc.returncode, out[-TAIL_CHARS:]
+
+
+def default_invoke_seat(recipe: Sequence[str], brief: str) -> tuple[int, str]:
+    """Invoke one seat CLI with the brief substituted per its recipe."""
+    if recipe[-1] == "-":
+        return run_command(recipe, stdin_text=brief)
+    argv = [brief if part == "{brief}" else part for part in recipe]
+    return run_command(argv)
+
+
+def run_routine(
+    spec: RoutineSpec,
+    board: Board | None = None,
+    invoke_seat: Callable[[Sequence[str], str], tuple[int, str]] = default_invoke_seat,
+    run_check: Callable[..., tuple[int, str]] = run_command,
+    dry_run: bool = False,
+) -> str:
+    """Run one routine end-to-end; return the board thread id.
+
+    Sequence: checks → question posted → seats (R5-capped, R6
+    absent-tolerant) → one synthesis invocation → digest printed.
+    The thread is left UNPROMOTED for the chair (R8).
+
+    Args:
+        spec: The routine to run.
+        board: Board client; a default one when None.
+        invoke_seat: Seat invoker (injectable for tests).
+        run_check: Check runner (injectable for tests).
+        dry_run: Run checks and print the brief; skip the board and
+            every LLM invocation.
+    """
+    date = datetime.date.today().isoformat()
+    thread = f"routine-{spec.name}-{date}"
+
+    evidence: list[str] = []
+    for label, argv in spec.checks:
+        code, tail = run_check(argv, timeout=CHECK_TIMEOUT)
+        status = "PASS" if code == 0 else f"FAIL (exit {code})"
+        evidence.append(f"### {label}: {status}\n{tail}")
+    question = spec.question + "\n\n" + "\n\n".join(evidence)
+    brief = BRIEF_PREAMBLE + question
+
+    if dry_run:
+        print(f"[dry-run] thread would be {thread!r}; brief follows:\n\n{brief}")
+        return thread
+
+    board = board or Board()
+    board.ensure_functions()
+    board.post_message(thread, "moderator", "question", question, routine=spec.name)
+
+    invocations = 0
+    halted = False
+    positions: list[tuple[str, str]] = []
+    for seat, recipe in SEAT_RECIPES:
+        if invocations >= spec.max_invocations:
+            halted = True
+            board.post_message(
+                thread,
+                "moderator",
+                "halt",
+                f"invocation cap ({spec.max_invocations}) reached before seat {seat!r}",
+            )
+            break
+        invocations += 1
+        started = datetime.datetime.now()
+        code, reply = invoke_seat(recipe, brief)
+        duration = f"{(datetime.datetime.now() - started).total_seconds():.0f}s"
+        if code != 0 or not reply.strip():
+            board.post_message(
+                thread,
+                seat,
+                "position",
+                f"ABSENT — exit {code}: {reply[:200]}",
+                absent=True,
+                duration=duration,
+            )
+            continue
+        board.post_message(thread, seat, "position", reply, round=1, duration=duration)
+        positions.append((seat, reply))
+
+    if positions and invocations < spec.max_invocations:
+        invocations += 1
+        synthesis_brief = (
+            "You are the moderator of a round-table routine. Synthesize "
+            "the seat positions below into a digest: agreements, splits, "
+            "ranked actions, and any lesson candidate proposed. Be "
+            "compact. Text only.\n\n"
+            + "\n\n".join(f"## {seat}\n{reply}" for seat, reply in positions)
+        )
+        code, digest = invoke_seat(("claude", "-p", "{brief}"), synthesis_brief)
+        if code == 0 and digest.strip():
+            board.post_message(thread, "moderator", "synthesis", digest, round=1)
+    elif positions and not halted:
+        board.post_message(
+            thread,
+            "moderator",
+            "halt",
+            f"invocation cap ({spec.max_invocations}) reached before synthesis",
+        )
+
+    print(
+        f"routine {spec.name!r} complete: thread {thread!r} ({invocations} invocations). Review with /roundtable read {thread}; the thread is NOT promoted (R8)."
+    )
+    return thread
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """CLI entry: ``python -m attune.roundtable.routine <name> [--dry-run]``."""
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Run a round-table routine (manual-first; R8: never self-promotes)."
+    )
+    parser.add_argument("name", choices=sorted(ROUTINES))
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="run checks and print the brief; no board writes, no LLM invocations",
+    )
+    args = parser.parse_args(argv)
+    run_routine(ROUTINES[args.name], dry_run=args.dry_run)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/src/attune/roundtable/routine.py
+++ b/src/attune/roundtable/routine.py
@@ -106,23 +106,28 @@ def run_command(
     argv: Sequence[str],
     stdin_text: str | None = None,
     timeout: int = SEAT_TIMEOUT,
-    strip_api_key: bool = False,
+    provider_clean: bool = False,
 ) -> tuple[int, str]:
     """Run one fixed-argv command keyless; return (exit code, output tail).
 
-    Two keyless modes, both deliberate:
+    Two env modes, both deliberate (live-run receipts, 2026-07-18):
 
     - Checks (default): ``ANTHROPIC_API_KEY`` set to the EMPTY string
       — CI-faithful (unset would let dotenv re-inject a real key
       downstream).
-    - Seats (``strip_api_key=True``): the variable REMOVED — the
-      ``claude`` CLI 401s on an empty key instead of falling back to
-      subscription auth (live-run receipt, 2026-07-18), and members
-      should never inherit a real API key anyway (R1 hygiene).
+    - Seats (``provider_clean=True``): every ``ANTHROPIC_*`` and
+      ``CLAUDE*`` variable REMOVED. When the runner itself executes
+      inside a Claude Code session, the child inherits
+      ``ANTHROPIC_BASE_URL`` + ``CLAUDE_CODE_*`` and 401s against the
+      parent session's proxy; an EMPTY ``ANTHROPIC_API_KEY`` likewise
+      401s the ``claude`` CLI instead of letting its own stored auth
+      kick in. Scrubbing the whole provider surface fixes both and
+      keeps harness identifiers out of member processes (R1 hygiene).
     """
-    env = {**os.environ, "ANTHROPIC_API_KEY": ""}
-    if strip_api_key:
-        env.pop("ANTHROPIC_API_KEY")
+    if provider_clean:
+        env = {k: v for k, v in os.environ.items() if not k.startswith(("ANTHROPIC_", "CLAUDE"))}
+    else:
+        env = {**os.environ, "ANTHROPIC_API_KEY": ""}
     try:
         proc = subprocess.run(  # nosec B603 — fixed argv, shell=False
             list(argv),
@@ -143,9 +148,9 @@ def run_command(
 def default_invoke_seat(recipe: Sequence[str], brief: str) -> tuple[int, str]:
     """Invoke one seat CLI with the brief substituted per its recipe."""
     if recipe[-1] == "-":
-        return run_command(recipe, stdin_text=brief, strip_api_key=True)
+        return run_command(recipe, stdin_text=brief, provider_clean=True)
     argv = [brief if part == "{brief}" else part for part in recipe]
-    return run_command(argv, strip_api_key=True)
+    return run_command(argv, provider_clean=True)
 
 
 def run_routine(

--- a/tests/unit/plugins/test_plugin_config_validation.py
+++ b/tests/unit/plugins/test_plugin_config_validation.py
@@ -302,8 +302,8 @@ class TestPluginStructure:
         """Test that the expected number of skills exist."""
         skills_dir = PLUGIN_ROOT / "skills"
         skill_dirs = [d for d in skills_dir.iterdir() if d.is_dir() and (d / "SKILL.md").exists()]
-        assert len(skill_dirs) == 24, (
-            f"Expected 24 skills, found {len(skill_dirs)}: " f"{sorted(d.name for d in skill_dirs)}"
+        assert len(skill_dirs) == 25, (
+            f"Expected 25 skills, found {len(skill_dirs)}: " f"{sorted(d.name for d in skill_dirs)}"
         )
 
     def test_commands_directory_only_has_allowlisted_commands(self) -> None:

--- a/tests/unit/roundtable/test_board.py
+++ b/tests/unit/roundtable/test_board.py
@@ -194,3 +194,41 @@ class TestAgainstRealRedis:
         board.post_message(thread, author="a@s", kind="suggestion", body="x")
         with pytest.raises(redis.ResponseError, match="destination"):
             board.client.fcall("rt_promote", 1, Board.thread_key(thread), "")
+
+    def test_promote_records_chair_approved_item_ids(self) -> None:
+        """P2 per-item gates: approved ids land in meta, deduped and sorted."""
+        board = _real_board_or_skip()
+        thread = _fresh_thread()
+        for body in ("q", "pos-a", "pos-b"):
+            board.post_message(thread, author="a@s", kind="suggestion", body=body)
+        board.promote(thread, "docs/reports/roundtable/test.md", item_ids=[3, 1, 3])
+        meta = board.client.hgetall(Board.thread_key(thread) + ":meta")
+        assert meta["status"] == "promoted"
+        assert json.loads(meta["promoted_ids"]) == [1, 3]
+
+    def test_promote_unknown_item_id_rejected_with_no_meta_change(self) -> None:
+        """An out-of-range id rejects the whole call atomically (AC-3 spirit)."""
+        redis = pytest.importorskip("redis")
+        board = _real_board_or_skip()
+        thread = _fresh_thread()
+        board.post_message(thread, author="a@s", kind="suggestion", body="only one")
+        with pytest.raises(redis.ResponseError, match="unknown item id 2"):
+            board.promote(thread, "docs/reports/roundtable/test.md", item_ids=[2])
+        meta = board.client.hgetall(Board.thread_key(thread) + ":meta")
+        assert "status" not in meta and "promoted_ids" not in meta
+
+    def test_promote_malformed_ids_payload_rejected(self) -> None:
+        redis = pytest.importorskip("redis")
+        board = _real_board_or_skip()
+        thread = _fresh_thread()
+        board.post_message(thread, author="a@s", kind="suggestion", body="x")
+        with pytest.raises(redis.ResponseError, match="JSON array"):
+            board.client.fcall("rt_promote", 1, Board.thread_key(thread), "dest.md", "not-json")
+
+    def test_promote_without_ids_keeps_p1_whole_thread_behavior(self) -> None:
+        board = _real_board_or_skip()
+        thread = _fresh_thread()
+        board.post_message(thread, author="a@s", kind="suggestion", body="x")
+        board.promote(thread, "dest.md")
+        meta = board.client.hgetall(Board.thread_key(thread) + ":meta")
+        assert meta["status"] == "promoted" and "promoted_ids" not in meta

--- a/tests/unit/roundtable/test_lessons.py
+++ b/tests/unit/roundtable/test_lessons.py
@@ -1,0 +1,77 @@
+"""Lesson-candidate lane tests (agent-round-table Phase 2).
+
+The lint is the chair-ruled mechanical gate (thread
+lessons-flow-001): no receipt AND no waiver tag → blocked before
+the candidate reaches the chair. Pure logic — no Redis needed.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from attune.roundtable import WAIVER_TAG, LessonCandidate
+
+
+def _receipted(**overrides) -> LessonCandidate:
+    fields = {
+        "title": "codex exec blocks on non-TTY stdin",
+        "body": "Use `codex exec -` with the brief on stdin.",
+        "evidence": "hung 2026-07-18, ~0 CPU; `codex exec -` returned in 10s",
+        "thread": "lessons-flow-001",
+    }
+    fields.update(overrides)
+    return LessonCandidate(**fields)
+
+
+class TestBlockingRule:
+    def test_receipted_candidate_lints_clean(self) -> None:
+        assert _receipted().lint() == []
+
+    def test_no_receipt_no_waiver_is_blocked(self) -> None:
+        problems = _receipted(evidence="").lint()
+        assert any(p.startswith("BLOCKED") for p in problems)
+
+    def test_waiver_substitutes_for_receipt(self) -> None:
+        assert _receipted(evidence="", waived=True).lint() == []
+
+    def test_evidence_plus_waiver_is_flagged(self) -> None:
+        problems = _receipted(waived=True).lint()
+        assert problems == ["carries evidence AND a waiver tag — drop the waiver"]
+
+    def test_whitespace_evidence_is_no_receipt(self) -> None:
+        problems = _receipted(evidence="   \n ").lint()
+        assert any(p.startswith("BLOCKED") for p in problems)
+
+
+class TestCurationBar:
+    def test_missing_title_body_thread(self) -> None:
+        problems = LessonCandidate(title="", body="").lint()
+        assert "title is required" in problems
+        assert "body is required" in problems
+        assert any("thread id is required" in p for p in problems)
+
+    def test_multiline_title_rejected(self) -> None:
+        assert "title must be a single line" in _receipted(title="a\nb").lint()
+
+    def test_oversize_title_and_body_rejected(self) -> None:
+        problems = _receipted(title="t" * 101, body="b" * 2001).lint()
+        assert any("title exceeds" in p for p in problems)
+        assert any("body exceeds" in p for p in problems)
+
+
+class TestRender:
+    def test_blocked_candidate_refuses_to_render(self) -> None:
+        with pytest.raises(ValueError, match="does not lint clean"):
+            _receipted(evidence="").render()
+
+    def test_receipted_render_carries_evidence_and_thread(self) -> None:
+        entry = _receipted().render()
+        assert entry.startswith("- **codex exec blocks on non-TTY stdin**: ")
+        assert "  Evidence: hung 2026-07-18" in entry
+        assert "(round-table thread lessons-flow-001)" in entry
+        assert WAIVER_TAG not in entry
+
+    def test_waived_render_carries_the_visible_tag(self) -> None:
+        entry = _receipted(evidence="", waived=True).render()
+        assert f"[{WAIVER_TAG}]" in entry
+        assert "Evidence:" not in entry

--- a/tests/unit/roundtable/test_routine.py
+++ b/tests/unit/roundtable/test_routine.py
@@ -155,14 +155,24 @@ class TestPlumbing:
         code, out = default_invoke_seat(("cat", "-"), "stdin brief")
         assert code == 0 and out == "stdin brief"
 
-    def test_seats_get_api_key_stripped_not_emptied(self, monkeypatch) -> None:
-        """Live-run regression: an EMPTY key 401s the claude CLI; seats
-        need the variable absent so subscription auth kicks in."""
+    def test_seats_run_provider_clean(self, monkeypatch) -> None:
+        """Live-run regression: seats must not inherit ANTHROPIC_*/
+        CLAUDE* vars — an empty key or the parent session's BASE_URL
+        401s the claude CLI instead of its own stored auth."""
         monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-real")  # pragma: allowlist secret
+        monkeypatch.setenv("ANTHROPIC_BASE_URL", "http://parent-proxy")
+        monkeypatch.setenv("CLAUDECODE", "1")
+        monkeypatch.setenv("CLAUDE_CODE_ENTRYPOINT", "cli")
         code, out = default_invoke_seat(
-            ("sh", "-c", 'echo "set=${ANTHROPIC_API_KEY+yes}"'), "unused"
+            (
+                "sh",
+                "-c",
+                'echo "leaked=${ANTHROPIC_API_KEY+k}${ANTHROPIC_BASE_URL+u}'
+                '${CLAUDECODE+c}${CLAUDE_CODE_ENTRYPOINT+e}."',
+            ),
+            "unused",
         )
-        assert code == 0 and "set=" in out and "set=yes" not in out
+        assert code == 0 and "leaked=." in out
 
     def test_synthesis_failure_is_visible_on_the_thread(self) -> None:
         """Live-run regression: a failed synthesis must not read as a

--- a/tests/unit/roundtable/test_routine.py
+++ b/tests/unit/roundtable/test_routine.py
@@ -154,3 +154,28 @@ class TestPlumbing:
         assert code == 0 and out == "hello table"
         code, out = default_invoke_seat(("cat", "-"), "stdin brief")
         assert code == 0 and out == "stdin brief"
+
+    def test_seats_get_api_key_stripped_not_emptied(self, monkeypatch) -> None:
+        """Live-run regression: an EMPTY key 401s the claude CLI; seats
+        need the variable absent so subscription auth kicks in."""
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-real")  # pragma: allowlist secret
+        code, out = default_invoke_seat(
+            ("sh", "-c", 'echo "set=${ANTHROPIC_API_KEY+yes}"'), "unused"
+        )
+        assert code == 0 and "set=" in out and "set=yes" not in out
+
+    def test_synthesis_failure_is_visible_on_the_thread(self) -> None:
+        """Live-run regression: a failed synthesis must not read as a
+        successful digest-less run."""
+        board = _real_board_or_skip()
+
+        def invoke(recipe, brief):
+            if "moderator of a round-table routine" in brief:
+                return 1, "Failed to authenticate"
+            return 0, f"position from {recipe[0]}"
+
+        thread = run_routine(_spec(), board=board, invoke_seat=invoke, run_check=_ok_check)
+        msgs = board.read_thread(thread)
+        assert not any(m.kind == "synthesis" for m in msgs)
+        halts = [m for m in msgs if m.kind == "halt"]
+        assert len(halts) == 1 and "synthesis invocation failed (exit 1)" in halts[0].body

--- a/tests/unit/roundtable/test_routine.py
+++ b/tests/unit/roundtable/test_routine.py
@@ -1,0 +1,156 @@
+"""Routine runner tests (agent-round-table Phase 3).
+
+Seats and checks are injected fakes — no member CLI is invoked and
+no real check battery runs. Board writes go against a REAL Redis
+(same pattern as test_board.py) so the routine's thread shape is a
+non-mocked receipt; tests skip when Redis is unreachable.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from attune.roundtable import Board
+from attune.roundtable.routine import (
+    CLEAN_RUN,
+    ROUTINES,
+    RoutineSpec,
+    default_invoke_seat,
+    run_command,
+    run_routine,
+)
+
+
+def _real_board_or_skip() -> Board:
+    redis = pytest.importorskip("redis")
+    client = redis.Redis.from_url("redis://localhost:6379/0", decode_responses=True)
+    try:
+        client.ping()
+    except redis.RedisError:
+        pytest.skip("no reachable Redis on localhost:6379")
+    board = Board(client=client)
+    board.ensure_functions()
+    return board
+
+
+def _spec(**overrides) -> RoutineSpec:
+    fields = {
+        "name": "test-" + uuid.uuid4().hex[:8],
+        "question": "Is the tree healthy?",
+        "checks": (("noop", ("true",)),),
+        "max_invocations": 4,
+    }
+    fields.update(overrides)
+    return RoutineSpec(**fields)
+
+
+def _ok_check(argv, timeout=0):
+    return 0, "all green"
+
+
+def _seat_by_kind(messages):
+    return {(m.author, m.kind) for m in messages}
+
+
+class TestRunRoutine:
+    def test_full_run_posts_question_positions_synthesis(self) -> None:
+        board = _real_board_or_skip()
+
+        def invoke(recipe, brief):
+            return 0, f"position from {recipe[0]}"
+
+        thread = run_routine(_spec(), board=board, invoke_seat=invoke, run_check=_ok_check)
+        msgs = board.read_thread(thread)
+        kinds = _seat_by_kind(msgs)
+        assert ("moderator", "question") in kinds
+        for seat in ("claude", "antigravity", "codex"):
+            assert (seat, "position") in kinds
+        assert ("moderator", "synthesis") in kinds
+
+    def test_thread_is_left_unpromoted_for_the_chair(self) -> None:
+        """R8: a routine NEVER self-promotes."""
+        board = _real_board_or_skip()
+        thread = run_routine(
+            _spec(), board=board, invoke_seat=lambda r, b: (0, "pos"), run_check=_ok_check
+        )
+        meta = board.client.hgetall(Board.thread_key(thread) + ":meta")
+        assert "status" not in meta and "destination" not in meta
+
+    def test_check_evidence_lands_in_the_question(self) -> None:
+        board = _real_board_or_skip()
+
+        def failing_check(argv, timeout=0):
+            return 1, "3 failed, 1 passed"
+
+        thread = run_routine(
+            _spec(checks=(("suite", ("false",)),)),
+            board=board,
+            invoke_seat=lambda r, b: (0, "pos"),
+            run_check=failing_check,
+        )
+        question = board.read_thread(thread)[0]
+        assert "### suite: FAIL (exit 1)" in question.body
+        assert "3 failed, 1 passed" in question.body
+
+    def test_absent_seat_never_blocks_the_run(self) -> None:
+        """R6: one dead CLI -> absent position, run completes."""
+        board = _real_board_or_skip()
+
+        def invoke(recipe, brief):
+            if recipe[0] == "agy":
+                return 127, "agy: not found"
+            return 0, f"position from {recipe[0]}"
+
+        thread = run_routine(_spec(), board=board, invoke_seat=invoke, run_check=_ok_check)
+        msgs = board.read_thread(thread)
+        absent = [m for m in msgs if m.extra.get("absent")]
+        assert len(absent) == 1 and absent[0].author == "antigravity"
+        assert absent[0].body.startswith("ABSENT — exit 127")
+        assert ("moderator", "synthesis") in _seat_by_kind(msgs)
+
+    def test_invocation_cap_halts_before_the_next_seat(self) -> None:
+        """R5 / AC-5: invocation N+1 is not made; a halt is posted."""
+        board = _real_board_or_skip()
+        invoked: list[str] = []
+
+        def invoke(recipe, brief):
+            invoked.append(recipe[0])
+            return 0, "pos"
+
+        thread = run_routine(
+            _spec(max_invocations=2), board=board, invoke_seat=invoke, run_check=_ok_check
+        )
+        assert invoked == ["claude", "agy"]  # codex (3rd) never invoked
+        msgs = board.read_thread(thread)
+        halts = [m for m in msgs if m.kind == "halt"]
+        assert len(halts) == 1 and "cap (2) reached" in halts[0].body
+
+    def test_dry_run_touches_nothing(self, capsys) -> None:
+        def boom(*a, **k):
+            raise AssertionError("no invocation in dry-run")
+
+        run_routine(_spec(), board=None, invoke_seat=boom, run_check=_ok_check, dry_run=True)
+        out = capsys.readouterr().out
+        assert "[dry-run]" in out and "Is the tree healthy?" in out
+
+
+class TestPlumbing:
+    def test_clean_run_is_registered(self) -> None:
+        assert ROUTINES["clean-run"] is CLEAN_RUN
+        assert CLEAN_RUN.max_invocations == 4
+
+    def test_run_command_missing_binary_is_absent_not_raise(self) -> None:
+        code, out = run_command(("definitely-not-a-real-binary-xyz",))
+        assert code == 127 and "not found" in out
+
+    def test_run_command_is_keyless(self) -> None:
+        code, out = run_command(("sh", "-c", 'echo "key=[$ANTHROPIC_API_KEY]"'))
+        assert code == 0 and "key=[]" in out
+
+    def test_default_invoke_substitutes_brief_or_uses_stdin(self) -> None:
+        code, out = default_invoke_seat(("echo", "{brief}"), "hello table")
+        assert code == 0 and out == "hello table"
+        code, out = default_invoke_seat(("cat", "-"), "stdin brief")
+        assert code == 0 and out == "stdin brief"

--- a/website/app/docs/page.tsx
+++ b/website/app/docs/page.tsx
@@ -45,7 +45,7 @@ const faqItems = [
   {
     question: 'What Claude Code skills are included?',
     answer:
-      '24 auto-invoking skills: security audit, smart test, code quality, bug prediction, doc generation, refactor planning, release prep, planning, spec-driven development, fix-test, workflow orchestration, RAG-grounded code generation, content verification, cross-session recall, memory and context, personal memory, image analysis, batch processing, capability catalog, discovery sweep, form-driven elicitation, the coach help system, the attune hub router, and single-source feature-page authoring.',
+      '25 auto-invoking skills: security audit, smart test, code quality, bug prediction, doc generation, refactor planning, release prep, planning, spec-driven development, fix-test, workflow orchestration, RAG-grounded code generation, content verification, cross-session recall, memory and context, personal memory, image analysis, batch processing, capability catalog, discovery sweep, form-driven elicitation, the coach help system, the attune hub router, single-source feature-page authoring, and the multi-LLM round table.',
   },
   {
     question: 'Where do I install attune-help and attune-author from?',
@@ -66,7 +66,7 @@ const workflows = [
   { name: 'Release Prep', description: 'Changelog, version bump, health checks' },
 ];
 
-// The 24 plugin skills — keep in sync with plugin/skills/
+// The 25 plugin skills — keep in sync with plugin/skills/
 // (test_skill_count asserts the directory count).
 const skills = [
   'security-audit', 'smart-test', 'code-quality', 'bug-predict',
@@ -75,6 +75,7 @@ const skills = [
   'verify', 'recall', 'memory-and-context', 'personal-memory',
   'image-analysis', 'bulk', 'catalog', 'discovery-sweep',
   'elicit', 'coach', 'attune-hub', 'author-feature',
+  'roundtable',
 ];
 
 export default function DocsPage() {
@@ -177,7 +178,7 @@ export default function DocsPage() {
                   <p className="text-sm text-[var(--text-secondary)] mb-5 flex-1">
                     The whole platform: spec engine, AI workflows, project
                     memory, retrieval grounding, and verification.
-                    20 workflows, 24 skills, 47 MCP tools.
+                    20 workflows, 25 skills, 47 MCP tools.
                   </p>
                   <div className="bg-[#213145] text-white/90 rounded-xl font-mono text-xs p-3">
                     <span className="text-white/50">$ </span>pip install attune-ai
@@ -506,7 +507,7 @@ export default function DocsPage() {
               </h2>
               <p className="text-center text-[var(--text-secondary)] mb-12 max-w-2xl mx-auto">
                 Install from the marketplace. Progressive help, project
-                bootstrapping, and 24 skills right in your terminal.
+                bootstrapping, and 25 skills right in your terminal.
               </p>
 
               <div className="bg-[var(--background)] border-2 border-[var(--border)] rounded-lg p-8 mb-8">
@@ -573,7 +574,7 @@ export default function DocsPage() {
               </h2>
               <p className="text-center text-[var(--text-secondary)] mb-12 max-w-2xl mx-auto">
                 The build half of the loop: 20 workflows,
-                24 auto-triggering Claude Code skills,
+                25 auto-triggering Claude Code skills,
                 and an MCP server with 47 registered tools — review, tests,
                 bug prediction, refactor, and release prep.
               </p>
@@ -600,7 +601,7 @@ export default function DocsPage() {
 
                 <div>
                   <h3 className="font-bold text-lg mb-4">
-                    24 Claude Code Skills
+                    25 Claude Code Skills
                   </h3>
                   <p className="text-sm text-[var(--text-secondary)] mb-4">
                     Skills auto-invoke from natural language. Type the topic

--- a/website/app/faq/page.tsx
+++ b/website/app/faq/page.tsx
@@ -34,7 +34,7 @@ const faqData: FAQCategory[] = [
       },
       {
         question: 'What can Attune AI do, in numbers?',
-        answer: 'Attune AI ships 20 workflows, 47 MCP tools, 24 auto-triggering skills, 5 wizards, and 15 template kinds. The spec engine runs via /spec, progressive help via /coach, and cross-session recall via /recall.',
+        answer: 'Attune AI ships 20 workflows, 47 MCP tools, 25 auto-triggering skills, 5 wizards, and 15 template kinds. The spec engine runs via /spec, progressive help via /coach, and cross-session recall via /recall.',
       },
       {
         question: "What's the difference between attune-ai and attune-gui?",

--- a/website/app/page.tsx
+++ b/website/app/page.tsx
@@ -451,7 +451,7 @@ export default function Home() {
               </div>
               <h3 className="text-xl font-bold mb-3">attune-ai</h3>
               <p className="text-[var(--text-secondary)] leading-relaxed text-sm">
-                Full framework. Workflows, staleness detection, MCP server, and 24 auto-triggering skills for Claude Code.
+                Full framework. Workflows, staleness detection, MCP server, and 25 auto-triggering skills for Claude Code.
               </p>
             </div>
 

--- a/website/lib/features.ts
+++ b/website/lib/features.ts
@@ -46,7 +46,7 @@ export const PRODUCTS: Product[] = [
       "Generate concept, task, and reference templates",
       "Staleness detection via source hashing",
       "Auto-regeneration of stale templates",
-      "24 Claude Code skills included",
+      "25 Claude Code skills included",
       "MCP server with 47 registered tools",
     ],
   },
@@ -117,7 +117,7 @@ export const PRODUCTS: Product[] = [
       "/coach status — check template freshness",
       "/coach maintain — regenerate stale templates",
       "Auto-triggers on natural language (help, explain, learn)",
-      "24 auto-triggering skills (security, testing, review, etc.)",
+      "25 auto-triggering skills (security, testing, review, etc.)",
     ],
   },
 ];
@@ -269,7 +269,7 @@ export const DIFFERENTIATORS: Differentiator[] = [
  */
 export const CAPABILITIES = {
   workflows: 20,
-  skills: 24,
+  skills: 25,
   mcpTools: 47,
   templateKinds: 15,
   wizards: 5,


### PR DESCRIPTION
## Summary

Phases 1, 2, and 3 of `docs/specs/agent-round-table` — the complete deliberation loop, dogfooded end-to-end on real questions with real member CLIs.

### Phase 1 — /roundtable skill (D1)
Moderated round-trip: intake + spend gate → member briefs via verified headless recipes → R7-receipted positions → R6 absent seats → R9 origination → D3 bounded rounds → synthesis → chair-gated promotion. attune-hub row; skill-count gate 24 → 25.

### Phase 2 — promotion gates + lesson lane
Per-item `rt_promote` (server-side id validation, atomic rejection, `promoted_ids` in meta); `LessonCandidate` lint implementing the lessons-flow-001 chair rulings (no receipt AND no waiver → blocked; visible chair-waiver tag); skill Step 6 per-item flow.

### Phase 3 — routines (chair-ruled forks: clean-run first, manual-first, claude -p synthesis)
`python -m attune.roundtable.routine clean-run`: keyless check battery → seats deliberate → one synthesis pass → digest thread. R5 cap with halt, R6 absent seats, R8 never self-promotes. Fixes the phantom '§12 Clean-Run-Check' requirement reference.

### Live receipts
- **Deliberation** `lessons-flow-001`: 3 seats, unanimous (b), chair ruled + moderator-pushback amendment accepted, thread promoted via per-item flow (AC-2, AC-3 approve-half).
- **Proof run 1** caught 3 real defects incl. genuine website-count drift (24→25 fixed across features.ts + 3 pages) — the routine paid for itself on its first run.
- **Proof run 2**: checks PASS, 2 seats posted, synthesis failure visibly halted; claude seat absent — its stored OAuth token is revoked on this machine (chair re-auth queued; R6/AC-4 exercised live).

## Verification
43 roundtable tests vs real Redis (AC-1, AC-5, AC-6, per-item gates, provider-clean seat env, synthesis visibility) + plugin + website-accuracy suites: 203 passed locally. All pre-commit hooks green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)