### PR TITLE
fix(roundtable): project-skill shim, head-kept seat replies, stderr hygiene

### DIFF
--- a/.claude/skills/roundtable/SKILL.md
+++ b/.claude/skills/roundtable/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: roundtable
+description: "Convene the multi-LLM round table — Claude, Antigravity, and Codex deliberate a question; the user chairs promotion. Triggers on: roundtable, round table, convene the table, ask the table, what do the other models think, deliberate."
+argument-hint: "<question | read <thread> | promote <thread> | routine <name>>"
+---
+
+# Round Table (project shim)
+
+This is the in-repo projection of the plugin skill so `/roundtable`
+works in attune-ai sessions before the next plugin release ships
+it. The canonical skill body is the plugin copy — Read
+[plugin/skills/roundtable/SKILL.md](../../../plugin/skills/roundtable/SKILL.md)
+now and follow it exactly. Do not duplicate its content here; if
+this shim and the plugin copy ever disagree, the plugin copy wins.

--- a/src/attune/roundtable/routine.py
+++ b/src/attune/roundtable/routine.py
@@ -37,8 +37,12 @@ from attune.roundtable.board import Board
 CHECK_TIMEOUT = 900
 SEAT_TIMEOUT = 300
 
-#: Output kept per check/seat before truncation — briefs stay bounded.
+#: Check output kept (the TAIL — the failure summary lives at the end).
 TAIL_CHARS = 2000
+
+#: Seat reply kept (the HEAD — the position leads; live receipt
+#: 2026-07-18: a 2000-char tail cut claude's position off mid-sentence).
+SEAT_REPLY_CHARS = 8000
 
 
 @dataclass
@@ -147,6 +151,17 @@ def run_command(
         return 127, f"{argv[0]}: not found"
     except subprocess.TimeoutExpired:
         return 124, f"timed out after {timeout}s"
+    if provider_clean:
+        # Seat replies: the position leads, so keep the HEAD — and on
+        # success drop stderr entirely (CLIs emit permission/connector
+        # warnings there that otherwise pollute the board body). On
+        # failure stderr carries the diagnosis, so keep both.
+        if proc.returncode == 0:
+            reply = proc.stdout.strip()
+        else:
+            reply = (proc.stdout + proc.stderr).strip()
+        return proc.returncode, reply[:SEAT_REPLY_CHARS]
+    # Check output: the failure summary lives at the END — keep the tail.
     out = (proc.stdout + proc.stderr).strip()
     return proc.returncode, out[-TAIL_CHARS:]
 

--- a/tests/unit/roundtable/test_routine.py
+++ b/tests/unit/roundtable/test_routine.py
@@ -202,6 +202,18 @@ class TestPlumbing:
         code, out = default_invoke_seat(probe, "unused")
         assert code == 0 and "leaked= key=sk-real" in out
 
+    def test_seat_reply_keeps_head_and_drops_stderr_on_success(self) -> None:
+        """Live-run regression: tail-truncation cut a position off
+        mid-sentence, and CLI stderr warnings polluted board bodies."""
+        code, out = default_invoke_seat(
+            ("sh", "-c", 'echo "POSITION first"; echo "warning noise" >&2'), "unused"
+        )
+        assert code == 0 and out == "POSITION first"
+        code, out = default_invoke_seat(
+            ("sh", "-c", 'echo partial; echo "the diagnosis" >&2; exit 3'), "unused"
+        )
+        assert code == 3 and "the diagnosis" in out
+
     def test_seats_drop_empty_api_key(self, monkeypatch) -> None:
         """An EMPTY key must be removed, not passed through — empty
         401s the claude CLI instead of letting stored auth kick in."""


### PR DESCRIPTION
Follow-up to #1453 (this commit missed its merge window). Three fixes from the chair's first `/roundtable` attempt and from reading run-3 thread bodies:

1. **`.claude/skills/roundtable` shim** — `/roundtable` now works in attune-ai sessions before the next plugin release ships the skill (thin pointer to the plugin copy; canonical body stays single-source; the sync projector correctly shadows it for the `.agents` mirror). Registered live on write.
2. **Seat replies keep the HEAD (8000 chars)** — the 2000-char tail rule cut a position off mid-sentence. Checks keep the tail (failure summaries live at the end).
3. **Successful seat replies drop stderr** — CLI permission/connector warnings were polluting board bodies; failures keep stderr (it carries the diagnosis).

47 roundtable tests green; 192 with plugin suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)