### PR TITLE
docs(roundtable): promote first scheduled-routine digest (chair ruling)

### DIFF
--- a/docs/reports/roundtable/routine-clean-run-20260718-2233.md
+++ b/docs/reports/roundtable/routine-clean-run-20260718-2233.md
@@ -1,0 +1,40 @@
+# Round-table digest — clean-run health check (2026-07-18)
+
+Promoted from board thread `routine-clean-run-20260718-2233`
+(chair: Patrick, 2026-07-18 — "1, 2": action items declined,
+digest promoted as the first scheduled-routine record). First
+full-roster routine run: checks PASS (collaboration preflight +
+17,613-test keyless suite), all three seats present (claude 22s
+via the API-key path, antigravity 5s, codex 16s), 4 invocations
+(R5 cap exact), synthesis posted.
+
+## Verdict
+
+Tree HEALTHY. All seats agree the `RuntimeError: Event loop is
+closed` teardown traceback after the suite is non-failing
+cosmetic noise, and cached `origin/main` matches local.
+
+## Splits
+
+| Point | claude | antigravity | codex |
+|---|---|---|---|
+| Teardown traceback | already owned by `sdk-teardown-exit-guard` + `windows-exit139-segfault` — no new action | new hygiene item — audit async fixtures | investigate leaked subprocess cleanup |
+| 2 uncommitted files | not raised | Rank 1, medium — commit/stash | low — preserved state, account before merge |
+| Lesson candidate | decline — known/already-specced, no fresh receipt | propose "explicit async subprocess teardown" | decline — one receipt, no recurrence |
+
+## Ranked actions (both declined by the chair)
+
+1. (low) Teardown traceback — already tracked by two open specs;
+   escalate only if it ever mutates the process exit code. Shared
+   blind spot all seats flagged: they read the pass-count, not the
+   exit code — on Windows this same run could be red.
+2. (low–med) Reconcile the 2 uncommitted worktree files — resolved
+   before promotion (committed and merged via #1453/#1454).
+
+## Lesson candidate
+
+REJECTED 2–1 (claude + codex declining, moderator concurring):
+antigravity's "explicit async subprocess teardown" is real but
+redundant with two open specs and carries a single non-reproduced
+receipt. The lessons-flow-001 high-bar default, applied unprompted
+on the lane's first scheduled outing.


### PR DESCRIPTION
Chair ruling on thread `routine-clean-run-20260718-2233` (first full-roster scheduled-routine class run): both ranked actions declined (low / already spec-owned / resolved), synthesis digest promoted per-item (id 5) to `docs/reports/roundtable/` — the P2 per-item promotion path exercised on a real routine thread. Board meta records `promoted_ids=[5]` + destination; ruling posted to the thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)