### PR TITLE
fix(roundtable): bound Board's default client connect/socket timeouts

### DIFF
--- a/src/attune/roundtable/board.py
+++ b/src/attune/roundtable/board.py
@@ -194,7 +194,17 @@ class Board:
             import redis  # noqa: PLC0415 — optional dependency, import at use
 
             url = os.environ.get("REDIS_URL", "redis://127.0.0.1:6379/0")
-            client = redis.Redis.from_url(url, decode_responses=True)
+            # Bounded connect/ops: a stale REDIS_URL pointing at a dead
+            # remote host must fail in seconds, not hang for minutes in
+            # DNS/connect (live receipt 2026-07-19 — the fail-fast
+            # message in the routine runner was unreachable because the
+            # unbounded connect stalled first).
+            client = redis.Redis.from_url(
+                url,
+                decode_responses=True,
+                socket_connect_timeout=3.0,
+                socket_timeout=10.0,
+            )
         self.client = client
         self.ttl_seconds = ttl_seconds
 


### PR DESCRIPTION
A stale `REDIS_URL` pointing at a dead remote host hung the routine for minutes in unbounded DNS/connect before the #1453 fail-fast message could render (live receipt from the chair's terminal, 2026-07-19). `socket_connect_timeout=3` / `socket_timeout=10` on Board's default client; injected clients unaffected. 46 roundtable tests green; live probe against the real dead hostname now exits 2 with the pointer message in bounded time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)