### PR TITLE
fix(roundtable): teach the round-3 convergence-tag contract by worked example

### DIFF
--- a/src/attune/roundtable/producing.py
+++ b/src/attune/roundtable/producing.py
@@ -188,6 +188,22 @@ def _critique_brief(subject: str, pack: str, draft: str) -> str:
     )
 
 
+#: Literal worked example of a tagged item. Prose alone was not
+#: enough: two live headless runs had the drafter fail lint_final
+#: with every item untagged, twice each, until the brief showed
+#: this exact shape (receipts in the roundtable-producing-team
+#: spec's decisions.md).
+TAG_EXAMPLE = (
+    "EXAMPLE ITEM (copy this shape — the tag line sits alone on the "
+    "line immediately after the heading):\n"
+    "**RR-1 — Example requirement title**\n"
+    "[tag: agreed]\n"
+    "One-sentence rationale for the requirement.\n"
+    "- first acceptance bullet\n"
+    "- second acceptance bullet"
+)
+
+
 def _final_brief(subject: str, draft: str, critiques: dict[str, str]) -> str:
     parts = [
         "You are the DRAFTER seat. Revise your draft into the round-3 "
@@ -196,6 +212,7 @@ def _final_brief(subject: str, draft: str, critiques: dict[str, str]) -> str:
         "'[tag: agreed]' / '[tag: 2-1 <note>]' / '[tag: contested "
         "<note>]'; a '## Non-goals' section; a '## Dissent register' "
         "section (or the literal attestation 'Empty — attested').",
+        TAG_EXAMPLE,
         f"SUBJECT: {subject}",
         f"YOUR DRAFT:\n\n{draft}",
     ]
@@ -207,15 +224,19 @@ def _final_brief(subject: str, draft: str, critiques: dict[str, str]) -> str:
 
 
 def _repair_brief(brief: str, reply: str, problems: list[str]) -> str:
-    return (
-        "Your previous reply failed the mechanical lint. Problems:\n- "
-        + "\n- ".join(problems)
-        + "\n\nFix ONLY these problems and resend the full document."
-        + "\n\nORIGINAL BRIEF:\n\n"
-        + brief
-        + "\n\nYOUR PREVIOUS REPLY:\n\n"
-        + reply
-    )
+    parts = [
+        "Your previous reply failed the mechanical lint. Problems:\n- " + "\n- ".join(problems)
+    ]
+    if any("convergence tag" in p for p in problems):
+        parts.append(
+            "Every item heading must be followed by its own convergence "
+            "tag line: '[tag: agreed]' / '[tag: 2-1 <note>]' / "
+            "'[tag: contested <note>]'.\n\n" + TAG_EXAMPLE
+        )
+    parts.append("Fix ONLY these problems and resend the full document.")
+    parts.append("ORIGINAL BRIEF:\n\n" + brief)
+    parts.append("YOUR PREVIOUS REPLY:\n\n" + reply)
+    return "\n\n".join(parts)
 
 
 class _Terminal(Exception):

--- a/tests/unit/roundtable/test_producing.py
+++ b/tests/unit/roundtable/test_producing.py
@@ -15,13 +15,17 @@ import uuid
 
 import pytest
 
+from attune.roundtable import compiler
 from attune.roundtable.board import LEDGER_ORDER_KEY, Board
 from attune.roundtable.producing import (
     DEFAULT_MAX_INVOCATIONS,
     FAILURE_CODES,
+    TAG_EXAMPLE,
     TR6_CAP,
     FailureReceipt,
     ProducingSpec,
+    _final_brief,
+    _repair_brief,
     render_digest,
     run_producing,
 )
@@ -417,7 +421,6 @@ class TestReceiptsAndDigest:
             assert FailureReceipt(code=code, run_id="r").to_dict()["code"] == code
 
     def test_digest_puts_failures_before_candidates(self) -> None:
-        from attune.roundtable import compiler
 
         receipt = FailureReceipt(code="SEAT_ABSENT", run_id="r", seat="codex")
         final = compiler.parse_draft(FINAL_OK)
@@ -461,3 +464,35 @@ class TestRoleBudgets:
         )
         assert code == 0
         assert len(reply) == 8_000
+
+
+class TestBriefContracts:
+    """The convergence-tag contract is taught by worked example.
+
+    Prose alone failed twice in live headless runs (see the
+    roundtable-producing-team spec's decisions.md): the drafter
+    shipped every item untagged, including after the repair round.
+    A literal example block got the drafter through lint_final on
+    the first attempt in the interactive loop (us-refresh-001).
+    """
+
+    def test_final_brief_embeds_worked_example(self) -> None:
+        brief = _final_brief("subject", "the draft", {})
+        assert TAG_EXAMPLE in brief
+        assert "**RR-1 — Example requirement title**\n[tag: agreed]" in brief
+
+    def test_worked_example_actually_carries_the_tag(self) -> None:
+        # The taught shape must satisfy the parser it is teaching to.
+        draft = compiler.parse_draft(TAG_EXAMPLE)
+        assert [i.item_id for i in draft.items] == ["RR-1"]
+        assert draft.items[0].tag == "agreed"
+
+    def test_repair_brief_restates_example_on_tag_problems(self) -> None:
+        problems = ["RR-2: missing convergence tag (agreed / 2-1 / contested)"]
+        repair = _repair_brief("orig brief", "prev reply", problems)
+        assert TAG_EXAMPLE in repair
+        assert "ORIGINAL BRIEF:\n\norig brief" in repair
+
+    def test_repair_brief_stays_compact_without_tag_problems(self) -> None:
+        repair = _repair_brief("orig brief", "prev reply", ["no requirement items found"])
+        assert TAG_EXAMPLE not in repair


### PR DESCRIPTION
## Why

Two live headless producing runs (board threads `producing-pipeline-learner-v1-20260719` and `producing-usage-signals-refresh-20260719`; receipts mirrored in `docs/specs/roundtable-producing-team/decisions.md`) had the antigravity drafter fail `lint_final` with **every item missing its convergence tag — twice each, including after the repair round**. The round-3 tag contract (`[tag: agreed]` / `[tag: 2-1 <note>]` / `[tag: contested <note>]`) was described in prose only.

In the interactive loop (us-refresh-001, 2026-07-19), giving the drafter a **literal worked example block** (heading line, then `[tag: agreed]` on its own line, then rationale + bullets) got the drafter through `lint_final` on the first attempt.

## What

- `TAG_EXAMPLE` module constant — the worked example item, embedded in `_final_brief` right after the FORMAT paragraph.
- `_repair_brief` restates the tag format with the same example — but only when a lint problem mentions the convergence tag, so draft/critique repairs stay compact.
- Tests (`TestBriefContracts`): example present in the final brief; restated on tag problems; absent on unrelated problems; and the example itself round-trips through `compiler.parse_draft` with `tag == "agreed"` (the taught shape satisfies the parser it teaches to).

## Receipts

- `PYTEST_ADDOPTS="-p no:xdist -o addopts=" python -m pytest tests/unit/roundtable/ -q` → **124 passed** (serial).
- Pinned black/ruff pre-flighted clean on both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
