### PR TITLE
feat(telemetry): run-record corpus — canonical stream, provenance, RC-2 seam closure

### DIFF
--- a/.claude/lessons.md
+++ b/.claude/lessons.md
@@ -16335,3 +16335,48 @@ def ", start_idx + 1)` for module-
   delete any just-cut branch (`git branch -D` printing `(was
   <main-sha>)` with zero commits = nothing lost), and fold in the
   chip session's result when it lands.
+
+- **A shared-seam feature (telemetry epilogue, hooks) verified only
+  on the BASE-class path is silently bypassed by every subclass
+  that overrides the entry point — grep for overrides of the
+  wrapped method, then live-fire a MODERN caller, not the base
+  path**: 2026-07-19, run-record-corpus RC-2. The
+  `_emit_workflow_telemetry` seam existed, 3,380 telemetry/workflow
+  tests were green, and `ExecutionMixin.execute`'s epilogue called
+  it unconditionally — yet the canonical stream stayed empty on
+  live-fire because all 17 SDK-native workflows (`code-review`,
+  `security-audit`, …) override `execute()` wholesale and never
+  reach the epilogue. That was the SDK-era corpus dry-pipe's real
+  cause (five months of `workflow_runs.jsonl` had ~zero real
+  records while `usage.jsonl` showed ~418 real events/month).
+  Diagnostic pair: `grep -rln "async def execute"
+  src/attune/workflows/` (the override surface) + one live run of a
+  CURRENT-era workflow with `ATTUNE_HOME` pointed at scratch (the
+  receipt). Fix shape: close at ONE seam
+  (`BaseWorkflow.__init_subclass__` wraps subclass overrides) with
+  an idempotence marker, not N per-file edits. Extends "registered
+  ≠ working": unit tests of the seam prove the seam, not that
+  production paths still route through it.
+
+- **Guards keyed on a sentinel attribute must identity-check the
+  literal (`is True`), never truthiness — MagicMock fabricates a
+  truthy attr on ANY getattr**: 2026-07-19, the run-record
+  idempotence guard `getattr(result, "_run_record_emitted", False)`
+  returned a truthy auto-created child Mock for every
+  MagicMock-built result, so the guard skipped emission and a
+  mocked emit test failed with "record never constructed". Rule:
+  when production code checks a marker it also sets, compare `is
+  True` (or use a module-private sentinel object) so mock-built
+  objects can't accidentally satisfy — or defeat — the check.
+
+- **"Import and first use in the SAME edit" means the same Edit
+  TOOL CALL, not the same assistant message — batching the import
+  edit and the usage edit as two parallel calls still lets the
+  PostToolUse ruff-fix strip the import in between**: hit twice on
+  2026-07-19 (storage.py `os`/`timezone`, base.py
+  `functools`/`inspect`) despite knowing the existing lesson. The
+  hook runs after EACH Edit call, so an import-only edit is always
+  a strip candidate no matter what lands next in the same message.
+  Reliable orders: (a) one Edit whose old/new spans both the import
+  block and the first use, or (b) usage edit first, import edit
+  second, then grep the import line to confirm it stuck.

--- a/docs/specs/pipeline-learner/decisions.md
+++ b/docs/specs/pipeline-learner/decisions.md
@@ -1,0 +1,35 @@
+# Pipeline Learner — Decisions
+
+## 2026-07-19 — RR-1 external dependency resolved; source pin amended (chair)
+
+**The run-persistence diagnosis (RR-1's named external
+dependency).** The chip investigation session confirmed
+`src/attune/ops/runner.py` persists one JSON per run correctly —
+the 15-dirs/1-file signature is design, not breakage: persistence
+is wired only in the ops dashboard server, and a 30-day prune at
+every dashboard startup unlinks aging files while leaving empty
+workflow dirs. The ops store's ceiling ("dashboard-launched runs
+from the last 30 days") can never satisfy RR-1's corpus premise.
+
+**Owner and fix.** `docs/specs/run-record-corpus/` (chair-ruled
+2026-07-19) owns the fix: the telemetry seam
+(`TelemetryMixin._emit_workflow_telemetry`) already emits one
+`WorkflowRunRecord` per workflow execution on every path (MCP,
+CLI, dashboard subprocess); that stream is canonicalized
+home-global at `~/.attune/telemetry/workflow_runs.jsonl` with
+`trigger` + `project` fields, suite isolation, and no-delete
+rotation. See its decisions.md (D1–D3) for the fork evidence.
+
+**Amendment (D2, chair-ruled edit).** RR-4's source pin and the
+RR-1/RR-2 source references in requirements.md are amended
+in-place (marked "amended 2026-07-19") from
+`~/.attune/ops/runs/**/*.json` to the canonical stream. The
+table's other text stands; the amendment block at the top of
+requirements.md carries the rationale.
+
+**Start clean (D3).** Records predating the 2026-07-19 cutover
+are ineligible for mining: the pre-cutover archive is
+pytest-polluted (89% of real-named records inside test-like
+bursts) with no verifiable purity filter. RR-1's viability bar
+must be met by post-cutover accumulation — the readiness check
+reports honestly until then.

--- a/docs/specs/pipeline-learner/requirements.md
+++ b/docs/specs/pipeline-learner/requirements.md
@@ -8,12 +8,31 @@ unruled: none.
 
 Chair rulings 2026-07-19: all eight items approved, including the deferred-over-cap RR-8 restaged in the same chair-initiated session (TR-6 recourse path); RR-4 2-1 upheld as tabled (bulletin deferred, antigravity dissent preserved in the thread register). Authored by a HEADLESS producing run (V2-P4 dogfood #2); replaces the 2026-05-17 draft, whose stale premises the live probes in the grounding pack falsified. Prior draft preserved in git history.
 
+> **Amendment 2026-07-19 (chair-ruled edit per
+> `docs/specs/run-record-corpus/decisions.md` D2).** The RR-1
+> external dependency resolved with a different corpus than RR-4
+> pinned: the ops-runs store works as designed but is
+> dashboard-only + 30-day pruned (its ceiling can never satisfy
+> RR-1), while the telemetry seam already persists one
+> `WorkflowRunRecord` per workflow execution. v1's single mining
+> source is therefore the canonical run stream
+> `~/.attune/telemetry/workflow_runs.jsonl` (rotated archives in
+> `~/.attune/telemetry/archive/`), NOT `~/.attune/ops/runs/`.
+> Records carry `trigger` ("manual" | "attune-rec"; absent =
+> unknown, weighted as auto per RR-3) and `project` (repo-root
+> identifier; worktrees resolve to the parent repo) — the two
+> fields RR-3/RR-4 required. Historical backfill is ruled OUT
+> (D3: start clean at cutover; the pre-cutover archive is
+> pytest-polluted with no verifiable purity filter). Source pins
+> below are amended in place and marked; everything else in the
+> table-authored text stands.
+
 ## Requirements
 
 **RR-1 — Gate v1 on a working run-persistence prerequisite**
 The "thousands of runs going back months" premise is false today: `~/.attune/ops/runs/` has 15 workflow dirs but exactly 1 run JSON total (PACK-3), and the bulletin archive is 3 stale files (2026-05-27 → 2026-06-06). Mining is worthless without a corpus, and the 15-dirs-1-file signature strongly implies run persistence itself is broken or disabled. v1 must not ship a miner on top of a dry pipe; it must first establish and verify that runs accumulate.
 
-- A prerequisite check inspects `~/.attune/ops/runs/**/*.json` and reports: total eligible records (schema-valid, timestamp-parseable), distinct workflows, distinct active days, and date span before any mining runs.
+- A prerequisite check inspects `~/.attune/telemetry/workflow_runs.jsonl` (+ rotated archives; amended 2026-07-19) and reports: total eligible records (schema-valid, timestamp-parseable), distinct workflows, distinct active days, and date span before any mining runs. Eligibility excludes records predating the 2026-07-19 cutover (D3: start clean).
 - Readiness is operationally defined, not proxied by a single number: the corpus is "viable" only when it holds ≥ (2 × min-support) eligible records across ≥ 7 distinct active days AND at least one candidate pair clears min-support; otherwise the learner emits an explicit "insufficient corpus — not yet viable" status, prints the shortfall, and exits without proposing anything.
 - Persistence diagnosis is scoped OUT of the learner's own code: the spec names, as a hard external dependency with a named owner in `decisions.md`, the confirmation that `src/attune/ops/runner.py` persists one JSON per run. The learner's acceptance probe is "the readiness check runs and reports"; fixing the 15-dir/1-file anomaly is a separate spec's responsibility, not a circular self-dependency.
 (table: agreed; chair: approved)
@@ -21,7 +40,7 @@ The "thousands of runs going back months" premise is false today: `~/.attune/ops
 **RR-2 — Pair-mining algorithm testable against a fixture corpus with a declared record schema**
 The mining design (pair-mining, 30-min window, min-support ~5 / ratio ~0.5) is sound and does not depend on live-corpus size to be correct (PACK-4). Its correctness must be provable on committed fixtures so the algorithm can land and be trusted even while the live corpus is thin — but only if the fixture record shape and the pair semantics are pinned.
 
-- The spec declares the canonical fixture record schema mirroring `~/.attune/ops/runs/**/*.json`: the exact fields consumed (workflow name, start timestamp, provenance flag, project identifier). One schema, ops-runs only (bulletin deferred per RR-4); no dual-format fixture.
+- The spec declares the canonical fixture record schema mirroring `WorkflowRunRecord` JSONL rows in `~/.attune/telemetry/workflow_runs.jsonl` (amended 2026-07-19): the exact fields consumed (`workflow_name`, `started_at`, `trigger`, `project`). One schema, one source (bulletin deferred per RR-4); no dual-format fixture.
 - Pair semantics are fully specified so a fixture cannot pass two incompatible algorithms: ordering is by start timestamp; the ratio denominator is "count of A occurrences"; intervening unrelated workflows do not break an A→B pair within the window; A→A self-sequences are excluded; duplicate records and malformed/timezone-naive timestamps are normalized to UTC or dropped (and the drop is counted).
 - A fixture corpus containing a known 7-occurrence A→B sequence surfaces exactly that pair above the support/ratio thresholds; noise sequences below min-support (2–3 occurrences) are filtered; and an off-by-window case (two steps > 30 min apart) is asserted excluded.
 (table: agreed; chair: approved)
@@ -37,8 +56,8 @@ The mining design (pair-mining, 30-min window, min-support ~5 / ratio ~0.5) is s
 **RR-4 — Single input contract (ops-runs), single-project scope, bulletin explicitly deferred**
 The draft simultaneously described ops runs as the corpus, left bulletin open, and assumed a nested `YYYY-MM-DD/` archive layout that PACK-3 contradicts (archives are flat `archive/2026-05-27.jsonl`). A commit-or-kill spec cannot carry an ambiguous input contract.
 
-- v1 mines exactly one source: `~/.attune/ops/runs/**/*.json`. The bulletin archive is DEFERRED (Non-goal), and the spec deletes the stale nested-directory assumption, recording the observed flat shape as the reason deferral is cheap to reverse later.
-- Single-project scope is enforced, not assumed: a host-global `~/.attune/ops/runs/` can mix repositories, so the learner filters on a stable project identifier read from each record. RR-1's readiness check validates that field is present; if it is absent, viability is gated on adding it (named as a dependency), not silently mined across mixed projects.
+- v1 mines exactly one source: `~/.attune/telemetry/workflow_runs.jsonl` + its rotated archives (amended 2026-07-19 per run-record-corpus D1/D2). The bulletin archive is DEFERRED (Non-goal), and the spec deletes the stale nested-directory assumption, recording the observed flat shape as the reason deferral is cheap to reverse later.
+- Single-project scope is enforced, not assumed: the host-global canonical stream mixes repositories by design, so the learner filters on the `project` field each record now carries (amended 2026-07-19 — the dependency RR-4 named is DELIVERED by run-record-corpus RC-3). RR-1's readiness check validates that field is present; records without it are ineligible, not silently mined across mixed projects.
 - The spec cites `src/attune/ops/runner.py` as the record producer and pins the record fields the learner depends on, so a schema change surfaces as a failing readiness check rather than silent mis-mining.
 (table: 2-1 antigravity would fold bulletin in as a second v1 input; drafter + codex defer it to keep the contract commit-or-kill; chair: approved)
 
@@ -80,7 +99,7 @@ Per the chair's commit-or-kill framing (PACK-1) and the moderator read (PACK-4),
 - Mining the bulletin archive (`~/.attune/bulletin/archive/*.jsonl`) — DEFERRED to a later version; v1 is ops-runs only (RR-4).
 - Semantic understanding of what a sequence *means*; ranking is frequency/recency/provenance-based, not intent-based.
 - Real-time next-workflow prediction or in-session suggestion.
-- Cross-project mining — v1 filters to a single project identifier within the local `~/.attune/ops/runs/` corpus (RR-4).
+- Cross-project mining — v1 filters to a single project identifier within the canonical run stream (RR-4, amended 2026-07-19).
 - Sequences longer than pairs (triples/n-grams) — v1 is pair-mining only.
 - Fixing or redesigning the ops run-record schema — RR-1 confirms persistence works and names an owner; the fix itself is a separate spec.
 

--- a/docs/specs/run-record-corpus/decisions.md
+++ b/docs/specs/run-record-corpus/decisions.md
@@ -44,6 +44,51 @@ not mined. Evidence (measured 2026-07-19, this session):
   validation that does not exist today.
 
 Requirements header flipped DRAFT → chair-ruled in the same
-commit. Execution is NOT yet armed — next step is the chair
-queueing/authorizing implementation per the per-spec-arming
-cadence ruling (roundtable-producing-team decisions).
+commit.
+
+## 2026-07-19 — Execution armed and implemented (chair: option 1)
+
+Chair armed execution the same day. Implementation (branch
+`feat/run-record-corpus`): RC-1 canonical stream routing in
+`TelemetryStore` (explicit `storage_dir` still keeps every file
+local — test isolation unchanged); RC-3 `trigger`/`project` fields
++ `run_context.py` resolvers wired into BOTH emit paths
+(`TelemetryMixin` and `TelemetryService`); RC-4 store singleton
+reset added to the existing `_isolate_attune_home` autouse fixture
++ drift-guard test; RC-5 no-delete 50 MB rotation into
+`telemetry/archive/` + ops-prune non-interference test; RR-4
+amendment landed in pipeline-learner (see its decisions.md).
+
+**RC-2 audit result — the SDK-era dry pipe had a second cause.**
+Live-fire probing found the modern SDK-native workflows
+(code-review, security-audit, etc. — 17 files) override
+`execute()` wholesale and never reach `ExecutionMixin.execute`'s
+telemetry epilogue: they logged per-stage usage but NO run record.
+That, not only worktree fragmentation, is why the corpus has
+near-zero real records in the June–July SDK era. Closed at one
+seam: `BaseWorkflow.__init_subclass__` wraps any subclass-defined
+async `execute` to emit best-effort after completion, with an
+idempotence marker on the result object (guarded `is True` so
+MagicMock results can't fake it). A run that raises without
+producing a result emits nothing — not a run. Receipts: live-fire
+`CodeReviewWorkflow.execute()` from this worktree against a
+scratch `ATTUNE_HOME` landed records on both the validation-error
+and keyless-SDK-failure paths with `trigger=manual`,
+`project=attune-ai` (worktree resolved to parent repo); full unit
+suite 17,719 passed; new module serial-clean.
+
+**Audit gap (named follow-up, out of this PR):** agent-team
+workflows that bypass `BaseWorkflow` entirely (observed:
+`health-check`, `agents_executed=3`, ran green, emitted nothing)
+need their own emission seam. Low corpus impact — the volume is in
+the SDK workflows — but RC-2's "every path" is not fully closed
+until it lands.
+
+**Named follow-up (RC-3, not in this PR):** the dashboard
+rec-click attribution stamp — threading a `trigger` field through
+`POST /workflows/{name}/run` → `RunnerService.execute` →
+`ATTUNE_RUN_TRIGGER` in the subprocess env, plus the client-side
+send on next-workflow recommendation clicks. Until it lands,
+dashboard runs record as `manual` (correct for workflow-button
+clicks, conservative for rec clicks per `resolve_run_trigger`'s
+stated bias).

--- a/src/attune/models/telemetry/data_models.py
+++ b/src/attune/models/telemetry/data_models.py
@@ -105,6 +105,15 @@ class WorkflowRunRecord:
     user_id: str | None = None
     session_id: str | None = None
 
+    # Corpus provenance (docs/specs/run-record-corpus/ RC-3) — additive
+    # and optional so pre-RC-3 records keep loading via ``from_dict``.
+    # ``trigger``: "manual" | "attune-rec"; None means unknown provenance
+    # (miners weight it as auto per pipeline-learner RR-3).
+    trigger: str | None = None
+    # Stable project identifier (repo-root name; worktree runs resolve
+    # to the parent repo). None when resolution fails or predates RC-3.
+    project: str | None = None
+
     # Stages
     stages: list[WorkflowStageRecord] = field(default_factory=list)
 

--- a/src/attune/models/telemetry/run_context.py
+++ b/src/attune/models/telemetry/run_context.py
@@ -1,0 +1,76 @@
+"""Run-record context resolution (docs/specs/run-record-corpus/ RC-3).
+
+Resolves the two provenance fields every ``WorkflowRunRecord`` carries
+going forward: how the run was triggered and which project it belongs
+to. Both are best-effort — resolution failure degrades to a safe value
+and never raises into the workflow path.
+
+Copyright 2025 Smart-AI-Memory
+Licensed under the Apache License, Version 2.0
+"""
+
+import logging
+import os
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# Launchers that start a run on behalf of an ATTUNE_REC recommendation
+# export this before spawning the workflow process; everything else is
+# a manual run. Values outside the valid set degrade to "manual".
+TRIGGER_ENV = "ATTUNE_RUN_TRIGGER"
+
+_VALID_TRIGGERS = frozenset({"manual", "attune-rec"})
+
+
+def resolve_run_trigger() -> str:
+    """Return the current run's trigger: ``"manual"`` or ``"attune-rec"``.
+
+    Reads ``ATTUNE_RUN_TRIGGER`` from the environment; unset or invalid
+    values resolve to ``"manual"`` (the conservative default — manual
+    runs are the STRONGER evidence class, but a false "manual" only
+    overweights one record, while a false "attune-rec" would silently
+    discount genuine human intent).
+    """
+    value = os.environ.get(TRIGGER_ENV, "").strip().lower()
+    return value if value in _VALID_TRIGGERS else "manual"
+
+
+def resolve_project_identity(start: Path | None = None) -> str | None:
+    """Return a stable project identifier for run records, or ``None``.
+
+    Walks up from ``start`` (default: cwd) to the enclosing repository
+    root and returns its directory name. A linked worktree's ``.git``
+    FILE (``gitdir: <main>/.git/worktrees/<slug>``) resolves to the MAIN
+    repository, so runs from ``.claude/worktrees/*`` tag as the parent
+    project rather than the worktree slug. Pure-filesystem — no ``git``
+    subprocess in the workflow hot path.
+    """
+    try:
+        current = (start or Path.cwd()).resolve()
+    except OSError:
+        return None
+    for candidate in (current, *current.parents):
+        git = candidate / ".git"
+        if git.is_dir():
+            return candidate.name
+        if git.is_file():
+            return _worktree_parent_name(git) or candidate.name
+    return None
+
+
+def _worktree_parent_name(git_file: Path) -> str | None:
+    """Parent-repo name from a worktree's ``.git`` pointer file."""
+    try:
+        text = git_file.read_text(encoding="utf-8")
+    except OSError as exc:
+        logger.debug("run_context: unreadable .git file %s: %s", git_file, exc)
+        return None
+    for line in text.splitlines():
+        if not line.startswith("gitdir:"):
+            continue
+        gitdir = Path(line.split(":", 1)[1].strip())
+        # Layout: <main-repo>/.git/worktrees/<slug>
+        if gitdir.parent.name == "worktrees" and gitdir.parent.parent.name == ".git":
+            return gitdir.parent.parent.parent.name
+    return None

--- a/src/attune/models/telemetry/storage.py
+++ b/src/attune/models/telemetry/storage.py
@@ -8,9 +8,10 @@ Licensed under the Apache License, Version 2.0
 
 import json
 import logging
+import os
 from collections import deque
 from collections.abc import Callable
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, TypeVar
 
@@ -31,6 +32,25 @@ logger = logging.getLogger(__name__)
 
 T = TypeVar("T")
 
+# Size guard for the canonical run stream (run-record-corpus RC-5):
+# past this, history rotates into ``<dir>/archive/`` — never deleted,
+# so the pipeline-learner corpus keeps its full span.
+_RUNS_ROTATE_BYTES = 50 * 1024 * 1024
+
+
+def _canonical_runs_file() -> Path:
+    """Canonical home-global run-record stream (run-record-corpus RC-1).
+
+    Resolved under ``ATTUNE_HOME`` (env override -> ``~/.attune``), the
+    same mechanism ``UsageTracker`` uses, so run records from every
+    checkout and worktree consolidate into ONE stream — and the test
+    suite's ``ATTUNE_HOME`` isolation fixture redirects them off the
+    real corpus automatically.
+    """
+    home = os.environ.get("ATTUNE_HOME")
+    attune_dir = Path(home).expanduser() if home else Path.home() / ".attune"
+    return attune_dir / "telemetry" / "workflow_runs.jsonl"
+
 
 class TelemetryStore:
     """JSONL file-based telemetry backend (default implementation).
@@ -41,25 +61,34 @@ class TelemetryStore:
     Supports both core telemetry and Tier 1 automation monitoring.
     """
 
-    def __init__(self, storage_dir: str = ".attune"):
+    def __init__(self, storage_dir: str | None = None):
         """Initialize telemetry store.
 
         Args:
-            storage_dir: Directory for telemetry files
+            storage_dir: Directory for telemetry files. ``None`` (the
+                production default) keeps project-scoped files under the
+                cwd-relative ``.attune`` but routes workflow RUN records
+                to the canonical home-global stream
+                ``<ATTUNE_HOME|~/.attune>/telemetry/workflow_runs.jsonl``
+                (docs/specs/run-record-corpus/ RC-1). Passing an explicit
+                directory keeps EVERY file under it.
 
         Raises:
             ValueError: If storage_dir is invalid or targets a system directory
                 (prevents CWE-22 arbitrary-write via a caller-supplied path).
 
         """
+        explicit = storage_dir is not None
         # Validate before any filesystem op — storage_dir may come from a CLI
         # arg (`--storage-dir`) or other caller-controlled input.
-        self.storage_dir = _validate_file_path(str(storage_dir))
+        self.storage_dir = _validate_file_path(str(storage_dir if explicit else ".attune"))
         self.storage_dir.mkdir(parents=True, exist_ok=True)
 
         # Core telemetry files
         self.calls_file = self.storage_dir / "llm_calls.jsonl"
-        self.workflows_file = self.storage_dir / "workflow_runs.jsonl"
+        self.workflows_file = (
+            self.storage_dir / "workflow_runs.jsonl" if explicit else _canonical_runs_file()
+        )
 
         # Tier 1 automation monitoring files
         self.task_routing_file = self.storage_dir / "task_routing.jsonl"
@@ -144,8 +173,38 @@ class TelemetryStore:
         self._append_record(self.calls_file, record)
 
     def log_workflow(self, record: WorkflowRunRecord) -> None:
-        """Log a workflow run record."""
+        """Log a workflow run record to the canonical stream (size-rotated)."""
+        try:
+            self.workflows_file.parent.mkdir(parents=True, exist_ok=True)
+            self._rotate_runs_file_if_needed()
+        except OSError as exc:
+            logger.warning("telemetry: run-stream prep failed: %s", exc)
         self._append_record(self.workflows_file, record)
+
+    def _rotate_runs_file_if_needed(self) -> None:
+        """Rotate the run stream past ``_RUNS_ROTATE_BYTES`` (RC-5).
+
+        History moves to ``<dir>/archive/workflow_runs-<utc>.jsonl`` so
+        the miner keeps its full span; the live file stays bounded.
+        Never deletes.
+        """
+        try:
+            if (
+                not self.workflows_file.is_file()
+                or self.workflows_file.stat().st_size < _RUNS_ROTATE_BYTES
+            ):
+                return
+            archive_dir = self.workflows_file.parent / "archive"
+            archive_dir.mkdir(parents=True, exist_ok=True)
+            stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+            dest = archive_dir / f"workflow_runs-{stamp}.jsonl"
+            suffix = 0
+            while dest.exists():
+                suffix += 1
+                dest = archive_dir / f"workflow_runs-{stamp}-{suffix}.jsonl"
+            self.workflows_file.rename(dest)
+        except OSError as exc:
+            logger.warning("telemetry: run-stream rotation failed: %s", exc)
 
     def log_task_routing(self, record: TaskRoutingRecord) -> None:
         """Log a task routing decision."""

--- a/src/attune/workflows/base.py
+++ b/src/attune/workflows/base.py
@@ -15,6 +15,8 @@ Licensed under the Apache License, Version 2.0
 
 from __future__ import annotations
 
+import functools
+import inspect
 import logging
 from abc import ABC
 from typing import TYPE_CHECKING, Any
@@ -127,6 +129,34 @@ def estimate_tokens(obj: Any, max_chars: int = 1_000_000) -> int:
     return len(s) // 4
 
 
+def _wrap_execute_with_run_record(execute):
+    """Wrap a subclass ``execute`` override so it emits a run record.
+
+    SDK-native workflows override ``execute`` wholesale and never reach
+    ``ExecutionMixin.execute``'s telemetry epilogue — historically that
+    meant NO ``WorkflowRunRecord`` for exactly the workflows with real
+    usage (run-record-corpus RC-2). The wrapper closes the gap at one
+    seam instead of editing every override. Emission is best-effort and
+    idempotent (see ``TelemetryMixin._emit_workflow_telemetry``); an
+    override that raises emits nothing — a run that never produced a
+    result is not a run.
+    """
+
+    @functools.wraps(execute)
+    async def _execute(self, *args: Any, **kwargs: Any):
+        result = await execute(self, *args, **kwargs)
+        try:
+            self._emit_workflow_telemetry(result)
+        except Exception:  # noqa: BLE001
+            # INTENTIONAL: telemetry is optional diagnostics — never
+            # fail a workflow over a record write.
+            logger.debug("run-record emission failed", exc_info=True)
+        return result
+
+    _execute._emits_run_record = True
+    return _execute
+
+
 class BaseWorkflow(
     ContextProxyMixin,
     ExecutionMixin,
@@ -176,6 +206,17 @@ class BaseWorkflow(
     description: str = "Base workflow template"
     stages: list[str] = []
     tier_map: dict[str, ModelTier] = {}
+
+    def __init_subclass__(cls, **kwargs: Any) -> None:
+        """Ensure every ``execute`` override emits a run record (RC-2)."""
+        super().__init_subclass__(**kwargs)
+        execute = cls.__dict__.get("execute")
+        if (
+            execute is not None
+            and inspect.iscoroutinefunction(execute)
+            and not getattr(execute, "_emits_run_record", False)
+        ):
+            cls.execute = _wrap_execute_with_run_record(execute)
 
     # ``_stage_index`` cached_property lives on TierRoutingMixin so test
     # stubs that mix in TierRoutingMixin directly (without BaseWorkflow)

--- a/src/attune/workflows/services/telemetry_service.py
+++ b/src/attune/workflows/services/telemetry_service.py
@@ -252,9 +252,16 @@ class TelemetryService:
             for s in result.stages
         ]
 
+        from attune.models.telemetry.run_context import (
+            resolve_project_identity,
+            resolve_run_trigger,
+        )
+
         record = WorkflowRunRecord(
             run_id=self._run_id or str(uuid.uuid4()),
             workflow_name=self._workflow_name,
+            trigger=resolve_run_trigger(),
+            project=resolve_project_identity(),
             started_at=result.started_at.isoformat(),
             completed_at=result.completed_at.isoformat(),
             stages=stages,

--- a/src/attune/workflows/telemetry_mixin.py
+++ b/src/attune/workflows/telemetry_mixin.py
@@ -268,6 +268,23 @@ class TelemetryMixin:
 
         """
         from attune.models import WorkflowRunRecord, WorkflowStageRecord
+        from attune.models.telemetry.run_context import (
+            resolve_project_identity,
+            resolve_run_trigger,
+        )
+
+        # Idempotence guard (run-record-corpus RC-2): the BaseWorkflow
+        # execute-wrapper AND ExecutionMixin's epilogue both call this;
+        # if a future override chains through super().execute(), only
+        # the first emission for a given result object records.
+        # ``is True`` (not truthiness): a MagicMock result fabricates a
+        # truthy attr on access; only OUR literal marker counts.
+        if result is None or getattr(result, "_run_record_emitted", False) is True:
+            return
+        try:
+            result._run_record_emitted = True
+        except (AttributeError, TypeError):
+            pass  # non-standard result object — emit unguarded
 
         # Build stage records
         stages = [
@@ -293,6 +310,8 @@ class TelemetryMixin:
         record = WorkflowRunRecord(
             run_id=self._run_id or str(uuid.uuid4()),
             workflow_name=self.name,
+            trigger=resolve_run_trigger(),
+            project=resolve_project_identity(),
             started_at=result.started_at.isoformat(),
             completed_at=result.completed_at.isoformat(),
             stages=stages,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -676,9 +676,26 @@ def _isolate_attune_home(tmp_path, monkeypatch):
             # INTENTIONAL: telemetry is optional; env isolation still applies.
             pass
 
+    def _reset_store_singleton():
+        # The TelemetryStore singleton resolves the canonical run-record
+        # stream under ATTUNE_HOME at construction (run-record-corpus
+        # RC-1/RC-4). Reset it so each test re-resolves under its own tmp
+        # dir — a cached instance would leak one test's tmp path (or,
+        # constructed before this fixture, the REAL ~/.attune corpus)
+        # into every later test.
+        try:
+            import attune.models.telemetry as _mt
+
+            _mt._store_instance = None
+        except Exception:  # noqa: BLE001
+            # INTENTIONAL: telemetry is optional; env isolation still applies.
+            pass
+
     _reset_usage_singleton()
+    _reset_store_singleton()
     yield
     _reset_usage_singleton()
+    _reset_store_singleton()
 
 
 @pytest.fixture(autouse=True, scope="function")

--- a/tests/unit/telemetry/test_run_record_corpus.py
+++ b/tests/unit/telemetry/test_run_record_corpus.py
@@ -1,0 +1,236 @@
+"""Run-record corpus tests (docs/specs/run-record-corpus/ RC-1..RC-5).
+
+Covers the canonical home-global run stream, the provenance fields,
+suite isolation (the drift guard), rotation, and the ops-prune
+non-interference assert.
+"""
+
+import json
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from types import SimpleNamespace
+
+from attune.models.telemetry import storage as storage_mod
+from attune.models.telemetry.data_models import WorkflowRunRecord
+from attune.models.telemetry.run_context import (
+    TRIGGER_ENV,
+    resolve_project_identity,
+    resolve_run_trigger,
+)
+from attune.models.telemetry.storage import TelemetryStore
+from attune.ops.runner import prune_old_runs
+from attune.workflows.telemetry_mixin import TelemetryMixin
+
+
+def _record(**overrides) -> WorkflowRunRecord:
+    base = {
+        "run_id": "r1",
+        "workflow_name": "code-review",
+        "started_at": "2026-07-19T12:00:00+00:00",
+    }
+    base.update(overrides)
+    return WorkflowRunRecord(**base)
+
+
+class TestCanonicalStream:
+    """RC-1: default store routes run records home-global."""
+
+    def test_default_store_resolves_under_attune_home(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("ATTUNE_HOME", str(tmp_path / "home"))
+        monkeypatch.chdir(tmp_path)
+        store = TelemetryStore()
+        assert store.workflows_file == tmp_path / "home" / "telemetry" / "workflow_runs.jsonl"
+        # Project-scoped files stay cwd-relative — only run records move.
+        assert store.calls_file.parent.name == ".attune"
+        assert not str(store.calls_file).startswith(str(tmp_path / "home"))
+
+    def test_explicit_storage_dir_keeps_runs_local(self, tmp_path):
+        store = TelemetryStore(storage_dir=str(tmp_path / "iso"))
+        assert store.workflows_file == tmp_path / "iso" / "workflow_runs.jsonl"
+
+    def test_log_workflow_creates_stream_and_appends(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("ATTUNE_HOME", str(tmp_path / "home"))
+        monkeypatch.chdir(tmp_path)
+        store = TelemetryStore()
+        store.log_workflow(_record())
+        store.log_workflow(_record(run_id="r2"))
+        lines = store.workflows_file.read_text(encoding="utf-8").strip().splitlines()
+        assert len(lines) == 2
+        assert json.loads(lines[0])["workflow_name"] == "code-review"
+
+    def test_suite_isolation_drift_guard(self):
+        """The autouse ATTUNE_HOME fixture must redirect the default store.
+
+        This is the RC-4 drift guard: if suite isolation regresses (env
+        var dropped, singleton leak, resolution bypass), the default
+        store points at the developer's real ``~/.attune`` and this
+        fails loudly.
+        """
+        store = TelemetryStore()
+        real_home_stream = Path.home() / ".attune" / "telemetry" / "workflow_runs.jsonl"
+        assert store.workflows_file != real_home_stream
+        assert os.environ.get("ATTUNE_HOME"), "suite must run with ATTUNE_HOME isolation"
+        assert str(store.workflows_file).startswith(os.environ["ATTUNE_HOME"])
+
+
+class TestProvenanceFields:
+    """RC-3: trigger/project fields, additive compatibility."""
+
+    def test_pre_rc3_record_loads_with_none_provenance(self):
+        old = _record().to_dict()
+        del old["trigger"]
+        del old["project"]
+        loaded = WorkflowRunRecord.from_dict(old)
+        assert loaded.trigger is None
+        assert loaded.project is None
+
+    def test_resolve_run_trigger_defaults_manual(self, monkeypatch):
+        monkeypatch.delenv(TRIGGER_ENV, raising=False)
+        assert resolve_run_trigger() == "manual"
+
+    def test_resolve_run_trigger_accepts_attune_rec(self, monkeypatch):
+        monkeypatch.setenv(TRIGGER_ENV, "attune-rec")
+        assert resolve_run_trigger() == "attune-rec"
+
+    def test_resolve_run_trigger_rejects_junk(self, monkeypatch):
+        monkeypatch.setenv(TRIGGER_ENV, "pytest-says-hi")
+        assert resolve_run_trigger() == "manual"
+
+    def test_project_identity_plain_repo(self, tmp_path):
+        repo = tmp_path / "myproj"
+        (repo / ".git").mkdir(parents=True)
+        sub = repo / "src" / "pkg"
+        sub.mkdir(parents=True)
+        assert resolve_project_identity(sub) == "myproj"
+
+    def test_project_identity_worktree_resolves_parent(self, tmp_path):
+        main = tmp_path / "mainrepo"
+        (main / ".git" / "worktrees" / "slug").mkdir(parents=True)
+        wt = tmp_path / "wt"
+        wt.mkdir()
+        (wt / ".git").write_text(
+            f"gitdir: {main / '.git' / 'worktrees' / 'slug'}\n", encoding="utf-8"
+        )
+        assert resolve_project_identity(wt) == "mainrepo"
+
+    def test_project_identity_outside_repo(self, tmp_path):
+        assert resolve_project_identity(tmp_path) is None
+
+    def test_emit_populates_provenance(self, tmp_path, monkeypatch):
+        """RC-2/RC-3: the emit seam stamps trigger + project on records."""
+        monkeypatch.setenv(TRIGGER_ENV, "attune-rec")
+        repo = tmp_path / "emitproj"
+        (repo / ".git").mkdir(parents=True)
+        monkeypatch.chdir(repo)
+
+        captured: list[WorkflowRunRecord] = []
+        backend = SimpleNamespace(log_workflow=captured.append)
+        wf = TelemetryMixin.__new__(TelemetryMixin)
+        wf.name = "code-review"
+        wf._run_id = "rid-1"
+        wf._telemetry_backend = backend
+        now = datetime.now(timezone.utc)
+        result = SimpleNamespace(
+            stages=[],
+            started_at=now,
+            completed_at=now,
+            total_duration_ms=5,
+            success=True,
+            error=None,
+            cost_report=SimpleNamespace(
+                total_cost=0.0,
+                baseline_cost=0.0,
+                savings=0.0,
+                savings_percent=0.0,
+                by_tier={},
+            ),
+        )
+        wf._emit_workflow_telemetry(result)
+        assert len(captured) == 1
+        assert captured[0].trigger == "attune-rec"
+        assert captured[0].project == "emitproj"
+
+
+class TestExecuteWrap:
+    """RC-2: subclass ``execute`` overrides are wrapped to emit."""
+
+    def test_override_is_wrapped(self):
+        from attune.workflows.base import BaseWorkflow
+        from attune.workflows.code_review import CodeReviewWorkflow
+
+        # SDK-native override: wrapped by __init_subclass__.
+        assert getattr(CodeReviewWorkflow.execute, "_emits_run_record", False) is True
+        # Inherited mixin execute (no override): NOT wrapped — its own
+        # epilogue emits inline, and the idempotence guard prevents any
+        # double-record if a future override chains through super().
+        assert getattr(BaseWorkflow.execute, "_emits_run_record", False) is False
+
+    def test_emit_is_idempotent_per_result(self, tmp_path, monkeypatch):
+        repo = tmp_path / "onceproj"
+        (repo / ".git").mkdir(parents=True)
+        monkeypatch.chdir(repo)
+        captured: list[WorkflowRunRecord] = []
+        backend = SimpleNamespace(log_workflow=captured.append)
+        wf = TelemetryMixin.__new__(TelemetryMixin)
+        wf.name = "code-review"
+        wf._run_id = "rid-2"
+        wf._telemetry_backend = backend
+        now = datetime.now(timezone.utc)
+        result = SimpleNamespace(
+            stages=[],
+            started_at=now,
+            completed_at=now,
+            total_duration_ms=1,
+            success=True,
+            error=None,
+            cost_report=SimpleNamespace(
+                total_cost=0.0,
+                baseline_cost=0.0,
+                savings=0.0,
+                savings_percent=0.0,
+                by_tier={},
+            ),
+        )
+        wf._emit_workflow_telemetry(result)
+        wf._emit_workflow_telemetry(result)  # second call must no-op
+        assert len(captured) == 1
+
+
+class TestRetention:
+    """RC-5: rotation never deletes; ops prune never touches the stream."""
+
+    def test_rotation_archives_past_size_guard(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("ATTUNE_HOME", str(tmp_path / "home"))
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr(storage_mod, "_RUNS_ROTATE_BYTES", 64)
+        store = TelemetryStore()
+        store.workflows_file.parent.mkdir(parents=True, exist_ok=True)
+        store.workflows_file.write_text("x" * 200 + "\n", encoding="utf-8")
+        store.log_workflow(_record())
+        archive = sorted((store.workflows_file.parent / "archive").glob("*.jsonl"))
+        assert len(archive) == 1
+        assert archive[0].read_text(encoding="utf-8").startswith("x" * 10)
+        live = store.workflows_file.read_text(encoding="utf-8").strip().splitlines()
+        assert len(live) == 1  # fresh stream holds only the new record
+
+    def test_ops_prune_never_touches_canonical_stream(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("ATTUNE_HOME", str(tmp_path / "home"))
+        monkeypatch.chdir(tmp_path)
+        store = TelemetryStore()
+        store.log_workflow(_record())
+        # Age the stream far past any retention window.
+        old = datetime(2020, 1, 1, tzinfo=timezone.utc).timestamp()
+        os.utime(store.workflows_file, (old, old))
+
+        ops_runs = tmp_path / "home" / "ops" / "runs"
+        wf_dir = ops_runs / "code-review"
+        wf_dir.mkdir(parents=True)
+        stale = wf_dir / "deadbeef0001.json"
+        stale.write_text("{}", encoding="utf-8")
+        os.utime(stale, (old, old))
+
+        deleted = prune_old_runs(ops_runs, days=30)
+        assert deleted == 1
+        assert not stale.exists()
+        assert store.workflows_file.exists()  # the corpus is not prunable


### PR DESCRIPTION
Executes the chair-ruled [run-record-corpus spec](docs/specs/run-record-corpus/requirements.md) — the pipeline-learner RR-1 unblock (rulings: B / chair-ruled RR-4 edit / start clean).

**What changed**
- **RC-1** — default `TelemetryStore` routes run records to the canonical home-global stream `~/.attune/telemetry/workflow_runs.jsonl` (`ATTUNE_HOME`-resolved). Explicit `storage_dir` keeps every file local, so test constructions are unchanged.
- **RC-2** — the audit found the SDK-era dry pipe's second cause: all 17 SDK-native workflows override `execute()` and never reached the telemetry epilogue (no run records at all in the era with real usage). Closed at one seam: `BaseWorkflow.__init_subclass__` wraps subclass execute overrides to emit best-effort, idempotent per result.
- **RC-3** — `WorkflowRunRecord` gains `trigger` (manual|attune-rec via `ATTUNE_RUN_TRIGGER`) and `project` (repo-root id; worktrees resolve to the parent repo) — new `run_context.py`, wired into both emit paths.
- **RC-4** — `_isolate_attune_home` also resets the store singleton; a drift-guard test fails loudly if suite isolation regresses.
- **RC-5** — no-delete 50 MB rotation into `telemetry/archive/`; ops prune non-interference asserted. pipeline-learner RR-4 source pin amended in place (D2) + its `decisions.md` created.

**Receipts**
- Full unit suite: **17,719 passed** (post-final-edit run); new module 16 tests serial-clean.
- Live-fire: `CodeReviewWorkflow.execute()` from a worktree against scratch `ATTUNE_HOME` landed records on both the validation-error and keyless-SDK-failure paths with `trigger=manual`, `project=attune-ai`.

**Named follow-ups** (in decisions.md): dashboard rec-click trigger stamp; agent-team workflow emission (health-check bypasses BaseWorkflow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
