### PR TITLE
fix(roundtable): reject Unix-absolute paths on Windows in proposal validation

### DIFF
--- a/src/attune/roundtable/solutions.py
+++ b/src/attune/roundtable/solutions.py
@@ -32,7 +32,7 @@ import subprocess  # nosec B404 — fixed argv git/check commands, never shell=T
 import tempfile
 import uuid
 from dataclasses import dataclass, field
-from pathlib import Path
+from pathlib import Path, PurePosixPath, PureWindowsPath
 
 #: Output kept per check (tail — failure summaries live at the end).
 RECEIPT_TAIL_CHARS = 2000
@@ -89,7 +89,20 @@ def _validate_rel_path(raw: str) -> str:
     if not path:
         raise ProposalError("empty file path in proposal")
     pure = Path(path)
-    if pure.is_absolute() or path.startswith(("~", "\\")) or re.match(r"^[A-Za-z]:", path):
+    # Check absoluteness under BOTH path flavors, not the running
+    # platform's: on Windows, Path("/etc/passwd").is_absolute() is False
+    # (rooted but drive-less), so a platform-native check waves through
+    # Unix-style absolute paths — caught live by the windows-latest CI
+    # lanes. PurePosixPath flags "/..." everywhere; PureWindowsPath
+    # flags "C:\\..." and UNC "\\\\server\\share" everywhere; the
+    # prefix/drive checks keep rejecting rooted ("\\x") and
+    # drive-relative ("C:evil.py") forms neither flavor calls absolute.
+    if (
+        PurePosixPath(path).is_absolute()
+        or PureWindowsPath(path).is_absolute()
+        or path.startswith(("~", "/", "\\"))
+        or re.match(r"^[A-Za-z]:", path)
+    ):
         raise ProposalError(f"absolute path rejected: {path!r}")
     parts = pure.parts
     if ".." in parts:

--- a/tests/unit/roundtable/test_solutions.py
+++ b/tests/unit/roundtable/test_solutions.py
@@ -54,12 +54,20 @@ class TestPathSecurity:
     @pytest.mark.parametrize(
         "bad",
         [
+            # Unix-style absolute: on Windows, Path(...).is_absolute()
+            # is False for these (rooted, drive-less) — the validator
+            # must flag them under POSIX flavor explicitly. Regression
+            # guard for the windows-latest lane failure (2026-07-19).
             "/etc/passwd",
+            "/abs/unix.py",
             "../outside.py",
             "a/../../outside.py",
             ".git/hooks/pre-commit",
             "~/x.py",
             "C:evil.py",
+            "C:\\evil.py",
+            "\\\\server\\share\\evil.py",
+            "\\rooted.py",
         ],
     )
     def test_dangerous_paths_rejected(self, bad: str) -> None:


### PR DESCRIPTION
Fixes the pre-existing failure red on every full-matrix run since the V2-P3 solution materializer landed: `tests/unit/roundtable/test_solutions.py::TestPathSecurity::test_dangerous_paths_rejected[/etc/passwd]` on all five `windows-latest` lanes (surfaced by #1471/#1472's runs).

**Root cause:** `Path('/etc/passwd').is_absolute()` is **False on Windows** — the path is rooted but drive-less — so `_validate_rel_path`'s platform-native check waved Unix-style absolute paths through the dangerous-path rejection.

**Fix:** check absoluteness under BOTH flavors explicitly (`PurePosixPath` + `PureWindowsPath`, platform-independent by construction) while keeping the existing prefix/drive guards for the rooted (`\x`) and drive-relative (`C:evil.py`) forms neither flavor calls absolute. Regression parametrize widened with UNC, drive-absolute, and rooted cases.

**Receipts:** roundtable suite 128 passed serially (real Redis) on macOS; the Windows proof is the five `windows-latest` lanes on this PR — per the matrix-width lesson, this PR should produce the first fully-green full matrix in weeks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)