### PR TITLE
feat(pipeline-learner): fixture-buildable core — readiness gate, miner, ranker, ledger, scaffold

### DIFF
--- a/docs/specs/pipeline-learner/decisions.md
+++ b/docs/specs/pipeline-learner/decisions.md
@@ -33,3 +33,21 @@ pytest-polluted (89% of real-named records inside test-like
 bursts) with no verifiable purity filter. RR-1's viability bar
 must be met by post-cutover accumulation — the readiness check
 reports honestly until then.
+
+## 2026-07-19 — RR-8 lifecycle: fixture-only components LAND NOW (chair)
+
+The chair chose RR-8's first lifecycle option: the
+fixture-buildable core lands now with production surfacing
+disabled. Shipped as `src/attune/pipeline_learner/` — corpus
+loader + RR-1 readiness gate (`corpus.py`, cutover pinned at
+2026-07-19T17:41:26Z, fixture-name exclusion, per-drop counters),
+RR-2 miner + RR-3 ranker (`mining.py`; stated formula
+0.35·freq + 0.25·ratio + 0.25·recency(30d half-life) +
+0.15·manual-fraction, injected `now`, support-then-lexical
+tie-breaker), RR-6 ledger (`decisions.py`, reopen delta = 3), and
+the RR-7 acceptance scaffold (`scaffold.py`, validates against
+`_DEFAULT_WORKFLOW_NAMES`, never registers). `learn()` proposes
+nothing over an unready corpus and produces zero writes. RR-5
+(curator source) is explicitly NOT built — gated until RR-1's
+readiness passes on the live corpus; when it passes, RR-5 is the
+next execution unit.

--- a/src/attune/pipeline_learner/__init__.py
+++ b/src/attune/pipeline_learner/__init__.py
@@ -1,0 +1,128 @@
+"""Pipeline learner v1 — mine workflow-run pairs, rank, propose.
+
+Fixture-buildable core per RR-8's lifecycle: the readiness gate (RR-1),
+pair miner (RR-2), deterministic ranker (RR-3), decision ledger (RR-6),
+and acceptance scaffold (RR-7) — with NO production surfacing: the
+curator source (RR-5) stays gated until RR-1's readiness passes on the
+live corpus. `learn()` is the orchestrator: on an unready corpus it
+returns the explicit "insufficient corpus" report and proposes nothing.
+
+Spec: docs/specs/pipeline-learner/ (table-refreshed, chair-ruled
+2026-07-19; source amended to the canonical run stream per
+docs/specs/run-record-corpus/).
+
+Copyright 2026 Smart-AI-Memory
+Licensed under the Apache License, Version 2.0
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+
+from .corpus import (
+    CUTOVER,
+    LoadStats,
+    Readiness,
+    RunRecord,
+    assess_readiness,
+    default_stream_paths,
+    load_corpus,
+)
+from .decisions import (
+    REOPEN_DELTA,
+    Decision,
+    filter_proposable,
+    ledger_path,
+    load_decisions,
+    record_decision,
+)
+from .mining import (
+    MIN_RATIO,
+    MIN_SUPPORT,
+    WINDOW,
+    Candidate,
+    filter_candidates,
+    mine_pairs,
+    rank,
+)
+from .scaffold import ScaffoldError, scaffold_acceptance
+
+__all__ = [
+    "CUTOVER",
+    "MIN_RATIO",
+    "MIN_SUPPORT",
+    "REOPEN_DELTA",
+    "WINDOW",
+    "Candidate",
+    "Decision",
+    "LearnerReport",
+    "LoadStats",
+    "Readiness",
+    "RunRecord",
+    "ScaffoldError",
+    "assess_readiness",
+    "default_stream_paths",
+    "filter_candidates",
+    "filter_proposable",
+    "learn",
+    "ledger_path",
+    "load_corpus",
+    "load_decisions",
+    "mine_pairs",
+    "rank",
+    "record_decision",
+    "scaffold_acceptance",
+]
+
+
+@dataclass
+class LearnerReport:
+    """One `learn()` run's outcome: readiness verdict + proposals."""
+
+    readiness: Readiness
+    candidates: list[Candidate] = field(default_factory=list)
+
+    @property
+    def status(self) -> str:
+        """ "proposing", or the explicit RR-1 insufficiency statement."""
+        if not self.readiness.viable:
+            return self.readiness.shortfall()
+        if not self.candidates:
+            return "corpus viable — no unruled candidates above thresholds"
+        return f"proposing {len(self.candidates)} candidate(s)"
+
+
+def learn(
+    project: str,
+    *,
+    paths: list[Path] | None = None,
+    ledger: Path | None = None,
+    now: datetime | None = None,
+    min_support: int = MIN_SUPPORT,
+    min_ratio: float = MIN_RATIO,
+) -> LearnerReport:
+    """Run the fixture-safe learner pipeline: load → gate → mine → rank.
+
+    Produces ZERO writes (RR-6 asserts this): proposing is read-only;
+    only the explicit `record_decision`/`scaffold_acceptance` calls
+    write, and only the latter touches the pipeline-artifact path.
+    On an unready corpus the report carries the explicit
+    "insufficient corpus" status and an EMPTY candidate list — the
+    learner never proposes over the gate (RR-1).
+    """
+    records, stats = load_corpus(project, paths)
+    mined = mine_pairs(records)
+    surviving = filter_candidates(mined, min_support=min_support, min_ratio=min_ratio)
+    readiness = assess_readiness(
+        records,
+        stats,
+        min_support=min_support,
+        pairs_at_min_support=len(surviving),
+    )
+    if not readiness.viable:
+        return LearnerReport(readiness=readiness)
+    ranked = rank(surviving, now=now or datetime.now(timezone.utc))
+    proposable = filter_proposable(ranked, load_decisions(ledger))
+    return LearnerReport(readiness=readiness, candidates=proposable)

--- a/src/attune/pipeline_learner/corpus.py
+++ b/src/attune/pipeline_learner/corpus.py
@@ -1,0 +1,234 @@
+"""Corpus loading and the RR-1 readiness gate (pipeline-learner v1).
+
+Reads the canonical run stream (`~/.attune/telemetry/workflow_runs.jsonl`
+plus rotated archives — run-record-corpus RC-1/RC-5) into normalized,
+eligibility-filtered records, and computes the RR-1 readiness report.
+The learner NEVER mines an unready corpus: readiness is operationally
+defined (RR-1), not proxied by a single number.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under the Apache License, Version 2.0
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+
+from attune.models.telemetry.storage import _canonical_runs_file
+
+logger = logging.getLogger(__name__)
+
+#: Start-clean cutover (pipeline-learner decisions.md D3, chair-ruled
+#: 2026-07-19): records predating the run-record-corpus merge are
+#: ineligible — the pre-cutover archive is pytest-polluted with no
+#: verifiable purity filter.
+CUTOVER = datetime(2026, 7, 19, 17, 41, 26, tzinfo=timezone.utc)
+
+#: Known pytest fixture workflow names (run-record-corpus RC-4 purity
+#: rule): excluded outright even post-cutover, belt-and-suspenders on
+#: top of suite isolation.
+FIXTURE_NAMES: frozenset[str] = frozenset(
+    {
+        "stub-workflow",
+        "test-workflow",
+        "test-tier-fallback",
+        "success-workflow",
+        "successful-workflow",
+        "failing-workflow",
+        "failing-stub",
+        "simple-test-workflow",
+        "complete-test-workflow",
+        "complex-workflow",
+        "test-runner",
+    }
+)
+
+
+@dataclass(frozen=True)
+class RunRecord:
+    """One eligible, normalized run record (the RR-2 fixture schema)."""
+
+    workflow: str
+    started_at: datetime  # always timezone-aware UTC
+    trigger: str | None  # "manual" | "attune-rec" | None (unknown → auto)
+    project: str
+    run_id: str
+
+
+@dataclass
+class LoadStats:
+    """Counted drops — RR-2 requires drops to be counted, not silent."""
+
+    total_lines: int = 0
+    eligible: int = 0
+    dropped_malformed: int = 0
+    dropped_pre_cutover: int = 0
+    dropped_fixture: int = 0
+    dropped_no_project: int = 0
+    dropped_other_project: int = 0
+    dropped_duplicate: int = 0
+
+
+def default_stream_paths() -> list[Path]:
+    """The canonical stream plus its rotated archives, oldest-last."""
+    stream = _canonical_runs_file()
+    archives = sorted((stream.parent / "archive").glob("workflow_runs*.jsonl"))
+    return [*archives, stream]
+
+
+def _parse_started_at(raw: object) -> datetime | None:
+    if not isinstance(raw, str) or not raw:
+        return None
+    try:
+        parsed = datetime.fromisoformat(raw)
+    except ValueError:
+        return None
+    # Timezone-naive timestamps are normalized to UTC (RR-2: normalize
+    # or drop, counted either way — we normalize).
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _classify_line(line: str, project: str, cutover: datetime) -> RunRecord | str:
+    """Parse one JSONL line into a RunRecord, or a drop-counter name.
+
+    The string return value is the ``LoadStats`` field to increment —
+    RR-2 requires drops to be counted, never silent.
+    """
+    try:
+        data = json.loads(line)
+    except json.JSONDecodeError:
+        return "dropped_malformed"
+    if not isinstance(data, dict):
+        return "dropped_malformed"
+    name = data.get("workflow_name")
+    started = _parse_started_at(data.get("started_at"))
+    if not isinstance(name, str) or not name or started is None:
+        return "dropped_malformed"
+    if name in FIXTURE_NAMES:
+        return "dropped_fixture"
+    if started < cutover:
+        return "dropped_pre_cutover"
+    rec_project = data.get("project")
+    if not isinstance(rec_project, str) or not rec_project:
+        return "dropped_no_project"
+    if rec_project != project:
+        return "dropped_other_project"
+    run_id = data.get("run_id")
+    trigger = data.get("trigger")
+    return RunRecord(
+        workflow=name,
+        started_at=started,
+        trigger=trigger if trigger in ("manual", "attune-rec") else None,
+        project=rec_project,
+        run_id=run_id if isinstance(run_id, str) and run_id else f"{name}@{started.isoformat()}",
+    )
+
+
+def _read_lines(path: Path) -> list[str]:
+    if not path.is_file():
+        return []
+    try:
+        return path.read_text(encoding="utf-8").splitlines()
+    except OSError as exc:
+        logger.warning("pipeline_learner: unreadable corpus file %s: %s", path, exc)
+        return []
+
+
+def load_corpus(
+    project: str,
+    paths: list[Path] | None = None,
+    *,
+    cutover: datetime = CUTOVER,
+) -> tuple[list[RunRecord], LoadStats]:
+    """Load eligible records for ONE project (RR-4 single-project scope).
+
+    Eligibility: schema-valid, timestamp-parseable, post-cutover,
+    non-fixture, carrying a ``project`` field that matches. Records
+    without a project are ineligible — never silently mined across
+    mixed projects (RR-4). Duplicates (same ``run_id``) are dropped
+    and counted.
+    """
+    stats = LoadStats()
+    records: list[RunRecord] = []
+    seen_ids: set[str] = set()
+    for path in paths if paths is not None else default_stream_paths():
+        for line in _read_lines(path):
+            line = line.strip()
+            if not line:
+                continue
+            stats.total_lines += 1
+            outcome = _classify_line(line, project, cutover)
+            if isinstance(outcome, str):
+                setattr(stats, outcome, getattr(stats, outcome) + 1)
+                continue
+            if outcome.run_id in seen_ids:
+                stats.dropped_duplicate += 1
+                continue
+            seen_ids.add(outcome.run_id)
+            records.append(outcome)
+            stats.eligible += 1
+    records.sort(key=lambda r: (r.started_at, r.workflow, r.run_id))
+    return records, stats
+
+
+@dataclass
+class Readiness:
+    """The RR-1 readiness report — the four numbers plus the verdict."""
+
+    eligible_records: int
+    distinct_workflows: int
+    distinct_active_days: int
+    date_span_days: int
+    min_support: int
+    pairs_at_min_support: int
+    stats: LoadStats = field(repr=False, default_factory=LoadStats)
+
+    @property
+    def viable(self) -> bool:
+        """RR-1: ≥ 2×min-support eligible records across ≥ 7 distinct
+        active days AND at least one candidate pair at min-support."""
+        return (
+            self.eligible_records >= 2 * self.min_support
+            and self.distinct_active_days >= 7
+            and self.pairs_at_min_support >= 1
+        )
+
+    def shortfall(self) -> str:
+        """Human-readable 'insufficient corpus' detail (RR-1)."""
+        if self.viable:
+            return "corpus viable"
+        needs: list[str] = []
+        if self.eligible_records < 2 * self.min_support:
+            needs.append(f"eligible records {self.eligible_records}/{2 * self.min_support}")
+        if self.distinct_active_days < 7:
+            needs.append(f"distinct active days {self.distinct_active_days}/7")
+        if self.pairs_at_min_support < 1:
+            needs.append(f"no candidate pair at min-support {self.min_support}")
+        return "insufficient corpus — not yet viable: " + "; ".join(needs)
+
+
+def assess_readiness(
+    records: list[RunRecord],
+    stats: LoadStats,
+    *,
+    min_support: int,
+    pairs_at_min_support: int,
+) -> Readiness:
+    """Build the RR-1 report from an already-loaded corpus."""
+    days = {r.started_at.date() for r in records}
+    span = (max(days) - min(days)).days + 1 if days else 0
+    return Readiness(
+        eligible_records=len(records),
+        distinct_workflows=len({r.workflow for r in records}),
+        distinct_active_days=len(days),
+        date_span_days=span,
+        min_support=min_support,
+        pairs_at_min_support=pairs_at_min_support,
+        stats=stats,
+    )

--- a/src/attune/pipeline_learner/decisions.py
+++ b/src/attune/pipeline_learner/decisions.py
@@ -1,0 +1,125 @@
+"""Durable accept/decline decision state (pipeline-learner RR-6).
+
+The learner proposes; the chair disposes. Decisions persist to a named
+ledger — an authorized, NON-artifact write, distinct from the
+pipeline-artifact write (RR-7) and explicitly permitted. Re-runs are
+idempotent: accepted or declined fingerprints are not re-proposed; a
+declined candidate reopens only when its support has grown by at least
+``REOPEN_DELTA`` since the decline (the stated delta).
+
+Copyright 2026 Smart-AI-Memory
+Licensed under the Apache License, Version 2.0
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+from .mining import Candidate
+
+logger = logging.getLogger(__name__)
+
+#: A declined candidate reopens only when support has grown by ≥ this
+#: many co-occurrences since the decline (RR-6 "stated delta").
+REOPEN_DELTA = 3
+
+_VALID_DECISIONS = ("accepted", "declined")
+
+
+def ledger_path() -> Path:
+    """`<ATTUNE_HOME|~/.attune>/ops/pipeline_learner/decisions.jsonl`."""
+    home = os.environ.get("ATTUNE_HOME")
+    attune_dir = Path(home).expanduser() if home else Path.home() / ".attune"
+    return attune_dir / "ops" / "pipeline_learner" / "decisions.jsonl"
+
+
+@dataclass(frozen=True)
+class Decision:
+    """One chair ruling on a candidate fingerprint."""
+
+    fingerprint: str
+    decision: str  # "accepted" | "declined"
+    support_at_decision: int
+    decided_at: str  # ISO timestamp
+
+
+def record_decision(
+    fingerprint: str,
+    decision: str,
+    *,
+    support: int,
+    path: Path | None = None,
+) -> Decision:
+    """Append one decision to the ledger (the permitted non-artifact write)."""
+    if decision not in _VALID_DECISIONS:
+        raise ValueError(f"decision must be one of {_VALID_DECISIONS}, got {decision!r}")
+    entry = Decision(
+        fingerprint=fingerprint,
+        decision=decision,
+        support_at_decision=support,
+        decided_at=datetime.now(timezone.utc).isoformat(),
+    )
+    dest = path or ledger_path()
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    with dest.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry.__dict__) + "\n")
+    return entry
+
+
+def load_decisions(path: Path | None = None) -> dict[str, Decision]:
+    """Latest decision per fingerprint (later lines supersede earlier)."""
+    src = path or ledger_path()
+    out: dict[str, Decision] = {}
+    if not src.is_file():
+        return out
+    try:
+        lines = src.read_text(encoding="utf-8").splitlines()
+    except OSError as exc:
+        logger.warning("pipeline_learner: unreadable ledger %s: %s", src, exc)
+        return out
+    for line in lines:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            data = json.loads(line)
+            entry = Decision(
+                fingerprint=str(data["fingerprint"]),
+                decision=str(data["decision"]),
+                support_at_decision=int(data["support_at_decision"]),
+                decided_at=str(data["decided_at"]),
+            )
+        except (json.JSONDecodeError, KeyError, TypeError, ValueError):
+            logger.warning("pipeline_learner: skipping malformed ledger line")
+            continue
+        out[entry.fingerprint] = entry
+    return out
+
+
+def filter_proposable(
+    candidates: list[Candidate],
+    decisions: dict[str, Decision],
+    *,
+    reopen_delta: int = REOPEN_DELTA,
+) -> list[Candidate]:
+    """Drop already-ruled candidates (RR-6 idempotent re-runs).
+
+    Accepted: never re-proposed. Declined: re-proposed only when
+    support ≥ support-at-decline + ``reopen_delta``.
+    """
+    out: list[Candidate] = []
+    for cand in candidates:
+        ruling = decisions.get(cand.fingerprint())
+        if ruling is None:
+            out.append(cand)
+        elif (
+            ruling.decision == "declined"
+            and cand.support >= ruling.support_at_decision + reopen_delta
+        ):
+            out.append(cand)
+    return out

--- a/src/attune/pipeline_learner/mining.py
+++ b/src/attune/pipeline_learner/mining.py
@@ -1,0 +1,151 @@
+"""Pair mining and deterministic ranking (pipeline-learner RR-2/RR-3).
+
+Pair semantics (RR-2, pinned so a fixture cannot pass two incompatible
+algorithms): records are ordered by start timestamp; for each occurrence
+of workflow A, each DISTINCT workflow B ≠ A whose first subsequent run
+starts within the window contributes ONE co-occurrence to A→B —
+intervening unrelated workflows do not break the pair, A→A
+self-sequences are excluded, and the ratio denominator is the count of
+A occurrences.
+
+Ranking (RR-3, the stated formula — deterministic, reproducible)::
+
+    score = 0.35 * freq_norm        # support / max support in batch
+          + 0.25 * ratio            # support / count(A)
+          + 0.25 * recency          # exp(-ln 2 · age_days / 30)
+          + 0.15 * manual_fraction  # manual-triggered pairs / support
+
+``recency`` decays from the MOST RECENT contributing pair with a fixed
+30-day half-life against an injected ``now`` (never wall-clock inside
+the ranker — two runs over the same corpus produce identical ordering).
+A pair's provenance is the trigger of its A record; unknown provenance
+weighs as auto (RR-3). Tie-breaker: higher support, then lexical
+(a, b).
+
+Copyright 2026 Smart-AI-Memory
+Licensed under the Apache License, Version 2.0
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta
+
+from .corpus import RunRecord
+
+#: RR-2 defaults (30-min window, min-support ~5, ratio ~0.5).
+WINDOW = timedelta(minutes=30)
+MIN_SUPPORT = 5
+MIN_RATIO = 0.5
+HALF_LIFE_DAYS = 30.0
+
+_WEIGHT_FREQ = 0.35
+_WEIGHT_RATIO = 0.25
+_WEIGHT_RECENCY = 0.25
+_WEIGHT_MANUAL = 0.15
+
+
+@dataclass
+class Candidate:
+    """A mined A→B pair with the evidence the chair needs (RR-5 shape)."""
+
+    a: str
+    b: str
+    support: int
+    a_occurrences: int
+    manual_pairs: int
+    last_pair_at: datetime
+    sample_run_ids: list[str] = field(default_factory=list)
+    score: float = 0.0
+
+    @property
+    def ratio(self) -> float:
+        """support / count(A) — the RR-2 denominator."""
+        return self.support / self.a_occurrences if self.a_occurrences else 0.0
+
+    @property
+    def manual_fraction(self) -> float:
+        """Manual-triggered pairs / support; unknown provenance = auto."""
+        return self.manual_pairs / self.support if self.support else 0.0
+
+    def fingerprint(self, window: timedelta = WINDOW) -> str:
+        """Candidate identity (RR-6): ordered members + window class."""
+        return f"{self.a}->{self.b}@w{int(window.total_seconds() // 60)}"
+
+
+def mine_pairs(records: list[RunRecord], *, window: timedelta = WINDOW) -> list[Candidate]:
+    """Mine A→B co-occurrences from a time-ordered corpus (RR-2)."""
+    ordered = sorted(records, key=lambda r: (r.started_at, r.workflow, r.run_id))
+    occurrences: dict[str, int] = {}
+    for rec in ordered:
+        occurrences[rec.workflow] = occurrences.get(rec.workflow, 0) + 1
+
+    pairs: dict[tuple[str, str], Candidate] = {}
+    for i, a_rec in enumerate(ordered):
+        seen_b: set[str] = set()
+        for b_rec in ordered[i + 1 :]:
+            gap = b_rec.started_at - a_rec.started_at
+            if gap > window:
+                break
+            if gap <= timedelta(0):
+                # Same-instant records carry no temporal order — "A then
+                # B" requires strictly-later (deterministic under the
+                # name tie-broken sort).
+                continue
+            b = b_rec.workflow
+            if b == a_rec.workflow or b in seen_b:
+                continue
+            seen_b.add(b)
+            key = (a_rec.workflow, b)
+            cand = pairs.get(key)
+            if cand is None:
+                cand = Candidate(
+                    a=a_rec.workflow,
+                    b=b,
+                    support=0,
+                    a_occurrences=occurrences[a_rec.workflow],
+                    manual_pairs=0,
+                    last_pair_at=b_rec.started_at,
+                )
+                pairs[key] = cand
+            cand.support += 1
+            if a_rec.trigger == "manual":
+                cand.manual_pairs += 1
+            if b_rec.started_at > cand.last_pair_at:
+                cand.last_pair_at = b_rec.started_at
+            if len(cand.sample_run_ids) < 5:
+                cand.sample_run_ids.append(a_rec.run_id)
+    return list(pairs.values())
+
+
+def filter_candidates(
+    candidates: list[Candidate],
+    *,
+    min_support: int = MIN_SUPPORT,
+    min_ratio: float = MIN_RATIO,
+) -> list[Candidate]:
+    """Apply the RR-2 support/ratio thresholds."""
+    return [c for c in candidates if c.support >= min_support and c.ratio >= min_ratio]
+
+
+def rank(candidates: list[Candidate], *, now: datetime) -> list[Candidate]:
+    """Score and order candidates by the RR-3 formula (deterministic).
+
+    ``now`` is injected, never read from the wall clock, so two runs
+    over the same corpus produce identical ordering (asserted in
+    tests). Ties break on higher support, then lexical (a, b).
+    """
+    if not candidates:
+        return []
+    max_support = max(c.support for c in candidates)
+    for c in candidates:
+        age_days = max((now - c.last_pair_at).total_seconds(), 0.0) / 86_400.0
+        recency = math.exp(-math.log(2.0) * age_days / HALF_LIFE_DAYS)
+        c.score = (
+            _WEIGHT_FREQ * (c.support / max_support)
+            + _WEIGHT_RATIO * c.ratio
+            + _WEIGHT_RECENCY * recency
+            + _WEIGHT_MANUAL * c.manual_fraction
+        )
+    return sorted(candidates, key=lambda c: (-c.score, -c.support, c.a, c.b))

--- a/src/attune/pipeline_learner/scaffold.py
+++ b/src/attune/pipeline_learner/scaffold.py
@@ -1,0 +1,114 @@
+"""Acceptance scaffolding (pipeline-learner RR-7).
+
+On explicit acceptance ONLY, scaffold `<name>.yaml` + `<name>.evidence.json`
+under `docs/specs/pipelines/` — atomically (both or neither), with the
+member workflow names VALIDATED against the live registry
+(`_DEFAULT_WORKFLOW_NAMES`) and never written to it: a pipeline is a
+composition of EXISTING workflows; nothing is registered (RR-7,
+contested→resolved).
+
+Copyright 2026 Smart-AI-Memory
+Licensed under the Apache License, Version 2.0
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+
+from .mining import WINDOW, Candidate
+
+#: Chair-supplied pipeline names: lowercase slug, no path metacharacters
+#: (RR-7 name sanitization / containment).
+_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9-]{0,63}$")
+
+
+class ScaffoldError(ValueError):
+    """A scaffold request that cannot be safely written."""
+
+
+def _registry_names() -> set[str]:
+    from attune.workflows import _DEFAULT_WORKFLOW_NAMES
+
+    return set(_DEFAULT_WORKFLOW_NAMES)
+
+
+def _pipeline_yaml(name: str, candidate: Candidate) -> str:
+    """Render the pipeline YAML (composition of EXISTING workflows)."""
+    return (
+        f"name: {name}\n"
+        "kind: pipeline\n"
+        "# Mined by pipeline-learner v1; members must exist in the\n"
+        "# workflow registry — nothing is registered by acceptance (RR-7).\n"
+        "members:\n"
+        f"  - {candidate.a}\n"
+        f"  - {candidate.b}\n"
+        f"window_minutes: {int(WINDOW.total_seconds() // 60)}\n"
+        f"evidence: {name}.evidence.json\n"
+    )
+
+
+def scaffold_acceptance(
+    candidate: Candidate,
+    name: str,
+    pipelines_dir: Path,
+) -> tuple[Path, Path]:
+    """Write `<name>.yaml` + `<name>.evidence.json` atomically (RR-7).
+
+    Raises:
+        ScaffoldError: Invalid/escaping name, unknown member workflow,
+            or a collision with an existing scaffold (collision
+            behavior: refuse — the chair picks a new name; nothing is
+            overwritten).
+        OSError: Filesystem failure after rollback of any partial write.
+    """
+    if not _NAME_RE.match(name):
+        raise ScaffoldError(f"invalid pipeline name {name!r} (need ^[a-z0-9][a-z0-9-]*$)")
+    pipelines_dir.mkdir(parents=True, exist_ok=True)
+    yaml_dest = pipelines_dir / f"{name}.yaml"
+    evidence_dest = pipelines_dir / f"{name}.evidence.json"
+    # Containment: the sanitized name must resolve inside pipelines_dir.
+    root = pipelines_dir.resolve()
+    if yaml_dest.resolve().parent != root or evidence_dest.resolve().parent != root:
+        raise ScaffoldError(f"pipeline name escapes the pipelines directory: {name!r}")
+    unknown = {candidate.a, candidate.b} - _registry_names()
+    if unknown:
+        raise ScaffoldError(f"pipeline references unknown workflows: {sorted(unknown)}")
+    if yaml_dest.exists() or evidence_dest.exists():
+        raise ScaffoldError(f"pipeline {name!r} already scaffolded — pick a new name")
+
+    evidence = {
+        "fingerprint": candidate.fingerprint(),
+        "support": candidate.support,
+        "ratio": round(candidate.ratio, 4),
+        "members": [candidate.a, candidate.b],
+        "sample_run_ids": candidate.sample_run_ids,
+        "provenance_mix": {
+            "manual_pairs": candidate.manual_pairs,
+            "auto_or_unknown_pairs": candidate.support - candidate.manual_pairs,
+        },
+        "last_pair_at": candidate.last_pair_at.isoformat(),
+        "scaffolded_at": datetime.now(timezone.utc).isoformat(),
+    }
+
+    yaml_tmp = pipelines_dir / f"{name}.yaml.tmp"
+    evidence_tmp = pipelines_dir / f"{name}.evidence.json.tmp"
+    written: list[Path] = []
+    try:
+        yaml_tmp.write_text(_pipeline_yaml(name, candidate), encoding="utf-8")
+        evidence_tmp.write_text(json.dumps(evidence, indent=2) + "\n", encoding="utf-8")
+        yaml_tmp.replace(yaml_dest)
+        written.append(yaml_dest)
+        evidence_tmp.replace(evidence_dest)
+        written.append(evidence_dest)
+    except OSError:
+        # Both-or-neither: roll back any half-landed artifact (RR-7).
+        for path in (yaml_tmp, evidence_tmp, *written):
+            try:
+                path.unlink(missing_ok=True)
+            except OSError:  # pragma: no cover - best-effort rollback
+                pass
+        raise
+    return yaml_dest, evidence_dest

--- a/tests/unit/pipeline_learner/test_learner.py
+++ b/tests/unit/pipeline_learner/test_learner.py
@@ -1,0 +1,353 @@
+"""Pipeline-learner fixture tests — every RR-pinned assertion.
+
+Spec: docs/specs/pipeline-learner/requirements.md (chair-ruled
+2026-07-19, source amended to the canonical run stream). These tests
+ARE the RR-2/RR-3/RR-6/RR-7 acceptance probes; live surfacing (RR-5)
+stays gated on RR-1 readiness and has no tests here by design.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from attune.pipeline_learner import (
+    Candidate,
+    LearnerReport,
+    ScaffoldError,
+    filter_candidates,
+    learn,
+    ledger_path,
+    load_corpus,
+    load_decisions,
+    mine_pairs,
+    rank,
+    record_decision,
+    scaffold_acceptance,
+)
+from attune.pipeline_learner.corpus import RunRecord
+
+# All fixture timestamps are post-cutover (start-clean, D3).
+BASE = datetime(2026, 8, 1, 10, 0, tzinfo=timezone.utc)
+NOW = datetime(2026, 8, 20, 12, 0, tzinfo=timezone.utc)
+PROJECT = "attune-ai"
+
+
+def _rec(
+    workflow: str, at: datetime, *, trigger: str | None = "manual", rid: str = ""
+) -> RunRecord:
+    return RunRecord(
+        workflow=workflow,
+        started_at=at,
+        trigger=trigger,
+        project=PROJECT,
+        run_id=rid or f"{workflow}-{at.isoformat()}",
+    )
+
+
+def _line(workflow: str, at: str, *, project: str | None = PROJECT, rid: str | None = None) -> str:
+    data = {"workflow_name": workflow, "started_at": at, "run_id": rid or f"{workflow}@{at}"}
+    if project is not None:
+        data["project"] = project
+    return json.dumps(data)
+
+
+def _seven_pair_corpus() -> list[RunRecord]:
+    """7 A→B occurrences across 7 days + sub-threshold noise (RR-2)."""
+    records: list[RunRecord] = []
+    for day in range(7):
+        at = BASE + timedelta(days=day)
+        records.append(_rec("code-review", at))
+        records.append(_rec("security-audit", at + timedelta(minutes=5)))
+    # Noise: 2 C→D occurrences — below min-support, must be filtered.
+    for day in range(2):
+        at = BASE + timedelta(days=day, hours=4)
+        records.append(_rec("doc-audit", at))
+        records.append(_rec("perf-audit", at + timedelta(minutes=3)))
+    return records
+
+
+class TestLoadCorpus:
+    """RR-2 record schema + RR-4 single-project eligibility."""
+
+    def test_eligible_record_loads_and_naive_ts_normalizes(self, tmp_path):
+        f = tmp_path / "runs.jsonl"
+        f.write_text(_line("code-review", "2026-08-01T10:00:00") + "\n", encoding="utf-8")
+        records, stats = load_corpus(PROJECT, [f])
+        assert stats.eligible == 1
+        assert records[0].started_at.tzinfo is not None  # normalized to UTC
+
+    def test_drops_are_counted_not_silent(self, tmp_path):
+        f = tmp_path / "runs.jsonl"
+        lines = [
+            "{not json",
+            _line("code-review", "not-a-timestamp"),
+            _line("code-review", "2026-01-01T10:00:00+00:00"),  # pre-cutover
+            _line("stub-workflow", "2026-08-01T10:00:00+00:00"),  # fixture name
+            _line("code-review", "2026-08-01T10:00:00+00:00", project=None),
+            _line("code-review", "2026-08-01T11:00:00+00:00", project="other-repo"),
+            _line("code-review", "2026-08-01T12:00:00+00:00", rid="dup"),
+            _line("code-review", "2026-08-01T12:30:00+00:00", rid="dup"),
+        ]
+        f.write_text("\n".join(lines) + "\n", encoding="utf-8")
+        records, stats = load_corpus(PROJECT, [f])
+        assert stats.eligible == len(records) == 1
+        assert stats.dropped_malformed == 2
+        assert stats.dropped_pre_cutover == 1
+        assert stats.dropped_fixture == 1
+        assert stats.dropped_no_project == 1
+        assert stats.dropped_other_project == 1
+        assert stats.dropped_duplicate == 1
+
+
+class TestMinePairs:
+    """RR-2 pair semantics, pinned."""
+
+    def test_seven_occurrence_pair_surfaces_noise_filtered(self):
+        cands = filter_candidates(mine_pairs(_seven_pair_corpus()))
+        assert len(cands) == 1
+        (c,) = cands
+        assert (c.a, c.b) == ("code-review", "security-audit")
+        assert c.support == 7
+        assert c.ratio == 1.0
+
+    def test_off_by_window_excluded(self):
+        records = [
+            _rec("code-review", BASE),
+            _rec("security-audit", BASE + timedelta(minutes=31)),  # > 30-min window
+        ]
+        assert mine_pairs(records) == []
+
+    def test_self_sequence_excluded(self):
+        records = [_rec("code-review", BASE), _rec("code-review", BASE + timedelta(minutes=5))]
+        assert mine_pairs(records) == []
+
+    def test_intervening_workflow_does_not_break_pair(self):
+        records = [
+            _rec("code-review", BASE),
+            _rec("doc-audit", BASE + timedelta(minutes=2)),  # intervening
+            _rec("security-audit", BASE + timedelta(minutes=10)),
+        ]
+        pairs = {(c.a, c.b) for c in mine_pairs(records)}
+        assert ("code-review", "security-audit") in pairs
+
+    def test_ratio_denominator_is_a_occurrences(self):
+        # 3 A runs, only 1 followed by B → ratio 1/3.
+        records = [
+            _rec("code-review", BASE),
+            _rec("security-audit", BASE + timedelta(minutes=5)),
+            _rec("code-review", BASE + timedelta(days=1)),
+            _rec("code-review", BASE + timedelta(days=2)),
+        ]
+        (c,) = [x for x in mine_pairs(records) if x.b == "security-audit"]
+        assert c.a_occurrences == 3
+        assert c.support == 1
+        assert c.ratio == pytest.approx(1 / 3)
+
+
+class TestRank:
+    """RR-3 deterministic, manual-over-auto, recency-decayed ranking."""
+
+    def _candidate(self, a: str, support: int, manual: int, last_at: datetime) -> Candidate:
+        return Candidate(
+            a=a,
+            b="security-audit",
+            support=support,
+            a_occurrences=support,  # ratio 1.0
+            manual_pairs=manual,
+            last_pair_at=last_at,
+        )
+
+    def test_two_runs_produce_identical_ordering(self):
+        cands = [
+            self._candidate("code-review", 7, 7, NOW - timedelta(days=3)),
+            self._candidate("doc-audit", 5, 2, NOW - timedelta(days=1)),
+            self._candidate("perf-audit", 5, 2, NOW - timedelta(days=1)),
+        ]
+        first = [(c.a, c.score) for c in rank(list(cands), now=NOW)]
+        second = [(c.a, c.score) for c in rank(list(cands), now=NOW)]
+        assert first == second
+
+    def test_manual_strictly_outranks_attune_rec_at_equal_stats(self):
+        manual = self._candidate("code-review", 5, 5, NOW - timedelta(days=2))
+        auto = self._candidate("doc-audit", 5, 0, NOW - timedelta(days=2))
+        ranked = rank([auto, manual], now=NOW)
+        assert [c.a for c in ranked] == ["code-review", "doc-audit"]
+        assert ranked[0].score > ranked[1].score  # strictly below, not tie-broken
+
+    def test_months_old_burst_does_not_outrank_recent_pattern(self):
+        old_burst = self._candidate("doc-audit", 7, 0, NOW - timedelta(days=90))
+        recent = self._candidate("code-review", 5, 0, NOW - timedelta(days=1))
+        ranked = rank([old_burst, recent], now=NOW)
+        assert [c.a for c in ranked] == ["code-review", "doc-audit"]
+
+    def test_tie_breaker_higher_support_then_lexical(self):
+        a = self._candidate("b-flow", 5, 0, NOW)
+        b = self._candidate("a-flow", 5, 0, NOW)
+        ranked = rank([a, b], now=NOW)
+        assert [c.a for c in ranked] == ["a-flow", "b-flow"]
+
+
+def _write_corpus(tmp_path: Path, records: list[RunRecord]) -> Path:
+    f = tmp_path / "runs.jsonl"
+    lines = [
+        json.dumps(
+            {
+                "workflow_name": r.workflow,
+                "started_at": r.started_at.isoformat(),
+                "trigger": r.trigger,
+                "project": r.project,
+                "run_id": r.run_id,
+            }
+        )
+        for r in records
+    ]
+    f.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return f
+
+
+class TestReadinessGate:
+    """RR-1: the learner never proposes over an unready corpus."""
+
+    def test_insufficient_corpus_proposes_nothing(self, tmp_path):
+        records = [_rec("code-review", BASE), _rec("security-audit", BASE + timedelta(minutes=5))]
+        report = learn(PROJECT, paths=[_write_corpus(tmp_path, records)], now=NOW)
+        assert "insufficient corpus — not yet viable" in report.status
+        assert report.candidates == []
+        assert not report.readiness.viable
+
+    def test_viable_corpus_reports_and_proposes(self, tmp_path):
+        report = learn(PROJECT, paths=[_write_corpus(tmp_path, _seven_pair_corpus())], now=NOW)
+        assert report.readiness.viable
+        assert report.readiness.eligible_records == 18
+        assert report.readiness.distinct_workflows == 4
+        assert report.readiness.distinct_active_days == 7
+        assert report.status == "proposing 1 candidate(s)"
+        assert report.candidates[0].fingerprint() == "code-review->security-audit@w30"
+
+    def test_readiness_requires_a_pair_at_min_support(self, tmp_path):
+        # Plenty of records + days, but no repeated sequence.
+        records = [
+            _rec(w, BASE + timedelta(days=d, hours=h))
+            for d in range(8)
+            for h, w in [(0, "code-review"), (8, "doc-audit")]  # 8h gap: no pair
+        ]
+        report = learn(PROJECT, paths=[_write_corpus(tmp_path, records)], now=NOW)
+        assert "no candidate pair at min-support" in report.status
+
+
+class TestDecisions:
+    """RR-6: opt-in, durable, idempotent decision state."""
+
+    def _one_candidate(self, tmp_path: Path) -> tuple[LearnerReport, Path]:
+        corpus = _write_corpus(tmp_path, _seven_pair_corpus())
+        ledger = tmp_path / "ledger.jsonl"
+        return learn(PROJECT, paths=[corpus], ledger=ledger, now=NOW), ledger
+
+    def test_learn_produces_zero_artifact_writes(self, tmp_path):
+        pipelines_dir = tmp_path / "pipelines"
+        report, ledger = self._one_candidate(tmp_path)
+        assert report.candidates  # it proposed…
+        assert not pipelines_dir.exists()  # …and wrote no artifacts
+        assert not ledger.exists()  # …and no ledger entries either
+
+    def test_accepted_fingerprint_not_reproposed(self, tmp_path):
+        report, ledger = self._one_candidate(tmp_path)
+        cand = report.candidates[0]
+        record_decision(cand.fingerprint(), "accepted", support=cand.support, path=ledger)
+        rerun = learn(
+            PROJECT, paths=[_write_corpus(tmp_path, _seven_pair_corpus())], ledger=ledger, now=NOW
+        )
+        assert rerun.candidates == []
+
+    def test_declined_reopens_only_on_support_delta(self, tmp_path):
+        report, ledger = self._one_candidate(tmp_path)
+        cand = report.candidates[0]
+        record_decision(cand.fingerprint(), "declined", support=cand.support, path=ledger)
+        # Same evidence → stays closed.
+        rerun = learn(
+            PROJECT, paths=[_write_corpus(tmp_path, _seven_pair_corpus())], ledger=ledger, now=NOW
+        )
+        assert rerun.candidates == []
+        # Support grows by the stated delta (+3) → reopens.
+        grown = _seven_pair_corpus()
+        for day in range(7, 10):
+            at = BASE + timedelta(days=day)
+            grown.append(_rec("code-review", at))
+            grown.append(_rec("security-audit", at + timedelta(minutes=5)))
+        reopened = learn(PROJECT, paths=[_write_corpus(tmp_path, grown)], ledger=ledger, now=NOW)
+        assert [c.fingerprint() for c in reopened.candidates] == [cand.fingerprint()]
+
+    def test_invalid_decision_rejected(self, tmp_path):
+        with pytest.raises(ValueError, match="decision must be one of"):
+            record_decision("x->y@w30", "maybe", support=5, path=tmp_path / "l.jsonl")
+
+    def test_ledger_path_resolves_under_attune_home(self):
+        # The suite's ATTUNE_HOME isolation fixture must contain it.
+        import os
+
+        assert str(ledger_path()).startswith(os.environ["ATTUNE_HOME"])
+        assert load_decisions() == {}
+
+
+class TestScaffold:
+    """RR-7: atomic, validated, contained acceptance artifacts."""
+
+    def _candidate(self) -> Candidate:
+        return Candidate(
+            a="code-review",
+            b="security-audit",
+            support=7,
+            a_occurrences=7,
+            manual_pairs=6,
+            last_pair_at=NOW,
+            sample_run_ids=["r1", "r2"],
+        )
+
+    def test_acceptance_writes_yaml_and_evidence(self, tmp_path):
+        yaml_path, evidence_path = scaffold_acceptance(
+            self._candidate(), "review-then-audit", tmp_path / "pipelines"
+        )
+        assert yaml_path.is_file() and evidence_path.is_file()
+        evidence = json.loads(evidence_path.read_text(encoding="utf-8"))
+        assert evidence["support"] == 7
+        assert evidence["members"] == ["code-review", "security-audit"]
+        assert evidence["sample_run_ids"] == ["r1", "r2"]
+        assert evidence["provenance_mix"] == {"manual_pairs": 6, "auto_or_unknown_pairs": 1}
+
+    def test_scaffold_yaml_is_well_formed(self, tmp_path):
+        yaml = pytest.importorskip("yaml")
+        yaml_path, _ = scaffold_acceptance(self._candidate(), "wf-pair", tmp_path / "p")
+        doc = yaml.safe_load(yaml_path.read_text(encoding="utf-8"))
+        assert doc["name"] == "wf-pair"
+        assert doc["kind"] == "pipeline"
+        assert doc["members"] == ["code-review", "security-audit"]
+        assert doc["window_minutes"] == 30
+
+    def test_unknown_member_workflow_rejected(self, tmp_path):
+        bad = self._candidate()
+        bad.b = "not-a-registered-workflow"
+        with pytest.raises(ScaffoldError, match="unknown workflows"):
+            scaffold_acceptance(bad, "nope", tmp_path / "p")
+        assert not (tmp_path / "p" / "nope.yaml").exists()
+
+    @pytest.mark.parametrize("name", ["../escape", "Evil", "a/b", "", "-lead", "x" * 70])
+    def test_unsafe_names_rejected(self, tmp_path, name):
+        with pytest.raises(ScaffoldError):
+            scaffold_acceptance(self._candidate(), name, tmp_path / "p")
+
+    def test_collision_refused_nothing_overwritten(self, tmp_path):
+        target = tmp_path / "p"
+        scaffold_acceptance(self._candidate(), "dup-name", target)
+        before = (target / "dup-name.yaml").read_text(encoding="utf-8")
+        with pytest.raises(ScaffoldError, match="already scaffolded"):
+            scaffold_acceptance(self._candidate(), "dup-name", target)
+        assert (target / "dup-name.yaml").read_text(encoding="utf-8") == before
+
+    def test_registry_is_never_mutated(self):
+        from attune.workflows import _DEFAULT_WORKFLOW_NAMES
+
+        assert "review-then-audit" not in _DEFAULT_WORKFLOW_NAMES


### PR DESCRIPTION
Executes pipeline-learner RR-8's chair-chosen lifecycle (recorded in [decisions.md](docs/specs/pipeline-learner/decisions.md)): the **fixture-buildable core lands now with production surfacing disabled** — RR-5 (curator source) stays gated until RR-1's readiness passes on the live corpus.

**New package `src/attune/pipeline_learner/`:**
- **corpus.py** — canonical-stream loader (RR-4 single-project scope, D3 start-clean cutover, fixture-name purity filter, per-drop counters) + the RR-1 readiness gate with the explicit insufficient-corpus status.
- **mining.py** — RR-2 pair miner with the pinned semantics (30-min window, first-B-per-occurrence counting, A→A excluded, intervening runs don't break pairs) + the RR-3 stated-formula ranker (0.35·freq + 0.25·ratio + 0.25·recency(30d half-life) + 0.15·manual-fraction; injected `now` for reproducibility; support-then-lexical tie-breaker).
- **decisions.py** — RR-6 durable accept/decline ledger (ATTUNE_HOME-resolved); accepted never re-proposed; declined reopens only at +3 support.
- **scaffold.py** — RR-7 acceptance artifacts: atomic `<name>.yaml` + `<name>.evidence.json`, members VALIDATED against `_DEFAULT_WORKFLOW_NAMES` (nothing registered), name sanitization + path containment, collisions refused.
- **`learn()`** — proposes nothing over an unready corpus and produces zero writes (asserted).

**Receipts:** 30 fixture tests implementing every RR-pinned assertion; full unit suite **17,753 passed**; complexity ratchet green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
