### PR TITLE
feat(usage-signals): US-4 capture contract, US-6 three-panel receipt, US-7 ledger annotation

### DIFF
--- a/docs/specs/usage-signals/decisions.md
+++ b/docs/specs/usage-signals/decisions.md
@@ -409,7 +409,7 @@ into the 8.6.0 release; the client ships default-OFF as already built.
 
 No copy changes needed — existing telemetry text remains accurate.
 
-## D11 — first-run consent prompt shipped (the D9 opt-in lever) (2026-06-20, 8.6.1)
+## D11a — first-run consent prompt shipped (the D9 opt-in lever) (2026-06-20, 8.6.1)
 
 D9 kept the ping default-OFF and named a first-run consent prompt as the
 opt-in lever, deferred to a follow-up. After 8.6.0 shipped the client,
@@ -441,15 +441,15 @@ approved by Patrick. Remaining: Phase 2c Reach dashboard, R5/R6.
 
 ## D12 — consent ask also reaches the plugin/MCP channel (2026-06-20)
 
-D11's prompt fires only from `cli_minimal.main()` in an interactive
+D11a's prompt fires only from `cli_minimal.main()` in an interactive
 terminal. But the dominant channel is the **Claude Code plugin + MCP
 tools**, which never call `main()` — yet their workflows still write
 local `usage.jsonl` records. So plugin users generate the data but were
-never offered the choice: the exact "nobody was ever told" gap D11 closed
+never offered the choice: the exact "nobody was ever told" gap D11a closed
 for the CLI persisted verbatim for the larger audience.
 
 **Constraint:** hooks run as piped subprocesses (no TTY) and the MCP
-server is a JSON-RPC stdio server, so neither can reuse D11's
+server is a JSON-RPC stdio server, so neither can reuse D11a's
 `input()`-based prompt — `_is_interactive()` would always skip.
 
 **Shipped:** a SessionStart hook `plugin/hooks/usage_consent_notice.py`
@@ -555,7 +555,7 @@ any useful timescale; the product-direction-review instruments
 ones. No further investment here recommended until a conversation
 or inbound report proves a human population to measure.
 
-## D11 — attune-rag download figure declared uninterpreted noise (2026-07-12)
+## D11b — attune-rag download figure declared uninterpreted noise (2026-07-12)
 
 The 2026-07-12 snapshot shows attune-rag at **27,410
 downloads/month — 5× attune-ai's 5,501** — for a sub-package with
@@ -604,3 +604,54 @@ completeness manifest — kills the 10.5.0 silent-0/5 class); US-6 =
 R3 closes only on a three-panel receipt; US-7 = D11a/D11b ledger
 disambiguation + the refreshed done-when. `requirements.md` replaced
 (prior text in git history).
+
+## D15 — US-4/US-6/US-7 executed: capture contract, three-panel receipt, ledger annotation (2026-07-19)
+
+Executed by the follow-up session on branch
+`feat/usage-signals-us4-us6-us7`; evidence per US-7's closure rule.
+
+**US-4 (reach capture reliability) — SHIPPED.**
+`scripts/reach_snapshot.py` now enforces the full capture contract:
+an explicit five-package allowlist with a persisted `manifest`
+(expected/captured/missing, source, observed_at, complete) on every
+snapshot including partial writes; Retry-After honored in the 429
+message; a per-day attempt budget (1 initial + 2 additional, ≥60 min
+apart) enforced BEFORE any request via a durable `attempts` ledger in
+the day file — a zero-capture run still logs its attempt, so the
+budget cannot be bypassed; incomplete snapshots exit non-zero with an
+unmistakable `WARNING: INCOMPLETE SNAPSHOT` (never silent completion,
+never indefinite blocking). Receipts: 16 tests in
+`tests/unit/scripts/test_reach_snapshot.py` covering complete,
+partial, and zero-package captures, the simulated 429 boundary with
+Retry-After, gap refusal before any request, and budget exhaustion.
+
+**US-6 (three-panel receipt) — SHIPPED; R3 DONE on this receipt.**
+The `/telemetry` page now renders all three panels together:
+reach (latest COMPLETE snapshot with per-package values +
+observation timestamp; a newer incomplete snapshot is labeled
+INCOMPLETE with its missing packages and does NOT replace the
+complete one — `read_reach_panel`), freshness (usage.jsonl
+last-write age via file mtime, STALE flag above 48h —
+`read_usage_freshness`), and spend (the shipped D13 alarm, extracted
+to a shared `_spend_alarm.html` include used by home + telemetry).
+Receipts: 9 tests in `tests/unit/ops/test_telemetry_three_panels.py`
+through the real file-to-render boundary (persisted snapshot JSONs +
+usage.jsonl → FastAPI route → rendered HTML), including the
+47.5h/48.5h boundary flip and the three-panels-together assertion.
+
+**US-7 (ledger annotation) — DONE in this entry's commit.**
+The duplicate D11 identifiers are annotated non-destructively:
+consent entry → **D11a**, attune-rag noise verdict → **D11b**
+(headers + intra-entry prose; dates, text, and order unchanged;
+no other decisions renumbered; DEC-* identifiers preserved). Audit:
+zero bare `D11` references remain in `docs/specs/usage-signals/`,
+tracked handoffs, or the tracked memory corpus (the memory hit for
+"D11" belongs to the help single-source spec, not this ledger).
+The original spend-alarm requirement is marked **DONE citing D13**;
+no additional spend-monitoring scope is opened.
+
+**NOT closed by this entry:** US-3 (chair-led outreach) and US-5
+(comparable release pair — bound to the next planned release using
+the US-4 strategy). The refreshed done-when therefore remains open;
+this entry contributes the US-4 receipts, the US-6 three-panel
+receipt, and the completed ledger audit toward it.

--- a/scripts/reach_snapshot.py
+++ b/scripts/reach_snapshot.py
@@ -55,8 +55,44 @@ PACKAGES = [
 REPO = "Smart-AI-Memory/attune-ai"
 
 
+#: US-4: the manifest names its data source explicitly.
+SOURCE = "pypistats.org/api/recent"
+
+#: US-4 attempt budget: one initial attempt plus at most two
+#: additional attempts per day, separated by >= 60 minutes.
+MAX_ATTEMPTS_PER_DAY = 3
+MIN_ATTEMPT_GAP_SECONDS = 60 * 60
+
+
 class RateLimitedError(RuntimeError):
     """pypistats returned 429 — stop immediately, retrying makes it worse."""
+
+
+class AttemptBudgetError(RuntimeError):
+    """The US-4 per-day attempt budget is exhausted or the gap unmet."""
+
+
+def build_manifest(
+    expected: list[str],
+    captured: dict[str, dict[str, int]],
+    observed_at: str,
+) -> dict[str, object]:
+    """The US-4 completeness contract: expected vs captured vs missing.
+
+    A snapshot is complete only when every allowlisted package has a
+    valid observation; the status travels with the artifact so an
+    incomplete snapshot is unmistakable downstream (dashboard, release
+    ritual) rather than silently shaped like a complete one.
+    """
+    missing = [pkg for pkg in expected if pkg not in captured]
+    return {
+        "expected": list(expected),
+        "captured": [pkg for pkg in expected if pkg in captured],
+        "missing": missing,
+        "source": SOURCE,
+        "observed_at": observed_at,
+        "complete": not missing,
+    }
 
 
 def fetch_pypistats_recent(package: str) -> dict[str, int]:
@@ -71,10 +107,17 @@ def fetch_pypistats_recent(package: str) -> dict[str, int]:
             payload = json.loads(resp.read().decode("utf-8"))
     except urllib.error.HTTPError as e:
         if e.code == 429:
+            # US-4: honor server-provided retry guidance when present.
+            retry_after = e.headers.get("Retry-After") if e.headers else None
+            guidance = (
+                f"server says retry after {retry_after}s"
+                if retry_after
+                else "wait at least 60 minutes (the penalty outlasts short retries)"
+            )
             raise RateLimitedError(
-                f"pypistats rate-limited on {package}. Wait 15 minutes, "
-                "then rerun with --spacing 60 (the penalty outlasts "
-                "short retries)."
+                f"pypistats rate-limited on {package}; {guidance}. "
+                "Rerun later — already-captured packages are reused, "
+                "and at most two additional attempts are budgeted today."
             ) from e
         raise
     data = payload.get("data", {})
@@ -167,6 +210,8 @@ def build_snapshot(
             "taken_at": taken_at,
             "pypi_recent": pypi,
             "github": github,
+            # US-4: the completeness contract travels with the artifact.
+            "manifest": build_manifest(list(packages), pypi, taken_at),
         }
 
     remaining = [pkg for pkg in packages if pkg not in pypi]
@@ -201,12 +246,8 @@ def render_table(snapshot: dict[str, object]) -> str:
     return "\n".join(lines) + "\n"
 
 
-def _load_seed(path: Path) -> dict[str, dict[str, int]]:
-    """Load already-captured pypi_recent from today's day file, if any.
-
-    Best-effort: a missing or malformed file degrades to an empty seed
-    (a fresh full run), never an error.
-    """
+def _load_day(path: Path) -> dict[str, object]:
+    """Load today's day file; missing/malformed degrades to empty."""
     if not path.exists():
         return {}
     try:
@@ -214,10 +255,55 @@ def _load_seed(path: Path) -> dict[str, dict[str, int]]:
     except (OSError, json.JSONDecodeError) as e:
         logger.warning("could not load existing snapshot %s: %s", path, e)
         return {}
-    pypi = data.get("pypi_recent", {})
+    return data if isinstance(data, dict) else {}
+
+
+def _load_seed(path: Path) -> dict[str, dict[str, int]]:
+    """Load already-captured pypi_recent from today's day file, if any.
+
+    Best-effort: a missing or malformed file degrades to an empty seed
+    (a fresh full run), never an error.
+    """
+    pypi = _load_day(path).get("pypi_recent", {})
     if not isinstance(pypi, dict):
         return {}
     return {pkg: stats for pkg, stats in pypi.items() if isinstance(stats, dict)}
+
+
+def check_attempt_budget(
+    attempts: list[dict[str, object]],
+    now: datetime,
+    *,
+    remaining: int,
+) -> None:
+    """Enforce the US-4 per-day attempt budget BEFORE any request.
+
+    One initial attempt + at most two additional per day, separated by
+    at least 60 minutes. Only enforced when packages remain — a rerun
+    on an already-complete snapshot costs no pypistats request.
+
+    Raises:
+        AttemptBudgetError: budget exhausted or the gap unmet.
+    """
+    if remaining <= 0 or not attempts:
+        return
+    if len(attempts) >= MAX_ATTEMPTS_PER_DAY:
+        raise AttemptBudgetError(
+            f"attempt budget exhausted ({MAX_ATTEMPTS_PER_DAY}/day). Proceed "
+            "with the incomplete receipt — do not keep retrying (US-4)."
+        )
+    last_raw = attempts[-1].get("at")
+    try:
+        last_at = datetime.fromisoformat(str(last_raw))
+    except ValueError:
+        return  # malformed ledger entry — do not block on it
+    gap = (now - last_at).total_seconds()
+    if gap < MIN_ATTEMPT_GAP_SECONDS:
+        wait_min = int((MIN_ATTEMPT_GAP_SECONDS - gap) // 60) + 1
+        raise AttemptBudgetError(
+            f"last attempt was {int(gap // 60)} minutes ago; attempts must be "
+            f">= 60 minutes apart — wait ~{wait_min} more minutes (US-4)."
+        )
 
 
 def _atomic_write_json(path: Path, data: dict[str, object]) -> None:
@@ -253,34 +339,76 @@ def main(argv: list[str] | None = None) -> int:
     logging.basicConfig(level=logging.WARNING, format="%(levelname)s %(message)s")
 
     args.out.mkdir(parents=True, exist_ok=True)
-    date = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    now = datetime.now(timezone.utc)
+    date = now.strftime("%Y-%m-%d")
     out_path = args.out / f"{date}.json"
+    day = _load_day(out_path)
     seed = _load_seed(out_path)
+    attempts = day.get("attempts") if isinstance(day.get("attempts"), list) else []
+
+    remaining = [pkg for pkg in args.packages if pkg not in seed]
+    try:
+        check_attempt_budget(attempts, now, remaining=len(remaining))
+    except AttemptBudgetError as e:
+        print(f"error: {e}", file=sys.stderr)
+        _warn_if_incomplete(args.packages, seed)
+        return 1
 
     def persist(snapshot: dict[str, object]) -> None:
+        snapshot["attempts"] = attempts
         _atomic_write_json(out_path, snapshot)
 
+    outcome = "complete"
+    snapshot: dict[str, object] = {}
     try:
         snapshot = build_snapshot(
             args.packages, args.spacing, seed=seed, date=date, persist=persist
         )
     except RateLimitedError as e:
-        captured = len(_load_seed(out_path))
-        total = len(args.packages)
+        outcome = "rate-limited"
         print(f"error: {e}", file=sys.stderr)
-        print(
-            f"captured {captured}/{total} today; rerun after the cooldown " "to finish the rest.",
-            file=sys.stderr,
-        )
-        return 1
     except (urllib.error.URLError, OSError) as e:
+        outcome = "error"
         print(f"error: network failure: {e}", file=sys.stderr)
+
+    if remaining:  # a pypistats request was actually made — log the attempt
+        captured_now = len(args.packages) if outcome == "complete" else len(_load_seed(out_path))
+        attempts.append({"at": now.isoformat(), "captured": captured_now, "outcome": outcome})
+
+    if outcome != "complete":
+        # ALWAYS persist the day file on failure — even a zero-capture
+        # run must durably log its attempt, or the US-4 budget could
+        # never engage and retries would be unbounded.
+        partial = _load_day(out_path) or {
+            "date": date,
+            "taken_at": now.isoformat(),
+            "pypi_recent": dict(seed),
+            "github": {},
+            "manifest": build_manifest(list(args.packages), seed, now.isoformat()),
+        }
+        partial["attempts"] = attempts
+        _atomic_write_json(out_path, partial)
+        _warn_if_incomplete(args.packages, _load_seed(out_path))
         return 1
 
+    snapshot["attempts"] = attempts
     _atomic_write_json(out_path, snapshot)
     print(render_table(snapshot))
     print(f"wrote {out_path}")
     return 0
+
+
+def _warn_if_incomplete(expected: list[str], captured: dict[str, dict[str, int]]) -> None:
+    """US-4: an incomplete snapshot must be UNMISTAKABLE, never silent."""
+    missing = [pkg for pkg in expected if pkg not in captured]
+    if missing:
+        print(
+            "WARNING: INCOMPLETE SNAPSHOT — missing packages: "
+            + ", ".join(missing)
+            + f" ({len(captured)}/{len(expected)} captured). A release may "
+            "continue only with this incomplete-receipt warning attached.",
+            file=sys.stderr,
+        )
 
 
 if __name__ == "__main__":

--- a/src/attune/ops/data.py
+++ b/src/attune/ops/data.py
@@ -1745,3 +1745,113 @@ def _resolve_version(package: str) -> FamilyVersion:
     except Exception:  # noqa: BLE001
         # INTENTIONAL: metadata resolution is best-effort.
         return FamilyVersion(package=package, version=None, source="missing")
+
+
+# ---------------------------------------------------------------------------
+# US-6 three-panel receipt: reach + freshness (spend is build_spend_alarm)
+# ---------------------------------------------------------------------------
+
+#: The five expected reach packages — mirrors ``scripts/reach_snapshot.py``
+#: ``PACKAGES`` (the US-4 allowlist). A legacy snapshot without a manifest
+#: counts complete only when all five are present.
+REACH_PACKAGES: tuple[str, ...] = (
+    "attune-ai",
+    "attune-rag",
+    "attune-help",
+    "attune-author",
+    "attune-verify",
+)
+
+#: US-6: the freshness panel flags a usage.jsonl last-write age above this.
+USAGE_STALE_HOURS = 48.0
+
+
+@dataclass
+class ReachPanel:
+    """Latest COMPLETE reach snapshot + any newer incomplete one (US-6).
+
+    An incomplete snapshot never replaces the latest complete snapshot —
+    it is surfaced separately, labeled incomplete.
+    """
+
+    latest_complete: dict[str, Any] | None
+    newer_incomplete: dict[str, Any] | None
+
+
+def _snapshot_is_complete(data: dict[str, Any]) -> bool:
+    manifest = data.get("manifest")
+    if isinstance(manifest, dict):
+        return manifest.get("complete") is True
+    pypi = data.get("pypi_recent")
+    return isinstance(pypi, dict) and set(REACH_PACKAGES) <= set(pypi)
+
+
+def read_reach_panel(config: Config) -> ReachPanel:
+    """Scan the tracked snapshots dir for the reach panel's data (US-6).
+
+    Reads ``<project_root>/docs/specs/usage-signals/snapshots/*.json``
+    newest-first (dated filenames sort chronologically). The first
+    complete snapshot wins; incomplete snapshots encountered BEFORE it
+    (i.e. newer) are reported separately with their missing packages.
+    """
+    snap_dir = config.project_root / "docs" / "specs" / "usage-signals" / "snapshots"
+    latest_complete: dict[str, Any] | None = None
+    newer_incomplete: dict[str, Any] | None = None
+    if not snap_dir.is_dir():
+        return ReachPanel(None, None)
+    for path in sorted(snap_dir.glob("*.json"), reverse=True):
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            logger.warning("ops.reach: unreadable snapshot %s: %s", path, exc)
+            continue
+        if not isinstance(data, dict):
+            continue
+        if _snapshot_is_complete(data):
+            latest_complete = {
+                "date": data.get("date") or path.stem,
+                "taken_at": data.get("taken_at"),
+                "packages": data.get("pypi_recent") or {},
+            }
+            break
+        if newer_incomplete is None:
+            pypi = data.get("pypi_recent") if isinstance(data.get("pypi_recent"), dict) else {}
+            manifest = data.get("manifest") if isinstance(data.get("manifest"), dict) else {}
+            missing = manifest.get("missing") or [pkg for pkg in REACH_PACKAGES if pkg not in pypi]
+            newer_incomplete = {
+                "date": data.get("date") or path.stem,
+                "taken_at": data.get("taken_at"),
+                "captured": sorted(pypi),
+                "missing": missing,
+            }
+    return ReachPanel(latest_complete=latest_complete, newer_incomplete=newer_incomplete)
+
+
+@dataclass
+class UsageFreshness:
+    """Last-write age of ``usage.jsonl`` for the freshness panel (US-6)."""
+
+    exists: bool
+    last_write_at: str | None
+    age_hours: float | None
+    stale: bool  # age > USAGE_STALE_HOURS
+
+
+def read_usage_freshness(config: Config, *, now: datetime | None = None) -> UsageFreshness:
+    """Compute usage.jsonl freshness from file mtime (real boundary)."""
+    path = config.telemetry_path
+    if not path.is_file():
+        return UsageFreshness(exists=False, last_write_at=None, age_hours=None, stale=True)
+    try:
+        mtime = datetime.fromtimestamp(path.stat().st_mtime, tz=timezone.utc)
+    except OSError as exc:
+        logger.warning("ops.freshness: cannot stat %s: %s", path, exc)
+        return UsageFreshness(exists=False, last_write_at=None, age_hours=None, stale=True)
+    current = now or datetime.now(timezone.utc)
+    age_hours = max((current - mtime).total_seconds(), 0.0) / 3600.0
+    return UsageFreshness(
+        exists=True,
+        last_write_at=mtime.isoformat(),
+        age_hours=age_hours,
+        stale=age_hours > USAGE_STALE_HOURS,
+    )

--- a/src/attune/ops/routes/dashboard.py
+++ b/src/attune/ops/routes/dashboard.py
@@ -192,6 +192,19 @@ async def telemetry_page(request: Request) -> HTMLResponse:
     memory_signal = data.estimate_intervention_signal(cfg.memory_events_path)
     # Noise side — findings surfaced then dropped as noise.
     memory_feedback = data.estimate_feedback_signal(cfg.memory_events_path)
+    # US-6 three-panel receipt: reach + freshness + spend TOGETHER on
+    # one page. Reach reads the tracked snapshots dir; freshness reads
+    # usage.jsonl's mtime; spend reuses the shipped D13 alarm (local
+    # source here — the account-level fetch stays on the home route).
+    reach = data.read_reach_panel(cfg)
+    freshness = data.read_usage_freshness(cfg)
+    try:
+        spend = data.build_spend_alarm(cfg, None)
+    except Exception:  # noqa: BLE001
+        # INTENTIONAL: the alarm is a best-effort signal; never block
+        # the telemetry page on it (mirrors the home route).
+        logger.debug("data.build_spend_alarm raised", exc_info=True)
+        spend = None
     return _render(
         request,
         "telemetry.html",
@@ -202,6 +215,9 @@ async def telemetry_page(request: Request) -> HTMLResponse:
         memory_summary=memory_summary,
         memory_signal=memory_signal,
         memory_feedback=memory_feedback,
+        reach=reach,
+        freshness=freshness,
+        spend=spend,
     )
 
 

--- a/src/attune/ops/templates/_spend_alarm.html
+++ b/src/attune/ops/templates/_spend_alarm.html
@@ -1,0 +1,35 @@
+{# Spend alarm (R6 of usage-signals). Daily API-spend anomaly + approach
+   to the monthly ceiling. ``spend.source`` is "account" (admin
+   cost-report — sees CI) or "local" (usage.jsonl, CI-blind). The panel's
+   accent follows ``spend.level``: ok / alarm / insufficient_data. #}
+{% if spend is not none %}
+  <section class="panel spend-alarm spend-alarm-{{ spend.level }}">
+    <div class="spend-alarm-head">
+      <h2>API spend watch</h2>
+      {% if spend.level == "alarm" %}
+        <span class="chip chip-danger">⚠ anomaly</span>
+      {% elif spend.level == "insufficient_data" %}
+        <span class="chip chip-muted">building baseline</span>
+      {% else %}
+        <span class="chip chip-ok">normal</span>
+      {% endif %}
+    </div>
+    <p class="spend-alarm-detail">{{ spend.detail }}</p>
+    <div class="spend-gauge" role="img"
+         aria-label="Month-to-date ${{ '%.0f'|format(spend.month_to_date) }} of ${{ '%.0f'|format(spend.monthly_ceiling) }} monthly ceiling ({{ '%.0f'|format(spend.ceiling_pct) }}%)">
+      <div class="spend-gauge-track">
+        {# Cap the visual fill at 100% so an over-ceiling month doesn't
+           overflow the bar; the numeric % below still shows the truth. #}
+        <div class="spend-gauge-fill{% if 'ceiling' in spend.triggered_by %} spend-gauge-fill-hot{% endif %}"
+             style="width: {{ [spend.ceiling_pct, 100]|min }}%;"></div>
+      </div>
+      <div class="spend-gauge-foot">
+        <span>${{ '%.2f'|format(spend.month_to_date) }} MTD</span>
+        <span>{{ '%.0f'|format(spend.ceiling_pct) }}% of ${{ '%.0f'|format(spend.monthly_ceiling) }}</span>
+      </div>
+    </div>
+    <p class="spend-alarm-source">
+      Source: {{ "Anthropic account billing (includes CI)" if spend.source == "account" else "local telemetry only — CI spend not counted" }}
+    </p>
+  </section>
+{% endif %}

--- a/src/attune/ops/templates/home.html
+++ b/src/attune/ops/templates/home.html
@@ -83,42 +83,7 @@
   </section>
 {% endif %}
 
-{# Spend alarm (R6 of usage-signals). Daily API-spend anomaly + approach
-   to the monthly ceiling. ``spend.source`` is "account" (admin
-   cost-report — sees CI) or "local" (usage.jsonl, CI-blind). The panel's
-   accent follows ``spend.level``: ok / alarm / insufficient_data. #}
-{% if spend is not none %}
-  <section class="panel spend-alarm spend-alarm-{{ spend.level }}">
-    <div class="spend-alarm-head">
-      <h2>API spend watch</h2>
-      {% if spend.level == "alarm" %}
-        <span class="chip chip-danger">⚠ anomaly</span>
-      {% elif spend.level == "insufficient_data" %}
-        <span class="chip chip-muted">building baseline</span>
-      {% else %}
-        <span class="chip chip-ok">normal</span>
-      {% endif %}
-    </div>
-    <p class="spend-alarm-detail">{{ spend.detail }}</p>
-    <div class="spend-gauge" role="img"
-         aria-label="Month-to-date ${{ '%.0f'|format(spend.month_to_date) }} of ${{ '%.0f'|format(spend.monthly_ceiling) }} monthly ceiling ({{ '%.0f'|format(spend.ceiling_pct) }}%)">
-      <div class="spend-gauge-track">
-        {# Cap the visual fill at 100% so an over-ceiling month doesn't
-           overflow the bar; the numeric % below still shows the truth. #}
-        <div class="spend-gauge-fill{% if 'ceiling' in spend.triggered_by %} spend-gauge-fill-hot{% endif %}"
-             style="width: {{ [spend.ceiling_pct, 100]|min }}%;"></div>
-      </div>
-      <div class="spend-gauge-foot">
-        <span>${{ '%.2f'|format(spend.month_to_date) }} MTD</span>
-        <span>{{ '%.0f'|format(spend.ceiling_pct) }}% of ${{ '%.0f'|format(spend.monthly_ceiling) }}</span>
-      </div>
-    </div>
-    <p class="spend-alarm-source">
-      Source: {{ "Anthropic account billing (includes CI)" if spend.source == "account" else "local telemetry only — CI spend not counted" }}
-    </p>
-  </section>
-{% endif %}
-
+{% include "_spend_alarm.html" %}
 <section class="panel">
   <h2>Recent runs</h2>
   {% if recent_runs %}

--- a/src/attune/ops/templates/telemetry.html
+++ b/src/attune/ops/templates/telemetry.html
@@ -57,6 +57,50 @@
   <p class="meta">Last event recorded: <code>{{ telemetry.last_event_at }}</code></p>
 {% endif %}
 
+{# US-6 three-panel receipt: reach + freshness + spend together. #}
+<section class="panel" id="reach-panel">
+  <h2>Reach — latest complete snapshot</h2>
+  {% if reach.latest_complete %}
+    <p class="meta">Snapshot <code>{{ reach.latest_complete.date }}</code>
+      observed <code>{{ reach.latest_complete.taken_at }}</code></p>
+    <table class="data-table">
+      <thead><tr><th>Package</th><th class="num">last_day</th><th class="num">last_week</th><th class="num">last_month</th></tr></thead>
+      <tbody>
+        {% for pkg, stats in reach.latest_complete.packages.items() %}
+          <tr><td><code>{{ pkg }}</code></td><td class="num">{{ stats.last_day }}</td><td class="num">{{ stats.last_week }}</td><td class="num">{{ stats.last_month }}</td></tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  {% else %}
+    <p class="empty">No complete reach snapshot yet.</p>
+  {% endif %}
+  {% if reach.newer_incomplete %}
+    <p class="meta warn">
+      ⚠ Newer snapshot <code>{{ reach.newer_incomplete.date }}</code> is
+      <strong>INCOMPLETE</strong> (missing:
+      {% for pkg in reach.newer_incomplete.missing %}<code>{{ pkg }}</code>{% if not loop.last %}, {% endif %}{% endfor %})
+      — it does not replace the complete snapshot above.
+    </p>
+  {% endif %}
+</section>
+
+<section class="panel" id="freshness-panel">
+  <h2>Freshness — usage.jsonl last write</h2>
+  {% if freshness.exists %}
+    <p class="meta">Last write: <code>{{ freshness.last_write_at }}</code>
+      ({{ '%.1f'|format(freshness.age_hours) }}h ago)</p>
+    {% if freshness.stale %}
+      <p class="meta warn">⚠ <strong>STALE</strong> — no usage.jsonl write in over 48 hours.</p>
+    {% else %}
+      <p class="meta">Fresh (under the 48-hour threshold).</p>
+    {% endif %}
+  {% else %}
+    <p class="empty warn">⚠ usage.jsonl not found — freshness unknown (treated as stale).</p>
+  {% endif %}
+</section>
+
+{% include "_spend_alarm.html" %}
+
 <section class="panel">
   <h2>Short-term memory</h2>
   <p class="page-sub">

--- a/tests/unit/ops/test_telemetry_three_panels.py
+++ b/tests/unit/ops/test_telemetry_three_panels.py
@@ -1,0 +1,160 @@
+"""US-6 three-panel receipt tests — reach, freshness, spend TOGETHER.
+
+usage-signals US-6: verification exercises the dashboard through its
+REAL file-to-render boundary — representative persisted artifacts on
+disk (snapshot JSONs, usage.jsonl), rendered via the actual FastAPI
+route + Jinja template — not only mocked helpers.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("fastapi")
+pytest.importorskip("jinja2")
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from attune.ops import data  # noqa: E402
+from attune.ops.config import build_config  # noqa: E402
+from attune.ops.server import create_app  # noqa: E402
+
+PACKAGES = list(data.REACH_PACKAGES)
+STATS = {"last_day": 3, "last_week": 21, "last_month": 90}
+
+
+def _client(tmp_path: Path) -> TestClient:
+    config = build_config(project_root=tmp_path, trusted_hosts=("testserver", "test"))
+    return TestClient(create_app(config))
+
+
+def _write_snapshot(
+    tmp_path: Path,
+    date: str,
+    packages: list[str],
+    *,
+    complete: bool | None = None,
+) -> Path:
+    """Write a snapshot artifact shaped like scripts/reach_snapshot.py's."""
+    snap_dir = tmp_path / "docs" / "specs" / "usage-signals" / "snapshots"
+    snap_dir.mkdir(parents=True, exist_ok=True)
+    pypi = {pkg: dict(STATS) for pkg in packages}
+    missing = [p for p in PACKAGES if p not in packages]
+    payload = {
+        "date": date,
+        "taken_at": f"{date}T12:00:00+00:00",
+        "pypi_recent": pypi,
+        "github": {},
+        "manifest": {
+            "expected": PACKAGES,
+            "captured": packages,
+            "missing": missing,
+            "source": "pypistats.org/api/recent",
+            "observed_at": f"{date}T12:00:00+00:00",
+            "complete": complete if complete is not None else not missing,
+        },
+    }
+    path = snap_dir / f"{date}.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def _write_usage(age_hours: float) -> Path:
+    """Write a real usage.jsonl under ATTUNE_HOME, aged via mtime."""
+    home = Path(os.environ["ATTUNE_HOME"])
+    usage = home / "telemetry" / "usage.jsonl"
+    usage.parent.mkdir(parents=True, exist_ok=True)
+    event = {
+        "v": "1.0",
+        "ts": datetime.now(timezone.utc).isoformat(),
+        "seq": 1,
+        "workflow": "code-review",
+        "tier": "SDK",
+        "model": "agent-sdk",
+        "provider": "anthropic",
+        "cost": 0.42,
+    }
+    usage.write_text(json.dumps(event) + "\n", encoding="utf-8")
+    stamp = (datetime.now(timezone.utc) - timedelta(hours=age_hours)).timestamp()
+    os.utime(usage, (stamp, stamp))
+    return usage
+
+
+class TestReachPanel:
+    def test_complete_snapshot_renders_per_package_values(self, tmp_path):
+        _write_snapshot(tmp_path, "2026-08-01", PACKAGES)
+        _write_usage(age_hours=1)
+        html = _client(tmp_path).get("/telemetry").text
+        assert "Reach — latest complete snapshot" in html
+        assert "2026-08-01" in html
+        for pkg in PACKAGES:
+            assert pkg in html
+        assert html.count(">21<") >= len(PACKAGES)  # last_week per package
+
+    def test_newer_incomplete_labeled_and_does_not_replace_complete(self, tmp_path):
+        _write_snapshot(tmp_path, "2026-08-01", PACKAGES)
+        _write_snapshot(tmp_path, "2026-08-03", PACKAGES[:2])  # newer, partial
+        _write_usage(age_hours=1)
+        html = _client(tmp_path).get("/telemetry").text
+        # The complete snapshot stays the rendered one…
+        assert "Snapshot <code>2026-08-01</code>" in html
+        # …and the newer partial is unmistakably labeled, with missing names.
+        assert "INCOMPLETE" in html
+        assert "2026-08-03" in html
+        for pkg in PACKAGES[2:]:
+            assert html.count(pkg) >= 2  # complete table + missing list
+
+    def test_no_snapshots_renders_empty_state(self, tmp_path):
+        _write_usage(age_hours=1)
+        html = _client(tmp_path).get("/telemetry").text
+        assert "No complete reach snapshot yet." in html
+
+
+class TestFreshnessPanel:
+    @pytest.mark.parametrize(
+        ("age_hours", "stale"),
+        [(47.5, False), (48.5, True)],
+    )
+    def test_flag_changes_at_48_hour_boundary(self, tmp_path, age_hours, stale):
+        _write_usage(age_hours=age_hours)
+        html = _client(tmp_path).get("/telemetry").text
+        assert "Freshness — usage.jsonl last write" in html
+        if stale:
+            assert "STALE" in html
+        else:
+            assert "STALE" not in html
+            assert "Fresh (under the 48-hour threshold)." in html
+
+    def test_missing_usage_file_reads_stale(self, tmp_path):
+        html = _client(tmp_path).get("/telemetry").text
+        assert "usage.jsonl not found" in html
+
+    def test_data_layer_boundary_values(self, tmp_path):
+        usage = _write_usage(age_hours=10)
+        cfg = build_config(project_root=tmp_path)
+        assert cfg.telemetry_path == usage
+        fresh = data.read_usage_freshness(cfg)
+        assert fresh.exists and not fresh.stale
+        assert fresh.age_hours == pytest.approx(10.0, abs=0.2)
+
+
+class TestSpendPanel:
+    def test_spend_alarm_renders_with_local_source(self, tmp_path):
+        _write_usage(age_hours=1)
+        html = _client(tmp_path).get("/telemetry").text
+        assert "API spend watch" in html
+        assert "local telemetry only" in html  # D13 source honesty line
+
+    def test_three_panels_render_together(self, tmp_path):
+        """The US-6 receipt condition: reach + freshness + spend on one page."""
+        _write_snapshot(tmp_path, "2026-08-01", PACKAGES)
+        _write_usage(age_hours=1)
+        html = _client(tmp_path).get("/telemetry").text
+        assert "Reach — latest complete snapshot" in html
+        assert "Freshness — usage.jsonl last write" in html
+        assert "API spend watch" in html

--- a/tests/unit/scripts/test_reach_snapshot.py
+++ b/tests/unit/scripts/test_reach_snapshot.py
@@ -20,6 +20,18 @@ SCRIPT_PATH = REPO_ROOT / "scripts" / "reach_snapshot.py"
 STATS = {"last_day": 1, "last_week": 7, "last_month": 30}
 
 
+def _age_attempts(out_dir: Path, *, minutes: int) -> None:
+    """Rewrite the day file's attempt timestamps ``minutes`` into the past."""
+    from datetime import datetime, timedelta, timezone
+
+    (day_file,) = out_dir.glob("*.json")
+    data = json.loads(day_file.read_text(encoding="utf-8"))
+    aged = (datetime.now(timezone.utc) - timedelta(minutes=minutes)).isoformat()
+    for attempt in data.get("attempts", []):
+        attempt["at"] = aged
+    day_file.write_text(json.dumps(data), encoding="utf-8")
+
+
 @pytest.fixture(scope="module")
 def mod():
     spec = importlib.util.spec_from_file_location("_reach_snapshot", SCRIPT_PATH)
@@ -133,6 +145,86 @@ class TestRenderTable:
         assert "GitHub:" not in mod.render_table(snap)
 
 
+class TestUs4CompletenessAndBudget:
+    """US-4: manifest contract, attempt budget, retry guidance."""
+
+    def test_complete_capture_manifest(self, mod, tmp_path: Path, monkeypatch) -> None:
+        monkeypatch.setattr(mod, "fetch_pypistats_recent", lambda pkg: dict(STATS))
+        monkeypatch.setattr(mod, "fetch_github_signals", lambda: {})
+        rc = mod.main(["--out", str(tmp_path), "--spacing", "0", "--packages", "a", "b"])
+        assert rc == 0
+        (day_file,) = tmp_path.glob("*.json")
+        data = json.loads(day_file.read_text(encoding="utf-8"))
+        manifest = data["manifest"]
+        assert manifest["complete"] is True
+        assert manifest["expected"] == manifest["captured"] == ["a", "b"]
+        assert manifest["missing"] == []
+        assert manifest["source"] == mod.SOURCE
+        assert data["attempts"][-1]["outcome"] == "complete"
+
+    def test_rerun_within_gap_refused_before_any_request(
+        self, mod, tmp_path: Path, monkeypatch, capsys
+    ) -> None:
+        def boom(pkg: str):
+            raise mod.RateLimitedError("rate-limited")
+
+        monkeypatch.setattr(mod, "fetch_pypistats_recent", boom)
+        argv = ["--out", str(tmp_path), "--spacing", "0", "--packages", "a"]
+        assert mod.main(argv) == 1
+
+        fetched: list[str] = []
+        monkeypatch.setattr(mod, "fetch_pypistats_recent", lambda pkg: fetched.append(pkg))
+        assert mod.main(argv) == 1  # refused: last attempt seconds ago
+        err = capsys.readouterr().err
+        assert ">= 60 minutes apart" in err
+        assert fetched == []  # refused BEFORE any request
+
+    def test_attempt_budget_exhausted_after_three(
+        self, mod, tmp_path: Path, monkeypatch, capsys
+    ) -> None:
+        def boom(pkg: str):
+            raise mod.RateLimitedError("rate-limited")
+
+        monkeypatch.setattr(mod, "fetch_pypistats_recent", boom)
+        argv = ["--out", str(tmp_path), "--spacing", "0", "--packages", "a"]
+        for _ in range(3):
+            assert mod.main(argv) == 1
+            _age_attempts(tmp_path, minutes=61)
+        capsys.readouterr()
+
+        fetched: list[str] = []
+        monkeypatch.setattr(mod, "fetch_pypistats_recent", lambda pkg: fetched.append(pkg))
+        assert mod.main(argv) == 1
+        err = capsys.readouterr().err
+        assert "attempt budget exhausted" in err
+        assert "INCOMPLETE SNAPSHOT" in err
+        assert fetched == []
+        (day_file,) = tmp_path.glob("*.json")
+        data = json.loads(day_file.read_text(encoding="utf-8"))
+        assert len(data["attempts"]) == 3  # the refused run logs no attempt
+
+    def test_completed_snapshot_rerun_skips_budget(self, mod, tmp_path: Path, monkeypatch) -> None:
+        monkeypatch.setattr(mod, "fetch_pypistats_recent", lambda pkg: dict(STATS))
+        monkeypatch.setattr(mod, "fetch_github_signals", lambda: {})
+        argv = ["--out", str(tmp_path), "--spacing", "0", "--packages", "a"]
+        assert mod.main(argv) == 0
+        # Immediate rerun: nothing remaining → no request, no budget trip.
+        assert mod.main(argv) == 0
+
+    def test_429_retry_after_header_is_reported(self, mod, monkeypatch) -> None:
+        import io
+        import urllib.error
+
+        def raise_429(url, timeout):
+            raise urllib.error.HTTPError(
+                url, 429, "Too Many Requests", {"Retry-After": "1800"}, io.BytesIO(b"")
+            )
+
+        monkeypatch.setattr(mod.urllib.request, "urlopen", raise_429)
+        with pytest.raises(mod.RateLimitedError, match="retry after 1800s"):
+            mod.fetch_pypistats_recent("attune-ai")
+
+
 class TestCli:
     def test_writes_dated_json_and_prints_table(
         self, mod, tmp_path: Path, monkeypatch, capsys
@@ -149,17 +241,30 @@ class TestCli:
         out = capsys.readouterr().out
         assert "| attune-ai | 1 | 7 | 30 |" in out
 
-    def test_rate_limited_exit_1_with_wait_message(
+    def test_rate_limited_exit_1_logs_attempt_even_with_zero_capture(
         self, mod, tmp_path: Path, monkeypatch, capsys
     ) -> None:
+        """US-4 zero-package capture: unmistakable warning + durable attempt."""
+
         def boom(pkg: str):
             raise mod.RateLimitedError("pypistats rate-limited. Wait 15 minutes")
 
         monkeypatch.setattr(mod, "fetch_pypistats_recent", boom)
         rc = mod.main(["--out", str(tmp_path), "--spacing", "0", "--packages", "attune-ai"])
         assert rc == 1
-        assert "Wait 15 minutes" in capsys.readouterr().err
-        assert not list(tmp_path.glob("*.json"))
+        err = capsys.readouterr().err
+        assert "Wait 15 minutes" in err
+        assert "INCOMPLETE SNAPSHOT" in err
+        assert "0/1 captured" in err
+        # Even a zero-capture run persists its attempt — else the US-4
+        # budget could never engage.
+        (day_file,) = tmp_path.glob("*.json")
+        data = json.loads(day_file.read_text(encoding="utf-8"))
+        assert data["pypi_recent"] == {}
+        assert data["manifest"]["complete"] is False
+        assert data["manifest"]["missing"] == ["attune-ai"]
+        assert len(data["attempts"]) == 1
+        assert data["attempts"][0]["outcome"] == "rate-limited"
 
     def test_partial_then_rate_limit_persists_progress(
         self, mod, tmp_path: Path, monkeypatch, capsys
@@ -175,12 +280,15 @@ class TestCli:
         rc = mod.main(["--out", str(tmp_path), "--spacing", "0", "--packages", "a", "b", "c"])
         assert rc == 1
         err = capsys.readouterr().err
-        assert "captured 2/3 today" in err
+        assert "INCOMPLETE SNAPSHOT" in err
+        assert "2/3 captured" in err
         # the day file holds the two packages fetched before the 429
         files = list(tmp_path.glob("*.json"))
         assert len(files) == 1
         data = json.loads(files[0].read_text(encoding="utf-8"))
         assert set(data["pypi_recent"]) == {"a", "b"}
+        assert data["manifest"]["missing"] == ["c"]
+        assert data["manifest"]["complete"] is False
 
     def test_rerun_completes_remainder_then_clears(
         self, mod, tmp_path: Path, monkeypatch, capsys
@@ -202,7 +310,8 @@ class TestCli:
         assert mod.main(argv) == 1
         assert fetched == ["a", "b", "c"]
 
-        # cooldown over: rerun skips a,b and fetches only c
+        # cooldown over (age the logged attempt past the 60-min gap):
+        _age_attempts(tmp_path, minutes=61)
         flaky["raise_on_c"] = False
         fetched.clear()
         assert mod.main(argv) == 0


### PR DESCRIPTION
Executes the three non-chair-led items from the table-refreshed [usage-signals requirements](docs/specs/usage-signals/requirements.md) (7/7 approved, #1468). Closure evidence recorded as **D15** in decisions.md.

**US-4 — reach capture contract** (`scripts/reach_snapshot.py`)
- Persisted `manifest` (expected/captured/missing, source, observed_at, complete) on every snapshot including partial writes
- Per-day attempt budget — 1 initial + 2 additional, ≥60 min apart — enforced BEFORE any request via a durable `attempts` ledger; a zero-capture run still logs its attempt so the budget cannot be bypassed
- Retry-After honored in the 429 guidance; incomplete snapshots exit non-zero with an unmistakable `WARNING: INCOMPLETE SNAPSHOT` (never silent completion, never indefinite blocking)
- 16 tests: complete/partial/zero captures, simulated 429 boundary with Retry-After, gap refusal, budget exhaustion

**US-6 — three-panel receipt** (`/telemetry`)
- Reach: latest COMPLETE snapshot with per-package values + observation timestamp; a newer incomplete snapshot is labeled INCOMPLETE and never replaces it
- Freshness: usage.jsonl last-write age via mtime, STALE flag above 48h
- Spend: the shipped D13 alarm, extracted to a shared `_spend_alarm.html` include (home + telemetry)
- 9 tests through the REAL file-to-render boundary (persisted artifacts → route → HTML), including the 47.5h/48.5h boundary flip and the three-panels-together assertion. **R3 is DONE on this receipt** (D15).

**US-7 — ledger annotation**
- Consent entry → **D11a**, attune-rag noise verdict → **D11b** (headers + intra-entry prose; dates/text/order unchanged; DEC-* preserved); zero bare `D11` references remain across the spec dir, handoffs, and memory corpus
- Original spend-alarm requirement marked DONE citing D13

**Still open (not this PR):** US-3 (chair-led outreach) and US-5 (comparable pair — bound to the next planned release using the US-4 strategy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
