### PR TITLE
fix(roundtable): teach the critique citation contract by worked example

### DIFF
--- a/src/attune/roundtable/producing.py
+++ b/src/attune/roundtable/producing.py
@@ -175,14 +175,33 @@ def _draft_brief(subject: str, pack: str) -> str:
     )
 
 
+#: Literal worked example of a cited critique item. Prose alone was
+#: not enough here either: the first spec-lifecycle-gates producing
+#: run (slot 20260719-1) failed LINT_DIRTY when codex emitted an
+#: uncited item and stayed dirty through its repair round — the same
+#: heterogeneous-seat format-contract class the TAG_EXAMPLE below
+#: closed for round 3 (#1470). Every item must contain the word
+#: "pack" or a concrete .py/.md path (compiler.lint_critique).
+CITATION_EXAMPLE = (
+    "EXAMPLE ITEM (copy this shape — every item cites the pack or a "
+    "concrete file path):\n"
+    "3. **RR-2:** The readiness threshold contradicts the pack's "
+    "risk-tiering seed (pack section 'Chair rulings'); align it or "
+    "record the deviation in decisions.md."
+)
+
+
 def _critique_brief(subject: str, pack: str, draft: str) -> str:
     return (
         "You are a CRITIC seat in a headless spec-authoring round "
         "table. Adversarially critique the draft below. Text only.\n\n"
         "FORMAT (mechanically linted): a numbered list; each item names "
         "a target id in bold (e.g. **RR-2:**) or **MISSING:**, and "
-        "cites a pack item or concrete file path; end with exactly one "
-        "line 'VERDICT: ready-with-edits' or 'VERDICT: needs-revision'."
+        "cites a pack item or concrete file path (the item text must "
+        "contain the word 'pack' or a .py/.md path); end with exactly "
+        "one line 'VERDICT: ready-with-edits' or "
+        "'VERDICT: needs-revision'.\n\n"
+        f"{CITATION_EXAMPLE}"
         f"\n\nSUBJECT: {subject}\n\nGROUNDING PACK:\n\n{pack}"
         f"\n\nTHE DRAFT:\n\n{draft}"
     )
@@ -232,6 +251,12 @@ def _repair_brief(brief: str, reply: str, problems: list[str]) -> str:
             "Every item heading must be followed by its own convergence "
             "tag line: '[tag: agreed]' / '[tag: 2-1 <note>]' / "
             "'[tag: contested <note>]'.\n\n" + TAG_EXAMPLE
+        )
+    if any("uncited" in p for p in problems):
+        parts.append(
+            "Every critique item must cite the grounding pack or a "
+            "concrete file path — the item text must contain the word "
+            "'pack' or a .py/.md path.\n\n" + CITATION_EXAMPLE
         )
     parts.append("Fix ONLY these problems and resend the full document.")
     parts.append("ORIGINAL BRIEF:\n\n" + brief)

--- a/tests/unit/roundtable/test_producing.py
+++ b/tests/unit/roundtable/test_producing.py
@@ -18,12 +18,14 @@ import pytest
 from attune.roundtable import compiler
 from attune.roundtable.board import LEDGER_ORDER_KEY, Board
 from attune.roundtable.producing import (
+    CITATION_EXAMPLE,
     DEFAULT_MAX_INVOCATIONS,
     FAILURE_CODES,
     TAG_EXAMPLE,
     TR6_CAP,
     FailureReceipt,
     ProducingSpec,
+    _critique_brief,
     _final_brief,
     _repair_brief,
     render_digest,
@@ -496,3 +498,32 @@ class TestBriefContracts:
     def test_repair_brief_stays_compact_without_tag_problems(self) -> None:
         repair = _repair_brief("orig brief", "prev reply", ["no requirement items found"])
         assert TAG_EXAMPLE not in repair
+
+
+class TestCritiqueCitationContract:
+    """The citation contract is taught by worked example too.
+
+    Prose alone failed live: the first spec-lifecycle-gates producing
+    run (slot 20260719-1) went LINT_DIRTY on an uncited codex critique
+    item that survived its repair round — the same heterogeneous-seat
+    format-contract class TAG_EXAMPLE closed for round 3 (#1470).
+    """
+
+    def test_critique_brief_embeds_worked_example(self) -> None:
+        brief = _critique_brief("subject", "the pack", "the draft")
+        assert CITATION_EXAMPLE in brief
+
+    def test_worked_example_actually_passes_the_citation_lint(self) -> None:
+        # The taught shape must satisfy the lint it is teaching to —
+        # wrap it exactly as a critique reply would arrive.
+        reply = CITATION_EXAMPLE.split(":\n", 1)[1] + "\nVERDICT: ready-with-edits"
+        assert compiler.lint_critique(reply) == []
+
+    def test_repair_brief_restates_example_on_uncited_problems(self) -> None:
+        problems = ["uncited critique item (no pack/file reference): '12. **RR-7:**'"]
+        repair = _repair_brief("orig brief", "prev reply", problems)
+        assert CITATION_EXAMPLE in repair
+
+    def test_repair_brief_stays_compact_without_citation_problems(self) -> None:
+        repair = _repair_brief("orig brief", "prev reply", ["no requirement items found"])
+        assert CITATION_EXAMPLE not in repair


### PR DESCRIPTION
The first spec-lifecycle-gates producing run (slot `20260719-1`) failed `LINT_DIRTY`: codex emitted an uncited critique item and stayed dirty through its one repair round. Same failure class as the round-3 convergence-tag misses #1470 closed — **prose-only format contracts fail heterogeneous seats; worked examples land**.

- `CITATION_EXAMPLE` embeds a literal cited critique item in `_critique_brief` (the item text must contain 'pack' or a .py/.md path, per `compiler.lint_critique`)
- `_repair_brief` restates the example when problems include an uncited item
- Self-consistency asserted: the taught shape passes the lint it teaches
- Receipts: 132 roundtable tests serial against real Redis; the slot `20260719-2` rerun (launched with this code) is the live-fire receipt — result will be posted on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)