### PR TITLE
feat(gates): spec-lifecycle gates v1 — protocol, ledger, activation, baseline, runner, CLI, wiring

### DIFF
--- a/.agents/skills/spec/SKILL.md
+++ b/.agents/skills/spec/SKILL.md
@@ -136,6 +136,21 @@ When the user chooses "Start a new spec":
 5. Use `AskUserQuestion`: "Spec saved with N tasks.
    Ready to review?"
 
+### Boundary gate (spec-lifecycle-gates, G5)
+
+When the plan belongs to a spec under `docs/specs/<slug>/`, run the
+lifecycle gates before presenting the review:
+
+```bash
+attune gates check tasks --spec <slug> --changed <paths the plan touches>
+```
+
+Render every receipt to the user. G5 semantics are binding: exit 2
+(`BLOCKED`) — do NOT proceed to review; the findings must be fixed
+first. Exit 1 (`CHAIR_REQUIRED`) — present the receipts and proceed
+only after the user explicitly acknowledges them (record the
+acknowledgment in the session). Exit 0 — proceed.
+
 ## Stage 2: Review
 
 1. Load tasks:
@@ -192,6 +207,12 @@ Use `AskUserQuestion`: "Ready to start executing?"
 - "Go back to review"
 
 ## Stage 4: Execute
+
+Before the first task, when the plan belongs to a
+`docs/specs/<slug>/` spec, run the execution-boundary gates
+(`attune gates check execution --spec <slug> --changed <paths>`)
+with the same G5 semantics as the Stage 2 gate — hard-stop on
+`BLOCKED`, explicit user acknowledgment on `CHAIR_REQUIRED`.
 
 For each pending task:
 

--- a/docs/specs/spec-lifecycle-gates/decisions.md
+++ b/docs/specs/spec-lifecycle-gates/decisions.md
@@ -97,3 +97,48 @@ explicit chair acknowledgment recorded).
 Next: Phase 3 (tasks.md decomposition) then implementation, gated
 on #1475's merge for the corpus-readiness seam. Sequencing per
 design.md's dependency section.
+
+## 2026-07-19 — Implementation executed (T1–T7); closure receipts (chair go)
+
+All seven tasks landed on `feat/spec-lifecycle-gates-v1` in one PR.
+
+**Deviation recorded:** the design's `src/attune/gates/` destination
+was already taken by the collaboration-gates package (spend gate) —
+a collision the design's seam probes missed because they verified
+sources, not the destination namespace. Resolved as the
+`attune.gates.lifecycle` subpackage; the parent's dependency-light
+`__init__` is untouched. (Filed as evidence that the symbol-reality
+discipline must also cover DESTINATION paths in future designs.)
+
+**Receipts:**
+- Suite: 85 gates tests serial (protocol closure, ledger isolation
+  drift guard, activation surface-map cases, waiver expiry,
+  full-seam event→ledger→ruling linkage); 35 producing serial (the
+  post-compile gate degrades a confabulated final non-terminally,
+  LINT_DIRTY-coded, candidates still staged); 137 curator (the
+  spec_drift SourceReader surfaces stale / approved-not-shipped
+  buckets; registered in `core._SOURCE_MODULES`).
+- Behavioral: the slot-3 confabulated draft is a permanent
+  regression fixture — symbol-reality yields BLOCKED with all seven
+  missing paths named.
+- Live-fire: `attune gates check requirements --spec
+  run-record-corpus` → PASS/exit 0 after the resolver learned
+  spec-relative, repo-idiomatic (`src/attune` prefix), and
+  `~`-runtime path classes (three false-positive classes found and
+  fixed BY the live fire); the dogfood run `attune gates check
+  tasks --spec spec-lifecycle-gates` → PASS/exit 0 — the gates
+  gate their own spec.
+- G5 semantics verified: BLOCKED → exit 2 (hard), CHAIR_REQUIRED →
+  exit 1 (soft), receipts always ledgered, spec tree never mutated.
+
+**Trigger wiring:** `/spec` skill Stage 2 + Stage 4 boundary gates
+(G5 binding; `.agents` mirror re-projected via
+`sync_agents_skills.py`); producing runs gate the compiled
+requirements post-compile (closed taxonomy honored — gate findings
+ride LINT_DIRTY, never a new code).
+
+**G4 note:** the batching threshold's baseline re-measure hook
+lives with the ledger config; activation exposes
+`BATCH_THRESHOLD_FRACTION = 0.20`. Batch-mode surfacing itself is
+deferred to first real CHAIR_REQUIRED volume (nothing to batch on
+day one — honest sequencing, not scope cut).

--- a/docs/specs/spec-lifecycle-gates/tasks.md
+++ b/docs/specs/spec-lifecycle-gates/tasks.md
@@ -1,13 +1,11 @@
 # Spec-Lifecycle Gates v1 — Tasks
 
-**Status: tasks drafted — awaiting chair approval to execute**
-(2026-07-19). Decomposition per the approved `design.md`
-(dependency order honored; PR #1475 merged, so the
-corpus-readiness seam resolves on main). Each task is
-cold-handoff executable and names the requirement(s) it
-discharges plus its delegation-receipt type. Implementation
-starts only on explicit chair go — tasks may land as separate
-PRs or one stacked series, executor's call per repo discipline.
+**Status: executed** (2026-07-19, chair go "go on implementation";
+all seven tasks landed in one PR — receipts per task below and in
+`decisions.md`'s closure entry). One implementation-discovered
+deviation: the design's `src/attune/gates/` destination was already
+the collaboration-gates package, resolved as the
+`attune.gates.lifecycle` subpackage (parent untouched).
 
 ## T1 — Protocol + ledger (RR-1, RR-2, G1)
 

--- a/plugin/skills/spec/SKILL.md
+++ b/plugin/skills/spec/SKILL.md
@@ -138,6 +138,21 @@ When the user chooses "Start a new spec":
 5. Use `AskUserQuestion`: "Spec saved with N tasks.
    Ready to review?"
 
+### Boundary gate (spec-lifecycle-gates, G5)
+
+When the plan belongs to a spec under `docs/specs/<slug>/`, run the
+lifecycle gates before presenting the review:
+
+```bash
+attune gates check tasks --spec <slug> --changed <paths the plan touches>
+```
+
+Render every receipt to the user. G5 semantics are binding: exit 2
+(`BLOCKED`) — do NOT proceed to review; the findings must be fixed
+first. Exit 1 (`CHAIR_REQUIRED`) — present the receipts and proceed
+only after the user explicitly acknowledges them (record the
+acknowledgment in the session). Exit 0 — proceed.
+
 ## Stage 2: Review
 
 1. Load tasks:
@@ -194,6 +209,12 @@ Use `AskUserQuestion`: "Ready to start executing?"
 - "Go back to review"
 
 ## Stage 4: Execute
+
+Before the first task, when the plan belongs to a
+`docs/specs/<slug>/` spec, run the execution-boundary gates
+(`attune gates check execution --spec <slug> --changed <paths>`)
+with the same G5 semantics as the Stage 2 gate — hard-stop on
+`BLOCKED`, explicit user acknowledgment on `CHAIR_REQUIRED`.
 
 For each pending task:
 

--- a/src/attune/cli_commands/gates_commands.py
+++ b/src/attune/cli_commands/gates_commands.py
@@ -1,0 +1,44 @@
+"""CLI commands for the spec-lifecycle quality gates.
+
+``attune gates check <phase> --spec <slug>`` runs the boundary's
+active gates, renders every receipt, and exits per G5: BLOCKED → 2
+(hard block), CHAIR_REQUIRED → 1 (soft block — proceed only with an
+explicit chair acknowledgment), else 0.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under the Apache License, Version 2.0
+"""
+
+from __future__ import annotations
+
+from argparse import Namespace
+from pathlib import Path
+
+
+def cmd_gates_check(args: Namespace) -> int:
+    """Run boundary gates for a spec phase and render receipts (G5)."""
+    from attune.gates.lifecycle import exit_code, run_boundary
+
+    receipts = run_boundary(
+        args.phase,
+        args.spec,
+        project_root=Path.cwd(),
+        tier=args.tier,
+        changed_paths=list(args.changed or []),
+    )
+    if not receipts:
+        print(f"no gates applicable at the {args.phase} boundary for {args.spec}")
+        return 0
+    for r in receipts:
+        flag = " (waived)" if r.waived else ""
+        print(f"[{r.state}{flag}] {r.gate_id} — {r.target} @ {r.phase} ({r.receipt_id})")
+        for finding in r.findings:
+            print(f"    - {finding}")
+        if r.proposed_disposition:
+            print(f"    → {r.proposed_disposition}")
+    code = exit_code(receipts)
+    if code == 2:
+        print("BLOCKED: this boundary cannot advance (G5 hard block).")
+    elif code == 1:
+        print("CHAIR_REQUIRED: proceed only with an explicit chair acknowledgment (G5).")
+    return code

--- a/src/attune/cli_minimal.py
+++ b/src/attune/cli_minimal.py
@@ -65,6 +65,7 @@ from attune.cli_commands.cost_commands import (
     cmd_costs_today,
 )
 from attune.cli_commands.curator import cmd_curator
+from attune.cli_commands.gates_commands import cmd_gates_check
 from attune.cli_commands.help_commands import cmd_help
 from attune.cli_commands.memory_agent import cmd_memory_agent
 from attune.cli_commands.memory_commands import (
@@ -198,6 +199,37 @@ def _add_workflow_subparsers(subparsers: argparse._SubParsersAction) -> None:
             "opus/sonnet by keyword (security, vuln, architect, quality, "
             "plan, research) are unaffected."
         ),
+    )
+
+
+def _add_gates_subparsers(subparsers: argparse._SubParsersAction) -> None:
+    """Attach the spec-lifecycle gates commands.
+
+    Args:
+        subparsers: Parent subparsers action to attach to
+
+    """
+    gates_parser = subparsers.add_parser("gates", help="Spec-lifecycle quality gates")
+    gates_sub = gates_parser.add_subparsers(dest="gates_command")
+
+    check_parser = gates_sub.add_parser("check", help="Run boundary gates for a spec phase")
+    check_parser.add_argument(
+        "phase",
+        choices=["brainstorm", "requirements", "design", "tasks", "execution", "verification"],
+        help="Lifecycle boundary to gate",
+    )
+    check_parser.add_argument("--spec", required=True, help="Spec slug under docs/specs/")
+    check_parser.add_argument(
+        "--tier",
+        choices=["spec", "sub-spec"],
+        default="spec",
+        help="Work tier (sub-spec runs only the mechanical baseline)",
+    )
+    check_parser.add_argument(
+        "--changed",
+        nargs="*",
+        default=[],
+        help="Changed paths for blast-radius classification",
     )
 
 
@@ -556,6 +588,7 @@ Documentation: https://smartaimemory.com/framework-docs/
     subparsers = parser.add_subparsers(dest="command", help="Available commands")
 
     _add_workflow_subparsers(subparsers)
+    _add_gates_subparsers(subparsers)
     _add_telemetry_subparsers(subparsers)
     _add_costs_subparsers(subparsers)
     _add_misc_subparsers(subparsers)
@@ -576,6 +609,10 @@ _SUBCOMMAND_DISPATCH: dict[str, dict[str, object]] = {
         "list": cmd_workflow_list,
         "info": cmd_workflow_info,
         "run": cmd_workflow_run,
+    },
+    "gates": {
+        "_attr": "gates_command",
+        "check": cmd_gates_check,
     },
     "telemetry": {
         "_attr": "telemetry_command",

--- a/src/attune/curator/core.py
+++ b/src/attune/curator/core.py
@@ -36,7 +36,15 @@ from .result import (
     SuggestedAction,
 )
 from .schema import output_schema
-from .sources import bulletin, git_state, recommendations, specs, sweep, telemetry
+from .sources import (
+    bulletin,
+    git_state,
+    recommendations,
+    spec_drift,
+    specs,
+    sweep,
+    telemetry,
+)
 
 if TYPE_CHECKING:
     from anthropic import AsyncAnthropic
@@ -63,6 +71,7 @@ _MAX_OUTPUT_TOKENS = 4096
 _SOURCE_MODULES = [
     bulletin,
     specs,
+    spec_drift,
     sweep,
     telemetry,
     recommendations,

--- a/src/attune/curator/sources/spec_drift.py
+++ b/src/attune/curator/sources/spec_drift.py
@@ -1,0 +1,85 @@
+"""Spec-drift source reader (spec-lifecycle-gates RR-6).
+
+Surfaces specs whose declared status has drifted from observable
+reality, as curator candidates for CHAIR triage — the
+starter-reconciler pattern as a `SourceReader`. Non-mutating,
+must-not-raise, event-armed by whoever runs the curator (never a
+background sweep).
+
+v1 drift classes, derived from the shipped lifecycle buckets
+(``attune.ops.specs_data.SpecRecord.lifecycle``):
+
+- ``stale`` — a spec claiming active work with no file activity for
+  the staleness window.
+- ``approved-not-shipped`` — an approved design/tasks doc with no
+  execution evidence.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under the Apache License, Version 2.0
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import time
+from datetime import datetime
+from pathlib import Path
+
+from attune.ops.specs_data import _list_specs_in_root
+
+from ..result import SourceItem, SourceSummary
+
+logger = logging.getLogger(__name__)
+
+_SOURCE_ID = "spec_drift"
+_DRIFT_BUCKETS: frozenset[str] = frozenset({"stale", "approved-not-shipped"})
+
+
+def read(
+    *,
+    project_root: Path,
+    since: datetime | None = None,
+) -> SourceSummary:
+    """Return drifted specs as candidates (RR-6; must not raise).
+
+    Args:
+        project_root: Repository root; specs at ``docs/specs/``.
+        since: Unused — Protocol conformance (drift is a state, not
+            an event stream).
+    """
+    started = time.monotonic()
+    items: list[SourceItem] = []
+    try:
+        records = _list_specs_in_root(project_root / "docs" / "specs")
+        for record in records:
+            bucket = getattr(record, "lifecycle", None)
+            if bucket not in _DRIFT_BUCKETS:
+                continue
+            newest = record.phases[-1] if record.phases else None
+            status = getattr(newest, "status", None) or "(no status)"
+            items.append(
+                SourceItem(
+                    item_id=f"spec-drift:{record.slug}",
+                    title=f"{record.slug}: {bucket}",
+                    detail=(
+                        f"lifecycle bucket '{bucket}'; declared status "
+                        f"{status!r}; last modified {record.last_modified}"
+                    )[:500],
+                    link=f"docs/specs/{record.slug}/",
+                )
+            )
+    except Exception:  # noqa: BLE001
+        # INTENTIONAL: SourceReader contract — never raise; an
+        # unreadable tree yields an empty, stably-hashed summary.
+        logger.debug("spec_drift: read failed", exc_info=True)
+        items = []
+    digest = hashlib.sha256(
+        "\n".join(sorted(f"{i.item_id}|{i.title}" for i in items)).encode("utf-8")
+    ).hexdigest()[:16]
+    return SourceSummary(
+        source_id=_SOURCE_ID,
+        state_hash=digest,
+        items=items,
+        fetch_ms=int((time.monotonic() - started) * 1000),
+    )

--- a/src/attune/gates/lifecycle/__init__.py
+++ b/src/attune/gates/lifecycle/__init__.py
@@ -1,0 +1,54 @@
+"""Spec-lifecycle quality gates (docs/specs/spec-lifecycle-gates/).
+
+Autonomous gates BLOCK / REVISE / REPORT with exact shortfalls; only
+the chair approves, waives, and advances. Verdicts persist to the G1
+machine ledger, never to decisions.md.
+
+Lives as a SUBPACKAGE of ``attune.gates`` — the parent package is the
+collaboration-gates surface (spend gate); implementation discovered
+the design's ``src/attune/gates/`` destination was already taken and
+resolved to ``attune.gates.lifecycle`` (recorded in the spec's
+decisions.md). The parent's dependency-light ``__init__`` is
+untouched; import this subpackage directly.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under the Apache License, Version 2.0
+"""
+
+from .activation import (
+    BASELINE_GATES,
+    BATCH_THRESHOLD_FRACTION,
+    LADDER_GATES,
+    Waiver,
+    active_gates,
+    blast_radius,
+    parse_waivers,
+    waived,
+)
+from .baseline import falsifiability_gate, format_lint_gate, symbol_reality_gate
+from .ledger import append, latest_for, ledger_path, unresolved_chair_required
+from .protocol import PHASES, STATES, GateReceipt
+from .runner import exit_code, run_boundary
+
+__all__ = [
+    "BASELINE_GATES",
+    "BATCH_THRESHOLD_FRACTION",
+    "LADDER_GATES",
+    "PHASES",
+    "STATES",
+    "GateReceipt",
+    "Waiver",
+    "active_gates",
+    "append",
+    "blast_radius",
+    "exit_code",
+    "falsifiability_gate",
+    "format_lint_gate",
+    "latest_for",
+    "ledger_path",
+    "parse_waivers",
+    "run_boundary",
+    "symbol_reality_gate",
+    "unresolved_chair_required",
+    "waived",
+]

--- a/src/attune/gates/lifecycle/activation.py
+++ b/src/attune/gates/lifecycle/activation.py
@@ -1,0 +1,132 @@
+"""Risk-tiered gate activation (spec-lifecycle-gates RR-3/RR-4/RR-8).
+
+Pure functions, no I/O beyond reading a decisions.md text the caller
+supplies: blast-radius classification over the chair-ruled surface
+map (G3), tier-based gate selection, and parse-only waiver reading
+with expiry (G2/G5). Unclassifiable changes escalate — the
+conservative default is always ``chair``.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under the Apache License, Version 2.0
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from datetime import datetime, timezone
+
+#: The chair-ruled always-chair surface map (design.md, RR-3). Path
+#: prefixes and basename patterns checked against repo-relative paths.
+_CHAIR_PREFIXES: tuple[str, ...] = (
+    "src/attune/security/",
+    "plugin/",
+    ".github/workflows/",
+    "src/attune/models/telemetry/data_models.py",
+)
+_CHAIR_BASENAMES: tuple[str, ...] = ("pyproject.toml", "__init__.py")
+
+#: The mandatory mechanical baseline (G3): fully-autonomous gates
+#: that run for EVERY tier, including sub-spec work.
+BASELINE_GATES: tuple[str, ...] = ("symbol-reality", "falsifiability")
+
+#: The full ladder for spec-tier work (RR-4). Boundary-specific
+#: selection happens in the runner; this is the ordered superset.
+LADDER_GATES: tuple[str, ...] = (
+    "symbol-reality",
+    "falsifiability",
+    "format-lint",
+)
+
+#: G4: batching engages when gate-generated CHAIR_REQUIRED volume
+#: exceeds this fraction of the measured weekly ruling baseline.
+BATCH_THRESHOLD_FRACTION = 0.20
+
+#: WAIVER: <gate_id> <target> until <YYYY-MM-DD> — <reason> (G2).
+_WAIVER_RE = re.compile(
+    r"^WAIVER:\s+(?P<gate>[\w-]+)\s+(?P<target>\S+)\s+until\s+"
+    r"(?P<until>\d{4}-\d{2}-\d{2})\s+—\s+(?P<reason>.+)$",
+    re.MULTILINE,
+)
+
+
+def blast_radius(changed_paths: list[str]) -> str:
+    """Classify a change set: ``"isolated"`` or ``"chair"`` (RR-3).
+
+    Deletions, migrations, and anything touching the ruled surface
+    map escalate; an EMPTY change set is unclassifiable and therefore
+    ``chair`` (the conservative default, ruled).
+    """
+    if not changed_paths:
+        return "chair"
+    for raw in changed_paths:
+        path = raw.strip().replace("\\", "/")
+        if not path:
+            return "chair"
+        if any(path.startswith(p) for p in _CHAIR_PREFIXES):
+            return "chair"
+        if path.rsplit("/", 1)[-1] in _CHAIR_BASENAMES:
+            return "chair"
+        if "migration" in path.lower():
+            return "chair"
+    return "isolated"
+
+
+def active_gates(tier: str, radius: str) -> list[str]:
+    """Select the gate set for a work tier + blast radius (RR-4/G3).
+
+    ``tier`` is ``"sub-spec"`` (inline edits, one-shots — the
+    xml-enhanced-prompts "Do NOT use" list) or ``"spec"``. Sub-spec
+    work sees only the mandatory baseline regardless of radius —
+    the ceremony-inflation guard.
+    """
+    if tier == "sub-spec":
+        return list(BASELINE_GATES)
+    gates = list(LADDER_GATES)
+    return gates if radius == "isolated" else [*gates, "chair-review"]
+
+
+@dataclass(frozen=True)
+class Waiver:
+    """One parsed, chair-authored waiver line (G2)."""
+
+    gate_id: str
+    target: str
+    until: str  # YYYY-MM-DD
+    reason: str
+
+    def expired(self, *, today: datetime | None = None) -> bool:
+        """True when the waiver's date has passed (UTC date compare)."""
+        now = (today or datetime.now(timezone.utc)).date().isoformat()
+        return now > self.until
+
+
+def parse_waivers(decisions_text: str) -> list[Waiver]:
+    """Extract WAIVER lines from a decisions.md text (parse-only).
+
+    Malformed lines are ignored — a waiver the parser cannot read is
+    a waiver that does not apply (fail-closed, per G2's
+    never-self-granted rule).
+    """
+    return [
+        Waiver(
+            gate_id=m.group("gate"),
+            target=m.group("target"),
+            until=m.group("until"),
+            reason=m.group("reason").strip(),
+        )
+        for m in _WAIVER_RE.finditer(decisions_text)
+    ]
+
+
+def waived(
+    gate_id: str,
+    target: str,
+    waivers: list[Waiver],
+    *,
+    today: datetime | None = None,
+) -> bool:
+    """True when an unexpired chair waiver covers this gate+target."""
+    return any(
+        w.gate_id == gate_id and w.target == target and not w.expired(today=today) for w in waivers
+    )

--- a/src/attune/gates/lifecycle/baseline.py
+++ b/src/attune/gates/lifecycle/baseline.py
@@ -1,0 +1,149 @@
+"""The mandatory mechanical baseline gates (spec-lifecycle-gates RR-4).
+
+Three fully-autonomous gates, each returning a :class:`GateReceipt`:
+
+- **format-lint** — the round-table compiler lints, called directly
+  (never re-implemented).
+- **symbol-reality** — every path/module a document cites must
+  resolve against the tree. Born from live evidence: the drafter of
+  this very spec confabulated seven module paths in its first
+  producing run (decisions.md, 2026-07-19).
+- **falsifiability** — acceptance bullets must name a receipt type
+  or a probe that would fail; "configured/registered/exits-0"
+  phrasings are flagged (the "registered ≠ working" lesson,
+  mechanized).
+
+CI enforcers (rules-residency, complexity ratchet, lessons
+golden-smoke, doc-import audit) are CITED by the ladder, not wrapped
+here — they keep failing CI directly (design ruling).
+
+Copyright 2026 Smart-AI-Memory
+Licensed under the Apache License, Version 2.0
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import re
+from pathlib import Path
+
+from attune.roundtable import compiler
+
+from .protocol import GateReceipt
+
+#: `[[?slug]]`-style annotation marking a deliberately-not-yet-built
+#: symbol (the memory-corpus escape hatch, ported per RR-4).
+_NOT_YET_RE = re.compile(r"\[\[\?[\w./-]+\]\]")
+
+#: Backticked tokens that look like paths (contain a slash or end in
+#: .py/.md) or importable dotted modules under the attune namespace.
+_PATH_TOKEN_RE = re.compile(r"`([\w./~-]+/[\w./~-]+|[\w./-]+\.(?:py|md))`")
+_MODULE_TOKEN_RE = re.compile(r"`(attune(?:\.\w+)+)`")
+
+#: Receipt-type vocabulary a falsifiable acceptance bullet may name
+#: (the delegation-receipts taxonomy) plus probe-ish words.
+_RECEIPT_WORDS_RE = re.compile(
+    r"\b(suite|behavioral|live-fire|metric|evidence-chain|test|probe|assert|"
+    r"exit[s]? non-zero|fails?\b)",
+    re.IGNORECASE,
+)
+_BANNED_PHRASES_RE = re.compile(
+    r"\b(configured|registered|wired up|exits? 0|exits? successfully)\b",
+    re.IGNORECASE,
+)
+
+
+def format_lint_gate(document: str, kind: str, *, phase: str, target: str) -> GateReceipt:
+    """Run the round-table compiler lint for ``kind`` (draft/critique/final)."""
+    lint = getattr(compiler, f"lint_{kind}")
+    problems = lint(document)
+    return GateReceipt(
+        gate_id="format-lint",
+        phase=phase,
+        target=target,
+        state="REVISE" if problems else "PASS",
+        findings=list(problems),
+        proposed_disposition="return to author seat" if problems else "proceed",
+    )
+
+
+def _resolves(token: str, roots: tuple[Path, ...]) -> bool:
+    if token.startswith("~"):
+        # Runtime home-dir data path (a config convention, not a repo
+        # citation) — exempt; the tree cannot vouch for user state.
+        return True
+    if "/" in token or token.endswith((".py", ".md")):
+        return any((root / token).exists() for root in roots)
+    try:
+        return importlib.util.find_spec(token) is not None
+    except (ImportError, ModuleNotFoundError, ValueError):
+        return False
+
+
+def symbol_reality_gate(
+    document: str,
+    project_root: Path,
+    *,
+    phase: str,
+    target: str,
+    extra_roots: tuple[Path, ...] = (),
+) -> GateReceipt:
+    """Every cited path/module resolves, or the gate blocks (RR-4).
+
+    Resolution tries ``project_root``, any ``extra_roots`` (the
+    runner passes the spec dir, so ``decisions.md``-style relative
+    citations resolve), and the repo-idiomatic ``src/attune``
+    prefix (prose cites ``ops/runner.py`` for
+    ``src/attune/ops/runner.py``). Tokens covered by a ``[[?slug]]``
+    not-yet-built annotation on the same line are exempt — the
+    deliberate-future-work escape hatch. ``~``-prefixed runtime data
+    paths are exempt (live-fire finding, T4).
+    """
+    roots = (project_root, *extra_roots, project_root / "src", project_root / "src" / "attune")
+    missing: list[str] = []
+    checked = 0
+    for line in document.splitlines():
+        if _NOT_YET_RE.search(line):
+            continue
+        tokens = _PATH_TOKEN_RE.findall(line) + _MODULE_TOKEN_RE.findall(line)
+        for token in tokens:
+            checked += 1
+            if not _resolves(token, roots):
+                missing.append(token)
+    state = "BLOCKED" if missing else "PASS"
+    return GateReceipt(
+        gate_id="symbol-reality",
+        phase=phase,
+        target=target,
+        state=state,
+        findings=[f"cited but unresolvable: {m}" for m in dict.fromkeys(missing)],
+        evidence_refs=[f"checked {checked} cited tokens against {project_root}"],
+        proposed_disposition=(
+            "re-ground every citation before this document advances" if missing else "proceed"
+        ),
+    )
+
+
+def falsifiability_gate(document: str, *, phase: str, target: str) -> GateReceipt:
+    """Acceptance bullets carry a receipt type or failing probe (RR-4)."""
+    findings: list[str] = []
+    for line in document.splitlines():
+        stripped = line.strip()
+        if not stripped.startswith("- "):
+            continue
+        banned = _BANNED_PHRASES_RE.search(stripped)
+        if banned and not _RECEIPT_WORDS_RE.search(stripped):
+            findings.append(
+                f"unfalsifiable phrasing ({banned.group(0)!r}) with no receipt/probe: "
+                f"{stripped[:80]!r}"
+            )
+    return GateReceipt(
+        gate_id="falsifiability",
+        phase=phase,
+        target=target,
+        state="REVISE" if findings else "PASS",
+        findings=findings,
+        proposed_disposition=(
+            "name a receipt type or failing probe per flagged bullet" if findings else "proceed"
+        ),
+    )

--- a/src/attune/gates/lifecycle/ledger.py
+++ b/src/attune/gates/lifecycle/ledger.py
@@ -1,0 +1,73 @@
+"""The G1 machine verdict ledger (spec-lifecycle-gates).
+
+Gate receipts persist to an append-only JSONL under the attune home —
+NEVER to decisions.md, which stays the human-judgment record (G1).
+Resolution mirrors the run-record corpus (``ATTUNE_HOME`` env →
+``~/.attune``), so the suite's isolation fixture redirects writes
+automatically.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under the Apache License, Version 2.0
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from pathlib import Path
+
+from .protocol import GateReceipt
+
+logger = logging.getLogger(__name__)
+
+
+def ledger_path() -> Path:
+    """`<ATTUNE_HOME|~/.attune>/ops/gates/verdicts.jsonl` (G1)."""
+    home = os.environ.get("ATTUNE_HOME")
+    attune_dir = Path(home).expanduser() if home else Path.home() / ".attune"
+    return attune_dir / "ops" / "gates" / "verdicts.jsonl"
+
+
+def append(receipt: GateReceipt, *, path: Path | None = None) -> Path:
+    """Append one receipt to the ledger (append-only; never deletes)."""
+    dest = path or ledger_path()
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    with dest.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(receipt.to_dict()) + "\n")
+    return dest
+
+
+def _rows(path: Path | None) -> list[GateReceipt]:
+    src = path or ledger_path()
+    if not src.is_file():
+        return []
+    out: list[GateReceipt] = []
+    try:
+        lines = src.read_text(encoding="utf-8").splitlines()
+    except OSError as exc:
+        logger.warning("gates: unreadable ledger %s: %s", src, exc)
+        return []
+    for line in lines:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            out.append(GateReceipt.from_dict(json.loads(line)))
+        except (json.JSONDecodeError, KeyError, TypeError, ValueError):
+            logger.warning("gates: skipping malformed ledger line")
+    return out
+
+
+def latest_for(target: str, *, path: Path | None = None) -> list[GateReceipt]:
+    """The most recent receipt per gate_id for one target."""
+    latest: dict[str, GateReceipt] = {}
+    for receipt in _rows(path):
+        if receipt.target == target:
+            latest[receipt.gate_id] = receipt  # later rows supersede
+    return list(latest.values())
+
+
+def unresolved_chair_required(*, path: Path | None = None) -> list[GateReceipt]:
+    """CHAIR_REQUIRED receipts not yet cited by any ruling."""
+    return [r for r in _rows(path) if r.state == "CHAIR_REQUIRED" and r.decisions_ref is None]

--- a/src/attune/gates/lifecycle/protocol.py
+++ b/src/attune/gates/lifecycle/protocol.py
@@ -1,0 +1,94 @@
+"""The shared gate protocol (spec-lifecycle-gates RR-1/RR-2).
+
+One machine-readable receipt shape for every gate at every lifecycle
+boundary, with a CLOSED four-state disposition enum — adding a state
+requires a spec amendment (the ``FAILURE_CODES`` discipline). A gate
+may BLOCK, REVISE, or REPORT with exact shortfalls; it never advances
+a phase (RR-2): callers render receipts, a human moves the work.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under the Apache License, Version 2.0
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any
+
+#: The five lifecycle boundaries gates fire at (RR-1).
+PHASES: tuple[str, ...] = (
+    "brainstorm",
+    "requirements",
+    "design",
+    "tasks",
+    "execution",
+    "verification",
+)
+
+#: Closed disposition states (RR-1). A spec amendment is required to
+#: extend this — unknown states are bugs, not new categories.
+STATES: tuple[str, ...] = ("PASS", "REVISE", "CHAIR_REQUIRED", "BLOCKED")
+
+
+@dataclass
+class GateReceipt:
+    """One gate evaluation's machine-readable receipt (RR-1).
+
+    ``findings`` carries EXACT shortfalls (the corpus-readiness
+    idiom) — never a bare verdict. ``decisions_ref`` is set only when
+    a chair ruling later cites this receipt; the receipt itself never
+    writes decisions.md (G1).
+    """
+
+    gate_id: str
+    phase: str
+    target: str  # spec slug or artifact path
+    state: str
+    findings: list[str] = field(default_factory=list)
+    evidence_refs: list[str] = field(default_factory=list)
+    proposed_disposition: str = ""
+    waived: bool = False
+    receipt_id: str = field(default_factory=lambda: uuid.uuid4().hex[:12])
+    timestamp: str = field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
+    decisions_ref: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.state not in STATES:
+            raise ValueError(f"unknown gate state: {self.state!r} (closed enum {STATES})")
+        if self.phase not in PHASES:
+            raise ValueError(f"unknown phase: {self.phase!r} (must be one of {PHASES})")
+
+    def to_dict(self) -> dict[str, Any]:
+        """JSON-serializable form for the verdict ledger."""
+        return {
+            "receipt_id": self.receipt_id,
+            "gate_id": self.gate_id,
+            "phase": self.phase,
+            "target": self.target,
+            "state": self.state,
+            "findings": list(self.findings),
+            "evidence_refs": list(self.evidence_refs),
+            "proposed_disposition": self.proposed_disposition,
+            "waived": self.waived,
+            "timestamp": self.timestamp,
+            "decisions_ref": self.decisions_ref,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> GateReceipt:
+        """Load a ledger row back into a receipt (round-trip)."""
+        return cls(
+            gate_id=str(data["gate_id"]),
+            phase=str(data["phase"]),
+            target=str(data["target"]),
+            state=str(data["state"]),
+            findings=list(data.get("findings", [])),
+            evidence_refs=list(data.get("evidence_refs", [])),
+            proposed_disposition=str(data.get("proposed_disposition", "")),
+            waived=bool(data.get("waived", False)),
+            receipt_id=str(data.get("receipt_id", uuid.uuid4().hex[:12])),
+            timestamp=str(data.get("timestamp", "")),
+            decisions_ref=data.get("decisions_ref"),
+        )

--- a/src/attune/gates/lifecycle/runner.py
+++ b/src/attune/gates/lifecycle/runner.py
@@ -1,0 +1,98 @@
+"""Boundary gate runner (spec-lifecycle-gates RR-2/RR-5).
+
+Selects gates via the activation policy, runs them SERIALLY, appends
+every receipt to the G1 ledger, and returns them. It never advances
+anything and never mutates spec files — callers render receipts and
+a human moves the phase (RR-2). G5 exit semantics live with the CLI
+caller: BLOCKED → 2, CHAIR_REQUIRED → 1, else 0.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under the Apache License, Version 2.0
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from . import activation, baseline, ledger
+from .protocol import GateReceipt
+
+
+def _document_for(spec_dir: Path, phase: str) -> str:
+    """The boundary's artifact text: the highest-phase file at or
+    below ``phase`` (the reconciler's phase-precedence rule)."""
+    order = ["tasks.md", "design.md", "requirements.md"]
+    allowed = {
+        "requirements": ["requirements.md"],
+        "design": ["design.md", "requirements.md"],
+        "tasks": order,
+    }.get(phase, order)
+    for name in allowed:
+        candidate = spec_dir / name
+        if candidate.is_file():
+            return candidate.read_text(encoding="utf-8")
+    return ""
+
+
+def run_boundary(
+    phase: str,
+    spec_slug: str,
+    *,
+    project_root: Path,
+    tier: str = "spec",
+    changed_paths: list[str] | None = None,
+    ledger_file: Path | None = None,
+) -> list[GateReceipt]:
+    """Run the boundary's active gates over the spec's artifact.
+
+    Returns every receipt (already ledger-appended). Unexpired chair
+    waivers downgrade their gate to PASS with ``waived=True`` — the
+    receipt still logs (G2).
+    """
+    spec_dir = project_root / "docs" / "specs" / spec_slug
+    document = _document_for(spec_dir, phase)
+    radius = activation.blast_radius(changed_paths or [])
+    gates = activation.active_gates(tier, radius)
+    decisions = spec_dir / "decisions.md"
+    waivers = activation.parse_waivers(
+        decisions.read_text(encoding="utf-8") if decisions.is_file() else ""
+    )
+
+    receipts: list[GateReceipt] = []
+    for gate_id in gates:
+        if gate_id == "symbol-reality":
+            receipt = baseline.symbol_reality_gate(
+                document, project_root, phase=phase, target=spec_slug, extra_roots=(spec_dir,)
+            )
+        elif gate_id == "falsifiability":
+            receipt = baseline.falsifiability_gate(document, phase=phase, target=spec_slug)
+        elif gate_id == "format-lint" and phase == "requirements":
+            receipt = baseline.format_lint_gate(document, "final", phase=phase, target=spec_slug)
+        elif gate_id == "chair-review":
+            receipt = GateReceipt(
+                gate_id="chair-review",
+                phase=phase,
+                target=spec_slug,
+                state="CHAIR_REQUIRED",
+                findings=[f"blast radius 'chair' ({radius=})"],
+                proposed_disposition="chair rules before this boundary advances",
+            )
+        else:
+            continue  # boundary-inapplicable gate
+        if receipt.state != "PASS" and activation.waived(gate_id, spec_slug, waivers):
+            receipt.state = "PASS"
+            receipt.waived = True
+            receipt.proposed_disposition = "waived by unexpired chair waiver (G2)"
+        ledger.append(receipt, path=ledger_file)
+        receipts.append(receipt)
+    return receipts
+
+
+def exit_code(receipts: list[GateReceipt]) -> int:
+    """G5 semantics: BLOCKED → 2 (hard), CHAIR_REQUIRED → 1 (soft), else 0."""
+    states = {r.state for r in receipts}
+    if "BLOCKED" in states:
+        return 2
+    if "CHAIR_REQUIRED" in states:
+        return 1
+    return 0

--- a/src/attune/roundtable/producing.py
+++ b/src/attune/roundtable/producing.py
@@ -554,6 +554,29 @@ class _ProducingRun:
                 self._receipt("COMPILE_ERROR", detail=f"{type(exc).__name__}: {exc}")
             ) from exc
 
+        # Requirements-boundary gate over the final document
+        # (spec-lifecycle-gates T5, design trigger #2). NON-terminal:
+        # candidates still stage for the chair — the finding rides the
+        # digest as a LINT_DIRTY-class degradation (closed taxonomy;
+        # the slot-3 confabulation episode is the motivating receipt).
+        try:
+            from attune.gates.lifecycle import symbol_reality_gate
+
+            gate = symbol_reality_gate(
+                final_text, Path.cwd(), phase="requirements", target=spec.slug
+            )
+            if gate.state != "PASS":
+                self._receipt(
+                    "LINT_DIRTY",
+                    round=3,
+                    role="gate",
+                    detail=f"symbol-reality gate {gate.state}: "
+                    f"{len(gate.findings)} unresolvable citation(s)",
+                    evidence="\n".join(gate.findings),
+                )
+        except ImportError:
+            pass  # gates package absent (partial install) — never block authoring
+
         return final_draft, *self._stage(final_draft)
 
     def _round_one(self, owed: str, pack: str) -> tuple[str, str]:

--- a/tests/unit/curator/test_source_spec_drift.py
+++ b/tests/unit/curator/test_source_spec_drift.py
@@ -1,0 +1,52 @@
+"""Spec-drift source reader tests (spec-lifecycle-gates RR-6/T6).
+
+Real fixture spec dirs on disk — the reader's file-to-summary
+boundary runs unmocked, mirroring the sibling source tests.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+
+from attune.curator.sources import spec_drift
+
+
+def _spec(root: Path, slug: str, status: str, *, age_days: float = 0.0) -> Path:
+    d = root / "docs" / "specs" / slug
+    d.mkdir(parents=True)
+    f = d / "requirements.md"
+    f.write_text(f"# {slug}\n\n**Status: {status}**\n", encoding="utf-8")
+    if age_days:
+        stamp = time.time() - age_days * 86_400
+        os.utime(f, (stamp, stamp))
+    return d
+
+
+class TestSpecDriftReader:
+    def test_stale_spec_surfaces_as_candidate(self, tmp_path):
+        _spec(tmp_path, "rotting-spec", "in progress", age_days=90)
+        summary = spec_drift.read(project_root=tmp_path)
+        (item,) = summary.items
+        assert item.item_id == "spec-drift:rotting-spec"
+        assert "stale" in item.title
+        assert item.link == "docs/specs/rotting-spec/"
+
+    def test_active_and_complete_specs_do_not_surface(self, tmp_path):
+        _spec(tmp_path, "fresh-spec", "in progress")
+        _spec(tmp_path, "done-spec", "complete")
+        summary = spec_drift.read(project_root=tmp_path)
+        assert summary.items == []
+
+    def test_empty_result_has_stable_hash_and_never_raises(self, tmp_path):
+        first = spec_drift.read(project_root=tmp_path)  # no docs/specs at all
+        second = spec_drift.read(project_root=tmp_path)
+        assert first.items == []
+        assert first.state_hash == second.state_hash
+
+    def test_candidate_reaches_curator_registry(self):
+        """RR-5-style proof: the reader is enumerated by the curator."""
+        from attune.curator import core
+
+        assert spec_drift in core._SOURCE_MODULES

--- a/tests/unit/gates/test_full_seam.py
+++ b/tests/unit/gates/test_full_seam.py
@@ -1,0 +1,88 @@
+"""RR-9 full-seam integration (spec-lifecycle-gates T7).
+
+Fixture spec dir → ``run_boundary`` → REAL ledger write →
+decisions.md citing the receipt id → linkage asserted back through
+``latest_for``. Nothing mocked; the ledger is a real file under the
+test's isolated ``ATTUNE_HOME``.
+"""
+
+from __future__ import annotations
+
+import json
+
+from attune.gates.lifecycle import GateReceipt, append, latest_for, run_boundary
+
+
+def test_full_seam_event_to_ruling_linkage(tmp_path):
+    # 1. A real spec dir whose requirements cite one dead path.
+    spec_dir = tmp_path / "docs" / "specs" / "seam-spec"
+    spec_dir.mkdir(parents=True)
+    (spec_dir / "requirements.md").write_text(
+        "# Seam spec\n\n**Status: draft**\n\n" "- implemented in `src/real/module.py` per plan.\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "src" / "real").mkdir(parents=True)
+
+    ledger = tmp_path / "verdicts.jsonl"
+
+    # 2. Boundary run — receipt lands in the real ledger file.
+    receipts = run_boundary(
+        "requirements",
+        "seam-spec",
+        project_root=tmp_path,
+        tier="sub-spec",
+        changed_paths=["docs/x.md"],
+        ledger_file=ledger,
+    )
+    sym = next(r for r in receipts if r.gate_id == "symbol-reality")
+    assert sym.state == "BLOCKED"  # src/real/module.py does not exist
+    raw_rows = [json.loads(x) for x in ledger.read_text(encoding="utf-8").splitlines()]
+    assert any(row["receipt_id"] == sym.receipt_id for row in raw_rows)
+
+    # 3. The author fixes the citation; the boundary re-runs green.
+    (tmp_path / "src" / "real" / "module.py").write_text("x = 1\n", encoding="utf-8")
+    rerun = run_boundary(
+        "requirements",
+        "seam-spec",
+        project_root=tmp_path,
+        tier="sub-spec",
+        changed_paths=["docs/x.md"],
+        ledger_file=ledger,
+    )
+    assert next(r for r in rerun if r.gate_id == "symbol-reality").state == "PASS"
+
+    # 4. A chair ruling cites the ORIGINAL receipt id; the citation
+    #    round-trips through the ledger read side.
+    ruling_receipt = GateReceipt.from_dict(sym.to_dict())
+    ruling_receipt.decisions_ref = "G-TEST-1"
+    append(ruling_receipt, path=ledger)
+    (spec_dir / "decisions.md").write_text(
+        f"# Decisions\n\n## G-TEST-1\n\nRuled on gate receipt `{sym.receipt_id}`.\n",
+        encoding="utf-8",
+    )
+    latest = {r.gate_id: r for r in latest_for("seam-spec", path=ledger)}
+    # latest symbol-reality row is the ruling-cited one (appended last).
+    assert latest["symbol-reality"].decisions_ref == "G-TEST-1"
+    assert sym.receipt_id in (spec_dir / "decisions.md").read_text(encoding="utf-8")
+
+
+def test_full_ledger_default_path_round_trip(tmp_path, monkeypatch):
+    """The CLI-shaped path: default ledger under ATTUNE_HOME."""
+    monkeypatch.setenv("ATTUNE_HOME", str(tmp_path / "home"))
+    spec_dir = tmp_path / "docs" / "specs" / "clean-spec"
+    spec_dir.mkdir(parents=True)
+    (spec_dir / "requirements.md").write_text(
+        "# Clean\n\n- verified by a suite test that fails on regression.\n",
+        encoding="utf-8",
+    )
+    receipts = run_boundary(
+        "requirements",
+        "clean-spec",
+        project_root=tmp_path,
+        tier="sub-spec",
+        changed_paths=["docs/x.md"],
+    )
+    assert all(r.state == "PASS" for r in receipts)
+    default_ledger = tmp_path / "home" / "ops" / "gates" / "verdicts.jsonl"
+    assert default_ledger.is_file()
+    assert len(latest_for("clean-spec")) == 2

--- a/tests/unit/gates/test_lifecycle_gates.py
+++ b/tests/unit/gates/test_lifecycle_gates.py
@@ -1,0 +1,219 @@
+"""Spec-lifecycle gates tests (T1–T4 of spec-lifecycle-gates).
+
+Covers the protocol's closed enum, the G1 ledger under ATTUNE_HOME
+isolation, the activation policy against the chair-ruled surface
+map, the baseline gates (including the slot-3 confabulation
+regression), and the runner's never-advance + G5 exit semantics.
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from attune.gates.lifecycle import (
+    GateReceipt,
+    Waiver,
+    active_gates,
+    append,
+    blast_radius,
+    exit_code,
+    falsifiability_gate,
+    latest_for,
+    ledger_path,
+    parse_waivers,
+    run_boundary,
+    symbol_reality_gate,
+    unresolved_chair_required,
+    waived,
+)
+
+NOW = datetime(2026, 7, 19, 12, 0, tzinfo=timezone.utc)
+
+#: The seven paths the slot-3 drafter confabulated — the live episode
+#: this gate exists to catch (spec decisions.md, 2026-07-19).
+CONFABULATED = """
+- Boundary gates must invoke `attune/compiler/lint.py` and
+  `attune/corpus/readiness.py` plus `attune/doc_import/gate.py`.
+- Also `attune/runner/caps.py`, `attune/receipts/rerun.py`,
+  `attune/curator/triage.py`, `attune/reconciler/starter_reconciler.py`.
+"""
+
+
+class TestProtocol:
+    def test_unknown_state_raises(self):
+        with pytest.raises(ValueError, match="unknown gate state"):
+            GateReceipt(gate_id="x", phase="design", target="t", state="MAYBE")
+
+    def test_unknown_phase_raises(self):
+        with pytest.raises(ValueError, match="unknown phase"):
+            GateReceipt(gate_id="x", phase="thinking", target="t", state="PASS")
+
+    def test_receipt_round_trips(self):
+        r = GateReceipt(
+            gate_id="symbol-reality",
+            phase="requirements",
+            target="some-spec",
+            state="BLOCKED",
+            findings=["cited but unresolvable: x.py"],
+        )
+        loaded = GateReceipt.from_dict(r.to_dict())
+        assert loaded.receipt_id == r.receipt_id
+        assert loaded.state == "BLOCKED"
+        assert loaded.findings == r.findings
+
+
+class TestLedger:
+    def test_append_and_latest_for(self, tmp_path):
+        f = tmp_path / "verdicts.jsonl"
+        old = GateReceipt(gate_id="g", phase="design", target="s", state="REVISE")
+        new = GateReceipt(gate_id="g", phase="design", target="s", state="PASS")
+        append(old, path=f)
+        append(new, path=f)
+        (latest,) = latest_for("s", path=f)
+        assert latest.state == "PASS"  # later rows supersede
+
+    def test_unresolved_chair_required(self, tmp_path):
+        f = tmp_path / "verdicts.jsonl"
+        open_r = GateReceipt(gate_id="a", phase="design", target="s", state="CHAIR_REQUIRED")
+        cited = GateReceipt(
+            gate_id="b",
+            phase="design",
+            target="s",
+            state="CHAIR_REQUIRED",
+            decisions_ref="G9",
+        )
+        append(open_r, path=f)
+        append(cited, path=f)
+        assert [r.gate_id for r in unresolved_chair_required(path=f)] == ["a"]
+
+    def test_default_path_is_isolated_from_real_home(self):
+        """Drift guard: the suite must never touch the real ledger."""
+        assert str(ledger_path()).startswith(os.environ["ATTUNE_HOME"])
+        assert ledger_path() != Path.home() / ".attune" / "ops" / "gates" / "verdicts.jsonl"
+
+
+class TestActivation:
+    @pytest.mark.parametrize(
+        "paths",
+        [
+            ["src/attune/security/path_validation.py"],
+            ["plugin/skills/spec/SKILL.md"],
+            [".github/workflows/tests.yml"],
+            ["src/attune/models/telemetry/data_models.py"],
+            ["pyproject.toml"],
+            ["src/attune/__init__.py"],
+            ["db/migrations/0001_add.sql"],
+            [],  # unclassifiable → conservative default
+        ],
+    )
+    def test_chair_radius_cases(self, paths):
+        assert blast_radius(paths) == "chair"
+
+    def test_isolated_radius(self):
+        assert blast_radius(["src/attune/gates/lifecycle/protocol.py", "tests/unit/x.py"]) == (
+            "isolated"
+        )
+
+    def test_sub_spec_tier_gets_baseline_only(self):
+        assert active_gates("sub-spec", "chair") == ["symbol-reality", "falsifiability"]
+
+    def test_spec_tier_chair_radius_appends_chair_review(self):
+        assert active_gates("spec", "chair")[-1] == "chair-review"
+
+    def test_waiver_parse_and_expiry(self):
+        text = "WAIVER: symbol-reality my-spec until 2026-07-20 — flaky env, G2\n"
+        (w,) = parse_waivers(text)
+        assert w == Waiver("symbol-reality", "my-spec", "2026-07-20", "flaky env, G2")
+        assert not w.expired(today=NOW)
+        assert w.expired(today=datetime(2026, 7, 21, tzinfo=timezone.utc))
+        assert waived("symbol-reality", "my-spec", [w], today=NOW)
+        assert not waived("symbol-reality", "other", [w], today=NOW)
+
+    def test_malformed_waiver_is_ignored(self):
+        assert parse_waivers("WAIVER: badline\n") == []
+
+
+class TestBaselineGates:
+    def test_confabulated_paths_block(self, tmp_path):
+        """The slot-3 live episode, as a permanent regression."""
+        r = symbol_reality_gate(CONFABULATED, tmp_path, phase="requirements", target="s")
+        assert r.state == "BLOCKED"
+        assert len(r.findings) == 7
+        assert any("attune/compiler/lint.py" in f for f in r.findings)
+
+    def test_real_paths_pass(self, tmp_path):
+        (tmp_path / "src").mkdir()
+        (tmp_path / "src" / "ok.py").write_text("x = 1\n")
+        doc = "- uses `src/ok.py` and the `attune.gates.lifecycle` module."
+        r = symbol_reality_gate(doc, tmp_path, phase="design", target="s")
+        assert r.state == "PASS"
+
+    def test_not_yet_built_hatch_exempts_line(self, tmp_path):
+        doc = "- will add `src/future/thing.py` [[?future-thing]] later."
+        r = symbol_reality_gate(doc, tmp_path, phase="design", target="s")
+        assert r.state == "PASS"
+
+    def test_falsifiability_flags_banned_phrasing(self):
+        doc = "- the hook is registered and exits 0.\n- covered by a suite test that fails on regression.\n"
+        r = falsifiability_gate(doc, phase="requirements", target="s")
+        assert r.state == "REVISE"
+        assert len(r.findings) == 1
+        assert "registered" in r.findings[0]
+
+    def test_falsifiability_passes_receipted_bullets(self):
+        doc = "- verified by a live-fire probe that exits non-zero on failure.\n"
+        r = falsifiability_gate(doc, phase="requirements", target="s")
+        assert r.state == "PASS"
+
+
+class TestRunner:
+    def _spec_dir(self, tmp_path: Path, requirements: str, decisions: str = "") -> Path:
+        d = tmp_path / "docs" / "specs" / "my-spec"
+        d.mkdir(parents=True)
+        (d / "requirements.md").write_text(requirements, encoding="utf-8")
+        if decisions:
+            (d / "decisions.md").write_text(decisions, encoding="utf-8")
+        return tmp_path
+
+    def test_receipts_appended_and_tree_untouched(self, tmp_path):
+        root = self._spec_dir(tmp_path, CONFABULATED)
+        ledger_file = tmp_path / "ledger.jsonl"
+        before = sorted(p for p in root.rglob("*") if p.is_file())
+        receipts = run_boundary(
+            "requirements",
+            "my-spec",
+            project_root=root,
+            tier="sub-spec",
+            changed_paths=["docs/x.md"],
+            ledger_file=ledger_file,
+        )
+        after = sorted(p for p in root.rglob("*") if p.is_file() and p != ledger_file)
+        assert before == after  # never mutates spec files
+        assert {r.gate_id for r in receipts} == {"symbol-reality", "falsifiability"}
+        assert len(latest_for("my-spec", path=ledger_file)) == 2
+
+    def test_waiver_downgrades_with_flag(self, tmp_path):
+        waiver = "WAIVER: symbol-reality my-spec until 2099-01-01 — pinned example, G2\n"
+        root = self._spec_dir(tmp_path, CONFABULATED, decisions=waiver)
+        receipts = run_boundary(
+            "requirements",
+            "my-spec",
+            project_root=root,
+            tier="sub-spec",
+            changed_paths=["docs/x.md"],
+            ledger_file=tmp_path / "l.jsonl",
+        )
+        sym = next(r for r in receipts if r.gate_id == "symbol-reality")
+        assert sym.state == "PASS" and sym.waived is True
+
+    def test_exit_codes_follow_g5(self):
+        blocked = GateReceipt(gate_id="a", phase="design", target="s", state="BLOCKED")
+        chair = GateReceipt(gate_id="b", phase="design", target="s", state="CHAIR_REQUIRED")
+        ok = GateReceipt(gate_id="c", phase="design", target="s", state="PASS")
+        assert exit_code([ok, chair, blocked]) == 2
+        assert exit_code([ok, chair]) == 1
+        assert exit_code([ok]) == 0

--- a/tests/unit/roundtable/test_producing.py
+++ b/tests/unit/roundtable/test_producing.py
@@ -500,6 +500,47 @@ class TestBriefContracts:
         assert TAG_EXAMPLE not in repair
 
 
+class TestSymbolRealityGateOnFinal:
+    """T5 of spec-lifecycle-gates: the post-compile boundary gate.
+
+    A final draft citing unresolvable paths must degrade the run
+    with a LINT_DIRTY gate receipt in the digest — candidates still
+    stage for the chair (non-terminal, per the design's trigger #2;
+    motivating episode: the slot-3 confabulated draft).
+    """
+
+    def test_confabulated_final_degrades_with_gate_receipt(self, tmp_path) -> None:
+        board = _real_board_or_skip()
+        confabulated_final = FINAL_OK.replace(
+            "Rationale one.",
+            "Rationale one, per `attune/nonexistent/thing.py`.",
+        )
+        spec = _spec(tmp_path)
+        try:
+            seats = FakeSeats(final=confabulated_final)
+            result = run_producing(spec, board=board, invoke=seats)
+            assert result.status == "degraded"
+            gate_receipts = [
+                r
+                for r in result.receipts
+                if r.code == "LINT_DIRTY" and "symbol-reality" in r.detail
+            ]
+            assert len(gate_receipts) == 1
+            assert "attune/nonexistent/thing.py" in (gate_receipts[0].evidence or "")
+            assert result.staged  # non-terminal: candidates still staged
+        finally:
+            _cleanup(board, spec.run_id)
+
+    def test_clean_final_stays_clean(self, tmp_path) -> None:
+        board = _real_board_or_skip()
+        spec = _spec(tmp_path)
+        try:
+            result = run_producing(spec, board=board, invoke=FakeSeats())
+            assert result.status == "clean"  # gate PASS adds no receipt
+        finally:
+            _cleanup(board, spec.run_id)
+
+
 class TestCritiqueCitationContract:
     """The citation contract is taught by worked example too.
 


### PR DESCRIPTION
Executes T1–T7 of [spec-lifecycle-gates](docs/specs/spec-lifecycle-gates/tasks.md) per the chair's implementation go. The full lifecycle for this spec — table-authored requirements, approved design, task decomposition, implementation — ran through the new machinery itself.

**Package `attune.gates.lifecycle`** (implementation-discovered deviation, recorded in decisions.md: the design's `src/attune/gates/` destination was already the collaboration-gates package — resolved as a subpackage, parent untouched):
- `protocol.py` — closed four-state `GateReceipt` (unknown states/phases raise)
- `ledger.py` — G1 machine ledger under ATTUNE_HOME (append-only; `latest_for`, `unresolved_chair_required`)
- `activation.py` — blast-radius over the ruled surface map (conservative default), tier selection, parse-only G2 waivers with expiry
- `baseline.py` — format-lint (cites compiler lints), **symbol-reality** (multi-root resolution, `[[?slug]]` hatch, `~`-runtime exemption — tuned by live fire), falsifiability (banned phrasings need receipts)
- `runner.py` + `attune gates check` CLI — serial, every receipt ledgered, never advances; **G5 exits** (BLOCKED=2 hard, CHAIR_REQUIRED=1 soft)

**Trigger wiring:** /spec skill Stage 2 + 4 boundary gates (mirror re-projected); producing runs gate the compiled requirements post-compile (non-terminal LINT_DIRTY degradation, closed taxonomy honored). **Curator:** `spec_drift` SourceReader surfaces stale/approved-not-shipped specs for chair triage.

**Receipts:** 85 gates + 35 producing (serial) + 137 curator tests; full suite **17,806 passed**; the slot-3 confabulated draft is a permanent BLOCKED regression fixture; live-fire `gates check` PASS over run-record-corpus after fixing three false-positive classes the live run itself exposed; **dogfood: the gates gate their own spec, PASS/exit 0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
