### PR TITLE
fix(telemetry): report-shaped results emit run records (RC-2 follow-up)

### DIFF
--- a/docs/specs/run-record-corpus/decisions.md
+++ b/docs/specs/run-record-corpus/decisions.md
@@ -92,3 +92,42 @@ send on next-workflow recommendation clicks. Until it lands,
 dashboard runs record as `manual` (correct for workflow-button
 clicks, conservative for rec clicks per `resolve_run_trigger`'s
 stated bias).
+
+## 2026-07-19 — RC-2 follow-up closed: report-shaped results emit
+
+**Root-cause correction.** The named follow-up ("agent-team
+workflows that bypass `BaseWorkflow` entirely") was mis-attributed:
+`OrchestratedHealthCheckWorkflow`, `DocumentationOrchestrator`, and
+`SecureReleasePipeline` all subclass `BaseWorkflow` and ARE wrapped
+by the RC-2 `__init_subclass__` seam. What they bypass is the
+`WorkflowResult` SHAPE: their `execute` returns report objects
+(`HealthCheckReport`, `OrchestratorResult`, `SecureReleaseResult`)
+without `stages`/`cost_report`/timestamps, so
+`_emit_workflow_telemetry` died on `result.stages`
+(`AttributeError`), was swallowed by the wrapper's best-effort
+catch, and recorded nothing — reproduced by probe before the fix.
+
+**Fix.** Emission is now shape-tolerant in BOTH emit paths
+(`TelemetryMixin._emit_workflow_telemetry` and
+`TelemetryService.emit_workflow_record`): a report-shaped result
+gets a degraded record — identity, `trigger`/`project` provenance,
+wall-clock timing captured by the execute-wrapper, success/error —
+with stage detail and cost totals honestly zero, not guessed. The
+service path also gained the idempotence marker it lacked (double
+emission was possible when ctx-based workflows chain
+`super().execute()`).
+
+**Receipts.** Repro probe (report-shaped result → 0 files,
+AttributeError in debug log) then post-fix probe (1 record,
+idempotent on re-emit); live-fire keyless
+`OrchestratedHealthCheckWorkflow(mode="daily").execute(path=".")`
+from this worktree against a scratch `ATTUNE_HOME` landed
+`workflow_name=orchestrated-health-check`, `trigger=manual`,
+`project=attune-ai`, `success=False` (one agent failed keyless —
+honest), `total_duration_ms=116339`. Serial suite:
+`tests/unit/telemetry/test_run_record_corpus.py` 22 passed (6 new
+in `TestReportShapedEmission`); breadth:
+`tests/unit/workflows tests/unit/telemetry` 3324 passed.
+
+**Still open (unchanged).** The dashboard rec-click attribution
+stamp (RC-3 follow-up) — dashboard runs still record as `manual`.

--- a/src/attune/workflows/base.py
+++ b/src/attune/workflows/base.py
@@ -144,9 +144,18 @@ def _wrap_execute_with_run_record(execute):
 
     @functools.wraps(execute)
     async def _execute(self, *args: Any, **kwargs: Any):
+        from datetime import datetime, timezone
+
+        started = datetime.now(timezone.utc)
         result = await execute(self, *args, **kwargs)
         try:
-            self._emit_workflow_telemetry(result)
+            # Wall-clock timestamps feed the fallback record for
+            # report-shaped results, which carry no timing of their own.
+            self._emit_workflow_telemetry(
+                result,
+                started_at=started,
+                completed_at=datetime.now(timezone.utc),
+            )
         except Exception:  # noqa: BLE001
             # INTENTIONAL: telemetry is optional diagnostics — never
             # fail a workflow over a record write.

--- a/src/attune/workflows/context_proxy_mixin.py
+++ b/src/attune/workflows/context_proxy_mixin.py
@@ -178,13 +178,21 @@ class ContextProxyMixin:
             fallback_used,
         )
 
-    def _emit_workflow_telemetry(self, result: Any) -> None:
+    def _emit_workflow_telemetry(
+        self,
+        result: Any,
+        *,
+        started_at: Any = None,
+        completed_at: Any = None,
+    ) -> None:
         """Emit workflow record -- delegates to TelemetryService when ctx is provided."""
         if self._ctx and self._ctx.telemetry:
             model_fn = self.get_model_for_tier if hasattr(self, "get_model_for_tier") else None
-            self._ctx.telemetry.emit_workflow_record(result, model_fn)
+            self._ctx.telemetry.emit_workflow_record(
+                result, model_fn, started_at=started_at, completed_at=completed_at
+            )
             return
-        super()._emit_workflow_telemetry(result)
+        super()._emit_workflow_telemetry(result, started_at=started_at, completed_at=completed_at)
 
     def _generate_run_id(self) -> str:
         """Generate run ID -- delegates to TelemetryService when ctx is provided."""

--- a/src/attune/workflows/services/telemetry_service.py
+++ b/src/attune/workflows/services/telemetry_service.py
@@ -226,15 +226,50 @@ class TelemetryService:
         self,
         result: Any,
         model_for_tier_fn: Any = None,
+        *,
+        started_at: datetime | None = None,
+        completed_at: datetime | None = None,
     ) -> None:
         """Emit a WorkflowRunRecord to the telemetry backend.
 
         Args:
-            result: The WorkflowResult to record
+            result: The WorkflowResult (or report object) to record
             model_for_tier_fn: Optional callable to resolve model name for a tier
+            started_at: Wall-clock start from the execute-wrapper; used
+                only for report-shaped results without own timestamps.
+            completed_at: Wall-clock end, same caveat as ``started_at``.
 
         """
         from attune.models import WorkflowRunRecord, WorkflowStageRecord
+        from attune.workflows.telemetry_mixin import (
+            build_fallback_run_record,
+            is_workflow_result_shaped,
+        )
+
+        # Idempotence guard mirroring TelemetryMixin's (run-record-corpus
+        # RC-2): only the first emission for a given result records.
+        if result is None or getattr(result, "_run_record_emitted", False) is True:
+            return
+        try:
+            result._run_record_emitted = True
+        except (AttributeError, TypeError):
+            pass  # non-standard result object — emit unguarded
+
+        # Report-shaped results (orchestrator/agent-team workflows) lack
+        # the WorkflowResult surface — emit the degraded record instead
+        # of dying on ``result.stages``.
+        if not is_workflow_result_shaped(result):
+            self._log_run_record(
+                build_fallback_run_record(
+                    run_id=self._run_id or str(uuid.uuid4()),
+                    workflow_name=self._workflow_name,
+                    provider=self._provider,
+                    result=result,
+                    started_at=started_at,
+                    completed_at=completed_at,
+                )
+            )
+            return
 
         stages = [
             WorkflowStageRecord(
@@ -277,6 +312,10 @@ class TelemetryService:
             providers_used=[self._provider],
             tiers_used=list(result.cost_report.by_tier.keys()),
         )
+        self._log_run_record(record)
+
+    def _log_run_record(self, record: Any) -> None:
+        """Write a run record to the backend — never raises."""
         try:
             if self._backend is not None:
                 self._backend.log_workflow(record)

--- a/src/attune/workflows/telemetry_mixin.py
+++ b/src/attune/workflows/telemetry_mixin.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 import logging
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any
 
 from attune.workflows.agent_sdk_adapter import AgentRunResult
@@ -31,6 +31,68 @@ try:
 except ImportError:
     TELEMETRY_AVAILABLE = False
     UsageTracker = None  # type: ignore
+
+
+def is_workflow_result_shaped(result: Any) -> bool:
+    """True when ``result`` carries the ``WorkflowResult`` surface.
+
+    The full run-record builder reads ``stages``, ``cost_report`` and
+    the ``started_at``/``completed_at`` datetimes. Orchestrator and
+    agent-team workflows return report objects (``HealthCheckReport``,
+    ``OrchestratorResult``, ``SecureReleaseResult``) that lack these —
+    they get :func:`build_fallback_run_record` instead (run-record-corpus
+    RC-2 follow-up).
+    """
+    return all(
+        hasattr(result, attr) for attr in ("stages", "cost_report", "started_at", "completed_at")
+    )
+
+
+def build_fallback_run_record(
+    *,
+    run_id: str,
+    workflow_name: str,
+    provider: str,
+    result: Any,
+    started_at: datetime | None,
+    completed_at: datetime | None,
+) -> Any:
+    """Build a degraded ``WorkflowRunRecord`` for a report-shaped result.
+
+    Stage/cost detail is unavailable on these results, so the record
+    carries identity, provenance, timing and outcome only — enough for
+    the run-record corpus miner (sequence, name, time, success), with
+    token/cost totals honestly zero rather than guessed.
+
+    ``started_at``/``completed_at`` come from the caller's wall clock
+    (the ``BaseWorkflow`` execute-wrapper); both default to now.
+    """
+    from attune.models import WorkflowRunRecord
+    from attune.models.telemetry.run_context import (
+        resolve_project_identity,
+        resolve_run_trigger,
+    )
+
+    now = datetime.now(timezone.utc)
+    start = started_at or now
+    end = completed_at or now
+    # ``is not False``: report objects without a ``success`` field count
+    # as success — the run returned a result without raising.
+    success = getattr(result, "success", True) is not False
+    error_raw = getattr(result, "error", None)
+    error = error_raw if isinstance(error_raw, str) and error_raw else None
+    return WorkflowRunRecord(
+        run_id=run_id,
+        workflow_name=workflow_name,
+        trigger=resolve_run_trigger(),
+        project=resolve_project_identity(),
+        started_at=start.isoformat(),
+        completed_at=end.isoformat(),
+        total_duration_ms=max(0, int((end - start).total_seconds() * 1000)),
+        success=success,
+        error=error,
+        providers_used=[provider],
+    )
 
 
 class TelemetryMixin:
@@ -260,11 +322,20 @@ class TelemetryMixin:
             # INTENTIONAL: Telemetry is optional diagnostics - never crash workflow
             logger.debug("Unexpected error logging call telemetry")
 
-    def _emit_workflow_telemetry(self, result: Any) -> None:
+    def _emit_workflow_telemetry(
+        self,
+        result: Any,
+        *,
+        started_at: datetime | None = None,
+        completed_at: datetime | None = None,
+    ) -> None:
         """Emit a WorkflowRunRecord to the telemetry backend.
 
         Args:
-            result: The WorkflowResult to record
+            result: The WorkflowResult (or report object) to record
+            started_at: Wall-clock start from the execute-wrapper; used
+                only for report-shaped results without own timestamps.
+            completed_at: Wall-clock end, same caveat as ``started_at``.
 
         """
         from attune.models import WorkflowRunRecord, WorkflowStageRecord
@@ -285,6 +356,22 @@ class TelemetryMixin:
             result._run_record_emitted = True
         except (AttributeError, TypeError):
             pass  # non-standard result object — emit unguarded
+
+        # Report-shaped results (orchestrator/agent-team workflows) lack
+        # the WorkflowResult surface — emit the degraded record instead
+        # of dying on ``result.stages`` (run-record-corpus RC-2).
+        if not is_workflow_result_shaped(result):
+            self._log_run_record(
+                build_fallback_run_record(
+                    run_id=self._run_id or str(uuid.uuid4()),
+                    workflow_name=self.name,
+                    provider=getattr(self, "_provider_str", "unknown"),
+                    result=result,
+                    started_at=started_at,
+                    completed_at=completed_at,
+                )
+            )
+            return
 
         # Build stage records
         stages = [
@@ -327,6 +414,10 @@ class TelemetryMixin:
             providers_used=[getattr(self, "_provider_str", "unknown")],
             tiers_used=list(result.cost_report.by_tier.keys()),
         )
+        self._log_run_record(record)
+
+    def _log_run_record(self, record: Any) -> None:
+        """Write a run record to the backend — never raises."""
         try:
             if self._telemetry_backend is not None:
                 self._telemetry_backend.log_workflow(record)

--- a/tests/unit/telemetry/test_run_record_corpus.py
+++ b/tests/unit/telemetry/test_run_record_corpus.py
@@ -234,3 +234,102 @@ class TestRetention:
         assert deleted == 1
         assert not stale.exists()
         assert store.workflows_file.exists()  # the corpus is not prunable
+
+
+class TestReportShapedEmission:
+    """RC-2 follow-up: orchestrator/agent-team workflows emit too.
+
+    Their ``execute`` overrides return report objects
+    (``HealthCheckReport``, ``OrchestratorResult``,
+    ``SecureReleaseResult``) without the ``WorkflowResult`` surface;
+    emission must degrade to a minimal record instead of dying on
+    ``result.stages`` and silently recording nothing.
+    """
+
+    def _mixin(self, captured):
+        wf = TelemetryMixin.__new__(TelemetryMixin)
+        wf.name = "orchestrated-health-check"
+        wf._run_id = "rid-report"
+        wf._telemetry_backend = SimpleNamespace(log_workflow=captured.append)
+        return wf
+
+    def test_report_shaped_result_emits_fallback_record(self, tmp_path, monkeypatch):
+        repo = tmp_path / "teamproj"
+        (repo / ".git").mkdir(parents=True)
+        monkeypatch.chdir(repo)
+        captured: list[WorkflowRunRecord] = []
+        wf = self._mixin(captured)
+        report = SimpleNamespace(success=True, agents_executed=3)
+        start = datetime(2026, 7, 19, 12, 0, 0, tzinfo=timezone.utc)
+        end = datetime(2026, 7, 19, 12, 0, 2, tzinfo=timezone.utc)
+        wf._emit_workflow_telemetry(report, started_at=start, completed_at=end)
+        assert len(captured) == 1
+        rec = captured[0]
+        assert rec.workflow_name == "orchestrated-health-check"
+        assert rec.project == "teamproj"
+        assert rec.trigger == "manual"
+        assert rec.success is True
+        assert rec.stages == []
+        assert rec.total_cost == 0.0
+        assert rec.total_duration_ms == 2000
+        assert rec.started_at == start.isoformat()
+        assert rec.completed_at == end.isoformat()
+
+    def test_report_failure_and_error_string_preserved(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        captured: list[WorkflowRunRecord] = []
+        wf = self._mixin(captured)
+        report = SimpleNamespace(success=False, error="agent blew up")
+        wf._emit_workflow_telemetry(report)
+        assert captured[0].success is False
+        assert captured[0].error == "agent blew up"
+
+    def test_report_without_success_field_counts_as_success(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        captured: list[WorkflowRunRecord] = []
+        wf = self._mixin(captured)
+        wf._emit_workflow_telemetry(SimpleNamespace(agents_executed=1))
+        assert captured[0].success is True
+        assert captured[0].error is None
+
+    def test_report_emission_is_idempotent(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        captured: list[WorkflowRunRecord] = []
+        wf = self._mixin(captured)
+        report = SimpleNamespace(success=True)
+        wf._emit_workflow_telemetry(report)
+        wf._emit_workflow_telemetry(report)
+        assert len(captured) == 1
+
+    def test_service_path_emits_fallback_record(self, tmp_path, monkeypatch):
+        from attune.workflows.services.telemetry_service import TelemetryService
+
+        monkeypatch.chdir(tmp_path)
+        captured: list[WorkflowRunRecord] = []
+        svc = TelemetryService.__new__(TelemetryService)
+        svc._workflow_name = "orchestrated-health-check"
+        svc._provider = "anthropic"
+        svc._run_id = "rid-svc"
+        svc._backend = SimpleNamespace(log_workflow=captured.append)
+        report = SimpleNamespace(success=True)
+        svc.emit_workflow_record(report)
+        svc.emit_workflow_record(report)  # idempotent on the ctx path too
+        assert len(captured) == 1
+        assert captured[0].workflow_name == "orchestrated-health-check"
+        assert captured[0].providers_used == ["anthropic"]
+
+    def test_orchestrator_family_execute_is_wrapped(self):
+        from attune.workflows.documentation_orchestrator import (
+            DocumentationOrchestrator,
+        )
+        from attune.workflows.orchestrated_health_check import (
+            OrchestratedHealthCheckWorkflow,
+        )
+        from attune.workflows.secure_release import SecureReleasePipeline
+
+        for cls in (
+            OrchestratedHealthCheckWorkflow,
+            DocumentationOrchestrator,
+            SecureReleasePipeline,
+        ):
+            assert getattr(cls.execute, "_emits_run_record", False) is True, cls


### PR DESCRIPTION
## Summary

Closes the RC-2 follow-up named in `docs/specs/run-record-corpus/decisions.md`: orchestrator/agent-team workflows (`orchestrated-health-check`, `documentation-orchestrator`, `secure-release`) ran green but emitted **no run record**.

**Root-cause correction:** they do NOT bypass `BaseWorkflow` (the follow-up's original attribution) — they're wrapped by the RC-2 seam, but their `execute()` returns report objects (`HealthCheckReport`, `OrchestratorResult`, `SecureReleaseResult`) without the `WorkflowResult` surface. Emission died on `result.stages` (`AttributeError`), was swallowed by the best-effort catch, and recorded nothing.

## Changes

- Both emit paths (`TelemetryMixin._emit_workflow_telemetry`, `TelemetryService.emit_workflow_record`) detect report-shaped results and emit a degraded record: identity, `trigger`/`project` provenance, wall-clock timing, success/error — stage/cost detail honestly zero, not guessed.
- The `__init_subclass__` execute-wrapper captures started/completed wall-clock and forwards them (report objects carry no timing of their own); `ContextProxyMixin` forwards the new kwargs so the ctx path can't `TypeError`-and-swallow.
- `TelemetryService` gains the idempotence marker the mixin path already had (double-emission was possible on ctx workflows chaining `super().execute()`).
- Closure + receipts recorded in `docs/specs/run-record-corpus/decisions.md`.

## Receipts

- Repro probe (pre-fix): report-shaped result → `AttributeError: 'FakeReport' object has no attribute 'stages'` in debug log, zero files written.
- Post-fix probe: exactly one record, idempotent on re-emit.
- **Live-fire**: keyless `OrchestratedHealthCheckWorkflow(mode="daily").execute(path=".")` from a worktree against scratch `ATTUNE_HOME` → record with `workflow_name=orchestrated-health-check`, `trigger=manual`, `project=attune-ai`, `success=False` (one agent failed keyless — honest), `total_duration_ms=116339`.
- Suite (serial): `tests/unit/telemetry/test_run_record_corpus.py` — 22 passed (6 new in `TestReportShapedEmission`). Breadth: `tests/unit/workflows tests/unit/telemetry` — 3324 passed.

Still open (unchanged): dashboard rec-click attribution stamp (RC-3 follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
