### PR TITLE
feat(ops): rec-click trigger attribution (RC-3 follow-up)

### DIFF
--- a/docs/specs/run-record-corpus/decisions.md
+++ b/docs/specs/run-record-corpus/decisions.md
@@ -131,3 +131,29 @@ in `TestReportShapedEmission`); breadth:
 
 **Still open (unchanged).** The dashboard rec-click attribution
 stamp (RC-3 follow-up) — dashboard runs still record as `manual`.
+
+## 2026-07-19 — RC-3 follow-up closed: rec-click attribution stamp
+
+The dashboard now stamps recommendation-launched runs end-to-end:
+the three rec surfaces in `run_view.js` (chain pills, rec cards,
+suggestion chips) send `{"trigger": "attune-rec"}` in the run POST;
+`POST /workflows/{name}/run` validates the field (unknown values
+400 at the API edge, though the child-side resolver stays
+junk-tolerant); `RunnerService.start` threads it onto the `Run`
+(persisted in the ops record via `to_dict`/`from_record`, additive
+— pre-RC-3 records load as `None`); and `_execute` exports
+`ATTUNE_RUN_TRIGGER` into the subprocess env so the workflow's own
+canonical run record carries the attribution via
+`resolve_run_trigger`. The manual Run button (`runner.js`) sends no
+trigger and keeps resolving to `manual` — `resolve_run_trigger`'s
+conservative bias is now only the fallback, not the steady state.
+
+Receipts: `tests/unit/ops/test_run_trigger_attribution.py` (9
+tests, serial) — including a REAL subprocess round-trip through
+`_execute` observing `ENV_TRIGGER=attune-rec` in the child, the
+400-on-junk contract, record round-trip, and source-level guards
+that all three rec surfaces stamp while the manual button doesn't;
+`tests/unit/ops` breadth 1463 passed. Browser-click verification
+deferred deliberately: a live dashboard click launches a real
+billable workflow; the subprocess seam test exercises the same
+boundary keylessly.

--- a/src/attune/ops/routes/runner.py
+++ b/src/attune/ops/routes/runner.py
@@ -60,15 +60,21 @@ def _ensure_allowed(request: Request) -> None:
         )
 
 
-async def _read_scope(request: Request) -> str | None:
-    """Parse optional ``{"path": "..."}`` body. Empty body → None.
+async def _read_run_body(request: Request) -> tuple[str | None, str | None]:
+    """Parse the optional ``{"path": ..., "trigger": ...}`` run body.
 
-    Treats an empty string the same as omitted so the picker's
+    Returns ``(path, trigger)``; an empty body yields ``(None, None)``.
+    Treats an empty-string path the same as omitted so the picker's
     "Project-wide" option doesn't have to send anything special.
+    ``trigger`` is the run's provenance stamp (run-record-corpus RC-3):
+    ``"attune-rec"`` for recommendation-launched runs, ``"manual"`` or
+    omitted otherwise; any other value is a 400 (the contract is
+    explicit at the API edge even though the subprocess-side resolver
+    is junk-tolerant).
     """
     body_bytes = await request.body()
     if not body_bytes:
-        return None
+        return None, None
     try:
         raw = json.loads(body_bytes)
     except json.JSONDecodeError as exc:
@@ -76,11 +82,19 @@ async def _read_scope(request: Request) -> str | None:
     if not isinstance(raw, dict):
         raise HTTPException(status_code=400, detail="body must be a JSON object")
     raw_path = raw.get("path")
-    if raw_path is None or raw_path == "":
-        return None
-    if not isinstance(raw_path, str):
+    if raw_path == "":
+        raw_path = None
+    if raw_path is not None and not isinstance(raw_path, str):
         raise HTTPException(status_code=400, detail="path must be a string")
-    return raw_path
+    raw_trigger = raw.get("trigger")
+    if raw_trigger == "":
+        raw_trigger = None
+    if raw_trigger is not None and raw_trigger not in ("manual", "attune-rec"):
+        raise HTTPException(
+            status_code=400,
+            detail="trigger must be 'manual' or 'attune-rec'",
+        )
+    return raw_path, raw_trigger
 
 
 @router.post("/workflows/{name}/run")
@@ -92,7 +106,7 @@ async def start_run(
     _ensure_allowed(request)
     svc = _service(request)
 
-    scope = await _read_scope(request)
+    scope, trigger = await _read_run_body(request)
     if scope is not None:
         # Reject scope for workflows that don't accept a path arg. The
         # registry is the source of truth for path-arg support; a
@@ -116,7 +130,7 @@ async def start_run(
         scope = str(validated)
 
     try:
-        run = await svc.start(name, path=scope)
+        run = await svc.start(name, path=scope, trigger=trigger)
     except RunnerBusyError as exc:
         raise HTTPException(
             status_code=409,

--- a/src/attune/ops/runner.py
+++ b/src/attune/ops/runner.py
@@ -111,6 +111,12 @@ class Run:
     # ``None`` means the workflow runs project-wide (no ``--path`` flag).
     # See docs/specs/ops-runner-tier2/ Phase 2.
     path: str | None = None
+    # Run provenance (run-record-corpus RC-3): ``"attune-rec"`` when the
+    # client launched this run from a next-workflow recommendation
+    # (chain pill, rec card, suggestion chip), ``"manual"`` or ``None``
+    # otherwise. Exported to the subprocess as ``ATTUNE_RUN_TRIGGER`` so
+    # the workflow's run record carries the attribution.
+    trigger: str | None = None
     # Full command line (argv list) the subprocess was invoked with.
     # Captured at execute time so the persistence record can reproduce
     # exactly what ran. ``None`` for runs that never executed.
@@ -159,6 +165,7 @@ class Run:
             "duration_seconds": self.duration_seconds,
             "line_count": len(self.lines),
             "path": self.path,
+            "trigger": self.trigger,
             "command": list(self.command) if self.command else None,
             "sdk_stderr": self.sdk_stderr,
             "sdk_error_kind": self.sdk_error_kind,
@@ -212,6 +219,7 @@ class Run:
             started_at=_parse_dt(data.get("started_at")),
             completed_at=_parse_dt(data.get("completed_at")),
             path=str(data["path"]) if isinstance(data.get("path"), str) else None,
+            trigger=(str(data["trigger"]) if isinstance(data.get("trigger"), str) else None),
             command=command,
             sdk_stderr=sdk_stderr,
             sdk_error_kind=sdk_error_kind,
@@ -648,12 +656,18 @@ class RunnerService:
     def recent(self, limit: int = 5) -> list[Run]:
         return list(reversed(list(self._runs.values())))[:limit]
 
-    async def start(self, workflow: str, *, path: str | None = None) -> Run:
+    async def start(
+        self,
+        workflow: str,
+        *,
+        path: str | None = None,
+        trigger: str | None = None,
+    ) -> Run:
         async with self._lock:
             current = self.current
             if current is not None:
                 raise RunnerBusyError(current.id)
-            run = Run(id=uuid.uuid4().hex[:12], workflow=workflow, path=path)
+            run = Run(id=uuid.uuid4().hex[:12], workflow=workflow, path=path, trigger=trigger)
             self._runs[run.id] = run
             while len(self._runs) > self._history_limit:
                 self._runs.popitem(last=False)
@@ -786,6 +800,13 @@ class RunnerService:
             # default elsewhere (keeps unit tests deterministic).
             "ATTUNE_SDK_ERROR_PROBE": "1",
         }
+        # Run provenance for the workflow's run record (run-record-corpus
+        # RC-3). Only known values cross the boundary; the child's
+        # ``resolve_run_trigger`` treats anything else as ``manual``.
+        if run.trigger in ("manual", "attune-rec"):
+            from attune.models.telemetry.run_context import TRIGGER_ENV
+
+            proc_env[TRIGGER_ENV] = run.trigger
         try:
             proc = await asyncio.create_subprocess_exec(
                 *cmd,

--- a/src/attune/ops/static/js/run_view.js
+++ b/src/attune/ops/static/js/run_view.js
@@ -316,7 +316,9 @@
       );
       return;
     }
-    var body = {};
+    // Chain pills are next-workflow recommendations — stamp the run's
+    // provenance so its record carries trigger=attune-rec (RC-3).
+    var body = { trigger: "attune-rec" };
     if (SOURCE_PATH) body.path = SOURCE_PATH;
     // Disable the pill to deduplicate double-clicks while the POST is
     // in flight.
@@ -539,7 +541,8 @@
       if (kind === "next-workflow") {
         var name = payload.name;
         if (!name) { action.disabled = false; return; }
-        var body_json = {};
+        // Rec-card runs are recommendation-launched (RC-3 provenance).
+        var body_json = { trigger: "attune-rec" };
         if (payload.args && typeof payload.args.path === "string") {
           body_json.path = payload.args.path;
         }
@@ -676,7 +679,8 @@
     }
     chip.addEventListener("click", function () {
       chip.disabled = true;
-      var body = {};
+      // Suggestion chips are next-workflow recommendations (RC-3).
+      var body = { trigger: "attune-rec" };
       if (DATA && typeof DATA.path === "string" && DATA.path) {
         body.path = DATA.path;
       }

--- a/tests/unit/ops/test_run_trigger_attribution.py
+++ b/tests/unit/ops/test_run_trigger_attribution.py
@@ -1,0 +1,134 @@
+"""Rec-click trigger attribution (run-record-corpus RC-3 follow-up).
+
+The dashboard stamps recommendation-launched runs with
+``trigger="attune-rec"``: client rec surfaces send it in the run POST,
+the route validates it, ``RunnerService`` threads it onto the ``Run``,
+and ``_execute`` exports it as ``ATTUNE_RUN_TRIGGER`` so the workflow
+subprocess's own run record carries the attribution. Manual runs send
+nothing and keep resolving to ``manual``.
+"""
+
+import asyncio
+import sys
+from pathlib import Path
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from attune.models.telemetry.run_context import TRIGGER_ENV
+from attune.ops.config import build_config
+from attune.ops.runner import Run, RunnerService
+from attune.ops.server import create_app
+
+JS_DIR = Path(__file__).resolve().parents[3] / "src" / "attune" / "ops" / "static" / "js"
+
+
+def _echo_trigger_cmd(workflow: str) -> tuple[str, ...]:
+    """Subprocess that prints the trigger env var it received."""
+    script = (
+        "import os; "
+        f"print('WORKFLOW={workflow}'); "
+        f"print('ENV_TRIGGER=' + os.environ.get('{TRIGGER_ENV}', 'MISSING'))"
+    )
+    return (sys.executable, "-c", script)
+
+
+def _make_app(tmp_path, monkeypatch, *, allow_run=True):
+    monkeypatch.setenv("ATTUNE_HOME", str(tmp_path / "attune-home"))
+    config = build_config(
+        project_root=tmp_path,
+        allow_run=allow_run,
+        trusted_hosts=("testserver", "test"),
+    )
+    runner = RunnerService(command_builder=_echo_trigger_cmd)
+    app = create_app(config, runner=runner)
+    return app, runner
+
+
+async def _wait_terminal(runner: RunnerService, run_id: str, *, timeout: float = 5.0):
+    deadline = asyncio.get_running_loop().time() + timeout
+    while True:
+        run = runner.get(run_id)
+        assert run is not None
+        if run.is_terminal:
+            return run
+        if asyncio.get_running_loop().time() > deadline:
+            pytest.fail(f"run {run_id} did not finish within {timeout}s")
+        await asyncio.sleep(0.02)
+
+
+class TestRoute:
+    @pytest.mark.asyncio
+    async def test_rec_trigger_reaches_subprocess_env(self, tmp_path, monkeypatch):
+        """attune-rec threads route → Run → ATTUNE_RUN_TRIGGER in the child."""
+        app, runner = _make_app(tmp_path, monkeypatch)
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.post("/workflows/code-review/run", json={"trigger": "attune-rec"})
+            assert resp.status_code == 201
+            run = await _wait_terminal(runner, resp.json()["run_id"])
+        assert run.trigger == "attune-rec"
+        assert any("ENV_TRIGGER=attune-rec" in ln for ln in run.lines)
+
+    @pytest.mark.asyncio
+    async def test_no_trigger_leaves_env_unset(self, tmp_path, monkeypatch):
+        """A body-less POST exports nothing — the child resolves manual."""
+        app, runner = _make_app(tmp_path, monkeypatch)
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.post("/workflows/code-review/run")
+            assert resp.status_code == 201
+            run = await _wait_terminal(runner, resp.json()["run_id"])
+        assert run.trigger is None
+        assert any("ENV_TRIGGER=MISSING" in ln for ln in run.lines)
+
+    @pytest.mark.asyncio
+    async def test_junk_trigger_is_rejected(self, tmp_path, monkeypatch):
+        app, _runner = _make_app(tmp_path, monkeypatch)
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.post("/workflows/code-review/run", json={"trigger": "cron"})
+        assert resp.status_code == 400
+        assert "trigger" in resp.json()["detail"]
+
+    @pytest.mark.asyncio
+    async def test_explicit_manual_is_accepted(self, tmp_path, monkeypatch):
+        app, runner = _make_app(tmp_path, monkeypatch)
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.post("/workflows/code-review/run", json={"trigger": "manual"})
+            assert resp.status_code == 201
+            run = await _wait_terminal(runner, resp.json()["run_id"])
+        assert run.trigger == "manual"
+        assert any("ENV_TRIGGER=manual" in ln for ln in run.lines)
+
+
+class TestRunRecordRoundTrip:
+    def test_to_dict_carries_trigger(self):
+        run = Run(id="abc123def456", workflow="code-review", trigger="attune-rec")
+        assert run.to_dict()["trigger"] == "attune-rec"
+
+    def test_from_record_restores_trigger(self):
+        run = Run(id="abc123def456", workflow="code-review", trigger="attune-rec")
+        record = run.to_record()
+        restored = Run.from_record(record)
+        assert restored.trigger == "attune-rec"
+
+    def test_from_record_tolerates_pre_rc3_records(self):
+        run = Run(id="abc123def456", workflow="code-review")
+        record = run.to_record()
+        record.pop("trigger", None)  # pre-RC-3 persisted record
+        assert Run.from_record(record).trigger is None
+
+
+class TestClientStamps:
+    """Source-level guard: every rec surface sends the stamp; the manual
+    Run button does not (matches the repo's JS-content test style)."""
+
+    def test_rec_surfaces_send_attune_rec(self):
+        text = (JS_DIR / "run_view.js").read_text(encoding="utf-8")
+        assert text.count('trigger: "attune-rec"') == 3
+
+    def test_manual_run_button_sends_no_trigger(self):
+        text = (JS_DIR / "runner.js").read_text(encoding="utf-8")
+        assert "attune-rec" not in text


### PR DESCRIPTION
## Summary

Closes the RC-3 follow-up named in `docs/specs/run-record-corpus/decisions.md`: dashboard runs launched from **next-workflow recommendation clicks** now record `trigger="attune-rec"` in the canonical run stream. Until now every dashboard run recorded as `manual` (correct for the Run button, conservative for rec clicks) — which mattered because pipeline-learner RR-3's ranking formula weights manual runs as the stronger evidence class.

## Changes

- **Client** (`run_view.js`): the three rec surfaces — chain pills, rec cards, suggestion chips — send `{"trigger": "attune-rec"}` in the run POST. The manual Run button (`runner.js`) sends nothing, unchanged.
- **Route** (`POST /workflows/{name}/run`): optional `trigger` field validated at the API edge (`manual` | `attune-rec`, 400 on anything else; the child-side resolver stays junk-tolerant as defense in depth).
- **Runner**: `RunnerService.start(trigger=...)` → `Run.trigger` (additive in `to_dict`/`from_record`; pre-RC-3 persisted ops records load as `None`) → `_execute` exports `ATTUNE_RUN_TRIGGER` into the workflow subprocess env, where `resolve_run_trigger` stamps the canonical record.

## Receipts

- `tests/unit/ops/test_run_trigger_attribution.py` — 9 tests (serial), including a **real subprocess round-trip** through `_execute` observing `ENV_TRIGGER=attune-rec` in the spawned child, the 400-on-junk contract, ops-record round-trip, and source-level guards (all 3 rec surfaces stamp; the manual button doesn't).
- Breadth: `tests/unit/ops` — 1463 passed.
- Browser-click verification deliberately deferred: a live dashboard click launches a real billable workflow; the subprocess seam test exercises the same boundary keylessly.

Closure recorded in `docs/specs/run-record-corpus/decisions.md`. With RC-2 (#1483) and this, all named run-record-corpus follow-ups are closed except the cosmetic ops-prune `rmdir`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
