### PR TITLE
docs(spec): advanced-debugging-plugin — treatment + table-authored requirements (RR-1..8 chair-ruled)

### DIFF
--- a/docs/specs/advanced-debugging-plugin/decisions.md
+++ b/docs/specs/advanced-debugging-plugin/decisions.md
@@ -1,0 +1,51 @@
+# Advanced Debugging Plugin — Decisions
+
+## 2026-07-19 — Origin and pre-spec rulings (chair: Patrick)
+
+Born from a live brainstorm the same day the run-record corpus
+closed (RC-2 #1483, RC-3 rec-click attribution #1485): the
+self-healing loop's "diagnose" stage is the gap this plugin
+fills. Chair-ratified leans, folded into the treatment and the
+producing run's grounding pack as hard constraints:
+
+- **First target:** attune's own failed runs (dogfood-first).
+- **Propose-only v1:** the chair rules on every fix; auto-apply is
+  a later rung behind its own gate.
+- **On-demand trigger first:** the run-view button; auto-diagnosis
+  only as a later opt-in threshold.
+- **Self-records stamped:** diagnostic runs carry `attune-heal`,
+  enter the corpus, excluded from mining.
+
+Artifacts: `treatment.md` (chair-approved one-pager),
+`grounding-pack.md` (producing-run input).
+
+## 2026-07-19 — Requirements chair-ruled per item (thread `producing-advanced-debugging-plugin-001`)
+
+Producing run staged 8 candidates (RR-1..RR-8); the chair approved
+**all eight**. RR-7 approved WITH the panel's 2-1 binding
+(manual-command-only triage in v1; scheduler deferred). RR-8
+approved despite `deferred_over_cap` (TR-6 cap 7) — read-only
+curator source, unanimously agreed by seats.
+
+**Run degradations (receipts, per failure-honesty):**
+
+- `SEAT_ABSENT` round 2: claude critic seat failed
+  `401 OAuth access token has been revoked` after retry — critique
+  round ran on antigravity + codex only. Operational follow-up:
+  re-auth the `claude` CLI before the next table run.
+- `LINT_DIRTY` round 3: symbol-reality gate blocked one bare
+  `producing.py` citation; staged texts carry full paths.
+
+**Dissent register (stands until ruled):**
+
+- Lesson-corpus ownership unresolved — graduated diagnostic
+  lessons to `.claude/lessons.md` directly vs. a dedicated
+  projected source. Implementation keeps lesson publication behind
+  an interface until this is ruled.
+- Confidence scale and the hypothesis-vs-fix-eligible threshold
+  are configuration decisions; every `DiagnosisRecord` exposes the
+  values used rather than hard-coding policy.
+
+Board thread promoted with item ids 6–13; requirements compiled
+deterministically by `attune.roundtable.compiler`
+(`compile_requirements`, approved-only).

--- a/docs/specs/advanced-debugging-plugin/decisions.md
+++ b/docs/specs/advanced-debugging-plugin/decisions.md
@@ -49,3 +49,17 @@ curator source, unanimously agreed by seats.
 Board thread promoted with item ids 6–13; requirements compiled
 deterministically by `attune.roundtable.compiler`
 (`compile_requirements`, approved-only).
+
+## 2026-07-19 — Design approved (chair)
+
+Design ratified as drafted. Load-bearing choices: (1) a diagnosis
+IS a dashboard run — the on-demand endpoint spawns
+`attune diagnose <run_id>` through `RunnerService` with
+`trigger=attune-heal`, reusing the RC-3 seam end-to-end;
+(2) `diagnosis_records.jsonl` as the telemetry layer's third file
+(inherits isolation + rotation); (3) panel/fix-loop bind to the
+shipped roundtable seams, no parallel executor; (4) lesson
+publication behind a `LessonPublisher` protocol and `config_used`
+stamped per record (dissent honored structurally); (5) four build
+phases (substrate → engine → surface → loops), one PR each with
+that phase's RR receipts.

--- a/docs/specs/advanced-debugging-plugin/decisions.md
+++ b/docs/specs/advanced-debugging-plugin/decisions.md
@@ -63,3 +63,12 @@ publication behind a `LessonPublisher` protocol and `config_used`
 stamped per record (dissent honored structurally); (5) four build
 phases (substrate → engine → surface → loops), one PR each with
 that phase's RR receipts.
+
+## 2026-07-19 — Tasks approved (chair)
+
+tasks.md ratified as drafted: eight XML-decomposed tasks across
+the four design phases (T1/T2 substrate, T3/T4 engine, T5
+surface, T6/T7/T8 loops), one PR per phase, receipts named per
+task. Execution NOT yet armed — Phase A starts on a separate
+chair go. T4/T6 live-fire receipts are billable and each needs a
+spend go at execution time.

--- a/docs/specs/advanced-debugging-plugin/design.md
+++ b/docs/specs/advanced-debugging-plugin/design.md
@@ -1,0 +1,168 @@
+# Advanced Debugging Plugin — Design
+
+**Status:** draft for chair review (2026-07-19). Requirements
+chair-ruled per item (RR-1..RR-8, thread
+`producing-advanced-debugging-plugin-001`); this design binds each
+requirement to concrete seams and names the build phases.
+
+## Design stance
+
+Reuse over invention, three ways:
+
+1. **A diagnosis IS a dashboard run.** The on-demand entry point
+   spawns `attune diagnose <run_id>` through the existing
+   `RunnerService` with `ATTUNE_RUN_TRIGGER=attune-heal`. That one
+   choice buys SSE streaming, the busy-lock, the run view, run
+   persistence, AND RR-2's corpus stamping with zero new runner
+   machinery — the diagnostic run is just another run.
+2. **The panel and fix loop are the shipped roundtable seams**
+   (`Board`, `producing` failure taxonomy, `solutions`
+   materialize/validate/review/discard) — no parallel executor.
+3. **The store is the telemetry layer's third file.**
+   `TelemetryStore` grows `diagnoses_file` beside
+   `workflow_runs.jsonl`, inheriting home-global resolution,
+   suite isolation (RC-4 fixture), and no-delete rotation.
+
+## Components
+
+### 1. Schema + store (RR-1)
+
+- `DiagnosisRecord` in `src/attune/models/telemetry/data_models.py`
+  (`schema_version: 1`): `diagnosis_id`, `source_run_id`,
+  `workflow_name`, `created_at`, `status`
+  (`open | fix-proposed | verified | rejected | graduated`),
+  `priors` (lesson refs + degraded-mode reason), `evidence`
+  (typed entries: kind, source, content-digest — priors and
+  observed evidence are distinct kinds per RR-4), `hypotheses`
+  (statement, rank, confidence, supporting/contradicting evidence
+  refs), `synthesis`, `dissent`, `panel` (seat ids, absences,
+  failure codes), `proposed_fix`
+  (diff digest, checks + results, reviewer seat, verdict,
+  disposition), and `config_used`
+  (confidence scale + fix threshold — the dissent register's
+  exposure requirement).
+- Persisted at `~/.attune/telemetry/diagnosis_records.jsonl` via
+  `TelemetryStore.log_diagnosis`; loader
+  `src/attune/diagnosis/store.py` applies purity rules mirroring
+  `pipeline_learner/corpus.py` (fixture-name exclusion, cutover
+  pin at this spec's ship date, malformed-line skip counters).
+
+### 2. Trigger extension (RR-2)
+
+- `attune-heal` joins `_VALID_TRIGGERS` in
+  `src/attune/models/telemetry/run_context.py` and the ops route
+  validator. Only the diagnosis engine sets it (via the runner's
+  existing trigger threading — the RC-3 seam, unchanged).
+- `pipeline_learner/mining.py` counts `attune-heal` as non-manual;
+  `pipeline_learner/corpus.py` excludes it from eligible records.
+  Triage selection (component 6) and graduation exclude it too —
+  no diagnose-the-diagnosis loops by default.
+
+### 3. Diagnosis engine (`src/attune/diagnosis/`)
+
+New package; CLI `attune diagnose <run_id>` (manual-first, and
+what the dashboard spawns).
+
+Pipeline (each stage writes into the record as it goes):
+
+1. **Load** the source `WorkflowRunRecord` (+ ops run record's log
+   tail when one exists) — refuse non-failed or `attune-heal`
+   sources.
+2. **Priors** (RR-4): query `idx:attune_memory`
+   (`FCALL recall_digest` with error-shape terms, OR-joined);
+   Redis-down → explicit `priors_degraded` reason, never a block.
+3. **Evidence pack** (`evidence.py`): bounded-bytes packet — run
+   record fields, log tail, source excerpts for files named in the
+   error, recent `git log --oneline` context. Deterministic
+   assembly, size cap in config.
+4. **Panel** (RR-5, `panel.py`): ≥2 seats invoked independently
+   with the same pack (R1 text-only), moderator synthesis with
+   ranked hypotheses + retained dissent; failures map onto
+   `producing.FAILURE_CODES`; R5 cap 10 invocations; absent seats
+   degrade the panel, never block it (observed live: the claude
+   seat 401'd during this spec's own authoring).
+5. **Fix proposal** (RR-6, gated): only when top confidence ≥ the
+   exposed threshold. Binds `solutions.materialize` (scratch
+   worktree) → `solutions.validate` (named checks, exact-tail
+   receipts) → different-seat review → `solutions.discard`.
+   Everything lands in `proposed_fix`; the user's tree is never
+   touched; failed validation stays visible (TAC-4).
+
+### 4. On-demand surface (RR-3)
+
+- `POST /runs/{run_id}/diagnose` in `src/attune/ops/routes/`
+  (client-token + `allow_run` gates): validates the source run
+  exists and failed, checks the diagnosis store for an existing
+  record for that `source_run_id` (idempotency — returns the link
+  instead of double-spending), then dispatches ONE runner
+  subprocess: `attune diagnose <run_id>` with trigger
+  `attune-heal`.
+- `run_view.js`: "Why did this fail?" button rendered only on
+  terminal-failed runs; navigates to the diagnostic run's own view
+  (streaming for free); a diagnosis chip links completed
+  diagnoses back to their source run. No auto-start anywhere.
+
+### 5. Lesson graduation interface (dissent-bound)
+
+- `graduation.py` defines a `LessonPublisher` protocol; v1 ships
+  only a render-for-chair implementation reusing the roundtable
+  `LessonCandidate` lint (receipt-or-waiver gate). Publication
+  target (`.claude/lessons.md` direct vs. projected source) stays
+  behind the interface until the chair rules — no direct corpus
+  writes in v1.
+
+### 6. Triage routine (RR-7)
+
+- Registered beside `clean-run` in
+  `src/attune/roundtable/routine.py` as `failed-run-triage`:
+  select the last N non-`attune-heal` failed runs since the prior
+  digest, run the engine per failure (bounded), cluster repeated
+  root-cause hypotheses, digest thread
+  `routine-failed-run-triage-<date>` — R8 absolute, manual
+  invocation only in v1 (the 2-1 binding).
+
+### 7. Curator source (RR-8)
+
+- `src/attune/curator/sources/diagnoses.py`: read-only over the
+  canonical loader, same exclusion rules as mining; emits
+  provenance, status, confidence, verification state, lesson refs,
+  dissent. Diffs and raw evidence redacted unless the detailed
+  view is explicitly requested.
+
+## Configuration
+
+`DiagnosisConfig` (env-overridable, defaults conservative):
+`confidence_scale` (three-level: low/medium/high),
+`fix_proposal_threshold` (default: high), `panel_seats` (default
+2), `evidence_budget_bytes` (default 64 KB), `triage_batch_max`
+(default 5). Every record stamps `config_used` — policy is data,
+never hard-code.
+
+## Build phases
+
+- **A — substrate:** RR-1 schema/store + RR-2 trigger extension.
+  Pure model/telemetry layer; unit + live-fire persist/reload.
+- **B — engine core:** load → priors → evidence → panel; CLI
+  `attune diagnose`; DiagnosisRecord written end-to-end (RR-4,
+  RR-5).
+- **C — surface:** endpoint + run-view button + chip (RR-3).
+- **D — loops:** fix proposal (RR-6), triage routine (RR-7),
+  curator source (RR-8), graduation interface.
+
+Each phase lands as its own PR with the RR acceptance receipts it
+covers; Phase B's canonical receipt is a live diagnosis of a real
+failed run from the corpus.
+
+## Risks
+
+- **Spend:** a panel diagnosis is multiple CLI invocations —
+  bounded by caps, on-demand-only, and the R5 ceiling; the triage
+  batch max bounds the routine.
+- **Evidence vs. context limits:** the byte budget truncates
+  deterministically (largest-value-first ordering: error, log
+  tail, source excerpts).
+- **Seat auth fragility:** absent-seat degradation is first-class
+  in the record (`panel.absences`), proven necessary by this
+  spec's own authoring run.
+- **Store growth:** same 50 MB rotate-to-archive policy as the run
+  corpus.

--- a/docs/specs/advanced-debugging-plugin/grounding-pack.md
+++ b/docs/specs/advanced-debugging-plugin/grounding-pack.md
@@ -1,0 +1,87 @@
+# Grounding pack — advanced-debugging-plugin (producing-run input)
+
+**Subject:** An advanced debugging plugin — the "diagnose" stage of
+a self-healing loop for attune — that turns failed workflow runs
+into first-class, minable DiagnosisRecords, uses the multi-LLM
+round table as debugging staff, and proposes (never auto-applies)
+fixes.
+**Provenance:** chair-approved one-page treatment at
+`docs/specs/advanced-debugging-plugin/treatment.md` (2026-07-19,
+drafted from a live brainstorm; chair: Patrick). **Arming:**
+per-spec (chair queued this pack with "proceed"; no standing
+cadence).
+
+## The frame the treatment fixed (seed, not contract)
+
+- Self-healing loop = sense → diagnose → propose → verify → learn.
+  Attune ships four stages; diagnose is the gap this plugin fills.
+- Core artifact: **DiagnosisRecord** — symptom → evidence chain →
+  root-cause hypothesis → confidence → proposed fix → verification
+  receipt. Persisted beside the run corpus; minable; verified
+  diagnoses graduate into lessons.
+- Moat: **lessons as diagnostic priors** — recall the 727-lesson
+  corpus (receipt-backed root-cause episodes for this codebase)
+  BEFORE evidence gathering.
+- LLM team roles (all machinery shipped): diagnosis panel
+  (independent seat hypotheses → moderator synthesis, dissent
+  recorded); fix loop with cross-seat review (solutions loop:
+  text proposals → scratch-worktree materialize → receipted checks
+  → different-seat review → chair); automated error-check routines
+  on the clean-run pattern (headless battery → seats deliberate →
+  digest; R8 never promotes).
+- Use cases, nearest first: "Why did this fail?" button on the run
+  view; nightly failed-run triage digest; automated error-check
+  sweep; deepened test-failure debugging (v2); CI red-lane
+  diagnosis (v2); runtime self-healing for arbitrary apps
+  (horizon only).
+
+## Chair rulings already made (constraints — conform, don't re-litigate)
+
+1. **First target: attune's own failed runs** (dogfood-first).
+2. **Propose-only v1** — the chair rules on every fix; auto-apply
+   is a later rung behind its own gate.
+3. **On-demand trigger first** — diagnosis is LLM spend; the
+   button, then opt-in auto thresholds later.
+4. **Self-records included but stamped** — diagnostic runs carry a
+   new trigger class (`attune-heal`), enter the corpus, excluded
+   from mining.
+
+## Code reality (cite these seams; verify claims against them)
+
+- Run corpus: `~/.attune/telemetry/workflow_runs.jsonl`;
+  `WorkflowRunRecord` in
+  `src/attune/models/telemetry/data_models.py` (has `trigger`,
+  `project`, `sdk stage detail`, `success`, `error`).
+- Trigger contract: `src/attune/models/telemetry/run_context.py` —
+  `TRIGGER_ENV=ATTUNE_RUN_TRIGGER`, `_VALID_TRIGGERS={manual,
+  attune-rec}` (adding `attune-heal` means touching this frozenset,
+  the ops route validator in `src/attune/ops/routes/runner.py`,
+  and pipeline-learner's manual-fraction weighting in
+  `src/attune/pipeline_learner/mining.py`).
+- Emission seams: `src/attune/workflows/telemetry_mixin.py`
+  (RC-2: every BaseWorkflow path emits, report-shaped tolerated).
+- Miner + readiness: `src/attune/pipeline_learner/corpus.py`
+  (cutover pin, fixture-name exclusion — a DiagnosisRecord store
+  should expect the same purity discipline).
+- Rec/diagnosis surface: `src/attune/ops/static/js/run_view.js`
+  (chips/cards/pills + run POST), `src/attune/ops/routes/`
+  (runner, runs_history), curator sources in
+  `src/attune/curator/sources/`.
+- Round table: `src/attune/roundtable/` — `Board`, `solutions.py`
+  (materialize/validate/diff/discard), `producing.py` (failure
+  taxonomy, R5 cap 10), `routine.py` (`clean-run`), rotation
+  ledger.
+- Lessons recall: Redis `idx:attune_memory`
+  (`FT.SEARCH`/`FCALL recall_digest`), hydrated from
+  `.claude/lessons.md`.
+- Existing shallow diagnoser: `fix-test` skill — v1 does NOT
+  replace it (non-goal).
+
+## Draft expectations
+
+REQ items must be buildable against the seams above, honor the
+four chair rulings, keep v1 scope to the nearest two or three use
+cases, and name acceptance receipts (live-fire where a boundary is
+crossed — a diagnosis of a real failed run from the corpus is the
+canonical receipt). Non-goals from the treatment stand unless a
+seat argues a boundary correction with citation.

--- a/docs/specs/advanced-debugging-plugin/requirements.md
+++ b/docs/specs/advanced-debugging-plugin/requirements.md
@@ -1,0 +1,80 @@
+# Advanced Debugging Plugin — Requirements
+
+**Status: requirements chair-ruled per item** — authored by the
+round table (thread `producing-advanced-debugging-plugin-001`); compiled deterministically by
+`attune.roundtable.compiler` (V2-P2). Approved items only;
+declined: none;
+unruled: none.
+
+All eight items chair-approved 2026-07-19. RR-7 carries the panel's 2-1 binding (manual-only triage in v1). RR-8 approved over the TR-6 staging cap. Run was DEGRADED: claude critic seat absent (401), one LINT_DIRTY round-3 citation gate trip — receipts in decisions.md.
+
+## Requirements
+
+**RR-1 — Persist first-class DiagnosisRecords**
+Define a versioned `DiagnosisRecord` in `src/attune/models/telemetry/data_models.py`, persisted at `~/.attune/telemetry/diagnosis_records.jsonl` beside—but separate from—the workflow-run corpus.
+- Each record identifies its source `WorkflowRunRecord` and captures symptom, evidence chain, root-cause hypothesis, confidence, proposed fix, verification receipt, status, timestamps, and schema version.
+- Records are append-safe, reloadable, and minable without modifying `~/.attune/telemetry/workflow_runs.jsonl`.
+- Malformed, fixture-derived, and pre-cutover records are rejected or excluded using explicit purity rules comparable to `src/attune/pipeline_learner/corpus.py`.
+- A live-fire test persists and reloads a `DiagnosisRecord` for a real failed corpus run without losing provenance.
+(table: untagged; chair: approved)
+
+**RR-2 — Stamp and isolate diagnostic runs**
+Diagnostic workflows must enter the standard telemetry path under a distinct `attune-heal` trigger while remaining excluded from diagnosis mining and learning inputs.
+- `attune-heal` is accepted by the trigger contract in `src/attune/models/telemetry/run_context.py` and the route validation in `src/attune/ops/routes/runner.py`.
+- `src/attune/workflows/telemetry_mixin.py` emits diagnostic runs through the same workflow telemetry lifecycle and schema as other runs, differing only in trigger and diagnostic metadata.
+- Pipeline-learner weighting in `src/attune/pipeline_learner/mining.py` does not classify `attune-heal` runs as manual activity.
+- Failed-run selection, headless triage, and lesson graduation exclude all `attune-heal` runs.
+- An integration receipt demonstrates emission of an `attune-heal` run and its omission from a subsequent mining pass.
+(table: untagged; chair: approved)
+
+**RR-3 — Provide on-demand diagnosis from the run view**
+The v1 entry point must be an explicit “Why did this fail?” action for failed attune runs, preserving chair control over LLM spend.
+- `src/attune/ops/static/js/run_view.js` exposes the action only for eligible failed runs and displays pending, completed, failed, and unavailable states using existing conventions.
+- `src/attune/ops/routes/runner.py` owns the on-demand diagnosis endpoint, accepts a run identifier, validates that the source run exists and failed, and dispatches exactly one traceable diagnostic run.
+- Repeated requests are idempotent or visibly linked to prior `DiagnosisRecord` entries rather than silently duplicating spend.
+- No diagnosis starts automatically from run ingestion or page load in v1.
+- An integration receipt exercises the run-view request through the endpoint and links the returned diagnostic run to its source failure.
+(table: untagged; chair: approved)
+
+**RR-4 — Recall lessons before gathering evidence**
+Diagnosis must query `idx:attune_memory` before evidence gathering so verified historical lessons act as diagnostic priors rather than post-hoc decoration.
+- Each diagnostic attempt records whether `FT.SEARCH` or `FCALL recall_digest` was used, the returned lesson references, and any degraded-mode reason.
+- Recalled lessons inform candidate hypotheses, but the `DiagnosisRecord` distinguishes recalled priors from evidence observed in the failed run.
+- Redis unavailability degrades to an explicit no-priors state and does not prevent diagnosis.
+- A receipt shows a known lesson influencing a hypothesis while unsupported recalled claims are not promoted to evidence.
+(table: untagged; chair: approved)
+
+**RR-5 — Convene a receipted diagnosis panel**
+Use the shipped round-table machinery in `src/attune/roundtable/producing.py` to generate independent root-cause hypotheses and a moderator synthesis with visible uncertainty and dissent.
+- At least two independent diagnosis seats inspect the same bounded evidence pack before seeing one another’s hypotheses.
+- The moderator produces a ranked synthesis containing supporting evidence, contradictory evidence, confidence, and unresolved dissent.
+- Seat identities and rotation-ledger participation are retained in the `DiagnosisRecord`.
+- Panel execution maps failures onto the existing `producing.py` failure taxonomy and respects its R5 cap of 10 rather than retrying indefinitely.
+- A receipt covers successful synthesis, retained dissent, and at least one classified panel-failure path.
+(table: untagged; chair: approved)
+
+**RR-6 — Propose and verify fixes without applying them**
+For sufficiently supported diagnoses, use the seams in `src/attune/roundtable/solutions.py` to propose fixes, materialize them only in scratch worktrees, validate them, review their diffs, and discard them after reporting.
+- The implementation binds to the existing materialize, validate, diff, review, and discard lifecycle rather than creating a parallel execution mechanism.
+- No proposed change is applied to the user’s working tree, committed, pushed, or merged by the v1 plugin.
+- Every proposal includes its diff, validation commands, command results, reviewer verdict, residual risks, and disposition.
+- The reviewing seat differs from the proposing seat, and failed validation remains visible rather than being summarized as a successful fix.
+- A live-fire receipt demonstrates scratch-worktree materialization, a relevant check, different-seat review, and discard while the original worktree remains unchanged.
+(table: untagged; chair: approved)
+
+**RR-7 — Support opt-in failed-run triage and lesson graduation**
+Beyond the primary on-demand action, v1 may process failed attune runs through an explicitly invoked headless triage routine integrated with `src/attune/roundtable/routine.py`.
+- The routine follows the existing `clean-run` execution pattern: a bounded failed-run battery, seat deliberation, and a digest linking every conclusion to its `DiagnosisRecord`.
+- The digest groups repeated symptoms or root-cause hypotheses without merging conflicting evidence or concealing dissent.
+- Graduation requires a successful verification receipt and explicit chair approval; unverified, rejected, and `attune-heal` diagnoses never become lessons.
+- V1 exposes triage through a manual command only; scheduler integration is deferred.
+- A routine receipt shows eligible failures included, self-records excluded, and no automatic promotion at R8 or any other stage.
+(table: untagged; chair: approved)
+
+**RR-8 — Expose diagnoses through the curator grounding seam**
+Provide a read-only curator source under `src/attune/curator/sources/` so downstream reporting can consume eligible `DiagnosisRecord` entries without reading raw persistence files directly.
+- The source uses the canonical `DiagnosisRecord` loader and applies the same malformed-record, fixture, cutover, and `attune-heal` exclusion rules as diagnosis mining.
+- Curator output preserves source-run provenance, diagnosis status, confidence, verification state, lesson references, and unresolved dissent.
+- Proposed diffs and potentially sensitive evidence are excluded or redacted unless explicitly requested through an authorized detailed view.
+- A source-level integration receipt loads persisted diagnoses, excludes ineligible records, and produces deterministic grounding documents for downstream reporting.
+(table: untagged; chair: approved)

--- a/docs/specs/advanced-debugging-plugin/tasks.md
+++ b/docs/specs/advanced-debugging-plugin/tasks.md
@@ -1,0 +1,382 @@
+# Advanced Debugging Plugin — Tasks
+
+**Status:** draft for chair review (2026-07-19). Eight tasks across
+the design's four phases (A substrate, B engine, C surface,
+D loops). One PR per phase; each task names its RR receipts.
+Execute in order — every task builds on the previous task's
+landed seams.
+
+## Phase A — substrate
+
+### T1 — DiagnosisRecord schema + store (RR-1)
+
+```xml
+<task id="adp-1" name="diagnosis-record-and-store">
+  <objective>
+    Ship the versioned DiagnosisRecord and its jsonl store —
+    the substrate every later task writes through.
+  </objective>
+  <context>
+    <existing-code path="src/attune/models/telemetry/data_models.py">
+      WorkflowRunRecord: dataclass + from_dict tolerance idiom
+      (additive optional fields) to mirror.
+    </existing-code>
+    <existing-code path="src/attune/models/telemetry/storage.py">
+      TelemetryStore: canonical ATTUNE_HOME resolution +
+      50 MB rotate-to-archive; add diagnoses_file beside
+      workflows_file so isolation and rotation are inherited.
+    </existing-code>
+    <existing-code path="src/attune/pipeline_learner/corpus.py">
+      Purity discipline to mirror: fixture-name exclusion,
+      cutover pin, malformed-line skip counters.
+    </existing-code>
+  </context>
+  <files-to-create>
+    <file path="src/attune/diagnosis/__init__.py">Public exports.</file>
+    <file path="src/attune/diagnosis/store.py">
+      load_diagnoses(): canonical loader with purity rules;
+      records_for_run(source_run_id) for idempotency lookups.
+    </file>
+    <file path="tests/unit/diagnosis/test_record_store.py">
+      Round-trip, from_dict on pre-v1 dicts, purity exclusions,
+      ATTUNE_HOME isolation drift guard, rotation inheritance.
+    </file>
+  </files-to-create>
+  <files-to-modify>
+    <file path="src/attune/models/telemetry/data_models.py">
+      Add DiagnosisRecord (+ nested evidence/hypothesis/fix
+      dataclasses) per design.md §1, schema_version=1,
+      config_used stamped.
+    </file>
+    <file path="src/attune/models/telemetry/storage.py">
+      diagnoses_file property + log_diagnosis(record); same
+      rotation policy as workflow runs.
+    </file>
+  </files-to-modify>
+  <validation>
+    <check>Serial pytest tests/unit/diagnosis + tests/unit/telemetry — pass</check>
+    <check>Live-fire: persist + reload a DiagnosisRecord for a REAL failed run from ~/.attune/telemetry/workflow_runs.jsonl without provenance loss (RR-1 receipt)</check>
+  </validation>
+  <risks>
+    <risk severity="low">Schema over-design — keep nested dataclasses minimal; v2 can extend (schema_version exists for this).</risk>
+  </risks>
+</task>
+```
+
+### T2 — attune-heal trigger extension (RR-2)
+
+```xml
+<task id="adp-2" name="attune-heal-trigger">
+  <objective>
+    attune-heal becomes a valid trigger end-to-end while staying
+    excluded from mining, triage selection, and graduation.
+  </objective>
+  <context>
+    <existing-code path="src/attune/models/telemetry/run_context.py">
+      _VALID_TRIGGERS frozenset + resolve_run_trigger (junk →
+      manual). The RC-3 seam threads env → record.
+    </existing-code>
+    <existing-code path="src/attune/ops/routes/runner.py">
+      _read_run_body trigger validation (manual | attune-rec).
+    </existing-code>
+    <existing-code path="src/attune/pipeline_learner/mining.py">
+      manual-fraction weighting; corpus.py eligibility filter.
+    </existing-code>
+  </context>
+  <files-to-modify>
+    <file path="src/attune/models/telemetry/run_context.py">
+      Add "attune-heal" to _VALID_TRIGGERS.
+    </file>
+    <file path="src/attune/ops/routes/runner.py">
+      Route accepts attune-heal (engine-dispatched runs).
+    </file>
+    <file path="src/attune/pipeline_learner/mining.py">
+      attune-heal counts as non-manual in manual-fraction.
+    </file>
+    <file path="src/attune/pipeline_learner/corpus.py">
+      attune-heal records excluded from eligible set.
+    </file>
+    <file path="tests/unit/telemetry/test_run_record_corpus.py">
+      Trigger-contract cases extended.
+    </file>
+    <file path="tests/unit/pipeline_learner/test_learner.py">
+      Exclusion + weighting cases.
+    </file>
+  </files-to-modify>
+  <validation>
+    <check>Integration receipt: emit an attune-heal-stamped record, run a mining pass, show omission (RR-2 receipt)</check>
+    <check>Serial pytest of both touched test files — pass</check>
+  </validation>
+  <risks>
+    <risk severity="low">Widening _VALID_TRIGGERS silently reclassifies junk env values — junk still resolves manual; only the exact literal passes.</risk>
+  </risks>
+</task>
+```
+
+## Phase B — engine core
+
+### T3 — load, priors, evidence pack (RR-4)
+
+```xml
+<task id="adp-3" name="priors-and-evidence">
+  <objective>
+    The diagnosis pipeline's deterministic front half: source-run
+    load, lesson-prior recall, bounded evidence pack.
+  </objective>
+  <context>
+    <existing-code path="src/attune/models/telemetry/storage.py">
+      Run-corpus read path for source-run load.
+    </existing-code>
+    <existing-code path=".claude/CLAUDE.md">
+      Shared-memory recall recipe: FCALL recall_digest /
+      FT.SEARCH idx:attune_memory, OR-joined terms; degrade
+      silently when Redis is unreachable — here degrade LOUDLY
+      into the record (priors_degraded reason), per RR-4.
+    </existing-code>
+  </context>
+  <files-to-create>
+    <file path="src/attune/diagnosis/engine.py">
+      diagnose(run_id, config) orchestrator skeleton: load →
+      priors → evidence (panel wired in T4); refuses non-failed
+      and attune-heal sources.
+    </file>
+    <file path="src/attune/diagnosis/priors.py">
+      Error-shape term extraction + recall; returns lesson refs
+      or an explicit degraded reason. Priors are a distinct
+      evidence kind — never merged with observed evidence.
+    </file>
+    <file path="src/attune/diagnosis/evidence.py">
+      Bounded-bytes deterministic pack: record fields, log tail,
+      cited-file excerpts, recent git log. Largest-value-first
+      truncation order per design.md.
+    </file>
+    <file path="tests/unit/diagnosis/test_priors_evidence.py">
+      Degraded-mode explicitness, kind separation, byte-budget
+      truncation determinism, source-run refusal rules.
+    </file>
+  </files-to-create>
+  <validation>
+    <check>Receipt: a known lesson surfaces as a prior for a matching error shape; an unsupported recalled claim is NOT promoted to evidence (RR-4 receipt)</check>
+    <check>Redis stopped → diagnosis proceeds with priors_degraded set</check>
+  </validation>
+  <risks>
+    <risk severity="medium">Term extraction quality drives prior relevance — start with error-class + module tokens; tune later, never block.</risk>
+  </risks>
+</task>
+```
+
+### T4 — panel, synthesis, CLI (RR-5)
+
+```xml
+<task id="adp-4" name="panel-and-cli">
+  <objective>
+    The receipted diagnosis panel and the `attune diagnose`
+    command — a DiagnosisRecord written end-to-end.
+  </objective>
+  <context>
+    <existing-code path="src/attune/roundtable/producing.py">
+      Seat invocation recipes, FAILURE_CODES, R5 cap pattern,
+      absent-seat degradation.
+    </existing-code>
+    <existing-code path="src/attune/cli_minimal.py">
+      Command registration pattern (see gates_commands.py).
+    </existing-code>
+  </context>
+  <files-to-create>
+    <file path="src/attune/diagnosis/panel.py">
+      ≥2 independent seats over the same pack; moderator
+      synthesis (ranked hypotheses, confidence, dissent);
+      failures classified onto FAILURE_CODES; cap 10.
+    </file>
+    <file path="src/attune/cli_commands/diagnosis_commands.py">
+      attune diagnose &lt;run_id&gt; [--config overrides].
+    </file>
+    <file path="tests/unit/diagnosis/test_panel.py">
+      Synthesis retention of dissent, absent-seat degradation,
+      classified failure path, cap enforcement (mock seats —
+      panel logic, not LLM output, is under test).
+    </file>
+  </files-to-create>
+  <validation>
+    <check>Live-fire (chair-armed spend): `attune diagnose` a real failed corpus run end-to-end; DiagnosisRecord lands with panel receipts (Phase-B canonical receipt)</check>
+    <check>Serial unit pass; one seat absent → record shows absence, diagnosis completes</check>
+  </validation>
+  <risks>
+    <risk severity="medium">Seat auth fragility (observed 401) — absent-seat path is first-class and tested, not exceptional.</risk>
+  </risks>
+</task>
+```
+
+## Phase C — surface
+
+### T5 — endpoint, button, chip (RR-3)
+
+```xml
+<task id="adp-5" name="on-demand-surface">
+  <objective>
+    "Why did this fail?" from the run view: validated endpoint,
+    idempotent dispatch, diagnosis linked back to its source.
+  </objective>
+  <context>
+    <existing-code path="src/attune/ops/routes/runner.py">
+      start_run: token + allow_run gates, RunnerBusyError shape;
+      the RC-3 trigger threading the endpoint reuses.
+    </existing-code>
+    <existing-code path="src/attune/ops/static/js/run_view.js">
+      Chip/button conventions, attuneClientHeaders, 409 handling.
+    </existing-code>
+  </context>
+  <files-to-modify>
+    <file path="src/attune/ops/routes/runner.py">
+      POST /runs/{run_id}/diagnose: validate failed+terminal
+      source, idempotency via store.records_for_run, dispatch
+      `attune diagnose &lt;id&gt;` with trigger=attune-heal.
+    </file>
+    <file path="src/attune/ops/static/js/run_view.js">
+      Button on terminal-failed runs only; navigate to the
+      diagnostic run's view; completed-diagnosis chip links back.
+    </file>
+    <file path="tests/unit/ops/test_diagnose_endpoint.py">
+      (create) 404 unknown, 400 non-failed, idempotent second
+      call returns existing link, dispatch carries attune-heal
+      (subprocess env round-trip mirroring
+      test_run_trigger_attribution.py).
+    </file>
+  </files-to-modify>
+  <validation>
+    <check>Integration receipt: endpoint → runner → child env ATTUNE_RUN_TRIGGER=attune-heal observed (RR-3 receipt)</check>
+    <check>No auto-start: page load and run ingestion dispatch nothing (source-level guard test)</check>
+  </validation>
+  <risks>
+    <risk severity="low">Busy-lock contention: diagnosis occupies the single-run slot — 409 surface already handles it.</risk>
+  </risks>
+</task>
+```
+
+## Phase D — loops
+
+### T6 — propose-only fix loop (RR-6)
+
+```xml
+<task id="adp-6" name="fix-proposal-loop">
+  <objective>
+    Confidence-gated fix proposals through the solutions seams —
+    materialize, validate, cross-seat review, discard. Never
+    touches the user's tree.
+  </objective>
+  <context>
+    <existing-code path="src/attune/roundtable/solutions.py">
+      materialize / validate / diff_against_base / discard —
+      bind, don't reimplement (TAC-4 honesty).
+    </existing-code>
+  </context>
+  <files-to-create>
+    <file path="src/attune/diagnosis/fix_loop.py">
+      Threshold gate (config_used.fix_proposal_threshold), one
+      repair round max, reviewer seat != proposer seat, full
+      lifecycle into proposed_fix, unconditional discard.
+    </file>
+    <file path="tests/unit/diagnosis/test_fix_loop.py">
+      Threshold gating, reviewer-differs invariant, failed
+      validation stays visible, discard always runs.
+    </file>
+  </files-to-create>
+  <validation>
+    <check>Live-fire receipt: scratch-worktree materialize + one real check + different-seat review + discard; `git status` in the user worktree unchanged before/after (RR-6 receipt)</check>
+  </validation>
+  <risks>
+    <risk severity="medium">Scratch-worktree leak on crash — discard in finally; leaked-worktree sweep assertion in tests.</risk>
+  </risks>
+</task>
+```
+
+### T7 — failed-run triage routine (RR-7)
+
+```xml
+<task id="adp-7" name="triage-routine">
+  <objective>
+    Manual-command batch triage: bounded failed-run selection,
+    per-failure diagnosis, clustered digest. R8 absolute.
+  </objective>
+  <context>
+    <existing-code path="src/attune/roundtable/routine.py">
+      clean-run pattern: battery → deliberation → digest thread;
+      registration + dry-run mode.
+    </existing-code>
+  </context>
+  <files-to-create>
+    <file path="src/attune/diagnosis/triage.py">
+      Select last N non-attune-heal failures since prior digest
+      (triage_batch_max cap); cluster repeated hypotheses without
+      merging conflicting evidence; digest thread
+      routine-failed-run-triage-&lt;date&gt;.
+    </file>
+    <file path="tests/unit/diagnosis/test_triage.py">
+      Selection exclusions (attune-heal, non-failed), batch cap,
+      no promotion at any stage, digest links every conclusion to
+      its DiagnosisRecord.
+    </file>
+  </files-to-create>
+  <validation>
+    <check>Routine receipt: eligible failures in, self-records out, zero writes to tracked files (RR-7 receipt)</check>
+    <check>Manual command only — no scheduler registration exists (grep-level guard)</check>
+  </validation>
+  <risks>
+    <risk severity="low">Digest volume — clustering caps rendered hypotheses per cluster.</risk>
+  </risks>
+</task>
+```
+
+### T8 — curator source + graduation interface (RR-8, dissent)
+
+```xml
+<task id="adp-8" name="curator-and-graduation">
+  <objective>
+    Read-only curator grounding over diagnoses, and the
+    LessonPublisher interface that keeps corpus ownership
+    unruled but unblocking.
+  </objective>
+  <context>
+    <existing-code path="src/attune/curator/sources/spec_drift.py">
+      Newest curator-source shape to mirror.
+    </existing-code>
+    <existing-code path="src/attune/roundtable/__init__.py">
+      LessonCandidate lint (receipt-or-waiver) — graduation
+      renders through it; publication stays behind the protocol.
+    </existing-code>
+  </context>
+  <files-to-create>
+    <file path="src/attune/curator/sources/diagnoses.py">
+      Canonical loader + mining-identical exclusions; provenance,
+      status, confidence, dissent; diffs/evidence redacted unless
+      detailed view requested.
+    </file>
+    <file path="src/attune/diagnosis/graduation.py">
+      LessonPublisher protocol + render-for-chair impl (the ONLY
+      v1 impl); graduation requires verification receipt + chair
+      approval; attune-heal diagnoses never graduate.
+    </file>
+    <file path="tests/unit/diagnosis/test_curator_graduation.py">
+      Exclusion parity with mining, redaction default, protocol
+      has no direct-corpus-write impl in v1 (source-level guard).
+    </file>
+  </files-to-create>
+  <validation>
+    <check>Source-level receipt: deterministic grounding doc from persisted diagnoses; ineligible records excluded (RR-8 receipt)</check>
+  </validation>
+  <risks>
+    <risk severity="low">Redaction misses a sensitive field added later — redact by allowlist, not blocklist.</risk>
+  </risks>
+</task>
+```
+
+## Execution notes
+
+- Receipts re-run centrally before each phase PR ships (delegation
+  receipts rule) — a task's self-report is never the receipt.
+- Live-fire panel/fix-loop tasks (T4, T6) are billable — each
+  needs a chair spend go at execution time (spend gate).
+- The dissent register's two open items (lesson-corpus ownership,
+  confidence-scale values) must be ruled before T8 ships its
+  defaults; T8's interface design keeps T1–T7 unblocked either
+  way.

--- a/docs/specs/advanced-debugging-plugin/treatment.md
+++ b/docs/specs/advanced-debugging-plugin/treatment.md
@@ -1,0 +1,103 @@
+# Advanced Debugging Plugin — One-Page Treatment
+
+**Status:** treatment draft (2026-07-19) — pre-spec, for chair
+reaction. Chair-ratified leans from the originating conversation
+are marked ✓. Next artifact: `requirements.md` via `/spec`
+interview.
+
+## Vision
+
+A self-healing application closes a five-stage loop. Attune has
+quietly built four of the five stages; this plugin is the missing
+middle.
+
+| Stage | State | What exists |
+|-------|-------|-------------|
+| Sense | ✅ | Canonical run-record corpus (every path emits, with `trigger`/`project` provenance), typed `sdk_error_kind`, health checks, telemetry |
+| **Diagnose** | ⬅ gap | `fix-test` is shallow; everything else stops at "it failed" |
+| Propose | ✅ | Curator + next-workflow recs (attribution live), pipeline-learner miner behind RR-1's gate |
+| Verify | ✅ | Receipts discipline, lifecycle gates, drift-guard tests |
+| Learn | ✅ | Lessons corpus (727), Redis recall, decisions.md trail |
+
+## First target (✓ chair-ruled): attune's own failed runs
+
+Dogfood-first. The sensors, error taxonomy, and rec surface exist;
+every diagnosis is verifiable against a codebase we control; the
+corpus grows just by working.
+
+## Core artifact: the DiagnosisRecord
+
+A failed run record is picked up and produces a first-class,
+minable record: symptom → evidence chain → root-cause hypothesis →
+confidence → proposed fix → verification receipt. Verified
+diagnoses graduate into lessons; the learn stage closes the
+flywheel.
+
+**The moat: lessons as diagnostic priors.** The diagnoser recalls
+before it spelunks — 727 receipt-backed lessons are confirmed
+root-cause episodes for THIS codebase (MAPPING trap, stash dance,
+exit-139 class). Generic debuggers have no memory; attune's does.
+
+## The LLM team (roundtable) as debugging staff
+
+The multi-model round table (Claude, Antigravity, Codex —
+moderator/board/chair machinery all shipped) takes three debugging
+roles, reusing existing loops:
+
+1. **Diagnosis panel** — for hard or ambiguous failures, seats
+   hypothesize independently from the same evidence packet
+   (R1 text-only), the moderator synthesizes, dissent is recorded.
+   Judge-panel beats one-model-iterated exactly when the failure
+   space is wide.
+2. **Fix loop with cross-seat review** — the existing solutions
+   loop (V2-P3): seats propose fixes as text, the moderator
+   materializes in a scratch worktree, named checks produce
+   exact-tail receipts, a DIFFERENT seat reviews the diff, the
+   chair rules. Failures present failed-with-receipts, never
+   laundered green (TAC-4).
+3. **Automated error-check routines** — the `clean-run` routine
+   precedent: a headless check battery (preflight + unit suite +
+   failed-run triage) runs on cadence, seats deliberate the
+   results, and a digest thread waits for the chair. R8 holds: a
+   routine never promotes, never auto-fixes.
+
+### Use cases, nearest first
+
+- "Why did this fail?" button on a failed run view → diagnosis
+  chip on the rec surface (on-demand, v1).
+- Nightly failed-run triage digest: batch-diagnose the day's
+  `success=False` records, cluster by root cause, one digest.
+- Automated error-check sweep: run the keyless battery + targeted
+  probes, deliberate anomalies before they become incidents.
+- Test-failure debugging: `fix-test` deepened with evidence chains
+  and lesson priors (v2).
+- CI red-lane diagnosis from `gh` data (v2 — rich lesson priors).
+- Runtime self-healing for arbitrary apps (horizon — the vision,
+  not the plan).
+
+## Ratified v1 constraints (✓)
+
+- **Propose-only.** The chair rules on every fix (mirrors
+  roundtable R4). Auto-apply is a later rung behind its own gate.
+- **On-demand trigger.** Diagnosis is LLM spend; the button first,
+  auto-diagnosis as an opt-in threshold later.
+- **Self-records included but stamped.** Diagnostic runs carry a
+  new trigger class (`attune-heal`), enter the corpus, and are
+  excluded from mining — the diagnoser can diagnose itself without
+  polluting the manual-evidence class.
+
+## What v1 must build (the gap list)
+
+- `diagnose` workflow + `DiagnosisRecord` schema (+ persistence
+  beside the run corpus).
+- Lessons-recall priors step (query `idx:attune_memory` with the
+  error shape before evidence gathering).
+- Run-view button + diagnosis chip surface.
+- `attune-heal` trigger value threading (the RC-3 seam extends).
+- Roundtable debugging brief template + evidence-packet builder.
+- Failed-run triage routine registration (manual-first, then arm).
+
+## Non-goals (v1)
+
+Auto-apply of fixes; non-attune applications; always-on
+auto-diagnosis; replacing `fix-test` (it deepens later, not now).


### PR DESCRIPTION
## Summary

Seeds `docs/specs/advanced-debugging-plugin/` — the "diagnose" stage of attune's self-healing loop, spec'd the same day the run-record corpus closed (#1472/#1483/#1485 built its sensor substrate). Four artifacts land together:

- **`treatment.md`** — chair-approved one-pager: the five-stage loop (sense/diagnose/propose/verify/learn) with diagnose as the gap; `DiagnosisRecord` as the core artifact; lessons-as-diagnostic-priors as the moat; the LLM team's three roles (diagnosis panel, cross-seat fix loop, error-check routines).
- **`grounding-pack.md`** — the producing-run input: treatment frame + four chair rulings as hard constraints + code-reality seam anchors.
- **`requirements.md`** — table-authored (thread `producing-advanced-debugging-plugin-001`), compiled deterministically by `attune.roundtable.compiler`; **all eight items chair-approved** (RR-1 DiagnosisRecord store, RR-2 `attune-heal` isolation, RR-3 on-demand run-view diagnosis, RR-4 lesson priors, RR-5 diagnosis panel, RR-6 propose-only fix loop, RR-7 manual triage w/ 2-1 binding, RR-8 curator source).
- **`decisions.md`** — per-item rulings, the run's degradation receipts (claude critic seat absent on a revoked OAuth token; one symbol-reality lint trip), and the standing dissent register (lesson-corpus ownership behind an interface; confidence thresholds as exposed config).

Docs-only; no code changes. Implementation phases follow under this spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
