### PR TITLE
feat(diagnosis): Phase A substrate — DiagnosisRecord store + attune-heal trigger

### DIFF
--- a/docs/specs/advanced-debugging-plugin/decisions.md
+++ b/docs/specs/advanced-debugging-plugin/decisions.md
@@ -72,3 +72,28 @@ surface, T6/T7/T8 loops), one PR per phase, receipts named per
 task. Execution NOT yet armed — Phase A starts on a separate
 chair go. T4/T6 live-fire receipts are billable and each needs a
 spend go at execution time.
+
+## 2026-07-20 — Phase A executed (T1 + T2)
+
+Substrate landed: `DiagnosisRecord` (+ evidence/hypothesis
+dataclasses, `schema_version=1`, `config_used` stamped) in the
+telemetry models; `diagnosis_records.jsonl` as the canonical third
+stream (shared rotate-to-archive); `attune.diagnosis` package with
+the purity-ruled loader (counted drops) and `records_for_run`;
+`attune-heal` accepted by the trigger contract, route validator,
+and runner env-export, excluded from mining with a counted
+`dropped_attune_heal` stat.
+
+**Deviation from tasks.md (T2):** `mining.py` untouched —
+corpus-layer exclusion makes the named manual-fraction change
+unreachable dead code; the trigger normalizer already maps
+non-manual values to None.
+
+**Receipts:** live-fire T1 — the real failed run `63c533fb6e46`
+(2026-07-15 code-review) diagnosed, persisted, reloaded with
+provenance intact; live-fire T2 — an attune-heal-stamped record in
+the stream omitted by a mining pass (`dropped_attune_heal=1`); 77
+affected tests serial; 2715-test breadth pass. **Honest finding:**
+the real canonical run stream does not exist yet — all post-cutover
+runs to date were suite-isolated; RR-1 readiness accumulation
+starts from zero as of 2026-07-20.

--- a/src/attune/diagnosis/__init__.py
+++ b/src/attune/diagnosis/__init__.py
@@ -1,0 +1,20 @@
+"""Advanced debugging plugin — the diagnose stage of the self-healing
+loop (docs/specs/advanced-debugging-plugin/).
+
+Phase A ships the substrate: the ``DiagnosisRecord`` store and loader.
+The engine (priors, evidence, panel) arrives in Phase B.
+"""
+
+from .store import (
+    DIAGNOSIS_CUTOVER,
+    DiagnosisLoadStats,
+    load_diagnoses,
+    records_for_run,
+)
+
+__all__ = [
+    "DIAGNOSIS_CUTOVER",
+    "DiagnosisLoadStats",
+    "load_diagnoses",
+    "records_for_run",
+]

--- a/src/attune/diagnosis/store.py
+++ b/src/attune/diagnosis/store.py
@@ -1,0 +1,107 @@
+"""Canonical DiagnosisRecord loader (advanced-debugging-plugin RR-1).
+
+Reads ``<ATTUNE_HOME|~/.attune>/telemetry/diagnosis_records.jsonl``
+with the same purity discipline as the pipeline-learner corpus:
+malformed lines and fixture-named workflows are counted drops, never
+silent; records predating the cutover are ineligible. Writing goes
+through ``TelemetryStore.log_diagnosis`` — this module never writes.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+from attune.models.telemetry.data_models import DiagnosisRecord
+from attune.models.telemetry.storage import _canonical_diagnoses_file
+from attune.pipeline_learner.corpus import FIXTURE_NAMES
+
+logger = logging.getLogger(__name__)
+
+#: Diagnosis-stream cutover: the purity discipline exists from this
+#: spec's Phase A ship date; nothing legitimate can predate it.
+DIAGNOSIS_CUTOVER = datetime(2026, 7, 20, 0, 0, 0, tzinfo=timezone.utc)
+
+
+@dataclass
+class DiagnosisLoadStats:
+    """Counted drops — drops are counted, never silent (RC-4 idiom)."""
+
+    total_lines: int = 0
+    eligible: int = 0
+    dropped_malformed: int = 0
+    dropped_fixture: int = 0
+    dropped_pre_cutover: int = 0
+
+
+def _parse_created_at(value: object) -> datetime | None:
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(value)
+    except ValueError:
+        return None
+    return parsed if parsed.tzinfo else parsed.replace(tzinfo=timezone.utc)
+
+
+def _classify_line(line: str, cutover: datetime) -> DiagnosisRecord | str:
+    """Parse one JSONL line, or return the drop-counter name."""
+    try:
+        data = json.loads(line)
+    except json.JSONDecodeError:
+        return "dropped_malformed"
+    if not isinstance(data, dict):
+        return "dropped_malformed"
+    name = data.get("workflow_name")
+    created = _parse_created_at(data.get("created_at"))
+    if not isinstance(name, str) or not name or created is None:
+        return "dropped_malformed"
+    if name in FIXTURE_NAMES:
+        return "dropped_fixture"
+    if created < cutover:
+        return "dropped_pre_cutover"
+    try:
+        return DiagnosisRecord.from_dict(data)
+    except (TypeError, ValueError):
+        return "dropped_malformed"
+
+
+def load_diagnoses(
+    path: Path | None = None,
+    *,
+    cutover: datetime = DIAGNOSIS_CUTOVER,
+) -> tuple[list[DiagnosisRecord], DiagnosisLoadStats]:
+    """Load eligible diagnosis records plus counted drop stats."""
+    stream = path if path is not None else _canonical_diagnoses_file()
+    stats = DiagnosisLoadStats()
+    records: list[DiagnosisRecord] = []
+    if not stream.is_file():
+        return records, stats
+    try:
+        lines = stream.read_text(encoding="utf-8").splitlines()
+    except OSError as exc:
+        logger.warning("diagnosis: store read failed: %s", exc)
+        return records, stats
+    for line in lines:
+        if not line.strip():
+            continue
+        stats.total_lines += 1
+        outcome = _classify_line(line, cutover)
+        if isinstance(outcome, str):
+            setattr(stats, outcome, getattr(stats, outcome) + 1)
+            continue
+        stats.eligible += 1
+        records.append(outcome)
+    return records, stats
+
+
+def records_for_run(
+    source_run_id: str,
+    path: Path | None = None,
+) -> list[DiagnosisRecord]:
+    """Eligible diagnoses for one source run (RR-3 idempotency lookup)."""
+    records, _stats = load_diagnoses(path)
+    return [r for r in records if r.source_run_id == source_run_id]

--- a/src/attune/models/__init__.py
+++ b/src/attune/models/__init__.py
@@ -68,6 +68,7 @@ from .tasks import (
 from .telemetry import (
     AgentAssignmentRecord,
     CoverageRecord,
+    DiagnosisRecord,
     FileTestRecord,
     LLMCallRecord,
     TaskRoutingRecord,
@@ -99,6 +100,7 @@ __all__ = [
     "CircuitBreaker",
     "CircuitBreakerState",
     "CoverageRecord",
+    "DiagnosisRecord",
     "EmpathyLLMExecutor",
     "ExecutionContext",
     "FallbackPolicy",

--- a/src/attune/models/telemetry/__init__.py
+++ b/src/attune/models/telemetry/__init__.py
@@ -19,6 +19,7 @@ from .backend import TelemetryBackend
 from .data_models import (
     AgentAssignmentRecord,
     CoverageRecord,
+    DiagnosisRecord,
     FileTestRecord,
     LLMCallRecord,
     TaskRoutingRecord,
@@ -106,6 +107,7 @@ __all__ = [
     "TaskRoutingRecord",
     "TestExecutionRecord",
     "CoverageRecord",
+    "DiagnosisRecord",
     "AgentAssignmentRecord",
     "FileTestRecord",
     # Backend

--- a/src/attune/models/telemetry/data_models.py
+++ b/src/attune/models/telemetry/data_models.py
@@ -6,7 +6,7 @@ Copyright 2025 Smart-AI-Memory
 Licensed under the Apache License, Version 2.0
 """
 
-from dataclasses import asdict, dataclass, field
+from dataclasses import asdict, dataclass, field, fields
 from typing import Any
 
 
@@ -147,6 +147,93 @@ class WorkflowRunRecord:
         """Create from dictionary."""
         stages = [WorkflowStageRecord(**s) for s in data.pop("stages", [])]
         return cls(stages=stages, **data)
+
+
+@dataclass
+class DiagnosisEvidence:
+    """One evidence entry in a diagnosis (advanced-debugging-plugin RR-1).
+
+    ``kind`` separates recalled lesson priors from evidence observed in
+    the failed run itself (RR-4: priors are never merged with observed
+    evidence).
+    """
+
+    kind: str  # "prior" | "observed"
+    source: str  # lesson ref, file path, "run-record", "log-tail", ...
+    content: str = ""
+
+
+@dataclass
+class DiagnosisHypothesis:
+    """One ranked root-cause hypothesis."""
+
+    statement: str
+    rank: int = 1
+    confidence: str = "low"  # values from config_used["confidence_scale"]
+    supporting: list[str] = field(default_factory=list)  # evidence sources
+    contradicting: list[str] = field(default_factory=list)
+
+
+@dataclass
+class DiagnosisRecord:
+    """Record of one diagnosis of a failed workflow run.
+
+    The core artifact of docs/specs/advanced-debugging-plugin/ (RR-1):
+    symptom -> evidence chain -> hypotheses -> synthesis -> proposed
+    fix -> verification, persisted beside the run corpus. Later phases
+    fill ``panel`` (RR-5) and ``proposed_fix`` (RR-6) — both are plain
+    dicts so Phase A ships no speculative schema for them
+    (``schema_version`` exists for hardening later).
+    """
+
+    # Identification
+    diagnosis_id: str
+    source_run_id: str
+    workflow_name: str
+    created_at: str  # ISO format
+    schema_version: int = 1
+
+    # Lifecycle: open | fix-proposed | verified | rejected | graduated
+    status: str = "open"
+
+    # Symptom + priors (RR-4)
+    symptom: str = ""
+    prior_lessons: list[str] = field(default_factory=list)
+    priors_degraded: str | None = None  # reason recall was unavailable
+
+    # Evidence and reasoning
+    evidence: list[DiagnosisEvidence] = field(default_factory=list)
+    hypotheses: list[DiagnosisHypothesis] = field(default_factory=list)
+    synthesis: str | None = None
+    dissent: list[str] = field(default_factory=list)
+
+    # Panel receipts (RR-5, Phase B) and fix proposal (RR-6, Phase D)
+    panel: dict[str, Any] = field(default_factory=dict)
+    proposed_fix: dict[str, Any] = field(default_factory=dict)
+
+    # Policy is data (dissent register): the confidence scale and fix
+    # threshold used for THIS diagnosis, never hard-coded elsewhere.
+    config_used: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary for JSON serialization."""
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "DiagnosisRecord":
+        """Create from dictionary.
+
+        Tolerant in both directions: missing fields fall back to
+        defaults (pre-v1 records), unknown keys are dropped (records
+        written by a NEWER schema still load).
+        """
+        evidence = [DiagnosisEvidence(**e) for e in data.pop("evidence", []) if isinstance(e, dict)]
+        hypotheses = [
+            DiagnosisHypothesis(**h) for h in data.pop("hypotheses", []) if isinstance(h, dict)
+        ]
+        known = {f.name for f in fields(cls)}
+        kwargs = {k: v for k, v in data.items() if k in known}
+        return cls(evidence=evidence, hypotheses=hypotheses, **kwargs)
 
 
 @dataclass

--- a/src/attune/models/telemetry/run_context.py
+++ b/src/attune/models/telemetry/run_context.py
@@ -20,7 +20,10 @@ logger = logging.getLogger(__name__)
 # a manual run. Values outside the valid set degrade to "manual".
 TRIGGER_ENV = "ATTUNE_RUN_TRIGGER"
 
-_VALID_TRIGGERS = frozenset({"manual", "attune-rec"})
+# "attune-heal" marks diagnostic runs (advanced-debugging-plugin RR-2):
+# they enter the corpus stamped but are excluded from mining, triage
+# selection, and lesson graduation.
+_VALID_TRIGGERS = frozenset({"manual", "attune-rec", "attune-heal"})
 
 
 def resolve_run_trigger() -> str:

--- a/src/attune/models/telemetry/storage.py
+++ b/src/attune/models/telemetry/storage.py
@@ -21,6 +21,7 @@ from .backend import _parse_timestamp
 from .data_models import (
     AgentAssignmentRecord,
     CoverageRecord,
+    DiagnosisRecord,
     FileTestRecord,
     LLMCallRecord,
     TaskRoutingRecord,
@@ -50,6 +51,14 @@ def _canonical_runs_file() -> Path:
     home = os.environ.get("ATTUNE_HOME")
     attune_dir = Path(home).expanduser() if home else Path.home() / ".attune"
     return attune_dir / "telemetry" / "workflow_runs.jsonl"
+
+
+def _canonical_diagnoses_file() -> Path:
+    """Canonical home-global diagnosis stream (advanced-debugging-plugin
+    RR-1) — the telemetry layer's third file, resolved exactly like the
+    run stream so isolation and consolidation ride the same mechanism.
+    """
+    return _canonical_runs_file().parent / "diagnosis_records.jsonl"
 
 
 class TelemetryStore:
@@ -88,6 +97,11 @@ class TelemetryStore:
         self.calls_file = self.storage_dir / "llm_calls.jsonl"
         self.workflows_file = (
             self.storage_dir / "workflow_runs.jsonl" if explicit else _canonical_runs_file()
+        )
+        self.diagnoses_file = (
+            self.storage_dir / "diagnosis_records.jsonl"
+            if explicit
+            else _canonical_diagnoses_file()
         )
 
         # Tier 1 automation monitoring files
@@ -176,35 +190,45 @@ class TelemetryStore:
         """Log a workflow run record to the canonical stream (size-rotated)."""
         try:
             self.workflows_file.parent.mkdir(parents=True, exist_ok=True)
-            self._rotate_runs_file_if_needed()
+            self._rotate_stream_if_needed(self.workflows_file, "workflow_runs")
         except OSError as exc:
             logger.warning("telemetry: run-stream prep failed: %s", exc)
         self._append_record(self.workflows_file, record)
 
-    def _rotate_runs_file_if_needed(self) -> None:
-        """Rotate the run stream past ``_RUNS_ROTATE_BYTES`` (RC-5).
+    def log_diagnosis(self, record: "DiagnosisRecord") -> None:
+        """Log a diagnosis record (advanced-debugging-plugin RR-1).
 
-        History moves to ``<dir>/archive/workflow_runs-<utc>.jsonl`` so
-        the miner keeps its full span; the live file stays bounded.
+        Same canonical-stream discipline as run records: home-global,
+        size-rotated into ``archive/``, never deleted.
+        """
+        try:
+            self.diagnoses_file.parent.mkdir(parents=True, exist_ok=True)
+            self._rotate_stream_if_needed(self.diagnoses_file, "diagnosis_records")
+        except OSError as exc:
+            logger.warning("telemetry: diagnosis-stream prep failed: %s", exc)
+        self._append_record(self.diagnoses_file, record)
+
+    def _rotate_stream_if_needed(self, stream: Path, prefix: str) -> None:
+        """Rotate ``stream`` past ``_RUNS_ROTATE_BYTES`` (RC-5).
+
+        History moves to ``<dir>/archive/<prefix>-<utc>.jsonl`` so
+        miners keep their full span; the live file stays bounded.
         Never deletes.
         """
         try:
-            if (
-                not self.workflows_file.is_file()
-                or self.workflows_file.stat().st_size < _RUNS_ROTATE_BYTES
-            ):
+            if not stream.is_file() or stream.stat().st_size < _RUNS_ROTATE_BYTES:
                 return
-            archive_dir = self.workflows_file.parent / "archive"
+            archive_dir = stream.parent / "archive"
             archive_dir.mkdir(parents=True, exist_ok=True)
             stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
-            dest = archive_dir / f"workflow_runs-{stamp}.jsonl"
+            dest = archive_dir / f"{prefix}-{stamp}.jsonl"
             suffix = 0
             while dest.exists():
                 suffix += 1
-                dest = archive_dir / f"workflow_runs-{stamp}-{suffix}.jsonl"
-            self.workflows_file.rename(dest)
+                dest = archive_dir / f"{prefix}-{stamp}-{suffix}.jsonl"
+            stream.rename(dest)
         except OSError as exc:
-            logger.warning("telemetry: run-stream rotation failed: %s", exc)
+            logger.warning("telemetry: stream rotation failed for %s: %s", stream.name, exc)
 
     def log_task_routing(self, record: TaskRoutingRecord) -> None:
         """Log a task routing decision."""

--- a/src/attune/ops/routes/runner.py
+++ b/src/attune/ops/routes/runner.py
@@ -89,10 +89,10 @@ async def _read_run_body(request: Request) -> tuple[str | None, str | None]:
     raw_trigger = raw.get("trigger")
     if raw_trigger == "":
         raw_trigger = None
-    if raw_trigger is not None and raw_trigger not in ("manual", "attune-rec"):
+    if raw_trigger is not None and raw_trigger not in ("manual", "attune-rec", "attune-heal"):
         raise HTTPException(
             status_code=400,
-            detail="trigger must be 'manual' or 'attune-rec'",
+            detail="trigger must be 'manual', 'attune-rec', or 'attune-heal'",
         )
     return raw_path, raw_trigger
 

--- a/src/attune/ops/runner.py
+++ b/src/attune/ops/runner.py
@@ -803,7 +803,7 @@ class RunnerService:
         # Run provenance for the workflow's run record (run-record-corpus
         # RC-3). Only known values cross the boundary; the child's
         # ``resolve_run_trigger`` treats anything else as ``manual``.
-        if run.trigger in ("manual", "attune-rec"):
+        if run.trigger in ("manual", "attune-rec", "attune-heal"):
             from attune.models.telemetry.run_context import TRIGGER_ENV
 
             proc_env[TRIGGER_ENV] = run.trigger

--- a/src/attune/pipeline_learner/corpus.py
+++ b/src/attune/pipeline_learner/corpus.py
@@ -71,6 +71,7 @@ class LoadStats:
     dropped_no_project: int = 0
     dropped_other_project: int = 0
     dropped_duplicate: int = 0
+    dropped_attune_heal: int = 0
 
 
 def default_stream_paths() -> list[Path]:
@@ -121,6 +122,11 @@ def _classify_line(line: str, project: str, cutover: datetime) -> RunRecord | st
         return "dropped_other_project"
     run_id = data.get("run_id")
     trigger = data.get("trigger")
+    # Diagnostic self-records are stamped but never mined
+    # (advanced-debugging-plugin RR-2) — no diagnose-the-diagnosis
+    # feedback into the learner.
+    if trigger == "attune-heal":
+        return "dropped_attune_heal"
     return RunRecord(
         workflow=name,
         started_at=started,

--- a/tests/unit/diagnosis/test_record_store.py
+++ b/tests/unit/diagnosis/test_record_store.py
@@ -1,0 +1,169 @@
+"""Phase A substrate tests (advanced-debugging-plugin T1/T2).
+
+Covers the DiagnosisRecord schema, the canonical diagnosis stream,
+loader purity rules, and the attune-heal trigger contract.
+"""
+
+import json
+import os
+from datetime import datetime, timezone
+
+from attune.diagnosis.store import (
+    DIAGNOSIS_CUTOVER,
+    load_diagnoses,
+    records_for_run,
+)
+from attune.models.telemetry.data_models import (
+    DiagnosisEvidence,
+    DiagnosisHypothesis,
+    DiagnosisRecord,
+)
+from attune.models.telemetry.run_context import resolve_run_trigger
+from attune.models.telemetry.storage import TelemetryStore
+
+POST_CUTOVER = "2026-07-20T12:00:00+00:00"
+
+
+def _record(**overrides) -> DiagnosisRecord:
+    base = {
+        "diagnosis_id": "d1",
+        "source_run_id": "run-abc",
+        "workflow_name": "code-review",
+        "created_at": POST_CUTOVER,
+    }
+    base.update(overrides)
+    return DiagnosisRecord(**base)
+
+
+class TestSchema:
+    def test_round_trip_preserves_nested_types(self):
+        rec = _record(
+            evidence=[DiagnosisEvidence(kind="prior", source="lesson:mapping-trap")],
+            hypotheses=[DiagnosisHypothesis(statement="stale MAPPING", confidence="high")],
+            config_used={"confidence_scale": ["low", "medium", "high"]},
+        )
+        restored = DiagnosisRecord.from_dict(json.loads(json.dumps(rec.to_dict())))
+        assert restored == rec
+        assert isinstance(restored.evidence[0], DiagnosisEvidence)
+        assert isinstance(restored.hypotheses[0], DiagnosisHypothesis)
+
+    def test_from_dict_tolerates_missing_fields(self):
+        minimal = {
+            "diagnosis_id": "d2",
+            "source_run_id": "run-x",
+            "workflow_name": "code-review",
+            "created_at": POST_CUTOVER,
+        }
+        rec = DiagnosisRecord.from_dict(minimal)
+        assert rec.status == "open"
+        assert rec.evidence == [] and rec.priors_degraded is None
+
+    def test_from_dict_drops_unknown_keys(self):
+        data = _record().to_dict()
+        data["from_the_future"] = {"schema_version": 2}
+        assert DiagnosisRecord.from_dict(data).diagnosis_id == "d1"
+
+
+class TestStore:
+    def test_default_store_resolves_diagnoses_under_attune_home(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("ATTUNE_HOME", str(tmp_path / "home"))
+        monkeypatch.chdir(tmp_path)
+        store = TelemetryStore()
+        assert store.diagnoses_file == (tmp_path / "home" / "telemetry" / "diagnosis_records.jsonl")
+
+    def test_explicit_storage_dir_keeps_diagnoses_local(self, tmp_path):
+        store = TelemetryStore(storage_dir=str(tmp_path / "iso"))
+        assert store.diagnoses_file == tmp_path / "iso" / "diagnosis_records.jsonl"
+
+    def test_suite_isolation_covers_diagnosis_stream(self, tmp_path):
+        # The autouse ATTUNE_HOME fixture must redirect the third file
+        # exactly like the run stream — a drift guard for RC-4 parity.
+        store = TelemetryStore()
+        assert os.environ.get("ATTUNE_HOME"), "suite must run with ATTUNE_HOME isolation"
+        assert str(store.diagnoses_file).startswith(os.environ["ATTUNE_HOME"])
+
+    def test_log_diagnosis_appends_and_rotates(self, tmp_path, monkeypatch):
+        import attune.models.telemetry.storage as storage_mod
+
+        monkeypatch.setenv("ATTUNE_HOME", str(tmp_path / "home"))
+        monkeypatch.chdir(tmp_path)
+        store = TelemetryStore()
+        store.log_diagnosis(_record())
+        store.log_diagnosis(_record(diagnosis_id="d2"))
+        lines = store.diagnoses_file.read_text(encoding="utf-8").strip().splitlines()
+        assert len(lines) == 2
+
+        # Shrink the rotation threshold: next write rotates history.
+        monkeypatch.setattr(storage_mod, "_RUNS_ROTATE_BYTES", 1)
+        store.log_diagnosis(_record(diagnosis_id="d3"))
+        archive = list((store.diagnoses_file.parent / "archive").glob("diagnosis_records-*"))
+        assert len(archive) == 1
+        live = store.diagnoses_file.read_text(encoding="utf-8").strip().splitlines()
+        assert len(live) == 1  # fresh stream holds only the new record
+
+
+class TestLoaderPurity:
+    def test_drops_are_counted_never_silent(self, tmp_path):
+        stream = tmp_path / "diagnosis_records.jsonl"
+        good = _record().to_dict()
+        fixture = _record(diagnosis_id="dF", workflow_name="stub-workflow").to_dict()
+        pre_cutover = _record(diagnosis_id="dP", created_at="2026-07-01T00:00:00+00:00").to_dict()
+        lines = [json.dumps(good), "not-json{", json.dumps(fixture), json.dumps(pre_cutover)]
+        stream.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+        records, stats = load_diagnoses(stream)
+        assert [r.diagnosis_id for r in records] == ["d1"]
+        assert stats.total_lines == 4
+        assert stats.eligible == 1
+        assert stats.dropped_malformed == 1
+        assert stats.dropped_fixture == 1
+        assert stats.dropped_pre_cutover == 1
+
+    def test_records_for_run_filters_by_source(self, tmp_path):
+        stream = tmp_path / "diagnosis_records.jsonl"
+        a = _record(diagnosis_id="dA", source_run_id="run-a").to_dict()
+        b = _record(diagnosis_id="dB", source_run_id="run-b").to_dict()
+        stream.write_text(json.dumps(a) + "\n" + json.dumps(b) + "\n", encoding="utf-8")
+        found = records_for_run("run-b", stream)
+        assert [r.diagnosis_id for r in found] == ["dB"]
+
+    def test_missing_stream_is_empty_not_error(self, tmp_path):
+        records, stats = load_diagnoses(tmp_path / "absent.jsonl")
+        assert records == [] and stats.total_lines == 0
+
+    def test_cutover_is_pinned_post_run_corpus(self):
+        from attune.pipeline_learner.corpus import CUTOVER
+
+        assert DIAGNOSIS_CUTOVER >= CUTOVER  # diagnosis purity postdates corpus purity
+
+
+class TestAttuneHealTrigger:
+    def test_resolver_accepts_attune_heal(self, monkeypatch):
+        monkeypatch.setenv("ATTUNE_RUN_TRIGGER", "attune-heal")
+        assert resolve_run_trigger() == "attune-heal"
+
+    def test_resolver_still_rejects_junk(self, monkeypatch):
+        monkeypatch.setenv("ATTUNE_RUN_TRIGGER", "attune-healing")
+        assert resolve_run_trigger() == "manual"
+
+    def test_corpus_excludes_attune_heal_with_counter(self, tmp_path):
+        from attune.pipeline_learner.corpus import load_corpus
+
+        stream = tmp_path / "workflow_runs.jsonl"
+        base = {
+            "workflow_name": "code-review",
+            "started_at": POST_CUTOVER,
+            "project": "attune-ai",
+        }
+        heal = {**base, "run_id": "r-heal", "trigger": "attune-heal"}
+        manual = {**base, "run_id": "r-man", "trigger": "manual"}
+        stream.write_text(json.dumps(heal) + "\n" + json.dumps(manual) + "\n", encoding="utf-8")
+        records, stats = load_corpus("attune-ai", [stream])
+        assert [r.run_id for r in records] == ["r-man"]
+        assert stats.dropped_attune_heal == 1
+
+
+# Keep DIAGNOSIS_CUTOVER honest if someone edits it to a naive datetime.
+def test_cutover_is_timezone_aware():
+    assert DIAGNOSIS_CUTOVER.tzinfo is not None
+    assert DIAGNOSIS_CUTOVER > datetime(2026, 1, 1, tzinfo=timezone.utc)

--- a/tests/unit/ops/test_run_trigger_attribution.py
+++ b/tests/unit/ops/test_run_trigger_attribution.py
@@ -92,6 +92,18 @@ class TestRoute:
         assert "trigger" in resp.json()["detail"]
 
     @pytest.mark.asyncio
+    async def test_attune_heal_reaches_subprocess_env(self, tmp_path, monkeypatch):
+        """Diagnostic runs stamp attune-heal end-to-end (adv-debugging RR-2)."""
+        app, runner = _make_app(tmp_path, monkeypatch)
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.post("/workflows/code-review/run", json={"trigger": "attune-heal"})
+            assert resp.status_code == 201
+            run = await _wait_terminal(runner, resp.json()["run_id"])
+        assert run.trigger == "attune-heal"
+        assert any("ENV_TRIGGER=attune-heal" in ln for ln in run.lines)
+
+    @pytest.mark.asyncio
     async def test_explicit_manual_is_accepted(self, tmp_path, monkeypatch):
         app, runner = _make_app(tmp_path, monkeypatch)
         transport = ASGITransport(app=app)


### PR DESCRIPTION
## Summary

Phase A of `docs/specs/advanced-debugging-plugin/` (tasks T1+T2, chair-approved): the substrate every later phase writes through.

- **T1 (RR-1)**: `DiagnosisRecord` + nested evidence/hypothesis dataclasses (`schema_version=1`, `config_used` stamped per the dissent register) in the telemetry models; `diagnosis_records.jsonl` as the telemetry layer's third canonical file — home-global resolution and rotate-to-archive shared with the run stream via a generalized `_rotate_stream_if_needed`; new `attune.diagnosis` package with the purity-ruled loader (counted drops: malformed/fixture/pre-cutover) and `records_for_run` (RR-3's idempotency lookup).
- **T2 (RR-2)**: `attune-heal` joins the trigger contract (`run_context`), the ops route validator, and the runner's env-export allowlist; the pipeline-learner corpus drops `attune-heal` records with a counted `dropped_attune_heal` stat — no diagnose-the-diagnosis feedback into the miner.
- **Deviation (recorded in decisions.md)**: `mining.py` untouched — corpus-layer exclusion makes tasks.md's manual-fraction change unreachable.

## Receipts

- **T1 live-fire**: the real failed run `63c533fb6e46` (2026-07-15 code-review, exit 1) diagnosed → persisted → reloaded with provenance intact.
- **T2 live-fire**: an `attune-heal`-stamped record written to the stream, then a mining pass omits it (`eligible=1, dropped_attune_heal=1`).
- Serial: 77 tests across diagnosis/trigger/corpus suites. Breadth: 2715 passed over telemetry/ops/pipeline_learner/diagnosis/models.
- Honest finding (decisions.md): the real canonical run stream doesn't exist yet — RR-1 readiness accumulation starts from zero as of 2026-07-20.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
