### PR TITLE
feat(diagnosis): Phase B engine — priors, evidence, panel, attune diagnose CLI

### DIFF
--- a/docs/specs/advanced-debugging-plugin/decisions.md
+++ b/docs/specs/advanced-debugging-plugin/decisions.md
@@ -97,3 +97,29 @@ affected tests serial; 2715-test breadth pass. **Honest finding:**
 the real canonical run stream does not exist yet — all post-cutover
 runs to date were suite-isolated; RR-1 readiness accumulation
 starts from zero as of 2026-07-20.
+
+## 2026-07-20 — Phase B executed (T3 + T4) with live-fire receipt
+
+Engine landed: priors recall (explicit degradation), deterministic
+bounded evidence packs, the seat panel on the shipped roundtable
+machinery, `engine.diagnose()`, and `attune diagnose <run_id>`.
+44 diagnosis tests serial; 724-test breadth.
+
+**T4 live-fire receipt (chair-armed spend, 2026-07-20).** A real
+keyless workflow failure was generated into the REAL canonical
+stream (run `85c88fd9…`, code-review, "path argument is required" —
+the stream's first real record), then `attune diagnose` ran with
+REAL seats: claude ABSENT (revoked OAuth — the absent-seat receipt
+observed live, 2 retry invocations), antigravity + codex answered
+independently; BOTH top hypotheses correctly identified the missing
+path argument (high confidence), both offered a distinct
+low-confidence regression alternative citing the git-log evidence;
+4 invocations under the cap of 10; no dissent (material agreement
+detected). DiagnosisRecord `3264a8f6107b` persisted to the real
+diagnosis stream with `config_used` stamped and reload verified.
+
+**Observation for Phase C/D tuning:** priors degraded
+`no-terms-extracted` — the symptom text ("path argument is
+required") carries no error-class/module tokens; term extraction
+should also derive terms from the workflow name and argument names.
+Recorded, not fixed here.

--- a/src/attune/cli_commands/diagnosis_commands.py
+++ b/src/attune/cli_commands/diagnosis_commands.py
@@ -1,0 +1,48 @@
+"""CLI command for the diagnosis engine (advanced-debugging-plugin T4).
+
+``attune diagnose <run_id>`` diagnoses one failed run from the
+canonical stream end-to-end (priors -> evidence -> panel) and persists
+the DiagnosisRecord. Exit codes: 0 diagnosis persisted, 1 source run
+not diagnosable, 2 unexpected engine failure.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under the Apache License, Version 2.0
+"""
+
+from __future__ import annotations
+
+from argparse import Namespace
+
+
+def cmd_diagnose(args: Namespace) -> int:
+    """Diagnose a failed workflow run and print the receipted summary."""
+    from attune.diagnosis.engine import DiagnosisSourceError, diagnose
+
+    try:
+        record = diagnose(args.run_id)
+    except DiagnosisSourceError as exc:
+        print(f"cannot diagnose: {exc}")
+        return 1
+    except Exception as exc:  # noqa: BLE001 — CLI boundary, report and exit
+        print(f"diagnosis failed unexpectedly: {type(exc).__name__}: {exc}")
+        return 2
+
+    print(f"diagnosis {record.diagnosis_id} for run {record.source_run_id}")
+    print(f"  workflow: {record.workflow_name}")
+    print(f"  symptom:  {record.symptom}")
+    if record.priors_degraded:
+        print(f"  priors:   degraded ({record.priors_degraded})")
+    else:
+        print(f"  priors:   {len(record.prior_lessons)} lesson(s) recalled")
+    panel = record.panel or {}
+    print(
+        f"  panel:    {len(panel.get('seats_invoked', []))} seat(s), "
+        f"{len(panel.get('absences', []))} absent, "
+        f"{panel.get('invocations', 0)} invocation(s)"
+    )
+    if record.synthesis:
+        print("\n" + record.synthesis)
+    if record.dissent:
+        print(f"\n{len(record.dissent)} unresolved dissent line(s) retained")
+    print("\npersisted to the canonical diagnosis stream")
+    return 0

--- a/src/attune/cli_minimal.py
+++ b/src/attune/cli_minimal.py
@@ -65,6 +65,7 @@ from attune.cli_commands.cost_commands import (
     cmd_costs_today,
 )
 from attune.cli_commands.curator import cmd_curator
+from attune.cli_commands.diagnosis_commands import cmd_diagnose
 from attune.cli_commands.gates_commands import cmd_gates_check
 from attune.cli_commands.help_commands import cmd_help
 from attune.cli_commands.memory_agent import cmd_memory_agent
@@ -200,6 +201,19 @@ def _add_workflow_subparsers(subparsers: argparse._SubParsersAction) -> None:
             "plan, research) are unaffected."
         ),
     )
+
+
+def _add_diagnose_subparser(subparsers: argparse._SubParsersAction) -> None:
+    """Attach the diagnosis-engine command (advanced-debugging-plugin).
+
+    Args:
+        subparsers: Parent subparsers action to attach to
+
+    """
+    diagnose_parser = subparsers.add_parser(
+        "diagnose", help="Diagnose a failed workflow run from the canonical stream"
+    )
+    diagnose_parser.add_argument("run_id", help="run_id of a failed run to diagnose")
 
 
 def _add_gates_subparsers(subparsers: argparse._SubParsersAction) -> None:
@@ -588,6 +602,7 @@ Documentation: https://smartaimemory.com/framework-docs/
     subparsers = parser.add_subparsers(dest="command", help="Available commands")
 
     _add_workflow_subparsers(subparsers)
+    _add_diagnose_subparser(subparsers)
     _add_gates_subparsers(subparsers)
     _add_telemetry_subparsers(subparsers)
     _add_costs_subparsers(subparsers)
@@ -656,6 +671,7 @@ _SUBCOMMAND_DISPATCH: dict[str, dict[str, object]] = {
 }
 
 _SIMPLE_DISPATCH: dict[str, object] = {
+    "diagnose": cmd_diagnose,
     "remember": cmd_remember,
     "forget": cmd_forget,
     "lessons": cmd_lessons,

--- a/src/attune/diagnosis/__init__.py
+++ b/src/attune/diagnosis/__init__.py
@@ -1,10 +1,17 @@
 """Advanced debugging plugin — the diagnose stage of the self-healing
 loop (docs/specs/advanced-debugging-plugin/).
 
-Phase A ships the substrate: the ``DiagnosisRecord`` store and loader.
-The engine (priors, evidence, panel) arrives in Phase B.
+Phase A ships the substrate (the ``DiagnosisRecord`` store and
+loader); Phase B ships the engine: lesson priors, the bounded
+evidence pack, the seat panel, and ``diagnose()`` — the one entry
+point the CLI, the ops endpoint (Phase C), and the triage routine
+(Phase D) all call.
 """
 
+from .config import DiagnosisConfig
+from .engine import DiagnosisSourceError, diagnose, find_source_run
+from .panel import PanelResult, convene_panel
+from .priors import PriorsResult, extract_error_terms, recall_priors
 from .store import (
     DIAGNOSIS_CUTOVER,
     DiagnosisLoadStats,
@@ -14,7 +21,16 @@ from .store import (
 
 __all__ = [
     "DIAGNOSIS_CUTOVER",
+    "DiagnosisConfig",
     "DiagnosisLoadStats",
+    "DiagnosisSourceError",
+    "PanelResult",
+    "PriorsResult",
+    "convene_panel",
+    "diagnose",
+    "extract_error_terms",
+    "find_source_run",
     "load_diagnoses",
+    "recall_priors",
     "records_for_run",
 ]

--- a/src/attune/diagnosis/config.py
+++ b/src/attune/diagnosis/config.py
@@ -1,0 +1,52 @@
+"""Diagnosis configuration — policy is data (advanced-debugging-plugin).
+
+The dissent register requires every ``DiagnosisRecord`` to carry the
+policy values used (``config_used``) rather than hard-coding them;
+this module is the single place those values live.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import asdict, dataclass, field
+from typing import Any
+
+#: Ordered confidence scale (weakest -> strongest). Hypothesis
+#: confidence values come from this scale; the fix loop (Phase D)
+#: compares against ``fix_proposal_threshold`` by index.
+DEFAULT_CONFIDENCE_SCALE = ("low", "medium", "high")
+
+
+@dataclass
+class DiagnosisConfig:
+    """Tunable policy for one diagnosis run."""
+
+    confidence_scale: tuple[str, ...] = DEFAULT_CONFIDENCE_SCALE
+    fix_proposal_threshold: str = "high"
+    panel_seats: int = 2
+    evidence_budget_bytes: int = 64 * 1024
+    triage_batch_max: int = 5
+    extra: dict[str, Any] = field(default_factory=dict)
+
+    def to_config_used(self) -> dict[str, Any]:
+        """The dict stamped into ``DiagnosisRecord.config_used``."""
+        data = asdict(self)
+        data["confidence_scale"] = list(self.confidence_scale)
+        return data
+
+    @classmethod
+    def from_env(cls) -> DiagnosisConfig:
+        """Build from ``ATTUNE_DIAGNOSIS_*`` env overrides (all optional)."""
+        cfg = cls()
+        threshold = os.environ.get("ATTUNE_DIAGNOSIS_FIX_THRESHOLD")
+        if threshold in cfg.confidence_scale:
+            cfg.fix_proposal_threshold = threshold
+        for attr, env in (
+            ("panel_seats", "ATTUNE_DIAGNOSIS_PANEL_SEATS"),
+            ("evidence_budget_bytes", "ATTUNE_DIAGNOSIS_EVIDENCE_BUDGET"),
+            ("triage_batch_max", "ATTUNE_DIAGNOSIS_TRIAGE_MAX"),
+        ):
+            raw = os.environ.get(env)
+            if raw and raw.isdigit() and int(raw) > 0:
+                setattr(cfg, attr, int(raw))
+        return cfg

--- a/src/attune/diagnosis/engine.py
+++ b/src/attune/diagnosis/engine.py
@@ -1,0 +1,131 @@
+"""Diagnosis engine — load, priors, evidence, panel, persist
+(advanced-debugging-plugin RR-4/RR-5, design.md §3).
+
+``diagnose(run_id)`` is the one entry point the CLI, the ops endpoint
+(Phase C), and the triage routine (Phase D) all call. Every stage
+writes into the DiagnosisRecord as it goes; the record persists even
+when later stages degrade — a diagnosis with an absent panel is still
+a diagnosis.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import uuid
+from collections.abc import Callable, Sequence
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from attune.models.telemetry.data_models import (
+    DiagnosisEvidence,
+    DiagnosisRecord,
+    WorkflowRunRecord,
+)
+from attune.models.telemetry.storage import TelemetryStore, _canonical_runs_file
+
+from .config import DiagnosisConfig
+from .evidence import build_evidence_pack, ops_log_tail, recent_git_context
+from .panel import convene_panel
+from .priors import extract_error_terms, recall_priors
+
+logger = logging.getLogger(__name__)
+
+
+class DiagnosisSourceError(ValueError):
+    """The named run cannot be diagnosed (missing, succeeded, or heal)."""
+
+
+def find_source_run(run_id: str, *, stream: Path | None = None) -> WorkflowRunRecord | None:
+    """Find a run record by id in the canonical stream (newest wins)."""
+    path = stream if stream is not None else _canonical_runs_file()
+    if not path.is_file():
+        return None
+    found: WorkflowRunRecord | None = None
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except OSError as exc:
+        logger.warning("diagnosis: run-stream read failed: %s", exc)
+        return None
+    for line in lines:
+        if not line.strip() or f'"{run_id}"' not in line:
+            continue
+        try:
+            data = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(data, dict) and data.get("run_id") == run_id:
+            try:
+                found = WorkflowRunRecord.from_dict(data)
+            except (TypeError, ValueError):
+                continue
+    return found
+
+
+def diagnose(
+    run_id: str,
+    config: DiagnosisConfig | None = None,
+    *,
+    store: TelemetryStore | None = None,
+    run_stream: Path | None = None,
+    redis_client: Any = None,
+    invoke_seat: Callable[[Sequence[str], str], tuple[int, str]] | None = None,
+    repo_root: Path | None = None,
+) -> DiagnosisRecord:
+    """Diagnose one failed run end-to-end and persist the record.
+
+    Raises:
+        DiagnosisSourceError: Unknown run, non-failed run, or an
+            ``attune-heal`` self-record (no diagnose-the-diagnosis).
+    """
+    config = config or DiagnosisConfig.from_env()
+    run = find_source_run(run_id, stream=run_stream)
+    if run is None:
+        raise DiagnosisSourceError(f"run {run_id!r} not found in the canonical stream")
+    if run.success:
+        raise DiagnosisSourceError(f"run {run_id!r} succeeded — nothing to diagnose")
+    if run.trigger == "attune-heal":
+        raise DiagnosisSourceError(f"run {run_id!r} is a diagnostic self-record")
+
+    symptom = str(run.error or f"workflow {run.workflow_name} failed")
+
+    # Priors BEFORE evidence gathering (RR-4) — degraded is explicit.
+    priors = recall_priors(
+        extract_error_terms(f"{symptom} {run.workflow_name}"), client=redis_client
+    )
+
+    evidence = build_evidence_pack(
+        run,
+        log_tail=ops_log_tail(run_id),
+        git_context=recent_git_context(repo_root),
+        budget_bytes=config.evidence_budget_bytes,
+    )
+    # Priors ride as a DISTINCT evidence kind — never merged (RR-4).
+    prior_entries = [
+        DiagnosisEvidence(kind="prior", source="lesson", content=lesson)
+        for lesson in priors.lessons
+    ]
+
+    panel_kwargs: dict[str, Any] = {}
+    if invoke_seat is not None:
+        panel_kwargs["invoke_seat"] = invoke_seat
+    panel = convene_panel(evidence, priors, config, **panel_kwargs)
+
+    record = DiagnosisRecord(
+        diagnosis_id=uuid.uuid4().hex[:12],
+        source_run_id=run_id,
+        workflow_name=run.workflow_name,
+        created_at=datetime.now(timezone.utc).isoformat(),
+        symptom=symptom,
+        prior_lessons=priors.lessons,
+        priors_degraded=priors.degraded,
+        evidence=prior_entries + evidence,
+        hypotheses=panel.hypotheses,
+        synthesis=panel.synthesis,
+        dissent=panel.dissent,
+        panel=panel.meta,
+        config_used=config.to_config_used(),
+    )
+    (store or TelemetryStore()).log_diagnosis(record)
+    return record

--- a/src/attune/diagnosis/evidence.py
+++ b/src/attune/diagnosis/evidence.py
@@ -1,0 +1,120 @@
+"""Bounded, deterministic evidence-pack assembly
+(advanced-debugging-plugin RR-4/RR-5).
+
+The pack is what every panel seat sees — identical, bounded, and
+assembled in a fixed value order so truncation is deterministic:
+run-record fields first (highest value), then the ops log tail, then
+source excerpts, then recent git context. Priors are NOT part of this
+module's output — they are a distinct evidence kind added by the
+engine, never merged with observed evidence (RR-4).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import subprocess
+from pathlib import Path
+
+from attune.models.telemetry.data_models import DiagnosisEvidence, WorkflowRunRecord
+
+logger = logging.getLogger(__name__)
+
+#: Max lines of ops-run log carried as evidence.
+LOG_TAIL_LINES = 40
+
+
+def ops_log_tail(run_id: str, *, ops_runs_dir: Path | None = None) -> str | None:
+    """Log tail from the ops dashboard's persisted run record, if any."""
+    if ops_runs_dir is None:
+        import os  # noqa: PLC0415
+
+        home = os.environ.get("ATTUNE_HOME")
+        attune_dir = Path(home).expanduser() if home else Path.home() / ".attune"
+        ops_runs_dir = attune_dir / "ops" / "runs"
+    if not ops_runs_dir.is_dir():
+        return None
+    for candidate in ops_runs_dir.glob(f"*/{run_id}.json"):
+        try:
+            data = json.loads(candidate.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        lines = data.get("lines")
+        if isinstance(lines, list):
+            return "\n".join(str(ln) for ln in lines[-LOG_TAIL_LINES:])
+    return None
+
+
+def recent_git_context(repo_root: Path | None = None, *, count: int = 5) -> str | None:
+    """``git log --oneline -<count>`` for the repo, or None off-repo."""
+    try:
+        proc = subprocess.run(  # noqa: S603 — fixed argv, no shell
+            ["git", "log", "--oneline", f"-{count}"],
+            cwd=str(repo_root) if repo_root else None,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    return proc.stdout.strip() or None if proc.returncode == 0 else None
+
+
+def build_evidence_pack(
+    run: WorkflowRunRecord,
+    *,
+    log_tail: str | None = None,
+    source_excerpts: dict[str, str] | None = None,
+    git_context: str | None = None,
+    budget_bytes: int = 64 * 1024,
+) -> list[DiagnosisEvidence]:
+    """Assemble observed-evidence entries under a hard byte budget.
+
+    Fixed value order: run record, log tail, source excerpts (sorted by
+    path for determinism), git context. The entry that crosses the
+    budget is truncated with a visible marker; later entries are
+    dropped entirely — bounded beats complete for seat context.
+    """
+    candidates: list[tuple[str, str]] = [
+        (
+            "run-record",
+            json.dumps(
+                {
+                    "run_id": run.run_id,
+                    "workflow": run.workflow_name,
+                    "trigger": run.trigger,
+                    "started_at": run.started_at,
+                    "success": run.success,
+                    "error": run.error,
+                    "tiers_used": run.tiers_used,
+                },
+                indent=2,
+            ),
+        )
+    ]
+    if log_tail:
+        candidates.append(("log-tail", log_tail))
+    for path in sorted(source_excerpts or {}):
+        candidates.append((f"source:{path}", (source_excerpts or {})[path]))
+    if git_context:
+        candidates.append(("git-log", git_context))
+
+    entries: list[DiagnosisEvidence] = []
+    remaining = budget_bytes
+    for source, content in candidates:
+        size = len(content.encode("utf-8"))
+        if size <= remaining:
+            entries.append(DiagnosisEvidence(kind="observed", source=source, content=content))
+            remaining -= size
+            continue
+        if remaining > 200:  # room for a useful truncated head
+            clipped = content.encode("utf-8")[: remaining - 60].decode("utf-8", "ignore")
+            entries.append(
+                DiagnosisEvidence(
+                    kind="observed",
+                    source=source,
+                    content=clipped + f"\n<TRUNCATED — budget {budget_bytes}B>",
+                )
+            )
+        break  # budget exhausted: later entries dropped, deterministically
+    return entries

--- a/src/attune/diagnosis/panel.py
+++ b/src/attune/diagnosis/panel.py
@@ -1,0 +1,217 @@
+"""The receipted diagnosis panel (advanced-debugging-plugin RR-5).
+
+Independent seats inspect the SAME bounded evidence pack (R1: text in,
+text out — seats never run tools) and return structured hypotheses;
+the moderator synthesis is DETERMINISTIC — parsed hypotheses ranked by
+confidence and seat agreement, with unresolved dissent retained, never
+a further LLM call. Failures map onto the shipped producing taxonomy
+(``SEAT_ABSENT``, ``BUDGET_EXHAUSTED``); an absent seat degrades the
+panel, it never blocks it.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass, field
+
+from attune.models.telemetry.data_models import DiagnosisEvidence, DiagnosisHypothesis
+from attune.roundtable.routine import SEAT_RECIPES, default_invoke_seat
+
+from .config import DiagnosisConfig
+from .priors import PriorsResult
+
+logger = logging.getLogger(__name__)
+
+#: Hard invocation ceiling, mirroring the producing run's R5 cap.
+MAX_INVOCATIONS = 10
+
+_BRIEF_TEMPLATE = """\
+You are one seat on a diagnosis panel for a failed attune workflow
+run. Other seats see the same evidence; you cannot see their answers.
+Analyze the evidence and reply in EXACTLY this format (1-3 hypotheses,
+most likely first; text only — do not run tools or take actions):
+
+HYPOTHESIS: <one-sentence root-cause statement>
+CONFIDENCE: <{scale}>
+SUPPORTING: <evidence source names that support it>
+CONTRADICTING: <evidence source names that cut against it, or "none">
+
+## Recalled lesson priors (historical, NOT observed evidence)
+{priors}
+
+## Observed evidence
+{evidence}
+"""
+
+_HYPOTHESIS_RE = re.compile(
+    r"HYPOTHESIS:\s*(?P<statement>.+?)\s*\n"
+    r"\s*CONFIDENCE:\s*(?P<confidence>[\w-]+)\s*\n"
+    r"(?:\s*SUPPORTING:\s*(?P<supporting>.*?)\s*\n)?"
+    r"(?:\s*CONTRADICTING:\s*(?P<contradicting>.*?)(?:\n|$))?",
+    re.IGNORECASE,
+)
+
+
+@dataclass
+class PanelResult:
+    """Everything the panel step contributes to a DiagnosisRecord."""
+
+    hypotheses: list[DiagnosisHypothesis] = field(default_factory=list)
+    synthesis: str | None = None
+    dissent: list[str] = field(default_factory=list)
+    meta: dict = field(default_factory=dict)  # -> DiagnosisRecord.panel
+
+
+def build_brief(
+    evidence: list[DiagnosisEvidence],
+    priors: PriorsResult,
+    config: DiagnosisConfig,
+) -> str:
+    """Render the seat brief — identical for every seat."""
+    priors_block = (
+        "\n".join(f"- {lesson}" for lesson in priors.lessons)
+        if priors.lessons
+        else f"(none — {priors.degraded or 'no priors'})"
+    )
+    evidence_block = "\n\n".join(f"### {e.source}\n{e.content}" for e in evidence)
+    return _BRIEF_TEMPLATE.format(
+        scale=" | ".join(config.confidence_scale),
+        priors=priors_block,
+        evidence=evidence_block,
+    )
+
+
+def parse_seat_reply(reply: str, seat: str, config: DiagnosisConfig) -> list[DiagnosisHypothesis]:
+    """Parse HYPOTHESIS blocks; unknown confidence values clamp to weakest."""
+    parsed: list[DiagnosisHypothesis] = []
+    for i, match in enumerate(_HYPOTHESIS_RE.finditer(reply or "")):
+        confidence = (match.group("confidence") or "").lower()
+        if confidence not in config.confidence_scale:
+            confidence = config.confidence_scale[0]
+        parsed.append(
+            DiagnosisHypothesis(
+                statement=f"[{seat}] {match.group('statement').strip()}",
+                rank=i + 1,
+                confidence=confidence,
+                supporting=_split_sources(match.group("supporting")),
+                contradicting=_split_sources(match.group("contradicting")),
+            )
+        )
+    return parsed
+
+
+def _split_sources(raw: str | None) -> list[str]:
+    if not raw or raw.strip().lower() in ("none", "n/a", "-"):
+        return []
+    return [s.strip() for s in re.split(r"[,;]", raw) if s.strip()]
+
+
+def convene_panel(
+    evidence: list[DiagnosisEvidence],
+    priors: PriorsResult,
+    config: DiagnosisConfig | None = None,
+    *,
+    seats: Sequence[tuple[str, tuple[str, ...]]] = SEAT_RECIPES,
+    invoke_seat: Callable[[Sequence[str], str], tuple[int, str]] = default_invoke_seat,
+    max_invocations: int = MAX_INVOCATIONS,
+) -> PanelResult:
+    """Convene up to ``config.panel_seats`` seats; degrade, never block."""
+    config = config or DiagnosisConfig()
+    brief = build_brief(evidence, priors, config)
+    hypotheses: list[DiagnosisHypothesis] = []
+    seats_invoked: list[str] = []
+    absences: list[dict[str, str]] = []
+    failure_codes: list[str] = []
+    invocations = 0
+
+    for seat, recipe in seats[: max(1, config.panel_seats)]:
+        reply = ""
+        ok = False
+        for _attempt in range(2):  # one retry, mirroring producing
+            if invocations >= max_invocations:
+                failure_codes.append("BUDGET_EXHAUSTED")
+                break
+            invocations += 1
+            code, reply = invoke_seat(recipe, brief)
+            ok = code == 0 and bool(reply.strip())
+            if ok:
+                break
+        if not ok:
+            if "BUDGET_EXHAUSTED" not in failure_codes or invocations < max_invocations:
+                failure_codes.append("SEAT_ABSENT")
+            absences.append({"seat": seat, "reason": (reply or "no reply")[-300:]})
+            continue
+        seats_invoked.append(seat)
+        hypotheses.extend(parse_seat_reply(reply, seat, config))
+
+    ranked = _rank(hypotheses, config)
+    dissent = _detect_dissent(ranked, seats_invoked)
+    return PanelResult(
+        hypotheses=ranked,
+        synthesis=_synthesize(ranked, dissent, seats_invoked, absences),
+        dissent=dissent,
+        meta={
+            "seats_invoked": seats_invoked,
+            "absences": absences,
+            "failure_codes": failure_codes,
+            "invocations": invocations,
+        },
+    )
+
+
+def _rank(
+    hypotheses: list[DiagnosisHypothesis], config: DiagnosisConfig
+) -> list[DiagnosisHypothesis]:
+    """Strongest confidence first; stable within a level (seat order)."""
+    order = {level: i for i, level in enumerate(config.confidence_scale)}
+    ranked = sorted(hypotheses, key=lambda h: -order.get(h.confidence, 0))
+    for i, hyp in enumerate(ranked):
+        hyp.rank = i + 1
+    return ranked
+
+
+def _detect_dissent(ranked: list[DiagnosisHypothesis], seats_invoked: list[str]) -> list[str]:
+    """Record top-hypothesis disagreement between seats — kept, not merged."""
+    if len(seats_invoked) < 2 or not ranked:
+        return []
+    tops: dict[str, str] = {}
+    for hyp in ranked:
+        seat = hyp.statement.split("]", 1)[0].lstrip("[")
+        tops.setdefault(seat, hyp.statement)
+    statements = list(tops.values())
+    dissent: list[str] = []
+    for i, a in enumerate(statements):
+        for b in statements[i + 1 :]:
+            if not _overlaps(a, b):
+                dissent.append(f"top hypotheses diverge: {a!r} vs {b!r}")
+    return dissent
+
+
+def _overlaps(a: str, b: str) -> bool:
+    """Cheap material-agreement test: shared significant tokens."""
+    tok = lambda s: {w.lower() for w in re.findall(r"[A-Za-z_]{4,}", s)}  # noqa: E731
+    shared = tok(a) & tok(b)
+    return len(shared) >= 3
+
+
+def _synthesize(
+    ranked: list[DiagnosisHypothesis],
+    dissent: list[str],
+    seats_invoked: list[str],
+    absences: list[dict[str, str]],
+) -> str | None:
+    """Deterministic moderator summary — assembled, never generated."""
+    if not ranked and not absences:
+        return None
+    lines = [f"panel: {len(seats_invoked)} seat(s) answered, {len(absences)} absent"]
+    for hyp in ranked[:5]:
+        support = ", ".join(hyp.supporting) or "unstated"
+        against = ", ".join(hyp.contradicting) or "none"
+        lines.append(
+            f"#{hyp.rank} [{hyp.confidence}] {hyp.statement} "
+            f"(for: {support}; against: {against})"
+        )
+    lines.extend(f"DISSENT: {d}" for d in dissent)
+    return "\n".join(lines)

--- a/src/attune/diagnosis/priors.py
+++ b/src/attune/diagnosis/priors.py
@@ -1,0 +1,122 @@
+"""Lesson-prior recall — the diagnoser remembers before it spelunks
+(advanced-debugging-plugin RR-4).
+
+Queries the ``idx:attune_memory`` index (kept warm by the SessionStart
+hydration hook) with terms extracted from the failure's error shape.
+Redis unavailability degrades to an EXPLICIT no-priors state recorded
+on the DiagnosisRecord — never a silent skip, never a block (RR-4
+inverts the usual degrade-silently memory rule: the record must say
+why priors are missing).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+from dataclasses import dataclass, field
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+MEMORY_INDEX = "idx:attune_memory"
+
+#: Error-shape token patterns, in extraction order: exception classes
+#: (``ValueError``), dotted module paths (``attune.ops.runner``),
+#: backtick-quoted names, and ``*.py`` basenames.
+_TERM_PATTERNS = (
+    re.compile(r"\b[A-Z][A-Za-z0-9_]*(?:Error|Exception)\b"),
+    re.compile(r"\b[a-z_][a-z0-9_]*(?:\.[a-z_][a-z0-9_]+){1,}\b"),
+    re.compile(r"`([^`\n]{2,60})`"),
+    re.compile(r"\b([A-Za-z0-9_]+\.py)\b"),
+)
+
+
+def extract_error_terms(text: str, *, limit: int = 8) -> list[str]:
+    """Extract dedup'd error-shape terms from failure text."""
+    terms: list[str] = []
+    for pattern in _TERM_PATTERNS:
+        for match in pattern.findall(text or ""):
+            token = match.strip() if isinstance(match, str) else match[0].strip()
+            if token and token not in terms:
+                terms.append(token)
+            if len(terms) >= limit:
+                return terms
+    return terms
+
+
+@dataclass
+class PriorsResult:
+    """Recalled lesson priors, or an explicit reason there are none."""
+
+    lessons: list[str] = field(default_factory=list)  # "name — description"
+    degraded: str | None = None
+
+
+def recall_priors(
+    terms: list[str],
+    *,
+    client: Any = None,
+    limit: int = 5,
+) -> PriorsResult:
+    """OR-join ``terms`` against the memory index; degrade explicitly.
+
+    Args:
+        terms: Error-shape terms from :func:`extract_error_terms`.
+        client: Optional connected ``redis.Redis`` (tests inject this).
+            When None, one is created from ``REDIS_URL``.
+        limit: Max lessons returned.
+    """
+    if not terms:
+        return PriorsResult(degraded="no-terms-extracted")
+    if client is None:
+        try:
+            import redis  # noqa: PLC0415 — optional dependency
+        except ImportError:
+            return PriorsResult(degraded="redis-package-not-installed")
+        url = os.environ.get("REDIS_URL", "redis://127.0.0.1:6379/0")
+        client = redis.Redis.from_url(url, decode_responses=True, socket_connect_timeout=2)
+    # OR-join (plain multi-word queries AND-join and miss paraphrases).
+    query = "|".join(t.replace("|", " ") for t in terms)
+    try:
+        raw = client.execute_command(
+            "FT.SEARCH",
+            MEMORY_INDEX,
+            query,
+            "RETURN",
+            "2",
+            "name",
+            "description",
+            "LIMIT",
+            "0",
+            str(limit),
+        )
+    except Exception as exc:  # noqa: BLE001 — any transport error degrades
+        logger.debug("diagnosis priors recall failed: %s", exc)
+        return PriorsResult(degraded=f"recall-failed: {type(exc).__name__}")
+    return PriorsResult(lessons=_parse_search_reply(raw))
+
+
+def _parse_search_reply(raw: Any) -> list[str]:
+    """Parse an FT.SEARCH reply: [count, key, [f, v, ...], key, ...]."""
+    lessons: list[str] = []
+    if not isinstance(raw, list | tuple) or len(raw) < 3:
+        return lessons
+    for i in range(2, len(raw), 2):
+        fields_raw = raw[i]
+        if not isinstance(fields_raw, list | tuple):
+            continue
+        pairs = {
+            _text(fields_raw[j]): _text(fields_raw[j + 1]) for j in range(0, len(fields_raw) - 1, 2)
+        }
+        name = pairs.get("name", "")
+        description = pairs.get("description", "")
+        if name or description:
+            lessons.append(f"{name} — {description}".strip(" —"))
+    return lessons
+
+
+def _text(value: Any) -> str:
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="replace")
+    return str(value)

--- a/tests/unit/diagnosis/test_engine.py
+++ b/tests/unit/diagnosis/test_engine.py
@@ -1,0 +1,141 @@
+"""Engine tests (advanced-debugging-plugin T3/T4) — refusal rules and
+the end-to-end pipeline with mocked seats and a fake Redis client.
+"""
+
+import json
+
+import pytest
+
+from attune.diagnosis import records_for_run
+from attune.diagnosis.config import DiagnosisConfig
+from attune.diagnosis.engine import DiagnosisSourceError, diagnose, find_source_run
+from attune.models.telemetry.storage import TelemetryStore
+
+_REPLY = (
+    "HYPOTHESIS: the SDK subprocess lost auth\n"
+    "CONFIDENCE: medium\n"
+    "SUPPORTING: run-record\n"
+    "CONTRADICTING: none\n"
+)
+
+
+def _stream(tmp_path, records):
+    path = tmp_path / "workflow_runs.jsonl"
+    path.write_text("\n".join(json.dumps(r) for r in records) + "\n", encoding="utf-8")
+    return path
+
+
+def _failed(run_id="run-f", trigger="manual", success=False):
+    return {
+        "run_id": run_id,
+        "workflow_name": "code-review",
+        "started_at": "2026-07-20T12:00:00+00:00",
+        "trigger": trigger,
+        "project": "attune-ai",
+        "success": success,
+        "error": "ValueError in attune.ops.runner",
+    }
+
+
+def _invoke(recipe, brief):
+    return 0, _REPLY
+
+
+class _NoRedis:
+    def execute_command(self, *args):
+        raise ConnectionError("test: no redis")
+
+
+class TestRefusals:
+    def test_unknown_run_refused(self, tmp_path):
+        stream = _stream(tmp_path, [_failed()])
+        with pytest.raises(DiagnosisSourceError, match="not found"):
+            diagnose("missing", run_stream=stream)
+
+    def test_successful_run_refused(self, tmp_path):
+        stream = _stream(tmp_path, [_failed(run_id="run-ok", success=True)])
+        with pytest.raises(DiagnosisSourceError, match="succeeded"):
+            diagnose("run-ok", run_stream=stream)
+
+    def test_attune_heal_run_refused(self, tmp_path):
+        stream = _stream(tmp_path, [_failed(run_id="run-h", trigger="attune-heal")])
+        with pytest.raises(DiagnosisSourceError, match="self-record"):
+            diagnose("run-h", run_stream=stream)
+
+
+class TestFindSourceRun:
+    def test_finds_by_id_newest_wins(self, tmp_path):
+        older = _failed()
+        newer = dict(_failed(), error="newer version of the record")
+        stream = _stream(tmp_path, [older, newer])
+        found = find_source_run("run-f", stream=stream)
+        assert found is not None and found.error == "newer version of the record"
+
+    def test_missing_stream_is_none(self, tmp_path):
+        assert find_source_run("x", stream=tmp_path / "absent.jsonl") is None
+
+
+class TestEndToEnd:
+    def test_pipeline_persists_receipted_record(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("ATTUNE_HOME", str(tmp_path / "home"))
+        stream = _stream(tmp_path, [_failed()])
+        store = TelemetryStore()
+
+        record = diagnose(
+            "run-f",
+            DiagnosisConfig(),
+            store=store,
+            run_stream=stream,
+            redis_client=_NoRedis(),
+            invoke_seat=_invoke,
+            repo_root=tmp_path,  # off-repo: git context degrades to None
+        )
+
+        # Priors degraded EXPLICITLY, never silently (RR-4)
+        assert record.priors_degraded == "recall-failed: ConnectionError"
+        assert record.prior_lessons == []
+        # Observed evidence present; no prior-kind entries when degraded
+        kinds = {e.kind for e in record.evidence}
+        assert kinds == {"observed"}
+        # Panel ran with mocked seats and produced ranked hypotheses
+        assert record.hypotheses and record.hypotheses[0].confidence == "medium"
+        assert record.panel["seats_invoked"]
+        # Policy is data (dissent register)
+        assert record.config_used["fix_proposal_threshold"] == "high"
+        # Persisted to the isolated canonical stream and reloadable
+        reloaded = records_for_run("run-f")
+        assert [r.diagnosis_id for r in reloaded] == [record.diagnosis_id]
+
+    def test_lessons_become_prior_kind_evidence(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("ATTUNE_HOME", str(tmp_path / "home"))
+        stream = _stream(tmp_path, [_failed()])
+
+        class _Hit:
+            def execute_command(self, *args):
+                return [1, "k", ["name", "mapping-trap", "description", "main shadows"]]
+
+        record = diagnose(
+            "run-f",
+            DiagnosisConfig(),
+            store=TelemetryStore(),
+            run_stream=stream,
+            redis_client=_Hit(),
+            invoke_seat=_invoke,
+            repo_root=tmp_path,
+        )
+        assert record.prior_lessons == ["mapping-trap — main shadows"]
+        priors = [e for e in record.evidence if e.kind == "prior"]
+        observed = [e for e in record.evidence if e.kind == "observed"]
+        assert priors and observed  # distinct kinds, both present (RR-4)
+
+
+class TestCli:
+    def test_cmd_diagnose_reports_refusal_as_exit_1(self, tmp_path, monkeypatch, capsys):
+        from argparse import Namespace
+
+        from attune.cli_commands.diagnosis_commands import cmd_diagnose
+
+        monkeypatch.setenv("ATTUNE_HOME", str(tmp_path / "home"))
+        code = cmd_diagnose(Namespace(run_id="nope"))
+        assert code == 1
+        assert "cannot diagnose" in capsys.readouterr().out

--- a/tests/unit/diagnosis/test_panel.py
+++ b/tests/unit/diagnosis/test_panel.py
@@ -1,0 +1,130 @@
+"""Panel tests (advanced-debugging-plugin T4) — panel LOGIC under
+mocked seats; LLM output quality is not under test here.
+"""
+
+from attune.diagnosis.config import DiagnosisConfig
+from attune.diagnosis.panel import (
+    build_brief,
+    convene_panel,
+    parse_seat_reply,
+)
+from attune.diagnosis.priors import PriorsResult
+from attune.models.telemetry.data_models import DiagnosisEvidence
+
+_EVIDENCE = [DiagnosisEvidence(kind="observed", source="run-record", content='{"x":1}')]
+
+_REPLY_HIGH = (
+    "HYPOTHESIS: stale editable-install MAPPING points at main\n"
+    "CONFIDENCE: high\n"
+    "SUPPORTING: run-record\n"
+    "CONTRADICTING: none\n"
+)
+_REPLY_LOW = (
+    "HYPOTHESIS: transient network failure during SDK call\n"
+    "CONFIDENCE: low\n"
+    "SUPPORTING: log-tail\n"
+    "CONTRADICTING: run-record\n"
+)
+
+
+def _seats(replies):
+    """Build a fake roster + invoker: seat name -> (code, reply)."""
+    roster = tuple((name, (name, "-")) for name in replies)
+    calls = []
+
+    def invoke(recipe, brief):
+        calls.append(recipe[0])
+        return replies[recipe[0]]
+
+    return roster, invoke, calls
+
+
+class TestParsing:
+    def test_parses_structured_blocks(self):
+        cfg = DiagnosisConfig()
+        parsed = parse_seat_reply(_REPLY_HIGH + "\n" + _REPLY_LOW, "codex", cfg)
+        assert len(parsed) == 2
+        assert parsed[0].statement.startswith("[codex] stale editable-install")
+        assert parsed[0].confidence == "high"
+        assert parsed[0].supporting == ["run-record"]
+        assert parsed[1].contradicting == ["run-record"]
+
+    def test_unknown_confidence_clamps_to_weakest(self):
+        cfg = DiagnosisConfig()
+        reply = "HYPOTHESIS: something\nCONFIDENCE: absolutely-certain\n"
+        assert parse_seat_reply(reply, "s", cfg)[0].confidence == "low"
+
+    def test_freeform_reply_yields_no_hypotheses(self):
+        assert parse_seat_reply("I think it broke somehow.", "s", DiagnosisConfig()) == []
+
+
+class TestConvene:
+    def test_two_seats_ranked_by_confidence(self):
+        roster, invoke, calls = _seats({"alpha": (0, _REPLY_LOW), "beta": (0, _REPLY_HIGH)})
+        result = convene_panel(
+            _EVIDENCE, PriorsResult(), DiagnosisConfig(), seats=roster, invoke_seat=invoke
+        )
+        assert result.meta["seats_invoked"] == ["alpha", "beta"]
+        assert result.hypotheses[0].confidence == "high"  # beta's outranks alpha's
+        assert result.hypotheses[0].rank == 1
+        assert calls == ["alpha", "beta"]
+
+    def test_absent_seat_degrades_never_blocks(self):
+        roster, invoke, calls = _seats({"alpha": (1, "401 revoked"), "beta": (0, _REPLY_HIGH)})
+        result = convene_panel(
+            _EVIDENCE, PriorsResult(), DiagnosisConfig(), seats=roster, invoke_seat=invoke
+        )
+        assert result.meta["seats_invoked"] == ["beta"]
+        assert result.meta["absences"][0]["seat"] == "alpha"
+        assert "401 revoked" in result.meta["absences"][0]["reason"]
+        assert "SEAT_ABSENT" in result.meta["failure_codes"]
+        assert calls == ["alpha", "alpha", "beta"]  # one retry then move on
+        assert result.hypotheses  # the panel still produced output
+
+    def test_invocation_cap_enforced(self):
+        roster, invoke, _calls = _seats({"alpha": (0, _REPLY_HIGH), "beta": (0, _REPLY_LOW)})
+        result = convene_panel(
+            _EVIDENCE,
+            PriorsResult(),
+            DiagnosisConfig(),
+            seats=roster,
+            invoke_seat=invoke,
+            max_invocations=1,
+        )
+        assert result.meta["invocations"] == 1
+        assert "BUDGET_EXHAUSTED" in result.meta["failure_codes"]
+        assert result.meta["seats_invoked"] == ["alpha"]
+
+    def test_dissent_retained_when_tops_diverge(self):
+        roster, invoke, _calls = _seats({"alpha": (0, _REPLY_HIGH), "beta": (0, _REPLY_LOW)})
+        result = convene_panel(
+            _EVIDENCE, PriorsResult(), DiagnosisConfig(), seats=roster, invoke_seat=invoke
+        )
+        assert result.dissent, "diverging top hypotheses must register dissent"
+        assert any("DISSENT" in line for line in (result.synthesis or "").splitlines())
+
+    def test_all_seats_absent_yields_empty_but_receipted_panel(self):
+        roster, invoke, _calls = _seats({"alpha": (1, ""), "beta": (1, "")})
+        result = convene_panel(
+            _EVIDENCE, PriorsResult(), DiagnosisConfig(), seats=roster, invoke_seat=invoke
+        )
+        assert result.hypotheses == []
+        assert len(result.meta["absences"]) == 2
+        assert result.synthesis is not None  # absences are still receipted
+
+
+class TestBrief:
+    def test_brief_separates_priors_from_observed(self):
+        brief = build_brief(
+            _EVIDENCE,
+            PriorsResult(lessons=["mapping-trap — main shadows worktree"]),
+            DiagnosisConfig(),
+        )
+        assert "Recalled lesson priors" in brief
+        assert "NOT observed evidence" in brief
+        assert "mapping-trap" in brief
+        assert "### run-record" in brief
+
+    def test_degraded_priors_shown_explicitly(self):
+        brief = build_brief(_EVIDENCE, PriorsResult(degraded="redis-down"), DiagnosisConfig())
+        assert "redis-down" in brief

--- a/tests/unit/diagnosis/test_priors_evidence.py
+++ b/tests/unit/diagnosis/test_priors_evidence.py
@@ -1,0 +1,140 @@
+"""Phase B front-half tests (advanced-debugging-plugin T3).
+
+Priors: term extraction, explicit degraded modes, prior/observed
+separation. Evidence: deterministic bounded assembly.
+"""
+
+import json
+
+from attune.diagnosis.evidence import build_evidence_pack, ops_log_tail
+from attune.diagnosis.priors import (
+    extract_error_terms,
+    recall_priors,
+)
+from attune.models.telemetry.data_models import WorkflowRunRecord
+
+
+def _run(**overrides) -> WorkflowRunRecord:
+    base = {
+        "run_id": "run-1",
+        "workflow_name": "code-review",
+        "started_at": "2026-07-20T12:00:00+00:00",
+        "success": False,
+        "error": "ValueError in attune.ops.runner during `start_run`",
+    }
+    base.update(overrides)
+    return WorkflowRunRecord(**base)
+
+
+class TestTermExtraction:
+    def test_extracts_error_classes_paths_and_backticks(self):
+        terms = extract_error_terms(
+            "ValueError in attune.ops.runner while calling `start_run` (runner.py)"
+        )
+        assert "ValueError" in terms
+        assert "attune.ops.runner" in terms
+        assert "start_run" in terms
+        assert "runner.py" in terms
+
+    def test_dedupes_and_caps(self):
+        text = "TimeoutError TimeoutError " + " ".join(f"mod.pkg{i}" for i in range(20))
+        terms = extract_error_terms(text, limit=5)
+        assert len(terms) == 5
+        assert terms.count("TimeoutError") == 1
+
+    def test_empty_text_yields_no_terms(self):
+        assert extract_error_terms("") == []
+
+
+class _FakeRedis:
+    def __init__(self, reply=None, exc=None):
+        self.reply = reply
+        self.exc = exc
+        self.commands = []
+
+    def execute_command(self, *args):
+        self.commands.append(args)
+        if self.exc:
+            raise self.exc
+        return self.reply
+
+
+class TestRecallPriors:
+    def test_no_terms_is_explicitly_degraded(self):
+        result = recall_priors([])
+        assert result.lessons == []
+        assert result.degraded == "no-terms-extracted"
+
+    def test_parses_search_reply_and_or_joins(self):
+        reply = [
+            2,
+            "attune:memory:lesson:1",
+            ["name", "mapping-trap", "description", "editable install maps to main"],
+            "attune:memory:lesson:2",
+            [b"name", b"stash-dance", b"description", b"pre-commit stash conflict"],
+        ]
+        client = _FakeRedis(reply=reply)
+        result = recall_priors(["ValueError", "runner.py"], client=client)
+        assert result.degraded is None
+        assert result.lessons == [
+            "mapping-trap — editable install maps to main",
+            "stash-dance — pre-commit stash conflict",
+        ]
+        # OR-join, not AND-join (paraphrase-miss lesson)
+        assert "ValueError|runner.py" in client.commands[0]
+
+    def test_transport_failure_degrades_with_reason(self):
+        client = _FakeRedis(exc=ConnectionError("refused"))
+        result = recall_priors(["ValueError"], client=client)
+        assert result.lessons == []
+        assert result.degraded == "recall-failed: ConnectionError"
+
+
+class TestEvidencePack:
+    def test_fixed_order_and_kinds(self):
+        entries = build_evidence_pack(
+            _run(),
+            log_tail="line1\nline2",
+            source_excerpts={"b.py": "bbb", "a.py": "aaa"},
+            git_context="abc123 fix",
+        )
+        assert [e.source for e in entries] == [
+            "run-record",
+            "log-tail",
+            "source:a.py",
+            "source:b.py",
+            "git-log",
+        ]
+        assert all(e.kind == "observed" for e in entries)
+        assert "run-1" in entries[0].content
+
+    def test_budget_truncates_deterministically(self):
+        entries = build_evidence_pack(
+            _run(),
+            log_tail="x" * 10_000,
+            git_context="never-reached",
+            budget_bytes=1_000,
+        )
+        assert entries[0].source == "run-record"  # highest value survives whole
+        assert entries[1].source == "log-tail"
+        assert "<TRUNCATED" in entries[1].content
+        assert all(e.source != "git-log" for e in entries)  # dropped past budget
+
+    def test_identical_inputs_identical_pack(self):
+        kwargs = {"log_tail": "t", "source_excerpts": {"a.py": "a"}, "git_context": "g"}
+        assert build_evidence_pack(_run(), **kwargs) == build_evidence_pack(_run(), **kwargs)
+
+
+class TestOpsLogTail:
+    def test_reads_persisted_ops_record(self, tmp_path):
+        wf_dir = tmp_path / "code-review"
+        wf_dir.mkdir(parents=True)
+        (wf_dir / "abc123.json").write_text(
+            json.dumps({"lines": [f"line-{i}" for i in range(60)]}), encoding="utf-8"
+        )
+        tail = ops_log_tail("abc123", ops_runs_dir=tmp_path)
+        assert tail is not None
+        assert "line-59" in tail and "line-10" not in tail  # last 40 only
+
+    def test_missing_record_is_none(self, tmp_path):
+        assert ops_log_tail("nope", ops_runs_dir=tmp_path) is None


### PR DESCRIPTION
## Summary

Phase B of `docs/specs/advanced-debugging-plugin/` (T3+T4, chair-approved): the diagnosis engine.

- **T3 (RR-4)**: error-shape term extraction + lesson-prior recall against `idx:attune_memory` (OR-joined; Redis-down degrades to an explicit `priors_degraded` reason on the record — never silent, never blocking); deterministic bounded evidence packs (fixed value order, byte budget, visible truncation); ops log-tail + git-context gatherers.
- **T4 (RR-5)**: the diagnosis panel on the shipped roundtable seat machinery — ≥2 independent seats over an identical brief, structured hypothesis parsing (unknown confidence clamps to weakest), deterministic moderator synthesis (ranked, dissent retained, absences receipted), failures on the producing taxonomy under the R5 cap. `engine.diagnose()` composes load → priors → evidence → panel → persist with refusal rules; `attune diagnose <run_id>` wires the CLI.

## Receipts (decisions.md Phase B closure)

- **Live-fire with real seats** (chair-armed): a real keyless failure became the canonical stream's first real record; `attune diagnose` ran the full pipeline — claude seat ABSENT live (revoked OAuth, receipted), Antigravity + Codex both independently identified the true root cause at high confidence; `DiagnosisRecord` persisted + reload-verified, 4 invocations under the cap of 10.
- 44 diagnosis tests serial; 724-test breadth over diagnosis/telemetry/cli/roundtable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
