### PR TITLE
docs(spec): claim-drift-gates — D7/D8 chair-ruled, all decisions resolved

### DIFF
--- a/docs/specs/claim-drift-gates/decisions.md
+++ b/docs/specs/claim-drift-gates/decisions.md
@@ -119,3 +119,19 @@ Patrick approved the spec as drafted. D1, D2, D3, D5, D6 ratified;
 D4 (workflow-count wording), D7 (pre-commit scope for test gates),
 and D8 (inverse command report) remain open. G1's claim manifest
 is the only work item blocked on an open decision (D4).
+
+## 2026-07-20 — D7 and D8 ruled (chair: Patrick, via briefing triage)
+
+- **D7 RULED: CI-only for the test gates (G1/G2/G3); pre-commit
+  carries G5 only.** The spec's stated default, ratified as-is:
+  pre-commit's isolated env can't guarantee an importable `attune`
+  for all contributors. Revisit only if drift keeps reaching CI.
+- **D8 RULED: report-only (non-gating).** The inverse-direction
+  report (exists-but-unadvertised commands) ships as a warning-tier
+  report; reassess after a month of real output. Gating would
+  manufacture failures for deliberate soft-launches; dropping it
+  loses a cheap signal.
+
+With D4 (2026-07-12) and these two, every open decision on this
+spec is resolved — implementation (G1 first per the ship order) is
+fully unblocked.

--- a/docs/specs/claim-drift-gates/requirements.md
+++ b/docs/specs/claim-drift-gates/requirements.md
@@ -1,6 +1,6 @@
 # Spec: Claim-drift gates
 
-**Status:** approved (2026-07-11) — see `decisions.md`; D4 ratified 2026-07-12 (option a, "20 workflows"); D7, D8 remain open; G1's claim manifest is now unblocked
+**Status:** approved (2026-07-11) — see `decisions.md`; D4 ratified 2026-07-12 (option a, "20 workflows"); D7, D8 ruled 2026-07-20 (CI-only test gates; report-only inverse) — all decisions resolved
 **Opened:** 2026-07-11
 **Layer:** attune-ai (tests / pre-commit / docs / plugin metadata)
 **Owner:** Patrick + agent


### PR DESCRIPTION
D7 ruled: test gates (G1/G2/G3) CI-only, G5 in pre-commit (importable-`attune` constraint on isolated envs). D8 ruled: inverse-direction (exists-but-unadvertised) report ships **report-only**, reassess after a month. Both are the spec's own stated defaults, ratified via the ops Briefing triage card; requirements status line amended in the same commit. Clears the top warning on the Briefing tab and fully unblocks G1 implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)