### PR TITLE
feat(ops): Phase C on-demand diagnosis surface — endpoint, run-view button, heal dispatch

### DIFF
--- a/docs/specs/advanced-debugging-plugin/decisions.md
+++ b/docs/specs/advanced-debugging-plugin/decisions.md
@@ -123,3 +123,29 @@ diagnosis stream with `config_used` stamped and reload verified.
 required") carries no error-class/module tokens; term extraction
 should also derive terms from the workflow name and argument names.
 Recorded, not fixed here.
+
+## 2026-07-20 — Phase C executed (T5)
+
+On-demand surface landed: `POST /runs/{run_id}/diagnose` (token +
+allow-run gated, failed-terminal-only, attune-heal sources
+refused, idempotent via `records_for_run`), dispatching ONE runner
+subprocess `attune diagnose <run_id>` stamped `attune-heal`; the
+run-view "Why did this fail?" button (terminal-failed runs only,
+explicit click, never auto-starts) and the "diagnosed" chip;
+`Run.extra_args` threading + a `diagnose` case in the runner's
+command builder.
+
+**Design deviation (recorded):** dashboard run ids (12-hex) and
+telemetry run ids (uuid4) are DIFFERENT id spaces —
+`find_source_run` gained an ops-record fallback that synthesizes a
+source `WorkflowRunRecord` from the persisted ops run, so the
+button's ops id diagnoses correctly.
+
+**Receipts:** endpoint suite incl. a real subprocess dispatch
+round-trip observing `ATTUNE_RUN_TRIGGER=attune-heal` + the source
+run id in the child argv; 1516-test ops+diagnosis breadth;
+source-level no-auto-start guards; BROWSER receipt — the ops
+dashboard restarted on worktree code (launch.json MAPPING fix,
+local-only) renders the button beside the failed chip on the real
+2026-07-15 run `63c533fb6e46`. The button was deliberately NOT
+clicked — a click launches a billable panel run (spend-gated).

--- a/src/attune/diagnosis/engine.py
+++ b/src/attune/diagnosis/engine.py
@@ -38,29 +38,68 @@ class DiagnosisSourceError(ValueError):
 
 
 def find_source_run(run_id: str, *, stream: Path | None = None) -> WorkflowRunRecord | None:
-    """Find a run record by id in the canonical stream (newest wins)."""
+    """Find a run record by id — canonical stream first, ops store second.
+
+    Dashboard (ops) run ids and telemetry run ids are DIFFERENT id
+    spaces: the runner allocates 12-hex ids while the telemetry seam
+    allocates uuid4. The run-view "Why did this fail?" button hands us
+    an ops id, so a miss in the canonical stream falls back to the
+    persisted ops record, synthesized into a ``WorkflowRunRecord``
+    (design deviation recorded in decisions.md, Phase C).
+    """
     path = stream if stream is not None else _canonical_runs_file()
-    if not path.is_file():
-        return None
     found: WorkflowRunRecord | None = None
-    try:
-        lines = path.read_text(encoding="utf-8").splitlines()
-    except OSError as exc:
-        logger.warning("diagnosis: run-stream read failed: %s", exc)
-        return None
-    for line in lines:
-        if not line.strip() or f'"{run_id}"' not in line:
-            continue
+    if path.is_file():
         try:
-            data = json.loads(line)
-        except json.JSONDecodeError:
-            continue
-        if isinstance(data, dict) and data.get("run_id") == run_id:
-            try:
-                found = WorkflowRunRecord.from_dict(data)
-            except (TypeError, ValueError):
+            lines = path.read_text(encoding="utf-8").splitlines()
+        except OSError as exc:
+            logger.warning("diagnosis: run-stream read failed: %s", exc)
+            lines = []
+        for line in lines:
+            if not line.strip() or f'"{run_id}"' not in line:
                 continue
-    return found
+            try:
+                data = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(data, dict) and data.get("run_id") == run_id:
+                try:
+                    found = WorkflowRunRecord.from_dict(data)
+                except (TypeError, ValueError):
+                    continue
+    if found is not None or stream is not None:
+        return found
+    return _source_from_ops_record(run_id)
+
+
+def _source_from_ops_record(run_id: str) -> WorkflowRunRecord | None:
+    """Synthesize a source record from a persisted ops dashboard run."""
+    import os  # noqa: PLC0415
+
+    home = os.environ.get("ATTUNE_HOME")
+    attune_dir = Path(home).expanduser() if home else Path.home() / ".attune"
+    for candidate in (attune_dir / "ops" / "runs").glob(f"*/{run_id}.json"):
+        try:
+            data = json.loads(candidate.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        if not isinstance(data, dict):
+            continue
+        exit_code = data.get("exit_code")
+        return WorkflowRunRecord(
+            run_id=run_id,
+            workflow_name=str(data.get("workflow") or "unknown"),
+            started_at=str(data.get("started_at") or ""),
+            trigger=(data.get("trigger") if isinstance(data.get("trigger"), str) else None),
+            success=data.get("status") == "completed" and exit_code == 0,
+            error=(
+                str(data.get("sdk_stderr"))
+                if data.get("sdk_stderr")
+                else f"ops run failed (exit {exit_code}, sdk_error_kind="
+                f"{data.get('sdk_error_kind')})"
+            ),
+        )
+    return None
 
 
 def diagnose(

--- a/src/attune/ops/routes/dashboard.py
+++ b/src/attune/ops/routes/dashboard.py
@@ -520,6 +520,16 @@ async def run_view_page(run_id: str, request: Request) -> HTMLResponse:
     # Live runs get an empty list — the SSE replay fills the pre on
     # subscribe. Disk-loaded runs ship their captured log inline.
     server_rendered_lines = list(run.lines) if loaded_from_disk else []
+    # Existing diagnoses for this run (advanced-debugging-plugin T5) —
+    # drives the "diagnosed" chip and suppresses the diagnose button.
+    # Best-effort: a broken diagnosis store never breaks the run view.
+    try:
+        from attune.diagnosis import records_for_run
+
+        diagnosis_ids = [r.diagnosis_id for r in records_for_run(run_id)]
+    except Exception:  # noqa: BLE001 — page render must survive store faults
+        logger.debug("ops.run_view: diagnosis lookup failed", exc_info=True)
+        diagnosis_ids = []
     return _render(
         request,
         "run_view.html",
@@ -528,6 +538,7 @@ async def run_view_page(run_id: str, request: Request) -> HTMLResponse:
         stream_url=stream_url,
         allow_run=request.app.state.config.allow_run,
         server_rendered_lines=server_rendered_lines,
+        diagnosis_ids=diagnosis_ids,
     )
 
 

--- a/src/attune/ops/routes/runner.py
+++ b/src/attune/ops/routes/runner.py
@@ -146,6 +146,67 @@ async def start_run(
     )
 
 
+@router.post("/runs/{run_id}/diagnose")
+async def diagnose_run(
+    run_id: str,
+    request: Request,
+    _client: None = Depends(require_client_token),  # noqa: B008
+) -> JSONResponse:
+    """On-demand diagnosis of a failed run (advanced-debugging-plugin RR-3).
+
+    Validates the source run exists and FAILED, is idempotent (an
+    existing diagnosis for this run returns its id instead of
+    double-spending), then dispatches exactly ONE runner subprocess —
+    ``attune diagnose <run_id>`` stamped ``attune-heal`` — so the
+    diagnostic run streams on the standard run view. Nothing here
+    auto-starts: this endpoint only fires on an explicit client POST.
+    """
+    _ensure_allowed(request)
+    svc = _service(request)
+    source = svc.get_or_load(run_id)
+    if source is None:
+        raise HTTPException(status_code=404, detail="run not found")
+    if not source.is_terminal or source.status != "failed":
+        raise HTTPException(
+            status_code=400,
+            detail="only terminal FAILED runs can be diagnosed",
+        )
+    if source.trigger == "attune-heal":
+        raise HTTPException(
+            status_code=400,
+            detail="diagnostic self-records are not diagnosable",
+        )
+
+    from attune.diagnosis import records_for_run
+
+    existing = records_for_run(run_id)
+    if existing:
+        return JSONResponse(
+            status_code=200,
+            content={
+                "existing": True,
+                "diagnosis_id": existing[-1].diagnosis_id,
+                "source_run_id": run_id,
+            },
+        )
+
+    try:
+        run = await svc.start("diagnose", trigger="attune-heal", extra_args=[run_id])
+    except RunnerBusyError as exc:
+        raise HTTPException(
+            status_code=409,
+            detail={"message": "runner busy", "current_run_id": exc.current_run_id},
+        ) from exc
+    return JSONResponse(
+        status_code=201,
+        content={
+            "run_id": run.id,
+            "stream_url": f"/runs/{run.id}/stream",
+            "status_url": f"/runs/{run.id}",
+        },
+    )
+
+
 @router.get("/runs/{run_id}")
 async def get_run(run_id: str, request: Request) -> JSONResponse:
     svc = _service(request)

--- a/src/attune/ops/runner.py
+++ b/src/attune/ops/runner.py
@@ -117,6 +117,11 @@ class Run:
     # otherwise. Exported to the subprocess as ``ATTUNE_RUN_TRIGGER`` so
     # the workflow's run record carries the attribution.
     trigger: str | None = None
+    # Extra argv appended after the command builder's output (and after
+    # ``--path``). Used by non-workflow dispatches like ``diagnose
+    # <source_run_id>`` (advanced-debugging-plugin T5). Ephemeral —
+    # ``command`` captures the full argv for persistence.
+    extra_args: list[str] | None = None
     # Full command line (argv list) the subprocess was invoked with.
     # Captured at execute time so the persistence record can reproduce
     # exactly what ran. ``None`` for runs that never executed.
@@ -343,7 +348,14 @@ def _default_command(workflow: str) -> Sequence[str]:
     Scope (``--path``) is appended by :meth:`RunnerService._execute` after
     the builder's output, so custom builders (test fixtures, alternative
     CLIs) don't need to know about it.
+
+    ``diagnose`` is a top-level CLI command, not a workflow — the
+    diagnosis engine (advanced-debugging-plugin T5) dispatches through
+    the runner to inherit SSE streaming, the busy-lock, and run
+    persistence; its source-run argument arrives via ``Run.extra_args``.
     """
+    if workflow == "diagnose":
+        return (sys.executable, "-m", "attune.cli_minimal", "diagnose")
     return (sys.executable, "-m", "attune.cli_minimal", "workflow", "run", workflow)
 
 
@@ -662,12 +674,19 @@ class RunnerService:
         *,
         path: str | None = None,
         trigger: str | None = None,
+        extra_args: list[str] | None = None,
     ) -> Run:
         async with self._lock:
             current = self.current
             if current is not None:
                 raise RunnerBusyError(current.id)
-            run = Run(id=uuid.uuid4().hex[:12], workflow=workflow, path=path, trigger=trigger)
+            run = Run(
+                id=uuid.uuid4().hex[:12],
+                workflow=workflow,
+                path=path,
+                trigger=trigger,
+                extra_args=list(extra_args) if extra_args else None,
+            )
             self._runs[run.id] = run
             while len(self._runs) > self._history_limit:
                 self._runs.popitem(last=False)
@@ -769,6 +788,8 @@ class RunnerService:
         # PATH_ARG_REGISTRY at the workflow layer.
         if run.path:
             cmd.extend(["--path", run.path])
+        if run.extra_args:
+            cmd.extend(run.extra_args)
         run.command = list(cmd)
         run.append_line(f"$ {' '.join(shlex.quote(c) for c in cmd)}")
         # Opt the spawned CLI process into the ATTUNE_RUN_META

--- a/src/attune/ops/static/js/run_view.js
+++ b/src/attune/ops/static/js/run_view.js
@@ -1057,6 +1057,88 @@
     }
   }
 
+  // --- "Why did this fail?" — on-demand diagnosis (adv-debugging T5).
+  // Renders ONLY for terminal FAILED runs on an explicit user click;
+  // nothing here auto-starts a diagnosis on page load or run ingestion.
+  function renderDiagnosedChip(diagnosisId) {
+    if (!statusEl || !statusEl.parentNode) return;
+    if (document.querySelector("[data-diagnosed-chip]")) return;
+    var chip = document.createElement("span");
+    chip.className = "chip chip-muted";
+    chip.setAttribute("data-diagnosed-chip", diagnosisId);
+    chip.textContent = "diagnosed: " + diagnosisId;
+    statusEl.parentNode.insertBefore(chip, statusEl.nextSibling);
+  }
+
+  function renderDiagnoseButton() {
+    if (!statusEl || !statusEl.parentNode) return;
+    if (document.querySelector("[data-diagnose-btn]")) return;
+    var btn = document.createElement("button");
+    btn.className = "btn btn-rec";
+    btn.type = "button";
+    btn.setAttribute("data-diagnose-btn", "1");
+    btn.textContent = "Why did this fail?";
+    btn.addEventListener("click", function () {
+      btn.disabled = true;
+      fetch("/runs/" + encodeURIComponent(RUN_ID) + "/diagnose", {
+        method: "POST",
+        headers: attuneClientHeaders({ Accept: "application/json" })
+      }).then(function (resp) {
+        return resp.json().then(function (data) {
+          return { status: resp.status, data: data };
+        });
+      }).then(function (result) {
+        if (result.status === 201 && result.data.run_id) {
+          window.location.assign(
+            "/runs/" + encodeURIComponent(result.data.run_id) +
+            "/view?from=" + encodeURIComponent(SOURCE_WORKFLOW)
+          );
+          return;
+        }
+        if (result.status === 200 && result.data.existing) {
+          btn.remove();
+          renderDiagnosedChip(result.data.diagnosis_id);
+          return;
+        }
+        btn.disabled = false;
+        if (result.status === 409) {
+          showInlineError(
+            "Cannot diagnose — run " + result.data.detail.current_run_id +
+            " is still active."
+          );
+          return;
+        }
+        showInlineError("Diagnosis request failed (" + result.status + ").");
+      }).catch(function () {
+        btn.disabled = false;
+        showInlineError("Diagnosis request failed.");
+      });
+    });
+    statusEl.parentNode.insertBefore(btn, statusEl.nextSibling);
+  }
+
+  function initDiagnose(status) {
+    if (!RUN_ID || !ALLOW_RUN) return;
+    if (DATA.trigger === "attune-heal") return;  // no self-diagnosis
+    var existing = DATA.diagnosis_ids || [];
+    if (existing.length) {
+      renderDiagnosedChip(existing[existing.length - 1]);
+      return;
+    }
+    if (status !== "failed") return;
+    renderDiagnoseButton();
+  }
+
+  initDiagnose(INITIAL_STATUS);
+  // A live run that fails after page load grows the button on "done".
+  if (typeof es !== "undefined" && es) {
+    es.addEventListener("done", function (ev) {
+      try {
+        initDiagnose(JSON.parse(ev.data).status);
+      } catch (e) { /* malformed done payload — no button */ }
+    });
+  }
+
   // Expose internals for tests.
   if (typeof window !== "undefined") {
     window.__attuneRunView = {

--- a/src/attune/ops/templates/run_view.html
+++ b/src/attune/ops/templates/run_view.html
@@ -123,7 +123,9 @@
   "run_id": {{ run.id|tojson }},
   "workflow": {{ run.workflow|tojson }},
   "path": {{ run.path|tojson }},
-  "allow_run": {{ allow_run|tojson }}
+  "trigger": {{ run.trigger|tojson }},
+  "allow_run": {{ allow_run|tojson }},
+  "diagnosis_ids": {{ diagnosis_ids|tojson }}
 }
 </script>
 {# runner.js provides the shared setupRecentRuns helper that

--- a/tests/unit/ops/test_diagnose_endpoint.py
+++ b/tests/unit/ops/test_diagnose_endpoint.py
@@ -1,0 +1,174 @@
+"""On-demand diagnosis endpoint tests (advanced-debugging-plugin T5).
+
+POST /runs/{run_id}/diagnose: validation, idempotency, and the
+attune-heal dispatch — plus source-level guards that the run-view
+button never auto-starts.
+"""
+
+import asyncio
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from attune.models import DiagnosisRecord
+from attune.models.telemetry.run_context import TRIGGER_ENV
+from attune.models.telemetry.storage import TelemetryStore
+from attune.ops.config import build_config
+from attune.ops.runner import RunnerService, _default_command
+from attune.ops.server import create_app
+
+JS_DIR = Path(__file__).resolve().parents[3] / "src" / "attune" / "ops" / "static" / "js"
+TPL_DIR = Path(__file__).resolve().parents[3] / "src" / "attune" / "ops" / "templates"
+
+
+def _fail_cmd(workflow: str) -> tuple[str, ...]:
+    script = f"import sys; print('boom {workflow}'); sys.exit(1)"
+    return (sys.executable, "-c", script)
+
+
+def _echo_dispatch_cmd(workflow: str) -> tuple[str, ...]:
+    """Print trigger env + trailing argv so dispatch is observable."""
+    script = (
+        "import os, sys; "
+        f"print('DISPATCH workflow={workflow}'); "
+        f"print('DISPATCH trigger=' + os.environ.get('{TRIGGER_ENV}', 'MISSING')); "
+        "print('DISPATCH args=' + ' '.join(sys.argv[1:]))"
+    )
+    return (sys.executable, "-c", script)
+
+
+def _make_app(tmp_path, monkeypatch, *, command_builder=_fail_cmd):
+    monkeypatch.setenv("ATTUNE_HOME", str(tmp_path / "attune-home"))
+    config = build_config(
+        project_root=tmp_path,
+        allow_run=True,
+        trusted_hosts=("testserver", "test"),
+    )
+    runner = RunnerService(command_builder=command_builder)
+    app = create_app(config, runner=runner)
+    return app, runner
+
+
+async def _wait_terminal(runner: RunnerService, run_id: str, *, timeout: float = 5.0):
+    deadline = asyncio.get_running_loop().time() + timeout
+    while True:
+        run = runner.get(run_id)
+        assert run is not None
+        if run.is_terminal:
+            return run
+        if asyncio.get_running_loop().time() > deadline:
+            pytest.fail(f"run {run_id} did not finish within {timeout}s")
+        await asyncio.sleep(0.02)
+
+
+class TestValidation:
+    @pytest.mark.asyncio
+    async def test_unknown_run_is_404(self, tmp_path, monkeypatch):
+        app, _runner = _make_app(tmp_path, monkeypatch)
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.post("/runs/deadbeef0000/diagnose")
+        assert resp.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_non_failed_run_is_400(self, tmp_path, monkeypatch):
+        def ok_cmd(workflow):
+            return (sys.executable, "-c", "print('fine')")
+
+        app, runner = _make_app(tmp_path, monkeypatch, command_builder=ok_cmd)
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            started = (await client.post("/workflows/code-review/run")).json()
+            await _wait_terminal(runner, started["run_id"])
+            resp = await client.post(f"/runs/{started['run_id']}/diagnose")
+        assert resp.status_code == 400
+        assert "FAILED" in resp.json()["detail"]
+
+    @pytest.mark.asyncio
+    async def test_attune_heal_source_is_400(self, tmp_path, monkeypatch):
+        app, runner = _make_app(tmp_path, monkeypatch)
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            started = (
+                await client.post("/workflows/code-review/run", json={"trigger": "attune-heal"})
+            ).json()
+            await _wait_terminal(runner, started["run_id"])
+            resp = await client.post(f"/runs/{started['run_id']}/diagnose")
+        assert resp.status_code == 400
+        assert "self-record" in resp.json()["detail"]
+
+
+class TestIdempotency:
+    @pytest.mark.asyncio
+    async def test_existing_diagnosis_returns_200_not_dispatch(self, tmp_path, monkeypatch):
+        app, runner = _make_app(tmp_path, monkeypatch)
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            started = (await client.post("/workflows/code-review/run")).json()
+            await _wait_terminal(runner, started["run_id"])
+            # Pre-existing diagnosis for this run in the isolated store.
+            TelemetryStore().log_diagnosis(
+                DiagnosisRecord(
+                    diagnosis_id="d-existing",
+                    source_run_id=started["run_id"],
+                    workflow_name="code-review",
+                    created_at=datetime.now(timezone.utc).isoformat(),
+                )
+            )
+            resp = await client.post(f"/runs/{started['run_id']}/diagnose")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["existing"] is True
+        assert body["diagnosis_id"] == "d-existing"
+
+
+class TestDispatch:
+    @pytest.mark.asyncio
+    async def test_dispatch_carries_attune_heal_and_source_id(self, tmp_path, monkeypatch):
+        app, runner = _make_app(tmp_path, monkeypatch, command_builder=_echo_dispatch_cmd)
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            # First run "fails" is not possible with echo builder — start
+            # a failing run via a per-call builder instead: mark the
+            # source failed by hand after it completes.
+            started = (await client.post("/workflows/code-review/run")).json()
+            source = await _wait_terminal(runner, started["run_id"])
+            source.status = "failed"
+            source.exit_code = 1
+
+            resp = await client.post(f"/runs/{started['run_id']}/diagnose")
+            assert resp.status_code == 201
+            diag = await _wait_terminal(runner, resp.json()["run_id"])
+
+        assert diag.workflow == "diagnose"
+        assert diag.trigger == "attune-heal"
+        joined = "\n".join(diag.lines)
+        assert "DISPATCH trigger=attune-heal" in joined
+        assert f"DISPATCH args={started['run_id']}" in joined
+
+    def test_default_command_maps_diagnose_to_cli(self):
+        argv = _default_command("diagnose")
+        assert argv[-2:] == ("attune.cli_minimal", "diagnose")
+        argv_wf = _default_command("code-review")
+        assert argv_wf[-3:] == ("workflow", "run", "code-review")
+
+
+class TestNoAutoStart:
+    """Source-level guards: diagnosis fires only on an explicit click."""
+
+    def test_button_requires_failed_status_and_click(self):
+        text = (JS_DIR / "run_view.js").read_text(encoding="utf-8")
+        assert 'if (status !== "failed") return;' in text
+        assert 'DATA.trigger === "attune-heal"' in text  # self-diagnosis guard
+        # The POST lives inside the button's click listener, not init.
+        click_idx = text.index('btn.addEventListener("click"')
+        post_idx = text.index('"/diagnose"')
+        assert post_idx > click_idx
+
+    def test_template_injects_diagnosis_ids(self):
+        text = (TPL_DIR / "run_view.html").read_text(encoding="utf-8")
+        assert '"diagnosis_ids"' in text
+        assert '"trigger"' in text


### PR DESCRIPTION
## Summary

Phase C of `docs/specs/advanced-debugging-plugin/` (T5, chair-approved): the on-demand diagnosis surface.

- `POST /runs/{run_id}/diagnose`: failed-terminal-only validation, `attune-heal` sources refused, **idempotent** (existing diagnosis → 200 with its id, no double spend), dispatching exactly one runner subprocess — `attune diagnose <run_id>` via `Run.extra_args` with `trigger=attune-heal`, so the diagnostic run streams on the standard run view and stamps the corpus through the RC-3 seam.
- Run view: "Why did this fail?" button on terminal-failed runs only (explicit click; source-level no-auto-start guards) + a "diagnosed" chip when a record exists.
- **Recorded deviation** (decisions.md): dashboard 12-hex run ids and telemetry uuid4 ids are different id spaces — `find_source_run` gained an ops-record fallback synthesizing the source record.

## Receipts (decisions.md Phase C closure)

- Endpoint suite incl. a real subprocess dispatch round-trip: `ATTUNE_RUN_TRIGGER=attune-heal` + the source run id observed in the child argv.
- 1516-test ops+diagnosis breadth; browser receipt — button live beside the failed chip on the real 2026-07-15 run, served from worktree code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
