### PR TITLE
feat(gates): G1 count-and-claim drift guard — landed red, fixed green

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,13 +6,13 @@
     "email": "patrick.roebuck@smartaimemory.com"
   },
   "metadata": {
-    "description": "Spec-driven development for Claude Code — take an idea through requirements, design, tasks, and gated execution with an approval loop. Plus 23 auto-triggering skills: security audits, code review, test generation, release prep.",
+    "description": "Spec-driven development for Claude Code — take an idea through requirements, design, tasks, and gated execution with an approval loop. Plus 25 auto-triggering skills: security audits, code review, test generation, release prep.",
     "version": "10.5.0"
   },
   "plugins": [
     {
       "name": "attune-ai",
-      "description": "Spec-driven development is the core workflow: /spec carries an idea through brainstorm, requirements, design, and task execution with quality gates and your approval at each stage. Backed by 23 auto-triggering skills — security audits, code reviews, test generation, bug prediction, and release preparation. For help content tools, also install attune-help and attune-author from this marketplace.",
+      "description": "Spec-driven development is the core workflow: /spec carries an idea through brainstorm, requirements, design, and task execution with quality gates and your approval at each stage. Backed by 25 auto-triggering skills — security audits, code reviews, test generation, bug prediction, and release preparation. For help content tools, also install attune-help and attune-author from this marketplace.",
       "source": "./plugin",
       "version": "10.5.0",
       "author": {

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ store, retrieved at P@3 96% on a frozen trap-moment benchmark
 below).
 
 Around that memory core, the same package also ships a spec-driven,
-multi-agent toolkit: 20 workflows and 47 MCP tools dispatching 2–6
+multi-agent toolkit: 20 workflows and 53 MCP tools dispatching 2–6
 domain-specific subagents behind Socratic quality gates, RAG
 grounding with a citation-per-claim contract (mean per-claim
 faithfulness CI-gated at ≥ 0.97; 0.98 currently measured, N=20 runs
@@ -316,10 +316,10 @@ per-surface extras (API-mode agents, ops dashboard, Redis memory).
 
 | Capability | Plugin only | Plugin + pip |
 | ---------- | ----------- | ------------ |
-| 23 auto-triggering skills | Yes | Yes |
+| 25 auto-triggering skills | Yes | Yes |
 | Security hooks | Yes | Yes |
 | Prompt-based analysis | Yes | Yes |
-| 47 MCP tools | -- | Yes |
+| 53 MCP tools | -- | Yes |
 | `attune` CLI | -- | Yes |
 | Multi-agent workflows | -- | Yes |
 | Help system maintenance | -- | Yes |

--- a/docs/getting-started/first-steps.md
+++ b/docs/getting-started/first-steps.md
@@ -65,7 +65,7 @@ asyncio.run(audit())
 
 ## Try More Workflows
 
-Attune AI includes 17 built-in workflows. Here are the most
+Attune AI includes 20 built-in workflows. Here are the most
 popular:
 
 | Workflow | Command | What It Does |

--- a/docs/getting-started/mcp-integration.md
+++ b/docs/getting-started/mcp-integration.md
@@ -88,7 +88,7 @@ Then restart Claude Desktop.
 
 ---
 
-## Available Tools (41 core + 5 with attune-redis)
+## Available Tools (53)
 
 The Attune MCP server exposes all production workflows as tools:
 

--- a/docs/getting-started/quickstart-plugin.md
+++ b/docs/getting-started/quickstart-plugin.md
@@ -21,7 +21,7 @@ inside the Claude Code session you already have.
 
 ## What you get
 
-The plugin ships **17 auto-triggering skills**. You don't memorize commands —
+The plugin ships **25 auto-triggering skills**. You don't memorize commands —
 you describe what you want, and the right skill activates.
 
 | Say something like… | Skill that activates | What it does |
@@ -120,7 +120,7 @@ Other skills worth trying by name or description:
 | If you want to… | Go to |
 |-----------------|-------|
 | Run workflows from a terminal or Python | [First Steps](first-steps.md) |
-| Add the full MCP toolset (41 tools) + CLI | [MCP Integration](mcp-integration.md) |
+| Add the full MCP toolset (53 tools) + CLI | [MCP Integration](mcp-integration.md) |
 | Pick a longer learning path | [Choose Your Path](choose-your-path.md) |
 | See every workflow | [First Steps → Try More Workflows](first-steps.md#try-more-workflows) |
 

--- a/docs/specs/claim-drift-gates/decisions.md
+++ b/docs/specs/claim-drift-gates/decisions.md
@@ -135,3 +135,23 @@ is the only work item blocked on an open decision (D4).
 With D4 (2026-07-12) and these two, every open decision on this
 spec is resolved — implementation (G1 first per the ship order) is
 fully unblocked.
+## 2026-07-20 — G1 landed (red-first proven)
+
+`tests/unit/gates/test_claim_drift.py`: live values derived from the
+owning registries (skills glob, `EmpathyMCPServer().tools`,
+`discover_workflows()` slugs AND distinct classes per D4,
+pyproject version) against a 13-entry claim-site manifest across
+README, marketplace.json, plugin/README, quickstart-plugin,
+mcp-integration, first-steps, and .claude/CLAUDE.md.
+Unmatched-regex is itself a failure (vanished claim = drift).
+
+**Red-first receipt:** against the pre-fix tree the gate failed
+10 of 14 checks — including drift ACCUMULATED SINCE THE 2026-07-11
+REVIEW (skills 24→25, tools 47→53 while docs still said 23/41/43/
+47), proving both the thesis and the gate. Same-PR fix set: all 10
+flagged instances updated to live values (skills 25, tools 53,
+workflows 20 per D4, plugin version 10.5.0); gate green 14/14;
+adjacent guards (plugins, website-version, mcp-tools) 300 passed.
+
+Per D7 the gate is CI-only (rides the unit suite); no pre-commit
+hook added. Next per ship order: G2.

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -4,7 +4,7 @@ Spec-driven development for Claude Code — turn requirements
 into reliable software. 18 auto-triggering skills, zero
 commands: say what you need and Claude picks the right skill.
 
-**Version:** 8.5.0 | **License:** Apache 2.0
+**Version:** 10.5.0 | **License:** Apache 2.0
 
 ## Install
 
@@ -79,7 +79,7 @@ The plugin ships two security hooks:
 ## Python Package (optional — unlocks CLI + MCP)
 
 The plugin works standalone. Add the Python package
-for CLI automation, 43 MCP tools, multi-agent
+for CLI automation, 53 MCP tools, multi-agent
 workflows, and cost tracking:
 
 ```bash
@@ -90,7 +90,7 @@ pip install 'attune-ai[developer]'
 | ---------- | ----------- | ----- |
 | 20 auto-triggering skills | Yes | Yes |
 | Prompt-based analysis | Yes | Yes |
-| 43 MCP tools | -- | Yes |
+| 53 MCP tools | -- | Yes |
 | `attune` CLI | -- | Yes |
 | Multi-agent workflows | -- | Yes |
 | Cost tracking | -- | Yes |

--- a/tests/unit/gates/test_claim_drift.py
+++ b/tests/unit/gates/test_claim_drift.py
@@ -1,0 +1,126 @@
+"""G1 — count-and-claim drift guard (docs/specs/claim-drift-gates/).
+
+Every hand-maintained count/version claim in a user-facing surface is
+asserted against the LIVE value derived from the owning registry. The
+manifest below is data: adding a new claim site is a one-line diff.
+An unmatched regex is itself a failure — a claim site that disappears
+silently is drift too.
+
+Ruled context: D4 (2026-07-12) — workflow totals use the DISTINCT
+CLASS count ("20 workflows"), not the slug count. D7 (2026-07-20) —
+this gate runs in CI only, not pre-commit (needs importable attune).
+
+Keyless, no network, < seconds (G goals). Run me serially:
+    pytest tests/unit/gates/test_claim_drift.py -p no:xdist
+"""
+
+from __future__ import annotations
+
+import glob
+import re
+from functools import lru_cache
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[3]
+
+
+@lru_cache(maxsize=1)
+def live_values() -> dict[str, str]:
+    """Derive every gated value from its owning registry."""
+    from attune.mcp.server import EmpathyMCPServer
+    from attune.workflows import discover_workflows
+
+    registry = discover_workflows()
+    version = re.search(
+        r'^version\s*=\s*"([^"]+)"',
+        (REPO / "pyproject.toml").read_text(encoding="utf-8"),
+        re.M,
+    ).group(1)
+    return {
+        "skills": str(len(glob.glob(str(REPO / "plugin" / "skills" / "*" / "SKILL.md")))),
+        "tools": str(len(EmpathyMCPServer().tools)),
+        # D4: totals quote distinct workflow classes, not slugs.
+        "workflows": str(len(set(registry.values()))),
+        "workflow_slugs": str(len(registry)),
+        "version": version,
+    }
+
+
+# --- The claim-site manifest -------------------------------------------
+# (file, human label, regex with ONE capture group, live-value key).
+# Every regex must match at least once in its file; every captured
+# value must equal the live value.
+MANIFEST: tuple[tuple[str, str, str, str], ...] = (
+    ("README.md", "hero workflow count", r"(\d+) workflows and \d+ MCP tools", "workflows"),
+    ("README.md", "hero tool count", r"\d+ workflows and (\d+) MCP tools", "tools"),
+    ("README.md", "skills table row", r"\| (\d+) auto-triggering skills", "skills"),
+    ("README.md", "tools table row", r"\| (\d+) MCP tools", "tools"),
+    (
+        ".claude-plugin/marketplace.json",
+        "marketplace skill claims",
+        r"(\d+) auto-triggering skills",
+        "skills",
+    ),
+    ("plugin/README.md", "plugin version", r"\*\*Version:\*\* (\d+\.\d+\.\d+)", "version"),
+    ("plugin/README.md", "plugin tool counts", r"(\d+) MCP tools", "tools"),
+    (
+        "docs/getting-started/quickstart-plugin.md",
+        "quickstart skill count",
+        r"\*\*(\d+) auto-triggering skills\*\*",
+        "skills",
+    ),
+    (
+        "docs/getting-started/quickstart-plugin.md",
+        "quickstart tool count",
+        r"\((\d+) tools\)",
+        "tools",
+    ),
+    (
+        "docs/getting-started/mcp-integration.md",
+        "tools heading",
+        r"## Available Tools \((\d+)\)",
+        "tools",
+    ),
+    (
+        "docs/getting-started/first-steps.md",
+        "built-in workflow count",
+        r"(\d+) built-in workflows",
+        "workflows",
+    ),
+    (".claude/CLAUDE.md", "header version", r"# Attune AI Framework v(\d+\.\d+\.\d+)", "version"),
+    (".claude/CLAUDE.md", "footer version", r"\*\*Version:\*\* (\d+\.\d+\.\d+)", "version"),
+)
+
+
+@pytest.mark.parametrize(
+    ("rel_path", "label", "pattern", "key"),
+    MANIFEST,
+    ids=[f"{m[0]}::{m[1]}" for m in MANIFEST],
+)
+def test_claim_matches_live_value(rel_path: str, label: str, pattern: str, key: str):
+    text = (REPO / rel_path).read_text(encoding="utf-8")
+    matches = re.findall(pattern, text)
+    assert matches, (
+        f"{rel_path}: claim site {label!r} (/{pattern}/) matched nothing — "
+        "the claim vanished or was reworded; update the manifest WITH the wording"
+    )
+    expected = live_values()[key]
+    stale = [m for m in matches if m != expected]
+    assert not stale, (
+        f"{rel_path}: {label} claims {stale} but the live {key} value is "
+        f"{expected} — update the claim (or the registry moved and docs "
+        "must follow)"
+    )
+
+
+def test_live_values_are_sane():
+    """Guard the gate itself: derivation returning zeros would let every
+    claim 'drift' to zero silently on an import regression."""
+    values = live_values()
+    assert int(values["skills"]) > 10
+    assert int(values["tools"]) > 20
+    assert int(values["workflows"]) > 10
+    assert int(values["workflow_slugs"]) >= int(values["workflows"])
+    assert re.fullmatch(r"\d+\.\d+\.\d+", values["version"])


### PR DESCRIPTION
First gate of `docs/specs/claim-drift-gates/` (ship order G1→G2→G3→G5→G4), armed by the chair via the Briefing card tonight after D7/D8 were ruled (#1495).

**The gate**: `tests/unit/gates/test_claim_drift.py` — live values derived from the owning registries (skills glob, `EmpathyMCPServer().tools`, `discover_workflows()` slugs + distinct classes per D4, pyproject version) asserted against a 13-entry claim-site manifest; an unmatched regex is itself a failure (a vanished claim is drift too). CI-only per D7; keyless, no network, <1s.

**Red-first receipt**: 10 of 14 checks failed against the pre-fix tree — including drift accumulated in the nine days since the spec's own review (skills 24→25 and tools 47→53 while docs still claimed 23/41/43/47). Same-PR fix set updates every flagged instance; gate green 14/14; adjacent guards (plugin refs, website-version, mcp-tools) 300 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)