### PR TITLE
feat(gates): G2 advertised-command validation — landed red, fixed green

### DIFF
--- a/docs/specs/claim-drift-gates/decisions.md
+++ b/docs/specs/claim-drift-gates/decisions.md
@@ -155,3 +155,28 @@ adjacent guards (plugins, website-version, mcp-tools) 300 passed.
 
 Per D7 the gate is CI-only (rides the unit suite); no pre-commit
 hook added. Next per ship order: G2.
+## 2026-07-20 — G2 landed (red-first proven)
+
+`tests/unit/gates/test_advertised_commands.py`: the advertised set
+is extracted by CALLING the render surfaces (`create_parser()`
+epilog, `_show_welcome`, `cmd_setup` with `Path.home` pointed at
+tmp), never by grepping source. Every line-leading `/token` must
+resolve to `src/attune/commands/<name>.md` or
+`plugin/commands/<name>.md`.
+
+**Red-first receipt:** exactly the spec's predicted ghosts —
+epilog advertised `/testing`, `/workflows`, `/docs` (the epilog
+block existed TWICE in cli_minimal.py, both stale) and the welcome
+screen advertised `/testing`. Fix set retargeted per the spec's
+candidates: `/testing`→`/smart-test`, `/workflows`→`/attune`,
+`/docs`→`/doc-gen`, both blocks. Gate green; 116-test gates+cli
+breadth.
+
+**D8 inverse report (report-only, as ruled)** fired its first
+output: 12 commands exist but are advertised on no CLI surface —
+agent, brainstorm, bulk, code-quality, deep-review, doc-gen*,
+fix-test, handoff, pipeline, plan, refactor, remember (*doc-gen
+now advertised post-fix). Reassess the list after a month.
+
+Next per ship order: G3 (blocked on hook-timeout-budgets Phase 0.2
+values) or G5.

--- a/src/attune/cli_minimal.py
+++ b/src/attune/cli_minimal.py
@@ -46,9 +46,9 @@ Utility commands:
 
 For interactive development, use Claude Code skills:
     /dev        Developer tools (commit, review, debug, refactor)
-    /testing    Run tests, coverage, generate tests
-    /workflows  AI-powered workflows (security, bug prediction)
-    /docs       Documentation generation
+    /smart-test Find test gaps, generate tests
+    /attune     AI-powered workflows via Socratic discovery
+    /doc-gen    Documentation generation
     /release    Release preparation
 """
 
@@ -583,9 +583,9 @@ NOTE: This CLI is for automation only. For interactive development,
 use Claude Code skills in VSCode or Claude Desktop:
 
     /dev        Developer tools (commit, review, debug, refactor)
-    /testing    Run tests, coverage, generate tests
-    /workflows  AI-powered workflows (security, bug prediction)
-    /docs       Documentation generation
+    /smart-test Find test gaps, generate tests
+    /attune     AI-powered workflows via Socratic discovery
+    /doc-gen    Documentation generation
     /release    Release preparation
 
 Documentation: https://smartaimemory.com/framework-docs/
@@ -731,7 +731,7 @@ Get started:
 For interactive development in Claude Code:
   /attune       Socratic discovery — finds the right workflow for you
   /dev          Developer tools (commit, review, debug, refactor)
-  /testing      Run tests, coverage, generate tests
+  /smart-test   Find test gaps, generate tests
   /wizard run   Guided multi-step wizards
 
 More: attune --help | Docs: https://smartaimemory.com/framework-docs/

--- a/tests/unit/gates/test_advertised_commands.py
+++ b/tests/unit/gates/test_advertised_commands.py
@@ -1,0 +1,86 @@
+"""G2 — advertised-command reference validation (claim-drift-gates).
+
+Every ``/command`` token printed by the CLI's user-facing surfaces —
+``create_parser()``'s epilog, ``_show_welcome``, and ``cmd_setup`` —
+must resolve to a real command file (``src/attune/commands/<name>.md``
+or ``plugin/commands/<name>.md``). The advertised set is extracted by
+CALLING the render surfaces, not by grepping source, so refactors
+can't bypass the gate.
+
+The inverse direction (commands that exist but are advertised
+nowhere) is a REPORT-ONLY warning tier per D8 (ruled 2026-07-20) —
+non-gating, reassess after a month of output.
+
+CI-only per D7. Keyless, no network. Run me serially:
+    pytest tests/unit/gates/test_advertised_commands.py -p no:xdist
+"""
+
+from __future__ import annotations
+
+import re
+import warnings
+from argparse import Namespace
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[3]
+
+#: Line-leading slash tokens ("  /dev   Developer tools"). Anchored to
+#: line start so URLs (https://...) and path fragments never match.
+_TOKEN_RE = re.compile(r"(?m)^\s+/([a-z][a-z0-9-]*)\b")
+
+
+def _existing_commands() -> set[str]:
+    names = {p.stem for p in (REPO / "src" / "attune" / "commands").glob("*.md")}
+    names |= {p.stem for p in (REPO / "plugin" / "commands").glob("*.md")}
+    return names
+
+
+def _advertised(capsys, monkeypatch, tmp_path) -> dict[str, set[str]]:
+    """Render each surface for real and extract its advertised tokens."""
+    from attune.cli_commands.utility_commands import cmd_setup
+    from attune.cli_minimal import _show_welcome, create_parser
+
+    surfaces: dict[str, set[str]] = {}
+
+    surfaces["epilog"] = set(_TOKEN_RE.findall(create_parser().epilog or ""))
+
+    _show_welcome()
+    surfaces["welcome"] = set(_TOKEN_RE.findall(capsys.readouterr().out))
+
+    # cmd_setup installs into Path.home()/.claude/commands — point home
+    # at tmp so the REAL renderer runs without touching the user's home.
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+    cmd_setup(Namespace())
+    surfaces["setup"] = set(_TOKEN_RE.findall(capsys.readouterr().out))
+
+    return surfaces
+
+
+def test_every_advertised_command_resolves(capsys, monkeypatch, tmp_path):
+    surfaces = _advertised(capsys, monkeypatch, tmp_path)
+    existing = _existing_commands()
+    assert any(surfaces.values()), "no advertised tokens extracted — renderers changed shape"
+    ghosts = {
+        surface: sorted(tokens - existing)
+        for surface, tokens in surfaces.items()
+        if tokens - existing
+    }
+    assert not ghosts, (
+        f"advertised commands with no command file: {ghosts} — retarget the "
+        "line to a real command in src/attune/commands/ (or delete it)"
+    )
+
+
+def test_unadvertised_commands_report_only(capsys, monkeypatch, tmp_path):
+    """D8 (ruled): the inverse direction is a non-gating discoverability
+    report — commands that exist but no CLI surface mentions."""
+    surfaces = _advertised(capsys, monkeypatch, tmp_path)
+    advertised = set().union(*surfaces.values())
+    unadvertised = sorted(_existing_commands() - advertised)
+    if unadvertised:
+        warnings.warn(
+            "commands that exist but are advertised on no CLI surface "
+            f"(D8 report-only): {unadvertised}",
+            UserWarning,
+            stacklevel=1,
+        )


### PR DESCRIPTION
Second gate of `docs/specs/claim-drift-gates/` (ship order): the advertised set is extracted by CALLING the render surfaces (`create_parser()` epilog, `_show_welcome`, `cmd_setup` with home redirected to tmp) and every line-leading `/token` must resolve to a real command file.

**Red-first receipt**: exactly the spec's predicted ghosts — `/testing`, `/workflows`, `/docs` (the advertisement block existed TWICE in cli_minimal.py, both stale) — retargeted to `/smart-test`, `/attune`, `/doc-gen` per the spec's candidates. The D8 inverse report (ruled report-only) fired its first output: 12 commands exist but are advertised on no CLI surface. Gate green; gates suite green post-rebase. CI-only per D7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)