### PR TITLE
feat(ci): opt-in auto-merge-when-green class (D8, red-first)

### DIFF
--- a/.github/scripts/auto_merge_guard.py
+++ b/.github/scripts/auto_merge_guard.py
@@ -1,13 +1,14 @@
 #!/usr/bin/env python3
 """Path-class guard for the ``auto-merge-safe`` workflow.
 
-Decides whether a PR's changed-file set is wholly within the
-pre-authorized auto-merge class (test/docs only). The whole point
-is to be **tight and fail-closed**: anything that isn't provably
-test/docs keeps the PR out of the class, and an empty file set is
-treated as unsafe.
+Decides whether a PR's changed-file set is wholly within a
+pre-authorized auto-merge class. The whole point is to be **tight
+and fail-closed**: anything that isn't provably in-class keeps the
+PR out, and an empty file set is treated as unsafe.
 
-In-class paths (every changed path must match one):
+Two modes (``--mode``):
+
+``tests-docs`` (default) — every changed path must match one of:
 
 - under ``tests/``
 - under ``docs/``
@@ -15,15 +16,23 @@ In-class paths (every changed path must match one):
 - a root-level markdown file (``*.md`` with no ``/`` in the path)
 
 Everything else — ``src/``, ``.github/``, ``pyproject.toml``,
-lockfiles, ``mkdocs.yml`` — is out-of-class by construction. The
-guard itself lives under ``.github/`` so a PR that edits it is
-out-of-class and can never self-auto-merge.
+lockfiles, ``mkdocs.yml`` — is out-of-class by construction.
+
+``when-green`` (Class 2, opt-in ``auto-merge-when-green`` label,
+archive spec D8) — every path is in-class EXCEPT ``.github/``:
+merge automation and CI config can never self-merge, even labeled.
+Green-ness is enforced by GitHub native auto-merge (all required
+checks), not by this guard.
+
+In both modes the guard itself lives under ``.github/`` so a PR
+that edits it is out-of-class and can never self-auto-merge.
 
 CLI:
-    python .github/scripts/auto_merge_guard.py PATH [PATH ...]
-    printf '%s\\n' tests/a.py docs/b.md | python .github/scripts/auto_merge_guard.py
+    python .github/scripts/auto_merge_guard.py [--mode MODE] PATH [PATH ...]
+    printf '%s\\n' tests/a.py | python .github/scripts/auto_merge_guard.py
 
-Exit 0 = safe (all in-class); exit 1 = unsafe (prints offenders).
+Exit 0 = safe (all in-class); exit 1 = unsafe (prints offenders);
+exit 2 = usage error (unknown mode).
 """
 
 from __future__ import annotations
@@ -33,6 +42,12 @@ import sys
 # Directory prefixes that are in-class. Trailing slash is required
 # so ``.help`` cannot be matched by a sibling like ``.helpers/``.
 SAFE_DIR_PREFIXES: tuple[str, ...] = ("tests/", "docs/", ".help/")
+
+# Prefixes BLOCKED in when-green mode: CI and merge automation can
+# never self-merge, even with the opt-in label applied.
+WHEN_GREEN_BLOCKED_PREFIXES: tuple[str, ...] = (".github/",)
+
+MODES: tuple[str, ...] = ("tests-docs", "when-green")
 
 
 def is_in_class(path: str) -> bool:
@@ -58,36 +73,67 @@ def is_in_class(path: str) -> bool:
     return "/" not in path and path.endswith(".md")
 
 
-def is_safe_change(paths: list[str]) -> tuple[bool, list[str]]:
+def is_when_green_safe(path: str) -> bool:
+    """Return True if a path is within the when-green class.
+
+    Args:
+        path: A repo-relative POSIX path (no leading slash), as
+            returned by the GitHub PR "files" API.
+
+    Returns:
+        True iff the path is NOT under a blocked prefix
+        (``.github/``). Empty paths and paths containing a ``..``
+        segment are rejected (fail-closed / traversal defense).
+    """
+    if not path:
+        return False
+    if ".." in path.split("/"):
+        return False
+    return not path.startswith(WHEN_GREEN_BLOCKED_PREFIXES)
+
+
+def is_safe_change(paths: list[str], mode: str = "tests-docs") -> tuple[bool, list[str]]:
     """Classify a full changed-file set.
 
     Args:
         paths: All changed paths for the PR. The caller should
             include each rename's previous path as well, so a move
-            out of ``src/`` is caught.
+            out of ``src/`` (or ``.github/``) is caught.
+        mode: ``tests-docs`` (default, tight class) or
+            ``when-green`` (opt-in class, ``.github/`` carve-out).
 
     Returns:
         ``(safe, offending)`` where ``safe`` is True only if every
         path is in-class and the set is non-empty. ``offending``
         lists the out-of-class paths.
     """
-    # Fail-closed: an empty set is not a provable test/docs PR.
+    predicate = is_when_green_safe if mode == "when-green" else is_in_class
+    # Fail-closed: an empty set is not a provable in-class PR.
     if not paths:
         return False, []
-    offending = [p for p in paths if not is_in_class(p)]
+    offending = [p for p in paths if not predicate(p)]
     return (not offending), offending
 
 
 def main(argv: list[str]) -> int:
     """CLI entry point. Paths from argv or, if none, stdin lines."""
-    if len(argv) > 1:
-        paths = [p.strip() for p in argv[1:] if p.strip()]
+    args = argv[1:]
+    mode = "tests-docs"
+    if args and args[0] == "--mode":
+        if len(args) < 2 or args[1] not in MODES:
+            print(f"usage: auto_merge_guard.py [--mode {{{'|'.join(MODES)}}}] [PATH ...]")
+            return 2
+        mode = args[1]
+        args = args[2:]
+
+    if args:
+        paths = [p.strip() for p in args if p.strip()]
     else:
         paths = [line.strip() for line in sys.stdin if line.strip()]
 
-    safe, offending = is_safe_change(paths)
+    safe, offending = is_safe_change(paths, mode=mode)
     if safe:
-        print(f"SAFE: all {len(paths)} path(s) within the auto-merge class")
+        print(f"SAFE: all {len(paths)} path(s) within the auto-merge class ({mode})")
         return 0
 
     if not paths:

--- a/.github/workflows/auto-merge-safe.yml
+++ b/.github/workflows/auto-merge-safe.yml
@@ -1,15 +1,26 @@
 name: Auto-merge safe (tests/docs only)
 
-# Pre-authorized auto-merge for a TIGHT class of PRs: every changed
-# file is under tests/, docs/, .help/, or is a root-level *.md, the
-# author is the repo owner, and the `coverage` required check is
-# green. The merge is performed DETERMINISTICALLY by GitHub Actions
-# (no agent, no safety classifier) and admin-bypasses only the
-# REDUNDANT hung lane (e.g. `test (ubuntu-latest, 3.12)`) — never the
-# `coverage` gate, which re-runs the full suite.
+# Pre-authorized auto-merge, two classes (both merged
+# DETERMINISTICALLY by GitHub Actions — no agent, no classifier):
 #
-# See docs/specs/archive/auto-merge-safe-class/ for the class definition and
-# the rejected alternatives.
+# Class 1 (tests/docs only, automation-labeled `auto-merge-safe`):
+# every changed file is under tests/, docs/, .help/, or is a
+# root-level *.md, the author is the repo owner, and the `coverage`
+# required check is green. Admin-bypasses only the REDUNDANT hung
+# lane (e.g. `test (ubuntu-latest, 3.12)`) — never the `coverage`
+# gate, which re-runs the full suite.
+#
+# Class 2 (opt-in, HUMAN-labeled `auto-merge-when-green`, D8):
+# labeling means "this PR is final; merge when fully green." The
+# `when-green` job arms GitHub NATIVE auto-merge — no --admin, no
+# check parsing by us; branch protection stays fully enforced and
+# GitHub's engine decides green-ness. Carve-out: any .github/ change
+# is out-of-class (merge automation can never self-merge); a push
+# that goes out-of-class disarms and strips the label; removing the
+# label disarms.
+#
+# See docs/specs/archive/auto-merge-safe-class/ for the class
+# definitions (D1, D8) and the rejected alternatives.
 #
 # Credential: the merge job authenticates with ADMIN_MERGE_TOKEN, a
 # fine-grained PAT owned by an admin (silversurfer562), repo-scoped,
@@ -19,7 +30,8 @@ name: Auto-merge safe (tests/docs only)
 
 on:
   pull_request_target:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types:
+      [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
   # NOT check_run: a check_run produced by the `Tests` workflow runs
   # under GITHUB_TOKEN, and GitHub does NOT start a new workflow run
   # from a GITHUB_TOKEN-triggered event (anti-recursion). So the
@@ -49,7 +61,10 @@ jobs:
   label:
     if: >-
       github.event_name == 'pull_request_target' &&
-      github.event.pull_request.user.login == 'silversurfer562'
+      github.event.pull_request.user.login == 'silversurfer562' &&
+      contains(fromJSON(
+        '["opened","synchronize","reopened","ready_for_review"]'),
+        github.event.action)
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
@@ -260,3 +275,122 @@ jobs:
               echo "::warning::PR #$pr unresolved after 5 merge attempts (left open)"
             echo "::endgroup::"
           done
+
+  # ---------------------------------------------------------------
+  # Class 2 (D8): opt-in `auto-merge-when-green`. A HUMAN applies
+  # the label ("PR is final; merge when fully green"); this job arms
+  # GitHub NATIVE auto-merge. No --admin, no check parsing here —
+  # branch protection stays fully enforced and GitHub's own engine
+  # decides green-ness (hung required lane = no merge, fail-closed).
+  #   labeled     -> verify gates, arm --auto (or plain-merge if
+  #                  already green; still non-admin)
+  #   synchronize -> if labeled, re-verify the path carve-out; a
+  #                  push that goes out-of-class disarms + unlabels
+  #   unlabeled   -> disarm
+  # ---------------------------------------------------------------
+  when-green:
+    if: >-
+      github.event_name == 'pull_request_target' &&
+      github.event.pull_request.user.login == 'silversurfer562' &&
+      (github.event.action == 'synchronize' ||
+       ((github.event.action == 'labeled' ||
+         github.event.action == 'unlabeled') &&
+        github.event.label.name == 'auto-merge-when-green'))
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      # Default ref on pull_request_target is the BASE branch, so we
+      # always run the trusted base copy of the guard.
+      - name: Checkout base repo (trusted guard)
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Arm, keep, or disarm native auto-merge
+        env:
+          # The PAT (not GITHUB_TOKEN) so the eventual merge is
+          # attributed to a user and downstream main-push workflows
+          # fire (GITHUB_TOKEN-initiated merges are anti-recursion
+          # suppressed).
+          GH_TOKEN: ${{ secrets.ADMIN_MERGE_TOKEN }}
+          PR: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+          ACTION: ${{ github.event.action }}
+        run: |
+          set -euo pipefail
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "ADMIN_MERGE_TOKEN not set; when-green job inert (fail-closed)."
+            exit 0
+          fi
+          # D6 defense: strip stray whitespace from the secret.
+          GH_TOKEN="$(printf '%s' "$GH_TOKEN" | tr -d '[:space:]')"
+          export GH_TOKEN
+
+          if [ "$ACTION" = "unlabeled" ]; then
+            gh pr merge "$PR" --disable-auto || true
+            echo "label removed -> native auto-merge disarmed"
+            exit 0
+          fi
+
+          meta=$(gh api "repos/$REPO/pulls/$PR" --jq '{
+            state: .state, draft: .draft, base_ref: .base.ref,
+            head_repo: .head.repo.full_name,
+            base_repo: .base.repo.full_name,
+            armed: (.auto_merge != null),
+            has_label: ([.labels[].name] |
+                        index("auto-merge-when-green") != null)
+          }')
+
+          # synchronize on an unlabeled PR: nothing to manage.
+          if [ "$ACTION" = "synchronize" ] && \
+             [ "$(echo "$meta" | jq -r .has_label)" != "true" ]; then
+            echo "skip: no auto-merge-when-green label"
+            exit 0
+          fi
+
+          disarm() {
+            echo "Disarming (fail-closed): $1"
+            gh pr merge "$PR" --disable-auto || true
+            gh pr edit "$PR" --remove-label auto-merge-when-green || true
+            exit 0
+          }
+
+          [ "$(echo "$meta" | jq -r .state)" = "open" ] || \
+            { echo "skip: PR not open"; exit 0; }
+          [ "$(echo "$meta" | jq -r .draft)" = "false" ] || \
+            disarm "draft PR"
+          [ "$(echo "$meta" | jq -r .base_ref)" = "main" ] || \
+            disarm "base != main"
+          [ "$(echo "$meta" | jq -r .head_repo)" = \
+            "$(echo "$meta" | jq -r .base_repo)" ] || disarm "fork PR"
+
+          # Path carve-out, re-verified on every event (label =
+          # necessary, not sufficient): .github/ can never self-merge.
+          mapfile -t paths < <(
+            gh api --paginate "repos/$REPO/pulls/$PR/files" \
+              --jq '.[] | .filename, (.previous_filename // empty)'
+          )
+          if [ "${#paths[@]}" -eq 0 ] || \
+             ! printf '%s\n' "${paths[@]}" | \
+             python3 .github/scripts/auto_merge_guard.py --mode when-green; then
+            disarm "out-of-class path(s) for the when-green class"
+          fi
+
+          # Already armed: the class was just re-verified on the
+          # current head; GitHub re-evaluates green-ness itself.
+          if [ "$(echo "$meta" | jq -r .armed)" = "true" ]; then
+            echo "auto-merge already armed; class re-verified"
+            exit 0
+          fi
+
+          # Arm native auto-merge. If the PR is ALREADY fully green,
+          # enabling auto-merge is rejected ("clean status") — fall
+          # back to a plain NON-ADMIN merge; protection is still
+          # enforced, so a non-green PR fails loudly and stays open.
+          if gh pr merge "$PR" --auto --squash --delete-branch; then
+            echo "native auto-merge armed for PR #$PR"
+          else
+            echo "arming failed (already green, or already armed) -> plain merge attempt"
+            gh pr merge "$PR" --squash --delete-branch || \
+              echo "::warning::PR #$PR neither armed nor merged (left open, fail-closed)"
+          fi

--- a/docs/specs/archive/auto-merge-safe-class/decisions.md
+++ b/docs/specs/archive/auto-merge-safe-class/decisions.md
@@ -236,3 +236,48 @@ self-merge — correct). Pairs with D6 (the token-newline auth fix):
 both are "the merge job resolved the PR but the merge call failed"
 shapes — D6 was an auth error swallowed by process substitution,
 D7 is a race swallowed by `|| echo`.
+
+---
+
+## D8 — Class 2: opt-in `auto-merge-when-green` (native auto-merge)
+
+**Date:** 2026-07-20
+**Status:** chair-approved (Patrick — Option A, `.github/`-only
+carve-out)
+
+**Problem.** Class 1 covers only tests/docs PRs, so a routine
+cascade of green src PRs (e.g. the 2026-07-20 overnight
+advanced-debugging/claim-gates run, ~10 PRs) still needed a session
+babysitting every merge with a gated one-liner.
+
+**Class definition** (all fail-closed):
+
+| # | Gate | Detail |
+|---|------|--------|
+| 1 | Opt-in label | `auto-merge-when-green`, applied by a HUMAN only — semantics "PR is final; merge when fully green." Automation never applies it (inverse of Class 1's label ownership). Resolves the stranded-follow-ups trap (2026-06-20 lesson) by intent instead of a settle-timer |
+| 2 | Author/provenance | author == `silversurfer562`, head repo == base repo, not draft, open, base `main` (same as Class 1) |
+| 3 | Path carve-out | no changed path (incl. rename origins) under `.github/` — merge automation can never self-merge, even labeled (`auto_merge_guard.py --mode when-green`) |
+| 4 | Full green | ALL required contexts must pass — enforced by GitHub's NATIVE auto-merge engine, never by our own check parsing. **No `--admin` for this class**; branch protection stays fully enforced |
+| 5 | Re-verify on push | `synchronize` re-runs the carve-out; a push that goes out-of-class disarms (`--disable-auto`) and strips the label; `unlabeled` disarms |
+
+**Why native auto-merge (Option A), not a custom evaluator
+(Option B).** The check-bucket-parsing trap (`gh pr checks` exits 0
+with failures) is eliminated rather than mitigated — GitHub's own
+engine decides green-ness. The original Rejected-C ("`--auto` waits
+forever on a hung required check") was a rejection for **Class 1**,
+whose purpose was to bypass a hung redundant lane; for Class 2 a
+hung lane correctly blocks the merge (for src PRs the full matrix
+is signal, not redundancy) — fail-closed and visible. Prereq
+`allow_auto_merge: true` verified live; the pattern is already
+proven in-repo by `dependabot-auto-merge.yml`. Arming uses
+`ADMIN_MERGE_TOKEN` (not `GITHUB_TOKEN`) so the eventual merge is
+user-attributed and downstream main-push workflows are not
+anti-recursion suppressed.
+
+**Receipt (D1 red-first, claim-drift-gates protocol).** Guard-mode
+tests (`tests/unit/github_scripts/test_auto_merge_guard.py`) and
+workflow invariants (`tests/unit/ci/test_workflow_yaml.py`:
+`TestAutoMergeWhenGreen` — job exists, label-lifecycle triggers,
+owner+label gate, `--auto` never `--admin`, guard re-verification,
+disarm on unlabeled) landed red first; the implementation commits
+in the same PR turned them green.

--- a/tests/unit/ci/test_workflow_yaml.py
+++ b/tests/unit/ci/test_workflow_yaml.py
@@ -500,3 +500,85 @@ class TestDynamicMatrixRequiredLane:
             f"required check `test ({self.REQUIRED_OS}, {self.REQUIRED_PY})` "
             "would never emit and the PR would be blocked forever."
         )
+
+
+# ---------------------------------------------------------------------------
+# auto-merge-safe.yml — Class 2 "when-green" invariants (archive spec D8)
+#
+# The opt-in class arms GitHub NATIVE auto-merge for a human-labeled
+# PR. Invariants: the job exists, fires on label lifecycle events, is
+# gated on the owner + the exact label name, re-verifies the path
+# carve-out via the guard's when-green mode, disarms on unlabeled,
+# and NEVER uses an admin bypass (branch protection stays enforced).
+# ---------------------------------------------------------------------------
+
+
+class TestAutoMergeWhenGreen:
+    """Drift guard for the opt-in auto-merge-when-green class."""
+
+    WF = "auto-merge-safe.yml"
+    JOB = "when-green"
+
+    @staticmethod
+    def _workflow() -> dict:
+        return ALL_WORKFLOWS["auto-merge-safe.yml"]
+
+    @classmethod
+    def _trigger_types(cls) -> list[str]:
+        wf = cls._workflow()
+        # YAML 1.1 parses a bare `on:` key as boolean True.
+        trigger = wf.get("on") or wf.get(True)
+        return trigger["pull_request_target"]["types"]
+
+    @classmethod
+    def _job(cls) -> dict:
+        return cls._workflow()["jobs"][cls.JOB]
+
+    @classmethod
+    def _run_text(cls) -> str:
+        return "\n".join(step.get("run", "") or "" for step in cls._job().get("steps", []))
+
+    def test_when_green_job_exists(self):
+        assert self.JOB in self._workflow()["jobs"], (
+            "auto-merge-safe.yml must define the `when-green` job "
+            "(Class 2, opt-in label — archive spec D8)."
+        )
+
+    def test_label_lifecycle_triggers_present(self):
+        types = self._trigger_types()
+        for needed in ("labeled", "unlabeled", "synchronize"):
+            assert needed in types, (
+                f"pull_request_target types must include {needed!r}: labeled "
+                "arms, unlabeled disarms, synchronize re-verifies the class "
+                "after every push (stranded-follow-ups defense)."
+            )
+
+    def test_job_gated_on_owner_and_label_name(self):
+        cond = self._job().get("if", "")
+        assert "silversurfer562" in cond
+        assert "auto-merge-when-green" in cond
+
+    def test_uses_native_auto_merge_never_admin(self):
+        run_text = self._run_text()
+        assert "--auto" in run_text, "when-green must arm GitHub native auto-merge"
+        assert "--admin" not in run_text, (
+            "the when-green class must NEVER admin-bypass branch protection — "
+            "full-green enforcement by GitHub is the whole design (D8)."
+        )
+
+    def test_reverifies_path_class_with_when_green_mode(self):
+        assert "auto_merge_guard.py --mode when-green" in self._run_text(), (
+            "the job must re-verify the .github/ carve-out via the guard's "
+            "when-green mode before arming (label = necessary, not sufficient)."
+        )
+
+    def test_disarms_on_unlabeled(self):
+        assert "--disable-auto" in self._run_text(), (
+            "removing the label must disarm native auto-merge, or a stripped "
+            "label would still merge."
+        )
+
+    def test_class1_merge_job_untouched(self):
+        # Regression guard: adding Class 2 must not remove Class 1's jobs.
+        jobs = self._workflow()["jobs"]
+        assert "label" in jobs and "merge" in jobs

--- a/tests/unit/github_scripts/test_auto_merge_guard.py
+++ b/tests/unit/github_scripts/test_auto_merge_guard.py
@@ -150,3 +150,113 @@ def test_cli_stdin_unsafe_exits_one(guard, monkeypatch):
 def test_cli_empty_stdin_is_unsafe(guard, monkeypatch):
     monkeypatch.setattr(sys, "stdin", io.StringIO(""))
     assert guard.main(["prog"]) == 1
+
+
+# ---------------------------------------------------------------------------
+# when-green mode (Class 2 — opt-in `auto-merge-when-green` label, D8)
+#
+# The when-green class allows ANY path EXCEPT `.github/` (merge
+# automation and CI config can never self-merge, even labeled). The
+# green-ness gate itself is GitHub native auto-merge, not this guard.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "src/attune/config.py",
+        "pyproject.toml",
+        "uv.lock",
+        "tests/unit/test_a.py",
+        "docs/guide.md",
+        "plugin/skills/x/SKILL.md",
+        "scripts/release.py",
+        "mkdocs.yml",
+        "attune_redis/foo.py",
+    ],
+)
+def test_when_green_allows_non_github_paths(guard, path):
+    assert guard.is_when_green_safe(path) is True
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        ".github/workflows/auto-merge-safe.yml",
+        ".github/scripts/auto_merge_guard.py",
+        ".github/workflows/tests.yml",
+        ".github/dependabot.yml",
+    ],
+)
+def test_when_green_blocks_github_paths(guard, path):
+    assert guard.is_when_green_safe(path) is False
+
+
+def test_when_green_blocks_traversal_and_empty(guard):
+    assert guard.is_when_green_safe("src/../.github/evil.yml") is False
+    assert guard.is_when_green_safe("") is False
+
+
+def test_when_green_mode_full_set_flags_github_offender(guard):
+    safe, offending = guard.is_safe_change(
+        ["src/a.py", ".github/workflows/x.yml"], mode="when-green"
+    )
+    assert safe is False
+    assert offending == [".github/workflows/x.yml"]
+
+
+def test_when_green_mode_all_safe(guard):
+    safe, offending = guard.is_safe_change(
+        ["src/a.py", "pyproject.toml", "tests/t.py"], mode="when-green"
+    )
+    assert safe is True
+    assert offending == []
+
+
+def test_when_green_mode_empty_set_failclosed(guard):
+    safe, offending = guard.is_safe_change([], mode="when-green")
+    assert safe is False
+    assert offending == []
+
+
+def test_when_green_rename_out_of_github_is_unsafe(guard):
+    # filename + previous_filename: a rename OUT of .github/ must be
+    # caught via the previous path.
+    safe, offending = guard.is_safe_change(
+        ["scripts/moved.py", ".github/scripts/old.py"], mode="when-green"
+    )
+    assert safe is False
+    assert ".github/scripts/old.py" in offending
+
+
+def test_default_mode_is_tests_docs(guard):
+    # No mode arg -> the original tight class; src/ stays out.
+    safe, _ = guard.is_safe_change(["src/a.py"])
+    assert safe is False
+
+
+# ---------------------------------------------------------------------------
+# CLI — --mode flag
+# ---------------------------------------------------------------------------
+
+
+def test_cli_mode_when_green_safe_exits_zero(guard):
+    assert guard.main(["prog", "--mode", "when-green", "src/a.py"]) == 0
+
+
+def test_cli_mode_when_green_unsafe_exits_one(guard):
+    assert guard.main(["prog", "--mode", "when-green", ".github/workflows/tests.yml"]) == 1
+
+
+def test_cli_mode_when_green_reads_stdin(guard, monkeypatch):
+    monkeypatch.setattr(sys, "stdin", io.StringIO("src/a.py\npyproject.toml\n"))
+    assert guard.main(["prog", "--mode", "when-green"]) == 0
+
+
+def test_cli_default_mode_unchanged(guard):
+    # Regression guard: adding --mode must not loosen the default class.
+    assert guard.main(["prog", "src/a.py"]) == 1
+
+
+def test_cli_unknown_mode_exits_two(guard):
+    assert guard.main(["prog", "--mode", "bogus", "src/a.py"]) == 2


### PR DESCRIPTION
## Summary

Extends the auto-merge-safe family with **Class 2: opt-in
`auto-merge-when-green`** (chair-approved 2026-07-20 — Option A,
`.github/`-only carve-out; recorded as D8 in
`docs/specs/archive/auto-merge-safe-class/decisions.md`), so routine
green merges of ANY PR class need no model babysitting.

## Class definition (all fail-closed)

| # | Gate | Detail |
|---|------|--------|
| 1 | Opt-in label | `auto-merge-when-green`, HUMAN-applied only ("PR is final; merge when fully green") — resolves the stranded-follow-ups trap by intent, not a settle-timer |
| 2 | Author/provenance | owner-authored, same-repo, not draft, open, base `main` |
| 3 | Path carve-out | no `.github/` paths (incl. rename origins) — merge automation can never self-merge |
| 4 | Full green | ALL required contexts, enforced by GitHub **native auto-merge** — no `--admin`, no check-bucket parsing by us; hung required lane = no merge (fail-closed) |
| 5 | Lifecycle | `synchronize` re-verifies the carve-out (disarm+unlabel if out-of-class); `unlabeled` disarms |

Class 1 (tests/docs, automation-labeled) is unchanged.

## Red-first receipt (claim-drift-gates D1 protocol)

- Commit 1 (`test(ci): … landed red`): 27 gate tests failed against
  the pre-change tree — guard when-green mode + `TestAutoMergeWhenGreen`
  workflow invariants (`--auto` never `--admin`, label-lifecycle
  triggers, guard re-verification, disarm on unlabeled).
- Commit 2 (`feat(ci): … gate green`): implementation; suites now
  359 passed / 1 skipped.

## Notes

- `allow_auto_merge: true` verified live; the native-auto-merge
  pattern is already proven in-repo by `dependabot-auto-merge.yml`.
- Arming uses `ADMIN_MERGE_TOKEN` so the eventual merge is
  user-attributed and downstream main-push workflows fire.
- This PR touches `.github/` and is therefore out-of-class for BOTH
  classes — it must be merged by hand (correct by construction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
