### PR TITLE
fix(tests): harden clean-run suite against headless launchd env

### DIFF
--- a/.claude/lessons.md
+++ b/.claude/lessons.md
@@ -16534,3 +16534,21 @@ def ", start_idx + 1)` for module-
   explanation text is scanned like any other text. Describe the
   removal generically ("former framework dependency") or point at
   the decisions entry instead of naming the token.
+
+- **A scheduled/headless (launchd) run inherits a DIFFERENT env
+  than your shell — three distinct test-failure classes from one
+  root cause** (2026-07-20, first scheduled clean-run: 13 red rows
+  → 2 real families + 1 infra gap, each receipted): (1) launchd's
+  default PATH lacks `~/.local/bin` / `~/.npm-global/bin`, so seat
+  CLIs report "ABSENT (exit 127)" — fix the plist PATH, not the
+  seats; (2) no tty/pinentry means a global `commit.gpgsign=true`
+  fails `git commit` inside test fixtures that create real repos —
+  fixtures MUST set `commit.gpgsign=false` (receipt: breaking
+  GNUPGHOME reproduces the exact ERROR set); (3) any var the
+  runner itself must export (here `REDIS_URL` for the board)
+  leaks into env-precedence tests — tests asserting config-source
+  precedence must `monkeypatch.delenv` the higher-precedence vars
+  first (receipt: 3 fail with `REDIS_URL` set, 7 pass without).
+  Diagnostic rule: when a scheduled run fails but the same suite
+  passes in your shell, diff the ENV (PATH, pinentry/tty,
+  exported service vars) before reading a single traceback.

--- a/tests/unit/hooks/test_spec_audit.py
+++ b/tests/unit/hooks/test_spec_audit.py
@@ -1161,7 +1161,17 @@ class TestDriftSignalPrecision:
 
 def _git(cwd: Path, *args: str) -> None:
     _subprocess.run(
-        ["git", "-c", "user.email=t@t", "-c", "user.name=t", *args],
+        [
+            "git",
+            "-c",
+            "user.email=t@t",
+            "-c",
+            "user.name=t",
+            # A global commit.gpgsign=true has no pinentry under launchd/CI.
+            "-c",
+            "commit.gpgsign=false",
+            *args,
+        ],
         cwd=str(cwd),
         check=True,
         capture_output=True,

--- a/tests/unit/memory/test_memory_config.py
+++ b/tests/unit/memory/test_memory_config.py
@@ -130,6 +130,14 @@ class TestGetRedisMemory:
 
 @pytest.mark.unit
 class TestCheckRedisConnection:
+    @pytest.fixture(autouse=True)
+    def _no_ambient_redis_url(self, monkeypatch):
+        # The dev shell and the weekly clean-run launchd env export
+        # REDIS_URL, which outranks the vars these tests set.
+        monkeypatch.delenv("REDIS_URL", raising=False)
+        monkeypatch.delenv("REDIS_PRIVATE_URL", raising=False)
+        monkeypatch.delenv("REDIS_PUBLIC_URL", raising=False)
+
     def test_mock_mode_returns_connected_true(self):
         mock_cfg = {"use_mock": True}
         with patch("attune.memory.config.get_redis_config", return_value=mock_cfg):

--- a/tests/unit/patterns/test_git_extractor_roundtrip.py
+++ b/tests/unit/patterns/test_git_extractor_roundtrip.py
@@ -42,6 +42,8 @@ def real_repo(tmp_path):
     _git(repo, "init", "-q")
     _git(repo, "config", "user.email", "tester@example.com")
     _git(repo, "config", "user.name", "Round Trip Tester")
+    # A global commit.gpgsign=true has no pinentry under launchd/CI.
+    _git(repo, "config", "commit.gpgsign", "false")
     (repo / "app.py").write_text("def f(x):\n    return x\n", encoding="utf-8")
     _git(repo, "add", "app.py")
     _git(repo, "commit", "-q", "-m", "fix: handle null input in f")


### PR DESCRIPTION
Chair-ruled C1+C3 from the 2026-07-20 clean-run digest (thread `routine-clean-run-20260720-0600`). First scheduled run of the weekly clean-run failed with 13 red rows that collapse to two distinct families, both receipted and fixed here:

- **REDIS_URL env-leak (3 failures)** — the routine's launchd env exports `REDIS_URL` (required for the board); the `TestCheckRedisConnection` precedence tests set lower-precedence vars without clearing it. Fix: autouse `monkeypatch.delenv` fixture. Receipt: 3 fail with `REDIS_URL` set before the fix, 18 pass after.
- **GPG-signing fixture ERRORs (10)** — fixtures in `test_git_extractor_roundtrip.py` and `test_spec_audit.py` create real git commits without `commit.gpgsign=false`; a global `gpgsign=true` has no pinentry under launchd. Receipt: breaking GNUPGHOME reproduced the exact ERROR set before the fix; 171 pass after (both envs).
- **C3 lesson** appended to `.claude/lessons.md` (headless-env failure class); lessons golden-query suite run locally: 26 passed.

The third clean-run finding (seat CLIs ABSENT, exit 127) was a launchd PATH gap — fixed in the plist directly, no repo change (C2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)