### PR TITLE
refactor(redis): platform-neutral managed-Redis naming, deprecate get_railway_redis

### DIFF
--- a/docs/getting-started/redis-setup.md
+++ b/docs/getting-started/redis-setup.md
@@ -37,11 +37,11 @@ docker exec attune-redis redis-cli ping
 # Should return: PONG
 ```
 
-### Option 3: Railway (Production)
+### Option 3: Managed Redis (Production)
 
-1. Go to your Railway project dashboard
-2. Click **+ New** → **Database** → **Redis**
-3. Railway automatically sets `REDIS_URL` for linked services
+Managed platforms (Upstash/Vercel, Heroku, Railway, ...) provision Redis
+from their dashboard and set `REDIS_URL` automatically for linked
+services — Attune picks it up with no extra configuration.
 
 ## Configuration
 
@@ -53,8 +53,8 @@ Add to your `.env` file:
 # Local development
 REDIS_URL=redis://localhost:6379
 
-# Railway (auto-set when Redis service is linked)
-# REDIS_URL=redis://default:password@host.railway.internal:6379
+# Managed Redis (auto-set when the platform links a Redis service)
+# REDIS_URL=redis://default:password@your-managed-host:6379
 ```
 
 ### Verify Connection

--- a/src/attune/__init__.py
+++ b/src/attune/__init__.py
@@ -111,6 +111,7 @@ if TYPE_CHECKING:
         UnifiedMemory,
         check_redis_connection,
         detect_secrets,
+        get_managed_redis,
         get_railway_redis,
         get_redis_config,
         get_redis_memory,
@@ -177,6 +178,7 @@ _LAZY_IMPORTS: dict[str, tuple[str, str]] = {
     "UnifiedMemory": (".memory", "UnifiedMemory"),
     "check_redis_connection": (".memory", "check_redis_connection"),
     "detect_secrets": (".memory", "detect_secrets"),
+    "get_managed_redis": (".memory", "get_managed_redis"),
     "get_railway_redis": (".memory", "get_railway_redis"),
     "get_redis_config": (".memory", "get_redis_config"),
     "get_redis_memory": (".memory", "get_redis_memory"),
@@ -310,6 +312,7 @@ __all__ = [
     "detect_secrets",
     # Logging
     "get_logger",
+    "get_managed_redis",
     "get_railway_redis",
     "get_redis_config",
     # Redis Configuration

--- a/src/attune/memory/__init__.py
+++ b/src/attune/memory/__init__.py
@@ -64,6 +64,7 @@ if TYPE_CHECKING:
     from .claude_memory import ClaudeMemoryConfig, ClaudeMemoryLoader
     from .config import (
         check_redis_connection,
+        get_managed_redis,
         get_railway_redis,
         get_redis_config,
         get_redis_memory,
@@ -135,6 +136,7 @@ _LAZY_IMPORTS: dict[str, tuple[str, str]] = {
     "ClaudeMemoryLoader": (".claude_memory", "ClaudeMemoryLoader"),
     # config
     "check_redis_connection": (".config", "check_redis_connection"),
+    "get_managed_redis": (".config", "get_managed_redis"),
     "get_railway_redis": (".config", "get_railway_redis"),
     "get_redis_config": (".config", "get_redis_config"),
     "get_redis_memory": (".config", "get_redis_memory"),
@@ -341,6 +343,7 @@ __all__ = [
     "ensure_redis",
     "generate_agent_id",
     "get_file_session_memory",
+    "get_managed_redis",
     "get_railway_redis",
     "get_redis_config",
     "get_redis_memory",

--- a/src/attune/memory/config.py
+++ b/src/attune/memory/config.py
@@ -145,7 +145,7 @@ def check_redis_connection() -> dict:
     if os.getenv("REDIS_URL"):
         result["config_source"] = "REDIS_URL"
     elif os.getenv("REDIS_PUBLIC_URL"):
-        result["config_source"] = "REDIS_PUBLIC_URL (Railway)"
+        result["config_source"] = "REDIS_PUBLIC_URL"
     elif os.getenv("REDIS_PRIVATE_URL"):
         result["config_source"] = "REDIS_PRIVATE_URL"
     elif os.getenv("REDIS_HOST"):
@@ -169,15 +169,16 @@ def check_redis_connection() -> dict:
     return result
 
 
-# Convenience function for Railway deployments
-def get_railway_redis() -> RedisShortTermMemory:
-    """Get Redis configured for Railway deployment.
+# Convenience function for managed Redis deployments
+def get_managed_redis() -> RedisShortTermMemory:
+    """Get Redis configured from a managed-platform URL.
 
-    Railway automatically sets REDIS_URL when you add a Redis service.
-    For external access (like from VSCode extension), use REDIS_PUBLIC_URL.
+    Managed Redis platforms (Upstash/Vercel, Heroku, Railway, ...) set
+    REDIS_URL automatically; some also set REDIS_PUBLIC_URL (external
+    access) or REDIS_PRIVATE_URL.
 
     Returns:
-        RedisShortTermMemory configured for Railway
+        RedisShortTermMemory configured from the managed Redis URL
 
     Raises:
         EnvironmentError: If no Redis URL is set
@@ -189,9 +190,27 @@ def get_railway_redis() -> RedisShortTermMemory:
 
     if not redis_url:
         raise OSError(
-            "REDIS_URL not found. Make sure Redis is added to your Railway project.\n"
-            "Run: railway add --database redis\n"
-            "For external access, use REDIS_PUBLIC_URL",
+            "REDIS_URL not found. Set REDIS_URL (or REDIS_PUBLIC_URL / "
+            "REDIS_PRIVATE_URL) to your managed Redis URL "
+            "(Upstash/Vercel, Heroku, Railway, ...).",
         )
 
     return get_redis_memory(url=redis_url)
+
+
+def get_railway_redis() -> RedisShortTermMemory:
+    """Deprecated alias for :func:`get_managed_redis`.
+
+    .. deprecated::
+        The mechanism is platform-neutral; use ``get_managed_redis()``.
+
+    """
+    import warnings
+
+    warnings.warn(
+        "get_railway_redis() is deprecated; use get_managed_redis() — "
+        "the URL detection is platform-neutral, not Railway-specific.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return get_managed_redis()

--- a/src/attune/redis_config.py
+++ b/src/attune/redis_config.py
@@ -6,7 +6,8 @@ Superseded by attune_redis.AMSMemoryBackend (the Redis Agent Memory Server integ
     Use ``attune_redis.config.RedisPluginConfig`` for new code.
 
 Handles connection to Redis from environment variables.
-Supports Redis Cloud, Railway, local Docker, managed Redis, or mock mode.
+Supports Redis Cloud, managed Redis (Upstash/Vercel, Heroku, Railway, ...),
+local Docker, or mock mode.
 
 Environment Variables:
     REDIS_MODE: "cloud" or "local" (inferred from REDIS_HOST if not set)
@@ -39,9 +40,10 @@ Environment Variables:
     REDIS_SENTINEL_HOSTS: Comma-separated host:port pairs
     REDIS_SENTINEL_MASTER: Sentinel master name
 
-Railway Auto-Detection:
-    When deployed on Railway, REDIS_URL is automatically set.
-    For Railway Redis with SSL, the URL starts with "rediss://"
+Managed Redis Auto-Detection:
+    Managed platforms (Upstash/Vercel, Heroku, Railway, ...) set REDIS_URL
+    automatically; some also set REDIS_PRIVATE_URL.
+    For SSL-terminated managed Redis, the URL starts with "rediss://"
 
 Usage:
     from attune.redis_config import get_redis_memory
@@ -168,7 +170,8 @@ def get_redis_config() -> RedisConfig:
 
     Priority:
     1. EMPATHY_REDIS_MOCK=true -> mock mode
-    2. REDIS_URL (full URL, used by Railway/Heroku/managed services)
+    2. REDIS_URL (full URL, set by managed Redis platforms —
+       Upstash/Vercel, Heroku, Railway, ...)
     3. REDIS_MODE + individual env vars:
        - "cloud": uses REDIS_HOST, REDIS_PORT, REDIS_PASSWORD
        - "local": uses localhost:6379, no password (ignores REDIS_PASSWORD)
@@ -187,7 +190,7 @@ def get_redis_config() -> RedisConfig:
     if (get_attune_env("REDIS_MOCK", "") or "").lower() == "true":
         return RedisConfig(use_mock=True)
 
-    # Check for full URL (Railway, Heroku, managed services)
+    # Check for full URL (managed Redis — Upstash/Vercel, Heroku, Railway, ...)
     redis_url = os.getenv("REDIS_URL") or os.getenv("REDIS_PRIVATE_URL")
     if redis_url:
         url_config = parse_redis_url(redis_url)
@@ -397,14 +400,15 @@ def check_redis_connection() -> dict:
     return result
 
 
-# Convenience function for Railway deployments
-def get_railway_redis() -> RedisShortTermMemory:
-    """Get Redis configured for Railway deployment.
+# Convenience function for managed Redis deployments
+def get_managed_redis() -> RedisShortTermMemory:
+    """Get Redis configured from a managed-platform URL.
 
-    Railway automatically sets REDIS_URL when you add a Redis service.
+    Managed Redis platforms (Upstash/Vercel, Heroku, Railway, ...) set
+    REDIS_URL automatically; some also set REDIS_PRIVATE_URL.
 
     Returns:
-        RedisShortTermMemory configured for Railway
+        RedisShortTermMemory configured from the managed Redis URL
 
     Raises:
         EnvironmentError: If REDIS_URL is not set
@@ -414,8 +418,26 @@ def get_railway_redis() -> RedisShortTermMemory:
 
     if not redis_url:
         raise OSError(
-            "REDIS_URL not found. Make sure Redis is added to your Railway project.\n"
-            "Run: railway add --database redis",
+            "REDIS_URL not found. Set REDIS_URL (or REDIS_PRIVATE_URL) to your "
+            "managed Redis URL (Upstash/Vercel, Heroku, Railway, ...).",
         )
 
     return get_redis_memory(url=redis_url)
+
+
+def get_railway_redis() -> RedisShortTermMemory:
+    """Deprecated alias for :func:`get_managed_redis`.
+
+    .. deprecated::
+        The mechanism is platform-neutral; use ``get_managed_redis()``.
+
+    """
+    import warnings
+
+    warnings.warn(
+        "get_railway_redis() is deprecated; use get_managed_redis() — "
+        "the URL detection is platform-neutral, not Railway-specific.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return get_managed_redis()

--- a/tests/unit/memory/test_memory_config.py
+++ b/tests/unit/memory/test_memory_config.py
@@ -5,7 +5,8 @@ Covers:
 - get_redis_config: use_mock=True path, real config path
 - get_redis_memory: use_mock=True, explicit URL, env-based (mock), env-based (real)
 - check_redis_connection: mock mode, REDIS_URL env, other env vars, ping success, exception
-- get_railway_redis: no URL → OSError, URL present → returns memory
+- get_managed_redis: no URL → OSError, URL present → returns memory
+- get_railway_redis: deprecated alias, warns and delegates
 """
 
 from __future__ import annotations
@@ -16,6 +17,7 @@ import pytest
 
 from attune.memory.config import (
     check_redis_connection,
+    get_managed_redis,
     get_railway_redis,
     get_redis_config,
     get_redis_memory,
@@ -188,7 +190,7 @@ class TestCheckRedisConnection:
         assert result["connected"] is False
         assert "refused" in result["error"]
 
-    def test_railway_env_sets_config_source(self):
+    def test_redis_public_url_env_sets_config_source(self):
         mock_cfg = {"use_mock": False, "host": "h", "port": 6379}
         mock_memory = MagicMock()
         mock_memory.ping.return_value = False
@@ -198,12 +200,12 @@ class TestCheckRedisConnection:
             patch("attune.memory.config.get_redis_memory", return_value=mock_memory),
             patch.dict(
                 "os.environ",
-                {"REDIS_PUBLIC_URL": "redis://railway"},
+                {"REDIS_PUBLIC_URL": "redis://managed-host"},
                 clear=False,
             ),
         ):
             result = check_redis_connection()
-        assert "Railway" in result["config_source"] or "PUBLIC_URL" in result["config_source"]
+        assert result["config_source"] == "REDIS_PUBLIC_URL"
 
     def test_redis_private_url_env_sets_config_source(self):
         mock_cfg = {"use_mock": False, "host": "h", "port": 6379}
@@ -220,12 +222,12 @@ class TestCheckRedisConnection:
 
 
 # ---------------------------------------------------------------------------
-# get_railway_redis
+# get_managed_redis (+ deprecated get_railway_redis alias)
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.unit
-class TestGetRailwayRedis:
+class TestGetManagedRedis:
     def test_no_url_raises_os_error(self):
         with patch.dict(
             "os.environ",
@@ -239,12 +241,22 @@ class TestGetRailwayRedis:
                 os.environ.pop(key, None)
 
             with pytest.raises(OSError, match="REDIS_URL not found"):
-                get_railway_redis()
+                get_managed_redis()
 
     def test_redis_url_returns_memory(self):
         with (
             patch.dict("os.environ", {"REDIS_URL": "redis://localhost:6379"}, clear=False),
             patch("attune.memory.config.get_redis_memory") as mock_mem,
+        ):
+            mock_mem.return_value = MagicMock()
+            get_managed_redis()
+        mock_mem.assert_called_once_with(url="redis://localhost:6379")
+
+    def test_railway_alias_warns_and_delegates(self):
+        with (
+            patch.dict("os.environ", {"REDIS_URL": "redis://localhost:6379"}, clear=False),
+            patch("attune.memory.config.get_redis_memory") as mock_mem,
+            pytest.warns(DeprecationWarning, match="get_managed_redis"),
         ):
             mock_mem.return_value = MagicMock()
             get_railway_redis()


### PR DESCRIPTION
## Summary

The managed-Redis URL detection in `attune.redis_config` / `attune.memory.config` was branded Railway, but the mechanism (`REDIS_URL` → `REDIS_PRIVATE_URL` → host/port precedence) is platform-neutral — it is exactly what Upstash/Vercel, Heroku, and Railway deployments set. This renames the branding without touching the mechanism.

- **`get_managed_redis()`** added as the canonical helper in both `attune.redis_config` and `attune.memory.config`; exported from `attune` and `attune.memory`.
- **`get_railway_redis()`** kept as a public deprecated alias (`DeprecationWarning`) — it is public API, so not removed (removing-dead-code gate: still exported, still referenced by external users of the published package).
- `check_redis_connection` `config_source` drops the ` (Railway)` suffix from `REDIS_PUBLIC_URL`.
- Module docstrings/comments re-worded to "managed Redis (Upstash/Vercel, Heroku, Railway, ...)".
- Tests: `TestGetManagedRedis` + alias-deprecation test in `tests/unit/memory/test_memory_config.py`; `config_source` assertion tightened. Legacy-path tests in `tests/memory/test_redis_config.py` / `test_coverage_batch13.py` still pass unchanged (they keep the alias covered).
- Docs: `redis-setup.md` Option 3 generalized from Railway to managed Redis. No `.help/` or `docs/reference/` Railway branding found; the Railway-internal-URL troubleshooting section kept (genuine platform-specific content).

**URL-precedence mechanism is byte-identical** — diff outside strings/docstrings is empty.

## Test plan
- [x] `pytest tests/unit/memory/test_memory_config.py tests/memory/test_redis_config.py tests/unit/test_coverage_batch13.py` — 113 passed (serial, worktree src)
- [x] Live check: `from attune import get_managed_redis, get_railway_redis` resolves; alias emits `DeprecationWarning`
- [x] Pinned black/ruff pre-flighted clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
