### PR TITLE
feat(lifecycle): status-line hygiene — vocabulary, parked bucket, gate, backfill

### DIFF
--- a/docs/specs/advanced-debugging-plugin/decisions.md
+++ b/docs/specs/advanced-debugging-plugin/decisions.md
@@ -1,5 +1,7 @@
 # Advanced Debugging Plugin — Decisions
 
+**Status:** shipped (2026-07-20) — spec complete (#1503)
+
 ## 2026-07-19 — Origin and pre-spec rulings (chair: Patrick)
 
 Born from a live brainstorm the same day the run-record corpus
@@ -241,3 +243,32 @@ receipt).** `run_fix_loop` on the high-confidence real diagnosis
 With all four phases, all eight RR receipts, and both live-fires
 executed, this spec is COMPLETE; the follow-ups above are the v1.1
 backlog.
+
+## 2026-07-20 — First-content triage of the diagnoses stream (q-briefing-triage-002 A3, chair ruled)
+
+The stream's first three records are all artifacts of this spec's own
+ship day, not operational failures:
+
+- `3264a8f6107b` (run `85c88fd9…`, "path argument is required") and
+  `7e751fed728a` (run `63c533fb46…`, ops exit 1) are the live-fire
+  receipt runs named in this file's Phase A/B entries.
+- `40482304b805` (run `0910cf106403`, diagnose exit 2, 05:49 UTC)
+  falls inside the overnight Phase C/D dogfood window; treated as
+  dogfood pending contrary evidence.
+
+The canonical stream was NOT hand-edited: `store.py` is
+read-only-by-design and append-only via `TelemetryStore.log_diagnosis`
+with no dedupe, so a "closure" append would double records instead of
+updating them. Two queued follow-ons (behind the T2 hygiene PR, per
+the codex no-parallel-program risk):
+
+1. **Phase B priors defect** — all 3/3 real records carry
+   `priors_degraded: no-terms-extracted` and the 05:49 record's
+   hypotheses have EMPTY summaries: the term extractor gets zero
+   signal from real symptoms. One fix task; not inline.
+2. **Origin-tag + closure seam** — an `origin` field
+   (live-fire | dogfood | operational) stamped at creation, a
+   status-update seam (last-wins by `diagnosis_id` or a tombstone
+   record), and automated-suite exclusion for the diagnoses curator
+   source, mirroring the RR corpus suite-isolation rule. Ruled
+   2-1: tag, never retro-delete (D3 no-backfill spirit).

--- a/docs/specs/advanced-debugging-plugin/design.md
+++ b/docs/specs/advanced-debugging-plugin/design.md
@@ -1,6 +1,6 @@
 # Advanced Debugging Plugin — Design
 
-**Status:** draft for chair review (2026-07-19). Requirements
+**Status:** shipped (2026-07-20) — executed as designed. Requirements
 chair-ruled per item (RR-1..RR-8, thread
 `producing-advanced-debugging-plugin-001`); this design binds each
 requirement to concrete seams and names the build phases.

--- a/docs/specs/advanced-debugging-plugin/requirements.md
+++ b/docs/specs/advanced-debugging-plugin/requirements.md
@@ -1,6 +1,6 @@
 # Advanced Debugging Plugin — Requirements
 
-**Status: requirements chair-ruled per item** — authored by the
+**Status:** shipped (2026-07-20) — Phases A–D landed (#1487–#1503); requirements chair-ruled per item — authored by the
 round table (thread `producing-advanced-debugging-plugin-001`); compiled deterministically by
 `attune.roundtable.compiler` (V2-P2). Approved items only;
 declined: none;

--- a/docs/specs/advanced-debugging-plugin/tasks.md
+++ b/docs/specs/advanced-debugging-plugin/tasks.md
@@ -1,6 +1,6 @@
 # Advanced Debugging Plugin — Tasks
 
-**Status: executed** (2026-07-20 — all four phases shipped, live-fires receipted; see decisions.md). Eight tasks across
+**Status:** shipped (2026-07-20) — all four phases shipped, live-fires receipted; see decisions.md. Eight tasks across
 the design's four phases (A substrate, B engine, C surface,
 D loops). One PR per phase; each task names its RR receipts.
 Execute in order — every task builds on the previous task's

--- a/docs/specs/agent-round-table/requirements.md
+++ b/docs/specs/agent-round-table/requirements.md
@@ -1,6 +1,6 @@
 # Agent Round Table — Requirements
 
-**Status: requirements APPROVED-pending-review (2026-07-18)** —
+**Status:** approved (2026-07-18) — pending final review;
 foundations chat-ratified by Patrick same day; D1/D2 picked, D3
 provisional (see [decisions.md](decisions.md), including the
 promoted probe-001 transcript).

--- a/docs/specs/antigravity-adapter/requirements.md
+++ b/docs/specs/antigravity-adapter/requirements.md
@@ -1,6 +1,6 @@
 # Antigravity Adapter — Requirements
 
-**Status: D1 RATIFIED (a)** — receipts passed and Patrick
+**Status:** active (2026-07-18) — D1 ratified (a); receipts passed and Patrick
 ratified option (a) same day (2026-07-18,
 app 2.3.1 + agy CLI 1.1.4; transcripts in
 [decisions.md](decisions.md)); D2 largely

--- a/docs/specs/attune-author-consolidation/design.md
+++ b/docs/specs/attune-author-consolidation/design.md
@@ -1,6 +1,6 @@
 # attune-author Consolidation — Design
 
-**Status:** parked (2026-07-13) — T1 (#1193) + T2a (#1203/#1205) shipped: projector/staleness/fact_check absorbed into attune.authoring, help_data in-process; remaining: scripts' attune_author consumer repoints (T1 acceptance), resolver fold-in (T2/#1191), T3 polish-upstream (D10), T4 package fate, T5 docs repoints · pairs with
+**Status:** parked (2026-07-13) — T1 (#1193) + T2a (#1203/#1205) shipped: projector/staleness/fact_check absorbed into attune.authoring, help_data in-process; remaining: scripts' attune_author consumer repoints (T1 acceptance), resolver fold-in (T2/#1191), T3 polish-upstream (D10), T4 package fate, T5 docs repoints · Resume-Trigger: evergreen (no external clock) · pairs with
 [requirements.md](requirements.md).
 
 ## The new home

--- a/docs/specs/cross-provider-collaboration-projector/requirements.md
+++ b/docs/specs/cross-provider-collaboration-projector/requirements.md
@@ -1,6 +1,6 @@
 # Cross-Provider Collaboration Projector — Requirements
 
-**Status: RATIFIED** — D1–D6 all ratified by Patrick 2026-07-18
+**Status:** active (2026-07-18) — D1–D6 all ratified by Patrick
 (option a in each; see [decisions.md](decisions.md)). Implementation state is recorded
 honestly: R1–R6 are already implemented on `codex/using-projectors`;
 R7+ are open pending decisions.

--- a/docs/specs/docs-wiring-audit/decisions.md
+++ b/docs/specs/docs-wiring-audit/decisions.md
@@ -1,6 +1,6 @@
 # Per-decision log — Docs wiring audit
 
-**Status:** approved
+**Status:** shipped (2026-07-20, closed per q-briefing-triage-002 A1)
 
 
 Append-only log. Resolutions for the open questions enumerated in

--- a/docs/specs/docs-wiring-audit/design.md
+++ b/docs/specs/docs-wiring-audit/design.md
@@ -1,5 +1,5 @@
 # Design: Documentation Wiring Audit
-**Status:** approved (2026-05-31)
+**Status:** shipped (2026-07-20, closed per q-briefing-triage-002 A1; approved 2026-05-31)
 **Phase:** 2 — Design
 **Predecessor:** [requirements.md](./requirements.md) (Phase 1
 approved 2026-05-31, see [decisions.md](./decisions.md))

--- a/docs/specs/docs-wiring-audit/requirements.md
+++ b/docs/specs/docs-wiring-audit/requirements.md
@@ -8,7 +8,7 @@
 >
 > **Orthogonal to content correctness.** This spec does not touch what
 > docs *say* — only how they connect.
-**Status:** approved — v1 shipped (scripts/audit_docs_wiring.py + anchor check, #518/#523); v1.1 shipped 2026-07-15 (nav + features + mkdocstrings checks, .audit/orphans.yml — see decisions.md Phase 4 entry); Task 10 (See-Also) deferred
+**Status:** shipped (2026-07-20, closed per q-briefing-triage-002 A1) — v1 shipped (scripts/audit_docs_wiring.py + anchor check, #518/#523); v1.1 shipped 2026-07-15 (nav + features + mkdocstrings checks, .audit/orphans.yml — see decisions.md Phase 4 entry); Task 10 (See-Also) deferred
 **Created:** 2026-05-30
 **Owner:** TBD
 **Related:**

--- a/docs/specs/docs-wiring-audit/tasks.md
+++ b/docs/specs/docs-wiring-audit/tasks.md
@@ -1,5 +1,5 @@
 # Tasks: Documentation Wiring Audit
-**Status:** approved (2026-07-13) — v1 shipped (#518/#523 anchor check via `scripts/audit_docs_wiring.py`; #540 CI job, since promoted to a required check on main); v1.1 shipped 2026-07-15 (Tasks 3, 4 adapted, 9 — see decisions.md Phase 4 entry); remaining: See-Also advisory (Task 10, deferred).
+**Status:** shipped (2026-07-20, closed per q-briefing-triage-002 A1) — v1 shipped (#518/#523 anchor check via `scripts/audit_docs_wiring.py`; #540 CI job, since promoted to a required check on main); v1.1 shipped 2026-07-15 (Tasks 3, 4 adapted, 9 — see decisions.md Phase 4 entry); remaining: See-Also advisory (Task 10, deferred).
 **Phase:** 3 — Tasks
 **Predecessor:** [design.md](./design.md) (Phase 2 authored
 2026-05-31)

--- a/docs/specs/elicitation-form-surface/design.md
+++ b/docs/specs/elicitation-form-surface/design.md
@@ -1,6 +1,6 @@
 # Elicitation Form Surface — Design (v1)
 
-**Status:** v1 shipped (verified 2026-07-14); v2+ status tracked in [requirements.md](requirements.md)
+**Status:** shipped (v1, verified 2026-07-14); v2+ status tracked in [requirements.md](requirements.md)
 
 Design for the [requirements](requirements.md), post-Phase 0. Surface
 decision is [decisions.md](decisions.md) **D4**: AskUserQuestion-first,

--- a/docs/specs/elicitation-form-surface/requirements.md
+++ b/docs/specs/elicitation-form-surface/requirements.md
@@ -1,6 +1,6 @@
 # Elicitation Form Surface — Requirements
 
-**Status:** v1 shipped (verified 2026-07-14 — src/attune/elicitation + MCP elicitation_* tools); v2 scope (v2-1/v2-2 reqs) recommitted at 2026-07-14 triage
+**Status:** shipped (v1, verified 2026-07-14 — src/attune/elicitation + MCP elicitation_* tools); v2 scope (v2-1/v2-2 reqs) recommitted at 2026-07-14 triage
 **Born:** a post-9.0.0 chat. Patrick — tech-writing / hypertext-help
 background — said he'd "missed the form-related options from working
 with HTML" and wanted to explore them, multi-select first. Two live

--- a/docs/specs/feature-page-scaffolder/tasks.md
+++ b/docs/specs/feature-page-scaffolder/tasks.md
@@ -1,6 +1,6 @@
 # Feature-Page Scaffolder — Tasks
 
-**Status:** parked (2026-07-13) — spec docs shipped (#1190); implementation not started (T1–T4 remain: template, scaffold/build verbs, tests, playbook retirement) · implements
+**Status:** parked (2026-07-13) — spec docs shipped (#1190); implementation not started (T1–T4 remain: template, scaffold/build verbs, tests, playbook retirement) · Resume-Trigger: evergreen (no external clock) · implements
 [design.md](design.md). Each task names its acceptance.
 
 ## T1 — Template + `scaffold` verb

--- a/docs/specs/gemini-projector/decisions.md
+++ b/docs/specs/gemini-projector/decisions.md
@@ -1,5 +1,7 @@
 # Gemini Projector Integration — Decisions
 
+**Status:** superseded (2026-07-18) — see [requirements.md](requirements.md)
+
 ## D1 — adapter shape (OPEN, receipt pending)
 
 **Candidate (a), config-only adapter, staged for the live test.**

--- a/docs/specs/gemini-projector/requirements.md
+++ b/docs/specs/gemini-projector/requirements.md
@@ -1,6 +1,6 @@
 # Gemini Projector Integration — Requirements
 
-**Status: PARKED — SUPERSEDED (ratified 2026-07-18, Patrick)** by
+**Status:** superseded (2026-07-18, ratified by Patrick) — replaced by
 [../antigravity-adapter/](../antigravity-adapter/requirements.md).
 Google retired the Gemini CLI's free individual tier the same day
 this spec was drafted (`IneligibleTierError` → "migrate to the

--- a/docs/specs/memory-feedback-signal/requirements.md
+++ b/docs/specs/memory-feedback-signal/requirements.md
@@ -1,7 +1,7 @@
 # Memory Feedback Signal (STEP 2) — Requirements
 
-**Status: requirements APPROVED (2026-07-19, chair: Patrick — all
-seven items, per-REQ)** — authored by the round table in its first
+**Status:** approved (2026-07-19, chair: Patrick — all
+seven items, per-REQ) — authored by the round table in its first
 V2-P1 spec-authoring loop (thread `mem-signal-001`, three rounds:
 draft → adversarial critique ×2 → revision; full record in
 [decisions.md](decisions.md)). Implements the memory-as-insurance

--- a/docs/specs/memory-recall-eval/requirements.md
+++ b/docs/specs/memory-recall-eval/requirements.md
@@ -5,7 +5,7 @@
 > recalls curated memory correctly — before investing further in the
 > subsystem or deciding it needs work.
 
-**Status:** in progress — feedback-signal step 1 (per-surfacing capture records on all three injection surfaces) shipped 2026-07-14; step 2 (Stop-hook verdict scorer + noise-denominator reader) scoped in decisions.md, design pass owed
+**Status:** active (2026-07-14) — feedback-signal step 1 (per-surfacing capture records on all three injection surfaces) shipped 2026-07-14; step 2 (Stop-hook verdict scorer + noise-denominator reader) scoped in decisions.md, design pass owed
 **Owner:** Patrick + agent
 **Related:**
 

--- a/docs/specs/ops-dashboard-polish/decisions.md
+++ b/docs/specs/ops-dashboard-polish/decisions.md
@@ -1,5 +1,5 @@
 # Decisions — Ops Dashboard Polish
-**Status:** partial — Phase A complete; Phase B (4/5), C (Sessions shipped, Memory not started), D (1/6) in progress
+**Status:** active (2026-07-20) — partial: Phase A complete; Phase B (4/5), C (Sessions shipped, Memory not started), D (1/6) in progress
 **Owner:** Patrick
 **Opened:** 2026-05-14
 **Predecessors:**

--- a/docs/specs/ops-dashboard-polish/tasks.md
+++ b/docs/specs/ops-dashboard-polish/tasks.md
@@ -1,6 +1,6 @@
 # Tasks — Ops Dashboard Polish
 
-**Status:** parked (2026-07-13) — Phases A+B shipped (#361 #365 #367; B2 in #371), C2 Sessions (#377 #387 #390), D5 (#376); remaining: C1 /memory page, C3 memory nav+KPIs, D1 sweep+CI gate, D2-D4, D6.
+**Status:** parked (2026-07-13) — Phases A+B shipped (#361 #365 #367; B2 in #371), C2 Sessions (#377 #387 #390), D5 (#376); remaining: C1 /memory page, C3 memory nav+KPIs, D1 sweep+CI gate, D2-D4, D6 · Resume-Trigger: evergreen (no external clock).
 **Owner:** Patrick
 
 Cross-references the QA punch list at

--- a/docs/specs/pipeline-learner/requirements.md
+++ b/docs/specs/pipeline-learner/requirements.md
@@ -1,6 +1,6 @@
 # Pipeline Learner v1 (table-refreshed) — Requirements
 
-**Status: requirements chair-ruled per item** — authored by the
+**Status:** approved (2026-07-19) — chair-ruled per item; live surfacing gated on RR-1 corpus readiness. Authored by the
 round table (thread `producing-pipeline-learner-v1-20260719-2`); compiled deterministically by
 `attune.roundtable.compiler` (V2-P2). Approved items only;
 declined: none;

--- a/docs/specs/roundtable-producing-team/requirements.md
+++ b/docs/specs/roundtable-producing-team/requirements.md
@@ -1,7 +1,7 @@
 # Round Table v2 — Producing Team: Requirements
 
-**Status: requirements DRAFTED from thread `table-v2-001`
-(2026-07-18)** — architecture converged by the table itself in one
+**Status:** active (2026-07-18) — requirements drafted from
+thread `table-v2-001`; architecture converged by the table itself in one
 round; initial settings chair-ratified same day (phase-1-minimal +
 fixed-roles-first, moderator pushback accepted — see
 [decisions.md](decisions.md)).

--- a/docs/specs/roundtable-triage/decisions.md
+++ b/docs/specs/roundtable-triage/decisions.md
@@ -1,5 +1,7 @@
 # Roundtable Triage — Decisions
 
+**Status:** active (2026-07-20) — chartered 2026-07-19 (n=1); n=2 validated 2026-07-20; requirements not yet authored
+
 ## 2026-07-19 — Charter (chair, "as synthesized"; thread q-briefing-triage-001)
 
 Born from a live demo in conversation: the moderator pulled the ops
@@ -57,3 +59,58 @@ The T2 status-line lint requires a `Resume-Trigger:` clause on any
 chair queues a pack, or direct) covering the appendix digest format,
 the ≤5-item cap mechanics, the freshness thresholds, and the
 demotion rule; n=2 manual validation runs alongside.
+
+## 2026-07-20 — n=2 validation run (thread q-briefing-triage-002; chair ruled "go all")
+
+Pre-authorized 2026-07-19 evening; run alongside the first scheduled
+clean-run digest (one sitting, per T4). Four items (cap held), none
+duplicating the clean-run digest. Seats: claude (session), agy,
+codex — independent, one round, halting.
+
+**A1 (3-0, ruled).** docs-wiring-audit CLOSED as shipped — n=1's
+"no activity since 07-15" evidence line misread shipped-and-quiet
+as silent-rot (v1 + required CI check on main; v1.1 07-15; only
+deferred Task 10 open). Status flipped in all four phase files.
+Lesson for briefing evidence: "no activity" must be cross-read
+against the spec's own status line before it feeds a sequencing
+ruling.
+
+**A2 (3-0, ruled).** T2 hygiene unit EXECUTED as the replacement
+next work unit, one PR: token-first status backfill (~24 dirs),
+`parked`/`living`/`shipped`/`superseded` in the detector vocabulary
+(+ `parked` lifecycle bucket), the third status-line bolding
+convention in the parser, the `status-line` baseline gate
+(CI sweep, D7 pattern), R9 Resume-Trigger enforcement, and the A1
+flip folded in (codex amendment). Scope guard honored: the Item-3
+tag parser did NOT ride in. usage-signals US-4 named the product
+unit next.
+
+**A3 (ruled).** The three 2026-07-20 diagnosis records are
+live-fire/dogfood artifacts (85c88fd9 + 63c533fb are the
+advanced-debugging spec's named receipts; 0910cf10 falls inside the
+overnight Phase C/D dogfood window). No closure/annotation seam
+exists yet (store is append-only by design), so the canonical
+stream was NOT hand-edited; disposition recorded in
+advanced-debugging-plugin/decisions.md with two queued follow-ons
+(priors defect; origin-tag + closure seam + automated-suite
+exclusion). RR corpus record 85c88fd9 stays (D3 no-backfill; 2-1
+tag-don't-delete, recorded evidence over agy's cleanup).
+
+**A4 (effective 3-0, ruled).** Gate verdict ledger is dark locally
+BY CONSTRUCTION (D7 CI-only; nothing invokes the lifecycle runner
+locally). Briefing contract amended: fetch CI gate verdicts at
+briefing render time (timestamped unavailable/expired handling, no
+scheduled refresh — T3-compliant). Queued behind this PR with the
+A3 follow-ons; not a parallel program (codex risk).
+
+**T4 (ruled: armed).** n=2 validation PASSED — cap held (4/5), zero
+digest overlap, and the appendix caught a mis-ruled work unit the
+clean-run alone would have missed. Headless appendix is ARMED per
+T4; implementation (extend the clean-run routine with the briefing
+appendix) queues behind the A3/A4 follow-ons. Auto-demote rule
+stands: two consecutive zero-ruling digests demote to
+chair-invoked.
+
+Deviation noted: n=2's question was posted as author `moderator`
+(chair pre-authorized but did not compose the brief live; n=1 used
+`chair`).

--- a/docs/specs/run-record-corpus/decisions.md
+++ b/docs/specs/run-record-corpus/decisions.md
@@ -1,5 +1,7 @@
 # Run-Record Corpus — Decisions
 
+**Status:** shipped (2026-07-19) — see [requirements.md](requirements.md)
+
 ## 2026-07-19 — Chair rulings on the three open questions (Patrick)
 
 **D1 — Fork: Option B (canonicalize the existing telemetry

--- a/docs/specs/run-record-corpus/requirements.md
+++ b/docs/specs/run-record-corpus/requirements.md
@@ -1,6 +1,6 @@
 # Run-Record Corpus (RR-1 unblock) — Requirements
 
-**Status: chair-ruled 2026-07-19** — all three open questions
+**Status:** shipped (2026-07-19) — implemented same day (#1472); chair-ruled: all three open questions
 ruled (B; chair-ruled RR-4 edit; start clean — see
 `decisions.md`). Drafted 2026-07-19 by the follow-up session
 (direct draft; not a producing run). This is

--- a/docs/specs/socratic-ambiguity-calibration/requirements.md
+++ b/docs/specs/socratic-ambiguity-calibration/requirements.md
@@ -1,7 +1,7 @@
 # Socratic Ambiguity Calibration — Requirements
 
 **Status:** parked (2026-07-13; reqs+design shipped #1071/#1072; #1068 = paired trigger fix, not this scope; remaining: G1–G4 impl — see
-[decisions.md](decisions.md)) · **Owner:** Patrick + agent
+[decisions.md](decisions.md)) · Resume-Trigger: evergreen (no external clock) · **Owner:** Patrick + agent
 **Sequencing:** queued **behind 9.0.0** (the Empathy framework removal).
 **Born:** the 8.10.0-ship session (2026-06-25). After a compound reply
 I'd *guessed* at, Patrick's feedback was "always query me on an

--- a/docs/specs/spec-lifecycle-gates/design.md
+++ b/docs/specs/spec-lifecycle-gates/design.md
@@ -1,6 +1,6 @@
 # Spec-Lifecycle Gates v1 — Design
 
-**Status: design chair-approved as written** (2026-07-19; both open
+**Status:** approved (2026-07-19) — design chair-approved as written (both open
 questions ruled per the moderator's recommendations — see G4/G5 in
 `decisions.md`).
 Grounded per RR-5's chair edit: every seam below was re-verified by

--- a/docs/specs/spec-lifecycle-gates/requirements.md
+++ b/docs/specs/spec-lifecycle-gates/requirements.md
@@ -1,6 +1,6 @@
 # Spec-Lifecycle Gates v1 (table-authored) — Requirements
 
-**Status: requirements chair-ruled per item** — authored by the
+**Status:** approved (2026-07-19) — chair-ruled per item; authored by the
 round table (thread `producing-spec-lifecycle-gates-20260719-3`); compiled deterministically by
 `attune.roundtable.compiler` (V2-P2). Approved items only;
 declined: none (RR-7 re-admitted amended, G4 2026-07-19);

--- a/docs/specs/spec-lifecycle-gates/tasks.md
+++ b/docs/specs/spec-lifecycle-gates/tasks.md
@@ -1,6 +1,6 @@
 # Spec-Lifecycle Gates v1 — Tasks
 
-**Status: executed** (2026-07-19, chair go "go on implementation";
+**Status:** shipped (2026-07-19) — executed (chair go "go on implementation";
 all seven tasks landed in one PR — receipts per task below and in
 `decisions.md`'s closure entry). One implementation-discovered
 deviation: the design's `src/attune/gates/` destination was already

--- a/docs/specs/telemetry-models-layering/requirements.md
+++ b/docs/specs/telemetry-models-layering/requirements.md
@@ -1,6 +1,6 @@
 # Telemetry / Models Layering + Pricing Single-Source — requirements
 
-**Status:** parked (2026-07-13) — no phase shipped; #1167/#1168 are the origin PRs that deferred this scope here, not implementers; remaining: Phases 1–4 (pricing single-source, layering, SRP splits, typed schemas) · **Owner:** Patrick + agent
+**Status:** parked (2026-07-13) — no phase shipped; #1167/#1168 are the origin PRs that deferred this scope here, not implementers; remaining: Phases 1–4 (pricing single-source, layering, SRP splits, typed schemas) · Resume-Trigger: evergreen (no external clock) · **Owner:** Patrick + agent
 
 Consolidates the **architectural** findings deferred from two code-review
 fix PRs — #1167 (`usage_tracker`) and #1168 (`auth_strategy`, `registry`,

--- a/docs/specs/test-discipline-controls/requirements.md
+++ b/docs/specs/test-discipline-controls/requirements.md
@@ -2,7 +2,7 @@
 
 > Four mechanical controls that close the test-coverage discipline
 > gap surfaced by PR #485 — without adopting strict TDD.
-**Status:** in-review
+**Status:** draft (2026-05-27) — in review
 **Created:** 2026-05-27
 **Owner:** TBD
 **Related:**

--- a/docs/specs/test-discipline-controls/tasks.md
+++ b/docs/specs/test-discipline-controls/tasks.md
@@ -5,7 +5,7 @@
 > Companion to [`requirements.md`](requirements.md) and
 > [`design.md`](design.md).
 
-**Status:** deferred (2026-06-09) — decisions recorded (D1–D6); D5 ("pre-push hook MUST run `--branch`") adopted as live policy (cited in CLAUDE.md); D1 decided (TDD rejected); remaining: coverage-gate hook, XML `<branches>` schema, drift-guard tests (unimplemented; PR #485 only motivated this spec).
+**Status:** parked (2026-06-09, deferred) · Resume-Trigger: evergreen (no external clock) — decisions recorded (D1–D6); D5 ("pre-push hook MUST run `--branch`") adopted as live policy (cited in CLAUDE.md); D1 decided (TDD rejected); remaining: coverage-gate hook, XML `<branches>` schema, drift-guard tests (unimplemented; PR #485 only motivated this spec).
 **Last updated:** 2026-05-27
 **Total estimate:** ~5.5h across 3 phases.
 

--- a/docs/specs/trap-battery/requirements.md
+++ b/docs/specs/trap-battery/requirements.md
@@ -6,7 +6,7 @@
 > Δp (prevention) term of the memory-as-insurance EV — and, once
 > stable, doubles as the memory system's regression suite.
 
-**Status:** MEASUREMENT CLOSED (2026-07-14) — phase 1 executed (pilot,
+**Status:** complete (2026-07-14) — measurement closed; phase 1 executed (pilot,
 verdicts in decisions.md); phase 2 designed, APPROVED, and **EXECUTED**
 as the full v2 battery (120 sessions, $32.40, 2026-07-14). Every cell
 favored memory-ON; nothing reached p<0.05 (best p=0.11). **No further

--- a/docs/specs/usage-signals/decisions.md
+++ b/docs/specs/usage-signals/decisions.md
@@ -1,6 +1,6 @@
 # Usage Signals — Decisions
 
-**Status:** R6 spend alarm shipped (2026-06-20) · Phase 2b live (D8) ·
+**Status:** active (2026-06-20) — R6 spend alarm shipped · Phase 2b live (D8) ·
 Phase 2 scoped (2026-06-15) · Phase 0 complete (2026-06-11)
 
 ## D1 — Phase 0 baseline snapshot (2026-06-11)

--- a/docs/specs/usage-signals/requirements.md
+++ b/docs/specs/usage-signals/requirements.md
@@ -1,6 +1,6 @@
 # Usage Signals (table-refreshed) — Requirements
 
-**Status: requirements chair-ruled per item** — authored by the
+**Status:** approved (2026-07-19) — chair-ruled per item; US-3 chair-led, US-4/US-6/US-7 open. Authored by the
 round table (thread `us-refresh-001`); compiled deterministically by
 `attune.roundtable.compiler` (V2-P2). Approved items only;
 declined: none;

--- a/docs/specs/windows-exit139-segfault/requirements.md
+++ b/docs/specs/windows-exit139-segfault/requirements.md
@@ -1,6 +1,6 @@
 # windows-exit139-segfault — requirements stub
 
-**Status:** open — fixable hypothesis confirmed (2026-07-06); fix plan drafted, not yet landed
+**Status:** active (2026-07-06) — fixable hypothesis confirmed; fix plan drafted, not yet landed
 
 This spec's substance lives in [README.md](README.md) (class
 signature, capture log, hypothesis, and fix plan — split from

--- a/src/attune/gates/lifecycle/__init__.py
+++ b/src/attune/gates/lifecycle/__init__.py
@@ -29,6 +29,7 @@ from .baseline import falsifiability_gate, format_lint_gate, symbol_reality_gate
 from .ledger import append, latest_for, ledger_path, unresolved_chair_required
 from .protocol import PHASES, STATES, GateReceipt
 from .runner import exit_code, run_boundary
+from .status_line import RESUME_TRIGGER_CLAUSE, status_line_gate
 
 __all__ = [
     "BASELINE_GATES",
@@ -42,12 +43,14 @@ __all__ = [
     "append",
     "blast_radius",
     "exit_code",
+    "RESUME_TRIGGER_CLAUSE",
     "falsifiability_gate",
     "format_lint_gate",
     "latest_for",
     "ledger_path",
     "parse_waivers",
     "run_boundary",
+    "status_line_gate",
     "symbol_reality_gate",
     "unresolved_chair_required",
     "waived",

--- a/src/attune/gates/lifecycle/status_line.py
+++ b/src/attune/gates/lifecycle/status_line.py
@@ -1,0 +1,79 @@
+"""Status-line baseline gate (T2, q-briefing-triage-001; n=2 ruled).
+
+Every spec directory must be legible to the lifecycle detector:
+
+- at least one canonical phase file carries a parseable
+  ``**Status:**`` line whose leading token is in
+  :data:`attune.ops.spec_lifecycle.STATUS_VOCABULARY`;
+- ``requirements.md``, when present, must itself be parseable and
+  in-vocabulary (it anchors the derivation cascade);
+- any phase whose leading token is ``parked`` must carry a
+  ``Resume-Trigger:`` clause in the same file (R9 — parked specs
+  cannot rot indefinitely).
+
+Enforced CI-only via ``tests/unit/gates/test_status_line_gate.py``
+sweeping ``docs/specs/`` (the D7 pattern — pre-commit is not
+guaranteed an importable ``attune``).
+
+Copyright 2026 Smart-AI-Memory
+Licensed under the Apache License, Version 2.0
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from attune.ops.spec_lifecycle import STATUS_VOCABULARY, _normalize
+from attune.ops.specs_data import _PHASE_FILES, _extract_status
+
+from .protocol import GateReceipt
+
+#: Clause R9 requires on any ``parked`` status (case-sensitive — the
+#: backfilled convention writes it verbatim).
+RESUME_TRIGGER_CLAUSE = "Resume-Trigger:"
+
+
+def status_line_gate(spec_dir: Path, *, phase: str = "verification") -> GateReceipt:
+    """Return a receipt for one spec directory's status legibility."""
+    findings: list[str] = []
+    parseable = 0
+    for fname in _PHASE_FILES:
+        file = spec_dir / fname
+        if not file.is_file():
+            continue
+        try:
+            text = file.read_text(encoding="utf-8")
+        except OSError as exc:
+            findings.append(f"{fname}: unreadable ({exc})")
+            continue
+        status = _extract_status(text)
+        if status is None:
+            if fname == "requirements.md":
+                findings.append("requirements.md: no parseable **Status:** line")
+            continue
+        token = _normalize(status)
+        if token not in STATUS_VOCABULARY:
+            findings.append(
+                f"{fname}: leading status token {token!r} not in vocabulary "
+                f"(write '**Status:** <token> (<date>) — <annotation>')"
+            )
+            continue
+        parseable += 1
+        if token == "parked" and RESUME_TRIGGER_CLAUSE not in text:
+            findings.append(
+                f"{fname}: 'parked' without a {RESUME_TRIGGER_CLAUSE} clause "
+                "(R9 — a date, a dependency milestone, or 'evergreen')"
+            )
+    if parseable == 0:
+        findings.append("no phase file carries a parseable, in-vocabulary **Status:** line")
+    return GateReceipt(
+        gate_id="status-line",
+        phase=phase,
+        target=spec_dir.name,
+        state="REVISE" if findings else "PASS",
+        findings=findings,
+        evidence_refs=[f"vocabulary: {', '.join(sorted(STATUS_VOCABULARY))}"],
+        proposed_disposition=(
+            "normalize the status line(s) token-first" if findings else "proceed"
+        ),
+    )

--- a/src/attune/ops/routes/dashboard.py
+++ b/src/attune/ops/routes/dashboard.py
@@ -572,7 +572,7 @@ async def specs_page(request: Request) -> HTMLResponse:
     # so the template can render chips with `0` counts for empty buckets
     # (better UX than missing chips that pop in/out as data shifts).
     bucket_counts = dict.fromkeys(
-        ("active", "approved-not-shipped", "complete", "paused", "stale", "draft"), 0
+        ("active", "approved-not-shipped", "complete", "paused", "parked", "stale", "draft"), 0
     )
     for s in specs:
         bucket_counts[s["lifecycle"]] = bucket_counts.get(s["lifecycle"], 0) + 1
@@ -609,7 +609,7 @@ async def specs_page(request: Request) -> HTMLResponse:
 # without spinning up the full FastAPI app.
 
 _VALID_BUCKETS: frozenset[str] = frozenset(
-    {"active", "approved-not-shipped", "complete", "paused", "stale", "draft"}
+    {"active", "approved-not-shipped", "complete", "paused", "parked", "stale", "draft"}
 )
 _VALID_SORTS: frozenset[str] = frozenset({"recent", "alpha", "oldest"})
 # Defaults match the JS DEFAULT_BUCKETS in specs_refined.js exactly:
@@ -618,6 +618,7 @@ _DEFAULT_BUCKETS: tuple[str, ...] = (
     "active",
     "approved-not-shipped",
     "paused",
+    "parked",
     "stale",
     "draft",
 )

--- a/src/attune/ops/spec_lifecycle.py
+++ b/src/attune/ops/spec_lifecycle.py
@@ -1,9 +1,11 @@
 """Lifecycle bucket derivation for spec records.
 
 Pure logic — takes a SpecRecord-like object (any object with ``.phases``
-and ``.last_modified`` attributes) and returns one of six bucket labels:
-``paused``, ``complete``, ``stale``, ``draft``, ``approved-not-shipped``,
-``active``.
+and ``.last_modified`` attributes) and returns one of seven bucket labels:
+``paused``, ``parked``, ``complete``, ``stale``, ``draft``,
+``approved-not-shipped``, ``active``. (``parked`` added 2026-07-20,
+q-briefing-triage-002 A2 — chair parks were previously invisible and
+mis-bucketed as approved-not-shipped drift.)
 
 The 6-rule cascade (first-match-wins) matches the spec at
 [docs/specs/ops-specs-page-refinement/decisions.md](../../../docs/specs/ops-specs-page-refinement/decisions.md)
@@ -25,11 +27,26 @@ from typing import Protocol, runtime_checkable
 # Revisit if 30d proves too noisy or too quiet in practice.
 STALE_THRESHOLD_DAYS: int = 30
 
-# Statuses we treat as "the phase is done." Three accepted aliases.
-_COMPLETE_STATUSES: frozenset[str] = frozenset({"complete", "completed", "done"})
+# Statuses we treat as "the phase is done." `shipped` closes a spec
+# whose deliverable landed; `superseded` closes one another spec
+# replaced (both terminal — ratified 2026-07-20, q-briefing-triage-002).
+_COMPLETE_STATUSES: frozenset[str] = frozenset(
+    {"complete", "completed", "done", "shipped", "superseded"}
+)
 
-# Statuses we treat as "the phase is approved." Includes complete-equivalents.
-_APPROVED_STATUSES: frozenset[str] = frozenset({"approved", "complete", "completed", "done"})
+# Statuses we treat as "the phase is approved." Includes complete-
+# equivalents plus the in-flight tokens (`active`, `living`) so they
+# clear the draft rule.
+_APPROVED_STATUSES: frozenset[str] = frozenset(
+    _COMPLETE_STATUSES | {"approved", "active", "living"}
+)
+
+#: The full recognized status vocabulary (leading token after
+#: `_normalize`). The status-line baseline gate
+#: (`attune.gates.lifecycle.status_line`) enforces membership; keep
+#: the two in one place. `parked` REQUIRES a `Resume-Trigger:` clause
+#: in the same file (R9, q-briefing-triage-001).
+STATUS_VOCABULARY: frozenset[str] = frozenset(_APPROVED_STATUSES | {"draft", "parked", "paused"})
 
 
 @runtime_checkable
@@ -59,25 +76,32 @@ def derive_lifecycle(spec: _SpecLike, *, now: datetime | None = None) -> str:
             testing. Defaults to ``datetime.now(timezone.utc)``.
 
     Returns:
-        One of: ``paused``, ``complete``, ``stale``, ``draft``,
-        ``approved-not-shipped``, ``active``. Always returns a value;
-        never raises.
+        One of: ``paused``, ``parked``, ``complete``, ``stale``,
+        ``draft``, ``approved-not-shipped``, ``active``. Always
+        returns a value; never raises.
 
     Cascade (first match wins):
         1. **paused** — ANY phase status contains "paused"
            (case-insensitive). Explicit pause signal wins everything.
+        1b. **parked** — ANY phase status has leading token "parked"
+           (a chair park; R9 requires a ``Resume-Trigger:`` clause,
+           enforced by the status-line gate, not here).
         2. **complete** — every phase that EXISTS has a status in
            ``_COMPLETE_STATUSES``, AND at least one phase exists. Note:
            the spec doc says "ALL 4 phases" but real specs sometimes ship
            with 3 phase files (no ``decisions.md``); treating non-existent
            phases as not-blocking matches author intent for those cases.
+        2b. **active** (via ``living``) — ANY phase status has leading
+           token "living": an evergreen program, never a rot alarm.
         3. **stale** — ``last_modified`` is older than
            ``STALE_THRESHOLD_DAYS``. Wins over Draft/Approved-not-shipped/
            Active so users see "rotting" instead of nominal state.
         4. **draft** — ``requirements.md`` missing OR its status is NOT
            in ``_APPROVED_STATUSES``.
-        5. **approved-not-shipped** — ``requirements.md`` approved AND
-           ``tasks.md`` exists AND no phase has a complete-status.
+        5. **approved-not-shipped** — ``requirements.md`` leading token
+           is exactly "approved" AND ``tasks.md`` exists AND no phase
+           has a complete-status. The in-flight tokens
+           (``active``/``living``/``shipped``) skip this alarm bucket.
         6. **active** — default.
     """
     # 1. Paused — explicit signal wins everything
@@ -85,12 +109,25 @@ def derive_lifecycle(spec: _SpecLike, *, now: datetime | None = None) -> str:
         if phase.status and "paused" in phase.status.lower():
             return "paused"
 
+    # 1b. Parked — an explicit chair park (leading token, so prose
+    # mentions of "parked" in annotations don't trip it). Requires a
+    # Resume-Trigger clause per R9; the status-line gate enforces that.
+    for phase in spec.phases:
+        if phase.status and _normalize(phase.status) == "parked":
+            return "parked"
+
     # 2. Complete — every existing phase is done, at least one exists
     existing = [p for p in spec.phases if p.exists]
     if existing and all(
         p.status is not None and _normalize(p.status) in _COMPLETE_STATUSES for p in existing
     ):
         return "complete"
+
+    # 2b. Living — an evergreen program (test-quality-program class):
+    # deliberately never "complete", never a rot alarm.
+    for phase in spec.phases:
+        if phase.status and _normalize(phase.status) == "living":
+            return "active"
 
     # 3. Stale — last_modified older than threshold
     if _is_stale(spec.last_modified, now=now):
@@ -108,14 +145,16 @@ def derive_lifecycle(spec: _SpecLike, *, now: datetime | None = None) -> str:
     ):
         return "draft"
 
-    # 5. Approved-not-shipped — requirements approved + tasks.md exists +
-    # no phase marked complete
+    # 5. Approved-not-shipped — requirements token is exactly
+    # "approved" (the in-flight tokens `active`/`living`/`shipped`
+    # deliberately skip this alarm bucket) + tasks.md exists + no
+    # phase marked complete
     tasks = phase_by_name.get("tasks")
     has_tasks = tasks is not None and tasks.exists
     any_complete = any(
         p.status is not None and _normalize(p.status) in _COMPLETE_STATUSES for p in spec.phases
     )
-    if has_tasks and not any_complete:
+    if _normalize(requirements.status) == "approved" and has_tasks and not any_complete:
         return "approved-not-shipped"
 
     # 6. Active — default

--- a/src/attune/ops/specs_data.py
+++ b/src/attune/ops/specs_data.py
@@ -30,12 +30,16 @@ _PHASE_FILES: tuple[str, ...] = (
     "tasks.md",
 )
 
-# Status line pattern — accepts both Markdown bolding conventions:
-#   **Status:** value   (colon inside the bolding — attune-ai convention)
-#   **Status**: value   (colon outside — attune-gui convention)
-# Captures the value, stripping trailing whitespace.
+# Status line pattern — accepts three Markdown bolding conventions:
+#   **Status:** value    (colon inside the bolding — attune-ai convention)
+#   **Status**: value    (colon outside — attune-gui convention)
+#   **Status: value**    (whole line bold — table-authored specs; the
+#                         closing ** may sit on the same line only)
+# Captures the value, stripping trailing whitespace. Ordered
+# alternation: the closed-bold forms first so `**Status:** x` never
+# matches the whole-bold branch.
 _STATUS_RE = re.compile(
-    r"^\s*\*\*Status(?::\*\*|\*\*:)\s*(.+?)\s*$",
+    r"^\s*\*\*Status(?::\*\*|\*\*:)\s*(.+?)\s*$|^\s*\*\*Status:\s*(.+?)\*\*",
     re.MULTILINE,
 )
 
@@ -69,7 +73,7 @@ class SpecRecord:
     # `__post_init__` so callers don't need to coordinate. `init=False`
     # keeps the constructor signature backward-compatible with the many
     # `SpecRecord(slug=..., phases=..., last_modified=...)` test fixtures.
-    # One of: "paused", "complete", "stale", "draft",
+    # One of: "paused", "parked", "complete", "stale", "draft",
     # "approved-not-shipped", "active". See
     # [docs/specs/ops-specs-page-refinement/decisions.md](../../../docs/specs/ops-specs-page-refinement/decisions.md).
     lifecycle: str = field(init=False, default="")
@@ -89,7 +93,8 @@ def _extract_status(text: str) -> str | None:
     match = _STATUS_RE.search(text)
     if not match:
         return None
-    return match.group(1).strip()
+    value = match.group(1) if match.group(1) is not None else match.group(2)
+    return value.strip()
 
 
 def _scan_spec_dir(spec_dir: Path) -> list[SpecPhase]:

--- a/src/attune/ops/static/css/main.css
+++ b/src/attune/ops/static/css/main.css
@@ -2594,6 +2594,13 @@ a.kpi:hover {
   color: #065f46;
   border-color: #a7f3d0;
 }
+/* Parked: cool slate — a deliberate chair park, calmer than Paused's
+   amber (parked is ruled-and-resting, paused is mid-flight). */
+.specs-toolbar .chip-active.bucket-parked {
+  background: #e2e8f0;
+  color: #334155;
+  border-color: #cbd5e1;
+}
 .specs-toolbar .chip-active.bucket-draft {
   background: #f3f4f6;
   color: #374151;

--- a/src/attune/ops/static/js/specs_refined.js
+++ b/src/attune/ops/static/js/specs_refined.js
@@ -23,6 +23,7 @@
     "active",
     "approved-not-shipped",
     "paused",
+    "parked",
     "stale",
     "draft",
   ];
@@ -32,6 +33,7 @@
     "approved-not-shipped",
     "complete",
     "paused",
+    "parked",
     "stale",
     "draft",
   ]);

--- a/src/attune/ops/templates/specs.html
+++ b/src/attune/ops/templates/specs.html
@@ -54,6 +54,7 @@
         ('approved-not-shipped', 'Approved-not-shipped', 'bucket-approved-not-shipped'),
         ('complete', 'Complete', 'bucket-complete'),
         ('paused', 'Paused', 'bucket-paused'),
+        ('parked', 'Parked', 'bucket-parked'),
         ('stale', 'Stale', 'bucket-stale'),
         ('draft', 'Draft', 'bucket-draft'),
       ] %}

--- a/tests/unit/gates/test_status_line_gate.py
+++ b/tests/unit/gates/test_status_line_gate.py
@@ -1,0 +1,87 @@
+"""Status-line baseline gate (T2) — unit tests + the CI corpus sweep.
+
+The sweep test is the D7-pattern enforcer: it fails CI whenever a spec
+directory under ``docs/specs/`` is illegible to the lifecycle
+detector. Landed red against the 2026-07-20 corpus (24 dirs), fixed
+green by the same PR's backfill.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from attune.gates.lifecycle import status_line_gate
+from attune.ops.specs_data import _PHASE_FILES
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SPECS_ROOT = REPO_ROOT / "docs" / "specs"
+
+
+def _write(spec_dir: Path, fname: str, status_line: str, extra: str = "") -> None:
+    spec_dir.mkdir(parents=True, exist_ok=True)
+    (spec_dir / fname).write_text(f"# Title\n\n{status_line}\n{extra}\n", encoding="utf-8")
+
+
+class TestStatusLineGate:
+    def test_in_vocabulary_status_passes(self, tmp_path):
+        _write(tmp_path / "s", "requirements.md", "**Status:** approved (2026-07-20) — ok")
+        receipt = status_line_gate(tmp_path / "s")
+        assert receipt.state == "PASS"
+        assert receipt.findings == []
+
+    def test_garbled_leading_token_revises(self, tmp_path):
+        _write(tmp_path / "s", "requirements.md", "**Status:** RATIFIED by chair")
+        receipt = status_line_gate(tmp_path / "s")
+        assert receipt.state == "REVISE"
+        assert any("ratified" in f for f in receipt.findings)
+
+    def test_missing_requirements_status_revises(self, tmp_path):
+        _write(tmp_path / "s", "requirements.md", "no status here at all")
+        receipt = status_line_gate(tmp_path / "s")
+        assert receipt.state == "REVISE"
+
+    def test_whole_bold_convention_parses(self, tmp_path):
+        # The table-authored convention: **Status: value** (whole bold).
+        _write(tmp_path / "s", "requirements.md", "**Status: approved (2026-07-20)** — chair")
+        receipt = status_line_gate(tmp_path / "s")
+        assert receipt.state == "PASS"
+
+    def test_parked_without_resume_trigger_revises(self, tmp_path):
+        _write(tmp_path / "s", "tasks.md", "**Status:** parked (2026-07-19) — chair ruling")
+        receipt = status_line_gate(tmp_path / "s")
+        assert receipt.state == "REVISE"
+        assert any("Resume-Trigger" in f for f in receipt.findings)
+
+    def test_parked_with_resume_trigger_passes(self, tmp_path):
+        _write(
+            tmp_path / "s",
+            "tasks.md",
+            "**Status:** parked (2026-07-19) — Resume-Trigger: 2026-07-28",
+        )
+        receipt = status_line_gate(tmp_path / "s")
+        assert receipt.state == "PASS"
+
+    def test_dir_with_no_parseable_file_revises(self, tmp_path):
+        _write(tmp_path / "s", "decisions.md", "just a log, no status")
+        receipt = status_line_gate(tmp_path / "s")
+        assert receipt.state == "REVISE"
+
+
+def _spec_dirs() -> list[Path]:
+    """Mirror `_list_specs_in_root`'s selection: >=1 canonical phase file."""
+    if not SPECS_ROOT.is_dir():
+        return []
+    return sorted(
+        d
+        for d in SPECS_ROOT.iterdir()
+        if d.is_dir() and any((d / f).is_file() for f in _PHASE_FILES)
+    )
+
+
+@pytest.mark.parametrize("spec_dir", _spec_dirs(), ids=lambda d: d.name)
+def test_corpus_sweep_every_spec_dir_is_legible(spec_dir):
+    """CI enforcer: every spec dir passes the status-line gate."""
+    receipt = status_line_gate(spec_dir)
+    assert receipt.state == "PASS", "\n".join(receipt.findings)

--- a/tests/unit/ops/test_spec_lifecycle.py
+++ b/tests/unit/ops/test_spec_lifecycle.py
@@ -508,6 +508,7 @@ class TestRealWorldSpecShapes:
 
 
 VALID_BUCKETS = {
+    "parked",
     "paused",
     "complete",
     "stale",
@@ -527,6 +528,88 @@ VALID_BUCKETS = {
     ],
 )
 def test_derive_lifecycle_always_returns_known_bucket(spec_factory):
-    """Even pathological inputs must return one of the 6 known buckets."""
+    """Even pathological inputs must return one of the 7 known buckets."""
     result = derive_lifecycle(spec_factory(), now=NOW)
     assert result in VALID_BUCKETS
+
+
+# ----- Rules 1b/2b + vocabulary tokens (q-briefing-triage-002 A2) -----
+
+
+class TestParkedRule:
+    """Rule 1b — a leading-token 'parked' on ANY phase wins (chair park)."""
+
+    def test_parked_tasks_wins_over_approved_not_shipped(self):
+        # The fable-premium-tier shape that motivated the rule: approved
+        # requirements + parked tasks previously alarmed as
+        # approved-not-shipped, hiding the chair's ruling.
+        spec = _Spec(
+            phases=_all_phases(
+                requirements="approved (2026-07-10)",
+                tasks="parked (2026-07-19) — Resume-Trigger: 2026-07-28",
+            ),
+            last_modified=FRESH,
+        )
+        assert derive_lifecycle(spec, now=NOW) == "parked"
+
+    def test_parked_is_leading_token_only(self):
+        # A prose MENTION of parking in an annotation must not trip it.
+        spec = _Spec(
+            phases=_all_phases(
+                requirements="approved (2026-07-10) — sibling spec parked separately", tasks="draft"
+            ),
+            last_modified=FRESH,
+        )
+        assert derive_lifecycle(spec, now=NOW) != "parked"
+
+    def test_parked_wins_over_stale(self):
+        old = (NOW - timedelta(days=STALE_THRESHOLD_DAYS + 10)).isoformat()
+        spec = _Spec(
+            phases=_all_phases(requirements="parked (2026-06-01) — Resume-Trigger: evergreen"),
+            last_modified=old,
+        )
+        assert derive_lifecycle(spec, now=NOW) == "parked"
+
+
+class TestLivingAndShippedTokens:
+    """Rule 2b (living -> active) + shipped/superseded complete-aliases."""
+
+    def test_living_is_active_never_stale(self):
+        old = (NOW - timedelta(days=STALE_THRESHOLD_DAYS + 10)).isoformat()
+        spec = _Spec(
+            phases=_all_phases(requirements="living (ongoing program)", tasks="living"),
+            last_modified=old,
+        )
+        assert derive_lifecycle(spec, now=NOW) == "active"
+
+    def test_shipped_all_phases_is_complete(self):
+        spec = _Spec(
+            phases=_all_phases(requirements="shipped (2026-07-20)", tasks="shipped (2026-07-20)"),
+            last_modified=FRESH,
+        )
+        assert derive_lifecycle(spec, now=NOW) == "complete"
+
+    def test_superseded_is_complete(self):
+        spec = _Spec(
+            phases=_all_phases(requirements="superseded (2026-07-18) — see sibling"),
+            last_modified=FRESH,
+        )
+        assert derive_lifecycle(spec, now=NOW) == "complete"
+
+    def test_active_token_skips_approved_not_shipped(self):
+        # 'active' requirements + tasks present + nothing complete used
+        # to alarm; the alarm is reserved for token 'approved' exactly.
+        spec = _Spec(
+            phases=_all_phases(
+                requirements="active (2026-07-18) — D1 ratified; D2+ open", tasks="draft"
+            ),
+            last_modified=FRESH,
+        )
+        assert derive_lifecycle(spec, now=NOW) == "active"
+
+    def test_approved_token_still_alarms(self):
+        spec = _Spec(
+            phases=_all_phases(requirements="approved (2026-07-10)", tasks="draft"),
+            last_modified=FRESH,
+        )
+        assert derive_lifecycle(spec, now=NOW) == "approved-not-shipped"

--- a/tests/unit/ops/test_specs_routes.py
+++ b/tests/unit/ops/test_specs_routes.py
@@ -551,6 +551,7 @@ class TestParseSpecsURLState:
             "active",
             "approved-not-shipped",
             "paused",
+            "parked",
             "stale",
             "draft",
         }
@@ -576,6 +577,7 @@ class TestParseSpecsURLState:
             "active",
             "approved-not-shipped",
             "paused",
+            "parked",
             "stale",
             "draft",
         }
@@ -603,6 +605,7 @@ class TestParseSpecsURLState:
             "active",
             "approved-not-shipped",
             "paused",
+            "parked",
             "stale",
             "draft",
         }


### PR DESCRIPTION
The T2 hygiene unit (chartered in `q-briefing-triage-001`, executed per the chair's n=2 "go all" ruling on thread `q-briefing-triage-002`) — one PR, one ruling, as chartered. Includes the A1 ruling fold-in per the codex amendment.

**Why**: the chair's park rulings were invisible to the lifecycle detector — `parked` was unrecognized, so fable-premium-tier and integration-coverage alarmed as approved-not-shipped drift, and ~22 spec dirs were status-illegible (a third bolding convention + free-text leading tokens). The drift detector that feeds the weekly triage briefing was half-blind.

**What**:
- `STATUS_VOCABULARY` single-sourced in `spec_lifecycle.py`; new `parked` bucket (rule 1b), `living` → active (rule 2b), `shipped`/`superseded` as terminal complete-aliases; the approved-not-shipped alarm now fires only on leading token `approved`.
- Parser accepts the whole-line-bold `**Status: value**` convention (table-authored specs).
- New `status-line` baseline gate + CI sweep test (D7 CI-only pattern). **Landed red: 22 dirs. Fixed green by this PR's backfill.**
- R9 enforced: `parked` without a `Resume-Trigger:` clause REVISEs; triggers added to 7 parked specs.
- Token-first backfill across 36 spec files, annotations preserved.
- **A1 (3-0)**: docs-wiring-audit closed as shipped (v1 + required CI check on main; v1.1 shipped 07-15; only deferred Task 10 open).
- Dashboard specs page: `parked` chip end-to-end (counts, URL state, JS, template, CSS).
- Rulings recorded: roundtable-triage decisions (n=2 entry, T4 headless armed), advanced-debugging-plugin decisions (A3 diagnosis disposition + two queued follow-ons).

**Receipts**: sweep 22 red pre-backfill → all green post; breadth `tests/unit/{gates,ops,curator,quality}` = 1768 passed; corpus bucket map now 16 active / 8 parked / 4 draft / 3 complete with zero false approved-not-shipped alarms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)