### PR TITLE
build(deps): lift attune-rag cap to <0.10, lock 0.9.0 — re-validated

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,7 @@ dependencies = [
     "langsmith>=0.7.31,<2.0.0",  # GHSA-rr7j-v2q5-chgv (transitive via langchain-core)
     "jinja2>=3.1.0,<4.0.0",  # Meta template rendering for help system
     "python-frontmatter>=1.0.0,<2.0.0",  # YAML frontmatter parsing for help templates — required by attune.help.engine which backs the help_lookup MCP tool (progressive/workflow_help/precursor/search_tag modes all parse template files). Vanilla pip install attune-ai without this breaks every help_lookup mode except `preamble`.
-    "attune-rag>=0.1.5,<0.9",  # RAG grounding for rag-code-gen workflow + rag_knowledge_query MCP tool. Core dep (not optional) — required for acceptable retrieval accuracy. Cap is <0.9: re-validated against attune-rag 0.8.0 (lock bumped 0.7.0->0.8.0; purely additive — model tiers premium/capable/cheap replace hardcoded model IDs, claude-fable-5 as premium default; all 0.7.x public symbols unchanged, confirmed by importing every attune-ai-consumed symbol); next minor (0.9.0) still requires explicit re-validation before lifting the cap.
+    "attune-rag>=0.1.5,<0.10",  # RAG grounding for rag-code-gen workflow + rag_knowledge_query MCP tool. Core dep (not optional) — required for acceptable retrieval accuracy. Cap is <0.10: re-validated against attune-rag 0.9.0 (lock bumped 0.8.0->0.9.0; KeywordRetriever ranking change — preview drops frontmatter aliases block, ALIASES_WEIGHT 1.5->2.0 — re-validated via the lessons golden-query suite (26 passed, real corpus/real ranking; attune.lessons imports KeywordRetriever directly) + consumer suites (personal memory, ops help_data, rag_code_gen, curator: 284 passed) + full consumed-symbol import sweep; alias-home migration satisfied by locked attune-help 0.13.0, in 0.9.0's required >=0.13,<0.14 window); next minor (0.10.0) still requires explicit re-validation before lifting the cap.
     "attune-verify>=0.1.0,<0.3",  # Generation fact-checker backing the /verify skill (deterministic entity checks: imports/flags/links/counts). Core dep — stdlib-only (zero transitive deps), so promoting to core is cheap and lets /verify work out of the box without an extra. Semantic layer is opt-in (the skill acts as the ambient judge). Cap raised to <0.3 to admit 0.2.0 (full dotted-path import resolution — catches private-submodule hallucinations the 0.1.0 top-level-only checker missed; purely additive, no API break).
     "tomli>=2.0.0; python_version < '3.11'",  # tomllib fallback for Python 3.10. Used by attune.utils.coverage (loaded transitively from release-prep + orchestrated-health-check workflows). Without this, those workflows fail to load on 3.10.
     # Redis memory runtime — CORE as of the 2026-07-04 packaging
@@ -233,7 +233,7 @@ dev = [
     # branches (rag tests use pytest.importorskip). Floor
     # matches the [rag] extra so dev + runtime deps stay in
     # lock-step.
-    "attune-rag>=0.1.5,<0.9",
+    "attune-rag>=0.1.5,<0.10",
     # Test deps for paths that import optional runtime libs
     # unconditionally. Without these, the unit suite fails at
     # collection on a fresh `pip install -e .[dev]`. See
@@ -413,7 +413,7 @@ dev = [
     # branches (rag tests use pytest.importorskip). Floor
     # matches the [rag] extra so dev + runtime deps stay in
     # lock-step.
-    "attune-rag>=0.1.5,<0.9",
+    "attune-rag>=0.1.5,<0.10",
     # Test deps for paths that import optional runtime libs
     # unconditionally. Without these, the unit suite fails at
     # collection on a fresh `pip install -e .[dev]`. See
@@ -811,10 +811,10 @@ exclude_lines = [
 ]
 
 # Sibling repos — all published to PyPI:
-#   attune-rag     — core dep (>=0.1.5,<0.9) — promoted from optional; required for accuracy
+#   attune-rag     — core dep (>=0.1.5,<0.10) — promoted from optional; required for accuracy
 #   attune-verify  — core dep (>=0.1.0,<0.3) — backs /verify; stdlib-only, zero transitive deps
 #   attune-author  — [author] optional extra (>=0.23,<0.26)
-#   attune-rag     — [rag] optional extra (>=0.1.5,<0.9) — no-op alias since rag is core
+#   attune-rag     — [rag] optional extra (>=0.1.5,<0.10) — no-op alias since rag is core
 #
 # No [tool.uv.sources] overrides needed: CI resolves all three
 # from PyPI (https://pypi.org/simple). For local iteration against

--- a/uv.lock
+++ b/uv.lock
@@ -531,8 +531,8 @@ requires-dist = [
     { name = "anthropic", marker = "extra == 'llm'", specifier = ">=0.40.0" },
     { name = "attune-author", marker = "extra == 'author'", specifier = ">=0.23,<0.26" },
     { name = "attune-help", marker = "extra == 'author'", specifier = ">=0.10.0" },
-    { name = "attune-rag", specifier = ">=0.1.5,<0.9" },
-    { name = "attune-rag", marker = "extra == 'dev'", specifier = ">=0.1.5,<0.9" },
+    { name = "attune-rag", specifier = ">=0.1.5,<0.10" },
+    { name = "attune-rag", marker = "extra == 'dev'", specifier = ">=0.1.5,<0.10" },
     { name = "attune-verify", specifier = ">=0.1.0,<0.3" },
     { name = "bandit", marker = "extra == 'all'", specifier = ">=1.7,<2.0" },
     { name = "bandit", marker = "extra == 'dev'", specifier = ">=1.7,<2.0" },
@@ -677,7 +677,7 @@ provides-extras = ["author", "anthropic", "llm", "memdocs", "agents", "backend",
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "attune-rag", specifier = ">=0.1.5,<0.9" },
+    { name = "attune-rag", specifier = ">=0.1.5,<0.10" },
     { name = "bandit", specifier = ">=1.7,<2.0" },
     { name = "black", specifier = ">=24.3.0,<27.0" },
     { name = "coverage", specifier = ">=7.0,<8.0" },
@@ -731,7 +731,7 @@ wheels = [
 
 [[package]]
 name = "attune-rag"
-version = "0.8.0"
+version = "0.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jinja2" },
@@ -740,9 +740,9 @@ dependencies = [
     { name = "rich" },
     { name = "structlog" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/66/f9/f4b9413c642fb1faf229f84183b620f590e01bdfc716957d8f3e78b91731/attune_rag-0.8.0.tar.gz", hash = "sha256:58bde0d1eda1ad8dee417fc136c258053e3b23287598ad536951fb7a4a81ee14", size = 128746, upload-time = "2026-07-09T15:37:35.185Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/fe/3028c782ac2808edfb5827de43367bf009bf3a99bbbfcdd4a6c5e652344e/attune_rag-0.9.0.tar.gz", hash = "sha256:eedd8909c632241f1ca358069afd470830598d4bbc07b61c5ac0c8305745a903", size = 129596, upload-time = "2026-07-18T00:44:19.715Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/50/e1/75e163599f3cf8c9613a04e759423268d52e3284684a8dec3d36be733f88/attune_rag-0.8.0-py3-none-any.whl", hash = "sha256:cf013a6843eac4b78c41a094405ccde3095894dc4fea5ad26f111a2de6f23346", size = 139146, upload-time = "2026-07-09T15:37:33.841Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/aa/77b4da4c089ff6515b971460ea2323da515cc5acdc10960762831050bedd/attune_rag-0.9.0-py3-none-any.whl", hash = "sha256:d4e5be798cbabe732d72502adbce6e48136febc217150dbc38f064ed61e90596", size = 139957, upload-time = "2026-07-18T00:44:18.027Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Replaces dependabot [#1493](https://github.com/Smart-AI-Memory/attune-ai/pull/1493) (closed after review): the deliberate cap-lift in the 0.8.0-template shape — pin + contract-comment rewrite + lock bump + receipts in one PR.

**Changes**
- `attune-rag>=0.1.5,<0.10` in core deps + both dev blocks; the inline comment now records the 0.9.0 re-validation and re-arms the contract for 0.10.0; dependency-map comment block updated (was drifting at `<0.9`).
- `uv.lock`: attune-rag 0.8.0 → 0.9.0.

**Re-validation receipts** (run under 0.9.0 with locked attune-help 0.13.0 — inside 0.9.0's required `>=0.13,<0.14` alias-home window):
- Consumed-symbol import sweep: `RagPipeline`, `KeywordRetriever`, `DirectoryCorpus`, `RetrievalEntry`, `RetrievalHit`, `format_citations_markdown` + dotted paths — all import.
- Lessons golden-query suite **26 passed** (serial, real corpus + real ranking — `attune.lessons` imports `KeywordRetriever` directly, so 0.9.0's preview/`ALIASES_WEIGHT` ranking change hits lessons retrieval; it holds at full margin).
- Consumer suites **284 passed**: personal memory, ops help_data, rag_code_gen (pins/path/security), curator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)