### PR TITLE
feat(usage-signals): US-4 pre-tag window verification (--verify-before)

### DIFF
--- a/docs/specs/usage-signals/decisions.md
+++ b/docs/specs/usage-signals/decisions.md
@@ -655,3 +655,30 @@ no additional spend-monitoring scope is opened.
 the US-4 strategy). The refreshed done-when therefore remains open;
 this entry contributes the US-4 receipts, the US-6 three-panel
 receipt, and the completed ledger audit toward it.
+
+## D16 — US-4 operationalized in the release ritual (2026-07-20)
+
+D15 shipped the capture contract but the release ritual still said
+"at tag time, kick off reach_snapshot" — the exact strategy US-4
+retired (the 10.5.0 silent-0/5 class). Closed the seam, chair go
+"go US-4":
+
+- `scripts/reach_snapshot.py --verify-before <tag-date>`: no-network
+  verification that a COMPLETE snapshot (full five-package
+  allowlist) exists with `observed_at` 24-72h before the planned
+  tag; newest in-window snapshot wins; exit 0/1 with the
+  unmistakable-warning contract (window-still-open → "capture NOW";
+  floor passed → "proceed with the incomplete receipt, do not
+  substitute a tag-time capture"). Receipts: 8 new tests
+  (in-window / too-old / too-fresh / incomplete / missing dir /
+  newest-wins / unparseable date exit 2 / no-network guard) —
+  24 total in `tests/unit/scripts/test_reach_snapshot.py`.
+- `~/.claude/skills/release-execute/SKILL.md` step 11: tag-time
+  kick-off REPLACED with pre-tag verify + capture-now remedy +
+  after-snapshot queued 24-72h post-tag (US-5 pairing).
+- `~/.claude/skills/attune-release-check/SKILL.md`: check 8 added,
+  WARN-only by design (US-4: snapshot absence must not block
+  tagging), attune-ai only.
+
+US-4's requirement set is now fully operational; US-5 (the
+comparable pair) becomes actionable at the next planned release.

--- a/scripts/reach_snapshot.py
+++ b/scripts/reach_snapshot.py
@@ -335,8 +335,20 @@ def main(argv: list[str] | None = None) -> int:
         default=PACKAGES,
         help="packages to snapshot",
     )
+    parser.add_argument(
+        "--verify-before",
+        metavar="TAG_DATE",
+        help=(
+            "verify a complete before-snapshot exists 24-72h before the "
+            "planned tag date (ISO date or datetime); exits non-zero with "
+            "an unmistakable warning otherwise. Makes no network requests."
+        ),
+    )
     args = parser.parse_args(argv)
     logging.basicConfig(level=logging.WARNING, format="%(levelname)s %(message)s")
+
+    if args.verify_before:
+        return verify_before(args.out, args.verify_before, list(args.packages))
 
     args.out.mkdir(parents=True, exist_ok=True)
     now = datetime.now(timezone.utc)
@@ -396,6 +408,90 @@ def main(argv: list[str] | None = None) -> int:
     print(render_table(snapshot))
     print(f"wrote {out_path}")
     return 0
+
+
+#: US-4 pre-tag window: the before snapshot must be captured 24-72
+#: hours before the planned tag, persisted before release activity.
+BEFORE_WINDOW_MIN_HOURS = 24
+BEFORE_WINDOW_MAX_HOURS = 72
+
+
+def find_before_snapshot(
+    out_dir: Path,
+    tag_at: datetime,
+    expected: list[str],
+) -> tuple[Path, dict[str, object]] | None:
+    """Return the newest COMPLETE snapshot inside the pre-tag window.
+
+    A qualifying snapshot has a manifest with ``complete: true`` for
+    the expected allowlist and an ``observed_at`` between 24 and 72
+    hours before ``tag_at``. Returns ``None`` when no day file
+    qualifies (missing dir, malformed files, incomplete or
+    out-of-window snapshots all degrade to None — the caller renders
+    the unmistakable warning, per US-4).
+    """
+    if not out_dir.is_dir():
+        return None
+    best: tuple[datetime, Path, dict[str, object]] | None = None
+    for path in sorted(out_dir.glob("*.json")):
+        day = _load_day(path)
+        manifest = day.get("manifest")
+        if not isinstance(manifest, dict) or not manifest.get("complete"):
+            continue
+        if sorted(manifest.get("expected", [])) != sorted(expected):
+            continue
+        try:
+            observed = datetime.fromisoformat(str(manifest.get("observed_at")))
+        except ValueError:
+            continue
+        if observed.tzinfo is None:
+            observed = observed.replace(tzinfo=timezone.utc)
+        age = (tag_at - observed).total_seconds() / 3600
+        if BEFORE_WINDOW_MIN_HOURS <= age <= BEFORE_WINDOW_MAX_HOURS:
+            if best is None or observed > best[0]:
+                best = (observed, path, day)
+    return (best[1], best[2]) if best else None
+
+
+def verify_before(out_dir: Path, tag_raw: str, expected: list[str]) -> int:
+    """CLI mode: exit 0 iff a complete before-snapshot is in-window.
+
+    ``tag_raw`` is the planned tag instant — a full ISO datetime, or a
+    bare date (interpreted as 00:00 UTC of that day).
+    """
+    try:
+        tag_at = datetime.fromisoformat(tag_raw)
+    except ValueError:
+        print(f"error: --verify-before got unparseable date {tag_raw!r}", file=sys.stderr)
+        return 2
+    if tag_at.tzinfo is None:
+        tag_at = tag_at.replace(tzinfo=timezone.utc)
+    found = find_before_snapshot(out_dir, tag_at, expected)
+    if found:
+        path, day = found
+        manifest = day["manifest"]
+        assert isinstance(manifest, dict)
+        print(f"before-snapshot OK: {path} (observed_at {manifest['observed_at']}, complete 5/5)")
+        return 0
+    now = datetime.now(timezone.utc)
+    hours_left = (tag_at - now).total_seconds() / 3600
+    if hours_left > BEFORE_WINDOW_MIN_HOURS:
+        remedy = (
+            "the window is still open — run `python scripts/reach_snapshot.py` "
+            f"NOW (planned tag is ~{int(hours_left)}h away)"
+        )
+    else:
+        remedy = (
+            "the 24h window floor has passed — the release may continue only "
+            "with this incomplete-receipt warning attached (US-4); do not "
+            "capture a substitute at tag time"
+        )
+    print(
+        "WARNING: NO COMPLETE BEFORE-SNAPSHOT in the 24-72h pre-tag window "
+        f"(planned tag {tag_at.isoformat()}). {remedy}.",
+        file=sys.stderr,
+    )
+    return 1
 
 
 def _warn_if_incomplete(expected: list[str], captured: dict[str, dict[str, int]]) -> None:

--- a/tests/unit/scripts/test_reach_snapshot.py
+++ b/tests/unit/scripts/test_reach_snapshot.py
@@ -322,3 +322,86 @@ class TestCli:
         data = json.loads(files[0].read_text(encoding="utf-8"))
         assert set(data["pypi_recent"]) == {"a", "b", "c"}
         assert data["github"] == {"stars": 9}
+
+
+class TestVerifyBefore:
+    """US-4 pre-tag window verification (--verify-before)."""
+
+    @staticmethod
+    def _write_snapshot(out_dir, mod, *, hours_before, tag_at, complete=True, name="day.json"):
+        from datetime import timedelta
+
+        out_dir.mkdir(parents=True, exist_ok=True)
+        packages = list(mod.PACKAGES) if complete else list(mod.PACKAGES[:3])
+        observed = (tag_at - timedelta(hours=hours_before)).isoformat()
+        captured = {pkg: dict(STATS) for pkg in packages}
+        day = {
+            "date": "2026-07-18",
+            "taken_at": observed,
+            "pypi_recent": captured,
+            "github": {},
+            "manifest": mod.build_manifest(list(mod.PACKAGES), captured, observed),
+        }
+        (out_dir / name).write_text(json.dumps(day), encoding="utf-8")
+
+    def _tag_at(self):
+        from datetime import datetime, timezone
+
+        return datetime(2026, 7, 25, 12, 0, 0, tzinfo=timezone.utc)
+
+    def test_complete_snapshot_in_window_exits_0(self, mod, tmp_path, capsys):
+        tag = self._tag_at()
+        self._write_snapshot(tmp_path / "snaps", mod, hours_before=48, tag_at=tag)
+        rc = mod.main(["--out", str(tmp_path / "snaps"), "--verify-before", tag.isoformat()])
+        assert rc == 0
+        assert "before-snapshot OK" in capsys.readouterr().out
+
+    def test_snapshot_too_old_exits_1(self, mod, tmp_path, capsys):
+        tag = self._tag_at()
+        self._write_snapshot(tmp_path / "snaps", mod, hours_before=90, tag_at=tag)
+        rc = mod.main(["--out", str(tmp_path / "snaps"), "--verify-before", tag.isoformat()])
+        assert rc == 1
+        assert "NO COMPLETE BEFORE-SNAPSHOT" in capsys.readouterr().err
+
+    def test_snapshot_too_fresh_exits_1(self, mod, tmp_path, capsys):
+        tag = self._tag_at()
+        self._write_snapshot(tmp_path / "snaps", mod, hours_before=2, tag_at=tag)
+        rc = mod.main(["--out", str(tmp_path / "snaps"), "--verify-before", tag.isoformat()])
+        assert rc == 1
+        assert "NO COMPLETE BEFORE-SNAPSHOT" in capsys.readouterr().err
+
+    def test_incomplete_snapshot_in_window_exits_1(self, mod, tmp_path, capsys):
+        tag = self._tag_at()
+        self._write_snapshot(tmp_path / "snaps", mod, hours_before=48, tag_at=tag, complete=False)
+        rc = mod.main(["--out", str(tmp_path / "snaps"), "--verify-before", tag.isoformat()])
+        assert rc == 1
+        assert "NO COMPLETE BEFORE-SNAPSHOT" in capsys.readouterr().err
+
+    def test_missing_dir_exits_1(self, mod, tmp_path, capsys):
+        rc = mod.main(
+            ["--out", str(tmp_path / "absent"), "--verify-before", self._tag_at().isoformat()]
+        )
+        assert rc == 1
+        assert "NO COMPLETE BEFORE-SNAPSHOT" in capsys.readouterr().err
+
+    def test_newest_in_window_snapshot_wins(self, mod, tmp_path):
+        tag = self._tag_at()
+        snaps = tmp_path / "snaps"
+        self._write_snapshot(snaps, mod, hours_before=70, tag_at=tag, name="older.json")
+        self._write_snapshot(snaps, mod, hours_before=30, tag_at=tag, name="newer.json")
+        found = mod.find_before_snapshot(snaps, tag, list(mod.PACKAGES))
+        assert found is not None
+        assert found[0].name == "newer.json"
+
+    def test_unparseable_date_exits_2(self, mod, tmp_path, capsys):
+        rc = mod.main(["--out", str(tmp_path), "--verify-before", "not-a-date"])
+        assert rc == 2
+        assert "unparseable" in capsys.readouterr().err
+
+    def test_verify_mode_makes_no_network_requests(self, mod, tmp_path, monkeypatch):
+        def boom(_pkg):
+            raise AssertionError("verify mode must not fetch")
+
+        monkeypatch.setattr(mod, "fetch_pypistats_recent", boom)
+        rc = mod.main(["--out", str(tmp_path), "--verify-before", self._tag_at().isoformat()])
+        assert rc == 1


### PR DESCRIPTION
Chair go "go US-4". Reconciliation first: US-4's capture contract already **shipped** in #1476 (D15) — the starter listed it as open work (the shipped-and-quiet trap again). The genuine remainder was operationalization: the release ritual still said "**at tag time**, kick off reach_snapshot" — the exact strategy US-4 retired after it silently lost the 10.5.0 before/after pair.

**What this PR ships (D16):**
- `scripts/reach_snapshot.py --verify-before <tag-date>` — no-network verification that a COMPLETE five-package snapshot exists with `observed_at` 24–72h before the planned tag (newest in-window wins). Exit 0/1 with the unmistakable-warning contract: window still open → "run the capture NOW"; 24h floor passed → "proceed with the incomplete receipt attached; do not substitute a tag-time capture."
- 8 new tests (24 total in `tests/unit/scripts/test_reach_snapshot.py`): in-window pass, too-old, too-fresh, incomplete-in-window, missing dir, newest-wins, unparseable-date exit 2, and a monkeypatched guard proving verify mode makes zero network requests.
- `decisions.md` D16 records the companion skill re-points (they live in `~/.claude/skills`, outside the repo): release-execute step 11 now verifies-then-captures pre-tag and queues the after-snapshot for US-5; attune-release-check gains check 8, WARN-only by design (US-4: absence must never block tagging).

US-5 (the comparable release pair) becomes actionable at the next planned release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)