### PR TITLE
feat(roundtable): headless triage appendix (T4 armed) + requirements

### DIFF
--- a/docs/specs/roundtable-triage/decisions.md
+++ b/docs/specs/roundtable-triage/decisions.md
@@ -1,6 +1,6 @@
 # Roundtable Triage — Decisions
 
-**Status:** active (2026-07-20) — chartered 2026-07-19 (n=1); n=2 validated 2026-07-20; requirements not yet authored
+**Status:** active (2026-07-20) — chartered 2026-07-19 (n=1); n=2 validated 2026-07-20; requirements authored + headless appendix implemented (see below)
 
 ## 2026-07-19 — Charter (chair, "as synthesized"; thread q-briefing-triage-001)
 
@@ -114,3 +114,20 @@ chair-invoked.
 Deviation noted: n=2's question was posted as author `moderator`
 (chair pre-authorized but did not compose the brief live; n=1 used
 `chair`).
+
+## 2026-07-20 — Headless appendix implemented + requirements authored (chair "go 1")
+
+`attune.roundtable.triage_appendix` lands the T4-armed contract:
+read-only briefing pull (curator sources + gate ledger + usage
+freshness), deterministic ≤5-item distillation with named drops,
+same-thread appendix (question → seats → synthesis) under a
+4-invocation sub-cap (clean-run + appendix ≤ 8 < R5 ceiling 10),
+`ATTUNE_TRIAGE_APPENDIX=off` kill switch, and the T4 demotion loop
+(digest records in `~/.attune/ops/triage_appendix.json`;
+`record_rulings()` is the ruling session's write; two RECORDED
+zero-ruling digests demote; unrecorded never demotes).
+`requirements.md` (TA-1..TA-8) codifies the ruled contract — no new
+scope. Receipts: 15 contract tests in
+`tests/unit/roundtable/test_triage_appendix.py`; first live receipt
+= next Monday's 06:00 scheduled run. TA-5's CI-artifact fetch stays
+the queued follow-on (A4).

--- a/docs/specs/roundtable-triage/requirements.md
+++ b/docs/specs/roundtable-triage/requirements.md
@@ -1,0 +1,73 @@
+# Roundtable Triage — Requirements
+
+**Status:** approved (2026-07-20) — codifies the chair-ruled contract
+(charter + T3/T4, q-briefing-triage-001; n=2 validation + "T4 y"
+arming, q-briefing-triage-002). New scope beyond those rulings needs
+new approval. Implementation: `attune.roundtable.triage_appendix`
+(landed with this document).
+
+## Purpose
+
+Turn the live ops briefing into a weekly, bounded, chair-ruled triage
+digest — attached to the existing clean-run routine, never a second
+ruling sitting. Born from the live demo promoted as
+q-briefing-triage-001; validated manually at n=1 (2026-07-19) and
+n=2 (2026-07-20) before headless arming (T4).
+
+## Requirements
+
+**TA-1 — Appendix, not a routine.** The triage digest runs as an
+appendix to the weekly clean-run, posting to the SAME board thread
+(one weekly ruling sitting). It never registers as an independent
+scheduled routine. (T4)
+
+**TA-2 — Item cap, no silent drops.** At most 5 decidable items per
+digest. Anything the cap drops is named in the brief ("N further
+candidate items dropped"), never silently truncated. (T4; the
+no-silent-caps discipline)
+
+**TA-3 — Deterministic distillation, read-only pull.** The briefing
+pull is read-only and free: curator source readers, the gate verdict
+ledger, usage.jsonl freshness. NO LLM curation pass. Distillation
+into items is deterministic code — seat deliberation is where model
+judgment enters. (charter; T3)
+
+**TA-4 — Honest darkness over refresh spend.** An empty source
+renders "dark" in the brief. The appendix never schedules or
+performs LLM sweeps to freshen a source; refresh happens only when
+a chair-authorized run does it anyway. (T3)
+
+**TA-5 — Gate-verdict input via CI artifacts.** The durable
+gate-verdict input is a CI-artifact fetch at digest render time
+(timestamped unavailable/expired handling, no scheduled refresh).
+Until that lands, the local ledger is read and its
+darkness-by-construction (D7 CI-only gates) is rendered honestly.
+(A4 ruling, 2026-07-20; follow-on queued)
+
+**TA-6 — Auto-demotion with a recorded-outcome ledger.** Each digest
+records `{thread, at, items, rulings: null}` in the appendix state
+file; the interactive ruling session records the chair's ruling
+count via `record_rulings()`. After two consecutive digests with a
+RECORDED ruling count of zero, the appendix demotes itself to
+chair-invoked and says so. Unrecorded outcomes never demote. (T4)
+
+**TA-7 — Carried table gates.** The appendix respects the shared R5
+ceiling (its own sub-cap of 4 invocations keeps clean-run + appendix
+≤ 8, under the ruled ceiling of 10), tolerates absent seats (R6),
+and NEVER promotes its own thread (R8).
+
+**TA-8 — Kill switch.** `ATTUNE_TRIAGE_APPENDIX=off` skips the
+appendix with a printed notice — operational off-ramp without a
+code change.
+
+## Done-when
+
+- A scheduled clean-run produces the appendix on the same thread
+  with ≤5 evidence-bearing items, or an explicit 0-item /
+  demoted / killed notice — receipts: the contract tests in
+  `tests/unit/roundtable/test_triage_appendix.py` plus the first
+  live scheduled run's thread.
+- The demotion loop closes: digests recorded, rulings recordable,
+  two recorded zero-ruling digests demote (test-receipted).
+- TA-5's CI-artifact fetch replaces the local-ledger read (queued
+  follow-on; not blocking the headless arming).

--- a/src/attune/roundtable/routine.py
+++ b/src/attune/roundtable/routine.py
@@ -319,6 +319,17 @@ def run_routine(
             f"invocation cap ({spec.max_invocations}) reached before synthesis",
         )
 
+    # T4 (armed 2026-07-20): the weekly clean-run carries the briefing
+    # triage appendix on the SAME thread — one weekly ruling sitting.
+    # Its own sub-cap keeps the combined run under the R5 ceiling of
+    # 10; kill switch + auto-demotion live in the appendix module.
+    if spec.name == "clean-run":
+        from pathlib import Path  # noqa: PLC0415
+
+        from attune.roundtable.triage_appendix import run_triage_appendix  # noqa: PLC0415
+
+        invocations += run_triage_appendix(board, thread, Path.cwd(), invoke_seat, SEAT_RECIPES)
+
     print(
         f"routine {spec.name!r} complete: thread {thread!r} ({invocations} invocations). Review with /roundtable read {thread}; the thread is NOT promoted (R8)."
     )

--- a/src/attune/roundtable/triage_appendix.py
+++ b/src/attune/roundtable/triage_appendix.py
@@ -1,0 +1,363 @@
+"""Briefing→table triage appendix to the weekly clean-run (T4, armed).
+
+Chartered in q-briefing-triage-001 (T4: appendix, not a new routine),
+validated manually n=1 (2026-07-19) and n=2 (2026-07-20), armed
+headless by chair ruling 2026-07-20 ("T4 y"). Contract details in
+docs/specs/roundtable-triage/requirements.md; rulings in its
+decisions.md.
+
+Shape per the ruled contract:
+
+- Briefing pull is READ-ONLY and free — the curator source readers,
+  the gate verdict ledger, and usage.jsonl freshness. NO LLM curation
+  pass (T3: no standing scheduled LLM spend); empty sources render
+  "dark" honestly instead of being refreshed with paid sweeps.
+- Distillation is DETERMINISTIC, capped at 5 items; anything dropped
+  by the cap is named in the brief (no silent caps).
+- The appendix posts to the SAME clean-run thread (one weekly ruling
+  sitting) with its own seat round + synthesis, under its own
+  invocation sub-cap (the combined run stays under the chair-ruled
+  R5 ceiling of 10).
+- Auto-demote (T4): after two consecutive digests whose RECORDED
+  ruling count is zero, the appendix stops running headless and
+  reports itself demoted to chair-invoked. Unrecorded outcomes never
+  demote (conservative).
+- The runner never promotes (R8).
+
+Copyright 2026 Smart-AI-Memory
+Licensed under Apache 2.0
+"""
+
+from __future__ import annotations
+
+import datetime
+import importlib
+import json
+import logging
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+#: Deterministic distillation cap (T4).
+MAX_ITEMS = 5
+
+#: Appendix invocation sub-cap: 3 seats + 1 synthesis.
+APPENDIX_MAX_INVOCATIONS = 4
+
+#: Kill switch — set to "off" to skip the appendix without editing code.
+KILL_SWITCH_ENV = "ATTUNE_TRIAGE_APPENDIX"
+
+#: Curator sources pulled for the briefing (read-only, no LLM).
+SOURCE_NAMES = (
+    "bulletin",
+    "diagnoses",
+    "git_state",
+    "recommendations",
+    "spec_drift",
+    "specs",
+    "sweep",
+    "telemetry",
+)
+
+#: Sources whose emptiness is rendered as "dark" (T3) rather than
+#: treated as a decidable item.
+DARK_RENDER_SOURCES = frozenset({"bulletin", "git_state", "recommendations", "sweep", "telemetry"})
+
+
+@dataclass
+class TriageItem:
+    """One decidable briefing item put to the table."""
+
+    title: str
+    evidence: str
+    question: str
+
+
+def _state_path() -> Path:
+    attune_dir = Path(os.environ.get("ATTUNE_HOME", str(Path.home() / ".attune")))
+    return attune_dir / "ops" / "triage_appendix.json"
+
+
+def _load_state(path: Path | None = None) -> dict[str, object]:
+    p = path or _state_path()
+    if not p.is_file():
+        return {"digests": []}
+    try:
+        data = json.loads(p.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        logger.warning("triage appendix: unreadable state %s: %s", p, exc)
+        return {"digests": []}
+    return data if isinstance(data, dict) else {"digests": []}
+
+
+def _save_state(state: dict[str, object], path: Path | None = None) -> None:
+    p = path or _state_path()
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(json.dumps(state, indent=2) + "\n", encoding="utf-8")
+
+
+def is_demoted(path: Path | None = None) -> bool:
+    """T4 auto-demote: two consecutive RECORDED zero-ruling digests."""
+    digests = _load_state(path).get("digests")
+    if not isinstance(digests, list) or len(digests) < 2:
+        return False
+    last_two = digests[-2:]
+    return all(isinstance(d, dict) and d.get("rulings") == 0 for d in last_two)
+
+
+def record_digest(thread: str, items: int, *, path: Path | None = None) -> None:
+    """Append one digest record with an unrecorded (null) ruling count."""
+    state = _load_state(path)
+    digests = state.setdefault("digests", [])
+    assert isinstance(digests, list)
+    digests.append(
+        {
+            "thread": thread,
+            "at": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+            "items": items,
+            "rulings": None,
+        }
+    )
+    _save_state(state, path)
+
+
+def record_rulings(thread: str, rulings: int, *, path: Path | None = None) -> bool:
+    """Record the chair's ruling count for a digest (the demotion input).
+
+    Called by the interactive ruling session when promoting. Returns
+    True when the thread's record was found and updated.
+    """
+    state = _load_state(path)
+    digests = state.get("digests")
+    if not isinstance(digests, list):
+        return False
+    for record in reversed(digests):
+        if isinstance(record, dict) and record.get("thread") == thread:
+            record["rulings"] = rulings
+            _save_state(state, path)
+            return True
+    return False
+
+
+def pull_briefing(project_root: Path) -> tuple[list[TriageItem], list[str], list[str]]:
+    """Read-only briefing pull: (candidate items, dark sources, extra evidence).
+
+    Sources must not raise (their contract); a reader that does is
+    reported as unreadable evidence rather than crashing the routine.
+    """
+    candidates: list[TriageItem] = []
+    dark: list[str] = []
+    extra: list[str] = []
+    for name in SOURCE_NAMES:
+        try:
+            mod = importlib.import_module(f"attune.curator.sources.{name}")
+            summary = mod.read(project_root=project_root)
+            items = list(summary.items)
+        except Exception as exc:  # noqa: BLE001 — appendix must not kill the routine
+            logger.warning("triage appendix: source %s failed: %s", name, exc)
+            extra.append(f"source {name}: UNREADABLE ({exc})")
+            continue
+        if not items:
+            if name in DARK_RENDER_SOURCES:
+                dark.append(name)
+            continue
+        if name in ("spec_drift", "diagnoses"):
+            for item in items:
+                candidates.append(
+                    TriageItem(
+                        title=str(getattr(item, "title", item)),
+                        evidence=str(getattr(item, "detail", "")),
+                        question="Recommend a disposition with a one-line rationale.",
+                    )
+                )
+    extra.extend(_gate_ledger_evidence())
+    extra.append(_usage_freshness_evidence())
+    return candidates, dark, extra
+
+
+def _gate_ledger_evidence() -> list[str]:
+    """Gate-verdict input: local ledger read; honest darkness otherwise.
+
+    Per the A4 ruling the durable input is a CI-artifact fetch at
+    render time; until that follow-on lands, the local ledger (dark by
+    construction — D7 runs the gates CI-only) is rendered honestly.
+    """
+    try:
+        from attune.gates.lifecycle import ledger  # noqa: PLC0415
+
+        path = ledger.ledger_path()
+        if not path.is_file():
+            return [f"gate verdict ledger: dark (no local ledger at {path}; A4 CI fetch pending)"]
+        unresolved = ledger.unresolved_chair_required()
+        if unresolved:
+            return [
+                "gate verdict ledger: "
+                f"{len(unresolved)} unresolved CHAIR_REQUIRED receipt(s): "
+                + "; ".join(f"{r.gate_id}:{r.target}" for r in unresolved[:5])
+            ]
+        return ["gate verdict ledger: present, no unresolved CHAIR_REQUIRED receipts"]
+    except Exception as exc:  # noqa: BLE001 — evidence, not a crash point
+        return [f"gate verdict ledger: UNREADABLE ({exc})"]
+
+
+def _usage_freshness_evidence() -> str:
+    """Local spend/freshness line: usage.jsonl last-write age."""
+    attune_dir = Path(os.environ.get("ATTUNE_HOME", str(Path.home() / ".attune")))
+    usage = attune_dir / "telemetry" / "usage.jsonl"
+    if not usage.is_file():
+        return "local spend: dark (no usage.jsonl)"
+    age_h = (
+        datetime.datetime.now(datetime.timezone.utc)
+        - datetime.datetime.fromtimestamp(usage.stat().st_mtime, tz=datetime.timezone.utc)
+    ).total_seconds() / 3600
+    return f"local spend: usage.jsonl last write {age_h:.0f}h ago"
+
+
+def distill(candidates: list[TriageItem]) -> tuple[list[TriageItem], int]:
+    """Deterministic cap at MAX_ITEMS; returns (kept, dropped_count)."""
+    return candidates[:MAX_ITEMS], max(0, len(candidates) - MAX_ITEMS)
+
+
+def compose_brief(
+    items: list[TriageItem],
+    dark: list[str],
+    extra: list[str],
+    dropped: int,
+    stamp: str,
+) -> str:
+    """The n=1/n=2 brief shape, composed deterministically."""
+    lines = [
+        "APPENDIX — briefing triage (T4 headless; the chair rules "
+        "per-item after your deliberation; recommend, do not execute; "
+        "compress his decisions, do not multiply them). Standing "
+        "rulings in docs/specs/roundtable-triage/decisions.md are "
+        "NOT to be re-litigated. For EACH item give a concrete "
+        "recommendation with a one-line rationale, then the main "
+        "RISK of your triage.",
+        "",
+        f"Briefing evidence gathered read-only {stamp}.",
+        "Dark sources (T3, rendered honestly, no refresh spend): "
+        + (", ".join(dark) if dark else "none"),
+        *extra,
+        "",
+    ]
+    for i, item in enumerate(items, 1):
+        lines += [
+            f"ITEM {i} — {item.title}",
+            f"  evidence: {item.evidence[:500]}",
+            f"  QUESTION: {item.question}",
+            "",
+        ]
+    if dropped:
+        lines.append(f"(cap: {dropped} further candidate item(s) dropped — named, not silent)")
+    return "\n".join(lines)
+
+
+def run_triage_appendix(
+    board,
+    thread: str,
+    project_root: Path,
+    invoke_seat,
+    seat_recipes,
+    *,
+    state_path: Path | None = None,
+) -> int:
+    """Run the appendix on an existing clean-run thread; return invocations used.
+
+    Returns 0 without any board write or LLM invocation when the kill
+    switch is off, the appendix is demoted, or the briefing has zero
+    decidable items (each is printed, so a silent skip is impossible).
+    """
+    if os.environ.get(KILL_SWITCH_ENV, "").lower() == "off":
+        print("  appendix: skipped (kill switch)", flush=True)
+        return 0
+    if is_demoted(state_path):
+        print(
+            "  appendix: DEMOTED to chair-invoked (two consecutive "
+            "zero-ruling digests, T4) — not running",
+            flush=True,
+        )
+        return 0
+    stamp = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+    candidates, dark, extra = pull_briefing(project_root)
+    items, dropped = distill(candidates)
+    if not items:
+        print("  appendix: 0 decidable items — skipped (no spend)", flush=True)
+        record_digest(thread, 0, path=state_path)
+        board.post_message(
+            thread,
+            "moderator",
+            "appendix",
+            f"Triage appendix {stamp}: 0 decidable items in the briefing "
+            f"(dark: {', '.join(dark) if dark else 'none'}). No seats convened.",
+            appendix="triage",
+        )
+        return 0
+    brief = compose_brief(items, dark, extra, dropped, stamp)
+    board.post_message(thread, "moderator", "question", brief, appendix="triage")
+
+    invocations = 0
+    positions: list[tuple[str, str]] = []
+    for seat, recipe in seat_recipes:
+        if invocations >= APPENDIX_MAX_INVOCATIONS - 1:
+            board.post_message(
+                thread,
+                "moderator",
+                "halt",
+                f"appendix invocation sub-cap before seat {seat!r}",
+                appendix="triage",
+            )
+            break
+        invocations += 1
+        print(f"  appendix seat {seat} ... briefing", flush=True)
+        code, reply = invoke_seat(recipe, brief)
+        if code != 0 or not reply.strip():
+            print(f"  appendix seat {seat}: ABSENT (exit {code})", flush=True)
+            board.post_message(
+                thread,
+                seat,
+                "position",
+                f"ABSENT — exit {code}: {reply[:200]}",
+                absent=True,
+                appendix="triage",
+            )
+            continue
+        print(f"  appendix seat {seat}: position posted", flush=True)
+        board.post_message(thread, seat, "position", reply, appendix="triage")
+        positions.append((seat, reply))
+
+    if positions:
+        invocations += 1
+        synthesis_brief = (
+            "You are the moderator of the triage appendix. Synthesize the "
+            "seat positions below per item: agreement counts, divergences "
+            "with the recorded evidence that resolves them, and a "
+            "per-item recommendation line the chair can rule on with "
+            "shorthand. Compact. Text only.\n\n"
+            + "\n\n".join(f"## {seat}\n{reply}" for seat, reply in positions)
+        )
+        print("  appendix synthesis ... running", flush=True)
+        code, digest = invoke_seat(("claude", "-p", "{brief}"), synthesis_brief)
+        if code == 0 and digest.strip():
+            board.post_message(thread, "moderator", "synthesis", digest, appendix="triage")
+            print("  appendix synthesis: posted", flush=True)
+        else:
+            board.post_message(
+                thread,
+                "moderator",
+                "halt",
+                f"appendix synthesis failed (exit {code}): {digest[:200]}",
+                appendix="triage",
+            )
+            print(f"  appendix synthesis: FAILED (exit {code})", flush=True)
+
+    record_digest(thread, len(items), path=state_path)
+    print(
+        f"  appendix complete: {len(items)} item(s), {invocations} invocation(s); "
+        "record rulings with attune.roundtable.triage_appendix.record_rulings() "
+        "when promoting (T4 demotion input).",
+        flush=True,
+    )
+    return invocations

--- a/tests/unit/roundtable/test_triage_appendix.py
+++ b/tests/unit/roundtable/test_triage_appendix.py
@@ -1,0 +1,168 @@
+"""Triage appendix (T4, headless) — contract tests.
+
+Board and seats are stubs; distillation, demotion state, brief
+composition, and the skip paths (kill switch, demoted, zero items)
+run real. No network, no Redis, no LLM.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from attune.roundtable import triage_appendix as ta
+
+RECIPES = (("claude", ("claude", "-p", "{brief}")),)
+
+
+class StubBoard:
+    def __init__(self) -> None:
+        self.messages: list[dict] = []
+
+    def post_message(self, thread, author, kind, body, **extra):
+        self.messages.append(
+            {"thread": thread, "author": author, "kind": kind, "body": body, **extra}
+        )
+        return len(self.messages)
+
+
+def _ok_seat(recipe, brief):
+    return 0, "ITEM 1: recommendation. RISK: none."
+
+
+@pytest.fixture
+def state(tmp_path: Path) -> Path:
+    return tmp_path / "state.json"
+
+
+class TestDistill:
+    def test_cap_at_five_names_dropped(self):
+        items = [ta.TriageItem(f"t{i}", "e", "q") for i in range(8)]
+        kept, dropped = ta.distill(items)
+        assert len(kept) == 5
+        assert dropped == 3
+
+    def test_under_cap_drops_nothing(self):
+        kept, dropped = ta.distill([ta.TriageItem("t", "e", "q")])
+        assert len(kept) == 1
+        assert dropped == 0
+
+
+class TestComposeBrief:
+    def test_brief_carries_items_dark_and_cap_note(self):
+        items = [ta.TriageItem("title-one", "evidence-one", "q?")]
+        brief = ta.compose_brief(items, ["sweep", "telemetry"], ["extra-line"], 2, "STAMP")
+        assert "ITEM 1 — title-one" in brief
+        assert "evidence-one" in brief
+        assert "sweep, telemetry" in brief
+        assert "extra-line" in brief
+        assert "2 further candidate item(s) dropped" in brief
+        assert "NOT to be re-litigated" in brief
+
+    def test_no_cap_note_when_nothing_dropped(self):
+        brief = ta.compose_brief([ta.TriageItem("t", "e", "q")], [], [], 0, "S")
+        assert "dropped" not in brief
+
+
+class TestDemotionState:
+    def test_fresh_state_not_demoted(self, state):
+        assert ta.is_demoted(state) is False
+
+    def test_two_recorded_zero_ruling_digests_demote(self, state):
+        ta.record_digest("t1", 3, path=state)
+        ta.record_digest("t2", 2, path=state)
+        ta.record_rulings("t1", 0, path=state)
+        ta.record_rulings("t2", 0, path=state)
+        assert ta.is_demoted(state) is True
+
+    def test_unrecorded_outcomes_never_demote(self, state):
+        ta.record_digest("t1", 3, path=state)
+        ta.record_digest("t2", 2, path=state)
+        assert ta.is_demoted(state) is False
+
+    def test_nonzero_ruling_resets_the_streak(self, state):
+        for thread, rulings in (("t1", 0), ("t2", 4)):
+            ta.record_digest(thread, 1, path=state)
+            ta.record_rulings(thread, rulings, path=state)
+        assert ta.is_demoted(state) is False
+
+    def test_record_rulings_unknown_thread_returns_false(self, state):
+        ta.record_digest("t1", 1, path=state)
+        assert ta.record_rulings("nope", 2, path=state) is False
+
+
+class TestRunSkipPaths:
+    def test_kill_switch_skips_everything(self, state, monkeypatch, capsys):
+        monkeypatch.setenv(ta.KILL_SWITCH_ENV, "off")
+        board = StubBoard()
+        used = ta.run_triage_appendix(
+            board, "t", Path("/nonexistent"), _ok_seat, RECIPES, state_path=state
+        )
+        assert used == 0
+        assert board.messages == []
+        assert "kill switch" in capsys.readouterr().out
+
+    def test_demoted_skips_everything(self, state, capsys):
+        for thread in ("t1", "t2"):
+            ta.record_digest(thread, 1, path=state)
+            ta.record_rulings(thread, 0, path=state)
+        board = StubBoard()
+        used = ta.run_triage_appendix(
+            board, "t", Path("/nonexistent"), _ok_seat, RECIPES, state_path=state
+        )
+        assert used == 0
+        assert board.messages == []
+        assert "DEMOTED" in capsys.readouterr().out
+
+    def test_zero_items_posts_note_no_seats(self, state, tmp_path, monkeypatch, capsys):
+        monkeypatch.setattr(ta, "pull_briefing", lambda root: ([], ["sweep"], []))
+        board = StubBoard()
+        used = ta.run_triage_appendix(board, "t", tmp_path, _ok_seat, RECIPES, state_path=state)
+        assert used == 0
+        assert len(board.messages) == 1
+        assert board.messages[0]["kind"] == "appendix"
+        assert "0 decidable items" in board.messages[0]["body"]
+        assert "no spend" in capsys.readouterr().out
+        # The zero-item digest still records (it feeds T4 demotion).
+        digests = ta._load_state(state)["digests"]
+        assert len(digests) == 1 and digests[0]["items"] == 0
+
+
+class TestRunWithItems:
+    def _items(self):
+        return [ta.TriageItem("drifted-spec", "bucket approved-not-shipped", "disposition?")]
+
+    def test_full_flow_posts_question_position_synthesis(self, state, tmp_path, monkeypatch):
+        monkeypatch.setattr(ta, "pull_briefing", lambda root: (self._items(), [], ["ev"]))
+        board = StubBoard()
+        used = ta.run_triage_appendix(board, "t", tmp_path, _ok_seat, RECIPES, state_path=state)
+        kinds = [m["kind"] for m in board.messages]
+        assert kinds == ["question", "position", "synthesis"]
+        assert all(m.get("appendix") == "triage" for m in board.messages)
+        assert used == 2  # one seat + synthesis
+        digests = ta._load_state(state)["digests"]
+        assert digests[-1]["items"] == 1 and digests[-1]["rulings"] is None
+
+    def test_absent_seat_tolerated_no_synthesis(self, state, tmp_path, monkeypatch):
+        monkeypatch.setattr(ta, "pull_briefing", lambda root: (self._items(), [], []))
+
+        def absent(recipe, brief):
+            return 127, "not found"
+
+        board = StubBoard()
+        used = ta.run_triage_appendix(board, "t", tmp_path, absent, RECIPES, state_path=state)
+        kinds = [m["kind"] for m in board.messages]
+        assert kinds == ["question", "position"]
+        assert board.messages[1]["absent"] is True
+        assert used == 1
+
+
+class TestPullBriefing:
+    def test_empty_project_renders_dark_not_items(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("ATTUNE_HOME", str(tmp_path / "attune-home"))
+        candidates, dark, extra = ta.pull_briefing(tmp_path)
+        assert candidates == []
+        assert set(dark) <= set(ta.DARK_RENDER_SOURCES)
+        assert any("gate verdict ledger" in line for line in extra)
+        assert any("local spend" in line for line in extra)


### PR DESCRIPTION
Chair "go 1" — the first queued follow-on behind #1507. Implements the T4-armed briefing→table triage appendix and authors the roundtable-triage requirements (TA-1..TA-8, codifying the chartered + n=2-validated contract; no new scope).

**What ships**
- `attune.roundtable.triage_appendix`: read-only briefing pull (curator sources, gate ledger, usage freshness) with T3-honest dark rendering and NO LLM curation; deterministic ≤5-item distillation with named drops; the appendix posts to the SAME clean-run thread (one weekly ruling sitting) with its own seat round + synthesis under a 4-invocation sub-cap (combined run ≤8, under the ruled R5 ceiling of 10); `ATTUNE_TRIAGE_APPENDIX=off` kill switch; R8 preserved (never promotes).
- **T4 demotion loop**: every digest is recorded (`~/.attune/ops/triage_appendix.json`); the ruling session records the chair's ruling count via `record_rulings()`; two consecutive RECORDED zero-ruling digests demote the appendix to chair-invoked (unrecorded outcomes never demote — conservative).
- `routine.py`: clean-run composes the appendix after its health-check half.
- Spec: `requirements.md` authored; `decisions.md` implementation entry; TA-5's CI-artifact gate-verdict fetch stays the queued A4 follow-on (local ledger rendered dark-by-construction honestly until then).

**Receipts**: 15 contract tests (distillation cap + named drops, demotion semantics incl. unrecorded-never-demotes, kill-switch/demoted/zero-item skip paths each printing their reason, absent-seat tolerance, dark rendering with `ATTUNE_HOME` isolated); roundtable + gates + quality breadth = 300 passed. First live receipt: next Monday's scheduled 06:00 clean-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)