### PR TITLE
feat(diagnosis): origin-tag + closure seam (D18) — A3 disposition executed

### DIFF
--- a/docs/specs/advanced-debugging-plugin/decisions.md
+++ b/docs/specs/advanced-debugging-plugin/decisions.md
@@ -300,3 +300,28 @@ extracts recall-able terms; "path argument is required" →
 traceback-shaped text; diagnosis suite 73 passed. Also corrected
 the A3 entry's false "empty hypothesis summaries" claim (probe
 misread, see annotation there).
+
+## D18 — Origin-tag + closure seam shipped; A3 disposition executed (2026-07-20, chair "go 3")
+
+- `DiagnosisRecord.origin` (operational | dogfood | live-fire),
+  stamped at creation (`diagnose(origin=...)`; `attune diagnose
+  --origin`). Legacy records load as operational (tolerant
+  from_dict).
+- Closure seam: the loader is now last-wins by `diagnosis_id` with a
+  `dropped_superseded` counter — an update is a re-appended full
+  record (`attune.diagnosis.retag_origin`), the stream stays
+  append-only, nothing is rewritten or deleted. The status enum
+  stays CLOSED: tagging an artifact's origin IS its closure, because
+  the diagnoses curator source surfaces operational records only.
+- A3 executed with the new seam: 3264a8f6/7e751fed retagged
+  live-fire, 40482304 retagged dogfood. Receipt: loader shows 3
+  superseded lines counted; the briefing source now surfaces 0
+  diagnosis items.
+- Automated-suite exclusion: already carried by the ATTUNE_HOME
+  test-isolation fixture + FIXTURE_NAMES drop; origin covers the
+  remaining dogfood/live-fire-in-real-home class.
+
+Receipts: 8 contract tests in
+`tests/unit/diagnosis/test_origin_seam.py` (default + legacy load,
+last-wins + superseded counter, retag round-trip, vocabulary guard,
+source exclusion); diagnosis+curator 218 passed.

--- a/src/attune/cli_commands/diagnosis_commands.py
+++ b/src/attune/cli_commands/diagnosis_commands.py
@@ -19,7 +19,7 @@ def cmd_diagnose(args: Namespace) -> int:
     from attune.diagnosis.engine import DiagnosisSourceError, diagnose
 
     try:
-        record = diagnose(args.run_id)
+        record = diagnose(args.run_id, origin=getattr(args, "origin", "operational"))
     except DiagnosisSourceError as exc:
         print(f"cannot diagnose: {exc}")
         return 1

--- a/src/attune/cli_minimal.py
+++ b/src/attune/cli_minimal.py
@@ -214,6 +214,15 @@ def _add_diagnose_subparser(subparsers: argparse._SubParsersAction) -> None:
         "diagnose", help="Diagnose a failed workflow run from the canonical stream"
     )
     diagnose_parser.add_argument("run_id", help="run_id of a failed run to diagnose")
+    diagnose_parser.add_argument(
+        "--origin",
+        choices=("operational", "dogfood", "live-fire"),
+        default="operational",
+        help=(
+            "provenance stamp (D18): dogfood/live-fire records are "
+            "excluded from the ops briefing; default operational"
+        ),
+    )
 
 
 def _add_gates_subparsers(subparsers: argparse._SubParsersAction) -> None:

--- a/src/attune/curator/sources/diagnoses.py
+++ b/src/attune/curator/sources/diagnoses.py
@@ -42,6 +42,10 @@ def read(
 
         records, stats = load_diagnoses()
         for record in records:
+            # D18: only operational records reach the briefing —
+            # dogfood/live-fire artifacts are closed by their tag.
+            if getattr(record, "origin", "operational") != "operational":
+                continue
             top = record.hypotheses[0] if record.hypotheses else None
             # ALLOWLIST rendering — never diff or raw evidence content.
             detail_parts = [

--- a/src/attune/diagnosis/__init__.py
+++ b/src/attune/diagnosis/__init__.py
@@ -8,6 +8,10 @@ point the CLI, the ops endpoint (Phase C), and the triage routine
 (Phase D) all call.
 """
 
+from .annotate import (  # noqa: E402  — ordered after store imports
+    ORIGINS,
+    retag_origin,
+)
 from .config import DiagnosisConfig
 from .engine import DiagnosisSourceError, diagnose, find_source_run
 from .panel import PanelResult, convene_panel
@@ -30,7 +34,9 @@ __all__ = [
     "diagnose",
     "extract_error_terms",
     "find_source_run",
+    "ORIGINS",
     "load_diagnoses",
     "recall_priors",
     "records_for_run",
+    "retag_origin",
 ]

--- a/src/attune/diagnosis/annotate.py
+++ b/src/attune/diagnosis/annotate.py
@@ -1,0 +1,49 @@
+"""Diagnosis re-annotation (D18): update by re-append, never rewrite.
+
+The canonical stream is append-only and ``store.py`` never writes;
+updates go through ``TelemetryStore.log_diagnosis`` as a re-appended
+full record with the SAME ``diagnosis_id`` — the loader's last-wins
+dedupe makes the newest line authoritative and counts the superseded
+one. Tagging a record's ``origin`` as dogfood/live-fire closes it for
+briefing purposes (the diagnoses curator source surfaces operational
+records only), so nothing is deleted and the status enum stays
+closed.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under the Apache License, Version 2.0
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from pathlib import Path
+
+from attune.models.telemetry.data_models import DiagnosisRecord
+from attune.models.telemetry.storage import TelemetryStore
+
+from .store import load_diagnoses
+
+ORIGINS = ("operational", "dogfood", "live-fire")
+
+
+def retag_origin(
+    diagnosis_id: str,
+    origin: str,
+    *,
+    store: TelemetryStore | None = None,
+    path: Path | None = None,
+) -> DiagnosisRecord | None:
+    """Re-append the named record with ``origin`` set; return the copy.
+
+    Returns None when the id is unknown. Raises ValueError on an
+    origin outside the D18 vocabulary.
+    """
+    if origin not in ORIGINS:
+        raise ValueError(f"unknown origin {origin!r} (D18 vocabulary: {ORIGINS})")
+    records, _stats = load_diagnoses(path)
+    current = next((r for r in records if r.diagnosis_id == diagnosis_id), None)
+    if current is None:
+        return None
+    updated = dataclasses.replace(current, origin=origin)
+    (store or TelemetryStore()).log_diagnosis(updated)
+    return updated

--- a/src/attune/diagnosis/engine.py
+++ b/src/attune/diagnosis/engine.py
@@ -111,6 +111,7 @@ def diagnose(
     redis_client: Any = None,
     invoke_seat: Callable[[Sequence[str], str], tuple[int, str]] | None = None,
     repo_root: Path | None = None,
+    origin: str = "operational",
 ) -> DiagnosisRecord:
     """Diagnose one failed run end-to-end and persist the record.
 
@@ -165,6 +166,7 @@ def diagnose(
         dissent=panel.dissent,
         panel=panel.meta,
         config_used=config.to_config_used(),
+        origin=origin,
     )
     (store or TelemetryStore()).log_diagnosis(record)
     return record

--- a/src/attune/diagnosis/store.py
+++ b/src/attune/diagnosis/store.py
@@ -35,6 +35,7 @@ class DiagnosisLoadStats:
     dropped_malformed: int = 0
     dropped_fixture: int = 0
     dropped_pre_cutover: int = 0
+    dropped_superseded: int = 0
 
 
 def _parse_created_at(value: object) -> datetime | None:
@@ -85,6 +86,7 @@ def load_diagnoses(
     except OSError as exc:
         logger.warning("diagnosis: store read failed: %s", exc)
         return records, stats
+    by_id: dict[str, DiagnosisRecord] = {}
     for line in lines:
         if not line.strip():
             continue
@@ -93,8 +95,15 @@ def load_diagnoses(
         if isinstance(outcome, str):
             setattr(stats, outcome, getattr(stats, outcome) + 1)
             continue
-        stats.eligible += 1
-        records.append(outcome)
+        # Last-wins by diagnosis_id (D18 closure seam): re-appending a
+        # record with the same id UPDATES it — the stream stays
+        # append-only, superseded lines are counted, never silent.
+        if outcome.diagnosis_id in by_id:
+            stats.dropped_superseded += 1
+        else:
+            stats.eligible += 1
+        by_id[outcome.diagnosis_id] = outcome
+    records.extend(by_id.values())
     return records, stats
 
 

--- a/src/attune/models/telemetry/data_models.py
+++ b/src/attune/models/telemetry/data_models.py
@@ -196,6 +196,12 @@ class DiagnosisRecord:
     # Lifecycle: open | fix-proposed | verified | rejected | graduated
     status: str = "open"
 
+    # Provenance (D18): operational | dogfood | live-fire. Stamped at
+    # creation; the diagnoses curator source surfaces ONLY
+    # operational records, so tagging an artifact IS its closure —
+    # the status enum stays closed and nothing is retro-deleted.
+    origin: str = "operational"
+
     # Symptom + priors (RR-4)
     symptom: str = ""
     prior_lessons: list[str] = field(default_factory=list)

--- a/tests/unit/diagnosis/test_origin_seam.py
+++ b/tests/unit/diagnosis/test_origin_seam.py
@@ -1,0 +1,110 @@
+"""D18 origin-tag + closure seam — contract tests.
+
+Real store round-trips against a tmp stream file; no Redis, no LLM.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from attune.diagnosis.annotate import retag_origin
+from attune.diagnosis.store import load_diagnoses
+from attune.models.telemetry.data_models import DiagnosisRecord
+
+NOW = (datetime(2026, 7, 20, 12, 0, tzinfo=timezone.utc) + timedelta(hours=1)).isoformat()
+
+
+def _record(diagnosis_id: str, **overrides) -> DiagnosisRecord:
+    base = {
+        "diagnosis_id": diagnosis_id,
+        "source_run_id": f"run-{diagnosis_id}",
+        "workflow_name": "code-review",
+        "created_at": NOW,
+    }
+    base.update(overrides)
+    return DiagnosisRecord(**base)
+
+
+def _write_stream(path: Path, *records: DiagnosisRecord) -> Path:
+    path.write_text(
+        "".join(json.dumps(r.to_dict()) + "\n" for r in records),
+        encoding="utf-8",
+    )
+    return path
+
+
+class TestOriginField:
+    def test_default_is_operational(self):
+        assert _record("aaa").origin == "operational"
+
+    def test_legacy_record_without_origin_loads_operational(self, tmp_path):
+        raw = _record("bbb").to_dict()
+        raw.pop("origin")
+        stream = tmp_path / "s.jsonl"
+        stream.write_text(json.dumps(raw) + "\n", encoding="utf-8")
+        records, stats = load_diagnoses(stream)
+        assert stats.eligible == 1
+        assert records[0].origin == "operational"
+
+
+class TestLastWinsDedupe:
+    def test_reappended_record_supersedes(self, tmp_path):
+        stream = _write_stream(
+            tmp_path / "s.jsonl",
+            _record("ccc", status="open"),
+            _record("ccc", status="open", origin="live-fire"),
+        )
+        records, stats = load_diagnoses(stream)
+        assert len(records) == 1
+        assert records[0].origin == "live-fire"
+        assert stats.eligible == 1
+        assert stats.dropped_superseded == 1
+
+    def test_distinct_ids_all_kept(self, tmp_path):
+        stream = _write_stream(tmp_path / "s.jsonl", _record("d1"), _record("d2"))
+        records, stats = load_diagnoses(stream)
+        assert {r.diagnosis_id for r in records} == {"d1", "d2"}
+        assert stats.dropped_superseded == 0
+
+
+class TestRetagOrigin:
+    def test_round_trip_retag(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("ATTUNE_HOME", str(tmp_path))
+        stream = tmp_path / "telemetry" / "diagnosis_records.jsonl"
+        stream.parent.mkdir(parents=True)
+        _write_stream(stream, _record("eee"))
+        updated = retag_origin("eee", "dogfood")
+        assert updated is not None and updated.origin == "dogfood"
+        records, stats = load_diagnoses()
+        assert records[0].origin == "dogfood"
+        assert stats.dropped_superseded == 1
+
+    def test_unknown_id_returns_none(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("ATTUNE_HOME", str(tmp_path))
+        assert retag_origin("nope", "dogfood") is None
+
+    def test_invalid_origin_raises(self):
+        with pytest.raises(ValueError, match="D18 vocabulary"):
+            retag_origin("any", "test-run")
+
+
+class TestSourceFilter:
+    def test_non_operational_records_excluded_from_briefing(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("ATTUNE_HOME", str(tmp_path))
+        stream = tmp_path / "telemetry" / "diagnosis_records.jsonl"
+        stream.parent.mkdir(parents=True)
+        _write_stream(
+            stream,
+            _record("op1"),
+            _record("lf1", origin="live-fire"),
+            _record("df1", origin="dogfood"),
+        )
+        from attune.curator.sources import diagnoses as source
+
+        summary = source.read(project_root=tmp_path)
+        ids = [str(i.item_id) for i in summary.items]
+        assert ids == ["diagnosis:op1"]


### PR DESCRIPTION
Chair "go 3" — queued follow-on 3 from `q-briefing-triage-002` A3 ("tag, never retro-delete").

**Design point:** no new status token. The `DiagnosisRecord.status` enum stays closed (protocol discipline) — instead, a new `origin` field (`operational | dogfood | live-fire`) is stamped at creation, and the diagnoses curator source surfaces **operational records only**. Tagging an artifact IS its closure.

**The seam:** the loader is now last-wins by `diagnosis_id` with a `dropped_superseded` counter — an "update" is a re-appended full record via `attune.diagnosis.retag_origin()`. The stream stays append-only; `store.py` still never writes (writes go through `TelemetryStore.log_diagnosis`); superseded lines are counted, never silent.

**A3 executed live** with the new seam: `3264a8f6`/`7e751fed` retagged `live-fire`, `40482304` retagged `dogfood`. Receipts: loader reports 3 superseded lines; the briefing source now surfaces **0** diagnosis items — a clean slate for real operational failures. Automated-suite exclusion is already carried by the `ATTUNE_HOME` isolation fixture + `FIXTURE_NAMES` drop; `origin` covers the dogfood/live-fire-in-real-home class.

Also: `attune diagnose --origin` CLI flag; legacy records load as `operational` (tolerant `from_dict`, test-pinned).

**Receipts:** 8 contract tests in `tests/unit/diagnosis/test_origin_seam.py`; diagnosis+curator+quality+cli breadth 252 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)