### PR TITLE
feat(roundtable): TA-5 — CI gate verdicts fetched at briefing render time

### DIFF
--- a/docs/specs/roundtable-triage/decisions.md
+++ b/docs/specs/roundtable-triage/decisions.md
@@ -131,3 +131,25 @@ scope. Receipts: 15 contract tests in
 `tests/unit/roundtable/test_triage_appendix.py`; first live receipt
 = next Monday's 06:00 scheduled run. TA-5's CI-artifact fetch stays
 the queued follow-on (A4).
+
+## 2026-07-20 — TA-5 shipped: CI gate verdicts fetched at render time (chair "go 4")
+
+Mechanism note (implementation latitude within the A4 ruling; chair
+may veto): the ruling's illustrative mechanism was "artifact fetch,"
+but nothing in CI uploads a verdicts artifact — the claim-drift
+gates run as plain pytest and the lifecycle runner's ledger writes
+land on the runner's discarded home. The CI-truth surface that
+EXISTS is check-run conclusions on main head, so
+`_ci_gate_verdicts()` fetches those via `gh api` (network-only, no
+LLM, at render time only — T3-compliant), rendering
+`N checks — counts by conclusion; FAILING: <names>` with the fetch
+timestamp, and a TIMESTAMPED unavailable line on any failure (gh
+missing, network, unparseable). The local ledger line stays for
+producing-run receipts. Live receipt at ship time: "30 checks — 6
+skipped, 24 success" against real main. If the chair prefers a true
+artifact pipeline (gates writing receipts in CI + upload +
+download), that is NEW scope needing its own approval.
+
+Queued follow-ons from q-briefing-triage-002 are now ALL closed:
+item 1 #1511, item 2 #1512 (D17), item 3 #1514 (D18), item 4 this
+entry.

--- a/docs/specs/roundtable-triage/requirements.md
+++ b/docs/specs/roundtable-triage/requirements.md
@@ -37,12 +37,16 @@ renders "dark" in the brief. The appendix never schedules or
 performs LLM sweeps to freshen a source; refresh happens only when
 a chair-authorized run does it anyway. (T3)
 
-**TA-5 — Gate-verdict input via CI artifacts.** The durable
-gate-verdict input is a CI-artifact fetch at digest render time
+**TA-5 — Gate-verdict input from CI at render time.** The durable
+gate-verdict input is fetched from CI at digest render time
 (timestamped unavailable/expired handling, no scheduled refresh).
-Until that lands, the local ledger is read and its
-darkness-by-construction (D7 CI-only gates) is rendered honestly.
-(A4 ruling, 2026-07-20; follow-on queued)
+SHIPPED 2026-07-20: implemented as a check-run-conclusions fetch on
+main head (`gh api .../commits/main/check-runs`) — the CI-truth
+surface that exists today; nothing in CI uploads a verdicts
+artifact, so an artifact fetch would read a void (see decisions.md).
+The local ledger is still read for producing-run receipts and its
+darkness-by-construction (D7 CI-only test gates) rendered honestly.
+(A4 ruling, 2026-07-20)
 
 **TA-6 — Auto-demotion with a recorded-outcome ledger.** Each digest
 records `{thread, at, items, rulings: null}` in the appendix state
@@ -69,5 +73,5 @@ code change.
   live scheduled run's thread.
 - The demotion loop closes: digests recorded, rulings recordable,
   two recorded zero-ruling digests demote (test-receipted).
-- TA-5's CI-artifact fetch replaces the local-ledger read (queued
-  follow-on; not blocking the headless arming).
+- TA-5's CI verdict fetch renders alongside the local-ledger read
+  (SHIPPED — see decisions.md 2026-07-20 follow-on entry).

--- a/src/attune/roundtable/triage_appendix.py
+++ b/src/attune/roundtable/triage_appendix.py
@@ -173,23 +173,87 @@ def pull_briefing(project_root: Path) -> tuple[list[TriageItem], list[str], list
                     )
                 )
     extra.extend(_gate_ledger_evidence())
+    extra.extend(_ci_gate_verdicts(project_root))
     extra.append(_usage_freshness_evidence())
     return candidates, dark, extra
+
+
+def _run_gh(argv: list[str], cwd: Path) -> tuple[int, str]:
+    """Run one fixed-argv gh command; (127, reason) when unavailable."""
+    import subprocess  # noqa: PLC0415 — nosec B404: fixed argv, never shell
+
+    try:
+        proc = subprocess.run(  # nosec B603
+            argv, capture_output=True, text=True, timeout=30, cwd=str(cwd)
+        )
+    except FileNotFoundError:
+        return 127, "gh not found"
+    except subprocess.TimeoutExpired:
+        return 124, "gh timed out"
+    return proc.returncode, (proc.stdout if proc.returncode == 0 else proc.stderr).strip()
+
+
+def _ci_gate_verdicts(project_root: Path, runner=None) -> list[str]:
+    """A4/TA-5: fetch CI gate verdicts (main check-run conclusions).
+
+    Network-only, no LLM, fetched at render time — never scheduled
+    (T3). Any failure renders a TIMESTAMPED unavailable line instead
+    of raising. ``runner`` is injectable for tests.
+    """
+    run = runner or _run_gh
+    checked_at = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+    code, repo = run(
+        ["gh", "repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner"], project_root
+    )
+    if code != 0 or not repo.strip():
+        return [
+            f"CI gate verdicts: unavailable (repo resolution: {repo[:80]}; checked {checked_at})"
+        ]
+    code, raw = run(
+        [
+            "gh",
+            "api",
+            f"repos/{repo.strip()}/commits/main/check-runs",
+            "--jq",
+            '{"runs": [.check_runs[] | {name, conclusion}]}',
+        ],
+        project_root,
+    )
+    if code != 0:
+        return [f"CI gate verdicts: unavailable ({raw[:80]}; checked {checked_at})"]
+    try:
+        runs = json.loads(raw).get("runs", [])
+    except json.JSONDecodeError:
+        return [f"CI gate verdicts: unavailable (unparseable reply; checked {checked_at})"]
+    by: dict[str, int] = {}
+    failing: list[str] = []
+    for entry in runs:
+        conclusion = str(entry.get("conclusion") or "pending")
+        by[conclusion] = by.get(conclusion, 0) + 1
+        if conclusion == "failure":
+            failing.append(str(entry.get("name", "?")))
+    counts = ", ".join(f"{n} {k}" for k, n in sorted(by.items()))
+    line = f"CI gate verdicts (main head, fetched {checked_at}): {len(runs)} checks — {counts}"
+    if failing:
+        line += "; FAILING: " + ", ".join(failing[:5])
+    return [line]
 
 
 def _gate_ledger_evidence() -> list[str]:
     """Gate-verdict input: local ledger read; honest darkness otherwise.
 
-    Per the A4 ruling the durable input is a CI-artifact fetch at
-    render time; until that follow-on lands, the local ledger (dark by
-    construction — D7 runs the gates CI-only) is rendered honestly.
+    The local ledger carries producing-run receipts when they exist;
+    it is dark by construction for the CI-only test gates (D7) — the
+    CI-truth half comes from :func:`_ci_gate_verdicts` (A4/TA-5).
     """
     try:
         from attune.gates.lifecycle import ledger  # noqa: PLC0415
 
         path = ledger.ledger_path()
         if not path.is_file():
-            return [f"gate verdict ledger: dark (no local ledger at {path}; A4 CI fetch pending)"]
+            return [
+                f"gate verdict ledger: dark (no local ledger at {path}; CI half is fetched live)"
+            ]
         unresolved = ledger.unresolved_chair_required()
         if unresolved:
             return [

--- a/tests/unit/roundtable/test_triage_appendix.py
+++ b/tests/unit/roundtable/test_triage_appendix.py
@@ -166,3 +166,45 @@ class TestPullBriefing:
         assert set(dark) <= set(ta.DARK_RENDER_SOURCES)
         assert any("gate verdict ledger" in line for line in extra)
         assert any("local spend" in line for line in extra)
+
+
+class TestCiGateVerdicts:
+    """A4/TA-5 — CI verdict fetch: timestamped, injectable, never raises."""
+
+    def test_success_path_counts_and_names_failures(self, tmp_path):
+        def runner(argv, cwd):
+            if "repo" in argv:
+                return 0, "Smart-AI-Memory/attune-ai"
+            return 0, (
+                '{"runs": [{"name": "pre-commit", "conclusion": "success"},'
+                ' {"name": "coverage", "conclusion": "failure"},'
+                ' {"name": "label", "conclusion": "skipped"}]}'
+            )
+
+        (line,) = ta._ci_gate_verdicts(tmp_path, runner=runner)
+        assert "3 checks" in line
+        assert "1 failure" in line and "1 success" in line
+        assert "FAILING: coverage" in line
+        assert "fetched" in line
+
+    def test_gh_missing_renders_timestamped_unavailable(self, tmp_path):
+        def runner(argv, cwd):
+            return 127, "gh not found"
+
+        (line,) = ta._ci_gate_verdicts(tmp_path, runner=runner)
+        assert "unavailable" in line and "checked" in line
+
+    def test_unparseable_reply_renders_unavailable(self, tmp_path):
+        def runner(argv, cwd):
+            if "repo" in argv:
+                return 0, "o/r"
+            return 0, "not-json"
+
+        (line,) = ta._ci_gate_verdicts(tmp_path, runner=runner)
+        assert "unparseable" in line
+
+    def test_pull_briefing_includes_ci_line(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("ATTUNE_HOME", str(tmp_path / "home"))
+        monkeypatch.setattr(ta, "_ci_gate_verdicts", lambda root: ["CI gate verdicts: STUB"])
+        _c, _d, extra = ta.pull_briefing(tmp_path)
+        assert "CI gate verdicts: STUB" in extra


### PR DESCRIPTION
Chair "go 4" — the **last** queued follow-on from `q-briefing-triage-002` (A4 ruling).

**Mechanism note (recorded in decisions.md, chair may veto):** the ruling's illustrative mechanism was "artifact fetch," but nothing in CI uploads a verdicts artifact — the claim-drift gates run as plain pytest, and the lifecycle runner's ledger writes land on the runner's discarded home. The CI-truth surface that *exists* is **check-run conclusions on main head**, so `_ci_gate_verdicts()` fetches those via `gh api` — network-only, no LLM, render-time only (T3-compliant), with a timestamped unavailable line on any failure (gh missing / network / unparseable). The local-ledger line stays for producing-run receipts. A true artifact pipeline (gates writing receipts in CI + upload + download) would be new scope needing its own approval.

**Live receipt at ship time:** `CI gate verdicts (main head, fetched 2026-07-20 13:37 UTC): 30 checks — 6 skipped, 24 success` against real main.

**Receipts:** 4 new contract tests (success parse + failing-name rendering, gh-missing, unparseable-reply, briefing wiring) — 19 total in the appendix suite; roundtable+gates+quality breadth 304 passed. TA-5 marked shipped in requirements.md.

This closes the full `q-briefing-triage-002` follow-on queue: #1511 (headless appendix), #1512 (D17 priors), #1514 (D18 origin seam), and this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)