### PR TITLE
feat(roundtable): TA-8a evidence tiers — receipt vs claim labels in digests

### DIFF
--- a/docs/specs/roundtable-triage/requirements.md
+++ b/docs/specs/roundtable-triage/requirements.md
@@ -60,6 +60,16 @@ ceiling (its own sub-cap of 4 invocations keeps clean-run + appendix
 ≤ 8, under the ruled ceiling of 10), tolerates absent seats (R6),
 and NEVER promotes its own thread (R8).
 
+**TA-8a — Evidence tiers (added 2026-07-20, chair "go all" on the
+session-feedback items).** Every digest item labels its evidence
+``[receipt]`` (read live this run — source-reader output, ledger
+rows, CI fetches) or ``[claim]`` (narrated/derived, unverified this
+run). Seats are instructed to weigh claim-tier evidence as softer
+ground; the chair sees which rulings rest on it BEFORE spending a
+batched "go". Born from the 2026-07-20 sitting, where two false
+claims rode through an 8-item ruling unmarked. Applies to headless
+AND interactive digests.
+
 **TA-8 — Kill switch.** `ATTUNE_TRIAGE_APPENDIX=off` skips the
 appendix with a printed notice — operational off-ramp without a
 code change.

--- a/src/attune/roundtable/triage_appendix.py
+++ b/src/attune/roundtable/triage_appendix.py
@@ -68,11 +68,20 @@ DARK_RENDER_SOURCES = frozenset({"bulletin", "git_state", "recommendations", "sw
 
 @dataclass
 class TriageItem:
-    """One decidable briefing item put to the table."""
+    """One decidable briefing item put to the table.
+
+    ``evidence_kind`` is the TA-9 tier: "receipt" for evidence that
+    was READ live (source-reader output, ledger rows, CI fetches);
+    "claim" for narrated/derived statements nobody re-verified this
+    run. Seats and chair weigh claim-tier evidence as unverified —
+    the 2026-07-20 sitting shipped two false claims precisely
+    because the digest didn't distinguish.
+    """
 
     title: str
     evidence: str
     question: str
+    evidence_kind: str = "receipt"
 
 
 def _state_path() -> Path:
@@ -299,7 +308,10 @@ def compose_brief(
         "rulings in docs/specs/roundtable-triage/decisions.md are "
         "NOT to be re-litigated. For EACH item give a concrete "
         "recommendation with a one-line rationale, then the main "
-        "RISK of your triage.",
+        "RISK of your triage. Evidence is tiered: [receipt] was read "
+        "live this run; [claim] is narrated and UNVERIFIED — treat "
+        "claim-tier evidence as softer ground and say so if your "
+        "recommendation leans on it.",
         "",
         f"Briefing evidence gathered read-only {stamp}.",
         "Dark sources (T3, rendered honestly, no refresh spend): "
@@ -310,7 +322,7 @@ def compose_brief(
     for i, item in enumerate(items, 1):
         lines += [
             f"ITEM {i} — {item.title}",
-            f"  evidence: {item.evidence[:500]}",
+            f"  evidence[{item.evidence_kind}]: {item.evidence[:500]}",
             f"  QUESTION: {item.question}",
             "",
         ]

--- a/tests/unit/roundtable/test_triage_appendix.py
+++ b/tests/unit/roundtable/test_triage_appendix.py
@@ -208,3 +208,47 @@ class TestCiGateVerdicts:
         monkeypatch.setattr(ta, "_ci_gate_verdicts", lambda root: ["CI gate verdicts: STUB"])
         _c, _d, extra = ta.pull_briefing(tmp_path)
         assert "CI gate verdicts: STUB" in extra
+
+
+class TestEvidenceTiers:
+    """TA-9 — receipt-vs-claim labels travel into the brief."""
+
+    def test_default_kind_is_receipt_and_rendered(self):
+        brief = ta.compose_brief([ta.TriageItem("t", "live read", "q?")], [], [], 0, "S")
+        assert "evidence[receipt]: live read" in brief
+
+    def test_claim_kind_rendered_and_instruction_present(self):
+        item = ta.TriageItem("t", "narrated statement", "q?", evidence_kind="claim")
+        brief = ta.compose_brief([item], [], [], 0, "S")
+        assert "evidence[claim]: narrated statement" in brief
+        assert "UNVERIFIED" in brief
+
+    def test_pull_briefing_items_are_receipts(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("ATTUNE_HOME", str(tmp_path / "home"))
+
+        class _Item:
+            title = "drift"
+            detail = "bucket x"
+            item_id = "spec-drift:x"
+            metadata = {}
+
+        class _Summary:
+            items = [_Item()]
+
+        real_import = ta.importlib.import_module
+
+        def fake_import(name):
+            if name.endswith(".spec_drift"):
+
+                class _Mod:
+                    @staticmethod
+                    def read(*, project_root):
+                        return _Summary()
+
+                return _Mod
+            return real_import(name)
+
+        monkeypatch.setattr(ta.importlib, "import_module", fake_import)
+        monkeypatch.setattr(ta, "_ci_gate_verdicts", lambda root: [])
+        candidates, _dark, _extra = ta.pull_briefing(tmp_path)
+        assert candidates and all(c.evidence_kind == "receipt" for c in candidates)


### PR DESCRIPTION
Session-feedback item (chair ruled "go all", 2026-07-20). The morning sitting batched 8 rulings with one token, and two of them rested on false claims that rode through unmarked — the digest gave no way to see which evidence had been read live versus narrated.

**What ships:**
- `TriageItem.evidence_kind`: `receipt` (read live this run — source-reader output, ledger rows, CI fetches) vs `claim` (narrated/derived, unverified). Curator-source items are receipts by construction.
- The brief renders `evidence[receipt]:` / `evidence[claim]:` per item and instructs seats to treat claim-tier evidence as softer ground and to say so when a recommendation leans on it.
- Requirements: **TA-8a** codifies the convention for headless AND interactive digests, with the chair-authorization noted.

Receipts: 3 new contract tests (default-receipt rendering, claim rendering + seat instruction, pull_briefing items are receipts) — 22 total in the appendix suite; roundtable+quality breadth 161 passed. Rebased onto current main (post-#1515); replayed commit re-signed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)