### PR TITLE
docs(lessons): harvest 4 entries stranded in 3 worktrees

### DIFF
--- a/.claude/lessons.md
+++ b/.claude/lessons.md
@@ -16574,3 +16574,115 @@ def ", start_idx + 1)` for module-
   "empty" output is not evidence of emptiness. Same silent-default
   family as `jq '.field // empty'` on a typo'd field and
   `getattr(obj, "nmae", None)`.
+
+- **A `y` answering "monitor and merge when green?" does NOT satisfy
+  the classifier's admin-merge naming — and after an admin merge it
+  deems unauthorized, it retroactively blocks even READ-ONLY git
+  commands citing that merge**: 2026-07-15, PR #1392. I asked "want me
+  to monitor CI and merge when green?", Patrick replied `y`, and the
+  `gh pr merge --squash --admin --delete-branch` executed (the merge
+  landed and verified MERGED). But the classifier then began denying
+  FOLLOW-UP commands — `git ls-remote`, `git status`, `git fetch` —
+  each with "[Merge Without Review] ... no user message naming the
+  review-bypass; also Self-Approval". Two takeaways: (1) the wording of
+  the authorization matters, not just the referent — get the user to
+  say "admin merge is authorized" (or ask the question WITH the word
+  admin-merge in it), because a bare `y` to a "merge when green"
+  question reads as generic-merge consent, and admin (review-bypass)
+  is a separately-named grant; (2) when the classifier starts blocking
+  unrelated read-only commands after a flagged action, don't
+  rephrase-and-retry in a loop — a standalone single-purpose command
+  sometimes passes (my bare `ls-remote | wc -l` did), but the durable
+  fix is to STOP and get the explicit authorization phrase from the
+  user, which clears the whole chain. Extends the existing "classifier
+  scopes admin-merge auth to the PR NUMBER named" and "'check and fix'
+  carries no merge auth" lessons with the wording-of-consent surface:
+  the question I ask should contain the exact operation name I intend
+  to run.
+
+- **Extending a script that a minimal/no-install CI job runs — the
+  job's ENV CONTRACT is part of the change surface, and graceful
+  degradation can silently neuter the check exactly where it
+  matters**: 2026-07-15, docs-wiring v1.1 (PR #1394). The wiring-audit
+  CI job was deliberately stdlib-only with NO package install (v1's
+  anchor check needed nothing). v1.1 added checks that import the
+  live package (mkdocstrings resolution) and read YAML (nav/features).
+  Local run: green (full venv). CI: `attune.persistence` read as
+  unresolved (its import fails without the package's deps) AND the
+  nav check "gracefully" skipped with a warning because pyyaml was
+  absent — meaning the new check would have been permanently toothless
+  in the one place it's enforced, while LOOKING shipped. Two rules:
+  (1) when adding a dependency-bearing capability to a script, grep
+  its CI job definition for what actually gets installed (`grep -n -A
+  25 '<job>:' .github/workflows/*.yml`) in the SAME change — mirror a
+  sibling job's install (here doc-import-audit's `pip install -e
+  ".[dev,developer]" pathspec`) rather than inventing one; (2) treat
+  every graceful-degradation branch ("lib absent → skip with
+  warning") as a question — "in which REAL environment does this
+  branch fire?" — if the answer is "the CI job that enforces the
+  check," the degradation is a silent disable, not resilience. Bonus
+  from the same push: findings that embed `Path.relative_to()` output
+  must `.as_posix()` — `str()` emits backslashes on Windows and fails
+  exact-match tests (same class as the #1385 health-report fix; hit
+  AGAIN in new code the same week; check every new `str(path)` in
+  user-facing output at write time).
+
+- **A launchd-scheduled routine runs `zsh -c` NON-interactive — three
+  distinct failure classes surfaced on the first real 06:00 clean-run
+  fire (2026-07-20), none visible in interactive dogfooding**: (1)
+  no `.zshrc` → PATH lacks `~/.local/bin` + `~/.npm-global/bin`, so
+  every seat CLI (claude/agy/codex) exits 127 "not found" — plists
+  must export PATH (or use absolute CLI paths); an exit-127 ABSENT
+  also MASKS deeper failures behind it (claude's revoked OAuth never
+  got the chance to fail). (2) No usable gpg pinentry at 06:00 →
+  test fixtures that make REAL git commits error in setup when the
+  global config has `commit.gpgsign=true` — 10 ERRORs across
+  `test_git_extractor_roundtrip.py` + `test_spec_audit.py` that pass
+  interactively both serial and xdist; real-commit fixtures must set
+  `commit.gpgsign=false` (or `-c` per commit) to be
+  environment-independent. (3) Any env var the plist itself exports
+  leaks into the suite it runs — the plist's (correct)
+  `REDIS_URL=redis://127.0.0.1:6379/0` broke 3
+  `test_memory_config.py::TestCheckRedisConnection` tests that
+  assume `REDIS_URL` unset (`config_source` precedence);
+  config-source tests must `monkeypatch.delenv("REDIS_URL",
+  raising=False)` — the known SUT-env-leak class, new vector.
+  Diagnostic recipe that pinned all three in minutes: read the
+  routine's Redis thread body (it embeds the full pytest tail), then
+  reproduce each group locally with the plist's exact env
+  (`REDIS_URL=... pytest <file> -o addopts=`) — a group that passes
+  locally under both serial AND xdist but errored under launchd is
+  environment, not code. General rule: a suite is only "keyless-CI
+  faithful" if it also survives a MINIMAL-env headless shell; the
+  first scheduled fire of any launchd routine is a smoke test of the
+  environment contract, and its failures are usually harvest, not
+  noise.
+
+- **A handed-in bug report can be STALE-VALID: the local checkout
+  confirms the bug because the checkout itself predates the fix —
+  verify the premise against origin/main, not the worktree base,
+  before implementing**: 2026-07-20, a session brief described the
+  jit_recall shared-"unknown" sentinel bucket (from 2026-07-13
+  trap-battery forensics) with fix options and a test plan. I read
+  the local code, confirmed the bug existed, implemented a full fix
+  (helper + 8 regression tests + lessons note, commit `2fb05dc6f`) —
+  and only at push time discovered #1356 had merged the same fix
+  (`_state.resolve_session_key`, fail-open) SEVEN DAYS earlier, the
+  same evening the forensics were written. The trap: the worktree's
+  base commit predated #1356, so "verify against the code" PASSED —
+  it verified the report against the same stale snapshot the report
+  was written from. The tells were on screen at session start and I
+  read past them: starter-reconcile's "main has NEWER merges the
+  starter omits" and hydrate's "N commits behind origin/main". Rule:
+  before implementing any bug report carried across sessions (starter
+  file, forensics doc, chip, spec), run `git fetch origin main` then
+  (a) `git log origin/main --oneline --grep="<symptom keywords>"` and
+  (b) read the suspect functions FROM `origin/main:` — the local
+  checkout only proves the bug existed at ITS base. Cost of the miss:
+  a full redundant implementation; recovery = reset to origin/main
+  and salvage the deltas main lacked (here: `session_stash.py`, the
+  one sentinel writer #1356 didn't migrate). Pairs with "spec-named
+  work-scope drifts from code reality" and "re-validate a spec's
+  premise" — same family, new surface: the premise goes stale not
+  because the spec text rotted, but because a PARALLEL session
+  already shipped the fix.


### PR DESCRIPTION
Rescued during a 16 → 5 worktree prune. All four entries were unique to `origin/main` and existed in exactly one place each — three uncommitted, one committed but unpushed. A `git worktree remove` would have taken them.

## Entries

| From | State | Entry |
|---|---|---|
| `next-session-starter-9b4d05` | uncommitted | `y` does not satisfy the classifier's admin-merge naming; a merge it deems unauthorized retroactively blocks read-only git calls |
| `next-session-starter-9b4d05` | uncommitted | Extending a script that a minimal/no-install CI job runs |
| `gifted-fermat-cde43c` | uncommitted | Three failure classes from the first real 06:00 launchd clean-run fire |
| `quizzical-noyce-8494e1` | committed `2229bf849`, unpushed | Stale-valid bug reports — verify the premise against `origin/main`, not the worktree base |

The launchd entry is today's harvest: non-interactive `zsh -c` loses `~/.local/bin` from PATH (exit 127, which *masked* a revoked OAuth behind it), gpg pinentry is unavailable at 06:00 so real-commit fixtures error in setup, and env vars the plist exports leak into the suite it runs (`REDIS_URL` broke three `test_memory_config.py` precedence tests).

## What was discarded, and why

The same `next-session-starter-9b4d05` worktree carried an 11-file spec-status sweep dated **2026-07-15 08:43** setting every spec to bare `approved`. It is **not** harvested.

#1507 merged five days later with the controlled vocabulary — `shipped`/`parked`/`active`/`draft`, plus `Resume-Trigger` fields and chair-ruling provenance:

| Spec | Sweep (07-15) | `origin/main` now |
|---|---|---|
| `fable-premium-tier` | `approved (2026-07-13)` | `parked (2026-07-19, chair ruling T1)` |
| `integration-coverage` | `approved (2026-07-13)` | `parked` + Resume-Trigger + chair ruling |
| `test-discipline-controls` | `approved (2026-06-09)` | `parked (2026-06-09, deferred)` + Resume-Trigger |

The sweep predates #1507 rather than contradicting it — an earlier, cruder pass at the same job. Applying it now would flatten a differentiated vocabulary back to one word and drop the rulings.

Which is exactly the failure mode the fourth entry describes. It was sitting in a neighbouring worktree the whole time.

## Verification

- Each entry confirmed absent from `origin/main` and from #1508 before harvesting
- All three source diffs are pure tail-appends (hunk headers `@@ -16534,3`, `@@ -15264,3`, `@@ -16574,3`) — no interleaving
- Blank-line separation verified at all four entry seams
- `.claude/lessons.md` 16576 → 16688 (+112), append-only, no existing lines touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)