### PR TITLE
docs(windows-exit139): close out — verification bar met, loopback regression guard

### DIFF
--- a/.claude/lessons.md
+++ b/.claude/lessons.md
@@ -16686,3 +16686,45 @@ def ", start_idx + 1)` for module-
   premise" — same family, new surface: the premise goes stale not
   because the spec text rotted, but because a PARALLEL session
   already shipped the fix.
+
+- **A same-evening chair-selected work queue can already be stale —
+  reconcile each queue item's DONE-WHEN against `gh`/`git` before
+  building, not just its spec-status mentions**: 2026-07-20 queue
+  (written that evening) listed three items; item 1's substance
+  ("fix plan drafted, not yet landed") had landed 14 days earlier
+  (#1282, 2026-07-06 — only the guard/receipts/status-flip remained),
+  and item 2's ENTIRE done-when ("RR-2 + RR-6 + RR-7 shipped
+  fixture-tested, decisions.md records the build") was met verbatim
+  by #1475 — merged hours BEFORE the queue was selected. The
+  starter-lint (#1516) cross-reads spec MENTIONS against status
+  lines, but a queue item is a WORK claim, not a status mention —
+  it names a done-when, and the done-when is what to reconcile:
+  for each item, grep merged PRs (`git log origin/main --grep`),
+  read the owning spec's decisions.md tail, and run the named
+  tests before writing any code. Partial staleness is the sneaky
+  case: item 1 still had real remaining work (regression guard,
+  sighting harvest from an unmerged branch, status flip), so
+  "already landed" and "nothing to do" are different verdicts —
+  reconcile down to the sub-deliverable. Pairs with "stale-valid
+  bug reports" (previous entry) — same family; new surface: the
+  carrier is the chair's own queue, and same-day authorship is no
+  freshness guarantee.
+
+- **A watchdog-timeout failure class can be cleared over a whole CI
+  window by JOB DURATION alone — failed jobs shorter than the
+  watchdog cannot be the wedge, no log reading needed**: closing
+  out windows-exit139 required proving "no new sighting in 14
+  days" across 28 failed runs — reading logs for each is
+  prohibitive (and `--log-failed` is unavailable in-flight). The
+  wedge class REQUIRES the 20-minute conftest watchdog to fire, so
+  any failed `windows-latest` job completing in <20 min is
+  structurally not the class. One `gh api .../runs/<id>/jobs` pass
+  computing `completed_at - started_at` over all failed windows
+  jobs (40 of them, all 16–17 min) cleared the entire window in
+  minutes and attributed the redness to the deterministic #1474
+  path bug instead. Generalization: when a failure class has a
+  structural time floor (watchdog, timeout-kill, retry budget),
+  triage the fleet by duration FIRST and read logs only for jobs
+  above the floor. Compute durations in `jq`
+  (`fromdateiso8601` subtraction) — piping to awk mangles
+  space-containing job names.

--- a/docs/specs/archive/ci-runner-hang/evidence/run-28810092051/hang-controller-proc.txt
+++ b/docs/specs/archive/ci-runner-hang/evidence/run-28810092051/hang-controller-proc.txt
@@ -1,0 +1,5 @@
+# ci-runner-hang process-state probe (worker=controller pid=6560 ppid=9456)
+## socket-inode -> pid map (all /proc)
+## ps tree
+ps: unknown option -- w
+Try `ps --help' for more information.

--- a/docs/specs/archive/ci-runner-hang/evidence/run-28810092051/hang-controller.txt
+++ b/docs/specs/archive/ci-runner-hang/evidence/run-28810092051/hang-controller.txt
@@ -1,0 +1,34 @@
+Timeout (0:20:00)!
+Thread 0x000023bc (most recent call first):
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\execnet\gateway_base.py", line 534 in read
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\execnet\gateway_base.py", line 567 in from_io
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\execnet\gateway_base.py", line 1160 in _thread_receiver
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\execnet\gateway_base.py", line 341 in run
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\execnet\gateway_base.py", line 411 in _perform_spawn
+
+Thread 0x000026ec (most recent call first):
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\execnet\gateway_base.py", line 534 in read
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\execnet\gateway_base.py", line 567 in from_io
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\execnet\gateway_base.py", line 1160 in _thread_receiver
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\execnet\gateway_base.py", line 341 in run
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\execnet\gateway_base.py", line 411 in _perform_spawn
+
+Thread 0x00002264 (most recent call first):
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\execnet\gateway_base.py", line 534 in read
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\execnet\gateway_base.py", line 567 in from_io
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\execnet\gateway_base.py", line 1160 in _thread_receiver
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\execnet\gateway_base.py", line 341 in run
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\execnet\gateway_base.py", line 411 in _perform_spawn
+
+Thread 0x00002150 (most recent call first):
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\execnet\gateway_base.py", line 534 in read
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\execnet\gateway_base.py", line 567 in from_io
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\execnet\gateway_base.py", line 1160 in _thread_receiver
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\execnet\gateway_base.py", line 341 in run
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\execnet\gateway_base.py", line 411 in _perform_spawn
+
+Thread 0x00002638 (most recent call first):
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\re\_parser.py", line 460 in opengroup
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\re\_parser.py", line 862 in _parse
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\re\_parser.py", line 460 in _parse_sub
+  File

--- a/docs/specs/archive/ci-runner-hang/evidence/run-28810092051/hang-gw0-proc.txt
+++ b/docs/specs/archive/ci-runner-hang/evidence/run-28810092051/hang-gw0-proc.txt
@@ -1,0 +1,4 @@
+# ci-runner-hang process-state probe (worker=gw0 pid=9840 ppid=6560)
+## ps tree
+ps: unknown option -- w
+Try `ps --help' for more information.

--- a/docs/specs/archive/ci-runner-hang/evidence/run-28810092051/hang-gw0.txt
+++ b/docs/specs/archive/ci-runner-hang/evidence/run-28810092051/hang-gw0.txt
@@ -1,0 +1,93 @@
+Timeout (0:20:00)!
+Thread 0x00002678 (most recent call first):
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\threading.py", line 359 in wait
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\threading.py", line 655 in wait
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\threading.py", line 1431 in run
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\threading.py", line 1075 in _bootstrap_inner
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\threading.py", line 1032 in _bootstrap
+
+Thread 0x00002574 (most recent call first):
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\asyncio\windows_events.py", line 774 in _poll
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\asyncio\windows_events.py", line 445 in select
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\asyncio\base_events.py", line 1961 in _run_once
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\asyncio\base_events.py", line 645 in run_forever
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\asyncio\windows_events.py", line 322 in run_forever
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\threading.py", line 1012 in run
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\threading.py", line 1075 in _bootstrap_inner
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\threading.py", line 1032 in _bootstrap
+
+Thread 0x000020b0 (most recent call first):
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\subprocess.py", line 1538 in _execute_child
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\subprocess.py", line 1026 in __init__
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\subprocess.py", line 548 in run
+  File "D:\a\attune-ai\attune-ai\tests\conftest.py", line 170 in _dump_process_state
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\threading.py", line 1433 in run
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\threading.py", line 1075 in _bootstrap_inner
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\threading.py", line 1032 in _bootstrap
+
+Thread 0x00002120 (most recent call first):
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\threading.py", line 359 in wait
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\threading.py", line 655 in wait
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\execnet\gateway_base.py", line 470 in waitall
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\execnet\gateway_base.py", line 1239 in _terminate_execution
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\execnet\gateway_base.py", line 1176 in _thread_receiver
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\execnet\gateway_base.py", line 341 in run
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\execnet\gateway_base.py", line 411 in _perform_spawn
+
+Thread 0x0000100c (most recent call first):
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\redis\connection.py", line 1566 in _connect
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\redis\connection.py", line 1034 in connect_check_health
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\redis\connection.py", line 1008 in <lambda>
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\redis\retry.py", line 120 in call_with_retry
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\redis\connection.py", line 1007 in connect
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\redis\connection.py", line 3163 in get_connection
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\redis\utils.py", line 258 in wrapper
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\redis\client.py", line 804 in _execute_command
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\redis\client.py", line 798 in execute_command
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\redis\commands\core.py", line 2031 in ping
+  File "D:\a\attune-ai\attune-ai\src\attune\memory\features.py", line 96 in is_redis_running
+  File "D:\a\attune-ai\attune-ai\src\attune\memory\features.py", line 147 in get_feature_status
+  File "D:\a\attune-ai\attune-ai\src\attune\memory\features.py", line 183 in check_redis
+  File "D:\a\attune-ai\attune-ai\src\attune\memory\short_term\facade.py", line 161 in __init__
+  File "D:\a\attune-ai\attune-ai\src\attune\memory\config.py", line 110 in get_redis_memory
+  File "D:\a\attune-ai\attune-ai\src\attune\memory\mixins\backend_init_mixin.py", line 129 in _initialize_backends
+  File "D:\a\attune-ai\attune-ai\src\attune\memory\unified.py", line 190 in __post_init__
+  File "<string>", line 7 in __init__
+  File "D:\a\attune-ai\attune-ai\tests\unit\meta_workflows\test_session_context.py", line 440 in test_workflow_with_session_context
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\_pytest\python.py", line 167 in pytest_pyfunc_call
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\pluggy\_callers.py", line 121 in _multicall
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\pluggy\_manager.py", line 120 in _hookexec
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\pluggy\_hooks.py", line 512 in __call__
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\_pytest\python.py", line 1707 in runtest
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\_pytest\runner.py", line 184 in pytest_runtest_call
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\pluggy\_callers.py", line 121 in _multicall
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\pluggy\_manager.py", line 120 in _hookexec
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\pluggy\_hooks.py", line 512 in __call__
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\_pytest\runner.py", line 250 in <lambda>
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\_pytest\runner.py", line 361 in from_call
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\_pytest\runner.py", line 249 in call_and_report
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\_pytest\runner.py", line 139 in runtestprotocol
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\_pytest\runner.py", line 118 in pytest_runtest_protocol
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\pluggy\_callers.py", line 121 in _multicall
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\pluggy\_manager.py", line 120 in _hookexec
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\pluggy\_hooks.py", line 512 in __call__
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\xdist\remote.py", line 227 in run_one_test
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\xdist\remote.py", line 206 in pytest_runtestloop
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\pluggy\_callers.py", line 121 in _multicall
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\pluggy\_manager.py", line 120 in _hookexec
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\pluggy\_hooks.py", line 512 in __call__
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\_pytest\main.py", line 384 in _main
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\_pytest\main.py", line 330 in wrap_session
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\_pytest\main.py", line 377 in pytest_cmdline_main
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\pluggy\_callers.py", line 121 in _multicall
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\pluggy\_manager.py", line 120 in _hookexec
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\pluggy\_hooks.py", line 512 in __call__
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\xdist\remote.py", line 427 in <module>
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\execnet\gateway_base.py", line 1291 in executetask
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\execnet\gateway_base.py", line 341 in run
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\execnet\gateway_base.py", line 411 in _perform_spawn
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\execnet\gateway_base.py", line 389 in integrate_as_primary_thread
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\execnet\gateway_base.py", line 1273 in serve
+  File "C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\site-packages\execnet\gateway_base.py", line 1806 in serve
+  File "<string>", line 8 in <module>
+  File "<string>", line 1 in <module>

--- a/docs/specs/windows-exit139-segfault/README.md
+++ b/docs/specs/windows-exit139-segfault/README.md
@@ -1,7 +1,7 @@
 # windows-exit139-segfault — tracked failure class
 
-**Status:** open — fixable hypothesis confirmed (2026-07-06)
-**Split from:** [ci-runner-hang](../ci-runner-hang/) per the 5th-capture
+**Status:** shipped (2026-07-20) — fix #1282 landed 2026-07-06; verification bar met (receipts below)
+**Split from:** [ci-runner-hang](../archive/ci-runner-hang/) per the 5th-capture
 tripwire ("if a THIRD exit-139 arrives, consider splitting"). The third
 arrived within 24 hours of the second, on the same lane.
 
@@ -19,8 +19,9 @@ faulthandler was mid-write* (controller dump truncated in
 | # | Date | Run | Where | Evidence |
 |---|------|-----|-------|----------|
 | 1 | 2026-07-05 | 10.0.1 release chain | #1272 | clean-log; getaddrinfo hypothesis formed, literal-loopback fix applied to the bootstrap-probe test |
-| 2 | 2026-07-06 | `28772959348` | PR #1274 | [ci-runner-hang capture #5](../ci-runner-hang/evidence/run-28772959348/) — end-of-session shape, controller dump truncated, worker dumps empty |
-| 3 | 2026-07-06 | `28806701681` | PR #1279 | [ci-runner-hang capture #6](../ci-runner-hang/evidence/run-28806701681/) — **complete worker dump with a test frame** |
+| 2 | 2026-07-06 | `28772959348` | PR #1274 | [ci-runner-hang capture #5](../archive/ci-runner-hang/evidence/run-28772959348/) — end-of-session shape, controller dump truncated, worker dumps empty |
+| 3 | 2026-07-06 | `28806701681` | PR #1279 | [ci-runner-hang capture #6](../archive/ci-runner-hang/evidence/run-28806701681/) — **complete worker dump with a test frame** |
+| 4 | 2026-07-06 | `28810092051` | PR #1281 (this spec's own docs-only PR) | [evidence](../archive/ci-runner-hang/evidence/run-28810092051/) — identical chain, different test (`test_session_context.py:440 test_workflow_with_session_context` → unmocked `UnifiedMemory` → `is_redis_running` → redis-py `_connect`). A markdown-only diff wedging the same way proved the trap was on `main`. Harvested 2026-07-20 from the unmerged `docs/exit139-class-split` branch. |
 
 ## Confirmed mechanism (sighting 3)
 
@@ -43,21 +44,43 @@ production call sites in `src/attune/memory/`: `unified.py` (77, 133),
 Any unit test that builds `UnifiedMemory` without mocking walks into
 the same resolver.
 
-## Fix plan (narrow, per parent decisions.md step 4)
+## Fix (landed — PR #1282, 2026-07-06)
 
-1. **Default the memory stack's Redis host to the literal loopback**
-   `127.0.0.1` (or resolve-once-and-cache), eliminating per-call
-   `getaddrinfo` on the default path. Env-provided hosts unchanged.
-2. **Test-lane belt-and-suspenders:** set `REDIS_HOST=127.0.0.1` in
-   `tests/conftest.py` so no unit test ever name-resolves, even where
-   a future call site regresses.
-3. Do **not** chase the segfault-during-faulthandler itself — it is
-   downstream of the wedge (interpreter/teardown internals); with no
-   wedge there is no dump to segfault in.
+1. **Literal-loopback defaults** — `"localhost"` → `"127.0.0.1"` at
+   24 sites across `src/attune/memory/` and the centralized
+   `src/attune/redis_config.py`, eliminating per-call `getaddrinfo`
+   on the default path. Env-provided hosts unchanged; `_LOCAL_HOSTS`
+   keeps `"localhost"` for string-compare mode inference only.
+2. **Test-lane belt-and-suspenders** — `tests/conftest.py` pins
+   `REDIS_HOST=127.0.0.1` (unset/empty/localhost only) so no unit
+   test ever name-resolves, even if a future call site regresses.
+3. The segfault-during-faulthandler was deliberately **not** chased —
+   it is downstream of the wedge; with no wedge there is no dump to
+   segfault in.
 
-**Verification bar (parent design.md G3):** the wedge is intermittent —
-require ≥10 clean `windows-latest` reruns under `-n auto` after the
-fix, and no new exit-139 sighting over a monitoring window.
+**Regression guard (2026-07-20):**
+`tests/unit/memory/test_loopback_default_guard.py` — source-scan
+over the full #1282 surface fails if a `host="localhost"` default or
+`REDIS_HOST`-fallback reappears, plus a runtime assert that the
+conftest pin is in effect. Fires on all planted regression shapes,
+silent on the deliberate string-compare uses.
+
+## Verification receipts (bar met, 2026-07-20)
+
+Bar (parent design.md G3): ≥10 clean `windows-latest` reruns under
+`-n auto` post-fix, no new exit-139 sighting over a monitoring
+window. Measured over 2026-07-06 → 2026-07-20 (`tests.yml`):
+
+- **99 successful full-matrix runs** since the fix merged — ~495
+  clean `windows-latest` lanes against the ≥10 bar.
+- **Zero wedge-shaped failures**: every failed `windows-latest` job
+  in the window (40, across 28 failed runs) completed in 16–17 min —
+  under the 20-minute watchdog, so none can be this class. That
+  redness was the deterministic `test_dangerous_paths_rejected`
+  path-validation failure, fixed by #1474 (2026-07-19); the matrix
+  has been fully green since.
+- **No exit-139 sighting in 14 days** of monitoring (last: sighting
+  4, 2026-07-06, pre-fix).
 
 **Reopen/expand criteria:** an exit-139 with the fix in place and no
 `getaddrinfo`/connect frame in the dump means a second mechanism —

--- a/docs/specs/windows-exit139-segfault/requirements.md
+++ b/docs/specs/windows-exit139-segfault/requirements.md
@@ -1,6 +1,6 @@
 # windows-exit139-segfault — requirements stub
 
-**Status:** active (2026-07-06) — fixable hypothesis confirmed; fix plan drafted, not yet landed
+**Status:** shipped (2026-07-20) — fix #1282 landed 2026-07-06; verification bar met (receipts in README)
 
 This spec's substance lives in [README.md](README.md) (class
 signature, capture log, hypothesis, and fix plan — split from

--- a/tests/unit/memory/test_loopback_default_guard.py
+++ b/tests/unit/memory/test_loopback_default_guard.py
@@ -1,0 +1,82 @@
+"""Regression guard: no ``"localhost"`` host defaults in the memory stack.
+
+``getaddrinfo("localhost")`` runs BEFORE ``socket_connect_timeout``
+applies and is uninterruptible by ``--timeout-method=thread``; a
+stalled resolver wedged ``windows-latest`` workers for 20 minutes and
+produced the exit-139 segfault class (sightings 1-4). PR #1282 swapped
+every default host in the memory stack and the centralized redis
+config to the literal loopback ``127.0.0.1``.
+
+This guard fails if a ``host=...="localhost"`` default or a
+``REDIS_HOST`` env fallback of ``"localhost"`` reappears anywhere on
+that surface. Deliberate string-compare uses (``_LOCAL_HOSTS`` mode
+inference, docstrings, CORS origin checks) do not match the patterns.
+
+Spec: docs/specs/windows-exit139-segfault/
+"""
+
+import os
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+# Every production file #1282 had to fix lives on this surface.
+GUARDED_PATHS = [
+    REPO_ROOT / "src" / "attune" / "memory",
+    REPO_ROOT / "src" / "attune" / "redis_config.py",
+]
+
+# ``host: str = "localhost"``, ``redis_host="localhost"``,
+# ``self.host = "localhost"`` — any lowercase *host name defaulted or
+# assigned the resolvable hostname. ``_LOCAL_HOSTS`` (uppercase, set
+# literal) and ``"host": "localhost"`` dict keys do not match.
+_LOCALHOST_DEFAULT = re.compile(r"""[a-z_]*host\w*\s*(?::\s*[^=\n]+?)?=\s*["']localhost["']""")
+
+# ``get_attune_env("REDIS_HOST", "localhost")`` / os.environ fallbacks.
+_ENV_FALLBACK = re.compile(r"""["']REDIS_HOST["']\s*,\s*["']localhost["']""")
+
+
+def _guarded_files() -> list[Path]:
+    files: list[Path] = []
+    for path in GUARDED_PATHS:
+        if path.is_file():
+            files.append(path)
+        else:
+            files.extend(sorted(path.rglob("*.py")))
+    return files
+
+
+def test_no_localhost_host_defaults_in_memory_stack() -> None:
+    """No guarded file defaults or assigns a host to "localhost"."""
+    files = _guarded_files()
+    assert len(files) > 10, f"guard surface unexpectedly small: {files}"
+
+    offenders: list[str] = []
+    for path in files:
+        text = path.read_text(encoding="utf-8")
+        for lineno, line in enumerate(text.splitlines(), start=1):
+            if _LOCALHOST_DEFAULT.search(line) or _ENV_FALLBACK.search(line):
+                rel = path.relative_to(REPO_ROOT)
+                offenders.append(f"{rel}:{lineno}: {line.strip()}")
+
+    assert not offenders, (
+        "'localhost' host default reintroduced — getaddrinfo on the "
+        "default path wedges Windows CI workers (exit-139 class, "
+        "docs/specs/windows-exit139-segfault/). Use the literal "
+        "loopback '127.0.0.1':\n" + "\n".join(offenders)
+    )
+
+
+def test_unit_lane_pins_redis_host_to_loopback() -> None:
+    """The tests/conftest.py belt-and-suspenders pin is in effect.
+
+    conftest replaces an unset/empty/"localhost" REDIS_HOST with
+    127.0.0.1 before collection; a deliberate non-default host is left
+    alone. Whatever the source, no unit test may run with a
+    resolvable-hostname default.
+    """
+    assert os.environ.get("REDIS_HOST") not in (None, "", "localhost"), (
+        "REDIS_HOST is unset or 'localhost' during the unit lane — the "
+        "tests/conftest.py loopback pin (PR #1282) is no longer applied"
+    )


### PR DESCRIPTION
Closes out the `windows-exit139-segfault` spec: the fix (#1282, loopback defaults + conftest `REDIS_HOST` pin) landed 2026-07-06, and the spec's G3 verification bar is now **met**:

- **99 successful full-matrix runs** since the fix (~495 clean `windows-latest` lanes vs the ≥10 bar)
- **Zero wedge-shaped failures** — all 40 failed windows jobs in the window ran 16–17 min, under the 20-minute watchdog, so none can be this class (that redness was the deterministic path-validation failure fixed by #1474)
- **No exit-139 sighting in 14 days**

What this PR adds:

- **Regression guard**: `tests/unit/memory/test_loopback_default_guard.py` — source-scan over the full #1282 surface (`src/attune/memory/` + `src/attune/redis_config.py`) failing on any reintroduced `host="localhost"` default or `REDIS_HOST` fallback, plus a runtime assert that the conftest pin is live. Verified it fires on 5 planted regression shapes and stays silent on the 5 deliberate string-compare uses.
- **Sighting-4 harvest**: run `28810092051` evidence recovered from the unmerged `docs/exit139-class-split` branch into `docs/specs/archive/ci-runner-hang/evidence/`; sighting row added; stale `../ci-runner-hang/` links repointed to `archive/`.
- **Status flip**: README + requirements stub → `shipped (2026-07-20)`; reopen criteria retained.

Receipts: guard fires-on-regression check; 121 tests serial (spec-lifecycle gate + spec + quality ratchet + guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
