### PR TITLE
feat(diagnosis): fix-loop role-fit + proposer-brief hardening (v1.1 item 2)

### DIFF
--- a/docs/specs/advanced-debugging-plugin/decisions.md
+++ b/docs/specs/advanced-debugging-plugin/decisions.md
@@ -325,3 +325,36 @@ Receipts: 8 contract tests in
 `tests/unit/diagnosis/test_origin_seam.py` (default + legacy load,
 last-wins + superseded counter, retag round-trip, vocabulary guard,
 source exclusion); diagnosis+curator 218 passed.
+
+## 2026-07-20 — v1.1 backlog item 2: proposer-brief hardening + roster role-fit (chair-picked)
+
+Both remedies from live-fire 2's named follow-up, executed:
+
+- **Roster role-fit.** `PLAN_ONLY_SEATS` (routine.py, deny-list —
+  antigravity's `--mode plan` structurally cannot emit file blocks;
+  new seats default code-emitting). `run_fix_loop` now: (1) selects
+  the proposer only from code-emitting seats, with an explicit
+  `no-code-emitting-proposer` disposition (zero spend) when the
+  roster has none; (2) on `proposer-absent`, falls to the NEXT
+  code-emitting seat (the live-fire's manual recovery — claude
+  absent → codex proposed, antigravity reviewed — is now the loop's
+  own behavior; `absent_proposers` recorded); `failed-materialize`
+  stays terminal — the loop never seat-shops a format failure;
+  (3) picks the reviewer skipping the proposer AND known-absent
+  seats; a roster with no distinct reviewer is `rejected`, never
+  laundered to `proposed`.
+- **Proposer-brief hardening** (teach-by-worked-example, the
+  producing-run precedent — `TAG_EXAMPLE` class): literal
+  `FILE_BLOCK_EXAMPLE` embedded in the brief. Root-cause note: the
+  old repair message ("unified diff names no target files / Fix the
+  format") actively steered seats TOWARD unified diffs; the repair
+  brief now names the materialize failure and restates the
+  file-block contract with the example. Accept-diff/prose-
+  interleaving was NOT built — codex's exact output shape wasn't
+  captured, so parser guessing is speculative; revisit only if a
+  worked-example round still fails live.
+
+Receipts: 14 fix-loop tests serial (5 new role-fit: plan-only skip,
+all-plan-only zero-spend, absent-fallback with reviewer exclusion,
+no-seat-shopping, solo-roster honesty; 1 new brief guard);
+diagnosis+roundtable 243 passed serial.

--- a/src/attune/diagnosis/fix_loop.py
+++ b/src/attune/diagnosis/fix_loop.py
@@ -16,7 +16,7 @@ from pathlib import Path
 from typing import Any
 
 from attune.models.telemetry.data_models import DiagnosisRecord
-from attune.roundtable.routine import SEAT_RECIPES, default_invoke_seat
+from attune.roundtable.routine import PLAN_ONLY_SEATS, SEAT_RECIPES, default_invoke_seat
 from attune.roundtable.solutions import (
     Candidate,
     ProposalError,
@@ -34,15 +34,32 @@ logger = logging.getLogger(__name__)
 #: only in the chair-facing presentation; the record stays bounded).
 DIFF_CHARS = 8_000
 
+#: Literal worked example of a file block. Prose alone was not enough:
+#: live-fire 2 (advanced-debugging-plugin decisions.md, 2026-07-20) had
+#: codex answer BOTH rounds with diff/prose interleaving that
+#: materialized to nothing — the producing-run precedent
+#: (``producing.TAG_EXAMPLE``) is a literal shape to copy.
+FILE_BLOCK_EXAMPLE = """\
+EXAMPLE REPLY (copy this shape exactly — a '--- file:' line, then a
+fenced block holding the COMPLETE new file content; nothing else):
+
+--- file: src/example/target.py
+```
+VALUE = 2
+```"""
+
 _PROPOSER_BRIEF = """\
 You are proposing a MINIMAL fix for a diagnosed workflow failure.
 Reply with ONLY full-file blocks in exactly this format (one per
-file, complete file contents, no prose outside the blocks):
+file, complete file contents, no prose outside the blocks — do NOT
+send a unified diff, an explanation, or partial snippets):
 
 --- file: <relative/path>
 ```
 <complete file content>
 ```
+
+{example}
 
 Diagnosis:
 {synthesis}
@@ -96,13 +113,22 @@ def run_fix_loop(
     seats: Sequence[tuple[str, tuple[str, ...]]] = SEAT_RECIPES,
     invoke_seat: Callable[[Sequence[str], str], tuple[int, str]] = default_invoke_seat,
     checks: list[tuple[str, list[str]]] | None = None,
+    plan_only: frozenset[str] = PLAN_ONLY_SEATS,
 ) -> dict[str, Any]:
     """Run one propose→materialize→validate→review→discard cycle.
 
     Returns the ``proposed_fix`` dict for the DiagnosisRecord. Every
-    disposition is explicit: ``below-threshold``, ``proposer-absent``,
+    disposition is explicit: ``below-threshold``,
+    ``no-code-emitting-proposer``, ``proposer-absent``,
     ``failed-materialize``, ``failed-validation``, ``proposed`` or
     ``rejected`` (reviewer verdicts). One repair round max.
+
+    Role fit (v1.1): the proposer must be a CODE-EMITTING seat —
+    seats named in ``plan_only`` never propose (they may review).
+    When a proposer is absent, the next code-emitting seat takes
+    over and absent seats are skipped for review too (live-fire
+    precedent: claude absent → codex proposed, antigravity
+    reviewed).
     """
     config = config or DiagnosisConfig()
     if not confidence_meets_threshold(record, config):
@@ -111,16 +137,23 @@ def run_fix_loop(
             "threshold": config.fix_proposal_threshold,
         }
 
-    proposer, proposer_recipe = seats[0]
-    reviewer, reviewer_recipe = seats[1 % len(seats)]
-    result: dict[str, Any] = {
-        "proposer": proposer,
-        "reviewer": reviewer,
-        "repair_rounds": 0,
-    }
+    proposers = [(name, recipe) for name, recipe in seats if name not in plan_only]
+    if not proposers:
+        return {
+            "disposition": "no-code-emitting-proposer",
+            "detail": "every roster seat is plan-only; code-native seats propose",
+        }
+
+    result: dict[str, Any] = {"repair_rounds": 0, "absent_proposers": []}
     candidate: Candidate | None = None
     try:
-        candidate = _propose_candidate(record, repo, proposer_recipe, invoke_seat, result)
+        for proposer, proposer_recipe in proposers:
+            result["proposer"] = proposer
+            result.pop("detail", None)  # a prior absent seat's detail is stale
+            candidate = _propose_candidate(record, repo, proposer_recipe, invoke_seat, result)
+            if candidate is not None or result["disposition"] != "proposer-absent":
+                break  # proposed, or a terminal format failure — never seat-shop those
+            result["absent_proposers"].append(proposer)
         if candidate is None:
             return result  # disposition already set by the propose step
 
@@ -136,7 +169,15 @@ def run_fix_loop(
             result["disposition"] = "failed-validation"
             return result
 
-        _review_candidate(record, diff, reviewer_recipe, invoke_seat, result)
+        reviewer = _pick_reviewer(seats, result["proposer"], result["absent_proposers"])
+        if reviewer is None:
+            # Never launder an unreviewed candidate to "proposed".
+            result["reviewer"] = None
+            result["review"] = "no distinct reviewer available"
+            result["disposition"] = "rejected"
+            return result
+        result["reviewer"] = reviewer[0]
+        _review_candidate(record, diff, reviewer[1], invoke_seat, result)
         return result
     finally:
         if candidate is not None:
@@ -158,6 +199,7 @@ def _propose_candidate(
     """
     hypothesis = record.hypotheses[0].statement
     brief = _PROPOSER_BRIEF.format(
+        example=FILE_BLOCK_EXAMPLE,
         synthesis=record.synthesis or record.symptom,
         hypothesis=hypothesis,
         repo=repo.name,
@@ -174,17 +216,42 @@ def _propose_candidate(
         except (ProposalError, RuntimeError) as exc:
             if attempt == 0:
                 result["repair_rounds"] = 1
+                # Name the failure AND restate the contract: the old
+                # "unified diff names no target files / fix the format"
+                # message steered seats TOWARD unified diffs (live-fire
+                # 2 — codex stayed dirty through its repair round).
                 brief = _PROPOSER_BRIEF.format(
+                    example=FILE_BLOCK_EXAMPLE,
                     synthesis=record.synthesis or record.symptom,
                     hypothesis=hypothesis,
                     repo=repo.name,
-                    repair=f"\nYour previous proposal failed: {exc}\nFix the format.",
+                    repair=(
+                        f"\nYour previous reply could not be materialized: {exc}\n"
+                        "Resend the COMPLETE fix as '--- file:' blocks in the "
+                        "EXAMPLE shape above — full file contents, no prose, "
+                        "no unified diff."
+                    ),
                 )
                 continue
             result["disposition"] = "failed-materialize"
             result["detail"] = str(exc)[:300]
             return None
     return None  # unreachable — loop returns on every path
+
+
+def _pick_reviewer(
+    seats: Sequence[tuple[str, tuple[str, ...]]],
+    proposer: str,
+    absent: Sequence[str],
+) -> tuple[str, tuple[str, ...]] | None:
+    """First roster seat that differs from the proposer and is not
+    known-absent — plan-only seats review fine. None when the roster
+    has no such seat.
+    """
+    for name, recipe in seats:
+        if name != proposer and name not in absent:
+            return name, recipe
+    return None
 
 
 def _review_candidate(

--- a/src/attune/roundtable/routine.py
+++ b/src/attune/roundtable/routine.py
@@ -97,6 +97,13 @@ SEAT_RECIPES: tuple[tuple[str, tuple[str, ...]], ...] = (
     ("codex", ("codex", "exec", "--skip-git-repo-check", "-")),
 )
 
+#: Seats that structurally CANNOT emit code proposals: antigravity
+#: runs ``--mode plan`` (reasoning-only, correct for R1 positions) and
+#: exits 0 with EMPTY output when asked for file blocks — live-fire 2,
+#: advanced-debugging-plugin decisions.md, 2026-07-20. Plan-mode seats
+#: review; code-native seats propose.
+PLAN_ONLY_SEATS: frozenset[str] = frozenset({"antigravity"})
+
 BRIEF_PREAMBLE = (
     "You are one seat at a three-model round table (Claude, "
     "Antigravity, Codex), convened by a scheduled routine. Answer "

--- a/tests/unit/diagnosis/test_fix_loop.py
+++ b/tests/unit/diagnosis/test_fix_loop.py
@@ -112,7 +112,11 @@ class TestLoop:
         result = run_fix_loop(_record(), repo, seats=roster, invoke_seat=invoke)
         assert result["disposition"] == "proposed"
         assert result["repair_rounds"] == 1
-        assert "failed" in calls[1][1]  # repair brief carries the error
+        # The repair brief names the failure and restates the file-block
+        # contract — the old "fix the format" wording steered seats
+        # toward unified diffs (live-fire 2).
+        assert "could not be materialized" in calls[1][1]
+        assert "no unified diff" in calls[1][1]
 
     def test_reviewer_reject_is_rejected(self, repo):
         roster, invoke, _calls = _seats((0, GOOD_PROPOSAL), (0, "VERDICT: REJECT\nrisky"))
@@ -120,10 +124,11 @@ class TestLoop:
         assert result["disposition"] == "rejected"
         assert "risky" in result["review"]
 
-    def test_proposer_absent_is_explicit(self, repo):
-        roster, invoke, _calls = _seats((1, "401 revoked"), (0, "VERDICT: APPROVE"))
+    def test_all_proposers_absent_is_explicit(self, repo):
+        roster, invoke, _calls = _seats((1, "401 revoked"), (1, "also down"))
         result = run_fix_loop(_record(), repo, seats=roster, invoke_seat=invoke)
         assert result["disposition"] == "proposer-absent"
+        assert result["absent_proposers"] == ["proposer", "reviewer"]
 
     def test_scratch_worktrees_discarded(self, repo, tmp_path):
         roster, invoke, _calls = _seats((0, GOOD_PROPOSAL), (0, "VERDICT: APPROVE"))
@@ -132,3 +137,99 @@ class TestLoop:
             ["git", "worktree", "list"], cwd=repo, capture_output=True, text=True
         ).stdout
         assert "rt-candidate-" not in leaked  # discard ran (finally)
+
+
+class TestRoleFit:
+    """v1.1 role fit — the proposer must be a code-emitting seat."""
+
+    @staticmethod
+    def _invoke(replies):
+        """replies: seat name -> (code, text) or an in-order list of them."""
+        calls = []
+
+        def invoke(recipe, brief):
+            calls.append((recipe[0], brief))
+            reply = replies[recipe[0]]
+            if isinstance(reply, list):
+                return reply.pop(0) if reply else (1, "")
+            return reply
+
+        return invoke, calls
+
+    def test_plan_only_seat_never_proposes(self, repo):
+        roster = (("plan-seat", ("plan-seat",)), ("coder", ("coder",)))
+        invoke, calls = self._invoke(
+            {"plan-seat": (0, "VERDICT: APPROVE"), "coder": (0, GOOD_PROPOSAL)}
+        )
+        result = run_fix_loop(
+            _record(),
+            repo,
+            seats=roster,
+            invoke_seat=invoke,
+            plan_only=frozenset({"plan-seat"}),
+        )
+        assert result["disposition"] == "proposed"
+        assert result["proposer"] == "coder"  # roster head skipped: plan-only
+        assert result["reviewer"] == "plan-seat"  # plan seats review fine
+        assert [c[0] for c in calls] == ["coder", "plan-seat"]
+
+    def test_all_plan_only_roster_is_explicit_without_spend(self, repo):
+        roster = (("plan-seat", ("plan-seat",)),)
+        invoke, calls = self._invoke({"plan-seat": (0, "anything")})
+        result = run_fix_loop(
+            _record(),
+            repo,
+            seats=roster,
+            invoke_seat=invoke,
+            plan_only=frozenset({"plan-seat"}),
+        )
+        assert result["disposition"] == "no-code-emitting-proposer"
+        assert calls == []  # no seat invoked, no spend
+
+    def test_absent_proposer_falls_to_next_code_emitting_seat(self, repo):
+        roster = (("p1", ("p1",)), ("p2", ("p2",)), ("plan-seat", ("plan-seat",)))
+        invoke, calls = self._invoke(
+            {
+                "p1": (1, "401 revoked"),
+                "p2": (0, GOOD_PROPOSAL),
+                "plan-seat": (0, "VERDICT: APPROVE"),
+            }
+        )
+        result = run_fix_loop(
+            _record(),
+            repo,
+            seats=roster,
+            invoke_seat=invoke,
+            plan_only=frozenset({"plan-seat"}),
+        )
+        assert result["disposition"] == "proposed"
+        assert result["proposer"] == "p2"
+        assert result["absent_proposers"] == ["p1"]
+        assert result["reviewer"] == "plan-seat"  # p1 skipped: known-absent
+        assert "detail" not in result  # the absent seat's error is not stale-carried
+
+    def test_failed_materialize_never_seat_shops(self, repo):
+        roster = (("p1", ("p1",)), ("p2", ("p2",)))
+        invoke, calls = self._invoke({"p1": (0, "prose, both rounds"), "p2": (0, GOOD_PROPOSAL)})
+        result = run_fix_loop(_record(), repo, seats=roster, invoke_seat=invoke)
+        assert result["disposition"] == "failed-materialize"
+        assert result["proposer"] == "p1"
+        assert [c[0] for c in calls] == ["p1", "p1"]  # repair round, then stop
+
+    def test_solo_roster_never_launders_unreviewed(self, repo):
+        roster = (("solo", ("solo",)),)
+        invoke, _calls = self._invoke({"solo": (0, GOOD_PROPOSAL)})
+        result = run_fix_loop(_record(), repo, seats=roster, invoke_seat=invoke)
+        assert result["disposition"] == "rejected"
+        assert result["reviewer"] is None
+        assert "no distinct reviewer" in result["review"]
+
+
+class TestProposerBrief:
+    def test_brief_carries_worked_example(self, repo):
+        roster, invoke, calls = _seats((0, GOOD_PROPOSAL), (0, "VERDICT: APPROVE"))
+        run_fix_loop(_record(), repo, seats=roster, invoke_seat=invoke)
+        brief = calls[0][1]
+        assert "EXAMPLE REPLY" in brief
+        assert "--- file: src/example/target.py" in brief
+        assert "do NOT" in brief  # the contract names what not to send


### PR DESCRIPTION
Closes advanced-debugging-plugin v1.1 backlog item 2 (chair-picked 2026-07-20): proposer-brief hardening + roster role-fit.

**Role fit** — the proposer must be a code-emitting seat:
- `PLAN_ONLY_SEATS` deny-list in `routine.py` (antigravity's `--mode plan` exits 0 with empty output when asked for file blocks — live-fire 2 receipt).
- Explicit `no-code-emitting-proposer` disposition (zero spend) when the roster has no code-emitting seat.
- On `proposer-absent`, the loop falls to the next code-emitting seat and excludes known-absent seats from review — the live-fire's manual recovery (claude absent → codex proposed, antigravity reviewed) is now the loop's own behavior. `failed-materialize` stays terminal: no seat-shopping a format failure.
- A roster with no distinct reviewer yields `rejected`, never a laundered `proposed`.

**Brief hardening** — teach-by-worked-example (producing-run `TAG_EXAMPLE` precedent): literal `FILE_BLOCK_EXAMPLE` in the brief; the repair message now names the materialize failure and restates the file-block contract instead of the old "unified diff names no target files / fix the format" wording that steered seats toward unified diffs.

Deliberately NOT built: diff/prose-interleaving acceptance in the parser — codex's exact output shape wasn't captured, so parser tolerance would be speculative; revisit only if a worked-example round still fails live (recorded in decisions.md).

**Receipts:** 14 fix-loop tests serial (6 new); diagnosis+roundtable 243 passed serial; pinned black/ruff pre-flighted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
