### PR TITLE
chore: weekly report 2026-07-20

### DIFF
--- a/weekly-reports/2026-07-20.md
+++ b/weekly-reports/2026-07-20.md
@@ -1,0 +1,201 @@
+# Anthropic Ecosystem Weekly — 2026-07-20
+
+## Summary
+
+A high-volume Claude Code week: six releases (v2.1.209–v2.1.215) covering
+two security-relevant hook bugs, a long-standing worktree isolation defect,
+a redesigned `/fork` command, per-session resource caps, and MCP
+auto-backgrounding. On the API side, mid-conversation system messages
+reached GA status on Opus 4.8, and the Enterprise Admin API gained
+user-management endpoints. No new models, no pricing changes.
+
+---
+
+## Recommendations
+
+**1. Verify `security_guard.py` hooks are effective in auto mode (HIGH)**
+
+v2.1.211 (July 15) fixed a bug where auto mode silently bypassed a
+PreToolUse hook's `ask` decision for unsandboxed Bash — meaning the hook
+ran and returned `ask`, but auto mode ignored the response and executed the
+command anyway. `security_guard.py` + `worktree_path_guard.py` are both
+PreToolUse hooks that block via exit-2. The blocking path appears unaffected
+(exit-2 is a hard stop), but any `ask` path may have been silently overridden
+in auto mode sessions prior to v2.1.211.
+
+- **Action:** In the next interactive session, run a quick sanity check: do
+  a supervised auto mode run that would trigger a hook `ask` response and
+  confirm the prompt appears rather than proceeding silently.
+- **Applies to:** `src/attune/hooks/scripts/security_guard.py`,
+  `src/attune/hooks/scripts/worktree_path_guard.py`
+- **Urgency:** High — the fix is in; the check confirms nothing leaked.
+
+---
+
+**2. Confirm `Edit(tests/unit/**)` rule intent vs. new scope (MEDIUM)**
+
+v2.1.214 (July 18) fixed single-segment `dir/**` allow rules to only match
+`<cwd>/dir`, not `dir/` nested anywhere in the filesystem. The commit at
+`edeca60` just added `"Edit(tests/unit/**)"` to `.claude/settings.json`.
+Before v2.1.214, this rule would auto-approve writes to ANY directory named
+`tests/unit` anywhere on the filesystem. After v2.1.214, it correctly matches
+only `<cwd>/tests/unit`.
+
+In practice the intended behavior is probably the correct one, but worth
+confirming: if you expected the old (broken) broad matching, nothing else
+needs adding; if you wanted repo-relative matching, this is now correct.
+
+- **Action:** Confirm in an interactive session that edits to
+  `tests/unit/**` auto-approve as expected with the narrower scope. No code
+  change likely needed.
+- **Applies to:** `.claude/settings.json`
+- **Urgency:** Medium — existing rule may now work differently than assumed.
+
+---
+
+**3. MCP auto-background supersedes idle-timeout recommendation (MEDIUM)**
+
+v2.1.212 (July 17) added automatic backgrounding for MCP tool calls that
+run longer than 2 minutes. The session continues; you are notified when the
+call completes. Configure via `CLAUDE_CODE_MCP_AUTO_BACKGROUND_MS` (default
+120000; set to `0` to disable). This directly addresses the June-29 Rec #1
+about `CLAUDE_CODE_MCP_TOOL_IDLE_TIMEOUT`.
+
+The stack's long-running MCP tools (`test_gen_parallel`, `deep_review`,
+`research_synthesis`) will now auto-background rather than block. This is
+generally better behavior than a hard timeout — the call finishes, not
+gets killed — but it changes observable behavior in scripts that expect
+blocking MCP calls.
+
+- **Action:** Test a long `mcp__attune-ai__test_gen_parallel` or
+  `mcp__attune-ai__deep_review` call in an interactive session to confirm
+  the background handoff works as expected. No code change needed unless
+  you want to tune the 2-minute threshold.
+- **Applies to:** Any MCP tool call that runs > 2 minutes.
+- **Urgency:** Medium — changes are live; behavior may surprise callers
+  expecting synchronous blocking.
+
+---
+
+**4. Mid-conversation system messages GA on Opus 4.8 (LOW)**
+
+The July 15 API release confirmed mid-conversation system messages are now
+GA (no beta header required) on Fable 5, Mythos 5, and Opus 4.8 — including
+on Bedrock and Vertex. Earlier notes had only listed Opus 4.8.
+
+The stack doesn't currently use mid-conversation system messages, but the
+premium tier routes to `claude-opus-4-8`. Multi-turn orchestration
+workflows that want to inject updated instructions mid-conversation can now
+do so without a beta header and without wrapping in a new session.
+
+- **Action:** None required now. Worth noting for any future multi-turn
+  workflow design that uses `claude-opus-4-8`.
+- **Applies to:** Premium-tier routes in `src/attune/models/`,
+  `src/attune/workflows/`
+- **Urgency:** Low — informational; no existing code needs to change.
+
+---
+
+**5. `/verify` and `/code-review` no longer auto-run (LOW)**
+
+v2.1.215 (July 19) changed both skills to run only on explicit invocation.
+Claude will no longer call them on its own initiative. CLAUDE.md already
+lists `/verify` as a skill to invoke deliberately, so this aligns with
+current practice. The only risk is if any workflow or hook was relying on
+Claude autonomously triggering `/verify` after edits — that's now broken.
+
+- **Action:** Scan for any prompt templates or workflow descriptions that
+  say "Claude will run /verify after changes." If found, update to say
+  "invoke /verify when you want it."
+- **Applies to:** `.claude/CLAUDE.md`, any workflow prompt text
+- **Urgency:** Low — likely already using explicit invocation.
+
+---
+
+## Carry-overs
+
+| # | First raised | Recommendation | Status |
+|---|---|---|---|
+| July-6 Rec #1 | 2026-07-06 | Fix `_OPUS_NO_SAMPLING_RE` regex for Sonnet 5 | **Open (HIGH)** — 6th week |
+| July-6 Rec #2 | 2026-07-06 | Handle `stop_reason: "refusal"` in `AnthropicProvider.generate()` | **Open (HIGH)** — 6th week |
+| July-6 Rec #3 | 2026-07-06 | Bump `max_tokens=8192` in MODEL_REGISTRY for Sonnet 5 / Opus 4.8 | Open (MEDIUM) |
+| July-6 Rec #4 | 2026-07-06 | Audit `max_tokens` call sites for adaptive thinking on Sonnet 5 | Open (MEDIUM) |
+| July-6 Rec #5 | 2026-07-06 | Update intro pricing in MODEL_REGISTRY (Sonnet 5 $2/$10 → expires Aug 31) | Open (LOW, **42 days**) |
+| June-29 Rec #1 | 2026-06-29 | `CLAUDE_CODE_MCP_TOOL_IDLE_TIMEOUT` for long-running MCP tools | **Superseded** — v2.1.212 auto-backgrounds; see Rec #3 above |
+| June-29 Rec #2 | 2026-06-29 | Verify hook matchers for hyphenated MCP server names | Open (low) |
+| June-29 Rec #3 | 2026-06-29 | `autoMode.classifyAllShell` awareness | Open (low) |
+| June-22 Rec #1 | 2026-06-22 | Adjust release workflows for destructive git blocking | Open (medium) |
+| June-22 Rec #2 | 2026-06-22 | Investigate prompt caching on `_CITATION_BASE_URL` | Open |
+| June-22 Rec #3 | 2026-06-22 | `Tool(param:value)` permission rules for cost control | Open (low) |
+| June-22 Rec #4 | 2026-06-22 | Set `CLAUDE_CODE_CLIENT_PRESENCE_FILE` for scheduled runs | Open (low) |
+| June-8 Rec #4 | 2026-06-08 | Stop hooks `additionalContext` for session-stash | Open (low) |
+| July-13 Rec #1 | 2026-07-13 | Set expiry + rotation reminder on ANTHROPIC_API_KEY | Open (low) |
+| July-13 Rec #2 | 2026-07-13 | Run `/doctor` in next interactive session | Open (low) |
+| May-25 #2 | 2026-05-25 | `attune-ops`: switch to `claude agents --json` | **Close** — 13 weeks, no reported pain |
+| May-25 #4 | 2026-05-25 | Update plugin docs `/simplify` → `/code-review` | **Close** — 13 weeks, no-longer-relevant distinction |
+
+July-6 Recs #1 and #2 are now six weeks old and HIGH. If Sonnet 5 is in
+any active codepath, these are generating silent bugs. Fix or explicitly
+close with a confirmed "Sonnet 5 not in live workflows."
+
+---
+
+## Watch list
+
+- **Sonnet 5 intro pricing expires Aug 31 (42 days).** $2/$10 → $3/$15 per
+  MTok. That is a 50% price increase on the capable tier. Benchmark Haiku 4.5
+  for workflows where Sonnet 5 is cost overkill; you have 6 weeks of real
+  data time left.
+- **`agent-memory-2026-07-22` header mandatory July 22 (2 days).** Stack
+  confirmed not using the Managed Agents memory API. SDK 0.116.0 already
+  sends the new header automatically. No action — flagging because the
+  deadline is imminent.
+- **Opus 4.7 fast mode removed July 24 (4 days).** Not in the stack
+  (confirmed by grep last week). No action.
+- **`/fork` + `/subtask` behavior change (v2.1.212).** If CLAUDE.md or any
+  workflow prompt references `/fork` as an in-session subagent launcher, it
+  now spawns a background session instead. `/subtask` is the new command for
+  the old behavior. Update any prompts that relied on the old `/fork`
+  semantics.
+
+---
+
+## No-ops
+
+| Item | Why skipped |
+|---|---|
+| Claude for Teachers (July 14) | Consumer/education product; no API surface change |
+| Ode with Anthropic $1.5B enterprise services firm (July 15) | Business announcement; implementation-services company built on Claude, but not an API or SDK change |
+| Anthropic $10M Canadian AI research (July 14) | Research funding; no product or API impact |
+| Admin API for Claude Enterprise user management (July 14) | Enterprise claude.ai org management; no Python SDK change |
+| HIPAA configuration self-serve (July 14) | Compliance/admin only |
+| EndConversation tool in Claude Code (v2.1.214) | CLI safety feature; no attune code change needed |
+| Progress heartbeat for long-running tool calls (v2.1.214) | Claude Code UX improvement; no code change needed |
+| Monthly recap + focus settings for claude.ai (July 15-ish) | Consumer product feature |
+| Trusted devices for Remote Control admin (July 15-ish) | Enterprise plan feature; not in stack |
+| Cowork expanded to mobile/web (July 15-ish) | Consumer feature |
+| `--forward-subagent-text` flag (v2.1.211) | Only relevant if using `stream-json` output mode with subagents |
+| `claude auto-mode reset` (v2.1.212) | CLI convenience; no code change needed |
+| WebSearch session limit 200 (v2.1.212) | Generous default; no workflow will hit it |
+| Subagent spawn cap 200 (v2.1.212) | Same — practical ceiling for attune workflows |
+| `claude agents --json` view improvements | CLI UX; no code change |
+| Repository-level "always allow" rules saved at repo root (v2.1.212) | Improves permission rule persistence; passive benefit |
+| `/resume` opens past session picker in agent view (v2.1.212) | CLI UX only |
+| Screen reader mode and accessibility improvements (v2.1.212) | Accessibility; no code change |
+| OTel attribute additions in v2.1.214 | Useful if you use OTel; stack has OTel support but no urgent change |
+| v2.1.209 `/model` dialog fix in background sessions | Narrow fix; no code change |
+
+---
+
+## Sources checked
+
+- `platform.claude.com/docs/en/release-notes/api` (through July 15, 2026)
+- `support.claude.com/en/articles/12138966-release-notes` (claude.ai help center)
+- `code.claude.com/docs/en/changelog` (Claude Code v2.1.209–v2.1.215, July 14-19, 2026)
+- `releasebot.io/updates/anthropic/claude-code` (Claude Code July 2026)
+- `releasebot.io/updates/anthropic/claude` (Claude consumer July 2026)
+- `www.anthropic.com/news` (Anthropic newsroom July 14-20, 2026)
+- Prior report: `weekly-reports/2026-07-13.md`
+- `uv.lock` — confirmed `anthropic==0.116.0`, `claude-agent-sdk==0.2.116`
+- `.claude/settings.json` — confirmed `Edit(tests/unit/**)` allow rule
+- Grep: `isolation.*worktree` in `src/` — no Python-level usage found


### PR DESCRIPTION
# Anthropic Ecosystem Weekly — 2026-07-20

## Summary

A high-volume Claude Code week: six releases (v2.1.209–v2.1.215) covering
two security-relevant hook bugs, a long-standing worktree isolation defect,
a redesigned `/fork` command, per-session resource caps, and MCP
auto-backgrounding. On the API side, mid-conversation system messages
reached GA status on Opus 4.8, and the Enterprise Admin API gained
user-management endpoints. No new models, no pricing changes.

---

## Recommendations

**1. Verify `security_guard.py` hooks are effective in auto mode (HIGH)**

v2.1.211 (July 15) fixed a bug where auto mode silently bypassed a
PreToolUse hook's `ask` decision for unsandboxed Bash — meaning the hook
ran and returned `ask`, but auto mode ignored the response and executed the
command anyway. `security_guard.py` + `worktree_path_guard.py` are both
PreToolUse hooks that block via exit-2. The blocking path appears unaffected
(exit-2 is a hard stop), but any `ask` path may have been silently overridden
in auto mode sessions prior to v2.1.211.

- **Action:** In the next interactive session, run a quick sanity check: do
  a supervised auto mode run that would trigger a hook `ask` response and
  confirm the prompt appears rather than proceeding silently.
- **Applies to:** `src/attune/hooks/scripts/security_guard.py`,
  `src/attune/hooks/scripts/worktree_path_guard.py`
- **Urgency:** High — the fix is in; the check confirms nothing leaked.

---

**2. Confirm `Edit(tests/unit/**)` rule intent vs. new scope (MEDIUM)**

v2.1.214 (July 18) fixed single-segment `dir/**` allow rules to only match
`<cwd>/dir`, not `dir/` nested anywhere in the filesystem. The commit at
`edeca60` just added `"Edit(tests/unit/**)"` to `.claude/settings.json`.
Before v2.1.214, this rule would auto-approve writes to ANY directory named
`tests/unit` anywhere on the filesystem. After v2.1.214, it correctly matches
only `<cwd>/tests/unit`.

In practice the intended behavior is probably the correct one, but worth
confirming: if you expected the old (broken) broad matching, nothing else
needs adding; if you wanted repo-relative matching, this is now correct.

- **Action:** Confirm in an interactive session that edits to
  `tests/unit/**` auto-approve as expected with the narrower scope. No code
  change likely needed.
- **Applies to:** `.claude/settings.json`
- **Urgency:** Medium — existing rule may now work differently than assumed.

---

**3. MCP auto-background supersedes idle-timeout recommendation (MEDIUM)**

v2.1.212 (July 17) added automatic backgrounding for MCP tool calls that
run longer than 2 minutes. The session continues; you are notified when the
call completes. Configure via `CLAUDE_CODE_MCP_AUTO_BACKGROUND_MS` (default
120000; set to `0` to disable). This directly addresses the June-29 Rec #1
about `CLAUDE_CODE_MCP_TOOL_IDLE_TIMEOUT`.

The stack's long-running MCP tools (`test_gen_parallel`, `deep_review`,
`research_synthesis`) will now auto-background rather than block. This is
generally better behavior than a hard timeout — the call finishes, not
gets killed — but it changes observable behavior in scripts that expect
blocking MCP calls.

- **Action:** Test a long `mcp__attune-ai__test_gen_parallel` or
  `mcp__attune-ai__deep_review` call in an interactive session to confirm
  the background handoff works as expected. No code change needed unless
  you want to tune the 2-minute threshold.
- **Applies to:** Any MCP tool call that runs > 2 minutes.
- **Urgency:** Medium — changes are live; behavior may surprise callers
  expecting synchronous blocking.

---

**4. Mid-conversation system messages GA on Opus 4.8 (LOW)**

The July 15 API release confirmed mid-conversation system messages are now
GA (no beta header required) on Fable 5, Mythos 5, and Opus 4.8 — including
on Bedrock and Vertex. Earlier notes had only listed Opus 4.8.

The stack doesn't currently use mid-conversation system messages, but the
premium tier routes to `claude-opus-4-8`. Multi-turn orchestration
workflows that want to inject updated instructions mid-conversation can now
do so without a beta header and without wrapping in a new session.

- **Action:** None required now. Worth noting for any future multi-turn
  workflow design that uses `claude-opus-4-8`.
- **Applies to:** Premium-tier routes in `src/attune/models/`,
  `src/attune/workflows/`
- **Urgency:** Low — informational; no existing code needs to change.

---

**5. `/verify` and `/code-review` no longer auto-run (LOW)**

v2.1.215 (July 19) changed both skills to run only on explicit invocation.
Claude will no longer call them on its own initiative. CLAUDE.md already
lists `/verify` as a skill to invoke deliberately, so this aligns with
current practice. The only risk is if any workflow or hook was relying on
Claude autonomously triggering `/verify` after edits — that's now broken.

- **Action:** Scan for any prompt templates or workflow descriptions that
  say "Claude will run /verify after changes." If found, update to say
  "invoke /verify when you want it."
- **Applies to:** `.claude/CLAUDE.md`, any workflow prompt text
- **Urgency:** Low — likely already using explicit invocation.

---

## Carry-overs

| # | First raised | Recommendation | Status |
|---|---|---|---|
| July-6 Rec #1 | 2026-07-06 | Fix `_OPUS_NO_SAMPLING_RE` regex for Sonnet 5 | **Open (HIGH)** — 6th week |
| July-6 Rec #2 | 2026-07-06 | Handle `stop_reason: "refusal"` in `AnthropicProvider.generate()` | **Open (HIGH)** — 6th week |
| July-6 Rec #3 | 2026-07-06 | Bump `max_tokens=8192` in MODEL_REGISTRY for Sonnet 5 / Opus 4.8 | Open (MEDIUM) |
| July-6 Rec #4 | 2026-07-06 | Audit `max_tokens` call sites for adaptive thinking on Sonnet 5 | Open (MEDIUM) |
| July-6 Rec #5 | 2026-07-06 | Update intro pricing in MODEL_REGISTRY (Sonnet 5 $2/$10 → expires Aug 31) | Open (LOW, **42 days**) |
| June-29 Rec #1 | 2026-06-29 | `CLAUDE_CODE_MCP_TOOL_IDLE_TIMEOUT` for long-running MCP tools | **Superseded** — v2.1.212 auto-backgrounds; see Rec #3 above |
| June-29 Rec #2 | 2026-06-29 | Verify hook matchers for hyphenated MCP server names | Open (low) |
| June-29 Rec #3 | 2026-06-29 | `autoMode.classifyAllShell` awareness | Open (low) |
| June-22 Rec #1 | 2026-06-22 | Adjust release workflows for destructive git blocking | Open (medium) |
| June-22 Rec #2 | 2026-06-22 | Investigate prompt caching on `_CITATION_BASE_URL` | Open |
| June-22 Rec #3 | 2026-06-22 | `Tool(param:value)` permission rules for cost control | Open (low) |
| June-22 Rec #4 | 2026-06-22 | Set `CLAUDE_CODE_CLIENT_PRESENCE_FILE` for scheduled runs | Open (low) |
| June-8 Rec #4 | 2026-06-08 | Stop hooks `additionalContext` for session-stash | Open (low) |
| July-13 Rec #1 | 2026-07-13 | Set expiry + rotation reminder on ANTHROPIC_API_KEY | Open (low) |
| July-13 Rec #2 | 2026-07-13 | Run `/doctor` in next interactive session | Open (low) |
| May-25 #2 | 2026-05-25 | `attune-ops`: switch to `claude agents --json` | **Close** — 13 weeks, no reported pain |
| May-25 #4 | 2026-05-25 | Update plugin docs `/simplify` → `/code-review` | **Close** — 13 weeks, no-longer-relevant distinction |

July-6 Recs #1 and #2 are now six weeks old and HIGH. If Sonnet 5 is in
any active codepath, these are generating silent bugs. Fix or explicitly
close with a confirmed "Sonnet 5 not in live workflows."

---

## Watch list

- **Sonnet 5 intro pricing expires Aug 31 (42 days).** $2/$10 → $3/$15 per
  MTok. That is a 50% price increase on the capable tier. Benchmark Haiku 4.5
  for workflows where Sonnet 5 is cost overkill; you have 6 weeks of real
  data time left.
- **`agent-memory-2026-07-22` header mandatory July 22 (2 days).** Stack
  confirmed not using the Managed Agents memory API. SDK 0.116.0 already
  sends the new header automatically. No action — flagging because the
  deadline is imminent.
- **Opus 4.7 fast mode removed July 24 (4 days).** Not in the stack
  (confirmed by grep last week). No action.
- **`/fork` + `/subtask` behavior change (v2.1.212).** If CLAUDE.md or any
  workflow prompt references `/fork` as an in-session subagent launcher, it
  now spawns a background session instead. `/subtask` is the new command for
  the old behavior. Update any prompts that relied on the old `/fork`
  semantics.

---

## No-ops

| Item | Why skipped |
|---|---|
| Claude for Teachers (July 14) | Consumer/education product; no API surface change |
| Ode with Anthropic $1.5B enterprise services firm (July 15) | Business announcement; implementation-services company, not an API or SDK change |
| Anthropic $10M Canadian AI research (July 14) | Research funding; no product or API impact |
| Admin API for Claude Enterprise user management (July 14) | Enterprise claude.ai org management; no Python SDK change |
| HIPAA configuration self-serve (July 14) | Compliance/admin only |
| EndConversation tool in Claude Code (v2.1.214) | CLI safety feature; no attune code change needed |
| Progress heartbeat for long-running tool calls (v2.1.214) | Claude Code UX improvement; no code change needed |
| Monthly recap + focus settings for claude.ai | Consumer product feature |
| Trusted devices for Remote Control admin | Enterprise plan feature; not in stack |
| Cowork expanded to mobile/web | Consumer feature |
| `--forward-subagent-text` flag (v2.1.211) | Only relevant if using `stream-json` output mode with subagents |
| `claude auto-mode reset` (v2.1.212) | CLI convenience; no code change needed |
| WebSearch session limit 200 (v2.1.212) | Generous default; no workflow will hit it |
| Subagent spawn cap 200 (v2.1.212) | Same — practical ceiling for attune workflows |
| Repository-level "always allow" rules saved at repo root (v2.1.212) | Improves permission rule persistence; passive benefit |
| `/resume` opens past session picker in agent view (v2.1.212) | CLI UX only |
| Screen reader mode and accessibility improvements | Accessibility; no code change |
| OTel attribute additions in v2.1.214 | Useful if you use OTel; stack has OTel support but no urgent change |
| v2.1.209 `/model` dialog fix in background sessions | Narrow fix; no code change |

---

## Sources checked

- `platform.claude.com/docs/en/release-notes/api` (through July 15, 2026)
- `support.claude.com/en/articles/12138966-release-notes` (claude.ai help center)
- `code.claude.com/docs/en/changelog` (Claude Code v2.1.209–v2.1.215, July 14-19, 2026)
- `releasebot.io/updates/anthropic/claude-code` (Claude Code July 2026)
- `releasebot.io/updates/anthropic/claude` (Claude consumer July 2026)
- `www.anthropic.com/news` (Anthropic newsroom July 14-20, 2026)
- Prior report: `weekly-reports/2026-07-13.md`
- `uv.lock` — confirmed `anthropic==0.116.0`, `claude-agent-sdk==0.2.116`
- `.claude/settings.json` — confirmed `Edit(tests/unit/**)` allow rule
- Grep: `isolation.*worktree` in `src/` — no Python-level usage found

---
_Generated by [Claude Code](https://claude.ai/code/session_011k2VN7245ahm8gjNcziGhQ)_