### PR TITLE
feat(diagnosis): LessonsFilePublisher — chair-ruled corpus appends

### DIFF
--- a/docs/specs/advanced-debugging-plugin/decisions.md
+++ b/docs/specs/advanced-debugging-plugin/decisions.md
@@ -456,3 +456,36 @@ shows verified-correct diagnoses sitting at `medium` and
 systematically blocked from staging, lower the threshold to
 `medium` — the stream's own `config_used`-stamped records are the
 evidence base.
+
+## 2026-07-20 — LessonsFilePublisher shipped (implements the corpus-ownership ruling)
+
+The follow-up build named in the dissent-register ruling above
+landed (#1529): `LessonsFilePublisher`
+(`src/attune/diagnosis/graduation.py`) — appends the rendered
+candidate to `.claude/lessons.md` in the corpus's entry format
+(dash-bulleted bold-lead, ~72-col wrap with two-space hanging
+indent, blank line between entries), keeps the
+RenderForChairPublisher lint gate (GraduationError), and validates
+the target against the project root via `_validate_file_path`
+(CWE-22). Opt-in at the call site: `graduate()`'s default stays
+render-for-chair.
+
+- **Duplicate policy (ruled here):** re-publishing a diagnosis whose
+  thread marker (`thread diagnosis:<id>)` — suffix-matched so `d1`
+  never false-matches `d12`) already appears in the corpus is
+  receipted as **already-published**, an idempotent no-op. A retried
+  chair-approval flow must neither double-append nor raise on a
+  state that is actually success.
+- The old source-level guard (`test_v1_publisher_writes_no_files`,
+  "no file writes anywhere in the module") pinned the UNRULED state
+  and is superseded by behavior pins: the default publisher writes
+  nothing; file writes are confined to `LessonsFilePublisher`.
+
+Receipts: 22 tests in
+`tests/unit/diagnosis/test_curator_graduation.py` (append format +
+72-col wrap, provenance thread, lint gate leaves file untouched,
+already-published no-op, prefix-id non-collision, missing-file
+create, no-trailing-newline seed, default path; security: traversal,
+absolute-escape, null byte, symlink escape all rejected);
+diagnosis+roundtable 261 passed serial; graduation.py 100% line
+coverage.

--- a/src/attune/diagnosis/graduation.py
+++ b/src/attune/diagnosis/graduation.py
@@ -1,11 +1,14 @@
 """Lesson graduation behind an interface (advanced-debugging-plugin
-Phase D — dissent-register bound).
+Phase D).
 
-The corpus-ownership question (write to ``.claude/lessons.md`` direct
-vs. a projected source) is UNRULED; until the chair rules, lesson
-publication stays behind :class:`LessonPublisher`, and the ONLY v1
-implementation renders the candidate for the chair — no file writes,
-no corpus writes, anywhere.
+Corpus ownership was chair-ruled 2026-07-20 (dissent register,
+``docs/specs/advanced-debugging-plugin/decisions.md``): graduated
+diagnostic lessons append DIRECTLY to ``.claude/lessons.md``,
+chair-gated per entry, with the candidate's ``diagnosis:<id>`` thread
+embedded inline as provenance so machine-graduated entries stay
+distinguishable from session-written ones. :func:`graduate`'s default
+remains render-for-chair; :class:`LessonsFilePublisher` is opt-in at
+the call site (the chair-approval flow).
 
 Graduation gates (RR-7): a verification receipt on the diagnosis and
 explicit chair approval; unverified or rejected diagnoses never
@@ -14,10 +17,16 @@ become lessons.
 
 from __future__ import annotations
 
+import textwrap
+from pathlib import Path
 from typing import Protocol
 
 from attune.models.telemetry.data_models import DiagnosisRecord
 from attune.roundtable.lessons import LessonCandidate
+from attune.security.path_validation import _validate_file_path
+
+#: Corpus wrap target — `.claude/lessons.md` entries are ~72-col.
+_WRAP_WIDTH = 72
 
 
 class GraduationError(ValueError):
@@ -25,10 +34,12 @@ class GraduationError(ValueError):
 
 
 class LessonPublisher(Protocol):
-    """Where an approved lesson candidate goes — implementation TBD.
+    """Where an approved lesson candidate goes.
 
-    The chair rules corpus ownership before any file-writing
-    implementation exists; v1 ships only render-for-chair.
+    Two implementations: :class:`RenderForChairPublisher` (default —
+    presents the entry, writes nothing) and
+    :class:`LessonsFilePublisher` (chair-approved appends to the
+    corpus, per the 2026-07-20 ruling).
     """
 
     def publish(self, candidate: LessonCandidate) -> str:
@@ -37,13 +48,98 @@ class LessonPublisher(Protocol):
 
 
 class RenderForChairPublisher:
-    """The v1 publisher: renders the linted candidate, writes nothing."""
+    """The default publisher: renders the linted candidate, writes nothing."""
 
     def publish(self, candidate: LessonCandidate) -> str:
         problems = candidate.lint()
         if problems:
             raise GraduationError("candidate fails lint: " + "; ".join(problems))
         return candidate.render()
+
+
+def _wrap_entry(rendered: str) -> str:
+    """Re-wrap a rendered entry to the corpus's ~72-col convention.
+
+    Each source line keeps its own leading indent; continuation lines
+    take the corpus's two-space hanging indent. Long unbreakable
+    tokens (ids, paths) are never split.
+    """
+    wrapped: list[str] = []
+    for line in rendered.splitlines():
+        indent = line[: len(line) - len(line.lstrip(" "))]
+        wrapped.append(
+            textwrap.fill(
+                line.strip(),
+                width=_WRAP_WIDTH,
+                initial_indent=indent,
+                subsequent_indent="  ",
+                break_long_words=False,
+                break_on_hyphens=False,
+            )
+        )
+    return "\n".join(wrapped)
+
+
+class LessonsFilePublisher:
+    """Chair-approved publisher: appends the entry to ``.claude/lessons.md``.
+
+    Per the 2026-07-20 corpus-ownership ruling. The candidate's
+    ``diagnosis:<id>`` thread is embedded in the rendered entry (via
+    :meth:`LessonCandidate.render`) as machine-graduation provenance.
+
+    Duplicate policy (documented decision): re-publishing a diagnosis
+    whose thread marker already appears in the corpus is receipted as
+    **already-published** — an idempotent no-op, not an error. The
+    chair-approval flow may be retried after an interruption, and a
+    duplicate append would double the corpus entry while an exception
+    would fail loudly on a state that is actually success.
+
+    Args:
+        lessons_path: Corpus file; defaults to
+            ``<project_root>/.claude/lessons.md``.
+        project_root: Directory writes are restricted to; defaults to
+            the current working directory. The resolved path is
+            validated against it (CWE-22 guard).
+
+    Raises:
+        ValueError: If the resolved path escapes ``project_root`` or
+            is otherwise unsafe.
+    """
+
+    def __init__(
+        self,
+        lessons_path: str | Path | None = None,
+        *,
+        project_root: str | Path | None = None,
+    ) -> None:
+        root = Path(project_root).resolve() if project_root else Path.cwd().resolve()
+        target = Path(lessons_path) if lessons_path else root / ".claude" / "lessons.md"
+        if not target.is_absolute():
+            target = root / target
+        self._path = _validate_file_path(str(target), allowed_dir=str(root))
+
+    def publish(self, candidate: LessonCandidate) -> str:
+        problems = candidate.lint()
+        if problems:
+            raise GraduationError("candidate fails lint: " + "; ".join(problems))
+        # The rendered provenance line ends "thread <id>)" — matching on
+        # that suffix keeps diagnosis:d1 from false-matching diagnosis:d12.
+        marker = f"thread {candidate.thread.strip()})"
+        existing = self._path.read_text(encoding="utf-8") if self._path.exists() else ""
+        title = candidate.title.strip()
+        if marker in existing:
+            return (
+                f"already published: {self._path} carries an entry for "
+                f"{candidate.thread.strip()} — nothing appended"
+            )
+        entry = _wrap_entry(candidate.render())
+        with self._path.open("a", encoding="utf-8") as fh:
+            if existing and not existing.endswith("\n"):
+                fh.write("\n")
+            if existing:
+                fh.write("\n")
+            fh.write(entry + "\n")
+        return f"appended to {self._path}: {title}"
 
 
 def build_candidate(

--- a/tests/unit/diagnosis/test_curator_graduation.py
+++ b/tests/unit/diagnosis/test_curator_graduation.py
@@ -1,17 +1,18 @@
 """Curator source + graduation tests (advanced-debugging-plugin T8).
 
 Exclusion parity with the store's purity rules, allowlist redaction,
-and the dissent-bound publisher interface (no corpus writes in v1).
+the publisher interface, and the file publisher shipped under the
+2026-07-20 corpus-ownership ruling (chair-gated appends to
+`.claude/lessons.md`).
 """
 
-import inspect
 import json
 
 import pytest
 
-from attune.diagnosis import graduation
 from attune.diagnosis.graduation import (
     GraduationError,
+    LessonsFilePublisher,
     RenderForChairPublisher,
     build_candidate,
     graduate,
@@ -100,13 +101,14 @@ class TestGraduation:
         rendered = graduate(_record(), evidence="", waived=True)
         assert "chair-waived" in rendered or "unverified" in rendered
 
-    def test_v1_publisher_writes_no_files(self):
-        # Source-level guard: the graduation module has no file-writing
-        # implementation — corpus ownership is unruled (dissent register).
-        source = inspect.getsource(graduation)
-        assert "write_text" not in source
-        assert "open(" not in source
-        assert ".write(" not in source
+    def test_default_publisher_writes_no_files(self, tmp_path, monkeypatch):
+        # The 2026-07-20 ruling made file writes legal, but ONLY via the
+        # opt-in LessonsFilePublisher — graduate()'s default still renders
+        # for the chair and leaves the filesystem untouched.
+        monkeypatch.chdir(tmp_path)
+        rendered = graduate(_record(), evidence="receipt")
+        assert "missing path kwarg" in rendered
+        assert list(tmp_path.iterdir()) == []
 
     def test_custom_publisher_receives_linted_candidate(self):
         received = []
@@ -124,3 +126,109 @@ class TestGraduation:
         assert isinstance(
             RenderForChairPublisher().publish(build_candidate(_record(), evidence="receipt")), str
         )
+
+
+class TestLessonsFilePublisher:
+    """Chair-approved corpus appends (2026-07-20 ruling)."""
+
+    def _publisher(self, tmp_path, seed="- **An earlier lesson**: already here.\n"):
+        corpus = tmp_path / ".claude" / "lessons.md"
+        corpus.parent.mkdir()
+        corpus.write_text(seed, encoding="utf-8")
+        return LessonsFilePublisher(corpus, project_root=tmp_path), corpus
+
+    def test_appends_in_corpus_format(self, tmp_path):
+        publisher, corpus = self._publisher(tmp_path)
+        receipt = graduate(
+            _record(), evidence="reproduced: exit 1, fixed by --path", publisher=publisher
+        )
+        text = corpus.read_text(encoding="utf-8")
+        # Existing content intact, blank line between entries, dash-bulleted
+        # bold-lead entry, single trailing newline.
+        assert text.startswith("- **An earlier lesson**: already here.\n\n- **code-review:")
+        assert text.endswith(")\n") and not text.endswith("\n\n")
+        entry_lines = text.split("\n\n", 1)[1].splitlines()
+        assert all(len(line) <= 72 for line in entry_lines)
+        assert all(line.startswith("  ") for line in entry_lines[1:])
+        assert str(corpus) in receipt and "code-review: path argument is required" in receipt
+
+    def test_provenance_thread_embedded(self, tmp_path):
+        publisher, corpus = self._publisher(tmp_path)
+        graduate(_record(), evidence="receipt", publisher=publisher)
+        assert "thread diagnosis:d1)" in corpus.read_text(encoding="utf-8")
+
+    def test_lint_gate_blocks_and_leaves_file_untouched(self, tmp_path):
+        publisher, corpus = self._publisher(tmp_path)
+        before = corpus.read_text(encoding="utf-8")
+        with pytest.raises(GraduationError, match="lint"):
+            graduate(_record(), evidence="", publisher=publisher)
+        assert corpus.read_text(encoding="utf-8") == before
+
+    def test_republish_is_already_published_noop(self, tmp_path):
+        # Documented duplicate policy: receipted as already-published,
+        # idempotent no-op — retrying an interrupted chair-approval flow
+        # must neither double-append nor raise.
+        publisher, corpus = self._publisher(tmp_path)
+        graduate(_record(), evidence="receipt", publisher=publisher)
+        after_first = corpus.read_text(encoding="utf-8")
+        receipt = graduate(_record(), evidence="receipt", publisher=publisher)
+        assert "already published" in receipt and "diagnosis:d1" in receipt
+        assert corpus.read_text(encoding="utf-8") == after_first
+
+    def test_prefix_thread_id_is_not_a_duplicate(self, tmp_path):
+        # diagnosis:d1 in the corpus must not block diagnosis:d12.
+        publisher, corpus = self._publisher(tmp_path)
+        graduate(_record(), evidence="receipt", publisher=publisher)
+        receipt = graduate(_record(diagnosis_id="d12"), evidence="receipt", publisher=publisher)
+        assert receipt.startswith("appended")
+        text = corpus.read_text(encoding="utf-8")
+        assert "thread diagnosis:d1)" in text and "thread diagnosis:d12)" in text
+
+    def test_creates_missing_corpus_file(self, tmp_path):
+        corpus = tmp_path / ".claude" / "lessons.md"
+        corpus.parent.mkdir()
+        publisher = LessonsFilePublisher(corpus, project_root=tmp_path)
+        graduate(_record(), evidence="receipt", publisher=publisher)
+        text = corpus.read_text(encoding="utf-8")
+        assert text.startswith("- **code-review:") and text.endswith(")\n")
+
+    def test_appends_after_file_missing_trailing_newline(self, tmp_path):
+        publisher, corpus = self._publisher(tmp_path, seed="- **No newline at EOF**: entry.")
+        graduate(_record(), evidence="receipt", publisher=publisher)
+        assert "entry.\n\n- **code-review:" in corpus.read_text(encoding="utf-8")
+
+    def test_default_path_is_dot_claude_lessons(self, tmp_path):
+        (tmp_path / ".claude").mkdir()
+        publisher = LessonsFilePublisher(project_root=tmp_path)
+        graduate(_record(), evidence="receipt", publisher=publisher)
+        assert (tmp_path / ".claude" / "lessons.md").exists()
+
+
+class TestLessonsFilePublisherSecurity:
+    """Path validation (CWE-22) on the corpus target."""
+
+    def test_traversal_outside_project_root_rejected(self, tmp_path):
+        root = tmp_path / "repo"
+        root.mkdir()
+        with pytest.raises(ValueError, match="outside allowed"):
+            LessonsFilePublisher("../escape.md", project_root=root)
+
+    def test_absolute_path_outside_root_rejected(self, tmp_path):
+        root = tmp_path / "repo"
+        root.mkdir()
+        with pytest.raises(ValueError, match="outside allowed"):
+            LessonsFilePublisher(tmp_path / "elsewhere.md", project_root=root)
+
+    def test_null_byte_rejected(self, tmp_path):
+        with pytest.raises(ValueError, match="null"):
+            LessonsFilePublisher("lessons\x00.md", project_root=tmp_path)
+
+    def test_symlink_escape_rejected(self, tmp_path):
+        root = tmp_path / "repo"
+        outside = tmp_path / "outside"
+        root.mkdir()
+        outside.mkdir()
+        link = root / "sneaky"
+        link.symlink_to(outside)
+        with pytest.raises(ValueError, match="outside allowed"):
+            LessonsFilePublisher(link / "lessons.md", project_root=root)


### PR DESCRIPTION
## Summary

Implements the 2026-07-20 chair ruling on the lesson-corpus-ownership dissent (advanced-debugging-plugin dissent register): graduated diagnostic lessons append **directly to `.claude/lessons.md`**, chair-gated per entry, with the candidate's `diagnosis:<id>` thread embedded inline as provenance so machine-graduated entries stay distinguishable from session-written ones.

- **`LessonsFilePublisher`** (`src/attune/diagnosis/graduation.py`): appends the rendered candidate in the corpus's entry format — dash-bulleted bold-lead, ~72-col wrap with two-space hanging indent, blank line between entries, single trailing newline. Receipt names the file and the appended entry's title.
- **Lint gate stays**: raises `GraduationError` on lint problems, matching `RenderForChairPublisher`; a failed lint leaves the file untouched.
- **Path validation**: target resolved and validated against `project_root` via `_validate_file_path` (CWE-22) — traversal, absolute-escape, null-byte, and symlink-escape all rejected, with security tests.
- **Duplicate policy (documented decision)**: re-publishing a diagnosis whose thread marker already appears in the corpus is receipted as **already-published** — an idempotent no-op, not an error. A retried chair-approval flow must neither double-append nor fail loudly on a state that is actually success. The marker is suffix-matched (`thread diagnosis:<id>)`) so `d1` never false-matches `d12`.
- **`graduate()` default unchanged** — render-for-chair; the file publisher is opt-in at the call site. The old source-level guard `test_v1_publisher_writes_no_files` pinned the *unruled* state ("no file writes anywhere in the module") and is superseded by behavior pins: default publisher writes nothing; file writes are confined to `LessonsFilePublisher`.
- Ruling + receipts recorded in `docs/specs/advanced-debugging-plugin/decisions.md` (the referenced entry did not yet exist in the tree — recorded here with the implementation).

## Receipts

- 22 tests in `tests/unit/diagnosis/test_curator_graduation.py` (12 new): append format + wrap, provenance thread, lint gate file-untouched, already-published no-op, prefix-id non-collision, missing-file create, no-trailing-newline seed, default path, 4 security rejections.
- diagnosis + roundtable suites: **261 passed** serial.
- `graduation.py`: **100% line coverage** (55/55 stmts).
- Pinned black/ruff pre-flighted clean before staging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
