### PR TITLE
docs(specs): record 2026-07-20 chair rulings — three specs ruled

### DIFF
--- a/docs/specs/post-commit-help-check-only/decisions.md
+++ b/docs/specs/post-commit-help-check-only/decisions.md
@@ -1,0 +1,24 @@
+# Post-Commit Help Check-Only — Decisions
+
+## 2026-07-20 — Spec approved; D1 ruled: option A (chair: Patrick)
+
+Approved in the chair-rulings sitting (stepped-through review).
+Premise re-verified live before the ruling: `run_hook`
+(`src/attune/help/maintenance.py`) still calls `run_maintenance`
+WITHOUT `dry_run`, so the per-commit whole-feature LLM re-polish
+the spec targets remains active on the post-commit path.
+
+**D1 — RULED: option A (dry-run flip).** `run_hook` passes
+`dry_run=True`; the existing `stale_count > 0` warning branch
+("N feature(s) are stale — run /coach maintain") is the surviving
+behavior; the regenerated-count branch becomes dead code and is
+removed. Option B (a `regenerate: bool = False` param) declined —
+the spec's grep found no caller wanting per-commit regen, and the
+no-hook-spend policy (polish-cost-reduction lever 1) argues for
+removing the path outright rather than parameterizing it.
+
+Validation per the spec: unit test asserting
+`regenerated_count == 0` and no template files written; a
+drift-guard regression test so the regen path cannot silently
+return; the stale pre-commit-hook lesson in `.claude/lessons.md`
+corrected to name the real surface as part of the close-out.

--- a/docs/specs/post-commit-help-check-only/requirements.md
+++ b/docs/specs/post-commit-help-check-only/requirements.md
@@ -1,6 +1,8 @@
 # Post-Commit Help Maintenance → Check-Only
 
-**Status:** draft — awaiting review; recommitted at 2026-07-14 triage
+**Status:** approved (2026-07-20, chair — D1 ruled option A, see
+[decisions.md](decisions.md); was draft since 2026-06-22, recommitted
+at 2026-07-14 triage)
 **Owner:** Patrick + agent
 **Created:** 2026-06-22
 

--- a/docs/specs/sdk-teardown-exit-guard/decisions.md
+++ b/docs/specs/sdk-teardown-exit-guard/decisions.md
@@ -80,3 +80,17 @@ the error-translation path unchanged.
 - Seam: `src/attune/workflows/agent_sdk_adapter.py`
   (`collect_agent_output`); `code_review.py:396-400` (representative
   consumption loop).
+
+---
+
+## 2026-07-20 — Design approved + execution armed (chair: Patrick)
+
+Ruled in the chair-rulings sitting (stepped-through review). The
+design stands as drafted with the already-resolved D1–D3 (success
+signal `subtype == "success"`; pass-through async generator at the
+`collect_agent_output` seam; `saw_success` gate primary +
+`"command failed"` substring secondary, `Exception` only).
+Implementation may proceed — one seam, regression-guarded, with
+the named constraint that the false-green dispatcher behavior
+(`attune workflow run` exits 0 on `success=False`) must not
+worsen.

--- a/docs/specs/sdk-teardown-exit-guard/requirements.md
+++ b/docs/specs/sdk-teardown-exit-guard/requirements.md
@@ -1,6 +1,8 @@
 # Spec: SDK teardown-exit-1 guard
 
-**Status:** DRAFT (2026-06-26) — recommitted at 2026-07-14 triage (failure class still live)
+**Status:** approved (2026-07-20, chair — design approved as drafted
+D1–D3 and execution ARMED, see decisions.md; was DRAFT 2026-06-26,
+recommitted at 2026-07-14 triage, failure class still live)
 **Owner:** Patrick + agent
 **Prior art (archived):**
 `docs/specs/archive/sdk-error-message-fidelity/` — flagged this exact

--- a/docs/specs/test-discipline-controls/decisions.md
+++ b/docs/specs/test-discipline-controls/decisions.md
@@ -187,3 +187,21 @@ not as separate gate conditions.
 **Reference:** opportunity surfaced 2026-05-27 during
 post-merge review of PR #484 (`docs/specs/ops-help-page`);
 locked here so Phase 1 implementation doesn't re-litigate.
+
+---
+
+## 2026-07-20 — CLOSED stale on premise drift (chair: Patrick)
+
+Ruled in the chair-rulings sitting. The motivating premise —
+docs say 80% while the codecov patch gate enforces ~90%, so
+agents targeting the documented bar get rejected by CI (PR #485)
+— has INVERTED since the 2026-05-27 draft: today codecov's patch
+gate is 50% (±5%) with project at 80% (±2%), `pyproject.toml`
+`fail_under=85`, and CLAUDE.md still says 80%. The strict-gate
+pain is gone; the residual misalignment runs the OTHER way (a
+patch can land at 50% while docs claim an 80% floor). Controls
+3–4 were partially overtaken by process shipped since (delegation
+receipts ratified 2026-07-14; the living test-quality-program).
+Ruling: close the spec; the one live residue — aligning the
+80/85/50 numbers to one story — is a small standalone hygiene
+fix, chipped separately, not a four-control spec.

--- a/docs/specs/test-discipline-controls/requirements.md
+++ b/docs/specs/test-discipline-controls/requirements.md
@@ -2,7 +2,8 @@
 
 > Four mechanical controls that close the test-coverage discipline
 > gap surfaced by PR #485 — without adopting strict TDD.
-**Status:** draft (2026-05-27) — in review
+**Status:** superseded (2026-07-20, chair — closed stale on premise
+drift, see decisions.md; was draft 2026-05-27 in review)
 **Created:** 2026-05-27
 **Owner:** TBD
 **Related:**


### PR DESCRIPTION
Records the 2026-07-20 stepped-through chair-rulings sitting, three specs ruled:

- **post-commit-help-check-only — APPROVED, D1 option A** (dry-run flip). Premise re-verified live first: run_hook still calls run_maintenance without dry_run, so the per-commit LLM re-polish is still active. New decisions.md carries the ruling.
- **sdk-teardown-exit-guard — design APPROVED as drafted (D1-D3), execution ARMED.** One seam (collect_agent_output), saw_success-gated, false-green constraint named.
- **test-discipline-controls — CLOSED stale on premise drift.** The motivating strict patch gate (~90%) is now 50%; the pain inverted. Residual 80/85/50 number alignment chipped as a standalone fix.

Status flips follow the leading-token vocabulary (approved/approved/superseded) with history preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
