### PR TITLE
chore(coverage): align coverage bars to the floor-80/local-85 story

### DIFF
--- a/.claude/python-standards.md
+++ b/.claude/python-standards.md
@@ -3,4 +3,5 @@
 - Use type hints
 - Follow PEP 8
 - Write docstrings
-- Target 90%+ test coverage
+- Test coverage: 80% enforced floor (codecov project + patch);
+  target 85%+ (the local `fail_under` bar)

--- a/codecov.yml
+++ b/codecov.yml
@@ -6,7 +6,9 @@ coverage:
         threshold: 2%
     patch:
       default:
-        target: 50%
+        # Chair-ruled 2026-07-20 ("floor 80, local 85" story): the
+        # patch gate enforces the documented 80% changed-code floor.
+        target: 80%
         threshold: 5%
 
 ignore:


### PR DESCRIPTION
Chair-ruled 2026-07-20 (the follow-up scoped when closing test-discipline-controls): align the coverage-bar surfaces to one story — **floor 80, local 85**.

- codecov **patch** gate: 50% -> **80%** (threshold 5% kept). The gate now enforces the changed-code floor the docs have claimed all along. Named tradeoff: PRs whose new lines are under ~75% covered will now fail the patch check — the intended bite.
- `.claude/python-standards.md`: the "Target 90%+" outlier restated as "80% enforced floor; target 85%+" so no surface invents a fourth number.
- Unchanged: codecov project 80% (+-2%), `fail_under = 85` (the deliberately stricter local suite bar), and every doc surface already saying 80%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
