### PR TITLE
fix(help): post-commit hook is check-only — never regenerates templates

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -822,25 +822,31 @@ this section only if core-worthy (and then keep both copies in sync).
   the actual end-to-end before declaring done. The receipt beats the
   promise (§7).
 
-- **The `.help` regen pre-commit hook does a full LLM RE-POLISH of a
-  feature's entire help corpus when ANY source file under that
-  feature's glob is added/changed — discard it from focused feature
-  PRs (it's warn-only / not CI-required), don't commit a −200-line LLM
-  rewrite**: adding `src/attune/memory/memory_tool.py` (a "memory"
-  feature source) made `regenerate-help-templates` rewrite
-  `.help/templates/memory/{concept,reference,task}.md` with a net
-  −207/+149 diff — NOT additive bridge docs, but the polish pass
-  re-doing the whole memory feature (with the attendant hallucination
-  risk). pre-commit stashes it as "unstaged" and it reappears on the
-  next commit. For a feature PR, `git checkout -- .help/templates/
-  <feature>/` to keep the PR focused — CI doesn't require it (the hook
-  is gated/warn-only). Extends the existing "Pre-commit's .help
-  template regen creates a stash-and-reappear dance" lesson with the
-  key nuance: the regen is a *whole-feature re-polish*, not an additive
-  doc update, so committing it blindly into an unrelated PR risks
-  losing/hallucinating help content. The durable fix (deferred) is to
-  make the regen additive-or-tightly-scoped, or stop leaving unstaged
-  files behind.
+- **The `.help` whole-feature LLM RE-POLISH fired from the POST-commit
+  hook, not pre-commit — both hook paths are now check-only (fixed
+  2026-07-20)**: this lesson originally blamed the pre-commit
+  `regenerate-help-templates` hook for rewriting
+  `.help/templates/memory/{concept,reference,task}.md` (net −207/+149,
+  a whole-feature re-polish with hallucination risk, reappearing
+  unstaged on the next commit). Premise corrected by
+  docs/specs/post-commit-help-check-only: the PRE-commit path was
+  already check-only (polish-cost-reduction lever 1, ratified
+  2026-06-10 — `scripts/regenerate_help_templates.py` warns which
+  features lag, never regenerates, never spends LLM); the live
+  re-polish surface was `plugin/hooks/help_post_commit.py` →
+  `attune.help.maintenance.run_hook()` calling `run_maintenance(...)`
+  in regenerate mode after every `git commit` (this is what rewrote
+  the plugin templates during the 8.7.1 ship). Fixed 2026-07-20:
+  `run_hook` passes `dry_run=True`, so the post-commit hook only
+  warns "N feature(s) are stale — run /coach maintain"; drift-guard
+  tests in `tests/unit/help/test_maintenance.py` and
+  `tests/unit/hooks/test_help_hooks.py` raise if the regenerating
+  branch is ever reachable from the hook path again. Still-true
+  guidance: if an unstaged LLM rewrite of `.help/templates/
+  <feature>/` ever appears in a focused PR, don't commit it —
+  `git checkout -- .help/templates/<feature>/`; polish-bearing regen
+  belongs at release-prep cadence (`/coach maintain` /
+  `attune-author regenerate`), never per-commit.
 
 - **Keyless-CI-faithful local runs need `ANTHROPIC_API_KEY=""`
   (EMPTY), not `env -u` (UNSET) — unset lets `load_dotenv` inject the

--- a/.claude/lessons.md
+++ b/.claude/lessons.md
@@ -7134,25 +7134,31 @@ files.
   report --rcfile=/dev/null -m` (the `-m` shows exact missing
   lines/branches). Took a 24-test suite at 84% patch → 37 tests at 99%.
 
-- **The `.help` regen pre-commit hook does a full LLM RE-POLISH of a
-  feature's entire help corpus when ANY source file under that
-  feature's glob is added/changed — discard it from focused feature
-  PRs (it's warn-only / not CI-required), don't commit a −200-line LLM
-  rewrite**: adding `src/attune/memory/memory_tool.py` (a "memory"
-  feature source) made `regenerate-help-templates` rewrite
-  `.help/templates/memory/{concept,reference,task}.md` with a net
-  −207/+149 diff — NOT additive bridge docs, but the polish pass
-  re-doing the whole memory feature (with the attendant hallucination
-  risk). pre-commit stashes it as "unstaged" and it reappears on the
-  next commit. For a feature PR, `git checkout -- .help/templates/
-  <feature>/` to keep the PR focused — CI doesn't require it (the hook
-  is gated/warn-only). Extends the existing "Pre-commit's .help
-  template regen creates a stash-and-reappear dance" lesson with the
-  key nuance: the regen is a *whole-feature re-polish*, not an additive
-  doc update, so committing it blindly into an unrelated PR risks
-  losing/hallucinating help content. The durable fix (deferred) is to
-  make the regen additive-or-tightly-scoped, or stop leaving unstaged
-  files behind.
+- **The `.help` whole-feature LLM RE-POLISH fired from the POST-commit
+  hook, not pre-commit — both hook paths are now check-only (fixed
+  2026-07-20)**: this lesson originally blamed the pre-commit
+  `regenerate-help-templates` hook for rewriting
+  `.help/templates/memory/{concept,reference,task}.md` (net −207/+149,
+  a whole-feature re-polish with hallucination risk, reappearing
+  unstaged on the next commit). Premise corrected by
+  docs/specs/post-commit-help-check-only: the PRE-commit path was
+  already check-only (polish-cost-reduction lever 1, ratified
+  2026-06-10 — `scripts/regenerate_help_templates.py` warns which
+  features lag, never regenerates, never spends LLM); the live
+  re-polish surface was `plugin/hooks/help_post_commit.py` →
+  `attune.help.maintenance.run_hook()` calling `run_maintenance(...)`
+  in regenerate mode after every `git commit` (this is what rewrote
+  the plugin templates during the 8.7.1 ship). Fixed 2026-07-20:
+  `run_hook` passes `dry_run=True`, so the post-commit hook only
+  warns "N feature(s) are stale — run /coach maintain"; drift-guard
+  tests in `tests/unit/help/test_maintenance.py` and
+  `tests/unit/hooks/test_help_hooks.py` raise if the regenerating
+  branch is ever reachable from the hook path again. Still-true
+  guidance: if an unstaged LLM rewrite of `.help/templates/
+  <feature>/` ever appears in a focused PR, don't commit it —
+  `git checkout -- .help/templates/<feature>/`; polish-bearing regen
+  belongs at release-prep cadence (`/coach maintain` /
+  `attune-author regenerate`), never per-commit.
 
 - **Composing Anthropic's `BetaAbstractMemoryTool` at call time keeps
   the SDK helper off the module import path; the Memory tool maps onto

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,14 @@ run-record corpus that future releases learn from.
   `ResultMessage` keeps its result instead of discarding it as a
   failure. A drift-guard test fails on any future bare consumption
   loop.
+- **Post-commit help hook is now check-only** — `run_hook()` runs
+  `run_maintenance(...)` in dry-run mode, so committing a file under a
+  feature's glob only warns "N feature(s) are stale — run /coach
+  maintain"; it no longer LLM-re-polishes the feature's whole
+  `.help/templates/` corpus per commit (repeat API spend +
+  stash-and-reappear churn). Drift-guard tests keep the regenerating
+  branch unreachable from the hook path
+  (docs/specs/post-commit-help-check-only).
 - **Ops spec status-flip never duplicates or rewrites descriptive
   status lines** (#1488) — the writer refuses to insert a second
   `**Status:**` line above a variant it cannot parse.

--- a/docs/specs/post-commit-help-check-only/decisions.md
+++ b/docs/specs/post-commit-help-check-only/decisions.md
@@ -22,3 +22,20 @@ Validation per the spec: unit test asserting
 drift-guard regression test so the regen path cannot silently
 return; the stale pre-commit-hook lesson in `.claude/lessons.md`
 corrected to name the real surface as part of the close-out.
+## 2026-07-20 — Shipped (#1532): execution evidence
+
+- Unit: `run_hook` with a stubbed generator asserts
+  `regenerated_count == 0`, generator never called, template
+  bytes unchanged, and the hook emits the stale warning
+  (`tests/unit/help/test_maintenance.py`,
+  `tests/unit/hooks/test_help_hooks.py`).
+- Drift guard: both suites include a test whose generator stub
+  RAISES if the post-commit path ever reaches the regenerating
+  branch, so the per-commit LLM re-polish cannot silently return.
+- The hook's `regenerated_count > 0` "auto-updated" branch became
+  dead code and was removed; the surviving behavior is the
+  `stale_count > 0` stderr warning ("N feature(s) are stale — run
+  /coach maintain").
+- Close-out: the stale lesson blaming the PRE-commit hook was
+  corrected in `.claude/lessons.md` (and its CLAUDE.md core
+  mirror) to name the post-commit surface and record the fix.

--- a/docs/specs/post-commit-help-check-only/requirements.md
+++ b/docs/specs/post-commit-help-check-only/requirements.md
@@ -1,8 +1,8 @@
 # Post-Commit Help Maintenance → Check-Only
 
 **Status:** approved (2026-07-20, chair — D1 ruled option A, see
-[decisions.md](decisions.md); was draft since 2026-06-22, recommitted
-at 2026-07-14 triage)
+[decisions.md](decisions.md); implemented same day in #1532; was
+draft since 2026-06-22, recommitted at 2026-07-14 triage)
 **Owner:** Patrick + agent
 **Created:** 2026-06-22
 
@@ -98,6 +98,8 @@ real non-release caller that wants regen (none known).
 
 ## Open questions
 
-- **D1**: approve A (dry-run flip) vs B (param)?
+- **D1**: approve A (dry-run flip) vs B (param)? — **RESOLVED: A**
+  (2026-07-20, Patrick; see decisions.md).
 - Is there any caller of `run_hook`/`run_maintenance` that *wants*
-  per-commit regen? (Grep found only the post-commit hook.)
+  per-commit regen? (Grep found only the post-commit hook —
+  re-verified at implementation: `engine.py` only re-exports.)

--- a/plugin/hooks/help_post_commit.py
+++ b/plugin/hooks/help_post_commit.py
@@ -1,8 +1,13 @@
-"""PostToolUse hook: auto-maintain .help/ after git commits.
+"""PostToolUse hook: check .help/ staleness after git commits.
 
 When the user runs a successful `git commit`, checks if
 any committed files match features in .help/features.yaml.
 If stale features are found, reports them via stderr.
+
+Check-only by design: this hook never regenerates templates,
+spends LLM budget, or writes to the working tree — run_hook()
+runs in dry-run mode (docs/specs/post-commit-help-check-only).
+Regeneration happens only via /coach maintain at release prep.
 
 Only fires on Bash tool calls that contain `git commit`.
 Exits 0 always (informational, never blocks).
@@ -95,23 +100,14 @@ def main() -> None:
         return
 
     if hook_result.stale_count > 0:
-        regen = hook_result.regenerated_count
-        if regen > 0:
-            print(
-                f"attune: auto-updated {regen} help "
-                f"template(s) in .help/. Stage and commit "
-                f"the changes with your next commit.",
-                file=sys.stderr,
-            )
-        else:
-            stale = hook_result.staleness.stale_features
-            names = ", ".join(stale[:5])
-            print(
-                f"attune: {hook_result.stale_count} help feature(s) "
-                f"are stale ({names}). Run /coach maintain "
-                f"to update.",
-                file=sys.stderr,
-            )
+        stale = hook_result.staleness.stale_features
+        names = ", ".join(stale[:5])
+        print(
+            f"attune: {hook_result.stale_count} help feature(s) "
+            f"are stale ({names}). Run /coach maintain "
+            f"to update.",
+            file=sys.stderr,
+        )
 
 
 if __name__ == "__main__":

--- a/src/attune/help/maintenance.py
+++ b/src/attune/help/maintenance.py
@@ -153,20 +153,23 @@ def run_hook(
     help_dir: str | Path,
     project_root: str | Path,
 ) -> MaintenanceResult | None:
-    """Post-commit hook entry point.
+    """Post-commit hook entry point — check-only.
 
     Gets changed files from the latest commit, matches them
-    against the feature manifest, and regenerates templates
-    for affected features only.
+    against the feature manifest, and reports staleness for
+    affected features. Never regenerates templates: hooks must
+    not spend LLM budget or write to the working tree
+    (docs/specs/post-commit-help-check-only). Regeneration
+    happens only at release-prep cadence via /coach maintain.
 
     Args:
         help_dir: Path to the .help/ directory.
         project_root: Project root directory.
 
     Returns:
-        MaintenanceResult if any features were affected,
-        None if the manifest doesn't exist or no features
-        matched.
+        MaintenanceResult (staleness report only) if any
+        features were affected, None if the manifest doesn't
+        exist or no features matched.
     """
     help_path = Path(help_dir)
     if not (help_path / "features.yaml").exists():
@@ -197,6 +200,7 @@ def run_hook(
         help_dir=help_dir,
         project_root=project_root,
         features=affected_names,
+        dry_run=True,
     )
 
 

--- a/tests/unit/help/test_maintenance.py
+++ b/tests/unit/help/test_maintenance.py
@@ -136,15 +136,52 @@ class TestRunHook:
         assert result is None
 
     @patch("attune.help.maintenance.get_changed_files")
-    def test_regenerates_affected_features(self, mock_changed: object, project: Path) -> None:
+    def test_reports_stale_without_regenerating(self, mock_changed: object, project: Path) -> None:
+        """Check-only: stale features are reported, never regenerated."""
         # Make auth source stale first
         (project / "src" / "auth" / "login.py").write_text("def login(u): pass\n", encoding="utf-8")
         mock_changed.return_value = ["src/auth/login.py"]  # type: ignore[union-attr]
 
-        result = run_hook(project / ".help", project)
+        template_dir = project / ".help" / "templates" / "auth"
+        before = {p: p.read_bytes() for p in sorted(template_dir.rglob("*")) if p.is_file()}
+
+        with patch("attune.help.maintenance.generate_feature_templates") as mock_gen:
+            result = run_hook(project / ".help", project)
+
         assert result is not None
-        assert result.regenerated_count == 1
-        assert result.regenerated[0].feature == "auth"
+        assert result.stale_count == 1
+        assert result.regenerated_count == 0
+        mock_gen.assert_not_called()
+        after = {p: p.read_bytes() for p in sorted(template_dir.rglob("*")) if p.is_file()}
+        assert after == before, "post-commit hook must not write template files"
+
+    @patch("attune.help.maintenance.get_changed_files")
+    def test_drift_guard_hook_cannot_reach_regenerating_branch(
+        self, mock_changed: object, project: Path
+    ) -> None:
+        """Regression guard (docs/specs/post-commit-help-check-only).
+
+        The post-commit hook path must never invoke the template
+        generator — the per-commit LLM re-polish must not silently
+        return. The generator stub raises if reached.
+        """
+        (project / "src" / "auth" / "login.py").write_text("def login(u): pass\n", encoding="utf-8")
+        (project / "src" / "api" / "routes.py").write_text("def routes(x): pass\n")
+        mock_changed.return_value = [  # type: ignore[union-attr]
+            "src/auth/login.py",
+            "src/api/routes.py",
+        ]
+
+        def _forbidden(*args: object, **kwargs: object) -> None:
+            raise AssertionError("post-commit hook reached the regenerating branch")
+
+        with patch("attune.help.maintenance.generate_feature_templates", side_effect=_forbidden):
+            result = run_hook(project / ".help", project)
+
+        assert result is not None
+        assert result.stale_count == 2
+        assert result.regenerated_count == 0
+        assert result.failed == []
 
 
 class TestFormatStatusReport:

--- a/tests/unit/hooks/test_help_hooks.py
+++ b/tests/unit/hooks/test_help_hooks.py
@@ -339,6 +339,74 @@ class TestHelpPostCommit:
         # Should not crash
         assert True
 
+    def test_stale_feature_warns_without_regenerating(self, mod, tmp_path: Path) -> None:
+        """Check-only end-to-end: stale feature → stderr warning, no regen.
+
+        Regression guard for docs/specs/post-commit-help-check-only:
+        the generator stub raises if the hook path ever reaches the
+        regenerating branch, and template bytes must be untouched.
+        """
+        pytest.importorskip("yaml")
+        from attune.help.generator import generate_feature_templates
+        from attune.help.manifest import Feature, FeatureManifest, save_manifest
+
+        src = tmp_path / "src" / "auth"
+        src.mkdir(parents=True)
+        (src / "login.py").write_text("def login(): pass\n", encoding="utf-8")
+        manifest = FeatureManifest(
+            version=1,
+            features={
+                "auth": Feature(
+                    name="auth",
+                    description="Authentication",
+                    files=["src/auth/**"],
+                ),
+            },
+        )
+        help_dir = tmp_path / ".help"
+        save_manifest(manifest, help_dir)
+        generate_feature_templates(manifest.features["auth"], help_dir, tmp_path)
+
+        # Make the feature stale
+        (src / "login.py").write_text("def login(user): pass\n", encoding="utf-8")
+
+        template_dir = help_dir / "templates" / "auth"
+        before = {p: p.read_bytes() for p in sorted(template_dir.rglob("*")) if p.is_file()}
+
+        payload = json.dumps(
+            {
+                "tool_name": "Bash",
+                "tool_input": {"command": "git commit -m 'test'"},
+                "tool_result": {"stdout": "[main abc1234] test"},
+            }
+        )
+        stderr_capture = StringIO()
+
+        def _forbidden(*args: object, **kwargs: object) -> None:
+            raise AssertionError("post-commit hook reached the regenerating branch")
+
+        with (
+            patch("sys.stdin", StringIO(payload)),
+            patch("sys.stderr", stderr_capture),
+            patch("pathlib.Path.cwd", return_value=tmp_path),
+            patch(
+                "attune.help.maintenance.get_changed_files",
+                return_value=["src/auth/login.py"],
+            ),
+            patch(
+                "attune.help.maintenance.generate_feature_templates",
+                side_effect=_forbidden,
+            ),
+        ):
+            mod.main()
+
+        output = stderr_capture.getvalue()
+        assert "1 help feature(s) are stale (auth)" in output
+        assert "/coach maintain" in output
+        assert "auto-updated" not in output
+        after = {p: p.read_bytes() for p in sorted(template_dir.rglob("*")) if p.is_file()}
+        assert after == before, "post-commit hook must not write template files"
+
     def test_tool_input_as_string(self, mod) -> None:
         """Handles tool_input as a plain string."""
         payload = json.dumps(


### PR DESCRIPTION
Implements the approved `post-commit-help-check-only` spec (D1 = option A, 2026-07-20).

## What

- `run_hook()` in `src/attune/help/maintenance.py` now calls `run_maintenance(..., dry_run=True)`: the post-commit path only REPORTS staleness — it never regenerates templates, never spends LLM budget, never writes to the working tree. Regeneration stays at release-prep cadence (`/coach maintain`).
- `plugin/hooks/help_post_commit.py`: the now-dead "auto-updated N templates" branch is removed; the surviving behavior is the stderr warning "N help feature(s) are stale — run /coach maintain".

## Validation (per spec)

1. **Unit** — `run_hook` with affected features + a stubbed generator asserts `regenerated_count == 0`, generator never called, template bytes unchanged; end-to-end hook test asserts the warning is emitted.
2. **Drift guards** — in both `tests/unit/help/test_maintenance.py` and `tests/unit/hooks/test_help_hooks.py`, the generator stub RAISES if the post-commit path ever reaches the regenerating branch, so the per-commit LLM re-polish can't silently return.
3. **Close-out** — the stale lesson blaming the PRE-commit hook is corrected in `.claude/lessons.md` and its CLAUDE.md core mirror (verbatim-synced; `test_core_mirror.py` green): pre-commit was fixed by polish-cost-reduction lever 1; the live surface was the POST-commit hook, fixed here.

Spec status flipped to approved; `decisions.md` records D1 and execution evidence. CHANGELOG `[Unreleased]` entry added.

## Receipts

- 89 tests pass serially (help maintenance, help hooks, lessons mirror, both MCP help-handler suites — the deliberate `/coach maintain` regen path is untouched).
- `attune.help.maintenance` at 91% coverage; all changed lines covered (misses are pre-existing error paths).
- Only caller of `run_hook` is the post-commit hook (`engine.py` just re-exports) — re-verified by grep.
- Pinned black/ruff pre-flighted clean before staging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
