### PR TITLE
fix(workflows): SDK teardown-exit guard covers all consumption loops (sdk-teardown-exit-guard executed)

### DIFF
--- a/.claude/lessons.md
+++ b/.claude/lessons.md
@@ -16897,3 +16897,29 @@ def ", start_idx + 1)` for module-
   content unlanded. Both pruned with receipts. Pairs with the
   deletion-counting subsumption lesson (same day) and the
   prune-worktree-self-deletion hazard memory.
+
+- **Spec status lines carry a CONTROLLED VOCABULARY — invented tokens
+  (e.g. `EXECUTED`) fail EVERY CI test lane via the corpus sweep;
+  pick from `STATUS_VOCABULARY` before flipping a status**: hit
+  2026-07-20 on PR #1534. Flipping sdk-teardown-exit-guard's three
+  phase files to `**Status:** EXECUTED (...)` failed
+  `tests/unit/gates/test_status_line_gate.py::
+  test_corpus_sweep_every_spec_dir_is_legible[<spec>]` on every
+  OS/Python lane — the status-line baseline gate (landed on main the
+  SAME DAY, in the 2026-07-20 chair-rulings window) enforces
+  membership in `attune.ops.spec_lifecycle.STATUS_VOCABULARY`:
+  `complete/completed/done/shipped/superseded` (terminal),
+  `approved/active/living` (in-flight), `draft/parked/paused`
+  (`parked` additionally requires a `Resume-Trigger:` clause).
+  `shipped` is the ruled terminal token for "deliverable landed";
+  `EXECUTED` and `RATIFIED` are out-of-vocabulary by design. Two
+  durable takeaways: (1) before writing/flipping any
+  `**Status:**` line under `docs/specs/`, use a vocabulary token —
+  the annotation after the em-dash is free text, the LEADING token
+  is not; (2) diagnostic shape: when EVERY test lane fails uniformly
+  right after a docs-only or spec-status change, suspect a single
+  corpus-sweep gate test and reproduce locally
+  (`pytest -x` found it in one run) instead of waiting out the
+  in-flight-run log lock. Same freshly-landed-gate class as the
+  admin-merge/docs-build lessons: main moves daily — a gate that
+  didn't exist when your branch was cut can still fail your PR.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,15 @@ run-record corpus that future releases learn from.
 
 ### Fixed
 
+- **SDK teardown-exit guard now covers every SDK workflow** — the
+  seven consumption loops the sdk-teardown-exit-guard spec's list
+  predated (`deep-review`, `refactor-plan`, `release-prep`,
+  `test-gen`, `test-audit`, `doc-audit`, `document-gen`) now wrap
+  `claude_agent_sdk.query()` in `iter_agent_messages`, so a nested
+  run whose subprocess exits 1 during teardown AFTER a successful
+  `ResultMessage` keeps its result instead of discarding it as a
+  failure. A drift-guard test fails on any future bare consumption
+  loop.
 - **Ops spec status-flip never duplicates or rewrites descriptive
   status lines** (#1488) — the writer refuses to insert a second
   `**Status:**` line above a variant it cannot parse.

--- a/docs/specs/sdk-teardown-exit-guard/decisions.md
+++ b/docs/specs/sdk-teardown-exit-guard/decisions.md
@@ -120,9 +120,17 @@ eight spec-named workflows.
   `capture_subprocess_failure` / error translation as before; the
   dispatcher's exit-0-on-`success=False` behavior was not touched.
 
-T3 (optional real nested dogfood run) not run this session — it
-spends real API money and stays a manual/keyed receipt per the
-design's risk note.
+**T3 dogfood receipt (2026-07-20, chair-authorized spend):** a real
+`CodeReviewWorkflow` run at quick depth over a planted-issue temp
+file, executed nested inside a live Claude Code session (the repro
+condition), returned `success=True`, `subtype="success"`,
+`is_error=False`, cost $0.60, 7 turns, with genuine findings (the
+planted command injection and path traversal). The teardown exit did
+NOT fire on this particular run (adapter guard warning absent — the
+stream ended cleanly), so the recovery branch was not exercised
+live; the design's T3 validation (success + findings + cost > 0
+while nested) is met, and the guard-fire path remains proven by the
+unit suite.
 
 ---
 

--- a/docs/specs/sdk-teardown-exit-guard/decisions.md
+++ b/docs/specs/sdk-teardown-exit-guard/decisions.md
@@ -1,6 +1,7 @@
 # Decisions: SDK teardown-exit-1 guard
 
-**Status:** DRAFT (2026-06-26) — recommitted at 2026-07-14 triage (failure class still live)
+**Status:** EXECUTED (2026-07-20) — design approved as drafted and
+execution armed by the chair 2026-07-20; see the execution log below
 **Requirements:** [requirements.md](requirements.md) ·
 **Design:** [design.md](design.md)
 
@@ -65,6 +66,63 @@ the error-translation path unchanged.
 - **OQ3 → D3.** Teardown matching: `saw_success` gate (primary) +
   `"command failed"` substring (secondary); `Exception` only, never
   `BaseException`.
+
+---
+
+## Execution log — 2026-07-20
+
+Design approved as drafted; execution armed by the chair 2026-07-20.
+
+**Already landed before this session (PR #1099):** T1 — the
+`iter_agent_messages` + `_is_benign_teardown_exit` wrapper in
+`agent_sdk_adapter.py`, its unit tests
+(`tests/unit/workflows/test_iter_agent_messages.py`: R1 recover,
+R2 pre-success propagates, R3 non-success propagates, D1
+`is_error=True`-with-`subtype="success"` still recovers,
+message-mismatch post-success propagates, `BaseException`
+propagates, clean stream passes through), and T2 adoption in the
+eight spec-named workflows.
+
+**This session — scope drift corrected + T2 completed + guards:**
+
+- Grepping the actual `async for … in claude_agent_sdk.query(`
+  instances (per the spec-scope-drift lesson) found SEVEN more
+  consumption loops the spec's list predated: `refactor_plan`,
+  `release_prep`, `deep_review`, `test_gen/workflow`,
+  `test_audit/workflow`, `doc_audit/workflow`,
+  `document_gen/workflow`. All seven now wrap the query in
+  `iter_agent_messages(...)` — the same one-line adoption, no other
+  body changes. No `claude_agent_sdk.query(` call sites exist
+  outside `src/attune/workflows/`.
+- Regression guard added
+  (`test_every_workflow_query_loop_is_wrapped`): scans
+  `src/attune/workflows/**/*.py` and fails on any bare
+  `async for … in claude_agent_sdk.query(` loop, so a new workflow
+  or a revert cannot silently reintroduce the discarded-success bug.
+- `CHANGELOG.md` `### Fixed` entry added.
+
+**Receipts (probes actually run):**
+
+- `pytest tests/unit/workflows/test_iter_agent_messages.py`
+  (serial, `-o addopts=`): 8 passed.
+- Existing unit tests for the seven newly wrapped workflows
+  (doc_audit, document_gen, test_audit, test_gen dirs +
+  deep_review / refactor_plan / release_prep / parallel_test_gen
+  execute+behavioral files, serial): 531 passed.
+- Coverage on the seven modified modules (coverage-from-/tmp
+  worktree dance): 98% total — deep_review 91%, test_audit 99%,
+  test_gen 99%, doc_audit / document_gen / refactor_plan /
+  release_prep 100%.
+- Pinned pre-commit `black` + `ruff` pre-flighted on all touched
+  files: Passed.
+- D3 false-green constraint unchanged: the wrapper still re-raises
+  everything pre-success (R2/R3 tests), so genuine failures reach
+  `capture_subprocess_failure` / error translation as before; the
+  dispatcher's exit-0-on-`success=False` behavior was not touched.
+
+T3 (optional real nested dogfood run) not run this session — it
+spends real API money and stays a manual/keyed receipt per the
+design's risk note.
 
 ---
 

--- a/docs/specs/sdk-teardown-exit-guard/decisions.md
+++ b/docs/specs/sdk-teardown-exit-guard/decisions.md
@@ -1,6 +1,6 @@
 # Decisions: SDK teardown-exit-1 guard
 
-**Status:** EXECUTED (2026-07-20) — design approved as drafted and
+**Status:** shipped (2026-07-20) — design approved as drafted and
 execution armed by the chair 2026-07-20; see the execution log below
 **Requirements:** [requirements.md](requirements.md) ·
 **Design:** [design.md](design.md)

--- a/docs/specs/sdk-teardown-exit-guard/design.md
+++ b/docs/specs/sdk-teardown-exit-guard/design.md
@@ -1,6 +1,6 @@
 # Design: SDK teardown-exit-1 guard
 
-**Status:** EXECUTED (2026-07-20) — approved as drafted by the chair
+**Status:** shipped (2026-07-20) — approved as drafted by the chair
 2026-07-20; see decisions.md execution log
 **Requirements:** [requirements.md](requirements.md) ·
 **Decisions:** [decisions.md](decisions.md)

--- a/docs/specs/sdk-teardown-exit-guard/design.md
+++ b/docs/specs/sdk-teardown-exit-guard/design.md
@@ -1,6 +1,7 @@
 # Design: SDK teardown-exit-1 guard
 
-**Status:** DRAFT (2026-06-26) — recommitted at 2026-07-14 triage (failure class still live)
+**Status:** EXECUTED (2026-07-20) — approved as drafted by the chair
+2026-07-20; see decisions.md execution log
 **Requirements:** [requirements.md](requirements.md) ·
 **Decisions:** [decisions.md](decisions.md)
 

--- a/docs/specs/sdk-teardown-exit-guard/requirements.md
+++ b/docs/specs/sdk-teardown-exit-guard/requirements.md
@@ -1,8 +1,8 @@
 # Spec: SDK teardown-exit-1 guard
 
-**Status:** EXECUTED (2026-07-20) — design approved as drafted D1–D3
+**Status:** shipped (2026-07-20) — design approved as drafted D1–D3
 and execution ARMED by the chair 2026-07-20, executed the same day;
-see decisions.md execution log (was DRAFT 2026-06-26, recommitted at
+see decisions.md execution log (was draft 2026-06-26, recommitted at
 2026-07-14 triage, failure class still live)
 **Owner:** Patrick + agent
 **Prior art (archived):**

--- a/docs/specs/sdk-teardown-exit-guard/requirements.md
+++ b/docs/specs/sdk-teardown-exit-guard/requirements.md
@@ -1,8 +1,9 @@
 # Spec: SDK teardown-exit-1 guard
 
-**Status:** approved (2026-07-20, chair — design approved as drafted
-D1–D3 and execution ARMED, see decisions.md; was DRAFT 2026-06-26,
-recommitted at 2026-07-14 triage, failure class still live)
+**Status:** EXECUTED (2026-07-20) — design approved as drafted D1–D3
+and execution ARMED by the chair 2026-07-20, executed the same day;
+see decisions.md execution log (was DRAFT 2026-06-26, recommitted at
+2026-07-14 triage, failure class still live)
 **Owner:** Patrick + agent
 **Prior art (archived):**
 `docs/specs/archive/sdk-error-message-fidelity/` — flagged this exact

--- a/src/attune/workflows/deep_review.py
+++ b/src/attune/workflows/deep_review.py
@@ -38,6 +38,7 @@ from .agent_sdk_adapter import (
     collect_agent_output,
     get_max_budget_usd,
     get_subagent_model,
+    iter_agent_messages,
     resolve_cwd_for_path,
     sdk_isolation_kwargs,
 )
@@ -293,18 +294,20 @@ class DeepReviewAgentSDKWorkflow(BaseWorkflow):
         assistant_parts: list[str] = []
         result_parts: list[str] = []
         run_result = AgentRunResult(result_text="No results returned.")
-        async for message in claude_agent_sdk.query(
-            prompt=_TASK_PROMPT_TEMPLATE.format(path=resolved_path),
-            options=claude_agent_sdk.ClaudeAgentOptions(
-                **sdk_isolation_kwargs(),
-                system_prompt=_SYSTEM_PROMPT,
-                cwd=resolve_cwd_for_path(resolved_path),
-                max_budget_usd=get_max_budget_usd(depth),
-                allowed_tools=["Read", "Glob", "Grep", "Agent"],
-                permission_mode="default",
-                max_turns=max_turns,
-                agents=agents,
-            ),
+        async for message in iter_agent_messages(
+            claude_agent_sdk.query(
+                prompt=_TASK_PROMPT_TEMPLATE.format(path=resolved_path),
+                options=claude_agent_sdk.ClaudeAgentOptions(
+                    **sdk_isolation_kwargs(),
+                    system_prompt=_SYSTEM_PROMPT,
+                    cwd=resolve_cwd_for_path(resolved_path),
+                    max_budget_usd=get_max_budget_usd(depth),
+                    allowed_tools=["Read", "Glob", "Grep", "Agent"],
+                    permission_mode="default",
+                    max_turns=max_turns,
+                    agents=agents,
+                ),
+            )
         ):
             sdk_result = collect_agent_output(message, assistant_parts, result_parts)
             if sdk_result is not None:

--- a/src/attune/workflows/doc_audit/workflow.py
+++ b/src/attune/workflows/doc_audit/workflow.py
@@ -28,6 +28,7 @@ from ..agent_sdk_adapter import (
     collect_agent_output,
     get_max_budget_usd,
     get_subagent_model,
+    iter_agent_messages,
     resolve_cwd_for_path,
     sdk_isolation_kwargs,
 )
@@ -206,57 +207,59 @@ class DocAuditWorkflow(BaseWorkflow):
         result_parts: list[str] = []
         run_result = AgentRunResult(result_text="No results returned.")
         system_prompt = _SYSTEM_PROMPT + (self._system_prompt_suffix or "")
-        async for message in claude_agent_sdk.query(
-            prompt=_TASK_PROMPT_TEMPLATE.format(path=resolved_path),
-            options=claude_agent_sdk.ClaudeAgentOptions(
-                **sdk_isolation_kwargs(),
-                system_prompt=system_prompt,
-                cwd=resolve_cwd_for_path(resolved_path),
-                max_budget_usd=get_max_budget_usd(depth, explicit=max_budget_usd),
-                allowed_tools=["Read", "Glob", "Grep", "Agent"],
-                permission_mode="default",
-                max_turns=max_turns,
-                agents={
-                    "staleness-checker": claude_agent_sdk.AgentDefinition(
-                        description="Staleness checker that finds outdated documentation.",
-                        prompt=(
-                            "You are a documentation staleness checker. "
-                            "Focus on: outdated docs, stale version "
-                            "references, dead links, and obsolete "
-                            "examples. Report each finding with file "
-                            "path, line number, severity, and "
-                            "remediation advice."
+        async for message in iter_agent_messages(
+            claude_agent_sdk.query(
+                prompt=_TASK_PROMPT_TEMPLATE.format(path=resolved_path),
+                options=claude_agent_sdk.ClaudeAgentOptions(
+                    **sdk_isolation_kwargs(),
+                    system_prompt=system_prompt,
+                    cwd=resolve_cwd_for_path(resolved_path),
+                    max_budget_usd=get_max_budget_usd(depth, explicit=max_budget_usd),
+                    allowed_tools=["Read", "Glob", "Grep", "Agent"],
+                    permission_mode="default",
+                    max_turns=max_turns,
+                    agents={
+                        "staleness-checker": claude_agent_sdk.AgentDefinition(
+                            description="Staleness checker that finds outdated documentation.",
+                            prompt=(
+                                "You are a documentation staleness checker. "
+                                "Focus on: outdated docs, stale version "
+                                "references, dead links, and obsolete "
+                                "examples. Report each finding with file "
+                                "path, line number, severity, and "
+                                "remediation advice."
+                            ),
+                            tools=["Read", "Glob", "Grep"],
+                            model=get_subagent_model("staleness-checker"),
                         ),
-                        tools=["Read", "Glob", "Grep"],
-                        model=get_subagent_model("staleness-checker"),
-                    ),
-                    "accuracy-reviewer": claude_agent_sdk.AgentDefinition(
-                        description="Accuracy reviewer that verifies docs match code.",
-                        prompt=(
-                            "You are a documentation accuracy reviewer. "
-                            "Focus on: verifying docs match current code "
-                            "behavior, API signatures, and config "
-                            "options. Report each finding with file "
-                            "path, severity, and correction advice."
+                        "accuracy-reviewer": claude_agent_sdk.AgentDefinition(
+                            description="Accuracy reviewer that verifies docs match code.",
+                            prompt=(
+                                "You are a documentation accuracy reviewer. "
+                                "Focus on: verifying docs match current code "
+                                "behavior, API signatures, and config "
+                                "options. Report each finding with file "
+                                "path, severity, and correction advice."
+                            ),
+                            tools=["Read", "Glob", "Grep"],
+                            model=get_subagent_model("accuracy-reviewer"),
                         ),
-                        tools=["Read", "Glob", "Grep"],
-                        model=get_subagent_model("accuracy-reviewer"),
-                    ),
-                    "gap-finder": claude_agent_sdk.AgentDefinition(
-                        description="Gap finder that identifies missing documentation.",
-                        prompt=(
-                            "You are a documentation gap finder. Focus "
-                            "on: identifying missing docs for public "
-                            "APIs, undocumented features, and missing "
-                            "examples. Report each finding with the "
-                            "affected module, severity, and what "
-                            "documentation should be added."
+                        "gap-finder": claude_agent_sdk.AgentDefinition(
+                            description="Gap finder that identifies missing documentation.",
+                            prompt=(
+                                "You are a documentation gap finder. Focus "
+                                "on: identifying missing docs for public "
+                                "APIs, undocumented features, and missing "
+                                "examples. Report each finding with the "
+                                "affected module, severity, and what "
+                                "documentation should be added."
+                            ),
+                            tools=["Read", "Glob", "Grep"],
+                            model=get_subagent_model("gap-finder"),
                         ),
-                        tools=["Read", "Glob", "Grep"],
-                        model=get_subagent_model("gap-finder"),
-                    ),
-                },
-            ),
+                    },
+                ),
+            )
         ):
             sdk_result = collect_agent_output(message, assistant_parts, result_parts)
             if sdk_result is not None:

--- a/src/attune/workflows/document_gen/workflow.py
+++ b/src/attune/workflows/document_gen/workflow.py
@@ -27,6 +27,7 @@ from ..agent_sdk_adapter import (
     collect_agent_output,
     get_max_budget_usd,
     get_subagent_model,
+    iter_agent_messages,
     resolve_cwd_for_path,
     sdk_isolation_kwargs,
 )
@@ -201,62 +202,64 @@ class DocumentGenerationWorkflow(BaseWorkflow):
         assistant_parts: list[str] = []
         result_parts: list[str] = []
         run_result = AgentRunResult(result_text="No results returned.")
-        async for message in claude_agent_sdk.query(
-            prompt=_TASK_PROMPT_TEMPLATE.format(path=resolved_path),
-            options=claude_agent_sdk.ClaudeAgentOptions(
-                **sdk_isolation_kwargs(),
-                system_prompt=_SYSTEM_PROMPT,
-                cwd=resolve_cwd_for_path(resolved_path),
-                max_budget_usd=get_max_budget_usd(depth),
-                allowed_tools=["Read", "Glob", "Grep", "Agent"],
-                permission_mode="default",
-                max_turns=max_turns,
-                agents={
-                    "outline-planner": claude_agent_sdk.AgentDefinition(
-                        description="Outline planner that analyzes codebase structure.",
-                        prompt=(
-                            "You are a documentation outline planner. "
-                            "Analyze the codebase structure and plan a "
-                            "comprehensive documentation outline. Focus "
-                            "on: module organization, public APIs, key "
-                            "classes and functions, configuration options, "
-                            "and usage examples. Produce a structured "
-                            "outline with sections and subsections."
+        async for message in iter_agent_messages(
+            claude_agent_sdk.query(
+                prompt=_TASK_PROMPT_TEMPLATE.format(path=resolved_path),
+                options=claude_agent_sdk.ClaudeAgentOptions(
+                    **sdk_isolation_kwargs(),
+                    system_prompt=_SYSTEM_PROMPT,
+                    cwd=resolve_cwd_for_path(resolved_path),
+                    max_budget_usd=get_max_budget_usd(depth),
+                    allowed_tools=["Read", "Glob", "Grep", "Agent"],
+                    permission_mode="default",
+                    max_turns=max_turns,
+                    agents={
+                        "outline-planner": claude_agent_sdk.AgentDefinition(
+                            description="Outline planner that analyzes codebase structure.",
+                            prompt=(
+                                "You are a documentation outline planner. "
+                                "Analyze the codebase structure and plan a "
+                                "comprehensive documentation outline. Focus "
+                                "on: module organization, public APIs, key "
+                                "classes and functions, configuration options, "
+                                "and usage examples. Produce a structured "
+                                "outline with sections and subsections."
+                            ),
+                            tools=["Read", "Glob", "Grep"],
+                            model=get_subagent_model("outline-planner"),
                         ),
-                        tools=["Read", "Glob", "Grep"],
-                        model=get_subagent_model("outline-planner"),
-                    ),
-                    "content-writer": claude_agent_sdk.AgentDefinition(
-                        description="Content writer that produces documentation text.",
-                        prompt=(
-                            "You are a documentation content writer. "
-                            "Write clear, accurate documentation for "
-                            "each section of the outline. Include: "
-                            "module descriptions, function signatures "
-                            "with type hints, parameter explanations, "
-                            "return value descriptions, code examples, "
-                            "and usage patterns. Use Google-style "
-                            "docstring format for API references."
+                        "content-writer": claude_agent_sdk.AgentDefinition(
+                            description="Content writer that produces documentation text.",
+                            prompt=(
+                                "You are a documentation content writer. "
+                                "Write clear, accurate documentation for "
+                                "each section of the outline. Include: "
+                                "module descriptions, function signatures "
+                                "with type hints, parameter explanations, "
+                                "return value descriptions, code examples, "
+                                "and usage patterns. Use Google-style "
+                                "docstring format for API references."
+                            ),
+                            tools=["Read", "Glob", "Grep"],
+                            model=get_subagent_model("content-writer"),
                         ),
-                        tools=["Read", "Glob", "Grep"],
-                        model=get_subagent_model("content-writer"),
-                    ),
-                    "polish-reviewer": claude_agent_sdk.AgentDefinition(
-                        description="Polish reviewer that checks docs for quality.",
-                        prompt=(
-                            "You are a documentation polish reviewer. "
-                            "Review the generated documentation for: "
-                            "clarity and readability, technical accuracy, "
-                            "completeness of API coverage, correct code "
-                            "examples, consistent formatting, and missing "
-                            "sections. Report issues and suggest specific "
-                            "improvements."
+                        "polish-reviewer": claude_agent_sdk.AgentDefinition(
+                            description="Polish reviewer that checks docs for quality.",
+                            prompt=(
+                                "You are a documentation polish reviewer. "
+                                "Review the generated documentation for: "
+                                "clarity and readability, technical accuracy, "
+                                "completeness of API coverage, correct code "
+                                "examples, consistent formatting, and missing "
+                                "sections. Report issues and suggest specific "
+                                "improvements."
+                            ),
+                            tools=["Read", "Glob", "Grep"],
+                            model=get_subagent_model("polish-reviewer"),
                         ),
-                        tools=["Read", "Glob", "Grep"],
-                        model=get_subagent_model("polish-reviewer"),
-                    ),
-                },
-            ),
+                    },
+                ),
+            )
         ):
             sdk_result = collect_agent_output(message, assistant_parts, result_parts)
             if sdk_result is not None:

--- a/src/attune/workflows/refactor_plan.py
+++ b/src/attune/workflows/refactor_plan.py
@@ -30,6 +30,7 @@ from .agent_sdk_adapter import (
     collect_agent_output,
     get_max_budget_usd,
     get_subagent_model,
+    iter_agent_messages,
     resolve_cwd_for_path,
     sdk_isolation_kwargs,
 )
@@ -220,61 +221,63 @@ class RefactorPlanWorkflow(BaseWorkflow):
         assistant_parts: list[str] = []
         result_parts: list[str] = []
         run_result = AgentRunResult(result_text="No results returned.")
-        async for message in claude_agent_sdk.query(
-            prompt=_TASK_PROMPT_TEMPLATE.format(path=resolved_path),
-            options=claude_agent_sdk.ClaudeAgentOptions(
-                **sdk_isolation_kwargs(),
-                system_prompt=_SYSTEM_PROMPT,
-                cwd=resolve_cwd_for_path(resolved_path),
-                max_budget_usd=get_max_budget_usd(depth),
-                allowed_tools=["Read", "Glob", "Grep", "Agent"],
-                permission_mode="default",
-                max_turns=max_turns,
-                agents={
-                    "debt-scanner": claude_agent_sdk.AgentDefinition(
-                        description=(
-                            "Tech debt scanner that finds code smells" " and duplication."
+        async for message in iter_agent_messages(
+            claude_agent_sdk.query(
+                prompt=_TASK_PROMPT_TEMPLATE.format(path=resolved_path),
+                options=claude_agent_sdk.ClaudeAgentOptions(
+                    **sdk_isolation_kwargs(),
+                    system_prompt=_SYSTEM_PROMPT,
+                    cwd=resolve_cwd_for_path(resolved_path),
+                    max_budget_usd=get_max_budget_usd(depth),
+                    allowed_tools=["Read", "Glob", "Grep", "Agent"],
+                    permission_mode="default",
+                    max_turns=max_turns,
+                    agents={
+                        "debt-scanner": claude_agent_sdk.AgentDefinition(
+                            description=(
+                                "Tech debt scanner that finds code smells" " and duplication."
+                            ),
+                            prompt=(
+                                "You are a tech debt scanner. Focus on: "
+                                "code smells, duplication, complex conditionals, "
+                                "dead code, overly long functions, and deeply "
+                                "nested logic. Report each finding with file "
+                                "path, line number, severity, and a brief "
+                                "description of the issue."
+                            ),
+                            tools=["Read", "Glob", "Grep"],
+                            model=get_subagent_model("debt-scanner"),
                         ),
-                        prompt=(
-                            "You are a tech debt scanner. Focus on: "
-                            "code smells, duplication, complex conditionals, "
-                            "dead code, overly long functions, and deeply "
-                            "nested logic. Report each finding with file "
-                            "path, line number, severity, and a brief "
-                            "description of the issue."
+                        "impact-analyzer": claude_agent_sdk.AgentDefinition(
+                            description=("Impact analyzer for refactoring risk assessment."),
+                            prompt=(
+                                "You are a refactoring impact analyzer. Focus on: "
+                                "test coverage of affected code, dependency chains, "
+                                "API surface changes, and downstream consumers. "
+                                "For each refactoring candidate, report the impact "
+                                "on tests, dependencies, and public interfaces."
+                            ),
+                            tools=["Read", "Glob", "Grep"],
+                            model=get_subagent_model("impact-analyzer"),
                         ),
-                        tools=["Read", "Glob", "Grep"],
-                        model=get_subagent_model("debt-scanner"),
-                    ),
-                    "impact-analyzer": claude_agent_sdk.AgentDefinition(
-                        description=("Impact analyzer for refactoring risk assessment."),
-                        prompt=(
-                            "You are a refactoring impact analyzer. Focus on: "
-                            "test coverage of affected code, dependency chains, "
-                            "API surface changes, and downstream consumers. "
-                            "For each refactoring candidate, report the impact "
-                            "on tests, dependencies, and public interfaces."
+                        "plan-generator": claude_agent_sdk.AgentDefinition(
+                            description=(
+                                "Plan generator that creates prioritized" " refactoring plans."
+                            ),
+                            prompt=(
+                                "You are a refactoring plan generator. Using "
+                                "findings from the debt scanner and impact "
+                                "analyzer, create a prioritized refactoring plan. "
+                                "For each item include: effort estimate "
+                                "(small/medium/large), risk level (low/medium/high), "
+                                "expected benefit, and suggested implementation order."
+                            ),
+                            tools=["Read", "Glob", "Grep"],
+                            model=get_subagent_model("plan-generator"),
                         ),
-                        tools=["Read", "Glob", "Grep"],
-                        model=get_subagent_model("impact-analyzer"),
-                    ),
-                    "plan-generator": claude_agent_sdk.AgentDefinition(
-                        description=(
-                            "Plan generator that creates prioritized" " refactoring plans."
-                        ),
-                        prompt=(
-                            "You are a refactoring plan generator. Using "
-                            "findings from the debt scanner and impact "
-                            "analyzer, create a prioritized refactoring plan. "
-                            "For each item include: effort estimate "
-                            "(small/medium/large), risk level (low/medium/high), "
-                            "expected benefit, and suggested implementation order."
-                        ),
-                        tools=["Read", "Glob", "Grep"],
-                        model=get_subagent_model("plan-generator"),
-                    ),
-                },
-            ),
+                    },
+                ),
+            )
         ):
             sdk_result = collect_agent_output(message, assistant_parts, result_parts)
             if sdk_result is not None:

--- a/src/attune/workflows/release_prep.py
+++ b/src/attune/workflows/release_prep.py
@@ -27,6 +27,7 @@ from .agent_sdk_adapter import (
     collect_agent_output,
     get_max_budget_usd,
     get_subagent_model,
+    iter_agent_messages,
     resolve_cwd_for_path,
     sdk_isolation_kwargs,
 )
@@ -195,71 +196,73 @@ class ReleasePreparationWorkflow(BaseWorkflow):
         assistant_parts: list[str] = []
         result_parts: list[str] = []
         run_result = AgentRunResult(result_text="No results returned.")
-        async for message in claude_agent_sdk.query(
-            prompt=_TASK_PROMPT_TEMPLATE.format(path=resolved_path),
-            options=claude_agent_sdk.ClaudeAgentOptions(
-                **sdk_isolation_kwargs(),
-                system_prompt=_SYSTEM_PROMPT,
-                cwd=resolve_cwd_for_path(resolved_path),
-                max_budget_usd=get_max_budget_usd(depth),
-                allowed_tools=["Read", "Glob", "Grep", "Bash", "Agent"],
-                permission_mode="default",
-                max_turns=max_turns,
-                agents={
-                    "health-checker": claude_agent_sdk.AgentDefinition(
-                        description="Health checker that runs tests and verifies CI status.",
-                        prompt=(
-                            "You are a release health checker. Focus on: "
-                            "running the test suite, checking dependency "
-                            "versions and lock files, verifying CI pipeline "
-                            "status, and confirming build artifacts are "
-                            "reproducible. Report each finding with status "
-                            "(pass/fail), details, and remediation if needed."
+        async for message in iter_agent_messages(
+            claude_agent_sdk.query(
+                prompt=_TASK_PROMPT_TEMPLATE.format(path=resolved_path),
+                options=claude_agent_sdk.ClaudeAgentOptions(
+                    **sdk_isolation_kwargs(),
+                    system_prompt=_SYSTEM_PROMPT,
+                    cwd=resolve_cwd_for_path(resolved_path),
+                    max_budget_usd=get_max_budget_usd(depth),
+                    allowed_tools=["Read", "Glob", "Grep", "Bash", "Agent"],
+                    permission_mode="default",
+                    max_turns=max_turns,
+                    agents={
+                        "health-checker": claude_agent_sdk.AgentDefinition(
+                            description="Health checker that runs tests and verifies CI status.",
+                            prompt=(
+                                "You are a release health checker. Focus on: "
+                                "running the test suite, checking dependency "
+                                "versions and lock files, verifying CI pipeline "
+                                "status, and confirming build artifacts are "
+                                "reproducible. Report each finding with status "
+                                "(pass/fail), details, and remediation if needed."
+                            ),
+                            tools=["Read", "Glob", "Grep", "Bash"],
+                            model=get_subagent_model("health-checker"),
                         ),
-                        tools=["Read", "Glob", "Grep", "Bash"],
-                        model=get_subagent_model("health-checker"),
-                    ),
-                    "security-scanner": claude_agent_sdk.AgentDefinition(
-                        description="Security scanner for vulnerabilities and secret leaks.",
-                        prompt=(
-                            "You are a security scanner for release prep. "
-                            "Focus on: known vulnerabilities in dependencies, "
-                            "outdated packages with CVEs, hardcoded secrets "
-                            "or credentials, eval/exec usage, and path "
-                            "traversal risks. Report each finding with "
-                            "severity, file path, and remediation advice."
+                        "security-scanner": claude_agent_sdk.AgentDefinition(
+                            description="Security scanner for vulnerabilities and secret leaks.",
+                            prompt=(
+                                "You are a security scanner for release prep. "
+                                "Focus on: known vulnerabilities in dependencies, "
+                                "outdated packages with CVEs, hardcoded secrets "
+                                "or credentials, eval/exec usage, and path "
+                                "traversal risks. Report each finding with "
+                                "severity, file path, and remediation advice."
+                            ),
+                            tools=["Read", "Glob", "Grep"],
+                            model=get_subagent_model("security-scanner"),
                         ),
-                        tools=["Read", "Glob", "Grep"],
-                        model=get_subagent_model("security-scanner"),
-                    ),
-                    "changelog-generator": claude_agent_sdk.AgentDefinition(
-                        description="Changelog generator from git history.",
-                        prompt=(
-                            "You are a changelog generator. Use git log to "
-                            "identify notable changes since the last release "
-                            "tag. Categorize changes as: Features, Fixes, "
-                            "Breaking Changes, Documentation, and Internal. "
-                            "Output a draft CHANGELOG section in Keep a "
-                            "Changelog format."
+                        "changelog-generator": claude_agent_sdk.AgentDefinition(
+                            description="Changelog generator from git history.",
+                            prompt=(
+                                "You are a changelog generator. Use git log to "
+                                "identify notable changes since the last release "
+                                "tag. Categorize changes as: Features, Fixes, "
+                                "Breaking Changes, Documentation, and Internal. "
+                                "Output a draft CHANGELOG section in Keep a "
+                                "Changelog format."
+                            ),
+                            tools=["Read", "Glob", "Grep", "Bash"],
+                            model=get_subagent_model("changelog-generator"),
                         ),
-                        tools=["Read", "Glob", "Grep", "Bash"],
-                        model=get_subagent_model("changelog-generator"),
-                    ),
-                    "release-assessor": claude_agent_sdk.AgentDefinition(
-                        description="Release assessor for overall readiness and go/no-go.",
-                        prompt=(
-                            "You are a release readiness assessor. Review "
-                            "the overall state of the project including: "
-                            "test coverage, documentation completeness, "
-                            "version bumps, migration guides, and any "
-                            "release blockers. Provide a clear go/no-go "
-                            "recommendation with justification."
+                        "release-assessor": claude_agent_sdk.AgentDefinition(
+                            description="Release assessor for overall readiness and go/no-go.",
+                            prompt=(
+                                "You are a release readiness assessor. Review "
+                                "the overall state of the project including: "
+                                "test coverage, documentation completeness, "
+                                "version bumps, migration guides, and any "
+                                "release blockers. Provide a clear go/no-go "
+                                "recommendation with justification."
+                            ),
+                            tools=["Read", "Glob", "Grep"],
+                            model=get_subagent_model("release-assessor"),
                         ),
-                        tools=["Read", "Glob", "Grep"],
-                        model=get_subagent_model("release-assessor"),
-                    ),
-                },
-            ),
+                    },
+                ),
+            )
         ):
             sdk_result = collect_agent_output(message, assistant_parts, result_parts)
             if sdk_result is not None:

--- a/src/attune/workflows/test_audit/workflow.py
+++ b/src/attune/workflows/test_audit/workflow.py
@@ -29,6 +29,7 @@ from ..agent_sdk_adapter import (
     collect_agent_output,
     get_max_budget_usd,
     get_subagent_model,
+    iter_agent_messages,
     resolve_cwd_for_path,
     sdk_isolation_kwargs,
 )
@@ -236,59 +237,61 @@ class TestAuditWorkflow(BaseWorkflow):
         result_parts: list[str] = []
         run_result = AgentRunResult(result_text="No results returned.")
         system_prompt = _SYSTEM_PROMPT + (self._system_prompt_suffix or "")
-        async for message in claude_agent_sdk.query(
-            prompt=_TASK_PROMPT_TEMPLATE.format(src_path=resolved_path),
-            options=claude_agent_sdk.ClaudeAgentOptions(
-                **sdk_isolation_kwargs(),
-                system_prompt=system_prompt,
-                cwd=resolve_cwd_for_path(resolved_path),
-                max_budget_usd=get_max_budget_usd(depth, explicit=max_budget_usd),
-                allowed_tools=["Read", "Glob", "Grep", "Bash", "Agent"],
-                permission_mode="default",
-                max_turns=max_turns,
-                agents={
-                    "coverage-auditor": claude_agent_sdk.AgentDefinition(
-                        description="Coverage auditor that analyzes test coverage metrics.",
-                        prompt=(
-                            "You are a test coverage auditor. Focus on: "
-                            "running pytest --cov to collect coverage data, "
-                            "analyzing line, branch, and function coverage, "
-                            "identifying modules with low coverage, and "
-                            "reporting coverage percentages per module. "
-                            "Use Bash to run coverage commands when possible."
+        async for message in iter_agent_messages(
+            claude_agent_sdk.query(
+                prompt=_TASK_PROMPT_TEMPLATE.format(src_path=resolved_path),
+                options=claude_agent_sdk.ClaudeAgentOptions(
+                    **sdk_isolation_kwargs(),
+                    system_prompt=system_prompt,
+                    cwd=resolve_cwd_for_path(resolved_path),
+                    max_budget_usd=get_max_budget_usd(depth, explicit=max_budget_usd),
+                    allowed_tools=["Read", "Glob", "Grep", "Bash", "Agent"],
+                    permission_mode="default",
+                    max_turns=max_turns,
+                    agents={
+                        "coverage-auditor": claude_agent_sdk.AgentDefinition(
+                            description="Coverage auditor that analyzes test coverage metrics.",
+                            prompt=(
+                                "You are a test coverage auditor. Focus on: "
+                                "running pytest --cov to collect coverage data, "
+                                "analyzing line, branch, and function coverage, "
+                                "identifying modules with low coverage, and "
+                                "reporting coverage percentages per module. "
+                                "Use Bash to run coverage commands when possible."
+                            ),
+                            tools=["Read", "Glob", "Grep", "Bash"],
+                            model=get_subagent_model("coverage-auditor"),
                         ),
-                        tools=["Read", "Glob", "Grep", "Bash"],
-                        model=get_subagent_model("coverage-auditor"),
-                    ),
-                    "gap-analyzer": claude_agent_sdk.AgentDefinition(
-                        description="Gap analyzer that finds untested code paths.",
-                        prompt=(
-                            "You are a test gap analyzer. Focus on: "
-                            "untested code paths, missing edge cases, "
-                            "untested error handling branches, uncovered "
-                            "exception handlers, and missing boundary "
-                            "condition tests. Report each gap with file "
-                            "path, line number, and risk assessment."
+                        "gap-analyzer": claude_agent_sdk.AgentDefinition(
+                            description="Gap analyzer that finds untested code paths.",
+                            prompt=(
+                                "You are a test gap analyzer. Focus on: "
+                                "untested code paths, missing edge cases, "
+                                "untested error handling branches, uncovered "
+                                "exception handlers, and missing boundary "
+                                "condition tests. Report each gap with file "
+                                "path, line number, and risk assessment."
+                            ),
+                            tools=["Read", "Glob", "Grep"],
+                            model=get_subagent_model("gap-analyzer"),
                         ),
-                        tools=["Read", "Glob", "Grep"],
-                        model=get_subagent_model("gap-analyzer"),
-                    ),
-                    "test-planner": claude_agent_sdk.AgentDefinition(
-                        description="Test planner that creates prioritized test plans.",
-                        prompt=(
-                            "You are a test planner. Based on coverage "
-                            "gaps and untested paths, create a prioritized "
-                            "test plan. For each suggested test include: "
-                            "test name, target file and function, test "
-                            "type (unit/integration/e2e), estimated effort "
-                            "(small/medium/large), and priority (high/"
-                            "medium/low). Order by priority then effort."
+                        "test-planner": claude_agent_sdk.AgentDefinition(
+                            description="Test planner that creates prioritized test plans.",
+                            prompt=(
+                                "You are a test planner. Based on coverage "
+                                "gaps and untested paths, create a prioritized "
+                                "test plan. For each suggested test include: "
+                                "test name, target file and function, test "
+                                "type (unit/integration/e2e), estimated effort "
+                                "(small/medium/large), and priority (high/"
+                                "medium/low). Order by priority then effort."
+                            ),
+                            tools=["Read", "Glob", "Grep"],
+                            model=get_subagent_model("test-planner"),
                         ),
-                        tools=["Read", "Glob", "Grep"],
-                        model=get_subagent_model("test-planner"),
-                    ),
-                },
-            ),
+                    },
+                ),
+            )
         ):
             sdk_result = collect_agent_output(message, assistant_parts, result_parts)
             if sdk_result is not None:

--- a/src/attune/workflows/test_gen/workflow.py
+++ b/src/attune/workflows/test_gen/workflow.py
@@ -30,6 +30,7 @@ from ..agent_sdk_adapter import (
     collect_agent_output,
     get_max_budget_usd,
     get_subagent_model,
+    iter_agent_messages,
     resolve_cwd_for_path,
     sdk_isolation_kwargs,
 )
@@ -189,63 +190,65 @@ class TestGenerationWorkflow(BaseWorkflow):
         assistant_parts: list[str] = []
         result_parts: list[str] = []
         run_result = AgentRunResult(result_text="No results returned.")
-        async for message in claude_agent_sdk.query(
-            prompt=_TASK_PROMPT_TEMPLATE.format(path=resolved_path),
-            options=claude_agent_sdk.ClaudeAgentOptions(
-                **sdk_isolation_kwargs(),
-                system_prompt=_SYSTEM_PROMPT,
-                cwd=resolve_cwd_for_path(resolved_path),
-                max_budget_usd=get_max_budget_usd(depth),
-                allowed_tools=["Read", "Glob", "Grep", "Agent"],
-                permission_mode="default",
-                max_turns=max_turns,
-                agents={
-                    "function-identifier": claude_agent_sdk.AgentDefinition(
-                        description="Identifies untested or under-tested functions.",
-                        prompt=(
-                            "You are a function identifier. Scan the "
-                            "codebase and identify functions that are "
-                            "untested or under-tested. For each function, "
-                            "report: file path, function name, signature, "
-                            "current test coverage status, and complexity "
-                            "level. Prioritize public API functions and "
-                            "functions with complex logic."
+        async for message in iter_agent_messages(
+            claude_agent_sdk.query(
+                prompt=_TASK_PROMPT_TEMPLATE.format(path=resolved_path),
+                options=claude_agent_sdk.ClaudeAgentOptions(
+                    **sdk_isolation_kwargs(),
+                    system_prompt=_SYSTEM_PROMPT,
+                    cwd=resolve_cwd_for_path(resolved_path),
+                    max_budget_usd=get_max_budget_usd(depth),
+                    allowed_tools=["Read", "Glob", "Grep", "Agent"],
+                    permission_mode="default",
+                    max_turns=max_turns,
+                    agents={
+                        "function-identifier": claude_agent_sdk.AgentDefinition(
+                            description="Identifies untested or under-tested functions.",
+                            prompt=(
+                                "You are a function identifier. Scan the "
+                                "codebase and identify functions that are "
+                                "untested or under-tested. For each function, "
+                                "report: file path, function name, signature, "
+                                "current test coverage status, and complexity "
+                                "level. Prioritize public API functions and "
+                                "functions with complex logic."
+                            ),
+                            tools=["Read", "Glob", "Grep"],
+                            model=get_subagent_model("function-identifier"),
                         ),
-                        tools=["Read", "Glob", "Grep"],
-                        model=get_subagent_model("function-identifier"),
-                    ),
-                    "test-designer": claude_agent_sdk.AgentDefinition(
-                        description="Designs test cases for identified functions.",
-                        prompt=(
-                            "You are a test designer. For each function "
-                            "identified by the function-identifier, design "
-                            "comprehensive test cases covering: happy path "
-                            "scenarios, edge cases (empty input, boundary "
-                            "values, None/null), error handling paths, and "
-                            "integration points. Report each test case with "
-                            "a descriptive name, input values, and expected "
-                            "outcome."
+                        "test-designer": claude_agent_sdk.AgentDefinition(
+                            description="Designs test cases for identified functions.",
+                            prompt=(
+                                "You are a test designer. For each function "
+                                "identified by the function-identifier, design "
+                                "comprehensive test cases covering: happy path "
+                                "scenarios, edge cases (empty input, boundary "
+                                "values, None/null), error handling paths, and "
+                                "integration points. Report each test case with "
+                                "a descriptive name, input values, and expected "
+                                "outcome."
+                            ),
+                            tools=["Read", "Glob", "Grep"],
+                            model=get_subagent_model("test-designer"),
                         ),
-                        tools=["Read", "Glob", "Grep"],
-                        model=get_subagent_model("test-designer"),
-                    ),
-                    "test-writer": claude_agent_sdk.AgentDefinition(
-                        description="Writes pytest test code following project conventions.",
-                        prompt=(
-                            "You are a test writer. Using the test cases "
-                            "designed by the test-designer, write pytest "
-                            "test code that follows project conventions: "
-                            "use pytest fixtures, parametrize where "
-                            "appropriate, include type hints, add "
-                            "docstrings, and follow the naming convention "
-                            "test_{function}_{scenario}_{expected}. Group "
-                            "related tests in classes."
+                        "test-writer": claude_agent_sdk.AgentDefinition(
+                            description="Writes pytest test code following project conventions.",
+                            prompt=(
+                                "You are a test writer. Using the test cases "
+                                "designed by the test-designer, write pytest "
+                                "test code that follows project conventions: "
+                                "use pytest fixtures, parametrize where "
+                                "appropriate, include type hints, add "
+                                "docstrings, and follow the naming convention "
+                                "test_{function}_{scenario}_{expected}. Group "
+                                "related tests in classes."
+                            ),
+                            tools=["Read", "Glob", "Grep"],
+                            model=get_subagent_model("test-writer"),
                         ),
-                        tools=["Read", "Glob", "Grep"],
-                        model=get_subagent_model("test-writer"),
-                    ),
-                },
-            ),
+                    },
+                ),
+            )
         ):
             sdk_result = collect_agent_output(message, assistant_parts, result_parts)
             if sdk_result is not None:

--- a/tests/unit/workflows/test_iter_agent_messages.py
+++ b/tests/unit/workflows/test_iter_agent_messages.py
@@ -11,6 +11,9 @@ Licensed under Apache 2.0
 
 from __future__ import annotations
 
+import re
+from pathlib import Path
+
 import pytest
 
 import attune.workflows.agent_sdk_adapter as adapter
@@ -125,3 +128,34 @@ async def test_clean_stream_passes_through():
     """No teardown exit: every message yielded, loop completes."""
     a, b = object(), _FakeResultMessage(subtype="success")
     assert await _drain(_FakeQuery([a, b])) == [a, b]
+
+
+# Direct consumption of the raw SDK stream, e.g.
+# ``async for message in claude_agent_sdk.query(...)``. Such a loop
+# discards an already-successful result when the SDK subprocess raises
+# during teardown — the exact failure class iter_agent_messages exists
+# to fix.
+_UNWRAPPED_LOOP_RE = re.compile(r"async for .+ in claude_agent_sdk\.query\(")
+
+
+def test_every_workflow_query_loop_is_wrapped():
+    """Drift guard: no workflow consumes claude_agent_sdk.query() bare.
+
+    Every SDK consumption loop must go through iter_agent_messages so
+    the teardown-exit guard applies. A new workflow (or a revert) that
+    iterates the raw query stream reintroduces the discarded-success
+    bug this spec fixed — fail loudly with the offending locations.
+    """
+    workflows_dir = Path(adapter.__file__).resolve().parent
+    offenders: list[str] = []
+    for path in sorted(workflows_dir.rglob("*.py")):
+        if path.name == "agent_sdk_adapter.py":
+            # The wrapper's own module documents the raw pattern.
+            continue
+        for lineno, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+            if _UNWRAPPED_LOOP_RE.search(line):
+                offenders.append(f"{path.relative_to(workflows_dir)}:{lineno}")
+    assert not offenders, (
+        "SDK consumption loops not wrapped in iter_agent_messages "
+        f"(teardown-exit guard bypassed): {offenders}"
+    )


### PR DESCRIPTION
## Summary

Completes the **sdk-teardown-exit-guard** spec (design approved as
drafted and execution armed by the chair 2026-07-20).

The failure class: a nested SDK workflow run yields
`ResultMessage(subtype="success")`, then the SDK subprocess raises
during teardown (exit 1), and the already-produced result is discarded
as a failure (`project_sdk_workflows_blocked_nested`).

T1 (the `iter_agent_messages` wrapper + unit tests) and the eight
spec-named adoptions landed earlier in #1099. This PR closes the gap
between the spec's list and code reality, plus the T4 docs lock:

- **Wraps the seven newer SDK consumption loops** the spec's list
  predated: `deep_review`, `refactor_plan`, `release_prep`,
  `test_gen`, `test_audit`, `doc_audit`, `document_gen` — same
  one-line adoption, no body changes (black re-indent accounts for
  most of the diff). No `claude_agent_sdk.query(` call sites exist
  outside `src/attune/workflows/`.
- **Drift-guard regression test**
  (`test_every_workflow_query_loop_is_wrapped`): fails on any future
  bare `async for … in claude_agent_sdk.query(` loop.
- **Spec flipped to EXECUTED** with a receipts-backed execution log
  in `decisions.md`; CHANGELOG `### Fixed` entry.

D3 false-green constraint held: nothing pre-success is swallowed —
genuine failures still reach `capture_subprocess_failure` / error
translation; the dispatcher's exit-0-on-`success=False` behavior is
untouched.

## Receipts

- Wrapper suite: 8 passed (serial, `-o addopts=`), incl. the new
  drift guard.
- Existing unit tests for the seven wrapped workflows: 531 passed
  (serial).
- Coverage on the seven modified modules: 98% total (lowest 91%).
- Pinned pre-commit black + ruff pre-flighted clean.
- **T3 dogfood (real spend, chair-authorized):** real
  `CodeReviewWorkflow` quick-depth run nested inside a live Claude
  Code session returned `success=True`, `subtype="success"`, cost
  $0.60, 7 turns, with genuine findings. The teardown exit did not
  fire on that particular run (stream ended cleanly), so the
  recovery branch stays proven by the unit suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
