### PR TITLE
fix(ops): spec status writer keeps LF on Windows

### DIFF
--- a/src/attune/ops/routes/specs.py
+++ b/src/attune/ops/routes/specs.py
@@ -243,7 +243,9 @@ def _atomic_write(target: Path, text: str) -> None:
     target.parent.mkdir(parents=True, exist_ok=True)
     fd, tmp = tempfile.mkstemp(prefix=f".{target.name}.", suffix=".tmp", dir=str(target.parent))
     try:
-        with os.fdopen(fd, "w", encoding="utf-8") as f:
+        # newline="\n" keeps LF on every platform — Windows text-mode
+        # translation would otherwise stamp CRLF into tracked LF markdown.
+        with os.fdopen(fd, "w", encoding="utf-8", newline="\n") as f:
             f.write(text)
         os.replace(tmp, target)
     except Exception:  # noqa: BLE001


### PR DESCRIPTION
## Summary

The PUT `/api/specs/{slug}/{phase}/status` atomic writer (`_atomic_write` in `src/attune/ops/routes/specs.py`) opened its temp file in text mode without `newline=`, so on Windows every written LF became CRLF — corrupting tracked markdown line endings and failing `tests/unit/ops/test_spec_status_rewrite.py::TestEndpointRoundTrip::test_double_put_is_byte_identical` on **every windows-latest lane since #1488 landed**. Main is currently Windows-red from this; #1529 inherited the failure (its diff never touches this code).

One-line fix: `newline="\n"` pins LF on every platform.

## Receipts

- `tests/unit/ops/test_spec_status_rewrite.py`: 13 passed locally (macOS; the definitive receipt is this PR's windows-latest lanes going green).
- Pinned black/ruff pre-flighted clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)