### PR TITLE
feat(ops): Specs page Stage column — derived pipeline position + next transition

### DIFF
--- a/docs/specs/agent-round-table/decisions.md
+++ b/docs/specs/agent-round-table/decisions.md
@@ -429,3 +429,5 @@ Final review = the 2026-07-27 06:00 first scheduled fire (#1539).
 On a green fire: flip this spec to shipped (or living — chair's
 pick); roundtable-triage / roundtable-producing-team carry active
 status.
+
+PHASE-WAIVED: design (2026-07-20 — completion pass above; thread q-agent-round-table-completion-001)

--- a/docs/specs/spec-lifecycle-gates/decisions.md
+++ b/docs/specs/spec-lifecycle-gates/decisions.md
@@ -142,3 +142,22 @@ lives with the ledger config; activation exposes
 `BATCH_THRESHOLD_FRACTION = 0.20`. Batch-mode surfacing itself is
 deferred to first real CHAIR_REQUIRED volume (nothing to batch on
 day one — honest sequencing, not scope cut).
+
+## 2026-07-20 — UI surface phase: the Specs page Stage column (chair-ruled)
+
+Chair asked for the Phases column to become tracked, managed phase
+state; pushback accepted (option 1): NO separate tracking store —
+stage is DERIVED at render time from the phase files' own status
+lines (`derive_stage`, `attune.ops.spec_lifecycle`), the same
+single-source discipline the status-line gate enforces. The column
+shows pipeline position (requirements → design → tasks → executing
+→ shipped) + a next-transition hint; the chip reuses the existing
+chair-gated status editor targeting the next-action phase (RR-2:
+advancement stays a chair action). A gate-verdict badge reads the
+RR-1 machine ledger (`~/.attune/ops/gates/verdicts.jsonl`,
+`read_gate_verdicts`) and degrades to nothing until gates emit —
+this column is the spec's render surface from day one. Old
+per-phase pills live on in the chip tooltip. Receipts: 139
+lifecycle/routes/rewrite tests serial-green incl. 8 new
+derive_stage + 3 ledger-reader tests; live render verified against
+a worktree-code server (31 specs, honest stages, editable chips).

--- a/src/attune/ops/routes/dashboard.py
+++ b/src/attune/ops/routes/dashboard.py
@@ -566,6 +566,10 @@ async def specs_page(request: Request) -> HTMLResponse:
                     "phases": [asdict(p) for p in record.phases],
                     "last_modified": record.last_modified,
                     "lifecycle": record.lifecycle,
+                    "stage": record.stage,
+                    "next_phase": record.next_phase,
+                    "next_action": record.next_action,
+                    "next_phase_status": record.next_phase_status,
                 }
             )
     # Bucket counts for the chip filter row. All 6 keys are always present
@@ -589,11 +593,18 @@ async def specs_page(request: Request) -> HTMLResponse:
     # like `?bucket=stale&q=rag` renders correctly without a flash of
     # default state followed by JS re-render.
     initial_buckets, initial_sort, initial_query = _parse_specs_url_state(request.query_params)
+    # Gate-verdict badges (spec-lifecycle-gates UI phase): newest
+    # machine receipt per slug from the RR-1 ledger; {} until the
+    # gates ship, and the column renders identically without it.
+    from attune.ops.spec_lifecycle import read_gate_verdicts
+
+    gate_verdicts = read_gate_verdicts(cfg.attune_home / "ops" / "gates" / "verdicts.jsonl")
     return _render(
         request,
         "specs.html",
         page="specs",
         specs=specs,
+        gate_verdicts=gate_verdicts,
         roots=[str(r) for r in roots],
         allow_run=cfg.allow_run,
         specs_candidates_enabled=cfg.specs_candidates_enabled,

--- a/src/attune/ops/routes/dashboard.py
+++ b/src/attune/ops/routes/dashboard.py
@@ -570,6 +570,7 @@ async def specs_page(request: Request) -> HTMLResponse:
                     "next_phase": record.next_phase,
                     "next_action": record.next_action,
                     "next_phase_status": record.next_phase_status,
+                    "waived_phases": list(record.waived_phases),
                 }
             )
     # Bucket counts for the chip filter row. All 6 keys are always present

--- a/src/attune/ops/routes/specs.py
+++ b/src/attune/ops/routes/specs.py
@@ -115,6 +115,7 @@ async def list_specs(request: Request) -> dict:
                 "stage": s.stage,
                 "next_phase": s.next_phase,
                 "next_action": s.next_action,
+                "waived_phases": list(s.waived_phases),
             }
             for s in specs
         ],

--- a/src/attune/ops/routes/specs.py
+++ b/src/attune/ops/routes/specs.py
@@ -112,6 +112,9 @@ async def list_specs(request: Request) -> dict:
                 "path": s.path,
                 "phases": [asdict(p) for p in s.phases],
                 "lifecycle": s.lifecycle,
+                "stage": s.stage,
+                "next_phase": s.next_phase,
+                "next_action": s.next_action,
             }
             for s in specs
         ],

--- a/src/attune/ops/spec_lifecycle.py
+++ b/src/attune/ops/spec_lifecycle.py
@@ -20,8 +20,11 @@ build SpecRecord objects via ``routes/specs.py`` and pass them here.
 
 from __future__ import annotations
 
+import json
+from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
-from typing import Protocol, runtime_checkable
+from pathlib import Path
+from typing import Any, Protocol, runtime_checkable
 
 # 30-day stale threshold. Ratified 2026-05-31 in decisions.md D1.
 # Revisit if 30d proves too noisy or too quiet in practice.
@@ -159,6 +162,124 @@ def derive_lifecycle(spec: _SpecLike, *, now: datetime | None = None) -> str:
 
     # 6. Active — default
     return "active"
+
+
+@dataclass(frozen=True)
+class StageInfo:
+    """Pipeline position + next transition for one spec.
+
+    The Specs page's Stage column (spec-lifecycle-gates UI phase,
+    chair-ruled 2026-07-20): ``stage`` is where the spec sits in the
+    authoring pipeline, ``next_phase`` names the phase file the next
+    chair action targets (None when shipped), ``next_action`` is the
+    short human hint rendered in the tooltip. Derived exclusively
+    from the phase files' own status lines — there is no separate
+    tracking store to drift.
+    """
+
+    stage: str
+    next_phase: str | None
+    next_action: str
+
+
+def derive_stage(spec: _SpecLike) -> StageInfo:
+    """Return the pipeline stage + next transition for one spec.
+
+    Ladder (first match wins); ``ok`` means the phase's leading token
+    is in ``_APPROVED_STATUSES`` (which includes the terminal set):
+
+    1. **shipped** — at least one phase exists and every existing
+       phase carries a terminal token.
+    2. **requirements** — requirements.md missing or not approved.
+    3. **design** — design.md exists but not approved, OR design.md
+       missing (next action: author it or record a waiver — the
+       round table's completion ruling made waivers first-class).
+    4. **tasks** — tasks.md exists but not approved.
+    5. **executing** — everything present is approved; the remaining
+       work is execution receipts in decisions.md + status flips.
+    """
+    phase_by_name = {p.name: p for p in spec.phases}
+
+    def _ok(name: str) -> bool:
+        p = phase_by_name.get(name)
+        return (
+            p is not None
+            and p.exists
+            and p.status is not None
+            and _normalize(p.status) in _APPROVED_STATUSES
+        )
+
+    def _exists(name: str) -> bool:
+        p = phase_by_name.get(name)
+        return p is not None and p.exists
+
+    existing = [p for p in spec.phases if p.exists]
+    if existing and all(
+        p.status is not None and _normalize(p.status) in _COMPLETE_STATUSES for p in existing
+    ):
+        return StageInfo("shipped", None, "Complete — archive when ready")
+
+    if not _ok("requirements"):
+        action = (
+            "Approve requirements" if _exists("requirements") else "Draft + approve requirements"
+        )
+        return StageInfo("requirements", "requirements", action)
+
+    if _exists("design") and not _ok("design"):
+        return StageInfo("design", "design", "Approve design")
+    if not _exists("design"):
+        return StageInfo("design", "design", "Author design.md (or record a waiver)")
+
+    if _exists("tasks") and not _ok("tasks"):
+        return StageInfo("tasks", "tasks", "Approve tasks")
+
+    return StageInfo(
+        "executing",
+        "decisions",
+        "Execute; record receipts in decisions.md, then flip statuses to shipped",
+    )
+
+
+def read_gate_verdicts(ledger_path: Path) -> dict[str, dict[str, Any]]:
+    """Latest gate receipt per spec slug from the verdicts ledger.
+
+    Reads the spec-lifecycle-gates machine ledger (RR-1:
+    ``~/.attune/ops/gates/verdicts.jsonl``) and returns the newest
+    receipt per spec slug, keyed by slug. A receipt is attributed to
+    a slug when the slug appears as a path segment of its
+    ``target_artifact``. Missing ledger, unreadable file, and
+    malformed lines all degrade to "no verdict" — the Specs page
+    renders identically to the pre-gates world.
+    """
+    if not ledger_path.is_file():
+        return {}
+    verdicts: dict[str, dict[str, Any]] = {}
+    try:
+        lines = ledger_path.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return {}
+    for line in lines:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            receipt = json.loads(line)
+        except ValueError:
+            continue
+        if not isinstance(receipt, dict):
+            continue
+        target = str(receipt.get("target_artifact", ""))
+        if not target:
+            continue
+        for segment in Path(target).parts:
+            if segment in {"docs", "specs", ""}:
+                continue
+            # Ledger order is append-only; later receipts win.
+            if segment.endswith(".md"):
+                continue
+            verdicts[segment] = receipt
+            break
+    return verdicts
 
 
 def _normalize(status: str) -> str:

--- a/src/attune/ops/spec_lifecycle.py
+++ b/src/attune/ops/spec_lifecycle.py
@@ -197,8 +197,16 @@ def derive_stage(spec: _SpecLike) -> StageInfo:
     4. **tasks** — tasks.md exists but not approved.
     5. **executing** — everything present is approved; the remaining
        work is execution receipts in decisions.md + status flips.
+
+    A ``PHASE-WAIVED: <phase>`` chair line in decisions.md (surfaced
+    as ``spec.waived_phases``) satisfies the ladder for a phase whose
+    file is ABSENT — the waiver-aware branch skips it instead of
+    demanding authorship. A file that exists is always governed by
+    its own status line; waiving an existing file is contradictory
+    and ignored.
     """
     phase_by_name = {p.name: p for p in spec.phases}
+    waived = set(getattr(spec, "waived_phases", ()) or ())
 
     def _ok(name: str) -> bool:
         p = phase_by_name.get(name)
@@ -227,7 +235,7 @@ def derive_stage(spec: _SpecLike) -> StageInfo:
 
     if _exists("design") and not _ok("design"):
         return StageInfo("design", "design", "Approve design")
-    if not _exists("design"):
+    if not _exists("design") and "design" not in waived:
         return StageInfo("design", "design", "Author design.md (or record a waiver)")
 
     if _exists("tasks") and not _ok("tasks"):

--- a/src/attune/ops/specs_data.py
+++ b/src/attune/ops/specs_data.py
@@ -96,15 +96,35 @@ class SpecRecord:
     # "approved-not-shipped", "active". See
     # [docs/specs/ops-specs-page-refinement/decisions.md](../../../docs/specs/ops-specs-page-refinement/decisions.md).
     lifecycle: str = field(init=False, default="")
+    # Pipeline stage + next transition (spec-lifecycle-gates UI phase):
+    # derived from the phase statuses via `derive_stage`, same
+    # single-source discipline as `lifecycle`. `next_phase_status` is
+    # the current status string of the phase the next action targets,
+    # threaded so the page's status editor can prefill it.
+    stage: str = field(init=False, default="")
+    next_phase: str | None = field(init=False, default=None)
+    next_action: str = field(init=False, default="")
+    next_phase_status: str | None = field(init=False, default=None)
 
     def __post_init__(self) -> None:
         # Lazy import to avoid any chance of an import cycle between
         # routes/specs.py and spec_lifecycle.py (defensive; no cycle
         # exists today since spec_lifecycle uses a structural Protocol).
-        from attune.ops.spec_lifecycle import derive_lifecycle
+        from attune.ops.spec_lifecycle import derive_lifecycle, derive_stage
 
         # Frozen dataclass — use object.__setattr__ to set the field.
         object.__setattr__(self, "lifecycle", derive_lifecycle(self))
+        info = derive_stage(self)
+        object.__setattr__(self, "stage", info.stage)
+        object.__setattr__(self, "next_phase", info.next_phase)
+        object.__setattr__(self, "next_action", info.next_action)
+        status = None
+        if info.next_phase is not None:
+            for p in self.phases:
+                if p.name == info.next_phase:
+                    status = p.status
+                    break
+        object.__setattr__(self, "next_phase_status", status)
 
 
 def _extract_status(text: str) -> str | None:

--- a/src/attune/ops/specs_data.py
+++ b/src/attune/ops/specs_data.py
@@ -87,6 +87,10 @@ class SpecRecord:
     # (which shouldn't happen since _list_specs_in_root requires at
     # least one canonical phase file, but handled defensively).
     last_modified: str | None = None
+    # Phases waived by `PHASE-WAIVED: <phase>` chair lines in this
+    # spec's decisions.md (see `_scan_waived_phases`). Only consulted
+    # by stage derivation for phase files that are ABSENT.
+    waived_phases: tuple[str, ...] = ()
     # Lifecycle bucket derived from `phases` + `last_modified` via
     # `attune.ops.spec_lifecycle.derive_lifecycle`. Computed in
     # `__post_init__` so callers don't need to coordinate. `init=False`
@@ -137,6 +141,28 @@ def _extract_status(text: str) -> str | None:
     if not match:
         return None
     return match.group(1).strip()
+
+
+# Chair waiver line for a phase, committed in decisions.md — the same
+# chair-line-in-decisions pattern as `P4-ROTATION: armed`. Example:
+# `PHASE-WAIVED: design (2026-07-20 — thread q-..., see entry below)`.
+# Only the phase token is machine-read; the parenthetical is provenance
+# for humans. A waiver affects stage derivation ONLY for phases whose
+# file is absent — an existing file's own status always governs.
+_PHASE_WAIVED_RE = re.compile(r"^PHASE-WAIVED:\s*([a-z]+)", re.MULTILINE)
+
+
+def _scan_waived_phases(spec_dir: Path) -> tuple[str, ...]:
+    """Return phases waived by chair lines in this spec's decisions.md."""
+    decisions = spec_dir / "decisions.md"
+    if not decisions.is_file():
+        return ()
+    try:
+        text = decisions.read_text(encoding="utf-8")
+    except OSError:
+        return ()
+    valid = {p.removesuffix(".md") for p in _PHASE_FILES}
+    return tuple(m for m in _PHASE_WAIVED_RE.findall(text) if m in valid)
 
 
 def _scan_spec_dir(spec_dir: Path) -> list[SpecPhase]:
@@ -203,6 +229,7 @@ def _list_specs_in_root(root: Path) -> list[SpecRecord]:
                 path=str(child),
                 phases=_scan_spec_dir(child),
                 last_modified=_newest_md_mtime(child),
+                waived_phases=_scan_waived_phases(child),
             )
         )
     return records

--- a/src/attune/ops/templates/specs.html
+++ b/src/attune/ops/templates/specs.html
@@ -128,7 +128,7 @@
       <tr>
         <th class="col-slug">Spec</th>
         <th class="col-mtime">Updated</th>
-        <th class="col-phases" data-tooltip="Decisions / Requirements / Design / Tasks">Phases <span class="phase-axis">D&middot;R&middot;D&middot;T</span></th>
+        <th class="col-phases" data-tooltip="Pipeline position derived from the phase files' own status lines. Click a stage chip to advance the next phase; per-phase statuses in the tooltip.">Stage</th>
         <th class="col-lifecycle">Lifecycle</th>
         <th class="col-kebab" aria-label="Row actions"></th>
       </tr>
@@ -154,31 +154,43 @@
             {% endif %}
           </td>
           <td class="col-phases">
-            <span class="phase-pills" role="group" aria-label="Phase statuses for {{ s.slug }}">
-              {% for phase in s.phases %}
-                {% if not phase.exists %}
-                  <span class="status-pill chip-muted" data-phase="{{ phase.name }}" data-tooltip="No {{ phase.name }}.md file" aria-label="No {{ phase.name }}.md file">—</span>
-                {% else %}
-                  {% set cls = chip_cls(phase.status)|trim %}
-                  {% set code = status_code(phase.status)|trim %}
-                  {% set custom = is_custom(phase.status)|trim == '1' %}
-                  <span
-                    class="status-pill {{ cls }}{% if custom %} status-pill-custom{% endif %}{% if allow_run %} status-pill-editable{% endif %}"
-                    data-phase="{{ phase.name }}"
-                    data-tooltip="{{ phase.name|capitalize }}: {{ phase.status or '(no status)' }}"
-                    {% if allow_run %}
-                    data-slug="{{ s.slug }}"
-                    data-original="{{ phase.status or '' }}"
-                    role="button"
-                    tabindex="0"
-                    aria-label="Status for {{ phase.name }} of {{ s.slug }}: {{ phase.status or 'no status' }}. Click to edit."
-                    {% else %}
-                    aria-label="Status for {{ phase.name }} of {{ s.slug }}: {{ phase.status or 'no status' }}"
-                    {% endif %}
-                  ><span class="status-dot" aria-hidden="true"></span><span class="status-code">{{ code or '(none)' }}</span></span>
-                {% endif %}
-              {% endfor %}
-            </span>
+            {#- Stage chip (spec-lifecycle-gates UI phase): pipeline
+                position derived from the phase status lines; the old
+                per-phase pills live on in the tooltip text. When
+                editing is allowed and a next transition exists, the
+                chip reuses the pill editor targeting the next-action
+                phase — advancement stays a chair action (RR-2). -#}
+            {%- set phase_summary = [] -%}
+            {%- for phase in s.phases -%}
+              {%- if phase.exists -%}
+                {%- set _ = phase_summary.append(phase.name ~ ': ' ~ (phase.status or '(no status)')) -%}
+              {%- else -%}
+                {%- set _ = phase_summary.append(phase.name ~ ': —') -%}
+              {%- endif -%}
+            {%- endfor -%}
+            {%- set stage_tip = (phase_summary | join(' · ')) ~ ' · Next: ' ~ s.next_action -%}
+            {%- set editable = allow_run and s.next_phase -%}
+            <span
+              class="lifecycle-badge stage-badge stage-{{ s.stage }}{% if editable %} status-pill-editable{% endif %}"
+              data-tooltip="{{ stage_tip }}"
+              {% if editable %}
+              data-slug="{{ s.slug }}"
+              data-phase="{{ s.next_phase }}"
+              data-original="{{ s.next_phase_status or '' }}"
+              role="button"
+              tabindex="0"
+              aria-label="Stage {{ s.stage }} for {{ s.slug }}. Next: {{ s.next_action }}. Click to edit {{ s.next_phase }} status."
+              {% else %}
+              aria-label="Stage {{ s.stage }} for {{ s.slug }}. Next: {{ s.next_action }}"
+              {% endif %}
+            >{{ s.stage }}</span>
+            {%- if s.slug in gate_verdicts -%}
+              {%- set v = gate_verdicts[s.slug] -%}
+              <span class="status-pill gate-badge gate-{{ (v.evaluation_state or 'unknown') | lower }}"
+                    data-tooltip="Gate {{ v.gate_id or '?' }} ({{ v.phase or '?' }}): {{ v.evaluation_state or 'unknown' }}"
+                    aria-label="Latest gate verdict for {{ s.slug }}: {{ v.evaluation_state or 'unknown' }}"
+              >{{ v.evaluation_state or '?' }}</span>
+            {%- endif -%}
           </td>
           <td class="col-lifecycle">
             <span class="lifecycle-badge lifecycle-{{ s.lifecycle }}" data-tooltip="Derived from phase statuses + last-modified date">

--- a/src/attune/ops/templates/specs.html
+++ b/src/attune/ops/templates/specs.html
@@ -164,6 +164,8 @@
             {%- for phase in s.phases -%}
               {%- if phase.exists -%}
                 {%- set _ = phase_summary.append(phase.name ~ ': ' ~ (phase.status or '(no status)')) -%}
+              {%- elif phase.name in (s.waived_phases or []) -%}
+                {%- set _ = phase_summary.append(phase.name ~ ': waived') -%}
               {%- else -%}
                 {%- set _ = phase_summary.append(phase.name ~ ': —') -%}
               {%- endif -%}

--- a/tests/unit/ops/test_spec_lifecycle.py
+++ b/tests/unit/ops/test_spec_lifecycle.py
@@ -714,3 +714,48 @@ class TestReadGateVerdicts:
         )
         verdicts = read_gate_verdicts(ledger)
         assert list(verdicts) == ["ok-spec"]
+
+
+class TestStageWaiverSignal:
+    """PHASE-WAIVED chair lines satisfy the ladder for ABSENT files."""
+
+    def test_waived_design_advances_past_design(self):
+        spec = _Spec(phases=_all_phases(requirements="approved (2026-07-18)"))
+        spec.waived_phases = ("design",)
+        info = derive_stage(spec)
+        assert info.stage == "executing"
+        assert info.next_phase == "decisions"
+
+    def test_waiver_ignored_when_design_file_exists(self):
+        """An existing file's own status governs; waiving it is contradictory."""
+        spec = _Spec(phases=_all_phases(requirements="approved", design="draft"))
+        spec.waived_phases = ("design",)
+        info = derive_stage(spec)
+        assert info.stage == "design"
+        assert info.next_action == "Approve design"
+
+    def test_no_waiver_still_demands_design(self):
+        spec = _Spec(phases=_all_phases(requirements="approved"))
+        info = derive_stage(spec)
+        assert info.stage == "design"
+        assert "waiver" in info.next_action
+
+    def test_scan_waived_phases_reads_chair_line(self, tmp_path):
+        from attune.ops.specs_data import _scan_waived_phases
+
+        d = tmp_path / "some-spec"
+        d.mkdir()
+        (d / "decisions.md").write_text(
+            "# Decisions\n\nbody text\n\n"
+            "PHASE-WAIVED: design (2026-07-20 — thread q-x-001)\n"
+            "PHASE-WAIVED: nonsense (not a phase)\n",
+            encoding="utf-8",
+        )
+        assert _scan_waived_phases(d) == ("design",)
+
+    def test_scan_waived_phases_missing_decisions(self, tmp_path):
+        from attune.ops.specs_data import _scan_waived_phases
+
+        d = tmp_path / "bare-spec"
+        d.mkdir()
+        assert _scan_waived_phases(d) == ()

--- a/tests/unit/ops/test_spec_lifecycle.py
+++ b/tests/unit/ops/test_spec_lifecycle.py
@@ -22,6 +22,8 @@ import pytest
 from attune.ops.spec_lifecycle import (
     STALE_THRESHOLD_DAYS,
     derive_lifecycle,
+    derive_stage,
+    read_gate_verdicts,
 )
 
 # ----- Test fixtures --------------------------------------------------
@@ -613,3 +615,102 @@ class TestLivingAndShippedTokens:
             last_modified=FRESH,
         )
         assert derive_lifecycle(spec, now=NOW) == "approved-not-shipped"
+
+
+# ----- Stage derivation (spec-lifecycle-gates UI phase) ----------------
+
+
+class TestDeriveStage:
+    """derive_stage: pipeline position + next transition."""
+
+    def test_shipped_when_all_existing_terminal(self):
+        spec = _Spec(phases=_all_phases(requirements="shipped (2026-07-20)", decisions="shipped"))
+        info = derive_stage(spec)
+        assert info.stage == "shipped"
+        assert info.next_phase is None
+
+    def test_requirements_stage_when_missing(self):
+        spec = _Spec(phases=_all_phases(decisions="draft"))
+        info = derive_stage(spec)
+        assert info.stage == "requirements"
+        assert info.next_phase == "requirements"
+        assert "Draft" in info.next_action
+
+    def test_requirements_stage_when_unapproved(self):
+        spec = _Spec(phases=_all_phases(requirements="draft (2026-07-01)"))
+        info = derive_stage(spec)
+        assert info.stage == "requirements"
+        assert info.next_action == "Approve requirements"
+
+    def test_design_stage_when_design_unapproved(self):
+        spec = _Spec(
+            phases=_all_phases(requirements="approved (2026-07-19)", design="draft — OQ open")
+        )
+        info = derive_stage(spec)
+        assert info.stage == "design"
+        assert info.next_phase == "design"
+        assert info.next_action == "Approve design"
+
+    def test_design_stage_when_design_missing(self):
+        spec = _Spec(phases=_all_phases(requirements="approved (2026-07-19)"))
+        info = derive_stage(spec)
+        assert info.stage == "design"
+        assert "waiver" in info.next_action
+
+    def test_tasks_stage_when_tasks_unapproved(self):
+        spec = _Spec(
+            phases=_all_phases(
+                requirements="approved", design="approved (2026-07-19)", tasks="draft"
+            )
+        )
+        info = derive_stage(spec)
+        assert info.stage == "tasks"
+        assert info.next_phase == "tasks"
+
+    def test_executing_when_all_present_approved(self):
+        spec = _Spec(
+            phases=_all_phases(
+                requirements="approved", design="approved", tasks="approved", decisions="active"
+            )
+        )
+        info = derive_stage(spec)
+        assert info.stage == "executing"
+        assert info.next_phase == "decisions"
+
+    def test_partial_terminal_is_not_shipped(self):
+        """One shipped phase + one in-flight phase != shipped spec."""
+        spec = _Spec(phases=_all_phases(requirements="shipped", design="draft"))
+        assert derive_stage(spec).stage == "design"
+
+
+class TestReadGateVerdicts:
+    """read_gate_verdicts: RR-1 ledger reader, graceful everywhere."""
+
+    def test_missing_ledger_returns_empty(self, tmp_path):
+        assert read_gate_verdicts(tmp_path / "nope.jsonl") == {}
+
+    def test_reads_latest_receipt_per_slug(self, tmp_path):
+        ledger = tmp_path / "verdicts.jsonl"
+        ledger.write_text(
+            '{"receipt_id": "r1", "target_artifact": "docs/specs/my-spec/design.md", '
+            '"evaluation_state": "REVISE", "gate_id": "g1", "phase": "design"}\n'
+            '{"receipt_id": "r2", "target_artifact": "docs/specs/my-spec/design.md", '
+            '"evaluation_state": "PASS", "gate_id": "g1", "phase": "design"}\n',
+            encoding="utf-8",
+        )
+        verdicts = read_gate_verdicts(ledger)
+        assert verdicts["my-spec"]["evaluation_state"] == "PASS"
+        assert verdicts["my-spec"]["receipt_id"] == "r2"
+
+    def test_malformed_lines_skipped(self, tmp_path):
+        ledger = tmp_path / "verdicts.jsonl"
+        ledger.write_text(
+            "not json at all\n"
+            '["a", "list"]\n'
+            '{"no_target": true}\n'
+            '{"target_artifact": "docs/specs/ok-spec/requirements.md", '
+            '"evaluation_state": "CHAIR_REQUIRED"}\n',
+            encoding="utf-8",
+        )
+        verdicts = read_gate_verdicts(ledger)
+        assert list(verdicts) == ["ok-spec"]

--- a/tests/unit/ops/test_specs_dashboard.py
+++ b/tests/unit/ops/test_specs_dashboard.py
@@ -73,17 +73,17 @@ def test_specs_page_lists_specs_with_status_chips(tmp_path):
 
 
 def test_specs_page_writeable_mode_shows_editable_pills(tmp_path):
-    """allow_run=True → status renders as an editable pill (click-to-edit).
+    """allow_run=True → the Stage chip is editable (click-to-edit).
 
-    Earlier versions rendered inline ``<select>`` dropdowns server-side.
-    PR #358 swapped that for compact status pills that swap to a select
-    on click via specs.js. We verify the writeable-mode markers
-    (status-pill-editable class, role=button, tabindex, data attributes)
-    are present, and that no inline ``<select>`` is rendered until the
-    user clicks the pill.
+    Earlier versions rendered per-phase pills (PR #358); the Stage
+    column replaced them with ONE derived chip that reuses the same
+    click-to-edit machinery, pre-targeted at the next-action phase.
+    We verify the writeable-mode markers (status-pill-editable class,
+    role=button, tabindex, data attributes) are present, and that no
+    inline ``<select>`` is rendered until the user clicks the chip.
     """
     root = tmp_path / "specs"
-    _make_spec(root, "alpha", files={"tasks.md": "**Status:** draft\n"})
+    _make_spec(root, "alpha", files={"requirements.md": "**Status:** draft\n"})
     client = _client(tmp_path, specs_roots=(root,), allow_run=True)
     r = client.get("/specs")
     assert r.status_code == 200
@@ -97,9 +97,11 @@ def test_specs_page_writeable_mode_shows_editable_pills(tmp_path):
     assert "status-pill-editable" in r.text
     assert 'role="button"' in r.text
     assert 'tabindex="0"' in r.text
-    # Per-cell data attributes feed the PUT /api/specs/.../status call.
+    # Per-cell data attributes feed the PUT /api/specs/.../status call —
+    # the chip targets the NEXT-action phase (unapproved requirements
+    # here) with its current status prefilled.
     assert 'data-slug="alpha"' in r.text
-    assert 'data-phase="tasks"' in r.text
+    assert 'data-phase="requirements"' in r.text
     assert 'data-original="draft"' in r.text
 
 
@@ -122,14 +124,19 @@ def test_specs_page_readonly_mode_no_status_dropdowns(tmp_path):
 
 
 def test_specs_page_shows_em_dash_for_missing_phases(tmp_path):
-    """A spec with only tasks.md → other 3 phase columns show em-dash."""
+    """A spec with only tasks.md → missing phases marked in the Stage tooltip.
+
+    The per-phase pills (and their ``chip-muted`` em-dash cells) were
+    replaced by the Stage chip; missing phases now render as
+    ``<name>: —`` inside the chip's tooltip summary.
+    """
     root = tmp_path / "specs"
     _make_spec(root, "alpha", files={"tasks.md": "**Status:** draft\n"})
     client = _client(tmp_path, specs_roots=(root,), allow_run=False)
-    r = client.text if False else client.get("/specs").text
-    # 3 missing phases → 3 em-dashes (one per cell). We can't count exactly because
-    # the page chrome may also contain em-dashes, but we can verify the chip class.
-    assert "chip-muted" in r
+    r = client.get("/specs").text
+    assert "requirements: —" in r
+    assert "design: —" in r
+    assert "tasks: draft" in r
 
 
 def test_specs_page_includes_specs_js_when_writeable(tmp_path):


### PR DESCRIPTION
## Summary

Chair-ruled tonight (pushback accepted, option 1): the Phases pills column becomes a **Stage** column — pipeline position derived at render time from the phase files' own status lines. No separate tracking store, nothing to drift; the status-line vocabulary + gate remain the single source of truth.

- `derive_stage` ladder: `requirements → design → tasks → executing → shipped`, with an honest next-transition hint per stage (incl. "author design.md (or record a waiver)" — waivers are first-class per the round-table completion ruling).
- The chip stays **click-to-manage**: it reuses the existing chair-gated status editor, pre-targeted at the next-action phase (RR-2: advancement is a chair action, never automatic).
- **Gate-verdict badge**: reads the spec-lifecycle-gates RR-1 machine ledger (`~/.attune/ops/gates/verdicts.jsonl`) and shows the newest receipt per spec; degrades to nothing until gates emit. This column is that spec's render surface from day one.
- Old per-phase pills live on in the chip tooltip; JSON API gains `stage`/`next_phase`/`next_action`.
- Homed as the spec-lifecycle-gates UI phase — decisions.md entry included.

## Receipts

- 139 lifecycle/routes/rewrite tests serial-green, incl. 8 new `derive_stage` + 3 ledger-reader tests (missing ledger, latest-wins, malformed lines).
- Live render verified against a worktree-code server: 31 specs, honest stages (memory-recall-eval → `executing` because its decisions.md really lacks a status line; agent-round-table → `design` matching the waiver just ruled), editable chips carrying the next-phase targeting.
- Pinned black/ruff clean.

Path-reading code included (ledger reader): **auto-merge label withheld until the windows-latest lanes pass** per the #1537 procedure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)