### PR TITLE
docs(spec): antigravity-adapter shipped — receipts closed, stale status corrected

### DIFF
--- a/docs/specs/antigravity-adapter/decisions.md
+++ b/docs/specs/antigravity-adapter/decisions.md
@@ -1,5 +1,9 @@
 # Antigravity Adapter — Decisions
 
+**Status:** shipped (2026-07-21) — completion pass below;
+reopen condition: Antigravity self-update breaks a verified
+mechanism
+
 ## D1 — contract delivery: RATIFIED (a) — 2026-07-18, Patrick
 
 Live receipts, 2026-07-18, Antigravity app 2.3.1 + `agy` CLI 1.1.4
@@ -186,3 +190,29 @@ Carried risk (unchanged from D1): the IDE-native
 `.agents/AGENTS.md` load path and the CLI's `trigger:` frontmatter
 + relative @-expansion are verified behaviors on app 2.3.1 /
 agy 1.1.4 — re-verify after self-updates.
+
+## 2026-07-21 — Completion pass: spec shipped (chair-requested)
+
+All design forks resolved and every acceptance criterion receipted;
+the stale "D3 still open" status line is corrected in this pass.
+
+| AC | Receipt | Where |
+|---|---|---|
+| AC-1 skills (zero-work) | PASS 41/41 mirrored skills discovered (`--add-dir`/workspace required — recorded caveat) | entry above (2026-07-18) |
+| AC-2 contract via rules | PASS with two doc-vs-tool corrections (`trigger: always_on` frontmatter; rules-file-relative `@`-paths) | entry above + transcripts |
+| AC-3 drift guard | D1=(a) ruled, so the (b)-conditional lapses; #1445's `.agents/AGENTS.md` fourth projector target carries `--check` drift-guarding + two tests anyway | #1445 (`cc2e7d1a2`) |
+| AC-4 preflight + checks | Re-run LIVE this pass: preflight 0 failed (governance 76 passed, skills-projection in sync), `project_collaboration_contract.py --check` all four targets unchanged, `sync_agents_skills.py --check` 42 ok | this entry |
+| AC-5 full keyless suite | All 10 required contexts green incl. the Windows lane | #1445 |
+
+R1-R6 hold: contract reaches Antigravity mechanically (rule file +
+`.agents/AGENTS.md` byte-copy), skills mirror consumed as-is, R4
+preflight check silent-when-absent, global config untouched. No
+design.md was ever authored — the design forks (D1-D3) lived in
+requirements.md and were resolved by receipts in this file; the
+stage ladder reads this spec as shipped from the terminal statuses.
+
+**Carried risk (standing, unchanged):** the verified behaviors are
+pinned to app 2.3.1 / agy 1.1.4 — re-verify the `trigger:`
+frontmatter, relative `@`-expansion, and IDE `.agents/AGENTS.md`
+load path after Antigravity self-updates. Reopen via a dated entry
+here if a self-update breaks either mechanism.

--- a/docs/specs/antigravity-adapter/requirements.md
+++ b/docs/specs/antigravity-adapter/requirements.md
@@ -1,14 +1,11 @@
 # Antigravity Adapter — Requirements
 
-**Status:** active (2026-07-18) — D1 ratified (a); receipts passed and Patrick
-ratified option (a) same day (2026-07-18,
-app 2.3.1 + agy CLI 1.1.4; transcripts in
-[decisions.md](decisions.md)); D2 largely
-resolved by the receipts; D3 (IDE parity) still open. Two
-mechanisms differ from the live docs — rules need
-`trigger: always_on` frontmatter and only rules-file-relative
-`@`-paths inline — exactly the schema-drift class the
-gemini-projector spec predicted.
+**Status:** shipped (2026-07-21 — D1 ratified (a) + #1445's
+.agents/AGENTS.md target; D2 resolved by receipts; D3 CLOSED
+(IDE parity probe PASS post-#1445); AC-1..AC-5 receipted, AC-4
+re-run live at close; see decisions.md completion pass. Carried
+risk: behaviors pinned to app 2.3.1 / agy 1.1.4 — re-verify
+after self-updates)
 
 Sibling of [gemini-projector](../gemini-projector/requirements.md)
 (PARKED 2026-07-18 — Google sunset the Gemini CLI free tier in


### PR DESCRIPTION
Completion pass, chair-requested 2026-07-21. The spec was substantively done — D1 ratified (a) with transcripts, D2 resolved by receipts, D3 CLOSED by the post-#1445 IDE parity probe, implementation shipped (#1445: `.agents/AGENTS.md` fourth projector target, all 10 required contexts green incl. Windows) — but the requirements status line still read "D3 still open".

This pass adds the AC-by-AC receipt table (AC-4 re-run LIVE at close: preflight 0 failed with governance 76 green, both projector checks clean, 42 skills in sync), flips both phase files to `shipped`, and pins the carried risk (behaviors verified on app 2.3.1 / agy 1.1.4; reopen on self-update breakage).

No design.md and no waiver marker needed: the design forks lived in requirements.md and all existing phase files now carry terminal tokens, so the Stage ladder reads shipped directly.

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)