### PR TITLE
docs(spec): round-table extensions ruled — P3 skeptic → P2 inbox → P4 telemetry; P1 cut

### DIFF
--- a/docs/specs/agent-round-table/decisions.md
+++ b/docs/specs/agent-round-table/decisions.md
@@ -431,3 +431,43 @@ pick); roundtable-triage / roundtable-producing-team carry active
 status.
 
 PHASE-WAIVED: design (2026-07-20 — completion pass above; thread q-agent-round-table-completion-001)
+
+## 2026-07-21 — Table extensions ruled (thread q-roundtable-extensions-001; chair: Patrick)
+
+Four chair-proposed extensions deliberated (1 round, all seats;
+unanimous adopt on three, unanimous CUT on one; ordering split
+resolved by a moderator fact-check: `verdicts.jsonl` does not exist
+yet, so inbox-before-mail lost to the seats' own contingency
+logic). Build order ruled: **P3 → P2 → P4-recording; P1 cut.**
+
+**P3 — rotating skeptic for closure claims (BUILD FIRST).** V1
+shape, R1-pure per antigravity's correction: when a spec closure
+entry is staged, the HARNESS re-runs the declared cheap receipt
+commands (reusing `solutions.validate`, isolated) and feeds the raw
+output as TEXT to a rotation-picked NON-AUTHOR seat, which emits a
+structured COUNTERSIGN or DISSENT citing the exact command + tail.
+One skeptic pass. **Dissent fork ruled: one author bounce first**
+(solution-loop precedent; counts against the cap), then the chair
+digest. Failure modes on record: rubber-stamp decay; spurious
+environment dissents training the chair to ignore dissent.
+
+**P4 — role telemetry (RECORD-ONLY).** Immutable per-run events
+appended alongside the rotation ledger: seat, role, run/spec,
+artifact version, outcome, reason codes (draft survival, critique
+absorption, skeptic dissent hit-rate). Aggregates exposed only past
+a chair-set minimum-N; NO assignment recommendations in v1 —
+Goodhart named independently by all three seats. Starts recording
+when P3/P2 launch.
+
+**P1 — seat-authored specialist agents: CUT (unanimous).** All
+three seats answered the cut question with P1: shelfware risk,
+meta-ceremony (RR-4), authority creep, supply-chain surface.
+Extraction path preserved: a receipt-auditor SKILL may later be
+EXTRACTED from a P3 procedure stable over N real closures plus P4
+evidence — never designed cold; the skeptic's governance
+(different-model rule, dissent semantics, caps, chair-only
+promotion) stays substrate-enforced, never agent-defined. Reopen
+only via that evidence path.
+
+P2 (gate-triage inbox) is recorded in
+`docs/specs/spec-lifecycle-gates/decisions.md` — its owning spec.

--- a/docs/specs/agent-round-table/decisions.md
+++ b/docs/specs/agent-round-table/decisions.md
@@ -454,7 +454,11 @@ environment dissents training the chair to ignore dissent.
 **P4 — role telemetry (RECORD-ONLY).** Immutable per-run events
 appended alongside the rotation ledger: seat, role, run/spec,
 artifact version, outcome, reason codes (draft survival, critique
-absorption, skeptic dissent hit-rate). Aggregates exposed only past
+absorption, skeptic dissent hit-rate), and — chair-added 2026-07-21
+— **chair latency**: staged/digested timestamp → ruling timestamp
+per item, so the load on the human-in-the-loop is measured before
+it saturates (the gates spec will multiply CHAIR_REQUIRED volume;
+the 07-27+ reads should see the trend, not discover it). Aggregates exposed only past
 a chair-set minimum-N; NO assignment recommendations in v1 —
 Goodhart named independently by all three seats. Starts recording
 when P3/P2 launch.

--- a/docs/specs/spec-lifecycle-gates/decisions.md
+++ b/docs/specs/spec-lifecycle-gates/decisions.md
@@ -161,3 +161,19 @@ per-phase pills live on in the chip tooltip. Receipts: 139
 lifecycle/routes/rewrite tests serial-green incl. 8 new
 derive_stage + 3 ledger-reader tests; live render verified against
 a worktree-code server (31 specs, honest stages, editable chips).
+
+## 2026-07-21 — P2 gate-triage inbox ruled (thread q-roundtable-extensions-001; chair: Patrick)
+
+The round table adopted (modified) the gate-triage inbox as the
+consumption surface for this spec's RR-1 ledger, to be built AFTER
+the P3 skeptic (order ruled on the moderator's fact-check:
+`verdicts.jsonl` not yet emitting). V1 shape: a READ-ONLY routine
+that groups unresolved CHAIR_REQUIRED receipts by spec+gate,
+convenes ONE D3-capped mini-table only past a threshold (N≥3
+pending OR oldest >48h), emits one disposition per shortfall from a
+closed enum, appends a single chair digest, and marks receipts
+triaged (dedup mandatory — never re-deliberate the same shortfall).
+Never alters gate state; RR-4 risk tiers govern eligibility from
+day one. P3 skeptic dissents route into this digest (one chair
+inbox). Failure mode on record: inbox ceremony — a meeting queue
+noisier than the raw ledger.


### PR DESCRIPTION
Round-table thread `q-roundtable-extensions-001` (1 round, all seats present), chair-ruled per the synthesized package:

- **P3 skeptic countersign — build first.** R1-pure shape (the harness re-runs `solutions.validate`; a rotation-picked non-author seat judges the raw output as text); structured countersign/dissent citing exact command + tail; one pass; **dissent bounces once to the author** before the chair digest.
- **P2 gate-triage inbox — second** (recorded in spec-lifecycle-gates, its owning spec): read-only, thresholded (N≥3 or >48h), deduped, closed disposition enum, RR-4 tiers from day one. Ordering flipped from the chair's initial 2-first on a moderator fact-check: the verdicts ledger does not exist yet.
- **P4 role telemetry — record-only**: immutable events + reason codes; aggregates gated on min-N; no recommendations (Goodhart named by all three seats).
- **P1 seat-authored agents — CUT, unanimously** (all three seats chose it as the one to cut), with the extraction path preserved: a receipt-auditor may later be extracted from a proven P3 procedure + P4 evidence, never designed cold.

Rulings only — builds are follow-on work in the ruled order. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)