### PR TITLE
feat(orchestration): Adaptive Friction Matrix + PreToolUse friction gate

### DIFF
--- a/docs/reports/roundtable/q-review-five-implementation-plans-001.md
+++ b/docs/reports/roundtable/q-review-five-implementation-plans-001.md
@@ -1,0 +1,18 @@
+# Round Table Deliberation Report: 5-PR Implementation Plan
+
+- **Thread ID:** q-review-five-implementation-plans-001
+- **Status:** Promoted (Chair-Ruled)
+- **Promoted Message IDs:** 2, 3, 5
+
+## Ratified Implementation Sequence
+
+1. **PR 1: Adaptive Friction Matrix** (`src/attune/orchestration/friction/`)
+   - Core 2D risk/clarity gating engine and pretooluse hook enforcement.
+2. **PR 5: AST-Driven Context Budgeting** (`src/attune/rag/ast_budget/`)
+   - AST skeleton generator & dynamic token budget manager (50%+ token cost reduction). Includes Redis caching for parsed ASTs (`attune:ast:<file_sha256>`).
+3. **PR 3: Self-Healing Traps** (`src/attune/telemetry/lessons/`)
+   - Pre-commit & verification failure listeners, root-cause synthesizer, `.claude/lessons.md` + Redis memory hydration.
+4. **PR 2: Ghost Simulator Sandbox** (`src/attune/orchestration/ghosts/`)
+   - Ephemeral Git worktrees under `.attune/ghosts`, parallel trajectory execution, comparative diff matrix. Includes ephemeral memory tagging (`ghost:true`) to prevent memory pollution.
+5. **PR 4: Visual Debate Theater** (`attune-gui/src/components/debate/`)
+   - Real-time WebSocket event broadcaster, Cytoscape graph UI, Executive Chair promotion panel in `attune-gui`.

--- a/plugin/hooks/friction_gate.py
+++ b/plugin/hooks/friction_gate.py
@@ -1,0 +1,106 @@
+"""PreToolUse Adaptive Friction gate for Bash commands.
+
+Scores each proposed Bash command with the Adaptive Friction Matrix
+(`attune.orchestration.friction`). PreToolUse payloads carry no user
+prompt, so intent clarity bottoms out at 1 and the gate keys off
+blast radius alone: high-risk commands land in zone 4.
+
+Modes:
+    advisory (default): zone-3/4 commands print a one-line warning to
+        stdout and the call proceeds (exit 0).
+    enforce (``ATTUNE_FRICTION_ENFORCE=1``): zone-4 commands are
+        blocked (exit 2, reason on stderr); everything else proceeds.
+
+The gate degrades silently: if the friction module is unavailable or
+the payload is malformed, the tool call is allowed (exit 0). Hard
+security invariants stay in ``security_guard.py`` — this hook is a
+risk-awareness layer, not the security boundary.
+
+Claude Code Protocol:
+    stdin: JSON with tool_name and tool_input
+    exit 0: allow tool call
+    exit 2: block tool call (reason printed to stderr)
+
+Copyright 2026 Smart-AI-Memory
+Licensed under Apache 2.0
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+_HOOK_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(_HOOK_DIR))
+
+from _bootstrap import ensure_utf8_stdio, read_stdin_utf8  # noqa: E402
+
+
+def _load_matrix_cls():
+    """Import FrictionMatrix from the installed package or a repo src/ tree."""
+    try:
+        from attune.orchestration.friction import FrictionMatrix
+
+        return FrictionMatrix
+    except ImportError:
+        pass
+
+    src = Path.cwd() / "src"
+    if (src / "attune" / "__init__.py").is_file():
+        sys.path.insert(0, str(src))
+        try:
+            from attune.orchestration.friction import FrictionMatrix
+
+            return FrictionMatrix
+        except ImportError:
+            return None
+    return None
+
+
+def main() -> int:
+    """Evaluate the incoming Bash command; return the hook exit code."""
+    ensure_utf8_stdio()
+
+    try:
+        payload = json.loads(read_stdin_utf8(100_000))
+    except (json.JSONDecodeError, ValueError):
+        return 0
+
+    if not isinstance(payload, dict) or payload.get("tool_name") != "Bash":
+        return 0
+
+    tool_input = payload.get("tool_input") or {}
+    command = tool_input.get("command", "") if isinstance(tool_input, dict) else ""
+    if not command:
+        return 0
+
+    matrix_cls = _load_matrix_cls()
+    if matrix_cls is None:
+        return 0
+
+    try:
+        result = matrix_cls().evaluate_action(user_prompt="", command_line=command)
+    except Exception as exc:  # noqa: BLE001 — hook must never crash a tool call
+        print(f"[friction-gate] evaluation skipped: {exc}", file=sys.stderr)
+        return 0
+
+    directive = result.get("directive", "")
+    reason = result.get("reason", "")
+
+    if directive == "socratic_gate" and os.environ.get("ATTUNE_FRICTION_ENFORCE") == "1":
+        print(f"[friction-gate] BLOCKED: {reason}", file=sys.stderr)
+        return 2
+
+    if directive in ("plan_review_gate", "socratic_gate"):
+        print(f"[friction-gate] high blast radius: {reason}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    from _sdk_gate import exit_if_sdk_subprocess
+
+    exit_if_sdk_subprocess()
+    sys.exit(main())

--- a/plugin/hooks/hooks.json
+++ b/plugin/hooks/hooks.json
@@ -80,6 +80,16 @@
         ]
       },
       {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "PY=$(command -v python3 || command -v python) && \"$PY\" ${CLAUDE_PLUGIN_ROOT}/hooks/friction_gate.py",
+            "timeout": 4000
+          }
+        ]
+      },
+      {
         "matcher": "Edit|Write",
         "hooks": [
           {

--- a/src/attune/orchestration/friction/__init__.py
+++ b/src/attune/orchestration/friction/__init__.py
@@ -1,0 +1,16 @@
+"""Friction Matrix module for attune-ai.
+
+Provides 2D risk/clarity evaluation and zone-based interruption governance.
+"""
+
+from .ambiguity import AmbiguityEvaluator
+from .blast_radius import BlastRadiusClassifier
+from .matrix import FrictionDirective, FrictionMatrix, FrictionZone
+
+__all__ = [
+    "BlastRadiusClassifier",
+    "AmbiguityEvaluator",
+    "FrictionMatrix",
+    "FrictionZone",
+    "FrictionDirective",
+]

--- a/src/attune/orchestration/friction/ambiguity.py
+++ b/src/attune/orchestration/friction/ambiguity.py
@@ -1,0 +1,59 @@
+"""Ambiguity Evaluator for Attune AI.
+
+Evaluates user prompt clarity and parameter completeness to assign an
+Intent Clarity score from 1 (highly ambiguous) to 5 (highly explicit).
+"""
+
+import re
+
+
+class AmbiguityEvaluator:
+    """Evaluates prompt specificity and parameter completeness."""
+
+    GENERIC_PROMPT_KEYWORDS: frozenset[str] = frozenset(
+        {
+            "fix this",
+            "clean up",
+            "make it work",
+            "do it",
+            "refactor",
+            "update code",
+            "improve performance",
+        }
+    )
+
+    # Matched on word boundaries so "line" does not fire on "pipeline"
+    # and "test" does not fire on "latest".
+    _SPECIFIC_INDICATORS = re.compile(r"\b(file|line|class|function|module|test|return|type)\b")
+
+    def evaluate_prompt(self, user_prompt: str, target_path: str | None = None) -> int:
+        """Evaluates user prompt clarity.
+
+        Args:
+            user_prompt: Raw prompt text provided by the user.
+            target_path: Target path if explicitly specified.
+
+        Returns:
+            Clarity score integer between 1 (ambiguous) and 5 (explicit).
+        """
+        if not user_prompt or not user_prompt.strip():
+            return 1
+
+        prompt_clean = user_prompt.strip().lower()
+        score = 3  # Neutral default
+
+        # Explicit target path boosts clarity
+        if target_path and target_path.strip():
+            score += 1
+
+        # Short prompts built around a generic phrase are ambiguous
+        if len(prompt_clean) < 30 and any(
+            generic in prompt_clean for generic in self.GENERIC_PROMPT_KEYWORDS
+        ):
+            score -= 2
+
+        # Structured prompts naming files/lines/functions boost clarity
+        if len(set(self._SPECIFIC_INDICATORS.findall(prompt_clean))) >= 3:
+            score += 1
+
+        return min(5, max(1, score))

--- a/src/attune/orchestration/friction/blast_radius.py
+++ b/src/attune/orchestration/friction/blast_radius.py
@@ -1,0 +1,141 @@
+"""Blast Radius Classifier for Attune AI.
+
+Evaluates structural risk, file path sensitivity, and command
+destructiveness to assign a blast radius score from 1 (lowest risk)
+to 5 (highest risk).
+
+The classifier is a fast heuristic, not a sandbox: destructive
+patterns are checked FIRST (a chained ``ls && rm -rf`` must never
+score as read-only), and paths are normalized to forward slashes so
+the same file scores identically on Windows and POSIX.
+"""
+
+import os
+import re
+
+# Path patterns are anchored to a path segment boundary so that e.g.
+# ``docs/oauth/notes.md`` does NOT match the ``auth/`` rule.
+_CRITICAL_PATH_PATTERNS: tuple[re.Pattern[str], ...] = tuple(
+    re.compile(p, re.IGNORECASE)
+    for p in (
+        r"(^|/)auth/",
+        r"(^|/)crypto/",
+        r"(^|/)security/",
+        r"(^|/)database/migrations/",
+        r"(^|/)\.env(\.[\w.-]+)?$",
+        r"(^|/)AGENTS\.md$",
+        r"(^|/)contract\.md$",
+    )
+)
+
+_DESTRUCTIVE_COMMAND_PATTERNS: tuple[re.Pattern[str], ...] = tuple(
+    re.compile(p, re.IGNORECASE)
+    for p in (
+        # rm with both recursive and force flags, in any order or grouping
+        # (-rf, -fr, -r -f, --recursive --force).
+        r"\brm\b(?=[^;|&]*\s-{1,2}[a-z-]*r)(?=[^;|&]*\s-{1,2}[a-z-]*f)",
+        r"\bdrop\s+table\b",
+        r"\btruncate\b",
+        r"\bgit\s+reset\s+--hard\b",
+        r"\bgit\s+clean\b[^;|&]*\s-[a-z]*f",
+        r"\bgit\s+checkout\s+--\s",
+        r"\bgit\s+push\b[^;|&]*(\s--force(-with-lease)?\b|\s-f\b)",
+        r"\bgit\s+branch\s+-D\b",
+    )
+)
+
+_MODIFYING_COMMAND_PATTERNS: tuple[re.Pattern[str], ...] = tuple(
+    re.compile(p, re.IGNORECASE)
+    for p in (
+        r"\bgit\s+commit\b",
+        r"\bgit\s+push\b",
+        r"\bpip\s+install\b",
+        r"\buv\s+(add|pip\s+install)\b",
+        r"\bmv\b",
+        r"\brm\b",
+    )
+)
+
+_READ_ONLY_PREFIX = re.compile(
+    r"^(ls|git\s+(status|diff|log|show)|cat|head|tail|grep|find|wc"
+    r"|pytest|python\s+-m\s+pytest)\b"
+)
+
+# Chaining/redirection tokens mean the first token no longer describes
+# the whole command — a read-only prefix must not short-circuit.
+_SHELL_CHAIN_TOKENS = re.compile(r"[;&|>`]|\$\(|<\(")
+
+
+class BlastRadiusClassifier:
+    """Classifies planned operations into numerical risk levels (1-5)."""
+
+    def __init__(self, workspace_root: str | None = None) -> None:
+        """Initialize classifier with optional workspace root.
+
+        Args:
+            workspace_root: Base directory for relative path calculation.
+        """
+        self.workspace_root = os.path.abspath(workspace_root) if workspace_root else os.getcwd()
+
+    def evaluate_file_path(self, target_path: str, is_deletion: bool = False) -> int:
+        """Evaluates blast radius score for a target file path.
+
+        Args:
+            target_path: Path to the target file.
+            is_deletion: Whether the action deletes the target.
+
+        Returns:
+            Risk score integer between 1 and 5.
+        """
+        if not target_path:
+            return 1
+
+        rel_path = self._sanitize_and_relativize(target_path)
+        base_score = 1
+
+        if is_deletion:
+            base_score += 2
+
+        if any(p.search(rel_path) for p in _CRITICAL_PATH_PATTERNS):
+            base_score += 3
+
+        return min(5, max(1, base_score))
+
+    def evaluate_command(self, command_line: str) -> int:
+        """Evaluates blast radius score for a shell command string.
+
+        Args:
+            command_line: Full command line string proposed for execution.
+
+        Returns:
+            Risk score integer between 1 and 5.
+        """
+        if not command_line or not command_line.strip():
+            return 1
+
+        cmd = command_line.strip()
+
+        # Destructive patterns dominate everything else, including a
+        # read-only first token (``git status; git reset --hard``).
+        if any(p.search(cmd) for p in _DESTRUCTIVE_COMMAND_PATTERNS):
+            return 5
+
+        # A read-only prefix only proves the command is read-only when
+        # nothing is chained, piped, or redirected after it.
+        if _READ_ONLY_PREFIX.match(cmd) and not _SHELL_CHAIN_TOKENS.search(cmd):
+            return 1
+
+        score = 1
+        if any(p.search(cmd) for p in _MODIFYING_COMMAND_PATTERNS):
+            score += 2
+
+        return min(5, max(1, score))
+
+    def _sanitize_and_relativize(self, raw_path: str) -> str:
+        """Normalizes a path relative to workspace root with '/' separators."""
+        abs_path = os.path.abspath(raw_path)
+        try:
+            rel = os.path.relpath(abs_path, self.workspace_root)
+        except ValueError:
+            rel = raw_path
+        return rel.replace("\\", "/")

--- a/src/attune/orchestration/friction/matrix.py
+++ b/src/attune/orchestration/friction/matrix.py
@@ -1,0 +1,113 @@
+"""Adaptive Friction Matrix Controller for Attune AI.
+
+Maps 2D (Blast Radius, Intent Clarity) scores into 4 Friction Zones and emits execution directives.
+"""
+
+from enum import Enum
+from typing import Any
+
+from .ambiguity import AmbiguityEvaluator
+from .blast_radius import BlastRadiusClassifier
+
+
+class FrictionZone(str, Enum):
+    """Enumeration of the 4 Adaptive Friction Zones."""
+
+    ZONE_1_AUTONOMOUS = "zone_1_autonomous"
+    ZONE_2_INFORM_PROCEED = "zone_2_inform_proceed"
+    ZONE_3_PLAN_GATE = "zone_3_plan_gate"
+    ZONE_4_SOCRATIC_GATE = "zone_4_socratic_gate"
+
+
+class FrictionDirective(str, Enum):
+    """Actionable execution directive for tool hooks and agent loops."""
+
+    ALLOW_AUTONOMOUS = "allow_autonomous"
+    INFORM_AND_PROCEED = "inform_and_proceed"
+    PLAN_REVIEW_GATE = "plan_review_gate"
+    SOCRATIC_GATE = "socratic_gate"
+
+
+class FrictionMatrix:
+    """Evaluates proposed actions against the 2D Adaptive Friction Matrix."""
+
+    def __init__(
+        self,
+        classifier: BlastRadiusClassifier | None = None,
+        evaluator: AmbiguityEvaluator | None = None,
+    ) -> None:
+        """Initialize FrictionMatrix controller.
+
+        Args:
+            classifier: Optional BlastRadiusClassifier instance.
+            evaluator: Optional AmbiguityEvaluator instance.
+        """
+        self.classifier = classifier or BlastRadiusClassifier()
+        self.evaluator = evaluator or AmbiguityEvaluator()
+
+    def evaluate_action(
+        self,
+        user_prompt: str,
+        target_path: str | None = None,
+        command_line: str | None = None,
+        is_deletion: bool = False,
+    ) -> dict[str, Any]:
+        """Evaluates an action and returns the friction zone and directive.
+
+        Args:
+            user_prompt: User request context.
+            target_path: Optional file path target.
+            command_line: Optional command line string target.
+            is_deletion: Whether action is destructive file deletion.
+
+        Returns:
+            Dictionary containing blast_radius, clarity, zone, directive, and reasoning.
+        """
+        # Calculate Blast Radius (R)
+        if command_line:
+            blast_radius = self.classifier.evaluate_command(command_line)
+        elif target_path:
+            blast_radius = self.classifier.evaluate_file_path(target_path, is_deletion=is_deletion)
+        else:
+            blast_radius = 1
+
+        # Calculate Intent Clarity (C)
+        clarity = self.evaluator.evaluate_prompt(user_prompt, target_path=target_path)
+
+        # Map to Zone
+        zone, directive, reason = self._map_to_zone(blast_radius, clarity)
+
+        return {
+            "blast_radius": blast_radius,
+            "clarity": clarity,
+            "zone": zone.value,
+            "directive": directive.value,
+            "reason": reason,
+        }
+
+    def _map_to_zone(self, R: int, C: int) -> tuple[FrictionZone, FrictionDirective, str]:
+        """Maps (R, C) to a Friction Zone and Directive."""
+        if R <= 2 and C >= 4:
+            return (
+                FrictionZone.ZONE_1_AUTONOMOUS,
+                FrictionDirective.ALLOW_AUTONOMOUS,
+                f"Low risk (R={R}) & high clarity (C={C}): Autonomous execution permitted.",
+            )
+        elif R <= 2 and C <= 3:
+            return (
+                FrictionZone.ZONE_2_INFORM_PROCEED,
+                FrictionDirective.INFORM_AND_PROCEED,
+                f"Low risk (R={R}) & moderate/low clarity (C={C}): Inform user of assumption and proceed.",
+            )
+        elif R >= 3 and C >= 4:
+            return (
+                FrictionZone.ZONE_3_PLAN_GATE,
+                FrictionDirective.PLAN_REVIEW_GATE,
+                f"High risk (R={R}) & high clarity (C={C}): Require plan preview & probe verification receipt before execution.",
+            )
+        else:  # R >= 3 and C <= 3
+            return (
+                FrictionZone.ZONE_4_SOCRATIC_GATE,
+                FrictionDirective.SOCRATIC_GATE,
+                f"High risk (R={R}) & low clarity (C={C}): Hard gate. Require interactive Socratic elicitation form.",
+            )

--- a/tests/unit/hooks/test_friction_gate.py
+++ b/tests/unit/hooks/test_friction_gate.py
@@ -1,0 +1,71 @@
+"""Tests for the friction_gate PreToolUse hook (non-mocked stdin round trips)."""
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+HOOK = REPO_ROOT / "plugin" / "hooks" / "friction_gate.py"
+SRC = REPO_ROOT / "src"
+
+
+def _run_hook(payload: object, extra_env: dict[str, str] | None = None):
+    env = dict(os.environ)
+    env["PYTHONPATH"] = str(SRC)
+    env.pop("ATTUNE_FRICTION_ENFORCE", None)
+    env.update(extra_env or {})
+    return subprocess.run(
+        [sys.executable, str(HOOK)],
+        input=payload if isinstance(payload, str) else json.dumps(payload),
+        capture_output=True,
+        text=True,
+        env=env,
+        cwd=str(REPO_ROOT),
+        timeout=30,
+    )
+
+
+class TestFrictionGateHook:
+    """stdin → exit-code round trips through the real hook script."""
+
+    def test_low_risk_command_allowed_silently(self) -> None:
+        proc = _run_hook({"tool_name": "Bash", "tool_input": {"command": "git status"}})
+        assert proc.returncode == 0
+        assert proc.stdout.strip() == ""
+
+    def test_destructive_command_gets_advisory_by_default(self) -> None:
+        proc = _run_hook({"tool_name": "Bash", "tool_input": {"command": "rm -rf build/"}})
+        assert proc.returncode == 0
+        assert "[friction-gate]" in proc.stdout
+
+    def test_destructive_command_blocked_in_enforce_mode(self) -> None:
+        proc = _run_hook(
+            {"tool_name": "Bash", "tool_input": {"command": "rm -rf build/"}},
+            extra_env={"ATTUNE_FRICTION_ENFORCE": "1"},
+        )
+        assert proc.returncode == 2
+        assert "BLOCKED" in proc.stderr
+
+    def test_chained_destructive_command_blocked_in_enforce_mode(self) -> None:
+        proc = _run_hook(
+            {
+                "tool_name": "Bash",
+                "tool_input": {"command": "ls && git reset --hard HEAD~3"},
+            },
+            extra_env={"ATTUNE_FRICTION_ENFORCE": "1"},
+        )
+        assert proc.returncode == 2
+
+    def test_non_bash_tool_ignored(self) -> None:
+        proc = _run_hook(
+            {"tool_name": "Edit", "tool_input": {"file_path": "x.py"}},
+            extra_env={"ATTUNE_FRICTION_ENFORCE": "1"},
+        )
+        assert proc.returncode == 0
+        assert proc.stdout.strip() == ""
+
+    def test_malformed_payload_degrades_open(self) -> None:
+        proc = _run_hook("{not json", extra_env={"ATTUNE_FRICTION_ENFORCE": "1"})
+        assert proc.returncode == 0

--- a/tests/unit/orchestration/test_friction_matrix.py
+++ b/tests/unit/orchestration/test_friction_matrix.py
@@ -1,0 +1,166 @@
+"""Unit tests for the Adaptive Friction Matrix system."""
+
+from attune.orchestration.friction import (
+    AmbiguityEvaluator,
+    BlastRadiusClassifier,
+    FrictionDirective,
+    FrictionMatrix,
+    FrictionZone,
+)
+
+
+class TestBlastRadiusClassifier:
+    """Tests for BlastRadiusClassifier."""
+
+    def test_read_only_command_low_risk(self) -> None:
+        classifier = BlastRadiusClassifier()
+        assert classifier.evaluate_command("ls -la") == 1
+        assert classifier.evaluate_command("pytest tests/unit") == 1
+        assert classifier.evaluate_command("git status") == 1
+
+    def test_destructive_command_high_risk(self) -> None:
+        classifier = BlastRadiusClassifier()
+        assert classifier.evaluate_command("rm -rf src/attune") == 5
+        assert classifier.evaluate_command("git reset --hard HEAD~1") == 5
+        assert classifier.evaluate_command("DROP TABLE users;") == 5
+
+    def test_destructive_flag_variants(self) -> None:
+        classifier = BlastRadiusClassifier()
+        assert classifier.evaluate_command("rm -fr build/") == 5
+        assert classifier.evaluate_command("rm -r -f build/") == 5
+        assert classifier.evaluate_command("git push --force origin main") == 5
+        assert classifier.evaluate_command("git push -f origin main") == 5
+
+    def test_chained_command_cannot_hide_behind_readonly_prefix(self) -> None:
+        # Regression: a read-only first token must not short-circuit
+        # classification of what comes after the chain operator.
+        classifier = BlastRadiusClassifier()
+        assert classifier.evaluate_command("ls && rm -rf /tmp/x") == 5
+        assert classifier.evaluate_command("git status; git reset --hard") == 5
+        assert classifier.evaluate_command("cat notes.md > /etc/hosts") >= 1
+        assert classifier.evaluate_command("ls | xargs rm -rf") == 5
+
+    def test_chained_readonly_is_not_scored_readonly(self) -> None:
+        classifier = BlastRadiusClassifier()
+        # Not destructive, but chained — must not take the read-only
+        # fast path (score falls through to modification scoring).
+        assert classifier.evaluate_command("git status && git commit -m x") == 3
+
+    def test_critical_path_high_risk(self) -> None:
+        classifier = BlastRadiusClassifier()
+        assert classifier.evaluate_file_path("src/attune/auth/login.py") >= 4
+        assert classifier.evaluate_file_path("database/migrations/001.sql") >= 4
+        assert classifier.evaluate_file_path("AGENTS.md") >= 4
+        assert classifier.evaluate_file_path(".env.production") >= 4
+
+    def test_critical_path_requires_segment_boundary(self) -> None:
+        # Regression: "oauth/" must not match the "auth/" rule.
+        classifier = BlastRadiusClassifier()
+        assert classifier.evaluate_file_path("docs/oauth/notes.md") == 1
+        assert classifier.evaluate_file_path("docs/envelope.md") == 1
+
+    def test_windows_style_path_normalized(self) -> None:
+        # Backslash-separated paths must classify like POSIX paths.
+        classifier = BlastRadiusClassifier(workspace_root="C:\\repo")
+        rel = classifier._sanitize_and_relativize("src\\attune\\auth\\login.py")
+        assert "\\" not in rel
+
+    def test_normal_file_edit(self) -> None:
+        classifier = BlastRadiusClassifier()
+        assert classifier.evaluate_file_path("docs/readme.md") == 1
+
+    def test_file_deletion_escalates_risk(self) -> None:
+        classifier = BlastRadiusClassifier()
+        normal_edit = classifier.evaluate_file_path("src/attune/utils.py", is_deletion=False)
+        deletion = classifier.evaluate_file_path("src/attune/utils.py", is_deletion=True)
+        assert deletion > normal_edit
+
+
+class TestAmbiguityEvaluator:
+    """Tests for AmbiguityEvaluator."""
+
+    def test_specific_prompt_high_clarity(self) -> None:
+        evaluator = AmbiguityEvaluator()
+        prompt = (
+            "Add type hints and docstring to function calculate_total " "in file utils.py line 45"
+        )
+        assert evaluator.evaluate_prompt(prompt, target_path="utils.py") >= 4
+
+    def test_generic_prompt_low_clarity(self) -> None:
+        evaluator = AmbiguityEvaluator()
+        assert evaluator.evaluate_prompt("fix this") <= 2
+        assert evaluator.evaluate_prompt("clean up") <= 2
+
+    def test_empty_prompt_minimum_clarity(self) -> None:
+        evaluator = AmbiguityEvaluator()
+        assert evaluator.evaluate_prompt("") == 1
+
+    def test_indicator_matching_uses_word_boundaries(self) -> None:
+        # Regression: "pipeline"/"latest"/"prototype" must not count as
+        # the indicators "line"/"test"/"type".
+        evaluator = AmbiguityEvaluator()
+        embedded = evaluator.evaluate_prompt("the latest pipeline prototype needs attention please")
+        assert embedded == 3  # no indicator bonus
+
+
+class TestFrictionMatrix:
+    """Tests for FrictionMatrix zone mapping."""
+
+    def test_zone_1_autonomous_routing(self) -> None:
+        matrix = FrictionMatrix()
+        result = matrix.evaluate_action(
+            user_prompt="Format docstring in docs/readme.md with line references",
+            target_path="docs/readme.md",
+        )
+        assert result["zone"] == FrictionZone.ZONE_1_AUTONOMOUS.value
+        assert result["directive"] == FrictionDirective.ALLOW_AUTONOMOUS.value
+
+    def test_zone_2_inform_proceed_routing(self) -> None:
+        matrix = FrictionMatrix()
+        result = matrix.evaluate_action(user_prompt="tidy up the docs a bit")
+        assert result["zone"] == FrictionZone.ZONE_2_INFORM_PROCEED.value
+        assert result["directive"] == FrictionDirective.INFORM_AND_PROCEED.value
+
+    def test_zone_3_plan_gate_routing(self) -> None:
+        matrix = FrictionMatrix()
+        result = matrix.evaluate_action(
+            user_prompt=(
+                "Delete the deprecated helper function in module utils, "
+                "file src/attune/auth/legacy.py, and update the test"
+            ),
+            target_path="src/attune/auth/legacy.py",
+        )
+        assert result["zone"] == FrictionZone.ZONE_3_PLAN_GATE.value
+        assert result["directive"] == FrictionDirective.PLAN_REVIEW_GATE.value
+
+    def test_zone_4_socratic_gate_routing(self) -> None:
+        matrix = FrictionMatrix()
+        result = matrix.evaluate_action(
+            user_prompt="clean up",
+            target_path="src/attune/auth/security.py",
+            is_deletion=True,
+        )
+        assert result["zone"] == FrictionZone.ZONE_4_SOCRATIC_GATE.value
+        assert result["directive"] == FrictionDirective.SOCRATIC_GATE.value
+
+    def test_command_evaluation_matrix(self) -> None:
+        matrix = FrictionMatrix()
+        result = matrix.evaluate_action(
+            user_prompt=(
+                "Run pytest test suite on file "
+                "tests/unit/orchestration/test_friction_matrix.py line 10"
+            ),
+            command_line="pytest tests/unit",
+        )
+        assert result["directive"] == FrictionDirective.ALLOW_AUTONOMOUS.value
+
+    def test_result_contains_all_fields(self) -> None:
+        matrix = FrictionMatrix()
+        result = matrix.evaluate_action(user_prompt="check", command_line="ls")
+        assert set(result) == {
+            "blast_radius",
+            "clarity",
+            "zone",
+            "directive",
+            "reason",
+        }


### PR DESCRIPTION
## Summary

Rescues **PR 1 of Antigravity's 5-track plan** (round-table thread `q-review-five-implementation-plans-001`) into the repo, hardened and wired to a real enforcement surface.

Antigravity's original landed untracked on the `main` checkout with a scoring bypass; this PR fixes that and adds the promised PreToolUse hook:

- **Bypass fixed**: destructive patterns are checked before the read-only fast path, and a read-only first token no longer short-circuits chained commands (`ls && rm -rf …`, `git status; git reset --hard` scored 1 before — now 5).
- **Windows**: backslash paths normalize to `/` before classification (critical-path rules would never fire on Windows otherwise).
- **Pattern quality**: segment-anchored critical paths (`docs/oauth/` no longer matches `auth/`), `rm -fr`/`-r -f`/`git push --force|-f` variants, compiled once.
- **Ambiguity scoring**: word-boundary indicator matching ("pipeline" ≠ "line").
- **NEW `plugin/hooks/friction_gate.py`** (PreToolUse, Bash matcher): advisory by default (one-line zone warning), `ATTUNE_FRICTION_ENFORCE=1` blocks zone-4 commands with exit 2. Degrades open; SDK-subprocess gated. Hard security invariants remain in `security_guard.py`.

## Receipts

- 26 tests: zone 1–4 routing, chained-command regression, Windows path, oauth false-positive regression, and non-mocked stdin→exit-code round trips through the real hook script (advisory, enforce-block, non-Bash ignore, malformed-payload degrade-open).
- `pytest tests/unit/orchestration/test_friction_matrix.py tests/unit/hooks/test_friction_gate.py tests/unit/plugins/test_plugin_config_validation.py` → 55 passed.
- Pinned black/ruff pre-flighted; full pre-commit suite passed at commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
