### PR TITLE
feat(context): AST skeleton generator + token budget allocator + inflater

### DIFF
--- a/src/attune/context/__init__.py
+++ b/src/attune/context/__init__.py
@@ -11,12 +11,18 @@ Copyright 2025 Smart AI Memory, LLC
 Licensed under the Apache License, Version 2.0
 """
 
+from attune.context.allocator import TokenBudgetAllocator
 from attune.context.compaction import CompactionStateManager, CompactState, WorkHandoff
+from attune.context.inflater import ContextInflater
 from attune.context.manager import ContextManager
+from attune.context.skeleton import ASTSkeletonGenerator
 
 __all__ = [
+    "ASTSkeletonGenerator",
     "CompactState",
     "CompactionStateManager",
+    "ContextInflater",
     "ContextManager",
+    "TokenBudgetAllocator",
     "WorkHandoff",
 ]

--- a/src/attune/context/allocator.py
+++ b/src/attune/context/allocator.py
@@ -1,0 +1,82 @@
+"""Token Budget Allocator for Attune AI.
+
+Manages dynamic allocation of full source code vs. AST skeletal context
+based on token budget constraints and target file prioritization.
+"""
+
+import logging
+
+from .skeleton import ASTSkeletonGenerator
+
+logger = logging.getLogger(__name__)
+
+
+class TokenBudgetAllocator:
+    """Balances full source inclusion vs. AST skeletal compression."""
+
+    def __init__(self, default_token_limit: int = 4000) -> None:
+        """Initialize TokenBudgetAllocator.
+
+        Args:
+            default_token_limit: Maximum estimated token budget for context.
+        """
+        self.default_token_limit = default_token_limit
+        self.generator = ASTSkeletonGenerator()
+
+    def allocate_context(
+        self,
+        files: dict[str, str],
+        primary_target: str | None = None,
+        token_limit: int | None = None,
+    ) -> dict[str, str]:
+        """Allocates context format (full vs skeleton) across files.
+
+        The primary target always retains full source, even when it
+        alone exceeds the budget (a warning is logged in that case).
+        Remaining files receive skeletons while budget lasts, then an
+        omission stub.
+
+        Args:
+            files: Dictionary mapping file paths to full source code.
+            primary_target: Target path that should retain full source.
+            token_limit: Custom token limit override.
+
+        Returns:
+            Dictionary mapping file paths to allocated context string
+            (full source, skeleton, or omission stub).
+        """
+        limit = token_limit or self.default_token_limit
+        allocated: dict[str, str] = {}
+        current_tokens = 0
+
+        if primary_target and primary_target in files:
+            full_code = files[primary_target]
+            allocated[primary_target] = full_code
+            current_tokens += self._estimate_tokens(full_code)
+            if current_tokens > limit:
+                logger.warning(
+                    "allocator: primary target %s alone exceeds token limit "
+                    "(%d > %d); all other files will be stubbed",
+                    primary_target,
+                    current_tokens,
+                    limit,
+                )
+
+        for path, code in files.items():
+            if path == primary_target:
+                continue
+
+            skeleton = self.generator.generate_skeleton(code)
+            skel_tokens = self._estimate_tokens(skeleton)
+
+            if current_tokens + skel_tokens <= limit:
+                allocated[path] = skeleton
+                current_tokens += skel_tokens
+            else:
+                allocated[path] = f"# AST skeleton omitted (token limit {limit} reached)\n"
+
+        return allocated
+
+    def _estimate_tokens(self, text: str) -> int:
+        """Heuristic token estimation (approx 4 chars per token)."""
+        return len(text) // 4

--- a/src/attune/context/inflater.py
+++ b/src/attune/context/inflater.py
@@ -1,0 +1,59 @@
+"""Context Inflater for Attune AI.
+
+Inflates AST skeletons back into full source code representations when
+an agent initiates code modifications on a file.
+"""
+
+from collections.abc import Iterable
+
+# Canonical (provider-neutral) mutating action names, matched
+# case-insensitively. Provider adapters that use different tool names
+# (e.g. an IDE's ``replace_file_content``) pass their own set via the
+# ``mutating_actions`` constructor argument.
+DEFAULT_MUTATING_ACTIONS: frozenset[str] = frozenset({"edit", "write", "multiedit", "notebookedit"})
+
+
+class ContextInflater:
+    """Manages on-demand context expansion from skeleton to full source."""
+
+    def __init__(
+        self,
+        full_source_repository: dict[str, str] | None = None,
+        mutating_actions: Iterable[str] | None = None,
+    ) -> None:
+        """Initialize ContextInflater.
+
+        Args:
+            full_source_repository: Optional map of path -> full source code.
+            mutating_actions: Optional override for the set of tool action
+                names treated as mutating (case-insensitive).
+        """
+        self.repository = full_source_repository or {}
+        self.mutating_actions = frozenset(
+            a.lower() for a in (mutating_actions or DEFAULT_MUTATING_ACTIONS)
+        )
+
+    def register_file(self, file_path: str, full_source: str) -> None:
+        """Registers a file's full source code in the repository."""
+        self.repository[file_path] = full_source
+
+    def inflate_if_requested(
+        self,
+        file_path: str,
+        current_context: str,
+        tool_action: str,
+    ) -> str:
+        """Expands skeleton context to full source if tool action mutates files.
+
+        Args:
+            file_path: Path of file being acted upon.
+            current_context: Currently held context (skeleton or full).
+            tool_action: Name of the tool action (e.g. ``Edit``, ``Write``).
+
+        Returns:
+            Full source code if mutating action, else original context.
+        """
+        if tool_action.lower() in self.mutating_actions and file_path in self.repository:
+            return self.repository[file_path]
+
+        return current_context

--- a/src/attune/context/skeleton.py
+++ b/src/attune/context/skeleton.py
@@ -1,0 +1,103 @@
+"""AST Skeleton Generator for Attune AI.
+
+Parses Python source code and generates compressed structural skeletons
+by preserving class contracts, function signatures, docstrings, and type
+hints while stripping method bodies.
+"""
+
+import ast
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class ASTSkeletonGenerator:
+    """Generates structural AST code skeletons to optimize LLM context usage."""
+
+    def __init__(self, strip_docstrings: bool = False) -> None:
+        """Initialize ASTSkeletonGenerator.
+
+        Args:
+            strip_docstrings: If True, also strips module, class, and
+                function docstrings for maximum compression.
+        """
+        self.strip_docstrings = strip_docstrings
+
+    def generate_skeleton(self, source_code: str) -> str:
+        """Parses source code string and returns a compressed skeleton.
+
+        Args:
+            source_code: Raw Python code string.
+
+        Returns:
+            Compressed skeletal Python code string; the original source
+            when it cannot be parsed or re-rendered.
+        """
+        if not source_code or not source_code.strip():
+            return ""
+
+        try:
+            tree = ast.parse(source_code)
+        except SyntaxError as exc:
+            logger.debug("skeleton: source does not parse, passing through: %s", exc)
+            return source_code
+
+        transformer = _SkeletonTransformer(strip_docstrings=self.strip_docstrings)
+        transformed_tree = transformer.visit(tree)
+        ast.fix_missing_locations(transformed_tree)
+
+        try:
+            return ast.unparse(transformed_tree)
+        except (ValueError, TypeError, RecursionError) as exc:
+            logger.debug("skeleton: unparse failed, passing through: %s", exc)
+            return source_code
+
+
+class _SkeletonTransformer(ast.NodeTransformer):
+    """Replaces function bodies with ``...`` and optionally drops docstrings."""
+
+    def __init__(self, strip_docstrings: bool = False) -> None:
+        super().__init__()
+        self.strip_docstrings = strip_docstrings
+
+    def visit_Module(self, node: ast.Module) -> ast.Module:
+        self.generic_visit(node)
+        if self.strip_docstrings:
+            self._drop_docstring(node)
+        return node
+
+    def visit_ClassDef(self, node: ast.ClassDef) -> ast.ClassDef:
+        self.generic_visit(node)
+        if self.strip_docstrings:
+            self._drop_docstring(node)
+            if not node.body:
+                node.body = [ast.Expr(value=ast.Constant(value=Ellipsis))]
+        return node
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> ast.FunctionDef:
+        return self._transform_callable(node)
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> ast.AsyncFunctionDef:
+        return self._transform_callable(node)
+
+    def _transform_callable(self, node):
+        self.generic_visit(node)
+        docstring = ast.get_docstring(node)
+
+        new_body = []
+        if docstring and not self.strip_docstrings:
+            new_body.append(ast.Expr(value=ast.Constant(value=docstring)))
+
+        new_body.append(ast.Expr(value=ast.Constant(value=Ellipsis)))
+        node.body = new_body
+        return node
+
+    @staticmethod
+    def _drop_docstring(node: ast.Module | ast.ClassDef) -> None:
+        if (
+            node.body
+            and isinstance(node.body[0], ast.Expr)
+            and isinstance(node.body[0].value, ast.Constant)
+            and isinstance(node.body[0].value.value, str)
+        ):
+            node.body = node.body[1:]

--- a/tests/unit/context/test_ast_budget.py
+++ b/tests/unit/context/test_ast_budget.py
@@ -1,0 +1,135 @@
+"""Unit tests for AST-driven dynamic context budgeting."""
+
+from attune.context import (
+    ASTSkeletonGenerator,
+    ContextInflater,
+    TokenBudgetAllocator,
+)
+
+SAMPLE_CODE = '''
+class DataProcessor:
+    """Processes analytical datasets."""
+
+    def __init__(self, config: dict) -> None:
+        self.config = config
+        self.items = []
+        for i in range(100):
+            self.items.append(i * 2)
+
+    def process(self, data: list) -> dict:
+        """Executes data transformation."""
+        result = {}
+        for x in data:
+            result[x] = x ** 2
+        return result
+'''
+
+
+class TestASTSkeletonGenerator:
+    """Tests for ASTSkeletonGenerator."""
+
+    def test_skeleton_generation_strips_bodies(self) -> None:
+        generator = ASTSkeletonGenerator()
+        skeleton = generator.generate_skeleton(SAMPLE_CODE)
+
+        assert "class DataProcessor" in skeleton
+        assert "def __init__(self, config: dict) -> None:" in skeleton
+        assert "def process(self, data: list) -> dict:" in skeleton
+        assert "self.items.append" not in skeleton
+        assert "result[x] = x ** 2" not in skeleton
+
+    def test_default_mode_retains_docstrings(self) -> None:
+        generator = ASTSkeletonGenerator()
+        skeleton = generator.generate_skeleton(SAMPLE_CODE)
+        assert "Processes analytical datasets." in skeleton
+        assert "Executes data transformation." in skeleton
+
+    def test_token_reduction_ratio_with_stripped_docstrings(self) -> None:
+        # The 50%+ reduction goal holds in maximum-compression mode;
+        # default mode keeps docstrings and lands lower (~47% here).
+        generator = ASTSkeletonGenerator(strip_docstrings=True)
+        skeleton = generator.generate_skeleton(SAMPLE_CODE)
+
+        compression_ratio = 1.0 - (len(skeleton) / len(SAMPLE_CODE))
+        assert compression_ratio >= 0.50
+
+    def test_strip_docstrings_removes_class_docstring(self) -> None:
+        generator = ASTSkeletonGenerator(strip_docstrings=True)
+        skeleton = generator.generate_skeleton(SAMPLE_CODE)
+        assert "Processes analytical datasets." not in skeleton
+
+    def test_unparseable_source_passes_through(self) -> None:
+        generator = ASTSkeletonGenerator()
+        broken = "def broken(:\n    pass"
+        assert generator.generate_skeleton(broken) == broken
+
+    def test_empty_source_returns_empty(self) -> None:
+        generator = ASTSkeletonGenerator()
+        assert generator.generate_skeleton("") == ""
+        assert generator.generate_skeleton("   \n") == ""
+
+
+class TestTokenBudgetAllocator:
+    """Tests for TokenBudgetAllocator."""
+
+    def test_allocator_prioritizes_primary_target(self) -> None:
+        allocator = TokenBudgetAllocator(default_token_limit=500)
+        files = {
+            "main.py": SAMPLE_CODE,
+            "utils.py": SAMPLE_CODE,
+        }
+
+        allocated = allocator.allocate_context(files, primary_target="main.py")
+
+        assert allocated["main.py"] == SAMPLE_CODE  # Retains full source
+        assert "self.items.append" not in allocated["utils.py"]  # Skeletal
+
+    def test_budget_exhaustion_emits_stub(self) -> None:
+        allocator = TokenBudgetAllocator(default_token_limit=1)
+        files = {"main.py": SAMPLE_CODE, "utils.py": SAMPLE_CODE}
+
+        allocated = allocator.allocate_context(files, primary_target="main.py")
+
+        assert allocated["main.py"] == SAMPLE_CODE  # primary always full
+        assert allocated["utils.py"].startswith("# AST skeleton omitted")
+
+    def test_no_primary_target_all_skeletal(self) -> None:
+        allocator = TokenBudgetAllocator(default_token_limit=4000)
+        allocated = allocator.allocate_context({"a.py": SAMPLE_CODE})
+        assert "self.items.append" not in allocated["a.py"]
+
+
+class TestContextInflater:
+    """Tests for ContextInflater."""
+
+    def test_inflation_on_mutating_action(self) -> None:
+        inflater = ContextInflater(full_source_repository={"main.py": SAMPLE_CODE})
+        skeleton = "... skeletal code ..."
+
+        # Read action keeps skeleton
+        res_read = inflater.inflate_if_requested("main.py", skeleton, "Read")
+        assert res_read == skeleton
+
+        # Mutating action inflates to full source (case-insensitive)
+        res_edit = inflater.inflate_if_requested("main.py", skeleton, "Edit")
+        assert res_edit == SAMPLE_CODE
+        res_write = inflater.inflate_if_requested("main.py", skeleton, "write")
+        assert res_write == SAMPLE_CODE
+
+    def test_adapter_supplied_mutating_actions(self) -> None:
+        # Provider adapters may use their own tool vocabulary.
+        inflater = ContextInflater(
+            full_source_repository={"main.py": SAMPLE_CODE},
+            mutating_actions={"replace_file_content"},
+        )
+        skeleton = "..."
+        assert (
+            inflater.inflate_if_requested("main.py", skeleton, "replace_file_content")
+            == SAMPLE_CODE
+        )
+        # Canonical names are NOT mutating once overridden
+        assert inflater.inflate_if_requested("main.py", skeleton, "Edit") == skeleton
+
+    def test_unregistered_file_keeps_context(self) -> None:
+        inflater = ContextInflater()
+        assert inflater.inflate_if_requested("ghost.py", "ctx", "Edit") == "ctx"


### PR DESCRIPTION
## Summary

Rescues **PR 5 of Antigravity's 5-track plan** (AST-driven context budgeting) into the repo. Two structural corrections and one honesty fix:

- **Relocated `attune.rag` → `attune.context`**: the RAG name is already owned by the separate `attune_rag` package (the `[rag]` extra) — a sibling `attune.rag` subpackage would collide confusingly. These modules are context management and join the existing `attune.context` package (compaction/manager) cleanly.
- **Provider vocabulary out of shared code**: the original `ContextInflater` hardcoded Antigravity IDE tool names (`replace_file_content`, `write_to_file`) as the mutating-action set. Now provider-neutral (`Edit`/`Write`/`MultiEdit`/`NotebookEdit`, case-insensitive) with a constructor override for provider adapters, per the collaboration contract.
- **The claimed "✅ Verifies 50%+ compression ratio" test actually FAILED as written** (0.467 measured). Fixed by making `strip_docstrings=True` strip module/class docstrings too (it was function-only), asserting the 50% goal in that mode where it genuinely holds, and adding a default-mode docstring-retention test.

Also: narrow, logged exception handling in the skeleton generator (was `except Exception`), and the allocator warns when the primary target alone blows the budget.

Not included (deliberately): the ratified plan's Redis AST cache (`attune:ast:<sha256>`) — worth its own PR once something consumes these classes at scale.

## Receipts

- `pytest tests/unit/context/` → 23 passed (12 new + existing smoke tests).
- Pinned black/ruff pre-flighted; full pre-commit suite passed at commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
