### PR TITLE
feat(orchestration): Ghost Simulator sandbox — ephemeral git worktrees, rebuilt safe

### DIFF
--- a/src/attune/orchestration/ghosts/__init__.py
+++ b/src/attune/orchestration/ghosts/__init__.py
@@ -1,0 +1,18 @@
+"""Ghost Simulator sandbox for attune-ai.
+
+Ephemeral git worktrees for speculative parallel trajectories, with
+comparison and fast-forward promotion of the winner.
+"""
+
+from .comparator import TrajectoryComparator
+from .promoter import TrajectoryPromoter
+from .runner import MultiTrajectoryRunner
+from .worktree import GhostWorktreeError, GhostWorktreeManager
+
+__all__ = [
+    "GhostWorktreeError",
+    "GhostWorktreeManager",
+    "MultiTrajectoryRunner",
+    "TrajectoryComparator",
+    "TrajectoryPromoter",
+]

--- a/src/attune/orchestration/ghosts/comparator.py
+++ b/src/attune/orchestration/ghosts/comparator.py
@@ -1,0 +1,53 @@
+"""Trajectory Comparator for Attune AI Ghost Simulator.
+
+Synthesizes comparative metrics, test pass ratios, and diff summaries
+across completed ghost trajectories.
+"""
+
+from typing import Any
+
+
+class TrajectoryComparator:
+    """Generates comparative matrices across executed ghost trajectories."""
+
+    def compare(self, trajectory_results: dict[str, dict[str, Any]]) -> dict[str, Any]:
+        """Compares results across trajectories and highlights the winner.
+
+        Args:
+            trajectory_results: Output map from MultiTrajectoryRunner.
+
+        Returns:
+            Comparative analysis dictionary with metric breakdown and
+            recommended trajectory (None when no trajectory succeeded).
+        """
+        best_trajectory: str | None = None
+        best_score = float("-inf")
+        matrix: list[dict[str, Any]] = []
+
+        for traj_id, data in trajectory_results.items():
+            success = data.get("success", False)
+            tests_passed = data.get("tests_passed", 0)
+            tests_total = data.get("tests_total", 0)
+            duration = data.get("duration_seconds", 0.0)
+
+            pass_rate = (tests_passed / tests_total) if tests_total > 0 else 0.0
+            score = (pass_rate * 100.0) - (duration * 0.1) if success else float("-inf")
+
+            if success and score > best_score:
+                best_score = score
+                best_trajectory = traj_id
+
+            matrix.append(
+                {
+                    "trajectory_id": traj_id,
+                    "success": success,
+                    "pass_rate": round(pass_rate * 100, 1),
+                    "duration_seconds": duration,
+                    "files_modified": data.get("files_modified", []),
+                }
+            )
+
+        return {
+            "recommended_trajectory": best_trajectory,
+            "comparison_matrix": matrix,
+        }

--- a/src/attune/orchestration/ghosts/promoter.py
+++ b/src/attune/orchestration/ghosts/promoter.py
@@ -1,0 +1,73 @@
+"""Trajectory Promoter for Attune AI Ghost Simulator.
+
+Promotes winning ghost trajectory changes back into the primary
+repository branch via fast-forward merge.
+"""
+
+import logging
+import subprocess
+
+from .worktree import GhostWorktreeManager
+
+logger = logging.getLogger(__name__)
+
+
+class TrajectoryPromoter:
+    """Promotes winning ghost trajectory changes into the repository."""
+
+    def __init__(self, manager: GhostWorktreeManager) -> None:
+        """Initialize TrajectoryPromoter.
+
+        Args:
+            manager: GhostWorktreeManager that owns the ghost sandboxes.
+        """
+        self.manager = manager
+
+    def promote(self, winning_trajectory_id: str, target_branch: str = "main") -> bool:
+        """Promotes changes from the winning ghost into the target branch.
+
+        The merge runs in the manager's repository root and only
+        proceeds when that repository currently has ``target_branch``
+        checked out — promoting into whatever happens to be checked
+        out is how work lands on the wrong branch. On failure the
+        ghost worktree is KEPT so the trajectory's work is not lost.
+
+        Args:
+            winning_trajectory_id: ID of the ghost sandbox to promote.
+            target_branch: Branch the ghost changes must land on.
+
+        Returns:
+            True if promotion succeeded (ghost is cleaned up), False
+            otherwise (ghost is retained for inspection).
+        """
+        repo = self.manager.repo_root
+        current = subprocess.run(
+            ["git", "-C", repo, "branch", "--show-current"],
+            capture_output=True,
+            text=True,
+        )
+        if current.returncode != 0 or current.stdout.strip() != target_branch:
+            logger.error(
+                "promotion refused: %s has %r checked out, not %r",
+                repo,
+                current.stdout.strip(),
+                target_branch,
+            )
+            return False
+
+        ghost_branch = f"ghost-{winning_trajectory_id}"
+        merge = subprocess.run(
+            ["git", "-C", repo, "merge", "--ff-only", ghost_branch],
+            capture_output=True,
+            text=True,
+        )
+        if merge.returncode != 0:
+            logger.error(
+                "promotion of %s failed (%s); ghost worktree retained",
+                ghost_branch,
+                merge.stderr.strip(),
+            )
+            return False
+
+        self.manager.remove_ghost_worktree(winning_trajectory_id)
+        return True

--- a/src/attune/orchestration/ghosts/runner.py
+++ b/src/attune/orchestration/ghosts/runner.py
@@ -1,0 +1,74 @@
+"""Trajectory Runner for Attune AI Ghost Simulator.
+
+Executes agent trajectories across separate ghost worktree sandboxes.
+Trajectories run sequentially in-process; isolation comes from each
+trajectory operating in its own worktree.
+"""
+
+import logging
+import time
+from collections.abc import Callable
+from typing import Any
+
+from .worktree import GhostWorktreeError, GhostWorktreeManager
+
+logger = logging.getLogger(__name__)
+
+
+class MultiTrajectoryRunner:
+    """Runs execution trajectories across isolated ghost sandboxes."""
+
+    def __init__(self, manager: GhostWorktreeManager) -> None:
+        """Initialize MultiTrajectoryRunner.
+
+        Args:
+            manager: GhostWorktreeManager providing the sandboxes.
+        """
+        self.manager = manager
+
+    def run_trajectories(
+        self,
+        trajectories: dict[str, Callable[[str], dict[str, Any]]],
+    ) -> dict[str, dict[str, Any]]:
+        """Runs given trajectory functions in ghost worktrees.
+
+        Args:
+            trajectories: Map of trajectory_id -> callable(worktree_path)
+                returning a result dictionary.
+
+        Returns:
+            Map of trajectory_id -> result telemetry dictionary. A
+            trajectory that raises (or whose sandbox cannot be created)
+            yields ``{"success": False, "error": ...}``.
+        """
+        results: dict[str, dict[str, Any]] = {}
+
+        for traj_id, func in trajectories.items():
+            start_time = time.time()
+            try:
+                worktree_path = self.manager.create_ghost_worktree(traj_id)
+            except GhostWorktreeError as exc:
+                logger.error("trajectory %s: sandbox creation failed: %s", traj_id, exc)
+                results[traj_id] = {
+                    "success": False,
+                    "error": str(exc),
+                    "duration_seconds": 0.0,
+                    "worktree_path": None,
+                }
+                continue
+
+            try:
+                res = func(worktree_path)
+                res["duration_seconds"] = round(time.time() - start_time, 2)
+                res["worktree_path"] = worktree_path
+                results[traj_id] = res
+            except Exception as exc:  # noqa: BLE001 — one bad trajectory must not kill the batch
+                logger.exception("trajectory %s failed", traj_id)
+                results[traj_id] = {
+                    "success": False,
+                    "error": str(exc),
+                    "duration_seconds": round(time.time() - start_time, 2),
+                    "worktree_path": worktree_path,
+                }
+
+        return results

--- a/src/attune/orchestration/ghosts/worktree.py
+++ b/src/attune/orchestration/ghosts/worktree.py
@@ -1,0 +1,133 @@
+"""Ghost Worktree Manager for Attune AI.
+
+Manages isolated, ephemeral Git worktrees under ``.attune/ghosts/`` for
+speculative execution. All git operations are scoped to an explicit
+repository root — never the process CWD — and failures are loud: a
+ghost that cannot be created as a real worktree raises instead of
+silently degrading to a plain directory.
+"""
+
+import logging
+import os
+import re
+import shutil
+import subprocess
+
+logger = logging.getLogger(__name__)
+
+_GHOST_ID_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+
+
+class GhostWorktreeError(RuntimeError):
+    """Raised when a ghost worktree cannot be created or removed."""
+
+
+class GhostWorktreeManager:
+    """Manages ephemeral Git worktrees for parallel agent sandboxing."""
+
+    def __init__(self, repo_root: str, base_dir: str | None = None) -> None:
+        """Initialize GhostWorktreeManager.
+
+        Args:
+            repo_root: Root of the git repository ghosts are based on.
+            base_dir: Root directory for ghost worktrees. Defaults to
+                ``<repo_root>/.attune/ghosts`` (gitignored via .attune/).
+        """
+        self.repo_root = os.path.abspath(repo_root)
+        self.base_dir = (
+            os.path.abspath(base_dir)
+            if base_dir
+            else os.path.join(self.repo_root, ".attune", "ghosts")
+        )
+
+    def create_ghost_worktree(self, ghost_id: str, commit_ref: str = "HEAD") -> str:
+        """Creates an isolated ghost worktree.
+
+        Args:
+            ghost_id: Unique identifier for the ghost sandbox
+                (alphanumeric plus ``._-``).
+            commit_ref: Git commit or ref to base the worktree on.
+
+        Returns:
+            Absolute path to the created ghost worktree directory.
+
+        Raises:
+            GhostWorktreeError: If the id is invalid or git cannot
+                create the worktree.
+        """
+        if not _GHOST_ID_PATTERN.match(ghost_id):
+            raise GhostWorktreeError(f"invalid ghost id: {ghost_id!r}")
+
+        target_path = os.path.join(self.base_dir, ghost_id)
+        os.makedirs(self.base_dir, exist_ok=True)
+
+        if os.path.exists(target_path):
+            self.remove_ghost_worktree(ghost_id)
+
+        proc = subprocess.run(
+            [
+                "git",
+                "-C",
+                self.repo_root,
+                "worktree",
+                "add",
+                "-b",
+                f"ghost-{ghost_id}",
+                target_path,
+                commit_ref,
+            ],
+            capture_output=True,
+            text=True,
+        )
+        if proc.returncode != 0:
+            raise GhostWorktreeError(
+                f"git worktree add failed for {ghost_id!r}: {proc.stderr.strip()}"
+            )
+
+        return target_path
+
+    def remove_ghost_worktree(self, ghost_id: str) -> bool:
+        """Removes a ghost worktree and its branch.
+
+        Args:
+            ghost_id: Identifier of the ghost sandbox to prune.
+
+        Returns:
+            True if a worktree existed and was removed, False if there
+            was nothing to remove.
+        """
+        target_path = os.path.join(self.base_dir, ghost_id)
+        if not os.path.exists(target_path):
+            return False
+
+        proc = subprocess.run(
+            ["git", "-C", self.repo_root, "worktree", "remove", "--force", target_path],
+            capture_output=True,
+            text=True,
+        )
+        if proc.returncode != 0:
+            logger.warning(
+                "ghost %s: git worktree remove failed (%s); falling back to rmtree",
+                ghost_id,
+                proc.stderr.strip(),
+            )
+            shutil.rmtree(target_path, ignore_errors=True)
+            subprocess.run(
+                ["git", "-C", self.repo_root, "worktree", "prune"],
+                capture_output=True,
+                text=True,
+            )
+
+        branch_proc = subprocess.run(
+            ["git", "-C", self.repo_root, "branch", "-D", f"ghost-{ghost_id}"],
+            capture_output=True,
+            text=True,
+        )
+        if branch_proc.returncode != 0:
+            logger.debug(
+                "ghost %s: branch delete skipped: %s",
+                ghost_id,
+                branch_proc.stderr.strip(),
+            )
+
+        return True

--- a/tests/unit/orchestration/test_ghost_simulator.py
+++ b/tests/unit/orchestration/test_ghost_simulator.py
@@ -1,0 +1,186 @@
+"""Tests for the Ghost Simulator sandbox.
+
+The worktree/promoter tests are non-mocked round trips through a real
+temporary git repository — creating a plain directory and calling it a
+worktree is exactly the failure mode these guard against.
+"""
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from attune.orchestration.ghosts import (
+    GhostWorktreeError,
+    GhostWorktreeManager,
+    MultiTrajectoryRunner,
+    TrajectoryComparator,
+    TrajectoryPromoter,
+)
+
+
+def _git(repo: Path, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["git", "-C", str(repo), *args],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+
+@pytest.fixture()
+def temp_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q", "-b", "main", str(repo)], check=True)
+    _git(repo, "config", "user.email", "ghost@test.local")
+    _git(repo, "config", "user.name", "Ghost Test")
+    _git(repo, "config", "commit.gpgsign", "false")
+    (repo / "hello.txt").write_text("hello\n", encoding="utf-8")
+    _git(repo, "add", "hello.txt")
+    _git(repo, "commit", "-q", "-m", "init")
+    return repo
+
+
+class TestGhostWorktreeManager:
+    """Real-git round trips for worktree lifecycle."""
+
+    def test_creates_a_real_git_worktree(self, temp_repo: Path) -> None:
+        manager = GhostWorktreeManager(repo_root=str(temp_repo))
+        path = Path(manager.create_ghost_worktree("t1"))
+
+        assert path.exists()
+        # It must be a REAL worktree: on branch ghost-t1 with the base
+        # commit's content, not a bare directory.
+        head = _git(path, "branch", "--show-current").stdout.strip()
+        assert head == "ghost-t1"
+        assert (path / "hello.txt").read_text(encoding="utf-8") == "hello\n"
+
+    def test_removal_deletes_worktree_and_branch(self, temp_repo: Path) -> None:
+        manager = GhostWorktreeManager(repo_root=str(temp_repo))
+        path = Path(manager.create_ghost_worktree("t2"))
+
+        assert manager.remove_ghost_worktree("t2") is True
+        assert not path.exists()
+        branches = _git(temp_repo, "branch", "--list", "ghost-t2").stdout
+        assert "ghost-t2" not in branches
+        assert manager.remove_ghost_worktree("t2") is False
+
+    def test_invalid_ghost_id_rejected(self, temp_repo: Path) -> None:
+        manager = GhostWorktreeManager(repo_root=str(temp_repo))
+        with pytest.raises(GhostWorktreeError):
+            manager.create_ghost_worktree("../escape")
+
+    def test_non_repo_raises_instead_of_fake_directory(self, tmp_path: Path) -> None:
+        # Regression: the original silently fell back to a bare
+        # directory when git failed, faking a sandbox.
+        not_repo = tmp_path / "not-a-repo"
+        not_repo.mkdir()
+        manager = GhostWorktreeManager(repo_root=str(not_repo))
+        with pytest.raises(GhostWorktreeError):
+            manager.create_ghost_worktree("t3")
+
+
+class TestMultiTrajectoryRunner:
+    """Runner behavior across real sandboxes."""
+
+    def test_run_trajectories_isolated_paths(self, temp_repo: Path) -> None:
+        manager = GhostWorktreeManager(repo_root=str(temp_repo))
+        runner = MultiTrajectoryRunner(manager=manager)
+
+        def traj(path: str) -> dict:
+            return {"success": True, "tests_passed": 10, "tests_total": 10}
+
+        results = runner.run_trajectories({"a": traj, "b": traj})
+
+        assert results["a"]["success"] is True
+        assert results["b"]["success"] is True
+        assert results["a"]["worktree_path"] != results["b"]["worktree_path"]
+
+    def test_raising_trajectory_reported_not_fatal(self, temp_repo: Path) -> None:
+        manager = GhostWorktreeManager(repo_root=str(temp_repo))
+        runner = MultiTrajectoryRunner(manager=manager)
+
+        def boom(path: str) -> dict:
+            raise ValueError("trajectory exploded")
+
+        def ok(path: str) -> dict:
+            return {"success": True}
+
+        results = runner.run_trajectories({"boom": boom, "ok": ok})
+        assert results["boom"]["success"] is False
+        assert "trajectory exploded" in results["boom"]["error"]
+        assert results["ok"]["success"] is True
+
+
+class TestTrajectoryComparator:
+    """Comparator scoring."""
+
+    def test_comparison_selects_best_pass_rate(self) -> None:
+        comparator = TrajectoryComparator()
+        results = {
+            "a": {
+                "success": True,
+                "tests_passed": 10,
+                "tests_total": 10,
+                "duration_seconds": 2.0,
+            },
+            "b": {
+                "success": True,
+                "tests_passed": 5,
+                "tests_total": 10,
+                "duration_seconds": 1.0,
+            },
+        }
+        res = comparator.compare(results)
+        assert res["recommended_trajectory"] == "a"
+        assert len(res["comparison_matrix"]) == 2
+
+    def test_all_failed_recommends_none(self) -> None:
+        # Regression: the original recommended a FAILED trajectory
+        # when every trajectory failed.
+        comparator = TrajectoryComparator()
+        res = comparator.compare({"a": {"success": False}, "b": {"success": False}})
+        assert res["recommended_trajectory"] is None
+
+
+class TestTrajectoryPromoter:
+    """Real-git promotion round trips."""
+
+    def test_promote_lands_ghost_commit_on_target(self, temp_repo: Path) -> None:
+        manager = GhostWorktreeManager(repo_root=str(temp_repo))
+        ghost = Path(manager.create_ghost_worktree("win"))
+
+        (ghost / "feature.txt").write_text("ghost work\n", encoding="utf-8")
+        _git(ghost, "add", "feature.txt")
+        _git(ghost, "commit", "-q", "-m", "ghost feature")
+
+        promoter = TrajectoryPromoter(manager=manager)
+        assert promoter.promote("win", target_branch="main") is True
+
+        assert (temp_repo / "feature.txt").read_text(encoding="utf-8") == "ghost work\n"
+        assert not ghost.exists()  # cleaned up after success
+
+    def test_promote_refused_on_wrong_branch(self, temp_repo: Path) -> None:
+        manager = GhostWorktreeManager(repo_root=str(temp_repo))
+        manager.create_ghost_worktree("w2")
+        promoter = TrajectoryPromoter(manager=manager)
+        assert promoter.promote("w2", target_branch="release") is False
+
+    def test_failed_promotion_keeps_ghost_worktree(self, temp_repo: Path) -> None:
+        manager = GhostWorktreeManager(repo_root=str(temp_repo))
+        ghost = Path(manager.create_ghost_worktree("div"))
+
+        # Diverge: commit on main AND on the ghost → ff-only must fail.
+        (temp_repo / "main.txt").write_text("main moved\n", encoding="utf-8")
+        _git(temp_repo, "add", "main.txt")
+        _git(temp_repo, "commit", "-q", "-m", "main moves")
+        (ghost / "ghost.txt").write_text("ghost work\n", encoding="utf-8")
+        _git(ghost, "add", "ghost.txt")
+        _git(ghost, "commit", "-q", "-m", "ghost diverges")
+
+        promoter = TrajectoryPromoter(manager=manager)
+        assert promoter.promote("div", target_branch="main") is False
+        # Regression: the original deleted the worktree on failure,
+        # destroying the winning trajectory's work.
+        assert ghost.exists()


### PR DESCRIPTION
## Summary

Rescues **PR 2 of Antigravity's 5-track plan** (Ghost Simulator). The original **never imported** — `runner.py` used `Optional` without importing it, so its "✅ passing" test suite couldn't even be collected — and its git behavior was unsafe. Rebuilt:

- **All git calls scoped to an explicit `repo_root`** — the original ran `git worktree add` / `merge` / `branch -D` in whatever CWD the process happened to have (running its tests inside a real repo would have created `ghost-*` branches in it).
- **Loud failures**: creation raises `GhostWorktreeError` instead of silently faking a sandbox with `os.makedirs` — the original's own test only ever exercised that fake-directory fallback, which is why it "passed" while the git path was untested.
- **Promoter fixed**: refuses to merge unless `target_branch` is actually checked out (the param was previously dead — it merged into whatever was checked out), and a failed promotion **retains** the ghost worktree instead of deleting the winning trajectory's work.
- **Comparator**: never recommends a failed trajectory (previously returned one when all failed).
- All `except: pass` blocks replaced with logged, specific handling.

## Receipts

- 11 tests, **non-mocked round trips through a real temp git repo**: worktree creation verified as a real worktree (branch + content), removal (worktree + branch gone), ff-only promotion landing a ghost commit on `main`, wrong-branch refusal, and divergence failure keeping the ghost.
- `pytest tests/unit/orchestration/test_ghost_simulator.py` → 11 passed.
- Pinned black/ruff pre-flighted; full pre-commit suite passed at commit.

Not yet wired to any orchestration surface — landing as a library module; consumers (parallel trajectory workflows) come separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
