### PR TITLE
rescue(roundtable): debate-theater track — stream module + parked UI

### DIFF
--- a/docs/rescue/debate-theater/DebateGraph.tsx
+++ b/docs/rescue/debate-theater/DebateGraph.tsx
@@ -1,0 +1,55 @@
+import React, { useEffect, useState } from 'react';
+
+export interface DebateNode {
+  id: string;
+  agent: 'claude' | 'antigravity' | 'codex';
+  topic: string;
+  proposal: string;
+  relation: 'supports' | 'challenges' | 'refines';
+  parentNodeId?: string;
+}
+
+export interface DebateGraphProps {
+  nodes: DebateNode[];
+  onSelectNode: (node: DebateNode) => void;
+}
+
+export const DebateGraph: React.FC<DebateGraphProps> = ({ nodes, onSelectNode }) => {
+  const getAgentColor = (agent: string) => {
+    switch (agent) {
+      case 'claude': return '#3b82f6'; // Blue
+      case 'antigravity': return '#10b981'; // Green
+      case 'codex': return '#8b5cf6'; // Purple
+      default: return '#6b7280';
+    }
+  };
+
+  return (
+    <div className="debate-graph-container border rounded-lg p-4 bg-slate-900 text-white min-h-[400px]">
+      <h3 className="text-lg font-semibold mb-4 border-b border-slate-700 pb-2">
+        Visual Debate Theater — Real-Time Multi-Agent Graph
+      </h3>
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+        {nodes.map((node) => (
+          <div
+            key={node.id}
+            onClick={() => onSelectNode(node)}
+            className="cursor-pointer p-4 rounded border border-slate-700 bg-slate-800 hover:border-blue-500 transition-all"
+            style={{ borderLeftWidth: '4px', borderLeftColor: getAgentColor(node.agent) }}
+          >
+            <div className="flex items-center justify-between mb-2">
+              <span className="text-xs uppercase font-bold tracking-wider" style={{ color: getAgentColor(node.agent) }}>
+                {node.agent}
+              </span>
+              <span className="text-xs px-2 py-0.5 rounded bg-slate-700 text-slate-300">
+                {node.relation}
+              </span>
+            </div>
+            <h4 className="font-medium text-sm mb-1">{node.topic}</h4>
+            <p className="text-xs text-slate-400 line-clamp-2">{node.proposal}</p>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};

--- a/docs/rescue/debate-theater/ExecutiveChairPanel.tsx
+++ b/docs/rescue/debate-theater/ExecutiveChairPanel.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { DebateNode } from './DebateGraph';
+
+export interface ExecutiveChairPanelProps {
+  selectedNode: DebateNode | null;
+  onPromoteNode: (nodeId: string) => void;
+  onVetoNode: (nodeId: string) => void;
+}
+
+export const ExecutiveChairPanel: React.FC<ExecutiveChairPanelProps> = ({
+  selectedNode,
+  onPromoteNode,
+  onVetoNode,
+}) => {
+  if (!selectedNode) {
+    return (
+      <div className="p-4 border border-slate-700 rounded bg-slate-800 text-slate-400 text-sm">
+        Select a node from the Debate Graph to exercise Chair promotion controls.
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-4 border border-slate-700 rounded bg-slate-800 text-white">
+      <div className="flex items-center justify-between mb-2">
+        <h4 className="text-md font-bold text-blue-400">Executive Chair Control Panel</h4>
+        <span className="text-xs text-slate-400">Node ID: {selectedNode.id}</span>
+      </div>
+      <div className="mb-4">
+        <p className="text-sm font-semibold">{selectedNode.topic}</p>
+        <p className="text-xs text-slate-300 mt-1">{selectedNode.proposal}</p>
+      </div>
+      <div className="flex gap-2">
+        <button
+          onClick={() => onPromoteNode(selectedNode.id)}
+          className="px-3 py-1.5 rounded bg-emerald-600 hover:bg-emerald-500 text-white text-xs font-semibold transition-colors"
+        >
+          [Promote Plan Branch]
+        </button>
+        <button
+          onClick={() => onVetoNode(selectedNode.id)}
+          className="px-3 py-1.5 rounded bg-rose-600 hover:bg-rose-500 text-white text-xs font-semibold transition-colors"
+        >
+          [Veto Proposal]
+        </button>
+      </div>
+    </div>
+  );
+};

--- a/docs/rescue/debate-theater/README.md
+++ b/docs/rescue/debate-theater/README.md
@@ -1,0 +1,18 @@
+# Rescue: Visual Debate Theater UI components
+
+Rescued from Antigravity's PR-4 track (round-table thread
+`q-review-five-implementation-plans-001`), which was written to the
+non-repo `~/antigravity IDE/` directory.
+
+These React components (`DebateGraph.tsx`, `ExecutiveChairPanel.tsx`)
+are **parked here, not served or built by this repo** — attune-ai has
+no `attune-gui/` tree; the GUI is a separate project. Disposition:
+
+- Move to the attune-gui project when the debate-theater surface is
+  picked up, wiring against `attune.roundtable.stream` events.
+- Note the gap between the plan and this code: no WebSocket client, no
+  Cytoscape graph (it renders a card grid), no event wiring — these
+  are static prop-driven components.
+
+Delete this directory when relocation happens (or when the track is
+ruled dead).

--- a/src/attune/roundtable/stream.py
+++ b/src/attune/roundtable/stream.py
@@ -1,0 +1,70 @@
+"""Debate event broadcaster for the round-table (rescue).
+
+In-process, synchronous pub/sub of typed debate-graph events. NOTE:
+despite the originating plan's "WebSocket broadcaster" framing, there
+is no transport here — subscribers are plain callables receiving JSON
+strings. A WebSocket (or SSE) transport would subscribe its own
+forwarding callback; that belongs to the GUI project, not this module.
+"""
+
+import json
+import logging
+from collections.abc import Callable
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+class DebateEventBroadcaster:
+    """Broadcaster for multi-agent roundtable graph events."""
+
+    def __init__(self) -> None:
+        self.subscribers: list[Callable[[str], None]] = []
+
+    def subscribe(self, callback: Callable[[str], None]) -> None:
+        """Subscribe a listener callback to the event stream."""
+        self.subscribers.append(callback)
+
+    def broadcast_node_proposed(
+        self,
+        thread_id: str,
+        agent: str,
+        node_id: str,
+        parent_node: str | None,
+        relation: str,
+        topic: str,
+        proposal: str,
+    ) -> dict[str, Any]:
+        """Broadcasts a new proposal node from an agent.
+
+        Args:
+            thread_id: ID of roundtable thread.
+            agent: Name of agent (claude, antigravity, codex).
+            node_id: Unique node identifier.
+            parent_node: Parent node ID if replying/challenging.
+            relation: Relationship type ('supports', 'challenges', 'refines').
+            topic: High-level topic title.
+            proposal: Proposal text content.
+
+        Returns:
+            Event payload dictionary.
+        """
+        payload = {
+            "event_type": "node_proposed",
+            "thread_id": thread_id,
+            "agent": agent,
+            "node_id": node_id,
+            "parent_node": parent_node or "",
+            "relation": relation,
+            "topic": topic,
+            "proposal": proposal,
+        }
+
+        json_str = json.dumps(payload)
+        for sub in self.subscribers:
+            try:
+                sub(json_str)
+            except Exception:  # noqa: BLE001 — one bad subscriber must not break the rest
+                logger.exception("debate subscriber failed for node %s", node_id)
+
+        return payload

--- a/tests/unit/roundtable/test_stream.py
+++ b/tests/unit/roundtable/test_stream.py
@@ -1,0 +1,28 @@
+"""Unit tests for Visual Debate Theater event broadcaster."""
+
+from attune.roundtable.stream import DebateEventBroadcaster
+
+
+class TestDebateEventBroadcaster:
+    """Tests for DebateEventBroadcaster."""
+
+    def test_broadcast_node_proposed(self) -> None:
+        broadcaster = DebateEventBroadcaster()
+        received = []
+
+        broadcaster.subscribe(lambda msg: received.append(msg))
+
+        payload = broadcaster.broadcast_node_proposed(
+            thread_id="rt-100",
+            agent="antigravity",
+            node_id="node-1",
+            parent_node=None,
+            relation="supports",
+            topic="AST Skeletonization",
+            proposal="Compress method bodies using stdlib ast",
+        )
+
+        assert payload["thread_id"] == "rt-100"
+        assert payload["agent"] == "antigravity"
+        assert len(received) == 1
+        assert "node-1" in received[0]


### PR DESCRIPTION
## Summary

**Rescue** of PR 4 of Antigravity's 5-track plan (Visual Debate Theater), preserved from the non-repo `~/antigravity IDE/` directory. **Draft** — the Python module is mergeable on its own, but the track's UI half belongs to another project.

- `stream.py` relocated into the **existing** `attune.roundtable` package — the original invented a parallel `attune.orchestration.roundtable` beside it.
- Docstring made honest: this is **in-process callable pub/sub**, not the "real-time WebSocket broadcaster" the plan claimed. A WS/SSE transport would subscribe a forwarding callback in the GUI project.
- Subscriber failures are now logged (`except: pass` removed).
- `DebateGraph.tsx` / `ExecutiveChairPanel.tsx` parked under `docs/rescue/debate-theater/` with a disposition README: attune-ai has no `attune-gui/` tree; they move to the attune-gui project when this surface is picked up. Known gaps documented there (no WebSocket client, no Cytoscape — it's a static card grid).

## Receipts

- `pytest tests/unit/roundtable/test_stream.py` → 1 passed.
- ruff/black clean; pre-commit suite passed at commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
