### PR TITLE
feat(roundtable): P3 rotating skeptic for spec-closure claims

### DIFF
--- a/docs/specs/agent-round-table/decisions.md
+++ b/docs/specs/agent-round-table/decisions.md
@@ -477,6 +477,28 @@ only via that evidence path.
 P2 (gate-triage inbox) is recorded in
 `docs/specs/spec-lifecycle-gates/decisions.md` — its owning spec.
 
+## 2026-07-21 — P3 skeptic V1 BUILT (merge held for the 07-27 fire)
+
+`attune.roundtable.skeptic` implements the ruled V1 shape:
+`RECEIPT-CMD: <label> :: <command>` structured lines in a staged
+closure entry declare the cheap receipts (capped at 5, shlex-split,
+fixed argv); the harness re-runs them via `solutions.validate` in a
+detached scratch worktree (always discarded); a rotation-picked
+non-author seat (pure `skeptic_for`, RR-2 pointer semantics,
+different-model rule enforced) gets the raw evidence as TEXT and
+must emit `VERDICT: COUNTERSIGN|DISSENT` with `CITE:`; a DISSENT
+without a cite is malformed, never laundered (TAC-4). One pass,
+one absent-fallback, one author bounce on dissent
+(`PASS_MAX_INVOCATIONS = 3`), digest posted unpromoted (R8). CLI:
+`python -m attune.roundtable.skeptic <spec-dir> --author <seat>`
+(+ `--dry-run`), reading the staged `decisions.md` diff.
+
+Suite receipt: `tests/unit/roundtable/` 186 passed serially
+(+30 new). **Merge deliberately HELD until after the 2026-07-27
+06:00 fire receipt** — the fire certifies the frozen system
+(session ruling 2026-07-21); first live pass and P4 telemetry
+start-of-recording follow the merge.
+
 ## 2026-07-22 — Digest disposition policy (chair-ruled)
 
 Standing default for routine digests once the appendix ledger

--- a/docs/specs/cross-review/receipts.md
+++ b/docs/specs/cross-review/receipts.md
@@ -83,5 +83,8 @@ the lift commit on the PR):
    `uncommitted_paths` raise `SkepticError` on nonzero git exit;
    an empty result can only mean "no staged closure".
 
-Regression tests for all four fixes in
-`tests/unit/roundtable/test_skeptic.py` (41 tests, serial pass).
+Copilot's PR review independently flagged findings 3 and 5 plus two
+CLI gaps (unvalidated `spec_dir` pathspec; `--dry-run` crashing on a
+bad declaration) — both CLI gaps fixed in the same lift commit.
+Regression tests for all fixes in
+`tests/unit/roundtable/test_skeptic.py` (48 tests, serial pass).

--- a/docs/specs/cross-review/receipts.md
+++ b/docs/specs/cross-review/receipts.md
@@ -57,3 +57,31 @@ For the #1559 lift review; anchors are the draft's
   pedantic (dismissed); run 5 correctly flagged a stale doc claim.
   Quality supports continuing advisory posture; no gate-upgrade
   claim from five runs.
+
+## Carried findings — #1559 dispositions (lift, 2026-07-29)
+
+Ruled at the #1559 lift (branch rebased onto main; fixes land in
+the lift commit on the PR):
+
+1. [high] worktree-from-HEAD — FIXED by surfacing, not re-design:
+   receipts still validate committed state (isolation is the
+   point), but `uncommitted_paths()` now records the blind spot
+   and the brief + chair digest name every uncommitted path the
+   receipts could not see (TAC-4 honesty over silent omission).
+2. [medium] scratch_root not created — DISMISSED, false positive:
+   `git worktree add` creates missing parents (probed live with a
+   3-level-deep nonexistent root, exit 0), and
+   `test_isolated_pass_and_fail_receipts` already passes a
+   nonexistent root — it stays as the regression guard.
+3. [medium] uncited COUNTERSIGN — FIXED: every verdict now
+   requires a CITE; an uncited countersign parses as malformed
+   (rubber-stamp decay is the ruling's named failure mode #1).
+4. [medium] CITE never validated — FIXED: `parse_skeptic_verdict`
+   accepts `valid_labels`; a CITE whose label names no executed
+   receipt records as malformed, never as a valid verdict.
+5. [low] silent git failure — FIXED: `staged_closure_text` and
+   `uncommitted_paths` raise `SkepticError` on nonzero git exit;
+   an empty result can only mean "no staged closure".
+
+Regression tests for all four fixes in
+`tests/unit/roundtable/test_skeptic.py` (41 tests, serial pass).

--- a/src/attune/roundtable/skeptic.py
+++ b/src/attune/roundtable/skeptic.py
@@ -410,28 +410,7 @@ def run_skeptic_pass(
     _post(board, thread, "moderator", "question", brief, skeptic_pass=spec)
 
     eligible = [seat for seat in _rotation_order(author, prior_records) if seat in recipes]
-    for seat in eligible[:2]:  # picked seat + one absent fallback
-        if record.invocations >= PASS_MAX_INVOCATIONS:
-            break
-        record.invocations += 1
-        code, reply = invoke(recipes[seat], brief)
-        if code != 0 or not reply.strip():
-            _post(
-                board,
-                thread,
-                seat,
-                "position",
-                f"ABSENT — exit {code}: {reply[:200]}",
-                absent=True,
-                skeptic_pass=spec,
-            )
-            continue
-        record.skeptic = seat
-        record.verdict = parse_skeptic_verdict(
-            reply, valid_labels=[r.label for r in record.receipts]
-        )
-        _post(board, thread, seat, "position", reply, skeptic_pass=spec)
-        break
+    _seek_verdict(record, eligible, recipes, invoke, brief, board, thread)
 
     if record.skeptic is None:
         record.outcome = "skeptic-absent"
@@ -452,24 +431,7 @@ def run_skeptic_pass(
         record.outcome = "malformed-verdict"
     else:
         record.outcome = "dissent"
-        if record.invocations < PASS_MAX_INVOCATIONS and author in recipes:
-            record.invocations += 1
-            code, reply = invoke(
-                recipes[author], build_bounce_brief(spec, verdict, record.receipts)
-            )
-            if code == 0 and reply.strip():
-                record.bounce_reply = reply
-                _post(board, thread, author, "position", reply, bounce=True, skeptic_pass=spec)
-            else:
-                _post(
-                    board,
-                    thread,
-                    author,
-                    "position",
-                    f"ABSENT on bounce — exit {code}: {reply[:200]}",
-                    absent=True,
-                    skeptic_pass=spec,
-                )
+        _bounce_author(record, verdict, recipes, invoke, board, thread)
 
     _post(
         board,
@@ -480,6 +442,69 @@ def run_skeptic_pass(
         skeptic_pass=spec,
     )
     return record
+
+
+def _seek_verdict(
+    record: SkepticPass,
+    eligible: Sequence[str],
+    recipes: Mapping[str, tuple[str, ...]],
+    invoke: Callable[[Sequence[str], str], tuple[int, str]],
+    brief: str,
+    board: object | None,
+    thread: str,
+) -> None:
+    """One verdict invocation, one absent fallback — mutates ``record``."""
+    for seat in eligible[:2]:  # picked seat + one absent fallback
+        if record.invocations >= PASS_MAX_INVOCATIONS:
+            break
+        record.invocations += 1
+        code, reply = invoke(recipes[seat], brief)
+        if code != 0 or not reply.strip():
+            _post(
+                board,
+                thread,
+                seat,
+                "position",
+                f"ABSENT — exit {code}: {reply[:200]}",
+                absent=True,
+                skeptic_pass=record.spec,
+            )
+            continue
+        record.skeptic = seat
+        record.verdict = parse_skeptic_verdict(
+            reply, valid_labels=[r.label for r in record.receipts]
+        )
+        _post(board, thread, seat, "position", reply, skeptic_pass=record.spec)
+        break
+
+
+def _bounce_author(
+    record: SkepticPass,
+    verdict: SkepticVerdict,
+    recipes: Mapping[str, tuple[str, ...]],
+    invoke: Callable[[Sequence[str], str], tuple[int, str]],
+    board: object | None,
+    thread: str,
+) -> None:
+    """The ONE author bounce after a dissent — mutates ``record``."""
+    author = record.author
+    if record.invocations >= PASS_MAX_INVOCATIONS or author not in recipes:
+        return
+    record.invocations += 1
+    code, reply = invoke(recipes[author], build_bounce_brief(record.spec, verdict, record.receipts))
+    if code == 0 and reply.strip():
+        record.bounce_reply = reply
+        _post(board, thread, author, "position", reply, bounce=True, skeptic_pass=record.spec)
+    else:
+        _post(
+            board,
+            thread,
+            author,
+            "position",
+            f"ABSENT on bounce — exit {code}: {reply[:200]}",
+            absent=True,
+            skeptic_pass=record.spec,
+        )
 
 
 def _rotation_order(author: str, records: Sequence[Mapping[str, object]]) -> list[str]:

--- a/src/attune/roundtable/skeptic.py
+++ b/src/attune/roundtable/skeptic.py
@@ -101,6 +101,7 @@ class SkepticPass:
     bounce_reply: str | None = None
     outcome: str = "pending"
     invocations: int = 0
+    isolation_gap: list[str] = field(default_factory=list)
 
 
 def parse_receipt_commands(text: str) -> list[tuple[str, list[str]]]:
@@ -140,6 +141,10 @@ def staged_closure_text(repo: Path, spec_dir: str) -> str:
     "Staged" per the ruling means the closure entry exists in the
     working tree but is not yet committed: ``git diff HEAD`` over the
     spec's ``decisions.md``, added lines only, ``+`` stripped.
+
+    Raises:
+        SkepticError: The git diff itself failed — an empty result
+            must mean "no staged closure", never a masked git error.
     """
     proc = subprocess.run(  # nosec B603 — fixed argv, shell=False
         ["git", "-C", str(repo), "diff", "HEAD", "--", f"{spec_dir}/decisions.md"],
@@ -147,6 +152,8 @@ def staged_closure_text(repo: Path, spec_dir: str) -> str:
         text=True,
         timeout=_GIT_TIMEOUT,
     )
+    if proc.returncode != 0:
+        raise SkepticError(f"git diff failed (exit {proc.returncode}): {proc.stderr.strip()[:300]}")
     added = [
         line[1:]
         for line in proc.stdout.splitlines()
@@ -192,6 +199,10 @@ def rerun_receipts(
     serial execution + tail receipts (the ruling's named mechanism);
     the worktree is always discarded, pass or fail.
 
+    Isolation contract: the worktree is created from ``base_ref``
+    (committed state) — uncommitted changes are NOT validated. Use
+    :func:`uncommitted_paths` to surface that gap to the chair.
+
     Raises:
         RuntimeError: Scratch worktree creation failed.
     """
@@ -212,6 +223,39 @@ def rerun_receipts(
         discard(candidate)
 
 
+def uncommitted_paths(repo: Path, exclude: Sequence[str] = ()) -> list[str]:
+    """Paths whose working state differs from HEAD (staged, unstaged,
+    or untracked) — the receipts' isolation blind spot.
+
+    The scratch worktree re-runs receipts from COMMITTED state, so
+    any path listed here is invisible to what the skeptic validates.
+    ``exclude`` names expected-uncommitted paths (the staged closure
+    entry itself).
+
+    Raises:
+        SkepticError: ``git status`` failed.
+    """
+    proc = subprocess.run(  # nosec B603 — fixed argv, shell=False
+        ["git", "-C", str(repo), "status", "--porcelain"],
+        capture_output=True,
+        text=True,
+        timeout=_GIT_TIMEOUT,
+    )
+    if proc.returncode != 0:
+        raise SkepticError(
+            f"git status failed (exit {proc.returncode}): {proc.stderr.strip()[:300]}"
+        )
+    paths: list[str] = []
+    for line in proc.stdout.splitlines():
+        path = line[3:].strip()
+        if " -> " in path:  # rename: validate the destination
+            path = path.split(" -> ", 1)[1]
+        path = path.strip('"')
+        if path and path not in exclude:
+            paths.append(path)
+    return paths
+
+
 def _format_receipts(receipts: Sequence[CheckReceipt]) -> str:
     blocks = []
     for r in receipts:
@@ -220,8 +264,29 @@ def _format_receipts(receipts: Sequence[CheckReceipt]) -> str:
     return "\n\n".join(blocks)
 
 
-def build_skeptic_brief(spec: str, closure_text: str, receipts: Sequence[CheckReceipt]) -> str:
-    """Build the R1 text-only brief for the skeptic seat."""
+def build_skeptic_brief(
+    spec: str,
+    closure_text: str,
+    receipts: Sequence[CheckReceipt],
+    isolation_gap: Sequence[str] = (),
+) -> str:
+    """Build the R1 text-only brief for the skeptic seat.
+
+    ``isolation_gap`` names uncommitted paths the receipts could not
+    see; the seat (and chair digest) must weigh the evidence knowing
+    the blind spot exists — TAC-4 honesty over silent omission.
+    """
+    gap_note = ""
+    if isolation_gap:
+        shown = "\n".join(f"- {p}" for p in list(isolation_gap)[:20])
+        more = len(isolation_gap) - 20
+        if more > 0:
+            shown += f"\n- … and {more} more"
+        gap_note = (
+            "\n\n## Isolation note\nReceipts were re-run from COMMITTED "
+            "state; these uncommitted paths are NOT reflected in the "
+            f"evidence:\n{shown}"
+        )
     return (
         "You are the rotating SKEPTIC seat at a three-model round "
         f"table. A closure entry for spec {spec!r} is staged. The "
@@ -242,7 +307,7 @@ def build_skeptic_brief(spec: str, closure_text: str, receipts: Sequence[CheckRe
         "the closure claim itself — spurious environment dissents "
         "train the chair to ignore dissent. Text only.\n\n"
         f"## Staged closure entry\n{closure_text}\n\n"
-        f"## Re-run receipts\n{_format_receipts(receipts)}"
+        f"## Re-run receipts\n{_format_receipts(receipts)}" + gap_note
     )
 
 
@@ -259,11 +324,16 @@ def build_bounce_brief(spec: str, verdict: SkepticVerdict, receipts: Sequence[Ch
     )
 
 
-def parse_skeptic_verdict(text: str) -> SkepticVerdict:
+def parse_skeptic_verdict(text: str, valid_labels: Sequence[str] | None = None) -> SkepticVerdict:
     """Parse the seat reply into a verdict — malformed is a verdict.
 
-    A DISSENT without a CITE is malformed (the ruling requires the
-    exact command to be cited); nothing is laundered to countersign.
+    EVERY verdict must carry a CITE (an uncited COUNTERSIGN is the
+    rubber stamp the ruling names as failure mode #1; a DISSENT
+    without the exact command cannot be bounced). When
+    ``valid_labels`` is given, the CITE's label part (before ``::``)
+    must name an executed receipt — an invented citation is
+    malformed, never recorded as valid. Nothing is laundered to
+    countersign.
     """
     m = _VERDICT_RE.search(text)
     if not m:
@@ -273,8 +343,12 @@ def parse_skeptic_verdict(text: str) -> SkepticVerdict:
     reason_m = _REASON_RE.search(text)
     cite = cite_m.group("cite") if cite_m else None
     reason = reason_m.group("reason") if reason_m else None
-    if kind == "dissent" and not cite:
+    if not cite:
         return SkepticVerdict(kind="malformed", cite=None, reason=reason, raw=text)
+    if valid_labels is not None:
+        label = cite.split("::", 1)[0].strip()
+        if label not in valid_labels:
+            return SkepticVerdict(kind="malformed", cite=cite, reason=reason, raw=text)
     return SkepticVerdict(kind=kind, cite=cite, reason=reason, raw=text)
 
 
@@ -289,6 +363,7 @@ def run_skeptic_pass(
     prior_records: Sequence[Mapping[str, object]] = (),
     thread: str | None = None,
     scratch_root: Path | None = None,
+    spec_dir: str | None = None,
 ) -> SkepticPass:
     """Run ONE skeptic pass over a staged closure; return the record.
 
@@ -297,6 +372,11 @@ def run_skeptic_pass(
     fallback to the remaining eligible seat) → on DISSENT, one
     author bounce → post the pass to the board thread for the chair.
     Never flips a status, never promotes (R8).
+
+    When ``spec_dir`` is given, uncommitted paths other than the
+    spec's own ``decisions.md`` are recorded as the isolation gap
+    (receipts validate committed state only) and surfaced in both
+    the brief and the chair digest.
     """
     from attune.roundtable.routine import SEAT_RECIPES, default_invoke_seat
 
@@ -324,7 +404,9 @@ def run_skeptic_pass(
         return record
 
     record.receipts = rerun_receipts(repo, checks, scratch_root=scratch_root)
-    brief = build_skeptic_brief(spec, closure_text, record.receipts)
+    exclude = (f"{spec_dir}/decisions.md",) if spec_dir else ()
+    record.isolation_gap = uncommitted_paths(repo, exclude=exclude) if spec_dir else []
+    brief = build_skeptic_brief(spec, closure_text, record.receipts, record.isolation_gap)
     _post(board, thread, "moderator", "question", brief, skeptic_pass=spec)
 
     eligible = [seat for seat in _rotation_order(author, prior_records) if seat in recipes]
@@ -345,7 +427,9 @@ def run_skeptic_pass(
             )
             continue
         record.skeptic = seat
-        record.verdict = parse_skeptic_verdict(reply)
+        record.verdict = parse_skeptic_verdict(
+            reply, valid_labels=[r.label for r in record.receipts]
+        )
         _post(board, thread, seat, "position", reply, skeptic_pass=spec)
         break
 
@@ -422,6 +506,11 @@ def _digest(record: SkepticPass) -> str:
     if verdict and verdict.kind == "dissent":
         lines.append(f"DISSENT cite: {verdict.cite}; reason: {verdict.reason or '(none)'}")
         lines.append("author bounce: " + ("recorded" if record.bounce_reply else "absent/none"))
+    if record.isolation_gap:
+        lines.append(
+            f"isolation gap: {len(record.isolation_gap)} uncommitted path(s) "
+            "NOT validated by the receipts"
+        )
     lines.append("Chair rules; this pass never flips the spec status (R8).")
     return "\n".join(lines)
 
@@ -466,12 +555,15 @@ def main(argv: Sequence[str] | None = None) -> int:
             print("no RECEIPT-CMD declarations in the staged closure")
             return 1
         receipts = rerun_receipts(repo, checks)
-        print(build_skeptic_brief(spec, closure, receipts))
+        gap = uncommitted_paths(repo, exclude=(f"{args.spec_dir}/decisions.md",))
+        print(build_skeptic_brief(spec, closure, receipts, gap))
         return 0
 
     from attune.roundtable.board import Board
 
-    record = run_skeptic_pass(spec, closure, repo, args.author, board=Board())
+    record = run_skeptic_pass(
+        spec, closure, repo, args.author, board=Board(), spec_dir=args.spec_dir
+    )
     print(f"skeptic pass complete: outcome={record.outcome}")
     return 0
 

--- a/src/attune/roundtable/skeptic.py
+++ b/src/attune/roundtable/skeptic.py
@@ -1,0 +1,480 @@
+"""Rotating skeptic for spec-closure claims — round-table P3.
+
+Ruled 2026-07-21 (thread ``q-roundtable-extensions-001``, chair:
+Patrick; build order P3 → P2 → P4-recording). V1 shape, R1-pure:
+when a spec closure entry is staged, the HARNESS re-runs the
+closure's declared cheap receipt commands (reusing
+:func:`attune.roundtable.solutions.validate`, isolated in a
+detached scratch worktree) and feeds the raw output as TEXT to a
+rotation-picked NON-AUTHOR seat, which emits a structured
+COUNTERSIGN or DISSENT citing the exact command + tail.
+
+Governance (substrate-enforced, never seat-defined):
+
+- **Different-model rule** — the skeptic is never the closure's
+  author seat; :func:`skeptic_for` cannot return the author.
+- **One skeptic pass** — a DISSENT gets ONE author bounce
+  (solution-loop precedent; counts against the invocation cap),
+  then everything goes to the chair digest. No auto-resolution.
+- **Chair-only promotion** — this module never flips a spec
+  status and never promotes a thread (R8).
+- **TAC-4** — malformed verdicts and absent seats are recorded
+  as such for the chair, never laundered into a countersign.
+
+Failure modes on record (the ruling, verbatim concerns):
+rubber-stamp decay; spurious environment dissents training the
+chair to ignore dissent. The brief instructs the seat on both;
+P4 role telemetry (record-only) will measure dissent hit-rate
+once it launches.
+
+Declared-receipt contract — a closure entry declares its cheap
+receipts as structured lines (the ``P4-ROTATION:`` /
+``PHASE-WAIVED:`` chair-line pattern)::
+
+    RECEIPT-CMD: <label> :: <command and args>
+
+Commands are shlex-split and run with fixed argv (never a
+shell) inside the scratch worktree.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under Apache 2.0
+"""
+
+from __future__ import annotations
+
+import datetime
+import re
+import shlex
+import subprocess  # nosec B404 — fixed argv git commands, never shell=True
+import tempfile
+import uuid
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from attune.roundtable.rotation import CANONICAL_SEATS
+from attune.roundtable.solutions import Candidate, CheckReceipt, discard, validate
+
+#: Cheap receipts only — a closure declaring more than this is not
+#: declaring *cheap* receipts and fails loudly for the chair.
+MAX_RECEIPT_CMDS = 5
+
+#: Invocation cap for one pass: skeptic attempt, one absent-fallback
+#: attempt on the remaining eligible seat, one author bounce.
+PASS_MAX_INVOCATIONS = 3
+
+_RECEIPT_CMD_RE = re.compile(
+    r"^\+?\s*RECEIPT-CMD:\s*(?P<label>[^:]+?)\s*::\s*(?P<cmd>.+?)\s*$",
+    re.MULTILINE,
+)
+
+_VERDICT_RE = re.compile(r"^\s*VERDICT:\s*(?P<kind>COUNTERSIGN|DISSENT)\s*$", re.MULTILINE)
+_CITE_RE = re.compile(r"^\s*CITE:\s*(?P<cite>.+?)\s*$", re.MULTILINE)
+_REASON_RE = re.compile(r"^\s*REASON:\s*(?P<reason>.+?)\s*$", re.MULTILINE)
+
+_GIT_TIMEOUT = 120
+
+
+class SkepticError(ValueError):
+    """A closure declaration this module refuses to act on."""
+
+
+@dataclass(frozen=True)
+class SkepticVerdict:
+    """The parsed seat verdict — or the fact that it did not parse."""
+
+    kind: str  # countersign | dissent | malformed
+    cite: str | None = None
+    reason: str | None = None
+    raw: str = ""
+
+
+@dataclass
+class SkepticPass:
+    """One complete pass — everything the chair digest needs."""
+
+    spec: str
+    author: str
+    skeptic: str | None
+    receipts: list[CheckReceipt] = field(default_factory=list)
+    verdict: SkepticVerdict | None = None
+    bounce_reply: str | None = None
+    outcome: str = "pending"
+    invocations: int = 0
+
+
+def parse_receipt_commands(text: str) -> list[tuple[str, list[str]]]:
+    """Extract ``RECEIPT-CMD:`` declarations from a closure entry.
+
+    Lines may carry a leading ``+`` (staged-diff form). Returns
+    ``(label, argv)`` pairs in declaration order.
+
+    Raises:
+        SkepticError: More than :data:`MAX_RECEIPT_CMDS` declarations,
+            a duplicate label, or a command that shlex cannot split.
+    """
+    checks: list[tuple[str, list[str]]] = []
+    seen: set[str] = set()
+    for m in _RECEIPT_CMD_RE.finditer(text):
+        label = m.group("label").strip()
+        if label in seen:
+            raise SkepticError(f"duplicate RECEIPT-CMD label: {label!r}")
+        seen.add(label)
+        try:
+            argv = shlex.split(m.group("cmd"))
+        except ValueError as exc:
+            raise SkepticError(f"unparseable RECEIPT-CMD {label!r}: {exc}") from exc
+        if not argv:
+            raise SkepticError(f"empty RECEIPT-CMD: {label!r}")
+        checks.append((label, argv))
+    if len(checks) > MAX_RECEIPT_CMDS:
+        raise SkepticError(
+            f"{len(checks)} RECEIPT-CMD lines — cheap receipts are capped at {MAX_RECEIPT_CMDS}"
+        )
+    return checks
+
+
+def staged_closure_text(repo: Path, spec_dir: str) -> str:
+    """Return the ADDED lines of the spec's staged/working decisions diff.
+
+    "Staged" per the ruling means the closure entry exists in the
+    working tree but is not yet committed: ``git diff HEAD`` over the
+    spec's ``decisions.md``, added lines only, ``+`` stripped.
+    """
+    proc = subprocess.run(  # nosec B603 — fixed argv, shell=False
+        ["git", "-C", str(repo), "diff", "HEAD", "--", f"{spec_dir}/decisions.md"],
+        capture_output=True,
+        text=True,
+        timeout=_GIT_TIMEOUT,
+    )
+    added = [
+        line[1:]
+        for line in proc.stdout.splitlines()
+        if line.startswith("+") and not line.startswith("+++")
+    ]
+    return "\n".join(added)
+
+
+def skeptic_for(author: str, records: Sequence[Mapping[str, object]]) -> str:
+    """Pick the rotation-owed NON-AUTHOR skeptic seat (pure).
+
+    Walks the canonical cycle starting after the last SERVED
+    skeptic; the author seat is skipped (different-model rule).
+    Unserved records never advance the pointer (the RR-2 semantic).
+
+    Raises:
+        SkepticError: Unknown author seat.
+    """
+    if author not in CANONICAL_SEATS:
+        raise SkepticError(f"unknown author seat: {author!r}")
+    start = 0
+    for record in reversed(records):
+        if bool(record.get("served")) and record.get("actual_skeptic") in CANONICAL_SEATS:
+            last = str(record["actual_skeptic"])
+            start = (CANONICAL_SEATS.index(last) + 1) % len(CANONICAL_SEATS)
+            break
+    for offset in range(len(CANONICAL_SEATS)):
+        seat = CANONICAL_SEATS[(start + offset) % len(CANONICAL_SEATS)]
+        if seat != author:
+            return seat
+    raise SkepticError("no eligible skeptic seat")  # pragma: no cover — 3 seats, 1 author
+
+
+def rerun_receipts(
+    repo: Path,
+    checks: list[tuple[str, list[str]]],
+    base_ref: str = "HEAD",
+    scratch_root: Path | None = None,
+) -> list[CheckReceipt]:
+    """Re-run declared receipts ISOLATED — detached scratch worktree.
+
+    Reuses :func:`attune.roundtable.solutions.validate` for the
+    serial execution + tail receipts (the ruling's named mechanism);
+    the worktree is always discarded, pass or fail.
+
+    Raises:
+        RuntimeError: Scratch worktree creation failed.
+    """
+    root = scratch_root or Path(tempfile.gettempdir())
+    worktree = root / f"rt-skeptic-{uuid.uuid4().hex[:12]}"
+    created = subprocess.run(  # nosec B603 — fixed argv, shell=False
+        ["git", "-C", str(repo), "worktree", "add", "--detach", str(worktree), base_ref],
+        capture_output=True,
+        text=True,
+        timeout=_GIT_TIMEOUT,
+    )
+    if created.returncode != 0:
+        raise RuntimeError(f"worktree add failed: {created.stderr.strip()[:300]}")
+    candidate = Candidate(worktree=worktree, files=[])
+    try:
+        return validate(candidate, checks).receipts
+    finally:
+        discard(candidate)
+
+
+def _format_receipts(receipts: Sequence[CheckReceipt]) -> str:
+    blocks = []
+    for r in receipts:
+        status = "PASS" if r.passed else f"FAIL (exit {r.exit_code})"
+        blocks.append(f"### {r.label}: {status}\n$ {shlex.join(r.argv)}\n{r.tail}")
+    return "\n\n".join(blocks)
+
+
+def build_skeptic_brief(spec: str, closure_text: str, receipts: Sequence[CheckReceipt]) -> str:
+    """Build the R1 text-only brief for the skeptic seat."""
+    return (
+        "You are the rotating SKEPTIC seat at a three-model round "
+        f"table. A closure entry for spec {spec!r} is staged. The "
+        "harness has RE-RUN the closure's declared receipt commands "
+        "in an isolated worktree; the raw results are below. Judge "
+        "ONLY from this evidence — do not run tools or invent checks "
+        "that were not run.\n\n"
+        "Reply with EXACTLY one verdict block:\n\n"
+        "VERDICT: COUNTERSIGN\n"
+        "CITE: <label> :: <the command you weight most>\n\n"
+        "or\n\n"
+        "VERDICT: DISSENT\n"
+        "CITE: <label> :: <the failing command>\n"
+        "REASON: <one line, grounded in that command's output tail>\n\n"
+        "Calibration: a countersign you did not check for is "
+        "rubber-stamp decay; an environment failure (exit 127 "
+        "not-found, 124 timeout) earns a DISSENT only when it blocks "
+        "the closure claim itself — spurious environment dissents "
+        "train the chair to ignore dissent. Text only.\n\n"
+        f"## Staged closure entry\n{closure_text}\n\n"
+        f"## Re-run receipts\n{_format_receipts(receipts)}"
+    )
+
+
+def build_bounce_brief(spec: str, verdict: SkepticVerdict, receipts: Sequence[CheckReceipt]) -> str:
+    """Build the ONE author-bounce brief for a dissent (R1 text-only)."""
+    return (
+        f"You are the AUTHOR seat of the staged closure for spec "
+        f"{spec!r}. The rotating skeptic DISSENTED:\n\n"
+        f"CITE: {verdict.cite}\nREASON: {verdict.reason or '(none given)'}\n\n"
+        "This is your ONE bounce before the chair digest. Either "
+        "concede (say what the closure entry must change) or rebut, "
+        "citing the exact receipt evidence below. Text only.\n\n"
+        f"## Re-run receipts\n{_format_receipts(receipts)}"
+    )
+
+
+def parse_skeptic_verdict(text: str) -> SkepticVerdict:
+    """Parse the seat reply into a verdict — malformed is a verdict.
+
+    A DISSENT without a CITE is malformed (the ruling requires the
+    exact command to be cited); nothing is laundered to countersign.
+    """
+    m = _VERDICT_RE.search(text)
+    if not m:
+        return SkepticVerdict(kind="malformed", raw=text)
+    kind = m.group("kind").lower()
+    cite_m = _CITE_RE.search(text)
+    reason_m = _REASON_RE.search(text)
+    cite = cite_m.group("cite") if cite_m else None
+    reason = reason_m.group("reason") if reason_m else None
+    if kind == "dissent" and not cite:
+        return SkepticVerdict(kind="malformed", cite=None, reason=reason, raw=text)
+    return SkepticVerdict(kind=kind, cite=cite, reason=reason, raw=text)
+
+
+def run_skeptic_pass(
+    spec: str,
+    closure_text: str,
+    repo: Path,
+    author: str,
+    board: object | None = None,
+    invoke_seat: Callable[[Sequence[str], str], tuple[int, str]] | None = None,
+    seat_recipes: Sequence[tuple[str, tuple[str, ...]]] | None = None,
+    prior_records: Sequence[Mapping[str, object]] = (),
+    thread: str | None = None,
+    scratch_root: Path | None = None,
+) -> SkepticPass:
+    """Run ONE skeptic pass over a staged closure; return the record.
+
+    Sequence: parse declared receipts → re-run isolated → rotation-
+    pick a non-author seat → one verdict invocation (one absent
+    fallback to the remaining eligible seat) → on DISSENT, one
+    author bounce → post the pass to the board thread for the chair.
+    Never flips a status, never promotes (R8).
+    """
+    from attune.roundtable.routine import SEAT_RECIPES, default_invoke_seat
+
+    invoke = invoke_seat or default_invoke_seat
+    recipes = dict(seat_recipes or SEAT_RECIPES)
+    record = SkepticPass(spec=spec, author=author, skeptic=None)
+    thread = thread or (f"skeptic-{spec}-{datetime.datetime.now().strftime('%Y%m%d-%H%M')}")
+
+    try:
+        checks = parse_receipt_commands(closure_text)
+    except SkepticError as exc:
+        record.outcome = "bad-declaration"
+        _post(board, thread, "moderator", "halt", f"skeptic pass refused: {exc}")
+        return record
+    if not checks:
+        record.outcome = "no-receipts"
+        _post(
+            board,
+            thread,
+            "moderator",
+            "halt",
+            f"closure for {spec!r} declares no RECEIPT-CMD lines — "
+            "nothing to countersign; chair reviews unassisted",
+        )
+        return record
+
+    record.receipts = rerun_receipts(repo, checks, scratch_root=scratch_root)
+    brief = build_skeptic_brief(spec, closure_text, record.receipts)
+    _post(board, thread, "moderator", "question", brief, skeptic_pass=spec)
+
+    eligible = [seat for seat in _rotation_order(author, prior_records) if seat in recipes]
+    for seat in eligible[:2]:  # picked seat + one absent fallback
+        if record.invocations >= PASS_MAX_INVOCATIONS:
+            break
+        record.invocations += 1
+        code, reply = invoke(recipes[seat], brief)
+        if code != 0 or not reply.strip():
+            _post(
+                board,
+                thread,
+                seat,
+                "position",
+                f"ABSENT — exit {code}: {reply[:200]}",
+                absent=True,
+                skeptic_pass=spec,
+            )
+            continue
+        record.skeptic = seat
+        record.verdict = parse_skeptic_verdict(reply)
+        _post(board, thread, seat, "position", reply, skeptic_pass=spec)
+        break
+
+    if record.skeptic is None:
+        record.outcome = "skeptic-absent"
+        _post(
+            board,
+            thread,
+            "moderator",
+            "halt",
+            f"no eligible skeptic seat reachable for {spec!r}; chair reviews unassisted",
+        )
+        return record
+
+    verdict = record.verdict
+    assert verdict is not None  # nosec B101 — set with record.skeptic above
+    if verdict.kind == "countersign":
+        record.outcome = "countersigned"
+    elif verdict.kind == "malformed":
+        record.outcome = "malformed-verdict"
+    else:
+        record.outcome = "dissent"
+        if record.invocations < PASS_MAX_INVOCATIONS and author in recipes:
+            record.invocations += 1
+            code, reply = invoke(
+                recipes[author], build_bounce_brief(spec, verdict, record.receipts)
+            )
+            if code == 0 and reply.strip():
+                record.bounce_reply = reply
+                _post(board, thread, author, "position", reply, bounce=True, skeptic_pass=spec)
+            else:
+                _post(
+                    board,
+                    thread,
+                    author,
+                    "position",
+                    f"ABSENT on bounce — exit {code}: {reply[:200]}",
+                    absent=True,
+                    skeptic_pass=spec,
+                )
+
+    _post(
+        board,
+        thread,
+        "moderator",
+        "synthesis",
+        _digest(record),
+        skeptic_pass=spec,
+    )
+    return record
+
+
+def _rotation_order(author: str, records: Sequence[Mapping[str, object]]) -> list[str]:
+    """Eligible seats in rotation order — owed seat first, author never."""
+    first = skeptic_for(author, records)
+    start = CANONICAL_SEATS.index(first)
+    ordered = [
+        CANONICAL_SEATS[(start + i) % len(CANONICAL_SEATS)] for i in range(len(CANONICAL_SEATS))
+    ]
+    return [seat for seat in ordered if seat != author]
+
+
+def _digest(record: SkepticPass) -> str:
+    """Compact chair-facing summary of one pass."""
+    verdict = record.verdict
+    lines = [
+        f"Skeptic pass for {record.spec!r}: outcome={record.outcome}",
+        f"author={record.author} skeptic={record.skeptic or 'ABSENT'}",
+        "receipts: "
+        + "; ".join(
+            f"{r.label}={'PASS' if r.passed else f'FAIL({r.exit_code})'}" for r in record.receipts
+        ),
+    ]
+    if verdict and verdict.kind == "dissent":
+        lines.append(f"DISSENT cite: {verdict.cite}; reason: {verdict.reason or '(none)'}")
+        lines.append("author bounce: " + ("recorded" if record.bounce_reply else "absent/none"))
+    lines.append("Chair rules; this pass never flips the spec status (R8).")
+    return "\n".join(lines)
+
+
+def _post(
+    board: object | None, thread: str, seat: str, kind: str, body: str, **fields: object
+) -> None:
+    """Post to the board when one is wired; print otherwise."""
+    if board is None:
+        print(f"[{thread}] {seat}/{kind}: {body[:160]}", flush=True)
+        return
+    board.post_message(thread, seat, kind, body, **fields)  # type: ignore[attr-defined]
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """CLI: ``python -m attune.roundtable.skeptic <spec-dir> --author <seat>``.
+
+    Reads the staged (uncommitted) closure entry from the spec's
+    ``decisions.md`` diff. ``--dry-run`` re-runs receipts and prints
+    the brief without any board write or LLM invocation.
+    """
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Rotating skeptic pass over a staged spec closure (P3; chair-only promotion)."
+    )
+    parser.add_argument("spec_dir", help="spec directory, e.g. docs/specs/<slug>")
+    parser.add_argument("--author", required=True, choices=sorted(CANONICAL_SEATS))
+    parser.add_argument("--repo", default=".", help="repository root (default: cwd)")
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args(argv)
+
+    repo = Path(args.repo).resolve()
+    spec = Path(args.spec_dir).name
+    closure = staged_closure_text(repo, args.spec_dir)
+    if not closure.strip():
+        print(f"no staged decisions.md changes under {args.spec_dir!r}; nothing to review")
+        return 1
+    if args.dry_run:
+        checks = parse_receipt_commands(closure)
+        if not checks:
+            print("no RECEIPT-CMD declarations in the staged closure")
+            return 1
+        receipts = rerun_receipts(repo, checks)
+        print(build_skeptic_brief(spec, closure, receipts))
+        return 0
+
+    from attune.roundtable.board import Board
+
+    record = run_skeptic_pass(spec, closure, repo, args.author, board=Board())
+    print(f"skeptic pass complete: outcome={record.outcome}")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/src/attune/roundtable/skeptic.py
+++ b/src/attune/roundtable/skeptic.py
@@ -543,14 +543,26 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser.add_argument("--dry-run", action="store_true")
     args = parser.parse_args(argv)
 
+    spec_path = Path(args.spec_dir)
+    if spec_path.is_absolute() or ".." in spec_path.parts:
+        print(f"invalid spec_dir {args.spec_dir!r}: must be repo-relative with no '..'")
+        return 2
     repo = Path(args.repo).resolve()
-    spec = Path(args.spec_dir).name
-    closure = staged_closure_text(repo, args.spec_dir)
+    spec = spec_path.name
+    try:
+        closure = staged_closure_text(repo, args.spec_dir)
+    except SkepticError as exc:
+        print(f"skeptic: {exc}")
+        return 2
     if not closure.strip():
         print(f"no staged decisions.md changes under {args.spec_dir!r}; nothing to review")
         return 1
     if args.dry_run:
-        checks = parse_receipt_commands(closure)
+        try:
+            checks = parse_receipt_commands(closure)
+        except SkepticError as exc:
+            print(f"skeptic: refusing this declaration — {exc}")
+            return 2
         if not checks:
             print("no RECEIPT-CMD declarations in the staged closure")
             return 1

--- a/tests/unit/roundtable/test_skeptic.py
+++ b/tests/unit/roundtable/test_skeptic.py
@@ -1,0 +1,319 @@
+"""Rotating-skeptic tests (round-table P3).
+
+Real git repos and worktrees in tmp for the receipt re-runs — no
+mocked git (the isolated-rerun seam is the point of the feature).
+Seat invocations and the board are injected fakes: substrate
+governance (different-model rule, one bounce, TAC-4 no-laundering,
+R8 never-promotes) is asserted from the pass record + posted
+messages.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under Apache 2.0
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+import pytest
+
+from attune.roundtable.rotation import CANONICAL_SEATS
+from attune.roundtable.skeptic import (
+    MAX_RECEIPT_CMDS,
+    SkepticError,
+    build_skeptic_brief,
+    parse_receipt_commands,
+    parse_skeptic_verdict,
+    rerun_receipts,
+    run_skeptic_pass,
+    skeptic_for,
+    staged_closure_text,
+)
+
+
+@pytest.fixture
+def repo(tmp_path):
+    """A tiny real git repo with one committed file."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+
+    def git(*args):
+        subprocess.run(["git", "-C", str(repo), *args], check=True, capture_output=True, text=True)
+
+    git("init", "-q")
+    git("config", "user.email", "t@example.com")
+    git("config", "user.name", "t")
+    git("config", "commit.gpgsign", "false")
+    (repo / "hello.py").write_text('GREETING = "hello"\n')
+    git("add", "hello.py")
+    git("commit", "-q", "-m", "seed")
+    return repo
+
+
+class FakeBoard:
+    """Collects posts; asserts R8 by never exposing a promote path."""
+
+    def __init__(self):
+        self.posts = []
+
+    def post_message(self, thread, seat, kind, body, **fields):
+        self.posts.append({"thread": thread, "seat": seat, "kind": kind, "body": body, **fields})
+        return len(self.posts)
+
+
+#: Fake recipes keyed so the invoker can tell which seat it plays.
+RECIPES = tuple((seat, (f"seat-{seat}",)) for seat in CANONICAL_SEATS)
+
+
+def invoker(replies):
+    """Build an invoke_seat fake: seat name -> (code, reply)."""
+
+    def invoke(recipe, brief):
+        seat = recipe[0].removeprefix("seat-")
+        return replies.get(seat, (1, ""))
+
+    return invoke
+
+
+CLOSURE = (
+    "## 2026-07-21 — closure staged\n"
+    "**Status:** shipped (2026-07-21)\n"
+    f"RECEIPT-CMD: smoke :: {sys.executable} -c pass\n"
+)
+
+COUNTERSIGN = "VERDICT: COUNTERSIGN\nCITE: smoke :: python -c pass\n"
+DISSENT = "VERDICT: DISSENT\nCITE: smoke :: python -c pass\nREASON: tail shows a failure\n"
+
+
+class TestParseReceiptCommands:
+    def test_basic_and_order(self):
+        text = "RECEIPT-CMD: a :: echo one\nRECEIPT-CMD: b :: pytest -q tests\n"
+        assert parse_receipt_commands(text) == [
+            ("a", ["echo", "one"]),
+            ("b", ["pytest", "-q", "tests"]),
+        ]
+
+    def test_staged_diff_plus_prefix(self):
+        assert parse_receipt_commands("+RECEIPT-CMD: a :: echo hi\n") == [("a", ["echo", "hi"])]
+
+    def test_no_declarations(self):
+        assert parse_receipt_commands("## just prose\n") == []
+
+    def test_duplicate_label_rejected(self):
+        with pytest.raises(SkepticError, match="duplicate"):
+            parse_receipt_commands("RECEIPT-CMD: a :: echo 1\nRECEIPT-CMD: a :: echo 2\n")
+
+    def test_cap_enforced(self):
+        lines = "\n".join(f"RECEIPT-CMD: c{i} :: echo {i}" for i in range(MAX_RECEIPT_CMDS + 1))
+        with pytest.raises(SkepticError, match="capped"):
+            parse_receipt_commands(lines)
+
+    def test_unparseable_command_rejected(self):
+        with pytest.raises(SkepticError, match="unparseable"):
+            parse_receipt_commands('RECEIPT-CMD: a :: echo "unclosed\n')
+
+
+class TestSkepticFor:
+    def test_first_pick_skips_author(self):
+        assert skeptic_for("claude", ()) == "antigravity"
+        assert skeptic_for("antigravity", ()) == "claude"
+
+    def test_pointer_advances_past_served(self):
+        records = [{"actual_skeptic": "antigravity", "served": True}]
+        assert skeptic_for("claude", records) == "codex"
+
+    def test_unserved_never_advances(self):
+        records = [{"actual_skeptic": "antigravity", "served": False}]
+        assert skeptic_for("claude", records) == "antigravity"
+
+    def test_advance_lands_on_author_then_skips(self):
+        records = [{"actual_skeptic": "codex", "served": True}]
+        # next in cycle is claude == author -> skip to antigravity
+        assert skeptic_for("claude", records) == "antigravity"
+
+    def test_unknown_author_rejected(self):
+        with pytest.raises(SkepticError, match="unknown author"):
+            skeptic_for("gpt", ())
+
+
+class TestParseVerdict:
+    def test_countersign(self):
+        v = parse_skeptic_verdict(COUNTERSIGN)
+        assert v.kind == "countersign"
+        assert v.cite == "smoke :: python -c pass"
+
+    def test_dissent_with_cite_and_reason(self):
+        v = parse_skeptic_verdict(DISSENT)
+        assert (v.kind, v.reason) == ("dissent", "tail shows a failure")
+
+    def test_dissent_without_cite_is_malformed(self):
+        v = parse_skeptic_verdict("VERDICT: DISSENT\nREASON: because\n")
+        assert v.kind == "malformed"
+
+    def test_garbage_is_malformed_never_laundered(self):
+        assert parse_skeptic_verdict("LGTM, ship it!").kind == "malformed"
+
+
+class TestRerunReceipts:
+    def test_isolated_pass_and_fail_receipts(self, repo, tmp_path):
+        checks = [
+            ("ok", [sys.executable, "-c", "print('fine')"]),
+            ("boom", [sys.executable, "-c", "raise SystemExit(3)"]),
+        ]
+        receipts = rerun_receipts(repo, checks, scratch_root=tmp_path / "scratch")
+        assert [r.passed for r in receipts] == [True, False]
+        assert receipts[1].exit_code == 3
+        # isolation receipt: the scratch worktree is gone afterwards
+        assert not list((tmp_path / "scratch").glob("rt-skeptic-*"))
+
+    def test_worktree_sees_committed_tree(self, repo, tmp_path):
+        checks = [
+            (
+                "read",
+                [
+                    sys.executable,
+                    "-c",
+                    "import pathlib;print(pathlib.Path('hello.py').read_text())",
+                ],
+            )
+        ]
+        receipts = rerun_receipts(repo, checks, scratch_root=tmp_path / "s2")
+        assert receipts[0].passed and "hello" in receipts[0].tail
+
+
+class TestStagedClosureText:
+    def test_added_lines_only(self, repo):
+        spec = repo / "docs" / "specs" / "demo"
+        spec.mkdir(parents=True)
+        (spec / "decisions.md").write_text("# Decisions\n\nold line\n")
+        subprocess.run(["git", "-C", str(repo), "add", "docs"], check=True, capture_output=True)
+        subprocess.run(
+            ["git", "-C", str(repo), "commit", "-q", "-m", "spec"],
+            check=True,
+            capture_output=True,
+        )
+        (spec / "decisions.md").write_text(
+            "# Decisions\n\nold line\n\n## closure\nRECEIPT-CMD: a :: echo hi\n"
+        )
+        text = staged_closure_text(repo, "docs/specs/demo")
+        assert "RECEIPT-CMD: a :: echo hi" in text
+        assert "old line" not in text
+
+    def test_clean_tree_is_empty(self, repo):
+        assert staged_closure_text(repo, "docs/specs/none") == ""
+
+
+class TestRunSkepticPass:
+    def _run(self, repo, closure=CLOSURE, replies=None, records=(), author="claude"):
+        board = FakeBoard()
+        record = run_skeptic_pass(
+            "demo-spec",
+            closure,
+            repo,
+            author,
+            board=board,
+            invoke_seat=invoker(replies or {}),
+            seat_recipes=RECIPES,
+            prior_records=records,
+            thread="t-demo",
+        )
+        return record, board
+
+    def test_countersign_path(self, repo):
+        record, board = self._run(repo, replies={"antigravity": (0, COUNTERSIGN)})
+        assert record.outcome == "countersigned"
+        assert record.skeptic == "antigravity"
+        assert record.invocations == 1
+        kinds = [p["kind"] for p in board.posts]
+        assert kinds == ["question", "position", "synthesis"]
+
+    def test_dissent_gets_one_author_bounce(self, repo):
+        record, board = self._run(
+            repo,
+            replies={"antigravity": (0, DISSENT), "claude": (0, "I concede; will amend.")},
+        )
+        assert record.outcome == "dissent"
+        assert record.bounce_reply == "I concede; will amend."
+        assert record.invocations == 2
+        bounce = [p for p in board.posts if p.get("bounce")]
+        assert len(bounce) == 1 and bounce[0]["seat"] == "claude"
+
+    def test_malformed_verdict_recorded_not_laundered(self, repo):
+        record, _ = self._run(repo, replies={"antigravity": (0, "ship it")})
+        assert record.outcome == "malformed-verdict"
+        assert record.bounce_reply is None
+
+    def test_absent_skeptic_falls_back_once(self, repo):
+        record, board = self._run(repo, replies={"antigravity": (1, ""), "codex": (0, COUNTERSIGN)})
+        assert record.skeptic == "codex"
+        assert record.outcome == "countersigned"
+        absents = [p for p in board.posts if p.get("absent")]
+        assert len(absents) == 1
+
+    def test_all_absent_is_chair_visible(self, repo):
+        record, board = self._run(repo, replies={})
+        assert record.outcome == "skeptic-absent"
+        assert any(p["kind"] == "halt" for p in board.posts)
+
+    def test_author_never_plays_skeptic(self, repo):
+        # every seat would countersign; the author's recipe must only
+        # ever be invoked for a bounce (never for the verdict)
+        invoked = []
+
+        def invoke(recipe, brief):
+            invoked.append(recipe[0].removeprefix("seat-"))
+            return (0, COUNTERSIGN)
+
+        board = FakeBoard()
+        record = run_skeptic_pass(
+            "demo-spec",
+            CLOSURE,
+            repo,
+            "claude",
+            board=board,
+            invoke_seat=invoke,
+            seat_recipes=RECIPES,
+            thread="t-demo",
+        )
+        assert record.skeptic != "claude"
+        assert invoked == ["antigravity"]
+
+    def test_rotation_records_shift_the_pick(self, repo):
+        record, _ = self._run(
+            repo,
+            replies={"codex": (0, COUNTERSIGN)},
+            records=[{"actual_skeptic": "antigravity", "served": True}],
+        )
+        assert record.skeptic == "codex"
+
+    def test_no_receipts_declared(self, repo):
+        record, board = self._run(repo, closure="## closure with no receipts\n")
+        assert record.outcome == "no-receipts"
+        assert record.invocations == 0
+        assert board.posts[0]["kind"] == "halt"
+
+    def test_bad_declaration_refused(self, repo):
+        closure = "RECEIPT-CMD: a :: echo 1\nRECEIPT-CMD: a :: echo 2\n"
+        record, board = self._run(repo, closure=closure)
+        assert record.outcome == "bad-declaration"
+        assert board.posts[0]["kind"] == "halt"
+
+    def test_never_promotes_and_never_flips_status(self, repo):
+        _, board = self._run(repo, replies={"antigravity": (0, COUNTERSIGN)})
+        assert all(p["kind"] != "ruling" for p in board.posts)
+        digest = [p for p in board.posts if p["kind"] == "synthesis"][0]
+        assert "never flips the spec status" in digest["body"]
+
+
+class TestBrief:
+    def test_brief_carries_evidence_and_calibration(self, repo, tmp_path):
+        receipts = rerun_receipts(
+            repo,
+            [("smoke", [sys.executable, "-c", "print('receipt-tail-marker')"])],
+            scratch_root=tmp_path / "s3",
+        )
+        brief = build_skeptic_brief("demo", CLOSURE, receipts)
+        assert "receipt-tail-marker" in brief
+        assert "rubber-stamp" in brief
+        assert "VERDICT: DISSENT" in brief

--- a/tests/unit/roundtable/test_skeptic.py
+++ b/tests/unit/roundtable/test_skeptic.py
@@ -23,6 +23,7 @@ from attune.roundtable.skeptic import (
     MAX_RECEIPT_CMDS,
     SkepticError,
     build_skeptic_brief,
+    main,
     parse_receipt_commands,
     parse_skeptic_verdict,
     rerun_receipts,
@@ -375,6 +376,63 @@ class TestRunSkepticPass:
         assert all(p["kind"] != "ruling" for p in board.posts)
         digest = [p for p in board.posts if p["kind"] == "synthesis"][0]
         assert "never flips the spec status" in digest["body"]
+
+
+class TestMain:
+    """CLI seam — path validation and concise failure surfacing."""
+
+    def _stage_closure(self, repo, closure_tail):
+        spec = repo / "docs" / "specs" / "demo"
+        spec.mkdir(parents=True)
+        (spec / "decisions.md").write_text("# Decisions\n")
+        subprocess.run(["git", "-C", str(repo), "add", "docs"], check=True, capture_output=True)
+        subprocess.run(
+            ["git", "-C", str(repo), "commit", "-q", "-m", "spec"],
+            check=True,
+            capture_output=True,
+        )
+        (spec / "decisions.md").write_text("# Decisions\n\n## closure\n" + closure_tail)
+
+    def test_traversal_spec_dir_rejected(self, repo, capsys):
+        code = main(["../evil", "--author", "claude", "--repo", str(repo)])
+        assert code == 2
+        assert "invalid spec_dir" in capsys.readouterr().out
+
+    def test_absolute_spec_dir_rejected(self, repo, capsys):
+        code = main([str(repo / "docs"), "--author", "claude", "--repo", str(repo)])
+        assert code == 2
+        assert "invalid spec_dir" in capsys.readouterr().out
+
+    def test_git_failure_surfaces_concise(self, tmp_path, capsys):
+        code = main(["docs/specs/x", "--author", "claude", "--repo", str(tmp_path / "nope")])
+        assert code == 2
+        assert "git diff failed" in capsys.readouterr().out
+
+    def test_nothing_staged_exits_1(self, repo, capsys):
+        code = main(["docs/specs/none", "--author", "claude", "--repo", str(repo)])
+        assert code == 1
+        assert "nothing to review" in capsys.readouterr().out
+
+    def test_dry_run_prints_brief_with_gap(self, repo, capsys):
+        self._stage_closure(repo, f"RECEIPT-CMD: smoke :: {sys.executable} -c pass\n")
+        (repo / "drifting.py").write_text("x = 1\n")
+        code = main(["docs/specs/demo", "--author", "claude", "--repo", str(repo), "--dry-run"])
+        out = capsys.readouterr().out
+        assert code == 0
+        assert "Re-run receipts" in out
+        assert "drifting.py" in out  # isolation gap named in the brief
+
+    def test_dry_run_bad_declaration_exits_2(self, repo, capsys):
+        self._stage_closure(repo, "RECEIPT-CMD: a :: echo 1\nRECEIPT-CMD: a :: echo 2\n")
+        code = main(["docs/specs/demo", "--author", "claude", "--repo", str(repo), "--dry-run"])
+        assert code == 2
+        assert "refusing this declaration" in capsys.readouterr().out
+
+    def test_dry_run_no_receipt_lines_exits_1(self, repo, capsys):
+        self._stage_closure(repo, "prose only, no receipts\n")
+        code = main(["docs/specs/demo", "--author", "claude", "--repo", str(repo), "--dry-run"])
+        assert code == 1
+        assert "no RECEIPT-CMD declarations" in capsys.readouterr().out
 
 
 class TestBrief:

--- a/tests/unit/roundtable/test_skeptic.py
+++ b/tests/unit/roundtable/test_skeptic.py
@@ -29,6 +29,7 @@ from attune.roundtable.skeptic import (
     run_skeptic_pass,
     skeptic_for,
     staged_closure_text,
+    uncommitted_paths,
 )
 
 
@@ -151,6 +152,20 @@ class TestParseVerdict:
         v = parse_skeptic_verdict("VERDICT: DISSENT\nREASON: because\n")
         assert v.kind == "malformed"
 
+    def test_countersign_without_cite_is_malformed(self):
+        # an uncited countersign is the rubber stamp the ruling names
+        v = parse_skeptic_verdict("VERDICT: COUNTERSIGN\n")
+        assert v.kind == "malformed"
+
+    def test_invented_cite_label_is_malformed(self):
+        v = parse_skeptic_verdict(COUNTERSIGN, valid_labels=["other"])
+        assert v.kind == "malformed"
+        assert v.cite == "smoke :: python -c pass"  # kept for the chair
+
+    def test_matching_cite_label_accepted(self):
+        v = parse_skeptic_verdict(COUNTERSIGN, valid_labels=["smoke"])
+        assert v.kind == "countersign"
+
     def test_garbage_is_malformed_never_laundered(self):
         assert parse_skeptic_verdict("LGTM, ship it!").kind == "malformed"
 
@@ -202,6 +217,29 @@ class TestStagedClosureText:
 
     def test_clean_tree_is_empty(self, repo):
         assert staged_closure_text(repo, "docs/specs/none") == ""
+
+    def test_git_failure_raises_not_empty(self, tmp_path):
+        # a failed git diff must never read as "nothing to review"
+        with pytest.raises(SkepticError, match="git diff failed"):
+            staged_closure_text(tmp_path / "not-a-repo", "docs/specs/x")
+
+
+class TestUncommittedPaths:
+    def test_clean_repo_is_empty(self, repo):
+        assert uncommitted_paths(repo) == []
+
+    def test_dirty_and_untracked_listed(self, repo):
+        (repo / "hello.py").write_text('GREETING = "changed"\n')
+        (repo / "new.py").write_text("x = 1\n")
+        assert sorted(uncommitted_paths(repo)) == ["hello.py", "new.py"]
+
+    def test_exclude_hides_the_closure_entry(self, repo):
+        (repo / "hello.py").write_text('GREETING = "changed"\n')
+        assert uncommitted_paths(repo, exclude=("hello.py",)) == []
+
+    def test_git_failure_raises(self, tmp_path):
+        with pytest.raises(SkepticError, match="git status failed"):
+            uncommitted_paths(tmp_path / "not-a-repo")
 
 
 class TestRunSkepticPass:
@@ -298,6 +336,39 @@ class TestRunSkepticPass:
         record, board = self._run(repo, closure=closure)
         assert record.outcome == "bad-declaration"
         assert board.posts[0]["kind"] == "halt"
+
+    def test_invented_cite_recorded_as_malformed(self, repo):
+        # the executed receipt label is "smoke"; the seat cites a
+        # check that never ran — never recorded as a valid verdict
+        invented = "VERDICT: COUNTERSIGN\nCITE: full-suite :: pytest -q\n"
+        record, _ = self._run(repo, replies={"antigravity": (0, invented)})
+        assert record.outcome == "malformed-verdict"
+
+    def test_isolation_gap_surfaced_when_spec_dir_given(self, repo):
+        (repo / "drifting.py").write_text("x = 1\n")
+        board = FakeBoard()
+        record = run_skeptic_pass(
+            "demo-spec",
+            CLOSURE,
+            repo,
+            "claude",
+            board=board,
+            invoke_seat=invoker({"antigravity": (0, COUNTERSIGN)}),
+            seat_recipes=RECIPES,
+            thread="t-demo",
+            spec_dir="docs/specs/demo-spec",
+        )
+        assert record.isolation_gap == ["drifting.py"]
+        brief = board.posts[0]["body"]
+        assert "Isolation note" in brief and "drifting.py" in brief
+        digest = [p for p in board.posts if p["kind"] == "synthesis"][0]
+        assert "isolation gap: 1 uncommitted path(s)" in digest["body"]
+
+    def test_no_spec_dir_means_no_gap_scan(self, repo):
+        (repo / "drifting.py").write_text("x = 1\n")
+        record, board = self._run(repo, replies={"antigravity": (0, COUNTERSIGN)})
+        assert record.isolation_gap == []
+        assert "Isolation note" not in board.posts[0]["body"]
 
     def test_never_promotes_and_never_flips_status(self, repo):
         _, board = self._run(repo, replies={"antigravity": (0, COUNTERSIGN)})


### PR DESCRIPTION
## Lifted 2026-07-29 — hold discharged

The 2026-07-27/28 fire receipt landed GREEN (`routine-clean-run-20260728-1020`, promoted; agent-round-table flipped shipped). Branch rebased onto main; the five carried cross-review findings (R5 ledger run 1, codex) are dispositioned in `docs/specs/cross-review/receipts.md` — 4 fixed in the lift commit (isolation gap surfaced, CITE required on every verdict, CITEs validated against executed receipts, git failures raise), 1 dismissed as a false positive with a live probe (`git worktree add` creates parents). Copilot's two CLI comments (spec_dir validation, dry-run error handling) fixed in the same commit.

## What

P3 rotating skeptic for spec-closure claims — the first of the three
table extensions ruled 2026-07-21 (`q-roundtable-extensions-001`,
build order **P3 → P2 → P4-recording**; P1 cut). V1 shape, R1-pure.

**Flow:** staged closure entry → declared `RECEIPT-CMD: <label> ::
<command>` lines parsed (shlex argv, cap 5) → harness re-runs them in
a **detached scratch worktree** via `solutions.validate` (always
discarded) → rotation-picked **non-author** seat gets the raw
evidence as TEXT → emits `VERDICT: COUNTERSIGN|DISSENT` with
`CITE:` → on DISSENT, **one** author bounce → digest posted
**unpromoted** for the chair.

**Governance (substrate-enforced):**

- Different-model rule: `skeptic_for` can never return the author;
  pure RR-2 pointer semantics over a served-skeptic ledger
- One pass, one absent-fallback, one bounce (`PASS_MAX_INVOCATIONS
  = 3`)
- TAC-4: malformed verdicts (incl. DISSENT-without-CITE) recorded
  as malformed, never laundered to countersign
- R8: never promotes, never flips a spec status
- Both ruled failure modes addressed in the brief (rubber-stamp
  decay; spurious environment dissents)

**CLI:** `python -m attune.roundtable.skeptic <spec-dir> --author
<seat> [--dry-run]` — reads the staged `decisions.md` diff.

## Receipts

- `tests/unit/roundtable/test_skeptic.py`: 30 tests — real git
  repos/worktrees for the re-run seam (non-mocked), injected fakes
  for seats/board
- Full `tests/unit/roundtable/` serial: **186 passed** (was 156)
- Pinned black + ruff pre-flighted clean
- Build recorded in `docs/specs/agent-round-table/decisions.md`

Post-merge follow-ups (already ruled): P2 gate-triage inbox (owned
by spec-lifecycle-gates), P4 role telemetry starts recording when
P3/P2 launch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

