### PR TITLE
docs(changelog): [Unreleased] entries for the overnight four (#1551–#1554)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,29 @@ run-record corpus that future releases learn from.
 - **Starter-lint hook** (#1516). SessionStart cross-reads the session
   starter's spec mentions against each spec's own status line and
   flags stale threads.
+- **Adaptive Friction Matrix + friction gate** (#1551).
+  `attune.orchestration.friction` scores commands into friction
+  zones; a new `friction_gate` PreToolUse/Bash plugin hook surfaces
+  the zone advisory-by-default, with `ATTUNE_FRICTION_ENFORCE=1`
+  blocking zone-4 commands. The hook activates organically once the
+  installed plugin updates to this release.
+- **AST context budgeting** (#1552). `attune.context` gains
+  `ASTSkeletonGenerator`, `TokenBudgetAllocator`, and
+  `ContextInflater` — skeleton-first file context that fits a token
+  budget and inflates on demand (Redis AST caching deliberately
+  deferred).
+- **Ghost Simulator sandbox** (#1553). `attune.orchestration.ghosts`
+  runs what-if changes in ephemeral git worktrees: repo-root-scoped
+  git, loud `GhostWorktreeError`, and a promoter branch-guard that
+  keeps the worktree on failure. Library-only in this release — no
+  consumer wired yet.
+- **Self-healing traps** (#1554). `attune.telemetry.lessons` + a new
+  `trap_stash` PostToolUse/Bash plugin hook deterministically capture
+  pre-commit and pytest failures into the existing session stash
+  (zero LLM spend, per-session dedupe, `ATTUNE_TRAP_STASH=0` to
+  disable); findings surface through the existing `/recall` flow.
+  Activates organically with the plugin update, like the friction
+  gate.
 
 ### Changed
 

--- a/docs/process/RELEASE_10_6_0_drafts.md
+++ b/docs/process/RELEASE_10_6_0_drafts.md
@@ -12,6 +12,13 @@ own `[Unreleased]` entry:
 - [ ] sdk-teardown-exit-guard implementation (chip session)
 - [ ] post-commit help hook dry-run flip (chip session)
 - [ ] #1531 coverage-bar alignment (patch gate 50→80)
+- [x] Overnight four (2026-07-21 antigravity-review arc):
+  #1551 friction matrix + gate, #1552 AST context budgeting,
+  #1553 ghost simulator, #1554 self-healing traps — `[Unreleased]`
+  entries added same-day (this checklist's own confirm pass).
+  Draft-A candidate line: **10.6.0 activates two new plugin hooks**
+  (`friction_gate`, `trap_stash`) on plugin update — the traps
+  spec's D5 caveat names the post-publish organic-fire check.
 - [ ] Anything else merged into `[Unreleased]` this week
 
 ---


### PR DESCRIPTION
## What

The Monday-runbook pre-step, done early to shrink the 07-27 sitting to tag-plus-refresh: \`[Unreleased]\` entries for the four features the 2026-07-21 overnight arc merged without changelog lines —

- **#1551** Adaptive Friction Matrix + \`friction_gate\` PreToolUse hook (advisory; \`ATTUNE_FRICTION_ENFORCE=1\` blocks zone-4)
- **#1552** AST context budgeting (\`attune.context\`: skeleton generator, budget allocator, inflater)
- **#1553** Ghost Simulator sandbox (\`attune.orchestration.ghosts\`, library-only)
- **#1554** Self-healing traps + \`trap_stash\` PostToolUse hook (deterministic failure capture into the session stash)

Both hook entries note organic activation on the 10.6.0 plugin update (the traps spec's D5 caveat). The 10.6.0 drafts refresh checklist gets a checked confirm-line + the Draft-A candidate line ("10.6.0 activates two new plugin hooks").

Docs-only; no version files touched; records already-merged features so it does not re-litigate the 10.6.0 hold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)