### PR TITLE
test(ops): close #1542 patch-coverage gaps in spec_lifecycle + specs_data

### DIFF
--- a/tests/unit/ops/test_spec_lifecycle.py
+++ b/tests/unit/ops/test_spec_lifecycle.py
@@ -715,6 +715,39 @@ class TestReadGateVerdicts:
         verdicts = read_gate_verdicts(ledger)
         assert list(verdicts) == ["ok-spec"]
 
+    def test_unreadable_ledger_returns_empty(self, tmp_path, monkeypatch):
+        """OSError on read degrades to "no verdict", same as a missing file."""
+        ledger = tmp_path / "verdicts.jsonl"
+        ledger.write_text("{}", encoding="utf-8")
+
+        def _boom(self, *args, **kwargs):
+            raise OSError("permission denied")
+
+        monkeypatch.setattr(type(ledger), "read_text", _boom)
+        assert read_gate_verdicts(ledger) == {}
+
+    def test_blank_lines_skipped(self, tmp_path):
+        ledger = tmp_path / "verdicts.jsonl"
+        ledger.write_text(
+            "\n"
+            '{"target_artifact": "docs/specs/ok-spec/tasks.md", '
+            '"evaluation_state": "PASS"}\n'
+            "   \n",
+            encoding="utf-8",
+        )
+        verdicts = read_gate_verdicts(ledger)
+        assert list(verdicts) == ["ok-spec"]
+
+    def test_md_only_target_yields_no_slug(self, tmp_path):
+        """A target with no slug segment (every part skipped or *.md) is dropped."""
+        ledger = tmp_path / "verdicts.jsonl"
+        ledger.write_text(
+            '{"target_artifact": "docs/requirements.md", "evaluation_state": "PASS"}\n'
+            '{"target_artifact": "docs/specs", "evaluation_state": "PASS"}\n',
+            encoding="utf-8",
+        )
+        assert read_gate_verdicts(ledger) == {}
+
 
 class TestStageWaiverSignal:
     """PHASE-WAIVED chair lines satisfy the ladder for ABSENT files."""
@@ -758,4 +791,19 @@ class TestStageWaiverSignal:
 
         d = tmp_path / "bare-spec"
         d.mkdir()
+        assert _scan_waived_phases(d) == ()
+
+    def test_scan_waived_phases_unreadable_decisions(self, tmp_path, monkeypatch):
+        """OSError on read degrades to no waivers, same as a missing file."""
+        from attune.ops.specs_data import _scan_waived_phases
+
+        d = tmp_path / "locked-spec"
+        d.mkdir()
+        decisions = d / "decisions.md"
+        decisions.write_text("PHASE-WAIVED: design\n", encoding="utf-8")
+
+        def _boom(self, *args, **kwargs):
+            raise OSError("permission denied")
+
+        monkeypatch.setattr(type(decisions), "read_text", _boom)
         assert _scan_waived_phases(d) == ()

--- a/tests/unit/ops/test_specs_data.py
+++ b/tests/unit/ops/test_specs_data.py
@@ -169,3 +169,25 @@ def test_spec_record_computes_lifecycle() -> None:
         last_modified=None,
     )
     assert isinstance(rec.lifecycle, str) and rec.lifecycle
+
+
+def test_spec_record_executing_stage_has_no_next_phase_status() -> None:
+    """`next_phase` may name a file with no SpecPhase entry (decisions.md).
+
+    The executing stage targets decisions.md, which is not a tracked
+    phase — the prefill lookup must exhaust gracefully to None.
+    """
+    rec = SpecRecord(
+        slug="x",
+        root="/r",
+        path="/r/x",
+        phases=[
+            SpecPhase(name="requirements", file="requirements.md", exists=True, status="approved"),
+            SpecPhase(name="design", file="design.md", exists=True, status="approved"),
+            SpecPhase(name="tasks", file="tasks.md", exists=True, status="approved"),
+        ],
+        last_modified=None,
+    )
+    assert rec.stage == "executing"
+    assert rec.next_phase == "decisions"
+    assert rec.next_phase_status is None


### PR DESCRIPTION
## Summary

Codecov flagged 90% patch coverage on the merged Stage-column PR #1542 (9 lines missing). This covers all of them — every one a defensive degradation branch:

- `read_gate_verdicts`: unreadable ledger (OSError → `{}`), blank-line skip, targets with no slug segment (`*.md`-only / exhausted parts) — the 4 missing + 3 partials in `spec_lifecycle.py`
- `_scan_waived_phases`: unreadable decisions.md (OSError → `()`) — the 2 missing in `specs_data.py`
- `SpecRecord` executing stage: `next_phase='decisions'` has no SpecPhase entry → prefill lookup exhausts to `None` (branch partial)

## Receipts

Branch-coverage run (serial, no xdist): 89 passed; `spec_lifecycle.py` **100%** (56/56 branches), `specs_data.py` **100% statements** — sole remaining partial (203→198) is pre-#1542 `_mtime` code outside the patch.

Tests-only (Class 1) — `auto-merge-when-green`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)