### PR TITLE
docs(specs): status-truth pass — 3 specs aligned to shipped evidence

### DIFF
--- a/docs/specs/attune-author-consolidation/decisions.md
+++ b/docs/specs/attune-author-consolidation/decisions.md
@@ -1,6 +1,6 @@
 # attune-author Consolidation — Decisions
 
-**Status:** draft (2026-06-30) · log for
+**Status:** active (2026-07-21; opened 2026-06-30) · log for
 [requirements.md](requirements.md) / [design.md](design.md).
 
 ## D1 — The split is authoring vs. mechanics, not "the package"

--- a/docs/specs/attune-author-consolidation/design.md
+++ b/docs/specs/attune-author-consolidation/design.md
@@ -1,6 +1,7 @@
 # attune-author Consolidation — Design
 
-**Status:** parked (2026-07-13) — T1 (#1193) + T2a (#1203/#1205) shipped: projector/staleness/fact_check absorbed into attune.authoring, help_data in-process; remaining: scripts' attune_author consumer repoints (T1 acceptance), resolver fold-in (T2/#1191), T3 polish-upstream (D10), T4 package fate, T5 docs repoints · Resume-Trigger: evergreen (no external clock) · pairs with
+**Status:** approved (2026-07-21 status-truth; was parked 2026-07-13, now
+executing) — T1 (#1193) + T2a (#1203/#1205) shipped: projector/staleness/fact_check absorbed into attune.authoring, help_data in-process; remaining: scripts' attune_author consumer repoints (T1 acceptance), resolver fold-in (T2/#1191), T3 polish-upstream (D10), T4 package fate, T5 docs repoints · Resume-Trigger: evergreen (no external clock) · pairs with
 [requirements.md](requirements.md).
 
 ## The new home

--- a/docs/specs/attune-author-consolidation/requirements.md
+++ b/docs/specs/attune-author-consolidation/requirements.md
@@ -1,6 +1,7 @@
 # attune-author Consolidation & Retirement — Requirements
 
-**Status:** draft (2026-06-30) · **Owner:** Patrick + agent
+**Status:** approved (2026-07-21 status-truth — executed through D12;
+drafted 2026-06-30) · **Owner:** Patrick + agent
 **Absorbs:** single-source-authoring (merged 2026-07-14 at triage —
 same domain; archived copy retains its draft reqs/design)
 **Born:** the single-source insights discussion. Patrick: "attune-author

--- a/docs/specs/claim-drift-gates/decisions.md
+++ b/docs/specs/claim-drift-gates/decisions.md
@@ -221,3 +221,17 @@ for cleanup. (2)
 zero consumers; stale artifact, future deletion candidate. All
 three retired with grep receipts; the sweep's only correction was
 replacing a fictional rebrand with an honest deletion.
+
+## 2026-07-21 — G4 build receipt + design-phase waiver (chair)
+
+G4 (a+b+c) is complete on branch `feat/claim-drift-g4` as **held
+draft #1561** (`hold-until-07-27`); it merges after the 10.6.0 tag
+per the standing merge hold. Recorded here so the spec's stage
+reflects reality on main: built, pending merge — not un-started.
+
+The chair ruled this session (AskUserQuestion, 2026-07-21) that the
+design phase is waived: G4 was chair-ruled and built without a
+design.md, and the requirements header already records every ruling
+(D4, D7, D8). The stage ladder honors the marker line below.
+
+PHASE-WAIVED: design (2026-07-21 — chair ruling this session; G4 built without a design phase, held #1561)

--- a/docs/specs/spec-lifecycle-gates/decisions.md
+++ b/docs/specs/spec-lifecycle-gates/decisions.md
@@ -1,5 +1,9 @@
 # Spec-Lifecycle Gates — Decisions
 
+**Status:** shipped (2026-07-19; header added 2026-07-21 status-truth) —
+gates executed (chair go, tasks.md); the triage consumption surface is
+homed in `roundtable-triage`, ordered after the P3 skeptic (#1559).
+
 ## 2026-07-19 — Charter (chair; round-table thread q-spec-gates-001)
 
 The chair convened the table on where to insert intelligent

--- a/docs/specs/spec-lifecycle-gates/design.md
+++ b/docs/specs/spec-lifecycle-gates/design.md
@@ -1,6 +1,6 @@
 # Spec-Lifecycle Gates v1 — Design
 
-**Status:** approved (2026-07-19) — design chair-approved as written (both open
+**Status:** shipped (2026-07-21 status-truth; approved 2026-07-19) — design chair-approved as written (both open
 questions ruled per the moderator's recommendations — see G4/G5 in
 `decisions.md`).
 Grounded per RR-5's chair edit: every seam below was re-verified by

--- a/docs/specs/spec-lifecycle-gates/requirements.md
+++ b/docs/specs/spec-lifecycle-gates/requirements.md
@@ -1,6 +1,6 @@
 # Spec-Lifecycle Gates v1 (table-authored) — Requirements
 
-**Status:** approved (2026-07-19) — chair-ruled per item; authored by the
+**Status:** shipped (2026-07-21 status-truth; approved 2026-07-19) — chair-ruled per item; authored by the
 round table (thread `producing-spec-lifecycle-gates-20260719-3`); compiled deterministically by
 `attune.roundtable.compiler` (V2-P2). Approved items only;
 declined: none (RR-7 re-admitted amended, G4 2026-07-19);


### PR DESCRIPTION
## Summary

Same class as #1558, found by running `derive_stage` across all specs during today's implementability review:

| Spec | Was | Now | Evidence |
|---|---|---|---|
| spec-lifecycle-gates | executing | **shipped** | tasks.md said shipped 2026-07-19 (chair go); requirements/design flipped to match; decisions.md gains its missing Status header |
| attune-author-consolidation | requirements (!) | **executing** | executed through D12; requirements draft→approved, design parked→approved, decisions draft→active |
| claim-drift-gates | design | **executing** | G4 built in held #1561 (receipt recorded); `PHASE-WAIVED: design` chair line ruled in-session today |

## Receipt

Re-ran the derive pass post-edit: `shipped / executing / executing`, waiver visible (`waived=('design',)`).

Docs-only — `auto-merge-when-green`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)