### PR TITLE
test(memory): claude_memory to 100% — omit label was false (#1569)

### DIFF
--- a/docs/specs/test-quality-program/decisions.md
+++ b/docs/specs/test-quality-program/decisions.md
@@ -769,3 +769,18 @@ not deprecated first).
 consider a check that flags `omit` entries whose files import cleanly
 keyless (the mislabel that let this debt accumulate). Tracked in
 omit-audit.md §Recommendations.
+
+## Tier-2 #1 resolved — claude_memory was an omit-mask illusion (2026-07-21, #1569)
+
+The backlog entry read "memory/claude_memory.py (309) — mock the
+client". Reality (QA#6 pattern — cross-check `omit` first): the module
+is pure file I/O, its 57-test suite in `tests/memory/` runs keyless in
+0.24s, and it already measured **96%**; the `omit` label "Requires
+Claude API" was false. The 309-missed number was the omit mask, not a
+gap. Close-out: one net-new behavioral file
+(`test_claude_memory_standard_path.py` — the `/etc/claude/CLAUDE.md`
+fallthrough branch, precedence + negative cases), omit entry removed
+with a dated tombstone comment. Module now **100.00%** under the repo
+exclude rules. No client mocking was ever needed — Tier-2 rank 1 cost
+~an hour, not the estimated mocking effort. Next Tier-2 pick:
+`monitoring/otel_backend.py`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -731,7 +731,9 @@ omit = [
     "*/memory/cross_session.py",  # Requires Redis server
     "*/memory/control_panel_api.py",  # FastAPI REST server
     "*/memory/short_term/sessions.py",  # Requires Redis server
-    "*/memory/claude_memory.py",  # Requires Claude API
+    # claude_memory.py omit entry removed 2026-07-21 (#1569): its
+    # Requires-Claude-API label was false — pure file I/O, keyless
+    # 60-test suite, measures ~100% covered.
     # Agent modules requiring live LLM
     "*/agents/release/release_prep_team.py",  # Requires LLM API calls
     # OpenTelemetry backend (requires otel infrastructure)

--- a/tests/memory/test_claude_memory_standard_path.py
+++ b/tests/memory/test_claude_memory_standard_path.py
@@ -1,0 +1,84 @@
+"""Behavioral tests for the enterprise standard-path branch.
+
+Closes the last uncovered branch in ``attune.memory.claude_memory``
+(test-quality-program #1569): ``_load_enterprise_memory`` falling
+through env var and config to the Unix standard location
+``/etc/claude/CLAUDE.md``. The path is mocked at the module boundary —
+tests must never depend on the host's real ``/etc/claude`` state.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from attune.memory.claude_memory import (
+    ClaudeMemoryConfig,
+    ClaudeMemoryLoader,
+    MemoryFile,
+)
+
+
+@pytest.fixture
+def loader(monkeypatch: pytest.MonkeyPatch) -> ClaudeMemoryLoader:
+    """Loader with no env-var and no config enterprise path set."""
+    monkeypatch.delenv("CLAUDE_ENTERPRISE_MEMORY", raising=False)
+    return ClaudeMemoryLoader(ClaudeMemoryConfig(enabled=True, enterprise_memory_path=None))
+
+
+def _fake_standard_path(exists: bool) -> MagicMock:
+    fake = MagicMock()
+    fake.exists.return_value = exists
+    fake.__str__ = MagicMock(return_value="/etc/claude/CLAUDE.md")
+    return fake
+
+
+class TestEnterpriseStandardPath:
+    def test_standard_path_loads_when_present(self, loader: ClaudeMemoryLoader) -> None:
+        """With no env var and no config path, an existing
+        /etc/claude/CLAUDE.md is loaded at enterprise level."""
+        sentinel = MemoryFile(
+            level="enterprise",
+            path="/etc/claude/CLAUDE.md",
+            content="org-wide rules",
+        )
+        with patch(
+            "attune.memory.claude_memory.Path",
+            return_value=_fake_standard_path(exists=True),
+        ):
+            with patch.object(loader, "_load_memory_file", return_value=sentinel) as load:
+                result = loader._load_enterprise_memory()
+
+        assert result is sentinel
+        load.assert_called_once_with("/etc/claude/CLAUDE.md", "enterprise")
+
+    def test_absent_standard_path_returns_none(self, loader: ClaudeMemoryLoader) -> None:
+        """No env var, no config path, no standard file → None, and the
+        file loader is never invoked."""
+        with patch(
+            "attune.memory.claude_memory.Path",
+            return_value=_fake_standard_path(exists=False),
+        ):
+            with patch.object(loader, "_load_memory_file") as load:
+                result = loader._load_enterprise_memory()
+
+        assert result is None
+        load.assert_not_called()
+
+    def test_env_var_wins_over_standard_path(
+        self, loader: ClaudeMemoryLoader, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Precedence: CLAUDE_ENTERPRISE_MEMORY short-circuits before
+        the standard location is even consulted."""
+        monkeypatch.setenv("CLAUDE_ENTERPRISE_MEMORY", "/custom/CLAUDE.md")
+        sentinel = MemoryFile(
+            level="enterprise",
+            path="/custom/CLAUDE.md",
+            content="custom",
+        )
+        with patch.object(loader, "_load_memory_file", return_value=sentinel) as load:
+            result = loader._load_enterprise_memory()
+
+        assert result is sentinel
+        load.assert_called_once_with("/custom/CLAUDE.md", "enterprise")


### PR DESCRIPTION
## test-quality #1569 — claude_memory omit-mask illusion resolved

Tier-2 backlog rank 1 read "claude_memory.py (309 missed) — mock the client". The QA#6 cross-check-omit-first pattern applied: the module is **pure file I/O**, its 57-test keyless suite already measured **96%**, and the `omit` label "Requires Claude API" was false — the 309 was the omit mask, not a gap.

- New behavioral file `tests/memory/test_claude_memory_standard_path.py`: the `/etc/claude/CLAUDE.md` enterprise fallthrough (load-when-present, absent→None, env-var precedence) — the one genuinely uncovered branch. Mocked at the module boundary; no host filesystem dependence, Windows-safe.
- `omit` entry removed with a dated tombstone comment (the omit-documentation hook validates the block).
- Tier-2 close-out recorded in `docs/specs/test-quality-program/decisions.md`; next pick is `monitoring/otel_backend.py`.

**Receipt:** module measures **100.00%** under the repo exclude rules (60 tests, serial, keyless).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
