### PR TITLE
docs: land Codex fable-workflow todo + cross-provider-memory-transport spec

### DIFF
--- a/.claude/plans/cross-provider-memory-transport.md
+++ b/.claude/plans/cross-provider-memory-transport.md
@@ -1,0 +1,42 @@
+# Execution plan: cross-provider-memory-transport
+
+Canonical spec: [tasks.md](../../docs/specs/cross-provider-memory-transport/tasks.md)
+with companion requirements, design, and decisions in the same directory.
+Status: APPROVED — implementation authorized 2026-07-22.
+
+```xml
+<plan>
+  <feature>cross-provider-memory-transport</feature>
+  <spec>docs/specs/cross-provider-memory-transport/tasks.md</spec>
+  <task id="T1">
+    <title>Truthful fallback and caller-scoped status</title>
+    <dependencies>none</dependencies>
+    <scope>file_stash write result, session_stash additive status, focused tests</scope>
+    <acceptance>EPERM returns false with a visible reason; existing status keys remain.</acceptance>
+  </task>
+  <task id="T2">
+    <title>Semantics gap and provider-neutral MCP handlers</title>
+    <dependencies>T1</dependencies>
+    <scope>Measure existing tools; add only missing session-memory adapters.</scope>
+    <acceptance>D3 verdict recorded; real dispatch and AMS round-trip pass; old schemas frozen.</acceptance>
+  </task>
+  <task id="T3">
+    <title>Recall skill capability routing</title>
+    <dependencies>T2</dependencies>
+    <scope>Plugin skill source, generated .agents mirror, projection guard.</scope>
+    <acceptance>MCP clients avoid sandboxed Python; drift guard passes.</acceptance>
+  </task>
+  <task id="T4">
+    <title>Hook regression, docs, and telemetry</title>
+    <dependencies>T3</dependencies>
+    <scope>Claude hooks, capability matrix, local-only failure signals.</scope>
+    <acceptance>Claude hook canary passes; docs stay honest; telemetry remains local/default-off.</acceptance>
+  </task>
+  <task id="T5">
+    <title>Live provider verification matrix</title>
+    <dependencies>T4</dependencies>
+    <scope>Codex, Claude Code, and Antigravity/Gemini receipts.</scope>
+    <acceptance>Real receipts or honest unsupported status; every canary deleted.</acceptance>
+  </task>
+</plan>
+```

--- a/docs/process/FABLE_SPEC_WORKFLOW_TODO.md
+++ b/docs/process/FABLE_SPEC_WORKFLOW_TODO.md
@@ -1,0 +1,101 @@
+# TODO — Reliable Fable Spec Authoring Workflow
+
+**Status:** todo
+**Priority:** high — collaboration workflow failure
+**Scope:** spec-authoring orchestration, not the cross-provider Redis-memory implementation
+**Created:** 2026-07-22
+
+## Problem
+
+The first Fable 5 spec call remained silent for more than 150 seconds and
+had to be interrupted. A context-free Fable probe returned in about seven
+seconds, proving the model/auth path was healthy. A bounded retry eventually
+completed, but only after another long interval with no progress signal.
+
+The surrounding workflow compounded the failure:
+
+- External-data authorization was requested after drafting had already begun,
+  rather than being front-loaded once with the scope.
+- Native elicitation failed without a useful recovery surface.
+- Prompt packets temporarily appeared as workspace edits, confusing the
+  promotion/review surface.
+- The lifecycle gate failed once because its ledger path under `~/.attune`
+  was not writable from the sandbox, then had to be rerun host-side.
+- The user experienced multiple stop/retry cycles before receiving the
+  requested artifact.
+
+## Outcome
+
+Fable-authored specs run through a bounded, observable workflow that either
+produces the artifact or fails quickly with an actionable reason. External
+authorization, scoping, scratch storage, generation, validation, and lifecycle
+gates form one coherent path rather than a sequence of reactive retries.
+
+## Work
+
+### 1. Measure before setting the generation budget
+
+- Benchmark Fable 5 with representative one-file, four-file, and five-file
+  spec packets.
+- Record time to first event, total duration, input/output size, and failure
+  mode using streaming JSON output where available.
+- Commit the decision matrix before selecting the default whole-spec versus
+  per-document strategy. Patrick ratifies the latency budget from measured
+  data; do not invent an arbitrary acceptable threshold.
+
+### 2. Add a bounded Fable drafting runner
+
+- Stream progress instead of waiting for one final stdout block.
+- Enforce separate time-to-first-event and total-run limits.
+- On a first-event timeout, stop once and switch to the preselected
+  per-document strategy; never repeat the same silent whole-spec call.
+- Capture the exact provider/model/auth/CLI failure without exposing secrets.
+- Validate required file markers and output-size limits before materializing.
+
+### 3. Front-load the workflow contract
+
+- Present one informed external-data authorization before any external model
+  invocation; treat the approval as session-durable for the same packet class
+  when the host policy permits.
+- Gather only genuinely missing scope. If rich elicitation is unavailable,
+  fall back immediately to one plain question or explicit documented defaults.
+- Select whole-spec versus split-document generation before launch using the
+  measured decision matrix.
+
+### 4. Keep scratch artifacts out of the review surface
+
+- Store prompt/reply packets in an isolated temporary directory, not the
+  repository working tree.
+- Guarantee cleanup on success, timeout, rejection, and interruption.
+- Assert `git status --short` shows only intended spec artifacts before review.
+
+### 5. Make gates sandbox-aware
+
+- Run lifecycle gates with a writable, isolated `ATTUNE_HOME`, or through the
+  trusted host boundary when the real ledger receipt is required.
+- Detect an unwritable ledger path before running the gate and report the
+  selected execution boundary.
+- Do not spend a failed attempt rediscovering the same sandbox restriction.
+
+## Acceptance criteria
+
+- A benchmark report and pre-committed routing matrix select whole-spec or
+  split-document generation from evidence.
+- Every Fable run emits an observable first event or terminates at the bounded
+  first-event gate with one actionable error.
+- The same failed generation strategy is never attempted twice in one run.
+- One informed authorization covers the scoped external drafting sequence when
+  platform policy allows it; unavoidable platform re-prompts are surfaced
+  before generation begins.
+- No prompt/reply scratch file appears in the repository review surface.
+- Native elicitation failure takes one deterministic fallback path.
+- Lifecycle gates produce their real receipts without a preliminary
+  permission failure.
+- A dogfood receipt creates a five-file draft spec, validates its XML plan,
+  runs lifecycle gates, and leaves only the five intended artifacts in Git.
+
+## Done when
+
+Patrick can request “use Fable 5 to write the spec” and receive either a
+validated review-ready draft or one early, legible failure—without silent
+multi-minute waits, repeated strategy attempts, or temporary-file confusion.

--- a/docs/specs/cross-provider-memory-transport/decisions.md
+++ b/docs/specs/cross-provider-memory-transport/decisions.md
@@ -1,0 +1,83 @@
+# Cross-Provider Memory Transport — Decisions
+
+**Provenance:** Drafted by Claude Fable 5 on 2026-07-22 from the live
+Codex-sandbox and host-side diagnosis recorded in `requirements.md`.
+Roundtable thread `q-cross-provider-memory-spec-review-001`; chair approved
+promotion candidates `#6`, `#7`, and `#8` on 2026-07-22.
+
+All decisions below are **RATIFIED**.
+
+## D1 — MCP-first for sandboxed clients — RATIFIED
+
+- **Options:** (a) MCP-first, with Python only in trusted host contexts;
+  (b) keep Python-first and improve errors; (c) build a generic bridge.
+- **Recommendation:** (a). MCP already passed the Codex canary and does not
+  weaken the sandbox. A new bridge duplicates the intended MCP boundary.
+- **Falsified if:** a required client cannot expose Attune MCP. That client
+  uses the honest degraded tier from D2; it does not invalidate MCP-first
+  where MCP exists.
+
+## D2 — Capability tiers rather than parity fiction — RATIFIED
+
+- **Options:** (a) explicit MCP, hooks + MCP, and unsupported/degraded tiers;
+  (b) advertise uniform best-effort support.
+- **Recommendation:** (a). Codex has no lifecycle hooks today. Promising
+  automatic capture there would repeat the silent-failure pattern.
+- **Falsified if:** Codex gains verified lifecycle hooks; its matrix row then
+  upgrades without changing the architecture.
+
+## D3 — Add `session_memory_*` tools for the verified semantics gap — RATIFIED
+
+- **Options:** (a) reuse `redis_memory_*`; (b) add thin provider-neutral
+  adapters; (c) make agents compose raw store + promote.
+- **Decision:** (b). The review verified that raw `redis_memory_store` is a
+  generic working-memory path and does not preserve the complete
+  sanitization, cwd, and TTL contract. Option (c) is rejected because
+  agent-side composition will drift.
+
+## D4 — Caller-scoped reachability — RATIFIED
+
+- **Options:** (a) `reachable`, `unreachable_local`, `unknown`; (b) boolean
+  up/down.
+- **Recommendation:** (a). The diagnosed bug was a caller-local block
+  misreported as a Redis failure.
+- **Falsified if:** no consumer uses the distinction after one release; then
+  simplify without restoring false global claims.
+
+## D5 — File fallback returns false after failed durable write — RATIFIED
+
+- **Options:** (a) return `False` and expose an additive reason; (b) raise;
+  (c) keep returning `True` and log.
+- **Recommendation:** (a). The API is intentionally never-raises, while (c)
+  is the verified data-loss bug.
+- **Falsified if:** caller audit proves exception classes are required. In
+  that case, exceptions stay inside the backend and the public wrapper still
+  returns a truthful result.
+
+## D6 — Preserve existing Redis MCP contracts — RATIFIED
+
+- **Options:** (a) freeze existing signatures and add tools if required;
+  (b) extend existing tools in place.
+- **Recommendation:** (a). These are public plugin surfaces; additive tools
+  avoid breaking consumers.
+- **Falsified if:** a required semantic cannot be expressed additively; any
+  extension then requires versioning and a changelog entry.
+
+## D7 — Live boundary matrix is the completion gate — RATIFIED
+
+## Roundtable revision ruling — RATIFIED
+
+- **CR-1 / board #6:** public `stash_entry()` propagates durable-write
+  failure and receives an EPERM regression at that boundary.
+- **CR-2 / board #7:** finding capture uses sanitized
+  `session_memory_capture`; raw `redis_memory_*` remains generic working
+  memory; a PII-bearing live canary proves sanitization.
+- **CR-3–CR-6 / board #8:** add changelog coverage, complete status-consumer
+  compatibility checks, explicit boolean-to-MCP result mapping, and cleanup
+  plus a sandbox JSON example for the file-writability probe.
+
+- **Options:** (a) the six receipts in R8; (b) mocked tests only.
+- **Recommendation:** (a). This spec exists because green local logic did not
+  prove the real boundary.
+- **Falsified if:** a provider cannot be run. Record an honest unsupported or
+  unprobed receipt; never substitute a synthetic pass.

--- a/docs/specs/cross-provider-memory-transport/design.md
+++ b/docs/specs/cross-provider-memory-transport/design.md
@@ -1,0 +1,144 @@
+# Cross-Provider Memory Transport — Design
+
+**Status:** APPROVED — implementation authorized 2026-07-22.
+
+## Transport flows
+
+### MCP-capable client
+
+Codex and any MCP-capable provider call Attune tools. The MCP server runs
+host-side with real network and filesystem access and delegates to
+`session_stash`, so sanitization, TTL, and cwd semantics stay centralized.
+
+```text
+agent → session_memory_capture (MCP host) → session_stash.stash_entry → AMS
+agent → session_memory_recall  (MCP host) → session_stash.recall_entries
+```
+
+Nothing memory-critical executes inside the agent sandbox.
+
+### Lifecycle-hook client
+
+Claude Code continues to run `plugin/hooks/session_stash.py` and
+`plugin/hooks/session_recall.py` in a trusted host context. Those hooks call
+`session_stash` directly. MCP remains available for on-demand operations.
+
+### Client with neither capability
+
+The integration reports capability status first. If the file backend is
+writable, the client may use explicitly degraded local-file mode. If it is
+not writable, the operation returns `unsupported` with a reason. It never
+reports success and never converts a caller-local failure into "Redis is
+down."
+
+## Proposed provider-neutral MCP surface
+
+The verified `redis_memory_*` surface remains a generic working-memory API;
+it does not implement the full `session_stash` sanitization, cwd, and TTL
+contract. Finding capture therefore uses these additive tools in
+`attune_redis/mcp_tools.py`:
+
+- `session_memory_capture(kind, content, cwd?, session_id?, tags?)`
+- `session_memory_recall(query, limit<=10, cwd?)`
+- `session_memory_recent(limit<=20, cwd?)`
+- `session_memory_forget(ids)`
+- `session_memory_status()`
+
+Each handler is a thin adapter over `src/attune/memory/session_stash.py`.
+Existing `redis_memory_*` tools remain untouched. No tool duplicates an
+existing operation that already preserves the required semantics.
+
+Python write results map explicitly onto MCP results: `True` becomes
+`{"ok": true, "reason": null}`; `False` becomes
+`{"ok": false, "reason": "<stable_reason_code>"}`. The adapter never
+turns a false Python result into MCP success. `session_memory_recent`
+delegates to the existing backend rather than reimplementing ordering.
+
+## Status and operation results
+
+Existing status fields stay compatible. New fields are additive:
+
+```json
+{
+  "backend": "AMSMemoryBackend",
+  "fallback": false,
+  "unreachable_upgrade": null,
+  "ok": true,
+  "transport": "mcp|direct|file|none",
+  "reachability": "reachable|unreachable_local|unknown",
+  "reason": null
+}
+```
+
+Write operations return `ok=false` after any non-durable write. A reason such
+as `file_write_denied`, `network_blocked_local`, or `bridge_unavailable`
+describes the caller's observed boundary without asserting global service
+health.
+
+Example from a sandbox that cannot reach localhost or write the fallback:
+
+```json
+{
+  "backend": "FileStashBackend",
+  "fallback": true,
+  "ok": false,
+  "transport": "none",
+  "reachability": "unreachable_local",
+  "reason": "file_write_denied"
+}
+```
+
+## Routing algorithm
+
+1. Trusted host hook or CLI: call Python `session_stash` directly.
+2. Otherwise, when Attune MCP tools are available: use MCP exclusively.
+3. Otherwise, test file-backend writability with a real temporary write and
+   remove the probe artifact on every success and failure path.
+4. Writable file backend: use explicit degraded mode and label it.
+5. Unwritable file backend: return `unsupported` with the observed reason.
+6. Never infer global Redis health from steps 3–5.
+
+`plugin/skills/recall/SKILL.md` owns the portable routing instructions.
+`.agents/skills/recall/SKILL.md` is generated with
+`python scripts/sync_agents_skills.py --write` and is never edited directly.
+
+## Security
+
+- MCP handlers use narrow validated schemas, bounded content/result sizes,
+  and validated cwd/path inputs.
+- PII and secret sanitization runs inside `session_stash` for every capture.
+- Credentials never appear in status or operation responses.
+- The adapter exposes no arbitrary file access or network proxy.
+- Sandbox policy remains unchanged; host-side MCP crosses the boundary by
+  the client's intended tool mechanism.
+
+## Compatibility and migration
+
+- Freeze `redis_memory_*` schemas with tests.
+- Treat the `FileStashBackend.remember()` return correction as a bug fix.
+- Record the public true-to-false behavior correction in `CHANGELOG.md`.
+- Audit callers that ignore write results and make failures legible at their
+  natural attention surface.
+- Change the recall skill source and regenerate its `.agents` mirror in the
+  same PR.
+
+## Telemetry
+
+Record local-only counts for selected transport/backend, failed-write reason,
+and `unreachable_local`. Preserve the existing default-off posture. These
+signals reveal whether clients repeatedly land in degraded tiers without
+storing content or credentials.
+
+## Verification
+
+- Unit: `EPERM` regression; additive status shape; routing order.
+- Integration: real MCP dispatch; disposable AMS capture/search/forget.
+- Live matrix: Codex MCP canary, Claude hook canary, Antigravity/Gemini
+  capability probe. Record unsupported honestly. Delete all canaries.
+
+## Rollback
+
+Tasks land independently. Skill rollback reverts the source and regenerates
+the mirror. Additive MCP handlers can be removed without changing existing
+Redis tools. The false-success fix must not be rolled back; any caller that
+depended on unconditional `True` must be corrected instead.

--- a/docs/specs/cross-provider-memory-transport/requirements.md
+++ b/docs/specs/cross-provider-memory-transport/requirements.md
@@ -1,0 +1,143 @@
+# Cross-Provider Memory Transport — Requirements
+
+**Status:** APPROVED — implementation authorized 2026-07-22.
+**Slug:** `cross-provider-memory-transport`
+
+## Problem
+
+Redis-backed short-term memory works from trusted host contexts but
+silently fails from sandboxed providers. In Codex, the recall skill's
+plain-Python recipe runs inside a network- and write-restricted sandbox:
+`backend_status()` selects `FileStashBackend` with
+`unreachable_upgrade=redis` (localhost blocked), and `stash_entry()` hits
+`file_stash_write_failed: Operation not permitted` yet returns `True`.
+The canary never reaches AMS and recall returns nothing — a false-success
+data-loss path.
+
+## Verified state (2026-07-22 receipts)
+
+- Codex sandbox: Python selects the file backend; its write fails;
+  `remember()` still returns `True`; no canary is recalled.
+- Host: Redis PING succeeds, AMS 0.14.0 `/v1/health` returns 200,
+  `AMSMemoryBackend` is selected, and stash → semantic recall → cleanup
+  succeeds.
+- Codex already has Attune MCP tools: `redis_health_check` returned
+  `connected=true`; `redis_memory_store` → `redis_memory_retrieve`
+  round-tripped an exact canary; the disposable session was deleted.
+- Root cause: the recall skill's sandboxed-Python recipe plus an
+  unwritable file fallback that reports success — not a Redis outage.
+  No new generic bridge is needed.
+
+## Goal
+
+Provide consistent, truthful short-term memory across Codex, Claude Code,
+Antigravity/Gemini, and future clients by routing capture and recall over
+each client's real capabilities, without weakening sandbox security or
+creating a second memory subsystem.
+
+## Requirements
+
+### R1 — Truthful file fallback
+
+`FileStashBackend` write failures must surface as failure.
+
+- `_rewrite()` must return whether the durable replace succeeded, and
+  `remember()` must return `False` after an `OSError`.
+- The public `session_stash.stash_entry()` boundary must propagate the
+  backend's durable-write result; it must not convert `False` back to success.
+- `backend_status()` must expose an additive machine-readable reason such
+  as `file_write_denied` when writability is known to have failed.
+- A regression test simulates `EPERM` on the temporary file through the
+  public `stash_entry()` API and asserts a false write result plus the
+  status/log reason.
+- No path may report success without a durable write. False success is
+  forbidden.
+
+### R2 — No global-outage inference from local denial
+
+Caller-local sandbox denial must be distinct from a verified service-down
+state.
+
+- Additive status fields distinguish `reachable`, `unreachable_local`, and
+  `unknown` while preserving the existing `backend`, `fallback`, and
+  `unreachable_upgrade` keys.
+- Documentation and skills must never claim "Redis is down" from a
+  sandboxed probe alone.
+
+### R3 — MCP-first transport
+
+When Attune MCP tools are available, capture and recall route through MCP
+(host-side execution), not in-process sandboxed Python. Direct Python
+remains valid for trusted host contexts such as lifecycle hooks and CLI.
+
+### R4 — Provider-neutral session operations, only if needed
+
+The verified `redis_memory_*` calls are generic working-memory operations;
+they do not preserve the complete `session_stash` sanitization, cwd, and TTL
+contract. Add narrow `session_memory_*` MCP tools that delegate to
+`session_stash`. Finding-capture flows must use `session_memory_capture`,
+never raw `redis_memory_store`, and agents must not compose raw operations to
+emulate a stash write.
+
+- Schemas are narrow, content and results bounded, inputs validated, and
+  credentials excluded.
+- The tools are memory operations, not an arbitrary filesystem or network
+  proxy.
+
+### R5 — Honest capability tiers
+
+- MCP clients receive explicit capture and recall.
+- Hook-capable clients such as Claude Code may additionally receive
+  automatic session-start recall and session-end capture.
+- Clients with neither receive a clear `unsupported` or `degraded` result.
+- Codex currently executes no `hooks.json` hooks; this spec must not promise
+  automatic end-of-session capture there.
+
+### R6 — Backward compatibility
+
+Existing `redis_memory_*` tools retain their signatures and behavior.
+The `session_stash` Python API remains compatible for host callers except
+that failed writes now honestly return `False`. Status changes are additive.
+
+### R7 — Semantics preserved
+
+PII/secrets sanitization, cwd soft-priority, the 30-day working TTL,
+user-gated promotion to curated memory, and precise deletion apply on every
+transport.
+
+### R8 — Boundary receipts
+
+Completion requires real receipts, with every canary cleaned up:
+
+1. File-write-failure regression returns `False` and exposes the reason.
+2. Real MCP dispatch exercises updated or new handlers.
+3. Disposable AMS capture → search → forget succeeds, including a
+   PII-bearing canary whose stored form proves sanitization.
+4. Codex completes a live MCP canary.
+5. Claude Code completes a live hook canary.
+6. Antigravity/Gemini produces a capability receipt or an honest
+   unsupported receipt.
+
+## Provider capability matrix
+
+| Client | MCP tools | Lifecycle hooks | Python context | Supported tier |
+|---|---|---|---|---|
+| Claude Code | yes | yes | trusted host | hooks + MCP |
+| Codex | yes (verified) | no | sandbox blocks network/write | explicit MCP |
+| Antigravity/Gemini | probe required | no | assume restricted | MCP or unsupported |
+| Unknown future client | unknown | unknown | assume restricted | capability-driven; degraded by default |
+
+## Non-goals
+
+- No second memory subsystem; reuse `session_stash`, `FileStashBackend`,
+  and `AMSMemoryBackend`.
+- No generic sandbox-to-host network bridge or proxy.
+- No reopening `docs/specs/archive/claude-cross-session-memory/`.
+
+## Done state
+
+Codex captures and recalls through MCP with exact-canary receipts; the
+Claude Code hook flow remains unchanged and re-verified; file fallback never
+lies; the recall skill routes by capability; Antigravity/Gemini has a real
+probe or documented unsupported status; all R8 receipts are recorded and all
+canaries deleted.

--- a/docs/specs/cross-provider-memory-transport/tasks.md
+++ b/docs/specs/cross-provider-memory-transport/tasks.md
@@ -1,0 +1,104 @@
+# Cross-Provider Memory Transport — Tasks
+
+**Status:** APPROVED — implementation authorized 2026-07-22. Tasks execute
+in dependency order.
+
+## T1 — Truthful fallback and status contract
+
+```xml
+<task id="T1" name="truthful-fallback-status">
+  <objective>Make failed file writes return false and add caller-scoped reachability fields without breaking existing status keys.</objective>
+  <files-to-modify>
+    <file path="src/attune/memory/file_stash.py">Return the durable replace result from _rewrite and remember.</file>
+    <file path="src/attune/memory/session_stash.py">Add compatible reachability/reason fields and preserve never-raises behavior.</file>
+    <file path="tests/unit/memory/test_file_stash.py">Add EPERM false-success regression.</file>
+    <file path="tests/unit/memory/test_session_stash.py">Cover additive status fields and local denial.</file>
+    <file path="CHANGELOG.md">Document the public false-success correction.</file>
+  </files-to-modify>
+  <validation>
+    <check>pytest tests/unit/memory/test_file_stash.py tests/unit/memory/test_session_stash.py -q</check>
+    <check>EPERM through public stash_entry() returns false and exposes a visible reason.</check>
+    <check>Search all status consumers for exact-dict assumptions and run the complete status-consuming suite.</check>
+  </validation>
+  <risks><risk severity="medium">Audit callers that assumed unconditional true.</risk></risks>
+</task>
+```
+
+## T2 — Semantics gap and provider-neutral MCP handlers
+
+```xml
+<task id="T2" name="session-memory-mcp" depends-on="T1">
+  <objective>Add thin session_memory adapters for the proven sanitization, cwd, and TTL gap while preserving generic redis_memory tools.</objective>
+  <files-to-modify>
+    <file path="attune_redis/mcp_tools.py">Conditionally add capture/recall/recent/forget/status handlers delegating to session_stash.</file>
+    <file path="attune_redis/tests/test_mcp_tools.py">Freeze old schemas and test any additive tools.</file>
+    <file path="tests/integration/test_mcp_dispatch.py">Exercise the real registration and dispatch chain.</file>
+    <file path="docs/specs/cross-provider-memory-transport/decisions.md">Record the D3 semantics-gap verdict.</file>
+  </files-to-modify>
+  <validation>
+    <check>Real MCP dispatch succeeds; direct handler-only mocks are insufficient.</check>
+    <check>Disposable AMS capture → search → forget succeeds and cleanup is confirmed.</check>
+    <check>A PII-bearing live canary is sanitized in the stored representation.</check>
+    <check>Python false maps to MCP {ok:false, reason:&lt;stable_code&gt;}.</check>
+    <check>Existing redis_memory_* schemas remain unchanged.</check>
+  </validation>
+  <risks><risk severity="medium">Do not duplicate a Redis tool that already preserves the contract.</risk></risks>
+</task>
+```
+
+## T3 — Provider routing in the recall skill
+
+```xml
+<task id="T3" name="recall-skill-routing" depends-on="T2">
+  <objective>Route trusted hooks to Python, MCP-capable clients to MCP, and all others to an honest degraded result.</objective>
+  <files-to-modify>
+    <file path="plugin/skills/recall/SKILL.md">Replace the universal Python recipe with capability routing and truthful status language.</file>
+    <file path=".agents/skills/recall/SKILL.md">Generated mirror; never edit directly.</file>
+  </files-to-modify>
+  <validation>
+    <check>python scripts/sync_agents_skills.py --write</check>
+    <check>Projection drift guard passes.</check>
+    <check>MCP clients are never instructed to run sandboxed Python for memory.</check>
+    <check>Finding capture names session_memory_capture and never redis_memory_store.</check>
+  </validation>
+  <risks><risk severity="high">Edit the plugin source first; committing only the mirror violates the single-source rule.</risk></risks>
+</task>
+```
+
+## T4 — Hook regression, documentation, and telemetry
+
+```xml
+<task id="T4" name="hooks-docs-telemetry" depends-on="T3">
+  <objective>Re-verify Claude lifecycle hooks, document capability tiers, and make degraded routing observable.</objective>
+  <files-to-modify>
+    <file path="plugin/hooks/session_stash.py">Adapt only if additive status fields require it.</file>
+    <file path="plugin/hooks/session_recall.py">Preserve host-side behavior and legible degradation.</file>
+    <file path="plugin/skills/recall/SKILL.md">Document the final matrix and operation receipts.</file>
+    <file path="src/attune/telemetry/memory_events.py">Add local-only transport/backend and failure-reason signals if absent.</file>
+  </files-to-modify>
+  <validation>
+    <check>Focused hook and telemetry unit suites pass.</check>
+    <check>Claude Code hook canary is captured, recalled next session, and deleted.</check>
+    <check>Telemetry remains local-only and default-off.</check>
+  </validation>
+  <risks><risk severity="medium">Documentation must not promise automatic hooks on Codex or Antigravity.</risk></risks>
+</task>
+```
+
+## T5 — Live provider verification matrix
+
+```xml
+<task id="T5" name="provider-live-matrix" depends-on="T4">
+  <objective>Prove the shipped boundary across providers and record honest unsupported states.</objective>
+  <files-to-create>
+    <file path="docs/specs/cross-provider-memory-transport/receipts.md">Dated commands/results and cleanup confirmation for every R8 receipt.</file>
+  </files-to-create>
+  <validation>
+    <check>Codex MCP capture → recall → forget passes.</check>
+    <check>Claude hook capture → next-session recall → forget passes.</check>
+    <check>Antigravity/Gemini records MCP success or an explicit unsupported/unprobed result.</check>
+    <check>Search confirms zero diagnostic canaries remain.</check>
+  </validation>
+  <risks><risk severity="high">A synthetic or mocked provider pass is forbidden.</risk></risks>
+</task>
+```


### PR DESCRIPTION
## What

Lands three Codex-authored artifacts that existed only as untracked files in the ephemeral Codex worktree (`~/.codex/worktrees/b567`, detached HEAD) — a prune would have lost them:

- `docs/process/FABLE_SPEC_WORKFLOW_TODO.md` — high-priority workflow-failure writeup (first Fable 5 spec call silent >150s) with 5 work items: benchmark-first generation budget, bounded streaming runner, front-loaded authorization, scratch isolation, sandbox-aware gates.
- `docs/specs/cross-provider-memory-transport/` — complete 4-file spec (requirements, design, tasks, decisions).
- `.claude/plans/cross-provider-memory-transport.md` — XML execution plan (T1–T4), marked approved 2026-07-22.

## Conflict check (done before landing)

- No path exists on `origin/main` (nearest name is the unrelated `cross-provider-collaboration-projector` spec).
- Zero of the 7 held-queue PRs (`hold-until-07-27`) touch these paths — cannot re-dirty the queue.
- Codex worktree had no modified tracked files; only these untracked artifacts.

Docs-class only — no source changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
