### PR TITLE
docs(specs): cross-provider-session-handoff — full spec authored (approved)

### DIFF
--- a/docs/specs/cross-provider-session-handoff/decisions.md
+++ b/docs/specs/cross-provider-session-handoff/decisions.md
@@ -1,0 +1,46 @@
+# Cross-Provider Session Handoff — Decisions
+
+Dated chair rulings. Newest last.
+
+## 2026-07-22 — Feature ratified (roundtable)
+
+Roundtable `q-multi-llm-obvious-win-001`: 2/3 seats independently
+converged on the tool-mediated cross-provider handoff. Chair ruling
+promoted the report and RATIFIED `handoff_create`/`handoff_resume`
+as the next multi-LLM feature. Same-day amendment: `cross_review`
+also ratified, sequenced second. Report:
+`docs/reports/roundtable/q-multi-llm-obvious-win-001.md` (#1600).
+Tracking issue: #1601.
+
+## 2026-07-22 — Scheduling amendment (chair)
+
+Spec AUTHORING moved pre-07-27 ("staged for implementation the 27th
+or near after" — chair, in-session); IMPLEMENTATION stays post-lift.
+Authoring runs against the held transport stack's code
+(#1593→#1598), which merges at the 07-27 sitting.
+
+## 2026-07-22 — Requirements APPROVED (chair)
+
+R1–R6 + non-goals as drafted. Binding highlights: no fabricated
+verification rows (R1); resume is a report, not a go signal (R2);
+degrade-silent memory linkage with stated skip (R3); terse-by-
+default caps as a requirement, not style (R5); live cross-provider
+receipt required, honest UNPROBED until the named client runs (R6).
+
+## 2026-07-22 — Design RATIFIED (chair)
+
+D1 frontmatter-over-template packet; D2 read-only subprocess git in
+`src/attune/handoff/`; D3 five report-only drift codes,
+verified-first report order; D4 caps 8 KB / 2 KB reject-with-reason,
+one packet per branch with `superseded_at`; D5 memory linkage via
+the session-stash helpers; D6 one structlog event per tool. CLI
+wrapper, auto-invocation, and cross-repo packets explicitly out.
+
+## 2026-07-22 — Tasks APPROVED (chair)
+
+T1 core module → T2 MCP surface → T3 memory/telemetry (post-lift
+only) → T4 docs + live receipt (post-distribution). T1/T2 have no
+transport dependency and MAY build early as held drafts if a slot
+opens; T3/T4 wait for the lift. Spec is now fully authored —
+requirements APPROVED, design RATIFIED, tasks APPROVED, all
+2026-07-22; implementation staged for the 07-27 sitting or after.

--- a/docs/specs/cross-provider-session-handoff/decisions.md
+++ b/docs/specs/cross-provider-session-handoff/decisions.md
@@ -44,3 +44,17 @@ transport dependency and MAY build early as held drafts if a slot
 opens; T3/T4 wait for the lift. Spec is now fully authored —
 requirements APPROVED, design RATIFIED, tasks APPROVED, all
 2026-07-22; implementation staged for the 07-27 sitting or after.
+
+## 2026-07-22 — T1+T2 BUILT (held draft #1605); one scope deviation
+
+Both tasks executed same-evening as held draft #1605
+(`claude/handoff-t1-t2`, hold-until-07-27). Deviation from tasks.md
+T2 wording: the real-dispatch integration tests live in a NEW file
+(`tests/integration/test_mcp_dispatch_handoff.py`) instead of
+extending `test_mcp_dispatch.py` — that module is modified by held
+PR #1594, and extending it would create a held-queue collision at
+the lift. Intent (real server, real dispatch table, real core)
+preserved. Receipts on the PR: 22 handoff unit tests + 86-test
+serial sweep (dispatch/counts/reference-validation) + quality
+ratchet green. Also recorded there: tool counts 49 core / 55 with
+redis; CHANGELOG entry owed at lift per the drafts-doc pattern.

--- a/docs/specs/cross-provider-session-handoff/design.md
+++ b/docs/specs/cross-provider-session-handoff/design.md
@@ -1,0 +1,99 @@
+# Cross-Provider Session Handoff — Design
+
+**Status:** RATIFIED (chair, 2026-07-22) — D1–D6 as drafted.
+**Slug:** `cross-provider-session-handoff`
+
+## Shape
+
+Core logic in a new `src/attune/handoff/` module; MCP surface
+registered on the main attune server per the plugin-reference
+checklist (schema in `tool_schemas.py`, handler, dispatch entry,
+tool-count test, skill reference). No redis-package coupling — the
+memory linkage goes through the same internal helpers the
+`session_memory_*` handlers use, and degrades silently (R3).
+
+```text
+src/attune/handoff/
+├── __init__.py      # handoff_create(), handoff_resume() public API
+├── packet.py        # assemble/render/parse the packet file
+└── verify.py        # drift matrix vs current git state
+```
+
+## D1 — packet file: markdown body + YAML frontmatter
+
+`docs/handoffs/<branch-slug>.md` stays the contract's location and
+template, with one addition: machine-readable YAML frontmatter
+carrying the VERIFIED fields (`branch`, `head_sha`, `merge_base`,
+`changed_files`, `created_at`, `provider`). The markdown body holds
+the ASSERTED prose (goal, acceptance criteria, decisions, risks,
+next action). `handoff_resume` re-checks frontmatter fields against
+git; body fields are surfaced as-is under an `asserted:` key. This
+keeps the file human-readable (the contract's existing consumers
+lose nothing) while making verification mechanical.
+
+## D2 — git reads via subprocess, read-only, path-validated
+
+`verify.py` shells to git (`branch --show-current`, `merge-base`,
+`diff --name-only`, `rev-parse`) with validated paths and no
+mutating commands anywhere in the module. Resume therefore works in
+read-restricted sandboxes (R4); create needs workspace write only
+for the packet file itself.
+
+## D3 — drift matrix (R2 warning codes)
+
+| Code | Trigger |
+|------|---------|
+| `branch_missing` | packet branch absent from the repo |
+| `head_moved` | current HEAD != packet `head_sha` |
+| `files_diverged` | actual diff set != packet `changed_files` |
+| `packet_stale_days` | `created_at` older than N days (report-only) |
+| `dirty_tree` | uncommitted changes present at resume time |
+
+All warnings are additive report fields — never blocking, never
+auto-fixed. The report's top-level key order is `verified`,
+`warnings`, `asserted`, `memory` (verified-first mirrors the
+contract's authority model).
+
+## D4 — caps (R5, concrete numbers)
+
+- Body cap: 8 KB total rendered packet; per-field cap 2 KB.
+- Oversize input → `{ok: false, reason: field_over_cap, field,
+  limit}`; never silent truncation.
+- Re-create on an existing slug overwrites in place (one packet per
+  branch); the previous packet's `created_at` is preserved in a
+  `superseded_at` frontmatter field for staleness honesty.
+
+## D5 — memory linkage internals
+
+`handoff_create` calls the session-stash capture helper directly
+(same code path the `session_memory_capture` handler wraps) with
+topic `handoff`; `handoff_resume` runs a recall for the slug.
+Backend resolution failures are caught per the contract's
+degrade-silently rule and reported as `memory: skipped` with the
+reason string — the same truthful-status discipline as the
+transport spec's R2.
+
+## D6 — telemetry
+
+Both tools emit one structlog event each (`handoff_create`,
+`handoff_resume`) with slug, warning codes, duration, and the
+memory-linkage outcome — same shape as the T4' transport fields, so
+provider-boundary usage becomes readable at the 07-27-style usage
+reads.
+
+## Explicitly not designed here
+
+- CLI wrapper (`attune handoff …`) — deferred until MCP usage
+  signal exists; MCP-only at ship.
+- Any auto-invocation (hooks) — non-goal per requirements.
+- Cross-repo handoffs — packet is branch-scoped within one repo.
+
+## Test plan (maps to R6)
+
+- `tests/unit/handoff/test_packet.py` — assemble from a fixture
+  repo; frontmatter fields provably git-derived; cap rejections.
+- `tests/unit/handoff/test_verify.py` — the D3 matrix, one case
+  per code, plus the clean path.
+- `tests/integration/test_mcp_dispatch.py` — extend the transport
+  spec's real-dispatch class with the two new tools.
+- Live receipt post-lift (receipts.md ledger, UNPROBED until run).

--- a/docs/specs/cross-provider-session-handoff/design.md
+++ b/docs/specs/cross-provider-session-handoff/design.md
@@ -1,6 +1,7 @@
 # Cross-Provider Session Handoff — Design
 
-**Status:** RATIFIED (chair, 2026-07-22) — D1–D6 as drafted.
+**Status:** approved (2026-07-22) — design D1–D6 ratified by the
+chair as drafted.
 **Slug:** `cross-provider-session-handoff`
 
 ## Shape

--- a/docs/specs/cross-provider-session-handoff/requirements.md
+++ b/docs/specs/cross-provider-session-handoff/requirements.md
@@ -1,0 +1,146 @@
+# Cross-Provider Session Handoff — Requirements
+
+**Status:** APPROVED (chair, 2026-07-22) — authored pre-07-27 per
+chair scheduling amendment; implementation staged post-lift.
+**Slug:** `cross-provider-session-handoff`
+**Provenance:** roundtable `q-multi-llm-obvious-win-001` (chair
+ruling + same-day amendment, 2026-07-22) — see
+`docs/reports/roundtable/q-multi-llm-obvious-win-001.md` and
+tracking issue #1601.
+
+## Problem
+
+Context degrades at the provider boundary. A task started in Claude
+Code cannot be reliably continued in Codex or Antigravity: the
+receiving session lacks the declared goal, acceptance criteria,
+changed-file set, decisions, verification receipts, and next action.
+The collaboration contract defines a handoff artifact
+(`templates/agent-handoff.md`, `docs/handoffs/<branch-slug>.md`) and
+a verification duty ("a handoff is context, not authority"), but
+both ends are manual prose today — nothing assembles the packet from
+real state, and nothing verifies it against the current tree on
+resume. Two of three roundtable seats independently named this the
+highest-value multi-LLM gap.
+
+## Goal
+
+Make the contract's handoff a first-class, validated tool call on
+both ends: `handoff_create` assembles a packet from actual git and
+session state; `handoff_resume` verifies that packet against the
+current worktree before any work continues. Providers become
+interchangeable seats on one task, using surfaces every client
+already has (MCP tools + tracked files + `session_memory_*`).
+
+## Requirements
+
+### R1 — `handoff_create` assembles from real state, never from claims
+
+An MCP tool `handoff_create` producing
+`docs/handoffs/<branch-slug>.md` per the contract template.
+
+- Git-derived fields (branch, changed files vs the merge base with
+  origin/main, ahead/behind counts, HEAD sha) come from actual git
+  reads at call time — never from caller-supplied text.
+- Caller-supplied fields (goal, acceptance criteria, decisions,
+  risks, next action) are recorded verbatim but clearly attributed.
+- Verification-table rows record only probes actually run; a claim
+  without a probe result is written as `not run` — the tool must
+  not fabricate pass rows.
+- Result is `{ok, path, packet}` with the written file path; a
+  write failure returns `{ok: false, reason}` (no false success —
+  transport spec R1 discipline).
+
+### R2 — `handoff_resume` verifies before continuing
+
+An MCP tool `handoff_resume` that reads a named packet (default:
+the current branch's slug) and returns a structured verification
+report, not a go signal.
+
+- Verifies against the CURRENT tree: branch exists, packet HEAD sha
+  vs current HEAD (drift), changed-file set vs actual diff,
+  uncommitted-state summary.
+- Every divergence is an explicit machine-readable warning
+  (`head_moved`, `files_diverged`, `branch_missing`,
+  `packet_stale_days`); warnings never auto-block and never
+  auto-fix.
+- The report separates VERIFIED (git-derived, re-checked) from
+  ASSERTED (caller-supplied prose) so the receiving agent knows
+  what is context and what is authority-free claim (contract:
+  "a handoff is context, not authority").
+- Resume performs no side effects: no checkout, no file writes, no
+  test runs.
+
+### R3 — memory linkage, degrade-silent
+
+- `handoff_create` additionally captures a pointer entry via the
+  `session_memory_capture` surface (topic `handoff`, body = slug +
+  goal one-liner) so cross-session recall surfaces open handoffs.
+- `handoff_resume` recalls topic-`handoff` entries for the slug and
+  includes them in the report.
+- When the memory backend is unreachable, both tools proceed and
+  report `memory: skipped` — the memory layer never blocks a
+  handoff (contract rule), and skipping is stated, not silent
+  success.
+
+### R4 — works from sandboxed providers
+
+- Both tools are registered through the same plugin MCP
+  registration path as `session_memory_*`, so any client that gets
+  those tools gets these (Codex marketplace, Antigravity MCP
+  config, Claude Code plugin).
+- `handoff_resume` requires only read access (git reads + file
+  read) and must work in a read-restricted sandbox.
+- `handoff_create` requires workspace write for the packet file; a
+  denied write surfaces as `{ok: false, reason: write_denied}`
+  (truthful-fallback discipline).
+
+### R5 — terse by default (anti-ceremony)
+
+Codex's named risk — ceremonial context duplication — is a binding
+constraint, not a style note.
+
+- The packet contains only sections with content; empty template
+  sections are omitted from the rendered file.
+- No transcript dumps: caller-supplied fields are bounded (packet
+  body capped; oversize input is rejected with the cap named, not
+  truncated silently).
+- One packet per branch (the contract's `<branch-slug>` rule);
+  re-running `handoff_create` updates the existing file rather than
+  accreting copies.
+
+### R6 — receipts (D7 discipline: no synthetic provider passes)
+
+- Unit: packet assembly from a fixture repo (git-derived fields
+  match reality; fabricated-claim path impossible by construction);
+  resume drift matrix (head_moved / files_diverged /
+  branch_missing / clean).
+- Integration: real MCP dispatch through the server (transport
+  spec receipt-2 pattern).
+- Live: one non-mocked cross-provider round trip — packet created
+  in a Claude Code session, resumed in a live Codex session after
+  the 07-27 lift + marketplace re-sync; receipt appended to this
+  spec's receipts.md. Honest `UNPROBED` rows stay until the named
+  client actually runs (receipts.md ledger, transport-spec R8
+  pattern).
+
+## Non-goals
+
+- No automatic handoff on session end — lifecycle hooks are not
+  promised on Codex/Antigravity (transport spec D2/R5); both tools
+  are explicit calls.
+- No provider routing or recommendation (deferred with the router
+  candidate; recorded-not-committed).
+- No second memory subsystem, no daemon, no board dependency — the
+  packet file plus existing memory transport is the whole
+  mechanism.
+- No auto-continue: `handoff_resume` reports; the receiving agent
+  (and its human) decide.
+
+## Dependencies
+
+- Held stack #1593→#1598 merged (07-27 lift) — `session_memory_*`
+  surface on main.
+- Distribution lag applies to live receipts: Codex sees new tools
+  only after a marketplace re-sync against main; Antigravity after
+  the 10.6.0 PyPI publish (proven 2026-07-22, transport receipts 4
+  and 6).

--- a/docs/specs/cross-provider-session-handoff/tasks.md
+++ b/docs/specs/cross-provider-session-handoff/tasks.md
@@ -1,0 +1,145 @@
+# Cross-Provider Session Handoff — Tasks
+
+**Status:** APPROVED (chair, 2026-07-22) — execution staged
+post-07-27 (see decisions.md scheduling amendment); T1/T2 may build
+early as held drafts.
+
+Execution note: T1 and T2 have NO code dependency on the held
+transport stack (pure new module + MCP wiring) — they may be built
+early as held drafts if a build slot opens. T3 imports the
+session-stash helpers and MUST wait for the 07-27 lift. T4's live
+receipt additionally waits for distribution (marketplace re-sync /
+PyPI publish). Before executing any task, re-grep the named scope
+against the current tree (spec text goes stale; code is the
+contract).
+
+## T1 — core module (packet + verify)
+
+```xml
+<task id="handoff-t1" name="core-module">
+  <objective>
+    Build src/attune/handoff/ — packet assembly from real git
+    state, packet rendering/parsing (D1 frontmatter + template
+    body), and the D3 drift matrix. No MCP wiring yet.
+  </objective>
+  <context>
+    <existing-code path="templates/agent-handoff.md">
+      Contract packet template — body sections must match it.
+    </existing-code>
+    <design>D1 frontmatter fields; D2 read-only subprocess git,
+    validated paths; D3 warning codes; D4 caps 8KB/2KB
+    reject-with-reason, overwrite-in-place + superseded_at.</design>
+  </context>
+  <files-to-create>
+    <file path="src/attune/handoff/__init__.py">public API:
+      handoff_create(), handoff_resume() (pure functions returning
+      dicts; no MCP imports)</file>
+    <file path="src/attune/handoff/packet.py">assemble/render/parse;
+      caps enforcement</file>
+    <file path="src/attune/handoff/verify.py">git reads + drift
+      matrix</file>
+    <file path="tests/unit/handoff/test_packet.py">fixture-repo
+      assembly; git-derived fields provably from git; cap
+      rejections; overwrite-in-place</file>
+    <file path="tests/unit/handoff/test_verify.py">one case per D3
+      code + clean path</file>
+  </files-to-create>
+  <validation>
+    <check>suite receipt: tests/unit/handoff run SERIALLY, exact
+      tail reported</check>
+    <check>no mutating git command anywhere in the module (grep
+      receipt: no commit/checkout/push/add tokens)</check>
+    <check>_validate_file_path() on every file operation; security
+      tests for the packet write path</check>
+  </validation>
+  <risks>
+    <risk severity="medium">Windows path/encoding in git subprocess
+      output — wait Windows lanes at merge.</risk>
+  </risks>
+</task>
+```
+
+## T2 — MCP surface
+
+```xml
+<task id="handoff-t2" name="mcp-surface">
+  <objective>
+    Register handoff_create / handoff_resume on the attune MCP
+    server per the plugin-reference checklist.
+  </objective>
+  <context>
+    <checklist>schema in src/attune/mcp/tool_schemas.py; handler;
+    dispatch entry in _build_dispatch_table(); tool-count test
+    update; skill references validated.</checklist>
+  </context>
+  <files-to-modify>
+    <file path="src/attune/mcp/tool_schemas.py">two tool schemas
+      (create: caller prose fields + optional slug; resume: slug
+      optional, defaults to current branch)</file>
+    <file path="tests/unit/test_mcp_memory_tools.py">tool-count
+      update</file>
+  </files-to-modify>
+  <validation>
+    <check>integration receipt: real-dispatch test class extended
+      (transport receipt-2 pattern) — call_tool through the real
+      server for both tools</check>
+    <check>tests/unit/plugins/test_plugin_reference_validation.py
+      green</check>
+  </validation>
+  <risks>
+    <risk severity="low">Exact-dict-equality response-shape tests in
+      OTHER files — run the full mcp handler test dir, not just the
+      new file.</risk>
+  </risks>
+</task>
+```
+
+## T3 — memory linkage + telemetry (post-lift only)
+
+```xml
+<task id="handoff-t3" name="memory-telemetry">
+  <objective>
+    D5: capture/recall topic-handoff pointers via the session-stash
+    helpers with degrade-silent reporting. D6: one structlog event
+    per tool (slug, warning codes, duration, memory outcome).
+  </objective>
+  <context>
+    <depends>session_memory_* helpers on main (07-27 lift).</depends>
+  </context>
+  <validation>
+    <check>suite receipt: unreachable-backend path asserts
+      memory:skipped WITH reason, and ok stays true</check>
+    <check>live local canary (Claude side): create → resume round
+      trip with a real backend; pointer recalled; canary
+      forgotten — logged in receipts.md</check>
+  </validation>
+  <risks>
+    <risk severity="medium">Helper import paths may shift in the
+      lift squashes — re-grep before wiring.</risk>
+  </risks>
+</task>
+```
+
+## T4 — docs, ledger, live cross-provider receipt
+
+```xml
+<task id="handoff-t4" name="docs-and-receipts">
+  <objective>
+    User-facing docs (feature page per the single-source playbook),
+    receipts.md ledger for this spec, and the R6 live receipt:
+    packet created in Claude Code, resumed in a live Codex session
+    post-distribution.
+  </objective>
+  <validation>
+    <check>evidence-chain: receipts.md rows dated; UNPROBED rows
+      stay honest until the named client runs</check>
+    <check>live-fire: Codex transcript appended (session id +
+      verbatim tool results)</check>
+  </validation>
+  <risks>
+    <risk severity="low">Distribution lag (proven 2026-07-22):
+      marketplace re-sync / PyPI publish gates the live row —
+      sequencing note, not a failure.</risk>
+  </risks>
+</task>
+```


### PR DESCRIPTION
Authors the full 4-file spec for the first roundtable-ratified multi-LLM feature: `handoff_create`/`handoff_resume` (thread `q-multi-llm-obvious-win-001`, report in #1600).

All three gates ruled by the chair 2026-07-22: requirements APPROVED (R1–R6: real-git-only packet assembly, report-not-go-signal resume, degrade-silent memory linkage, sandbox parity, terse-by-default caps, live-receipt discipline), design RATIFIED (D1–D6), tasks APPROVED (T1–T4 with declared receipt types; T1/T2 transport-independent, T3/T4 post-lift).

Implementation staged for the 07-27 sitting or after (#1601). Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
