### PR TITLE
docs(release): revert launch version to 10.6.0 as originally proposed

### DIFF
--- a/.claude/plans/launch-10-6-0-multi-llm.md
+++ b/.claude/plans/launch-10-6-0-multi-llm.md
@@ -1,12 +1,12 @@
-# 10.7.0 Launch — The Multi-LLM Release
+# 10.6.0 Launch — The Multi-LLM Release
 
 **Created:** 2026-07-22
-**Version note:** chair renumbered the release 10.6.0 → 10.7.0 in-session 2026-07-22 (multi-LLM wave widens the scope); the RELEASE_10_6_0_drafts.md doc and Monday-runbook tag references need the same rename at the sitting.
+**Version note:** chair briefly renumbered 10.6.0 → 10.7.0 in-session 2026-07-22, then REVERTED to **10.6.0 as originally proposed** (chair, 2026-07-22 EOD). All launch materials and the Monday runbook tag 10.6.0.
 **Source:** /brainstorm session (chair-ratified direction)
 
 ## Problem
 
-10.7.0 ships Monday 07-27 with a genuine story — one plugin, three
+10.6.0 ships Monday 07-27 with a genuine story — one plugin, three
 AI coding agents (Claude, Codex, Antigravity/Gemini) sharing memory,
 handing off work, and giving second opinions — but the launch
 materials (Draft A/B in `docs/process/RELEASE_10_6_0_drafts.md`)
@@ -56,7 +56,7 @@ Monday architecture-framed fire).
 4. Fri/Sat: website diffs staged (features.ts + counts + multi-LLM
    feature page); apply + verify post-lift.
 5. Mon (sitting, already runbooked): lift, receipts, publish
-   10.7.0.
+   10.6.0.
 6. Tue: apply website/docs PRs → fill receipt slots → chair rules
    the honesty gate → publish article + post.
 

--- a/docs/process/LAUNCH_10_6_0_article_draft.md
+++ b/docs/process/LAUNCH_10_6_0_article_draft.md
@@ -1,7 +1,7 @@
-# Launch article draft — 10.7.0, the multi-LLM release
+# Launch article draft — 10.6.0, the multi-LLM release
 
 **Written:** 2026-07-22 (launch plan item 1 —
-`.claude/plans/launch-10-7-0-multi-llm.md`). **Fires:** Tuesday
+`.claude/plans/launch-10-6-0-multi-llm.md`). **Fires:** Tuesday
 2026-07-28, AFTER the lift + live receipts (chair-ratified timing).
 **Venue:** LinkedIn article. **Status:** draft — `[RECEIPT: …]`
 slots fill from Monday's real transcripts; publishing with an
@@ -10,7 +10,7 @@ unfilled slot is forbidden (no claim without a receipt).
 Pre-publish checklist:
 
 - [ ] All `[RECEIPT: …]` slots filled with real transcript excerpts
-- [ ] Version/date claims match the actual v10.7.0 tag + PyPI 200
+- [ ] Version/date claims match the actual v10.6.0 tag + PyPI 200
 - [ ] Chair honesty-gate pass (same ruling session as Draft B)
 - [ ] Counts ("five tools", "26 skills") re-verified against the
       merged registries, not this draft
@@ -29,7 +29,7 @@ session knew is gone. The goal, the decisions, the half-finished
 state, the "don't touch that file, it's load-bearing" — all of it
 evaporates at the provider boundary. You paste fragments and hope.
 
-attune-ai 10.7.0 is about deleting that boundary. One plugin, three
+attune-ai 10.6.0 is about deleting that boundary. One plugin, three
 agents, and the interesting part isn't any single feature — it's
 that the features had to be *provable* across vendors before we'd
 call them shipped.
@@ -140,7 +140,7 @@ it gets a seat at the table and a key to the memory, not a fork.
 pip install attune-ai
 ```
 
-10.7.0 is on PyPI now. The round table is open.
+10.6.0 is on PyPI now. The round table is open.
 
 ---
 

--- a/docs/process/RELEASE_10_6_0_drafts.md
+++ b/docs/process/RELEASE_10_6_0_drafts.md
@@ -153,8 +153,9 @@ resolving this gate.
 ## Draft B-v2 — LinkedIn post, multi-LLM rework (2026-07-22)
 
 Reworked per the launch plan
-(`.claude/plans/launch-10-7-0-multi-llm.md`): the release is now
-**10.7.0** (chair renumbering, 07-22), the centerpiece is the
+(`.claude/plans/launch-10-6-0-multi-llm.md`): the release is
+**10.6.0** (chair briefly renumbered it 10.7.0 on 07-22, then
+reverted to 10.6.0 as originally proposed — chair, 07-22 EOD), the centerpiece is the
 multi-LLM story, and the post fires TUESDAY 07-28 with the launch
 article (it is the short-form companion; the article carries the
 receipts). **Draft B-v1's structural problem is solved by
@@ -177,7 +178,7 @@ backlog item).
 > seat's position, and my rulings are a tracked report in the
 > repo.
 >
-> So that's what shipped this week in attune-ai 10.7.0:
+> So that's what shipped this week in attune-ai 10.6.0:
 >
 > — Shared memory: a finding captured in one agent is recallable
 > in the next (Claude Code, Codex, Antigravity — same tools, no
@@ -217,7 +218,7 @@ backlog item).
       round-trip receipt (spec T4). DO NOT POST before it passes;
       if only the Claude-side receipt exists Tuesday, reword to
       per-agent truth or hold.
-- [ ] "10.7.0 … shipped this week" — requires the v10.7.0 tag +
+- [ ] "10.6.0 … shipped this week" — requires the v10.6.0 tag +
       PyPI 200 on Monday.
 - [ ] Antigravity named as a memory participant — requires
       receipt 6 (post-publish probe) OR reword to "Claude Code


### PR DESCRIPTION
Chair reverted the 07-22 in-session 10.7.0 renumbering back to **10.6.0 as originally proposed** (chair ruling, 07-22 EOD).

- Renames `.claude/plans/launch-10-7-0-multi-llm.md` → `launch-10-6-0-multi-llm.md`
- Renames `docs/process/LAUNCH_10_7_0_article_draft.md` → `LAUNCH_10_6_0_article_draft.md`
- Reverts all version claims in Draft B-v2 (`RELEASE_10_6_0_drafts.md`) and both pre-publish checklists to 10.6.0
- The brief renumbering is preserved as history in both version notes
- `docs/reports/roundtable/routine-clean-run-2026-07-18.md` left untouched (chair-promoted archive — historical record)

Docs-only; no changelog per policy. The session starter's Monday runbook is being updated in parallel (untracked file, not in this diff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)