### PR TITLE
feat(scripts): capability-count projector with ownership markers

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -321,6 +321,15 @@ jobs:
       if: needs.changes.outputs.website_only != 'true'
       run: python scripts/check_badge_freshness.py
 
+    # Capability-count projector (roundtable q-capability-count-projector-001):
+    # the three derived counts (skills, registered MCP tools, core-schema MCP
+    # tools) must match every allowlisted claim site. Needs an importable
+    # attune — this job just installed it. Repair drift with:
+    #   python scripts/project_capabilities.py --write
+    - name: Check capability count claims
+      if: needs.changes.outputs.website_only != 'true'
+      run: python scripts/project_capabilities.py --check
+
     - name: Run tests with coverage
       # Coverage RATCHET: --cov-fail-under is a one-way valve, not a static
       # floor. Main has measured 94.69–94.71% across recent runs (stable to

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,6 +77,10 @@ git commit -m "feat: Add anticipatory pattern detection
 git push origin feature/your-feature-name
 ```
 
+If your change adds or removes a plugin skill or MCP tool, run
+`python scripts/project_capabilities.py --write` in the same PR to
+sync the published capability counts (CI runs `--check`).
+
 ### Commit Message Format
 
 We follow conventional commits:

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ store, retrieved at P@3 96% on a frozen trap-moment benchmark
 below).
 
 Around that memory core, the same package also ships a spec-driven,
-multi-agent toolkit: 20 workflows and 53 MCP tools dispatching 2–6
+multi-agent toolkit: 20 workflows and <!-- cap:mcp_registered_tool_count -->53 MCP tools<!-- /cap --> dispatching 2–6
 domain-specific subagents behind Socratic quality gates, RAG
 grounding with a citation-per-claim contract (mean per-claim
 faithfulness CI-gated at ≥ 0.97; 0.98 currently measured, N=20 runs
@@ -316,10 +316,10 @@ per-surface extras (API-mode agents, ops dashboard, Redis memory).
 
 | Capability | Plugin only | Plugin + pip |
 | ---------- | ----------- | ------------ |
-| 25 auto-triggering skills | Yes | Yes |
+| <!-- cap:skill_count -->25 auto-triggering skills<!-- /cap --> | Yes | Yes |
 | Security hooks | Yes | Yes |
 | Prompt-based analysis | Yes | Yes |
-| 53 MCP tools | -- | Yes |
+| <!-- cap:mcp_registered_tool_count -->53 MCP tools<!-- /cap --> | -- | Yes |
 | `attune` CLI | -- | Yes |
 | Multi-agent workflows | -- | Yes |
 | Help system maintenance | -- | Yes |

--- a/docs/getting-started/mcp-integration.md
+++ b/docs/getting-started/mcp-integration.md
@@ -88,7 +88,7 @@ Then restart Claude Desktop.
 
 ---
 
-## Available Tools (53)
+## <!-- cap:mcp_registered_tool_count -->Available Tools (53)<!-- /cap -->
 
 The Attune MCP server exposes all production workflows as tools:
 

--- a/docs/getting-started/quickstart-plugin.md
+++ b/docs/getting-started/quickstart-plugin.md
@@ -21,7 +21,7 @@ inside the Claude Code session you already have.
 
 ## What you get
 
-The plugin ships **25 auto-triggering skills**. You don't memorize commands —
+The plugin ships <!-- cap:skill_count -->**25 auto-triggering skills**<!-- /cap -->. You don't memorize commands —
 you describe what you want, and the right skill activates.
 
 | Say something like… | Skill that activates | What it does |
@@ -120,12 +120,12 @@ Other skills worth trying by name or description:
 | If you want to… | Go to |
 |-----------------|-------|
 | Run workflows from a terminal or Python | [First Steps](first-steps.md) |
-| Add the full MCP toolset (53 tools) + CLI | [MCP Integration](mcp-integration.md) |
+| Add the full MCP toolset <!-- cap:mcp_registered_tool_count -->(53 tools)<!-- /cap --> + CLI | [MCP Integration](mcp-integration.md) |
 | Pick a longer learning path | [Choose Your Path](choose-your-path.md) |
 | See every workflow | [First Steps → Try More Workflows](first-steps.md#try-more-workflows) |
 
 !!! note "Plugin vs. package"
-    The **plugin** gives you the 17 natural-language skills with zero setup.
+    The **plugin** gives you the <!-- cap:skill_count -->25 natural-language skills<!-- /cap --> with zero setup.
     Installing the **Python package** (`pip install attune-ai`) adds the
-    `attune` CLI, the MCP server, and 41 MCP tools on top. You can start with
+    `attune` CLI, the MCP server, and <!-- cap:mcp_registered_tool_count -->53 MCP tools<!-- /cap --> on top. You can start with
     the plugin today and add the package later — they layer cleanly.

--- a/docs/handoffs/codex-capability-projector.md
+++ b/docs/handoffs/codex-capability-projector.md
@@ -1,0 +1,89 @@
+# Agent work handoff
+
+## Goal
+
+Finish the chair-approved capability-count projector
+(roundtable `q-capability-count-projector-001`): three derived
+values projected into a frozen allowlist of claim sites, with
+independent drift gates retained and a `--check` step in
+import-capable Linux CI.
+
+## Acceptance criteria
+
+- `python scripts/project_capabilities.py --check` exits 0 on a
+  synced tree; drift exits 1 with value/target/expected/observed;
+  structural failure exits 2 before any write.
+- A second `--write` is byte-idempotent.
+- Markdown claims carry `<!-- cap:VALUE -->…<!-- /cap -->`
+  whole-fragment ownership markers; marketplace JSON is parsed
+  (no comment markers); `features.ts` updates only named
+  `CAPABILITIES` fields.
+- Focused tests cover derivations, unequal registered/core
+  totals, all locator types, fail-closed modes, preservation,
+  and subprocess exit codes.
+- Independent gates keep their own derivation (no projector
+  imports) and stay green.
+
+## Scope and assumptions
+
+- Branch/worktree: `codex/capability-projector` at the main
+  checkout `~/attune-ai` (Fable session per
+  `new session starter.md`; no commit/push/PR made — by
+  instruction).
+- Provider/session: Claude Fable 5, 2026-07-22 late.
+- Assumptions: current derived values 25 skills / 53 registered
+  / 47 core-schema; PRs #1605/#1607 will shift tool counts at
+  the Monday lift — rerun `--write` after they merge if this
+  branch lands later.
+
+## Current state
+
+- Status: implementation complete; all verification receipts
+  green; NOT committed (session contract forbade it).
+- Changed files (working tree):
+  - `scripts/project_capabilities.py` (untracked; reworked —
+    marker locators, per-file sequential planning, atomic
+    writes, `main(argv, repo=None)`)
+  - `tests/unit/scripts/test_project_capabilities.py`
+    (untracked; 39 tests)
+  - `README.md`, `plugin/README.md`,
+    `docs/getting-started/quickstart-plugin.md`,
+    `docs/getting-started/mcp-integration.md` (markers + two
+    stale counts repaired by `--write`: plugin intro 18→25,
+    quickstart natural-language 17→25)
+  - `tests/unit/gates/test_claim_drift.py` (5 regexes made
+    marker-tolerant via `(?:<[^>]*>)?`; assertions unchanged)
+  - `.github/workflows/tests.yml` (coverage job: "Check
+    capability count claims" step after badge freshness)
+  - `CONTRIBUTING.md` (one-paragraph instruction: capability
+    PRs run `--write`)
+  - `docs/reports/roundtable/q-capability-count-projector-001.md`
+    (untracked design report, unchanged — commit with the rest)
+- Decisions: marker grammar `<!-- cap:VALUE -->` one-line spans;
+  gate regexes updated (sanctioned by the gate's own
+  "update the manifest WITH the wording" rule — independence
+  preserved, guarded by
+  `test_independent_gates_do_not_import_projector`).
+- Risks/open: none known; merge-order interaction with
+  #1605/#1607 handled by rerunning `--write`.
+
+## Verification
+
+| Claim | Failure-sensitive probe | Result |
+| --- | --- | --- |
+| Claims synced | `.venv/bin/python scripts/project_capabilities.py --check` | pass (exit 0; 25/53/47) |
+| Write idempotent | shasum 6 governed files, rerun `--write`, `shasum -c` | pass (byte-identical) |
+| Projector tests | `pytest tests/unit/scripts/test_project_capabilities.py -p no:xdist -o addopts=` | pass (39) |
+| Independent gates | `pytest tests/unit/gates/test_claim_drift.py tests/unit/test_website_version_accuracy.py` | pass (29) |
+| CI/workflow governance | `pytest tests/unit/ci/` | pass (326, 1 skip) |
+| Quality ratchet | `pytest tests/unit/quality/` | pass (5) |
+| Scripts neighborhood | `pytest tests/unit/scripts/` | pass (227) |
+| Format/lint | pinned pre-commit black + `uv run ruff check` on changed py files | pass |
+| Preflight | `python scripts/collaboration_preflight.py` | pass (0 failed) |
+| Whitespace | `git diff --check` | clean |
+
+## Next action
+
+Patrick reviews the diff on `codex/capability-projector`,
+commits (pre-flight already pinned-black clean), and opens the
+PR; delete this handoff when the branch merges.

--- a/docs/reports/roundtable/q-capability-count-projector-001.md
+++ b/docs/reports/roundtable/q-capability-count-projector-001.md
@@ -1,0 +1,138 @@
+# Capability Count Projector
+
+**Roundtable thread:** `q-capability-count-projector-001`
+**Chair ruling:** Promote board items 10, 11, and 12
+**Artifact tier:** XML task
+**Status:** Approved design; implementation not yet authorized
+
+## Goal
+
+Replace manual skill and MCP-tool count maintenance with a narrow,
+deterministic projector while retaining independently derived drift
+gates.
+
+## Approved scope
+
+Create `scripts/project_capabilities.py` to derive exactly three
+values from the checked-out revision:
+
+1. `skill_count` — publishable skills under
+   `plugin/skills/*/SKILL.md`.
+2. `mcp_registered_tool_count` — unique names in
+   `EmpathyMCPServer().tools`, including bundled plugin tools.
+3. `mcp_core_schema_tool_count` — unique names returned by the
+   canonical `attune.mcp.tool_schemas.get_*_tools()` getters.
+
+The projector must not use network data, cached counts, caller
+overrides, remembered constants, or anticipated future capabilities.
+Empty, duplicate, malformed, unavailable, or environment-dependent
+discovery fails closed.
+
+## Ownership model
+
+Maintain an explicit target manifest. Every entry declares:
+
+- the semantic value it publishes;
+- an exact locator;
+- its renderer;
+- expected match cardinality;
+- post-render validation.
+
+Format rules:
+
+- Markdown owns complete, uniquely marked claim fragments rather than
+  isolated numbers.
+- `website/lib/features.ts` updates exact named numeric fields inside
+  the existing `CAPABILITIES` object. It does not consume a generated
+  JSON sidecar.
+- `.claude-plugin/marketplace.json` is parsed as JSON. Only its exact
+  allowlisted description field is rendered; JSON receives no comment
+  markers.
+- Generated downstream documentation is never edited directly. The
+  projector targets its owning source.
+
+Explicit exclusions:
+
+- `.claude/CLAUDE.md` and `AGENTS.md`;
+- versions, workflows, and other marketing metrics;
+- changelogs and historical release material;
+- repository-wide regex or numeric replacement.
+
+## CLI contract
+
+```text
+python scripts/project_capabilities.py
+python scripts/project_capabilities.py --check
+python scripts/project_capabilities.py --write
+```
+
+- Default and `--check` are identical and read-only.
+- Drift exits nonzero with the semantic value, target, expected
+  rendering, and observed rendering.
+- `--write` computes and validates the complete edit plan before any
+  file changes, writes deterministically, and then reruns the check.
+- A repeated `--write` is byte-idempotent.
+- Unknown or incompatible arguments fail closed.
+
+## Rollout
+
+1. Keep the immediate PR #1605 and PR #1607 count corrections in
+   their owning feature PRs.
+2. Inventory and freeze the exact current skill/tool claim allowlist.
+3. Add the projector, target ownership, and tests against the
+   corrected baseline.
+4. Add `python scripts/project_capabilities.py --check` to an existing
+   import-capable Linux PR/push CI job.
+5. Retain the existing independently implemented claim-drift and
+   website-accuracy gates.
+6. Document that capability-changing PRs run `--write` in the same
+   change.
+
+Do not add a pre-commit projector or marker-only approximation. The
+authoritative MCP derivation requires an importable project
+environment, and a weaker local definition would add maintenance
+without proving the boundary.
+
+## Required verification
+
+- Unit tests derive all three values independently.
+- A regression fixture keeps registered-tool and core-schema totals
+  different and proves they cannot be interchanged.
+- Every governed target detects drift and is repaired by `--write`.
+- `--check` never writes.
+- A second `--write` produces no changes.
+- Missing, duplicate, renamed, malformed, ambiguous, or wrong-type
+  locators fail before any write.
+- One invalid target prevents every planned write.
+- Marketplace JSON remains valid and changes only its owned field.
+- TypeScript changes only owned `CAPABILITIES` keys.
+- Unrelated prose, formatting, newline style, and files are preserved.
+- Subprocess tests verify CLI exit codes and diagnostics.
+- Existing independent gates do not import projector manifests,
+  locators, renderers, or derivation helpers.
+- The existing 29 focused Python drift tests remain green.
+- The Python website capability-accuracy gate remains green.
+- CI exercises server construction in a controlled keyless
+  environment; network, credentials, mutable external state, or
+  nondeterministic registration are hard failures.
+
+## Principal risks
+
+1. **Semantic count confusion:** a total registered-tool count could
+   be projected into a surface describing core tools. Distinct value
+   names, explicit per-target mappings, and deliberately unequal test
+   fixtures are mandatory.
+2. **Environment-dependent registration:** constructing
+   `EmpathyMCPServer` could acquire optional-dependency or ambient-state
+   behavior. The projector must fail rather than publish a count from
+   an unstable environment.
+3. **Correlated false-green results:** sharing projector derivation
+   with drift tests could validate the same mistake twice. Small,
+   intentional duplication preserves independence.
+
+## Done when
+
+The XML task is implemented only after separate authorization, all
+required verification receipts are green, the exact projector check
+runs in import-capable CI, and the independent drift gates still catch
+deliberately corrupted claims.

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -1,7 +1,7 @@
 # attune-ai
 
 Spec-driven development for Claude Code — turn requirements
-into reliable software. 18 auto-triggering skills, zero
+into reliable software. <!-- cap:skill_count -->25 auto-triggering skills<!-- /cap -->, zero
 commands: say what you need and Claude picks the right skill.
 
 **Version:** 10.5.0 | **License:** Apache 2.0
@@ -79,7 +79,7 @@ The plugin ships two security hooks:
 ## Python Package (optional — unlocks CLI + MCP)
 
 The plugin works standalone. Add the Python package
-for CLI automation, 53 MCP tools, multi-agent
+for CLI automation, <!-- cap:mcp_registered_tool_count -->53 MCP tools<!-- /cap -->, multi-agent
 workflows, and cost tracking:
 
 ```bash
@@ -88,9 +88,9 @@ pip install 'attune-ai[developer]'
 
 | Capability | Plugin only | + pip |
 | ---------- | ----------- | ----- |
-| 20 auto-triggering skills | Yes | Yes |
+| <!-- cap:skill_count -->25 auto-triggering skills<!-- /cap --> | Yes | Yes |
 | Prompt-based analysis | Yes | Yes |
-| 53 MCP tools | -- | Yes |
+| <!-- cap:mcp_registered_tool_count -->53 MCP tools<!-- /cap --> | -- | Yes |
 | `attune` CLI | -- | Yes |
 | Multi-agent workflows | -- | Yes |
 | Cost tracking | -- | Yes |

--- a/scripts/project_capabilities.py
+++ b/scripts/project_capabilities.py
@@ -1,0 +1,607 @@
+#!/usr/bin/env python3
+"""Capability count projector (roundtable q-capability-count-projector-001).
+
+Derives exactly three semantic values from the checked-out revision and
+projects them into an explicit, frozen allowlist of claim sites:
+
+- ``skill_count`` — publishable skills under ``plugin/skills/*/SKILL.md``.
+- ``mcp_registered_tool_count`` — unique names in
+  ``EmpathyMCPServer().tools`` (includes bundled plugin tools).
+- ``mcp_core_schema_tool_count`` — unique names returned by the
+  canonical ``attune.mcp.tool_schemas.get_*_tools()`` getters.
+
+No network data, cached counts, caller overrides, remembered constants,
+or anticipated capabilities. Empty, duplicate, malformed, or
+environment-dependent discovery fails closed. The independent drift
+gates (``tests/unit/gates/test_claim_drift.py``,
+``tests/unit/test_website_version_accuracy.py``) deliberately do NOT
+share this module's derivation or manifest.
+
+Ownership model
+---------------
+
+- **Markdown** owns complete, uniquely marked claim fragments — never
+  isolated numbers. The marker grammar is a one-line span::
+
+      <!-- cap:VALUE -->fragment with the number<!-- /cap -->
+
+  Every marked span in a governed file must be claimed by exactly one
+  manifest target; stray, unclosed, unknown-value, or ambiguous
+  markers fail closed.
+- **JSON** (``.claude-plugin/marketplace.json``) is parsed as JSON; only
+  the exact allowlisted description fields are rewritten. JSON receives
+  no comment markers.
+- **TypeScript** (``website/lib/features.ts``) updates exact named
+  numeric fields inside the existing ``CAPABILITIES`` object. No
+  generated JSON sidecar.
+
+Usage::
+
+    python scripts/project_capabilities.py           # read-only check
+    python scripts/project_capabilities.py --check   # same as default
+    python scripts/project_capabilities.py --write   # repair drift
+
+Exit codes: 0 clean, 1 drift (check mode), 2 structural/derivation
+failure or bad usage. ``--write`` computes and validates the complete
+edit plan before touching any file, writes atomically per file, then
+reruns the check from disk. A repeated ``--write`` is byte-idempotent.
+
+Capability-changing PRs (adding/removing a plugin skill or MCP tool)
+run ``--write`` in the same change; CI runs ``--check``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+VALUE_NAMES = (
+    "skill_count",
+    "mcp_registered_tool_count",
+    "mcp_core_schema_tool_count",
+)
+
+
+class ProjectionError(RuntimeError):
+    """Structural failure — fail closed, never write."""
+
+
+# --- Derivation --------------------------------------------------------
+
+
+def derive_values(repo: Path) -> dict[str, int]:
+    """Derive the three semantic values from the checked-out revision.
+
+    Raises ProjectionError on any empty, duplicate, or inconsistent
+    discovery — a count from an unstable environment is never published.
+    """
+    skill_files = sorted((repo / "plugin" / "skills").glob("*/SKILL.md"))
+    if not skill_files:
+        raise ProjectionError(
+            f"no plugin/skills/*/SKILL.md found under {repo} — refusing to publish 0"
+        )
+
+    try:
+        from attune.mcp import tool_schemas
+        from attune.mcp.server import EmpathyMCPServer
+    except ImportError as exc:
+        raise ProjectionError(
+            f"attune is not importable ({exc}) — run from the project environment"
+        ) from exc
+
+    tools = EmpathyMCPServer().tools
+    if not isinstance(tools, dict) or not tools:
+        raise ProjectionError(
+            "EmpathyMCPServer().tools is not a non-empty dict — unstable registration"
+        )
+    registered = set(tools)
+
+    getter_names = sorted(
+        n for n in dir(tool_schemas) if n.startswith("get_") and n.endswith("_tools")
+    )
+    if not getter_names:
+        raise ProjectionError("no get_*_tools() getters found in attune.mcp.tool_schemas")
+    core: set[str] = set()
+    for name in getter_names:
+        schemas = getattr(tool_schemas, name)()
+        if not isinstance(schemas, dict) or not schemas:
+            raise ProjectionError(f"tool_schemas.{name}() returned a non-dict or empty result")
+        dupes = core & set(schemas)
+        if dupes:
+            raise ProjectionError(
+                f"duplicate tool names across get_*_tools() getters: {sorted(dupes)}"
+            )
+        core.update(schemas)
+
+    if not core <= registered:
+        raise ProjectionError(
+            "core schema tools missing from the registered server "
+            f"({sorted(core - registered)}) — environment-dependent registration, failing closed"
+        )
+    return {
+        "skill_count": len(skill_files),
+        "mcp_registered_tool_count": len(registered),
+        "mcp_core_schema_tool_count": len(core),
+    }
+
+
+# --- Target manifest ---------------------------------------------------
+#
+# Every entry declares the semantic value it publishes, an exact
+# locator, its renderer (via the dataclass type), expected match
+# cardinality, and gets post-render validation in its planner.
+
+
+@dataclass(frozen=True)
+class MarkedFragmentTarget:
+    """Markdown target: whole fragments wrapped in ownership markers.
+
+    The projector owns every ``<!-- cap:VALUE -->…<!-- /cap -->`` span
+    whose inner text matches ``template`` (which contains exactly one
+    ``{n}`` placeholder; everything else is literal). ``count`` is the
+    expected number of such spans in the file.
+    """
+
+    path: str
+    label: str
+    value: str
+    template: str
+    count: int = 1
+
+
+@dataclass(frozen=True)
+class JsonFieldTarget:
+    """JSON target: one allowlisted string field, located by path.
+
+    ``json_path`` elements are dict keys, except a (key, value) tuple
+    which selects exactly one entry from a list. Only the located field
+    is rewritten; the file's bytes are otherwise preserved and the
+    result is re-validated as JSON.
+    """
+
+    path: str
+    label: str
+    value: str
+    json_path: tuple = ()
+    fragment: str = ""
+
+
+@dataclass(frozen=True)
+class TsCapabilityTarget:
+    """features.ts target: one named numeric field inside CAPABILITIES."""
+
+    path: str
+    label: str
+    value: str
+    ts_field: str = ""
+
+
+MANIFEST: tuple = (
+    # skill_count
+    MarkedFragmentTarget(
+        "README.md",
+        "comparison table skills row",
+        "skill_count",
+        "{n} auto-triggering skills",
+    ),
+    MarkedFragmentTarget(
+        "plugin/README.md",
+        "intro + comparison table skills claims",
+        "skill_count",
+        "{n} auto-triggering skills",
+        count=2,
+    ),
+    MarkedFragmentTarget(
+        "docs/getting-started/quickstart-plugin.md",
+        "bold skills claim",
+        "skill_count",
+        "**{n} auto-triggering skills**",
+    ),
+    MarkedFragmentTarget(
+        "docs/getting-started/quickstart-plugin.md",
+        "plugin-vs-package skills note",
+        "skill_count",
+        "{n} natural-language skills",
+    ),
+    JsonFieldTarget(
+        ".claude-plugin/marketplace.json",
+        "marketplace metadata description",
+        "skill_count",
+        json_path=("metadata", "description"),
+        fragment="{n} auto-triggering skills",
+    ),
+    JsonFieldTarget(
+        ".claude-plugin/marketplace.json",
+        "attune-ai plugin description",
+        "skill_count",
+        json_path=("plugins", ("name", "attune-ai"), "description"),
+        fragment="{n} auto-triggering skills",
+    ),
+    TsCapabilityTarget(
+        "website/lib/features.ts",
+        "CAPABILITIES.skills",
+        "skill_count",
+        ts_field="skills",
+    ),
+    # mcp_registered_tool_count (total including bundled plugin tools)
+    MarkedFragmentTarget(
+        "README.md",
+        "hero + comparison table tool counts",
+        "mcp_registered_tool_count",
+        "{n} MCP tools",
+        count=2,
+    ),
+    MarkedFragmentTarget(
+        "plugin/README.md",
+        "intro + comparison table tool counts",
+        "mcp_registered_tool_count",
+        "{n} MCP tools",
+        count=2,
+    ),
+    MarkedFragmentTarget(
+        "docs/getting-started/quickstart-plugin.md",
+        "MCP toolset link row",
+        "mcp_registered_tool_count",
+        "({n} tools)",
+    ),
+    MarkedFragmentTarget(
+        "docs/getting-started/quickstart-plugin.md",
+        "plugin-vs-package tools note",
+        "mcp_registered_tool_count",
+        "{n} MCP tools",
+    ),
+    MarkedFragmentTarget(
+        "docs/getting-started/mcp-integration.md",
+        "available tools heading",
+        "mcp_registered_tool_count",
+        "Available Tools ({n})",
+    ),
+    # mcp_core_schema_tool_count (canonical tool_schemas getters only)
+    TsCapabilityTarget(
+        "website/lib/features.ts",
+        "CAPABILITIES.mcpTools",
+        "mcp_core_schema_tool_count",
+        ts_field="mcpTools",
+    ),
+)
+
+
+# --- Planning ----------------------------------------------------------
+
+MARKER_RE = re.compile(r"<!-- cap:([a-z_]+) -->(.*?)<!-- /cap -->")
+MARKER_TOKEN_RE = re.compile(r"<!-- /?cap\b")
+
+
+@dataclass
+class FilePlan:
+    """One governed file: original text, fully rendered text, drift."""
+
+    path: str
+    original: str
+    new_text: str
+    drifts: list[str]
+
+    @property
+    def changed(self) -> bool:
+        return self.new_text != self.original
+
+
+def _read(repo: Path, rel: str) -> str:
+    path = (repo / rel).resolve()
+    if not path.is_relative_to(repo.resolve()):
+        raise ProjectionError(f"target escapes the repository root: {rel}")
+    if not path.is_file():
+        raise ProjectionError(f"target file missing: {path}")
+    with path.open(encoding="utf-8", newline="") as fh:
+        return fh.read()
+
+
+def _template_pattern(template: str) -> re.Pattern[str]:
+    parts = template.split("{n}")
+    if len(parts) != 2:
+        raise ProjectionError(f"template must contain exactly one {{n}}: {template!r}")
+    return re.compile(re.escape(parts[0]) + r"(\d+)" + re.escape(parts[1]))
+
+
+def _render(template: str, expected: int) -> str:
+    return template.replace("{n}", str(expected))
+
+
+def _splice(text: str, spans: list[tuple[int, int]], replacement: str) -> str:
+    out, last = [], 0
+    for start, end in spans:
+        out.append(text[last:start])
+        out.append(replacement)
+        last = end
+    out.append(text[last:])
+    return "".join(out)
+
+
+def _scan_marked_spans(path_label: str, text: str) -> list[re.Match[str]]:
+    """All well-formed one-line marker spans; stray tokens fail closed."""
+    spans = list(MARKER_RE.finditer(text))
+    for token in MARKER_TOKEN_RE.finditer(text):
+        if not any(m.start() <= token.start() < m.end() for m in spans):
+            line = text.count("\n", 0, token.start()) + 1
+            raise ProjectionError(
+                f"{path_label}: malformed or unclosed capability marker at line {line}"
+            )
+    return spans
+
+
+def _validate_marker_coverage(
+    path_label: str, text: str, targets: list[MarkedFragmentTarget]
+) -> None:
+    """Every marked span is claimed by exactly one manifest target."""
+    for span in _scan_marked_spans(path_label, text):
+        value, inner = span.group(1), span.group(2)
+        claimants = [
+            t
+            for t in targets
+            if t.value == value and _template_pattern(t.template).fullmatch(inner)
+        ]
+        if not claimants:
+            line = text.count("\n", 0, span.start()) + 1
+            raise ProjectionError(
+                f"{path_label}: marker cap:{value} at line {line} with content "
+                f"{inner!r} is claimed by no manifest target — unknown value, "
+                "renamed claim, or wrong fragment shape"
+            )
+        if len(claimants) > 1:
+            labels = ", ".join(repr(t.label) for t in claimants)
+            raise ProjectionError(
+                f"{path_label}: marker cap:{value} content {inner!r} is claimed "
+                f"by {len(claimants)} targets ({labels}) — ambiguous ownership"
+            )
+
+
+def _plan_marked(target: MarkedFragmentTarget, text: str, expected: int) -> tuple[str, list[str]]:
+    where = f"{target.path}: {target.label}"
+    pattern = _template_pattern(target.template)
+    mine = [
+        m
+        for m in _scan_marked_spans(target.path, text)
+        if m.group(1) == target.value and pattern.fullmatch(m.group(2))
+    ]
+    if len(mine) != target.count:
+        raise ProjectionError(
+            f"{where}: {len(mine)} marked span(s) match template "
+            f"{target.template!r}, expected {target.count} — the claim moved, "
+            "vanished, or became ambiguous; fix the manifest WITH the wording"
+        )
+    observed = [m.group(2) for m in mine]
+    new_inner = _render(target.template, expected)
+    new_text = _splice(text, [m.span(2) for m in mine], new_inner)
+    rendered = [
+        m.group(2)
+        for m in MARKER_RE.finditer(new_text)
+        if m.group(1) == target.value and pattern.fullmatch(m.group(2))
+    ]
+    if rendered != [new_inner] * target.count:
+        raise ProjectionError(f"{where}: post-render validation failed")
+    drifts = []
+    if any(inner != new_inner for inner in observed):
+        drifts.append(
+            f"{target.path}: {target.label} publishes {target.value} — expected "
+            f"{new_inner!r}, observed {', '.join(repr(o) for o in observed)}"
+        )
+    return new_text, drifts
+
+
+def _resolve_json_field(data: object, json_path: tuple, where: str) -> str:
+    node = data
+    for step in json_path:
+        if isinstance(step, tuple):
+            key, value = step
+            if not isinstance(node, list):
+                raise ProjectionError(f"{where}: selector {step!r} applied to non-list")
+            hits = [e for e in node if isinstance(e, dict) and e.get(key) == value]
+            if len(hits) != 1:
+                raise ProjectionError(
+                    f"{where}: selector {step!r} matched {len(hits)} entries, expected 1"
+                )
+            node = hits[0]
+        else:
+            if not isinstance(node, dict) or step not in node:
+                raise ProjectionError(f"{where}: key {step!r} not found")
+            node = node[step]
+    if not isinstance(node, str):
+        raise ProjectionError(f"{where}: located field is {type(node).__name__}, expected string")
+    return node
+
+
+def _plan_json(target: JsonFieldTarget, text: str, expected: int) -> tuple[str, list[str]]:
+    where = f"{target.path}: {target.label}"
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise ProjectionError(f"{where}: invalid JSON ({exc})") from exc
+    old_field = _resolve_json_field(data, target.json_path, where)
+    pattern = _template_pattern(target.fragment)
+    matches = list(pattern.finditer(old_field))
+    if len(matches) != 1:
+        raise ProjectionError(
+            f"{where}: fragment /{pattern.pattern}/ matched {len(matches)} "
+            "time(s) in the field, expected 1"
+        )
+    observed = matches[0].group(0)
+    rendered = _render(target.fragment, expected)
+    new_field = _splice(old_field, [matches[0].span()], rendered)
+    if new_field == old_field:
+        return text, []
+
+    old_encoded = json.dumps(old_field, ensure_ascii=False)
+    if text.count(old_encoded) != 1:
+        raise ProjectionError(
+            f"{where}: JSON-encoded field value occurs {text.count(old_encoded)} "
+            "time(s) in the raw file, expected 1 — cannot rewrite unambiguously"
+        )
+    new_text = text.replace(old_encoded, json.dumps(new_field, ensure_ascii=False), 1)
+    # Post-render validation: still valid JSON, and only the owned field moved.
+    try:
+        new_data = json.loads(new_text)
+    except json.JSONDecodeError as exc:
+        raise ProjectionError(f"{where}: rewrite produced invalid JSON ({exc})") from exc
+    if _resolve_json_field(new_data, target.json_path, where) != new_field:
+        raise ProjectionError(f"{where}: rewrite did not land in the owned field")
+    drift = (
+        f"{target.path}: {target.label} publishes {target.value} — expected "
+        f"{rendered!r}, observed {observed!r}"
+    )
+    return new_text, [drift]
+
+
+CAPS_BLOCK = re.compile(r"export const CAPABILITIES = \{(.*?)\} as const;", re.S)
+
+
+def _plan_ts(target: TsCapabilityTarget, text: str, expected: int) -> tuple[str, list[str]]:
+    where = f"{target.path}: {target.label}"
+    blocks = list(CAPS_BLOCK.finditer(text))
+    if len(blocks) != 1:
+        raise ProjectionError(f"{where}: found {len(blocks)} CAPABILITIES blocks, expected 1")
+    block = blocks[0]
+    field_pattern = re.compile(r"\b" + re.escape(target.ts_field) + r"\s*:\s*(\d+)")
+    matches = list(field_pattern.finditer(text, block.start(1), block.end(1)))
+    if len(matches) != 1:
+        raise ProjectionError(
+            f"{where}: field {target.ts_field!r} matched {len(matches)} "
+            "time(s) inside CAPABILITIES, expected 1"
+        )
+    observed = matches[0].group(1)
+    new_text = _splice(text, [matches[0].span(1)], str(expected))
+    check = field_pattern.findall(new_text, block.start(1))
+    if not check or check[0] != str(expected):
+        raise ProjectionError(f"{where}: post-render validation failed")
+    drifts = []
+    if observed != str(expected):
+        drifts.append(
+            f"{target.path}: {target.label} publishes {target.value} — expected "
+            f"'{target.ts_field}: {expected}', observed '{target.ts_field}: {observed}'"
+        )
+    return new_text, drifts
+
+
+_PLANNERS = {
+    MarkedFragmentTarget: _plan_marked,
+    JsonFieldTarget: _plan_json,
+    TsCapabilityTarget: _plan_ts,
+}
+
+
+def build_plan(repo: Path, values: dict[str, int], manifest: tuple | None = None) -> list[FilePlan]:
+    """Validate every target and render each file's new content — no writes.
+
+    Targets on the same file are applied sequentially to the evolving
+    text, so one file plan carries every claim it owns. Raises
+    ProjectionError on the first structural problem so that one invalid
+    target prevents every planned write.
+    """
+    if manifest is None:
+        manifest = MANIFEST
+    by_path: dict[str, list] = {}
+    for target in manifest:
+        by_path.setdefault(target.path, []).append(target)
+
+    plans: list[FilePlan] = []
+    for path, targets in by_path.items():
+        original = _read(repo, path)
+        marked = [t for t in targets if isinstance(t, MarkedFragmentTarget)]
+        if marked:
+            _validate_marker_coverage(path, original, marked)
+        current, drifts = original, []
+        for target in targets:
+            if target.value not in values:
+                raise ProjectionError(
+                    f"{target.path}: {target.label!r} names unknown value {target.value!r}"
+                )
+            current, target_drifts = _PLANNERS[type(target)](target, current, values[target.value])
+            drifts.extend(target_drifts)
+        plans.append(FilePlan(path, original, current, drifts))
+    return plans
+
+
+def drift_lines(plans: list[FilePlan]) -> list[str]:
+    return [line for plan in plans for line in plan.drifts]
+
+
+def _atomic_write(path: Path, data: str) -> None:
+    tmp = path.with_name(path.name + ".capproj-tmp")
+    try:
+        with tmp.open("w", encoding="utf-8", newline="") as fh:
+            fh.write(data)
+        os.replace(tmp, path)
+    finally:
+        tmp.unlink(missing_ok=True)
+
+
+def apply_plan(repo: Path, plans: list[FilePlan]) -> list[str]:
+    """Atomically write every changed file; returns the changed paths."""
+    changed: list[str] = []
+    for plan in plans:
+        if plan.changed:
+            _atomic_write((repo / plan.path).resolve(), plan.new_text)
+            changed.append(plan.path)
+    return changed
+
+
+# --- CLI ---------------------------------------------------------------
+
+
+def main(argv: list[str] | None = None, repo: Path | None = None) -> int:
+    """Run the projector CLI; ``repo`` overrides the root for tests."""
+    parser = argparse.ArgumentParser(
+        description="Project derived capability counts into their allowlisted claim sites.",
+    )
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument("--check", action="store_true", help="read-only drift check (the default)")
+    group.add_argument("--write", action="store_true", help="repair drift, then re-check")
+    args = parser.parse_args(argv)
+
+    if repo is None:
+        repo = Path(__file__).resolve().parents[1]
+    try:
+        values = derive_values(repo)
+        plans = build_plan(repo, values)
+    except ProjectionError as exc:
+        print(f"projection failed closed: {exc}", file=sys.stderr)
+        return 2
+
+    for name in VALUE_NAMES:
+        print(f"{name} = {values[name]}")
+    drift = drift_lines(plans)
+
+    if not args.write:
+        if drift:
+            print("\nDRIFT:", file=sys.stderr)
+            for line in drift:
+                print(f"  {line}", file=sys.stderr)
+            print("\nrun: python scripts/project_capabilities.py --write", file=sys.stderr)
+            return 1
+        print("all capability claims match the derived values")
+        return 0
+
+    if not drift:
+        print("all capability claims already match — nothing to write")
+        return 0
+    changed = apply_plan(repo, plans)
+    for line in drift:
+        print(f"repaired: {line}")
+    print(f"wrote {len(changed)} file(s): {', '.join(changed)}")
+    try:
+        recheck = build_plan(repo, values)
+    except ProjectionError as exc:
+        print(f"post-write re-check failed closed: {exc}", file=sys.stderr)
+        return 2
+    if drift_lines(recheck):
+        print("post-write re-check still reports drift", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/project_capabilities.py
+++ b/scripts/project_capabilities.py
@@ -552,9 +552,15 @@ def _atomic_write(path: Path, data: str) -> None:
 def apply_plan(repo: Path, plans: list[FilePlan]) -> list[str]:
     """Atomically write every changed file; returns the changed paths."""
     changed: list[str] = []
+    root = repo.resolve()
     for plan in plans:
         if plan.changed:
-            _atomic_write((repo / plan.path).resolve(), plan.new_text)
+            path = (repo / plan.path).resolve()
+            if not path.is_relative_to(root):
+                raise ProjectionError(f"target escapes the repository root: {plan.path}")
+            if not path.is_file():
+                raise ProjectionError(f"target file missing: {path}")
+            _atomic_write(path, plan.new_text)
             changed.append(plan.path)
     return changed
 

--- a/scripts/project_capabilities.py
+++ b/scripts/project_capabilities.py
@@ -474,8 +474,11 @@ def _plan_ts(target: TsCapabilityTarget, text: str, expected: int) -> tuple[str,
         )
     observed = matches[0].group(1)
     new_text = _splice(text, [matches[0].span(1)], str(expected))
-    check = field_pattern.findall(new_text, block.start(1))
-    if not check or check[0] != str(expected):
+    new_blocks = list(CAPS_BLOCK.finditer(new_text))
+    if len(new_blocks) != 1:
+        raise ProjectionError(f"{where}: post-render validation failed (CAPABILITIES block)")
+    check = list(field_pattern.finditer(new_text, new_blocks[0].start(1), new_blocks[0].end(1)))
+    if len(check) != 1 or check[0].group(1) != str(expected):
         raise ProjectionError(f"{where}: post-render validation failed")
     drifts = []
     if observed != str(expected):
@@ -532,7 +535,14 @@ def drift_lines(plans: list[FilePlan]) -> list[str]:
 def _atomic_write(path: Path, data: str) -> None:
     tmp = path.with_name(path.name + ".capproj-tmp")
     try:
-        with tmp.open("w", encoding="utf-8", newline="") as fh:
+        fh = tmp.open("x", encoding="utf-8", newline="")
+    except FileExistsError as exc:
+        raise ProjectionError(
+            f"stale temp file {tmp} already exists (crashed prior write?) — "
+            "inspect and remove it, then re-run"
+        ) from exc
+    try:
+        with fh:
             fh.write(data)
         os.replace(tmp, path)
     finally:
@@ -588,7 +598,11 @@ def main(argv: list[str] | None = None, repo: Path | None = None) -> int:
     if not drift:
         print("all capability claims already match — nothing to write")
         return 0
-    changed = apply_plan(repo, plans)
+    try:
+        changed = apply_plan(repo, plans)
+    except ProjectionError as exc:
+        print(f"write failed closed: {exc}", file=sys.stderr)
+        return 2
     for line in drift:
         print(f"repaired: {line}")
     print(f"wrote {len(changed)} file(s): {', '.join(changed)}")

--- a/tests/unit/gates/test_claim_drift.py
+++ b/tests/unit/gates/test_claim_drift.py
@@ -89,7 +89,7 @@ MANIFEST: tuple[tuple[str, str, str, str], ...] = (
     (
         "docs/getting-started/mcp-integration.md",
         "tools heading",
-        r"## (?:<[^>]*>)?Available Tools \((\d+)\)",
+        r"## (?:<!-- cap:[a-z_]+ -->)?Available Tools \((\d+)\)",
         "tools",
     ),
     (

--- a/tests/unit/gates/test_claim_drift.py
+++ b/tests/unit/gates/test_claim_drift.py
@@ -60,7 +60,7 @@ MANIFEST: tuple[tuple[str, str, str, str], ...] = (
     (
         "README.md",
         "hero workflow count",
-        r"(\d+) workflows and (?:<[^>]*>)?\d+ MCP tools",
+        r"(\d+) workflows and (?:<!-- cap:[a-z_]+ -->)?\d+ MCP tools",
         "workflows",
     ),
     ("README.md", "hero tool count", r"\d+ workflows and (?:<[^>]*>)?(\d+) MCP tools", "tools"),

--- a/tests/unit/gates/test_claim_drift.py
+++ b/tests/unit/gates/test_claim_drift.py
@@ -52,11 +52,20 @@ def live_values() -> dict[str, str]:
 # (file, human label, regex with ONE capture group, live-value key).
 # Every regex must match at least once in its file; every captured
 # value must equal the live value.
+# `(?:<[^>]*>)?` tolerates the `<!-- cap:... -->` ownership markers
+# that scripts/project_capabilities.py wraps around governed claims.
+# The assertion is unchanged — same wording, same number, same count;
+# this gate stays independent (no projector imports, own derivation).
 MANIFEST: tuple[tuple[str, str, str, str], ...] = (
-    ("README.md", "hero workflow count", r"(\d+) workflows and \d+ MCP tools", "workflows"),
-    ("README.md", "hero tool count", r"\d+ workflows and (\d+) MCP tools", "tools"),
-    ("README.md", "skills table row", r"\| (\d+) auto-triggering skills", "skills"),
-    ("README.md", "tools table row", r"\| (\d+) MCP tools", "tools"),
+    (
+        "README.md",
+        "hero workflow count",
+        r"(\d+) workflows and (?:<[^>]*>)?\d+ MCP tools",
+        "workflows",
+    ),
+    ("README.md", "hero tool count", r"\d+ workflows and (?:<[^>]*>)?(\d+) MCP tools", "tools"),
+    ("README.md", "skills table row", r"\| (?:<[^>]*>)?(\d+) auto-triggering skills", "skills"),
+    ("README.md", "tools table row", r"\| (?:<[^>]*>)?(\d+) MCP tools", "tools"),
     (
         ".claude-plugin/marketplace.json",
         "marketplace skill claims",
@@ -80,7 +89,7 @@ MANIFEST: tuple[tuple[str, str, str, str], ...] = (
     (
         "docs/getting-started/mcp-integration.md",
         "tools heading",
-        r"## Available Tools \((\d+)\)",
+        r"## (?:<[^>]*>)?Available Tools \((\d+)\)",
         "tools",
     ),
     (

--- a/tests/unit/scripts/test_project_capabilities.py
+++ b/tests/unit/scripts/test_project_capabilities.py
@@ -397,6 +397,37 @@ def test_write_preserves_crlf_unicode_and_unrelated_files(tmp_path):
     assert not list(repo.glob("*.capproj-tmp"))  # atomic temp cleaned up
 
 
+def test_ts_same_field_name_after_block_is_ignored(tmp_path):
+    # Copilot review (PR #1626): post-render validation must be bounded
+    # to the re-located CAPABILITIES block, not scan to EOF.
+    repo = std_repo(tmp_path)
+    trailing = "export const LEGACY = { mcpTools: 9 };\n"
+    write(repo, "features.ts", FEATURES_TS + trailing)
+    plans = proj.build_plan(repo, VALUES, std_manifest())
+    proj.apply_plan(repo, plans)
+    ts = (repo / "features.ts").read_text(encoding="utf-8")
+    assert "mcpTools: 49" in ts  # inside CAPABILITIES
+    assert ts.endswith(trailing)  # the lookalike after the block untouched
+
+
+def test_stale_temp_file_fails_closed(tmp_path, monkeypatch):
+    # Copilot review (PR #1626): a leftover .capproj-tmp from a crashed
+    # write must never be truncated — exclusive create, fail closed.
+    repo = std_repo(tmp_path)
+    stale = repo / "page.md.capproj-tmp"
+    stale.write_text("crashed partial write", encoding="utf-8")
+    before = (repo / "page.md").read_bytes()
+    plans = proj.build_plan(repo, VALUES, std_manifest())
+    with pytest.raises(proj.ProjectionError, match="stale temp file"):
+        proj.apply_plan(repo, plans)
+    assert (repo / "page.md").read_bytes() == before
+    assert stale.read_text(encoding="utf-8") == "crashed partial write"
+    # And via the CLI: the write phase exits 2, not a traceback.
+    monkeypatch.setattr(proj, "MANIFEST", std_manifest())
+    monkeypatch.setattr(proj, "derive_values", lambda _repo: dict(VALUES))
+    assert proj.main(["--write"], repo=repo) == 2
+
+
 # --- The real manifest against copies of the real files -----------------
 
 

--- a/tests/unit/scripts/test_project_capabilities.py
+++ b/tests/unit/scripts/test_project_capabilities.py
@@ -1,0 +1,475 @@
+"""Focused tests for the capability count projector.
+
+Covers (roundtable q-capability-count-projector-001, required
+verification): the three independent derivations; deliberately unequal
+registered/core totals; every locator/format type; read-only default and
+``--check``; drift diagnostics and exit codes; write repair and
+second-write idempotence; missing, duplicate, renamed, malformed,
+ambiguous, and wrong-type targets; fail-before-write when one target is
+invalid; preservation of unrelated text and files; subprocess CLI exit
+codes; and the independence of the existing drift gates.
+
+The fixture manifest here is intentionally tiny and distinct from the
+real ``MANIFEST``; ``test_real_manifest_repairs_bumped_values_on_copies``
+exercises the real manifest against copies of the real governed files.
+"""
+
+from __future__ import annotations
+
+import glob
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from scripts import project_capabilities as proj
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCRIPT = REPO_ROOT / "scripts" / "project_capabilities.py"
+
+# Deliberately UNEQUAL registered/core totals: interchanging them in any
+# target mapping must be visible in every fixture assertion.
+VALUES = {
+    "skill_count": 7,
+    "mcp_registered_tool_count": 55,
+    "mcp_core_schema_tool_count": 49,
+}
+
+PAGE_MD = (
+    "Intro line.\n\n"
+    "Ships <!-- cap:skill_count -->3 auto skills<!-- /cap --> and "
+    "<!-- cap:mcp_registered_tool_count -->4 shiny tools<!-- /cap -->.\n"
+)
+META_JSON = json.dumps(
+    {"metadata": {"description": "Has 3 auto skills — really."}}, indent=2, ensure_ascii=False
+)
+FEATURES_TS = "export const CAPABILITIES = {\n  workflows: 20,\n  mcpTools: 9,\n} as const;\n"
+
+
+def std_manifest() -> tuple:
+    return (
+        proj.MarkedFragmentTarget("page.md", "skills claim", "skill_count", "{n} auto skills"),
+        proj.MarkedFragmentTarget(
+            "page.md", "tools claim", "mcp_registered_tool_count", "{n} shiny tools"
+        ),
+        proj.JsonFieldTarget(
+            "meta.json",
+            "metadata description",
+            "skill_count",
+            json_path=("metadata", "description"),
+            fragment="{n} auto skills",
+        ),
+        proj.TsCapabilityTarget(
+            "features.ts",
+            "CAPABILITIES.mcpTools",
+            "mcp_core_schema_tool_count",
+            ts_field="mcpTools",
+        ),
+    )
+
+
+def write(repo: Path, rel: str, text: str) -> Path:
+    path = repo / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8", newline="") as fh:
+        fh.write(text)
+    return path
+
+
+def std_repo(tmp_path: Path) -> Path:
+    write(tmp_path, "page.md", PAGE_MD)
+    write(tmp_path, "meta.json", META_JSON)
+    write(tmp_path, "features.ts", FEATURES_TS)
+    return tmp_path
+
+
+def read_all(repo: Path) -> dict[str, bytes]:
+    return {p.name: p.read_bytes() for p in repo.rglob("*") if p.is_file()}
+
+
+# --- The three derivations, independently recomputed -------------------
+
+
+class TestDerivations:
+    @pytest.fixture(scope="class")
+    def derived(self) -> dict[str, int]:
+        return proj.derive_values(REPO_ROOT)
+
+    def test_skill_count_matches_independent_glob(self, derived):
+        live = len(glob.glob(str(REPO_ROOT / "plugin" / "skills" / "*" / "SKILL.md")))
+        assert derived["skill_count"] == live > 10
+
+    def test_registered_count_matches_server_tools(self, derived):
+        from attune.mcp.server import EmpathyMCPServer
+
+        assert derived["mcp_registered_tool_count"] == len(set(EmpathyMCPServer().tools)) > 20
+
+    def test_core_schema_count_matches_getter_sum(self, derived):
+        from attune.mcp import tool_schemas as ts
+
+        names: set[str] = set()
+        for attr in dir(ts):
+            if attr.startswith("get_") and attr.endswith("_tools"):
+                names |= set(getattr(ts, attr)())
+        assert derived["mcp_core_schema_tool_count"] == len(names) > 20
+
+    def test_registered_and_core_totals_are_distinct_live(self, derived):
+        # The regression premise: the two totals are semantically
+        # different and must never be interchangeable. Live, bundled
+        # plugin tools make registered a strict superset.
+        assert derived["mcp_registered_tool_count"] > derived["mcp_core_schema_tool_count"]
+
+    def test_missing_skills_dir_fails_closed(self, tmp_path):
+        with pytest.raises(proj.ProjectionError, match="refusing to publish 0"):
+            proj.derive_values(tmp_path)
+
+
+# --- Unequal totals cannot be interchanged ------------------------------
+
+
+def test_unequal_totals_project_to_their_own_targets(tmp_path):
+    repo = std_repo(tmp_path)
+    plans = proj.build_plan(repo, VALUES, std_manifest())
+    proj.apply_plan(repo, plans)
+    page = (repo / "page.md").read_text(encoding="utf-8")
+    ts = (repo / "features.ts").read_text(encoding="utf-8")
+    assert "55 shiny tools" in page  # registered → markdown claim
+    assert "mcpTools: 49" in ts  # core → CAPABILITIES field
+    assert "49 shiny tools" not in page and "mcpTools: 55" not in ts
+
+
+# --- Every locator/format type detects drift and is repaired -----------
+
+
+def test_all_locator_types_drift_and_repair(tmp_path):
+    repo = std_repo(tmp_path)
+    plans = proj.build_plan(repo, VALUES, std_manifest())
+    drift = proj.drift_lines(plans)
+    assert len(drift) == 4  # every fixture target starts stale
+    changed = proj.apply_plan(repo, plans)
+    assert sorted(changed) == ["features.ts", "meta.json", "page.md"]
+    replan = proj.build_plan(repo, VALUES, std_manifest())
+    assert proj.drift_lines(replan) == []
+    assert (
+        json.loads((repo / "meta.json").read_text(encoding="utf-8"))["metadata"]["description"]
+        == "Has 7 auto skills — really."
+    )
+
+
+def test_same_file_targets_compose_without_clobbering(tmp_path):
+    # Two drifted targets in one file: both repairs must land.
+    repo = std_repo(tmp_path)
+    plans = proj.build_plan(repo, VALUES, std_manifest())
+    proj.apply_plan(repo, plans)
+    page = (repo / "page.md").read_text(encoding="utf-8")
+    assert "7 auto skills" in page and "55 shiny tools" in page
+
+
+# --- CLI flow (in-process, fixture repo) --------------------------------
+
+
+@pytest.fixture
+def cli_repo(tmp_path, monkeypatch) -> Path:
+    repo = std_repo(tmp_path)
+    monkeypatch.setattr(proj, "MANIFEST", std_manifest())
+    monkeypatch.setattr(proj, "derive_values", lambda _repo: dict(VALUES))
+    return repo
+
+
+class TestCliFlow:
+    @pytest.mark.parametrize("argv", [[], ["--check"]])
+    def test_default_and_check_are_read_only(self, cli_repo, argv, capsys):
+        before = read_all(cli_repo)
+        assert proj.main(argv, repo=cli_repo) == 1
+        assert read_all(cli_repo) == before
+        err = capsys.readouterr().err
+        # Diagnostics carry semantic value, target, expected + observed rendering.
+        assert "page.md: skills claim publishes skill_count" in err
+        assert "'7 auto skills'" in err and "'3 auto skills'" in err
+
+    def test_check_exits_zero_when_synced(self, cli_repo, capsys):
+        assert proj.main(["--write"], repo=cli_repo) == 0
+        assert proj.main(["--check"], repo=cli_repo) == 0
+        assert "all capability claims match" in capsys.readouterr().out
+
+    def test_write_repairs_then_second_write_is_byte_idempotent(self, cli_repo, capsys):
+        assert proj.main(["--write"], repo=cli_repo) == 0
+        first = read_all(cli_repo)
+        assert proj.main(["--write"], repo=cli_repo) == 0
+        assert "nothing to write" in capsys.readouterr().out
+        assert read_all(cli_repo) == first
+
+    def test_derivation_failure_exits_2(self, cli_repo, monkeypatch, capsys):
+        def boom(_repo):
+            raise proj.ProjectionError("unstable")
+
+        monkeypatch.setattr(proj, "derive_values", boom)
+        assert proj.main(["--check"], repo=cli_repo) == 2
+        assert "failed closed" in capsys.readouterr().err
+
+
+# --- Structural failure modes fail closed -------------------------------
+
+
+class TestFailClosed:
+    def test_missing_target_file(self, tmp_path):
+        repo = std_repo(tmp_path)
+        (repo / "meta.json").unlink()
+        with pytest.raises(proj.ProjectionError, match="target file missing"):
+            proj.build_plan(repo, VALUES, std_manifest())
+
+    def test_target_path_escaping_repo_root(self, tmp_path):
+        repo = std_repo(tmp_path)
+        bad = (proj.MarkedFragmentTarget("../page.md", "escape", "skill_count", "{n} auto skills"),)
+        with pytest.raises(proj.ProjectionError, match="escapes the repository root"):
+            proj.build_plan(repo, VALUES, bad)
+
+    def test_missing_marker_span(self, tmp_path):
+        repo = std_repo(tmp_path)
+        write(repo, "page.md", "No markers at all.\n")
+        with pytest.raises(proj.ProjectionError, match="0 marked span"):
+            proj.build_plan(repo, VALUES, std_manifest())
+
+    def test_duplicate_marker_span(self, tmp_path):
+        repo = std_repo(tmp_path)
+        write(
+            repo, "page.md", PAGE_MD + "Again <!-- cap:skill_count -->9 auto skills<!-- /cap -->.\n"
+        )
+        with pytest.raises(proj.ProjectionError, match="2 marked span"):
+            proj.build_plan(repo, VALUES, std_manifest())
+
+    def test_renamed_marker_value_is_unclaimed(self, tmp_path):
+        repo = std_repo(tmp_path)
+        write(
+            repo,
+            "page.md",
+            PAGE_MD.replace("cap:skill_count", "cap:legacy_skill_total"),
+        )
+        with pytest.raises(proj.ProjectionError, match="claimed by no manifest target"):
+            proj.build_plan(repo, VALUES, std_manifest())
+
+    def test_unclosed_marker_is_malformed(self, tmp_path):
+        repo = std_repo(tmp_path)
+        write(repo, "page.md", PAGE_MD + "Dangling <!-- cap:skill_count -->9 auto skills\n")
+        with pytest.raises(proj.ProjectionError, match="malformed or unclosed"):
+            proj.build_plan(repo, VALUES, std_manifest())
+
+    def test_wrong_type_marked_content_is_unclaimed(self, tmp_path):
+        repo = std_repo(tmp_path)
+        write(
+            repo,
+            "page.md",
+            PAGE_MD.replace("3 auto skills", "several auto skills"),
+        )
+        with pytest.raises(proj.ProjectionError, match="claimed by no manifest target"):
+            proj.build_plan(repo, VALUES, std_manifest())
+
+    def test_ambiguous_targets_for_one_span(self, tmp_path):
+        repo = std_repo(tmp_path)
+        manifest = std_manifest() + (
+            proj.MarkedFragmentTarget("page.md", "twin claim", "skill_count", "{n} auto skills"),
+        )
+        with pytest.raises(proj.ProjectionError, match="ambiguous ownership"):
+            proj.build_plan(repo, VALUES, manifest)
+
+    def test_unknown_semantic_value_in_target(self, tmp_path):
+        repo = std_repo(tmp_path)
+        manifest = (
+            proj.MarkedFragmentTarget("page.md", "bogus", "wizard_count", "{n} auto skills"),
+        )
+        with pytest.raises(proj.ProjectionError):
+            proj.build_plan(repo, VALUES, manifest)
+
+    def test_invalid_json_fails(self, tmp_path):
+        repo = std_repo(tmp_path)
+        write(repo, "meta.json", "{not json")
+        with pytest.raises(proj.ProjectionError, match="invalid JSON"):
+            proj.build_plan(repo, VALUES, std_manifest())
+
+    def test_json_path_key_missing(self, tmp_path):
+        repo = std_repo(tmp_path)
+        write(repo, "meta.json", json.dumps({"metadata": {}}))
+        with pytest.raises(proj.ProjectionError, match="not found"):
+            proj.build_plan(repo, VALUES, std_manifest())
+
+    def test_json_field_wrong_type(self, tmp_path):
+        repo = std_repo(tmp_path)
+        write(repo, "meta.json", json.dumps({"metadata": {"description": 3}}))
+        with pytest.raises(proj.ProjectionError, match="expected string"):
+            proj.build_plan(repo, VALUES, std_manifest())
+
+    def test_json_fragment_absent_from_field(self, tmp_path):
+        repo = std_repo(tmp_path)
+        write(repo, "meta.json", json.dumps({"metadata": {"description": "no counts here"}}))
+        with pytest.raises(proj.ProjectionError, match="matched 0 time"):
+            proj.build_plan(repo, VALUES, std_manifest())
+
+    def test_json_list_selector_cardinality(self, tmp_path):
+        repo = std_repo(tmp_path)
+        write(repo, "plugins.json", json.dumps({"plugins": [{"name": "a"}, {"name": "a"}]}))
+        target = proj.JsonFieldTarget(
+            "plugins.json",
+            "dup selector",
+            "skill_count",
+            json_path=("plugins", ("name", "a"), "description"),
+            fragment="{n} auto skills",
+        )
+        with pytest.raises(proj.ProjectionError, match="matched 2 entries"):
+            proj.build_plan(repo, VALUES, (target,))
+
+    def test_json_ambiguous_raw_encoding(self, tmp_path):
+        repo = std_repo(tmp_path)
+        # The owned field's encoded value appears twice in the raw file —
+        # a raw-text rewrite would be ambiguous, so it must fail closed.
+        write(
+            repo,
+            "meta.json",
+            '{"metadata": {"description": "Has 3 auto skills — really."},'
+            ' "copy": "Has 3 auto skills — really."}',
+        )
+        with pytest.raises(proj.ProjectionError, match="cannot rewrite unambiguously"):
+            proj.build_plan(repo, VALUES, std_manifest())
+
+    def test_ts_capabilities_block_missing(self, tmp_path):
+        repo = std_repo(tmp_path)
+        write(repo, "features.ts", "export const OTHER = {};\n")
+        with pytest.raises(proj.ProjectionError, match="CAPABILITIES blocks"):
+            proj.build_plan(repo, VALUES, std_manifest())
+
+    def test_ts_field_missing(self, tmp_path):
+        repo = std_repo(tmp_path)
+        write(repo, "features.ts", "export const CAPABILITIES = {\n  workflows: 20,\n} as const;\n")
+        with pytest.raises(proj.ProjectionError, match="matched 0 time"):
+            proj.build_plan(repo, VALUES, std_manifest())
+
+    def test_ts_field_duplicated(self, tmp_path):
+        repo = std_repo(tmp_path)
+        write(
+            repo,
+            "features.ts",
+            "export const CAPABILITIES = {\n  mcpTools: 9,\n  mcpTools: 9,\n} as const;\n",
+        )
+        with pytest.raises(proj.ProjectionError, match="matched 2 time"):
+            proj.build_plan(repo, VALUES, std_manifest())
+
+    def test_bad_template_placeholder(self, tmp_path):
+        repo = std_repo(tmp_path)
+        target = proj.MarkedFragmentTarget("page.md", "no slot", "skill_count", "auto skills")
+        with pytest.raises(proj.ProjectionError, match="exactly one"):
+            proj.build_plan(repo, VALUES, (target,))
+
+
+def test_one_invalid_target_prevents_every_write(tmp_path, monkeypatch):
+    repo = std_repo(tmp_path)
+    write(repo, "meta.json", "{broken")  # invalidates one target
+    before = read_all(repo)
+    monkeypatch.setattr(proj, "MANIFEST", std_manifest())
+    monkeypatch.setattr(proj, "derive_values", lambda _repo: dict(VALUES))
+    assert proj.main(["--write"], repo=repo) == 2
+    assert read_all(repo) == before  # the drifted page.md was NOT repaired
+
+
+# --- Preservation of unrelated content, newlines, and files -------------
+
+
+def test_write_preserves_crlf_unicode_and_unrelated_files(tmp_path):
+    repo = tmp_path
+    crlf = (
+        "Header — unrelated ünïcode.\r\n\r\n"
+        "Ships <!-- cap:skill_count -->3 auto skills<!-- /cap --> today.  \r\n"
+        "Trailing spaces above stay.\r\n"
+    )
+    write(repo, "page.md", crlf)
+    bystander = write(repo, "bystander.md", "Never touched.\n")
+    manifest = (
+        proj.MarkedFragmentTarget("page.md", "skills claim", "skill_count", "{n} auto skills"),
+    )
+    plans = proj.build_plan(repo, VALUES, manifest)
+    changed = proj.apply_plan(repo, plans)
+    assert changed == ["page.md"]
+    assert (repo / "page.md").read_bytes() == crlf.replace("3 auto skills", "7 auto skills").encode(
+        "utf-8"
+    )
+    assert bystander.read_bytes() == b"Never touched.\n"
+    assert not list(repo.glob("*.capproj-tmp"))  # atomic temp cleaned up
+
+
+# --- The real manifest against copies of the real files -----------------
+
+
+def test_real_manifest_repairs_bumped_values_on_copies(tmp_path):
+    """Every governed target detects drift and is repaired by --write."""
+    for target in proj.MANIFEST:
+        src = REPO_ROOT / target.path
+        dst = tmp_path / target.path
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        if not dst.exists():
+            shutil.copyfile(src, dst)
+    baseline = proj.build_plan(tmp_path, proj.derive_values(REPO_ROOT))
+    assert proj.drift_lines(baseline) == []  # repo claims are in sync
+    bumped = {k: v + 1 for k, v in proj.derive_values(REPO_ROOT).items()}
+    plans = proj.build_plan(tmp_path, bumped)
+    assert len(proj.drift_lines(plans)) == len(proj.MANIFEST)  # all 13 drift
+    proj.apply_plan(tmp_path, plans)
+    json.loads((tmp_path / ".claude-plugin/marketplace.json").read_text(encoding="utf-8"))
+    replan = proj.build_plan(tmp_path, bumped)
+    assert proj.drift_lines(replan) == []
+
+
+# --- Subprocess CLI: exit codes and diagnostics --------------------------
+
+
+class TestSubprocessCli:
+    def test_check_is_green_on_synced_repo(self):
+        result = subprocess.run(
+            [sys.executable, str(SCRIPT), "--check"],
+            capture_output=True,
+            text=True,
+            cwd=REPO_ROOT,
+            timeout=120,
+        )
+        assert result.returncode == 0, result.stderr
+        for name in proj.VALUE_NAMES:
+            assert f"{name} = " in result.stdout
+
+    def test_unknown_argument_fails_closed(self):
+        result = subprocess.run(
+            [sys.executable, str(SCRIPT), "--frobnicate"],
+            capture_output=True,
+            text=True,
+            cwd=REPO_ROOT,
+            timeout=60,
+        )
+        assert result.returncode == 2
+
+    def test_check_and_write_together_fail_closed(self):
+        result = subprocess.run(
+            [sys.executable, str(SCRIPT), "--check", "--write"],
+            capture_output=True,
+            text=True,
+            cwd=REPO_ROOT,
+            timeout=60,
+        )
+        assert result.returncode == 2
+        assert "not allowed with" in result.stderr
+
+
+# --- Gate independence ----------------------------------------------------
+
+
+def test_independent_gates_do_not_import_projector():
+    """The drift gates must keep their own derivation and locators."""
+    for rel in (
+        "tests/unit/gates/test_claim_drift.py",
+        "tests/unit/test_website_version_accuracy.py",
+    ):
+        source = (REPO_ROOT / rel).read_text(encoding="utf-8")
+        imports = [
+            line
+            for line in source.splitlines()
+            if line.lstrip().startswith(("import ", "from ")) and "project_capabilities" in line
+        ]
+        assert not imports, f"{rel} imports the projector: {imports}"


### PR DESCRIPTION
Implements the chair-approved capability-count projector (roundtable `q-capability-count-projector-001`; design report in `docs/reports/roundtable/`). Executed from the Codex-authored session starter; partial implementation continued, not redesigned.

## What this does

`scripts/project_capabilities.py` derives exactly three values from the checked-out revision and projects them into a frozen allowlist of claim sites:

- `skill_count` = 25 (`plugin/skills/*/SKILL.md`)
- `mcp_registered_tool_count` = 53 (`EmpathyMCPServer().tools`, incl. bundled plugin tools)
- `mcp_core_schema_tool_count` = 47 (`tool_schemas.get_*_tools()`)

No network, caches, caller overrides, or remembered constants; empty/duplicate/malformed/environment-dependent discovery fails closed (exit 2 before any write).

## Ownership model

- **Markdown**: whole-fragment ownership markers — `<!-- cap:VALUE -->…<!-- /cap -->` — 12 spans across README.md, plugin/README.md, quickstart-plugin.md, mcp-integration.md. `--write` repaired two stale claims in passing (plugin intro **18→25**, quickstart natural-language **17→25**).
- **JSON**: `.claude-plugin/marketplace.json` parsed as JSON; only the two allowlisted description fields rewritten; no comment markers.
- **TypeScript**: `website/lib/features.ts` — only named numeric `CAPABILITIES` fields; no generated sidecar.
- Registered vs core-schema totals stay semantically distinct at every target (deliberately unequal fixtures prove no interchange).

Also fixed while continuing the partial script: per-target planning from original text meant two drifted targets in the same file clobbered each other's repairs — planning is now per-file/sequential with atomic, newline-preserving writes.

## Gates stay independent

`test_claim_drift.py` keeps its own derivation and locators (zero projector imports — now guarded by a test). Five regexes got a `(?:<[^>]*>)?` marker-tolerance; wording, number, and count assertions unchanged. `test_website_version_accuracy.py` untouched.

## CI + contributor surface

- Coverage job (import-capable, keyless ubuntu): new step `python scripts/project_capabilities.py --check` after badge freshness.
- CONTRIBUTING.md: capability-changing PRs run `--write` in the same change.

## Receipts

| Probe | Result |
|---|---|
| `--check` on this branch | exit 0 (25/53/47) |
| Second `--write` | byte-idempotent (shasum-verified) |
| New projector tests | 39 passed (incl. real-manifest bumped-values repair on file copies) |
| Independent gates | 29 passed |
| CI/workflow governance | 326 passed, 1 skipped |
| Quality ratchet | 5 passed |
| Full scripts suite | 227 passed |
| Pinned black + ruff | clean |

## Notes for the queue

- `scripts/` + path handling → **wait Windows lanes** before merge.
- If held PRs #1605/#1607 lift first and shift tool counts, this branch's `--check` goes red by design — rerun `--write` here and re-push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
