### PR TITLE
fix(attune-ai-dev): redirect 404ing docs paths to GitHub-rendered docs

### DIFF
--- a/attune-ai-dev/vercel.json
+++ b/attune-ai-dev/vercel.json
@@ -4,6 +4,41 @@
   "trailingSlash": false,
   "redirects": [
     {
+      "source": "/docs",
+      "destination": "https://github.com/Smart-AI-Memory/attune-ai/tree/main/docs",
+      "permanent": false
+    },
+    {
+      "source": "/docs/:path*",
+      "destination": "https://github.com/Smart-AI-Memory/attune-ai/tree/main/docs",
+      "permanent": false
+    },
+    {
+      "source": "/framework-docs/:path*",
+      "destination": "https://github.com/Smart-AI-Memory/attune-ai/tree/main/docs",
+      "permanent": false
+    },
+    {
+      "source": "/getting-started/:path*",
+      "destination": "https://github.com/Smart-AI-Memory/attune-ai/tree/main/docs/getting-started",
+      "permanent": false
+    },
+    {
+      "source": "/reference/:path*",
+      "destination": "https://github.com/Smart-AI-Memory/attune-ai/tree/main/docs/reference",
+      "permanent": false
+    },
+    {
+      "source": "/guides/:path*",
+      "destination": "https://github.com/Smart-AI-Memory/attune-ai/tree/main/docs/guides",
+      "permanent": false
+    },
+    {
+      "source": "/tutorials/:path*",
+      "destination": "https://github.com/Smart-AI-Memory/attune-ai/tree/main/docs/tutorials",
+      "permanent": false
+    },
+    {
       "source": "/privacy",
       "destination": "https://smartaimemory.com/privacy",
       "permanent": false


### PR DESCRIPTION
Redirect-first fix for the attune-ai.dev doc-tree 404s, per the
q-user-friendliness-001 chair ruling (the table's unanimous #1 UX
item) and chip task unpark.

The six broken families — /docs, /framework-docs, /getting-started,
/reference, /guides, /tutorials (verified 404 live today) — now 302
to the matching GitHub-rendered docs section instead of dead-ending.
All temporary (`permanent: false`): the forward fix (serving mkdocs
natively on attune-ai.dev, blocked on the trailingSlash-vs-mkdocs
conflict) remains the parked scoped task.

Website-only change: no changelog entry per policy. Verification
after deploy: curl the previously-404 URLs, expect 302/200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
