### PR TITLE
docs(launch): 10.6.0 demo outline — new-feature emphasis

### DIFF
--- a/docs/process/DEMO_10_6_0_outline.md
+++ b/docs/process/DEMO_10_6_0_outline.md
@@ -1,126 +1,148 @@
 # 10.6.0 Demo Outline — "One Plugin, Three AI Coding Agents"
 
-**Created:** 2026-07-23 · **Status:** staged (records after the
-07-27 lift + receipts; releases launch week with the Tuesday
-07-28 fire) · **Format:** recorded screen demo, ~9 min, plus a
-2-minute social cut · **Companion materials:**
+**Created:** 2026-07-23 · **Revised:** 2026-07-23 per roundtable
+review `q-demo-outline-review-001` (chair-ruled amendments A1–A8;
+report in [docs/reports/roundtable/](../reports/roundtable/q-demo-outline-review-001.md))
+· **Status:** staged (records after the 07-27 lift + receipts;
+releases launch week with the Tuesday 07-28 fire) · **Format:**
+recorded screen demo, **~7:45 target**, plus a ~2-minute social
+cut · **Companion materials:**
 [LAUNCH_10_6_0_article_draft.md](LAUNCH_10_6_0_article_draft.md),
 [RELEASE_10_6_0_drafts.md](RELEASE_10_6_0_drafts.md)
 
-Narrative order is chair-ratified (roundtable
-`q-user-friendliness-001`, 2026-07-23): a compressed
-single-provider win as the on-ramp, then the NEW multi-LLM
-features carry the demo. Emphasis: what 10.6.0 ADDS. Honesty
-gate applies throughout — every on-screen claim is a live run or
-a receipt; no mockups, no staged output.
+Narrative order is chair-ratified (`q-user-friendliness-001`):
+a compressed single-provider win as the on-ramp, then the NEW
+multi-LLM features carry the demo as ONE continuous task. Honesty
+gate throughout — every on-screen claim is a live run or a
+receipt; no mockups, no staged output, and the **three-agent
+title is conditional on the Antigravity beat recording green**
+(fallback pre-written below).
 
 ---
 
-## Cold open (0:00–0:40) — the problem
+## Cold open (0:00–0:45) — demonstrate the loss, don't assert it (A1)
 
-- Split screen: a Claude Code session rich with project context;
-  beside it a fresh Codex session that knows nothing.
-- One line, on screen: **"The provider boundary is where context
-  dies."**
+- Claude Code names a specific, real repo fact on screen: "The
+  failure is in X because Y."
+- Cut to a fresh Codex session. Ask it: "What did Claude just
+  learn?" It cannot answer.
+- Caption: **"Every new AI session starts from zero. You are the
+  only thing carrying context between them."** Then: "Let's
+  cross it."
 - Thesis: 10.6.0 makes your AI coding agents share memory, hand
-  off work, and second-guess each other — Claude, Codex, and
-  Antigravity/Gemini, one plugin.
+  off work, and second-guess each other — one plugin.
 
-## Act 1 (0:40–2:00) — the five-minute win, compressed
+## Act 1 (0:45–1:45) — the on-ramp, 60 seconds, pinned (A2)
 
-Purpose: establish trust fast; this is the on-ramp, not the story.
-
-- `pip install attune-ai` (zero-config, subscription-first — call
-  out "no API key required" as the line executes).
-- One real workflow on a real repo (bug-predict or
-  security-audit), receipt on screen.
+- Pinned command: `attune security-audit .` (swap only if a
+  faster receipted workflow exists at record time — pin the
+  choice before recording, no script drift).
+- Install shown as a jump-cut with a **persistent on-screen 4×
+  badge** and "full unedited run linked below" — the compression
+  mechanic is itself a receipt.
+- Claim narrowed to what the visible path proves: "no API key
+  for subscription-backed use."
 - Beat line: "That's day one. Everything from here is what
   10.6.0 adds."
 
-## Act 2 (2:00–4:30) — NEW: memory that crosses providers
+## Act 2 (1:45–5:15) — ONE task crosses the boundary (A3, A4, A5)
 
-The `session_memory_*` MCP tools (cross-provider-memory-transport,
-new in 10.6.0).
+The `session_memory_*` transport + `handoff_create`/
+`handoff_resume` demoed as a single causal story — not two
+feature tours. The operator visibly triggers every boundary
+crossing; nothing implies autonomous coordination. A persistent
+task card tracks continuity: **Finding / Branch / Changed files /
+Next action**.
 
-- In Claude Code: a session finding gets stashed (show the Stop
-  hook stash or an explicit capture).
-- **The reveal:** open Codex — `codex` lists the same
-  `session_memory_*` tools; `session_memory_recall` returns the
-  finding Claude stashed. `[RECEIPT: post-lift Codex canary
-  transcript — R8 #4]`
-- Honesty beat (D2/R5, on screen): Claude gets automatic
-  lifecycle hooks; other providers get the SAME memory via MCP —
-  automatic hooks are not promised on Codex/Antigravity.
-- Mention, don't tour: the new ops `/memory` page shows the live
-  index the providers share (one glance, no dashboard crawl).
+1. **Reproducibility beat (A3, 20–30s):** the actual command /
+   config stanza that wires attune into Codex, on screen, before
+   any reveal. If the real path is longer than ~30s, show it
+   honestly — a reveal the viewer can't reproduce reads as
+   staged. `[RECEIPT: marketplace re-sync canary — R8 #4]`
+2. Claude finds the bug cause and captures the finding (operator
+   triggers the capture).
+3. **The reveal:** Codex runs `session_memory_recall` and
+   returns the exact finding Claude stashed. `[RECEIPT: post-lift
+   Codex canary transcript]`
+   - Honesty beat (D2/R5, on screen): Claude gets automatic
+     lifecycle hooks; other providers get the SAME memory via
+     MCP — automatic hooks are not promised on Codex/Antigravity.
+4. `handoff_create` in Claude — tied to the current branch and
+   diff (branch, changed files, next action visible on the task
+   card).
+5. `handoff_resume` in Codex — **hold the git-verification
+   receipt on screen (A5)** as it validates refs and tree before
+   continuing: "Handoffs are git-verified session contracts, not
+   loose prompt copies." Codex then performs the stated next
+   action. `[RECEIPT: live round-trip transcript]`
+6. **Conditional third seat:** if the post-publish Antigravity
+   probe is green by record time, show Antigravity querying the
+   same shared memory alongside Codex. `[RECEIPT: Antigravity
+   register+probe — R8 #6]` — see the fallback rule below.
+- Mention, don't tour: the new ops `/memory` page is the shared
+  index at a glance.
 
-## Act 3 (4:30–6:30) — NEW: hand the session across the boundary
+## Act 3 (5:15–6:45) — the second opinion (A6)
 
-`handoff_create` / `handoff_resume`
-(cross-provider-session-handoff, new in 10.6.0).
-
-- In Claude Code mid-task: `handoff_create` — show the handoff
-  validating against actual git state (branch, changed files,
-  next action).
-- In Codex: `handoff_resume` — the second provider verifies the
-  handoff against the working tree before continuing, then picks
-  up the task. `[RECEIPT: live round-trip transcript]`
-- Beat line: "Providers become interchangeable seats on one task
-  — parity by adapters, not by promises."
-
-## Act 4 (6:30–8:00) — NEW: the second opinion
-
-`cross_review` + the round table (cross-review new in 10.6.0;
-agent-round-table flips shipped/living on the 07-27 fire).
-
-- `/cross-review` on a REAL diff from this repo: a different
-  provider reviews it adversarially, findings advisory-only.
-  State the posture honestly on screen: "advisory, never a merge
+- `/cross-review` on a REAL diff from this repo — and show a
+  **concrete finding the second provider actually caught**. That
+  finding is the value demo.
+- Posture stated honestly on screen: "advisory, never a merge
   gate until dogfooded quality earns it."
-- Zoom out to the round table: three seats deliberating a real
-  question, chair ruling promotion.
-- **The meta-beat (the story's kicker):** the features in this
-  demo were themselves picked by the table — show the promoted
-  report `docs/reports/roundtable/q-multi-llm-obvious-win-001.md`
-  (the ruling that chose handoff + cross-review as the next two
-  features). The product plans itself; the human stays the chair.
+- Roundtable stinger (3 seconds, one spoken line over a flash of
+  the promoted report header): "The features you just watched
+  were chosen by this table — ruling linked." The full
+  self-planning story lives in the article, not here.
+- Closing line: **"The models advise. You decide."**
 
-## Close (8:00–9:00) — receipts, then the ask
+## Close (6:45–7:45) — a readable evidence card, then the ask (A7)
 
-- Flash the receipts trail: the 06:00 scheduled clean-run log
-  `[RECEIPT: Monday fire, green]`, the Codex canary, the
-  Antigravity probe `[RECEIPT: post-publish register+probe]`.
-  Line: "Every claim you just watched has a transcript."
-- Install line + docs (attune-ai.dev — links resolve; the docs
-  redirect shipped 07-23).
-- Day-2 invitation: "Start single-provider. When you hit a
-  judgment call, ask the table."
+- Hold a three-row evidence card long enough to read — each row:
+  claim, provider pair, timestamp, version, transcript link:
+  1. Cross-provider recall — passed
+  2. Handoff / tree verification — passed
+  3. Independent review — passed
+- Line: "Every claim you just watched has a transcript."
+- One CTA: **"Install the plugin. Run one workflow. Cross
+  providers when the task needs another seat."** Install line +
+  docs (attune-ai.dev — links resolve; redirect shipped 07-23).
 
 ---
 
-## 2-minute social cut (for the LinkedIn post)
+## ~2-minute social cut (A8)
 
-Cold open (condensed, 0:15) → Act 2 reveal only (Codex recalling
-Claude's memory, 0:45) → Act 3 handoff round-trip (0:40) →
-receipts flash + install line (0:20). No Act 1, no meta-beat —
-one boundary-crossing miracle per minute.
+- **0:00–0:10 — the miracle first:** Codex executing
+  `session_memory_recall` and returning Claude's finding.
+  Caption: "Codex just remembered something Claude learned."
+- 0:10–0:20 — ten seconds of context (the cold-open loss beat,
+  compressed).
+- 0:20–0:30 — `pip install attune-ai` flash (scrollers must see
+  how to try it).
+- 0:30–1:10 — the handoff round-trip.
+- 1:10–1:30 — evidence card + CTA.
 
 ---
 
 ## Production notes
 
 - **Record AFTER the Monday lift and receipts** (Tuesday morning
-  is the slot): the demoed tools must be live on PyPI 10.6.0 and
-  the `[RECEIPT]` beats must exist. Recording order: Acts 1/4
-  any time post-lift; Act 2's Codex beat needs the marketplace
-  re-sync canary; the Antigravity mention in the close needs the
-  post-publish probe.
-- **Cut-don't-fake rule (binding):** any beat whose receipt
-  doesn't exist by record time is CUT, not simulated. The
-  fallback demo is Acts 1 + 4 + roundtable (all live today).
+  is the slot): tools live on PyPI 10.6.0; `[RECEIPT]` beats must
+  exist. Act 2's Codex beats need the marketplace re-sync canary;
+  the third-seat beat needs the post-publish Antigravity probe.
+- **Cut-don't-fake (binding):** any beat whose receipt doesn't
+  exist at record time is CUT, not simulated.
+- **Segment isolation (contingency):** record each boundary
+  crossing as an independently usable segment, so a failed
+  Antigravity or marketplace beat cuts cleanly without
+  destroying the Claude→Codex story.
+- **Pre-written two-provider fallback:** if the Antigravity probe
+  is not green, the demo renames to the Claude/Codex
+  collaboration story ("one plugin, your agents share memory")
+  and Antigravity appears only in the evidence/adapter matrix —
+  a probe mention never poses as participation.
 - Cross-review cadence/default-seat language stays PROVISIONAL
-  until the OPEN-1..3 rulings at the Monday sitting — script says
-  "advisory second opinion," never a cadence promise.
+  until the OPEN-1..3 rulings at the Monday sitting — script
+  says "advisory second opinion," never a cadence promise.
 - What deliberately does NOT appear (UX-roundtable do-not list):
   the 25-skill catalog crawl, the ops dashboard tour, telemetry,
   config surfaces. One paved path per act.
@@ -132,6 +154,10 @@ one boundary-crossing miracle per minute.
 
 - [ ] Chair rules the recording slot (Tue morning fits the fire
       sequence).
+- [ ] Antigravity go/no-go: decided by the post-publish probe
+      BEFORE recording the third-seat beat (fallback above).
+- [ ] Verify the real Codex wiring path length for the A3 beat;
+      if >30s, script the honest longer version.
 - [ ] Fill `[RECEIPT]` beats from Monday's transcripts (same
       slots the article uses).
 - [ ] Chair honesty-gate pass on the final cut before publish

--- a/docs/process/DEMO_10_6_0_outline.md
+++ b/docs/process/DEMO_10_6_0_outline.md
@@ -1,0 +1,138 @@
+# 10.6.0 Demo Outline — "One Plugin, Three AI Coding Agents"
+
+**Created:** 2026-07-23 · **Status:** staged (records after the
+07-27 lift + receipts; releases launch week with the Tuesday
+07-28 fire) · **Format:** recorded screen demo, ~9 min, plus a
+2-minute social cut · **Companion materials:**
+[LAUNCH_10_6_0_article_draft.md](LAUNCH_10_6_0_article_draft.md),
+[RELEASE_10_6_0_drafts.md](RELEASE_10_6_0_drafts.md)
+
+Narrative order is chair-ratified (roundtable
+`q-user-friendliness-001`, 2026-07-23): a compressed
+single-provider win as the on-ramp, then the NEW multi-LLM
+features carry the demo. Emphasis: what 10.6.0 ADDS. Honesty
+gate applies throughout — every on-screen claim is a live run or
+a receipt; no mockups, no staged output.
+
+---
+
+## Cold open (0:00–0:40) — the problem
+
+- Split screen: a Claude Code session rich with project context;
+  beside it a fresh Codex session that knows nothing.
+- One line, on screen: **"The provider boundary is where context
+  dies."**
+- Thesis: 10.6.0 makes your AI coding agents share memory, hand
+  off work, and second-guess each other — Claude, Codex, and
+  Antigravity/Gemini, one plugin.
+
+## Act 1 (0:40–2:00) — the five-minute win, compressed
+
+Purpose: establish trust fast; this is the on-ramp, not the story.
+
+- `pip install attune-ai` (zero-config, subscription-first — call
+  out "no API key required" as the line executes).
+- One real workflow on a real repo (bug-predict or
+  security-audit), receipt on screen.
+- Beat line: "That's day one. Everything from here is what
+  10.6.0 adds."
+
+## Act 2 (2:00–4:30) — NEW: memory that crosses providers
+
+The `session_memory_*` MCP tools (cross-provider-memory-transport,
+new in 10.6.0).
+
+- In Claude Code: a session finding gets stashed (show the Stop
+  hook stash or an explicit capture).
+- **The reveal:** open Codex — `codex` lists the same
+  `session_memory_*` tools; `session_memory_recall` returns the
+  finding Claude stashed. `[RECEIPT: post-lift Codex canary
+  transcript — R8 #4]`
+- Honesty beat (D2/R5, on screen): Claude gets automatic
+  lifecycle hooks; other providers get the SAME memory via MCP —
+  automatic hooks are not promised on Codex/Antigravity.
+- Mention, don't tour: the new ops `/memory` page shows the live
+  index the providers share (one glance, no dashboard crawl).
+
+## Act 3 (4:30–6:30) — NEW: hand the session across the boundary
+
+`handoff_create` / `handoff_resume`
+(cross-provider-session-handoff, new in 10.6.0).
+
+- In Claude Code mid-task: `handoff_create` — show the handoff
+  validating against actual git state (branch, changed files,
+  next action).
+- In Codex: `handoff_resume` — the second provider verifies the
+  handoff against the working tree before continuing, then picks
+  up the task. `[RECEIPT: live round-trip transcript]`
+- Beat line: "Providers become interchangeable seats on one task
+  — parity by adapters, not by promises."
+
+## Act 4 (6:30–8:00) — NEW: the second opinion
+
+`cross_review` + the round table (cross-review new in 10.6.0;
+agent-round-table flips shipped/living on the 07-27 fire).
+
+- `/cross-review` on a REAL diff from this repo: a different
+  provider reviews it adversarially, findings advisory-only.
+  State the posture honestly on screen: "advisory, never a merge
+  gate until dogfooded quality earns it."
+- Zoom out to the round table: three seats deliberating a real
+  question, chair ruling promotion.
+- **The meta-beat (the story's kicker):** the features in this
+  demo were themselves picked by the table — show the promoted
+  report `docs/reports/roundtable/q-multi-llm-obvious-win-001.md`
+  (the ruling that chose handoff + cross-review as the next two
+  features). The product plans itself; the human stays the chair.
+
+## Close (8:00–9:00) — receipts, then the ask
+
+- Flash the receipts trail: the 06:00 scheduled clean-run log
+  `[RECEIPT: Monday fire, green]`, the Codex canary, the
+  Antigravity probe `[RECEIPT: post-publish register+probe]`.
+  Line: "Every claim you just watched has a transcript."
+- Install line + docs (attune-ai.dev — links resolve; the docs
+  redirect shipped 07-23).
+- Day-2 invitation: "Start single-provider. When you hit a
+  judgment call, ask the table."
+
+---
+
+## 2-minute social cut (for the LinkedIn post)
+
+Cold open (condensed, 0:15) → Act 2 reveal only (Codex recalling
+Claude's memory, 0:45) → Act 3 handoff round-trip (0:40) →
+receipts flash + install line (0:20). No Act 1, no meta-beat —
+one boundary-crossing miracle per minute.
+
+---
+
+## Production notes
+
+- **Record AFTER the Monday lift and receipts** (Tuesday morning
+  is the slot): the demoed tools must be live on PyPI 10.6.0 and
+  the `[RECEIPT]` beats must exist. Recording order: Acts 1/4
+  any time post-lift; Act 2's Codex beat needs the marketplace
+  re-sync canary; the Antigravity mention in the close needs the
+  post-publish probe.
+- **Cut-don't-fake rule (binding):** any beat whose receipt
+  doesn't exist by record time is CUT, not simulated. The
+  fallback demo is Acts 1 + 4 + roundtable (all live today).
+- Cross-review cadence/default-seat language stays PROVISIONAL
+  until the OPEN-1..3 rulings at the Monday sitting — script says
+  "advisory second opinion," never a cadence promise.
+- What deliberately does NOT appear (UX-roundtable do-not list):
+  the 25-skill catalog crawl, the ops dashboard tour, telemetry,
+  config surfaces. One paved path per act.
+- Terminal hygiene: fresh sessions, no secrets on screen
+  (`anthropic.env` never opened), repo = attune-ai itself
+  (dogfood is the credibility).
+
+## Open items
+
+- [ ] Chair rules the recording slot (Tue morning fits the fire
+      sequence).
+- [ ] Fill `[RECEIPT]` beats from Monday's transcripts (same
+      slots the article uses).
+- [ ] Chair honesty-gate pass on the final cut before publish
+      (same ruling moment as Draft B).

--- a/docs/process/DEMO_10_6_0_script.md
+++ b/docs/process/DEMO_10_6_0_script.md
@@ -1,0 +1,274 @@
+# 10.6.0 Demo Script — expanded draft (Patrick's voice)
+
+**Written:** 2026-07-23. **Status:** draft — records Tuesday
+07-28 after the lift and live receipts; every `[RECEIPT]` beat
+must exist before its segment records (cut-don't-fake, binding).
+**Structure:** expands
+[DEMO_10_6_0_outline.md](DEMO_10_6_0_outline.md) (v2, amendments
+A1–A8 applied) into narration + on-screen text + commands.
+**Voice note:** narration deliberately echoes the launch article's
+language — one campaign, one voice.
+
+Pre-record checklist:
+
+- [ ] PyPI serves 10.6.0 (a 200, not a promise)
+- [ ] Codex canary green (marketplace re-synced)
+- [ ] Antigravity probe ruled go/no-go — no-go = two-provider cut
+- [ ] Every command below rehearsed once, unrecorded, same machine
+
+---
+
+## The journey
+
+| Segment | Time | What the viewer sees |
+|---------|------|----------------------|
+| Cold open | 0:00–0:45 | Context dying at the boundary, live |
+| Day one | 0:45–1:45 | Install → one useful result |
+| One task, two agents | 1:45–5:15 | Memory + handoff, one story |
+| The second opinion | 5:15–6:45 | A real finding from a rival model |
+| The receipts | 6:45–7:45 | Evidence card, one ask |
+
+---
+
+## Cold open (0:00–0:45)
+
+**Screen:** Claude Code session on the attune-ai repo, mid-task.
+
+**Narration:**
+
+> I run three AI coding agents on the same repository. Watch what
+> happens at the boundary between them.
+>
+> Claude just worked something out — [reads the actual finding,
+> whatever it is that day, e.g. "the projector was importing the
+> wrong package because of where Python puts a script's
+> directory"]. That took real work to learn.
+
+**Screen:** fresh Codex session, same repo. Type: *"What did the
+last session learn about this repo?"* Codex answers honestly: it
+has no idea.
+
+**On-screen caption:**
+
+> Every new AI session starts from zero.
+> You are the only thing carrying context between them.
+
+**Narration:**
+
+> Until this week, I was the transport layer. Copy, paste, hope.
+> 10.6.0 deletes that job. Let's cross the boundary.
+
+*(No title card yet — the title lands after the cold open, so the
+first 20 seconds are all demonstration.)*
+
+## Day one (0:45–1:45)
+
+**Screen:** empty terminal.
+
+```bash
+pip install attune-ai
+```
+
+**Production:** jump-cut the install; persistent `4×` badge in the
+corner; caption "full unedited run linked below." The compression
+is visible because hiding it would be a claim.
+
+**Narration:**
+
+> One install. No API key for subscription-backed use — if you
+> already pay for Claude, you're done configuring.
+
+**Screen:**
+
+```bash
+attune security-audit .
+```
+
+Real output on the real repo. Point at one finding, not the
+report.
+
+**Narration:**
+
+> That's day one: install, run, get something useful back. Fine.
+> Every tool demo you've ever seen stops here. Everything from
+> this point is what 10.6.0 adds.
+
+## One task, two agents (1:45–5:15)
+
+**Production:** persistent task card in the corner from here on —
+Finding / Branch / Changed files / Next action. Every boundary
+crossing is me typing a command on screen. Nothing moves on its
+own, and I say so.
+
+### Wiring the second agent (1:45–2:15)
+
+**Screen:** the actual Codex config — the marketplace entry /
+MCP stanza, however many lines it really is.
+
+**Narration:**
+
+> First, the honest part: here's how Codex gets these tools.
+> [If it's one stanza: "One config block. That's the whole
+> setup."] [If it's more: walk it, at real speed. A reveal you
+> can't reproduce at your desk is a magic trick, and I'm not
+> selling tickets.]
+
+`[RECEIPT: marketplace re-sync canary — R8 #4]`
+
+### The finding crosses (2:15–3:30)
+
+**Screen:** back in Claude Code. The session captures the finding
+from the cold open — I trigger the capture, on screen.
+
+**Screen:** Codex.
+
+```text
+> use session_memory_recall to check what's known about <topic>
+```
+
+The exact finding comes back. Hold on it.
+
+**Narration:**
+
+> Codex just remembered something Claude learned. Not a summary I
+> pasted — the finding itself, PII-scrubbed on the way in, pulled
+> from the same store.
+>
+> One honest caveat, on screen because it stays true: Claude gets
+> automatic capture through lifecycle hooks. Codex and Antigravity
+> get the same memory surface through MCP — but automatic hooks
+> are not promised there. Same memory, different reflexes.
+
+`[RECEIPT: post-lift Codex canary transcript]`
+
+### The task crosses (3:30–5:15)
+
+**Screen:** Claude Code, mid-task on a real branch.
+
+```text
+> handoff_create
+```
+
+**Narration:**
+
+> The handoff packet's git facts — branch, changed files, HEAD —
+> come from git at call time, never from what the model says it
+> did. Claims without receipts get recorded as exactly that:
+> "not run."
+
+**Screen:** Codex.
+
+```text
+> handoff_resume
+```
+
+**Hold on the verification output** — refs checked, tree checked,
+drift reported.
+
+**Narration:**
+
+> Before Codex continues the work, it re-checks the packet against
+> the actual tree. Handoffs are git-verified session contracts,
+> not loose prompt copies. Our collaboration contract said "a
+> handoff is context, not authority" for months. Now it's
+> mechanical.
+
+Codex performs the stated next action. The task card updates.
+
+`[RECEIPT: create-in-Claude → resume-in-Codex round-trip
+transcript]`
+
+### Conditional third seat (inside 3:30–5:15, if probe green)
+
+**Screen:** Antigravity querying the same shared memory.
+
+**Narration:**
+
+> And it's not a two-vendor trick — Antigravity reads the same
+> store.
+
+`[RECEIPT: Antigravity register+probe — R8 #6]`
+
+*(Probe not green by record time → this beat does not exist, the
+title becomes the Claude/Codex story, and Antigravity appears in
+the evidence matrix only. Decided before recording, not in the
+edit.)*
+
+## The second opinion (5:15–6:45)
+
+**Screen:**
+
+```text
+/cross-review
+```
+
+on a real diff from this repo. Show the actual finding the second
+provider caught — read it out.
+
+**Narration:**
+
+> A different vendor's model just reviewed my actual diff — not a
+> summary of it — and caught something. Different model, different
+> blind spots. It's advisory, and it stays advisory until
+> dogfooded quality earns it more. I don't let it block a merge
+> and neither should you, yet.
+
+**Screen:** 3-second flash of the promoted roundtable report
+header.
+
+**Narration:**
+
+> One more thing, quickly: the features you just watched were
+> chosen by a round table of these same three models — ruling
+> linked below.
+>
+> The models advise. You decide.
+
+## The receipts (6:45–7:45)
+
+**Screen:** hold a three-row evidence card, long enough to read:
+
+| Claim | Providers | When | Transcript |
+|-------|-----------|------|------------|
+| Cross-provider recall | Claude → Codex | `[ts]` | `[link]` |
+| Handoff, tree-verified | Claude → Codex | `[ts]` | `[link]` |
+| Independent review | `[pair]` | `[ts]` | `[link]` |
+
+**Narration:**
+
+> Every claim in this video has a transcript, and they're linked
+> below — including the unedited runs behind the jump cuts. That's
+> the rule this project runs on: no claim without a receipt.
+>
+> Install the plugin. Run one workflow. Cross providers when the
+> task needs another seat.
+
+**Screen:** `pip install attune-ai` · attune-ai.dev
+
+---
+
+## Social cut (~90s)
+
+- 0:00–0:10 — the miracle, cold: Codex recalling Claude's finding.
+  Caption: "Codex just remembered something Claude learned."
+- 0:10–0:20 — the loss beat, compressed: "every new session starts
+  from zero — until now."
+- 0:20–0:30 — `pip install attune-ai` flash.
+- 0:30–1:10 — the handoff round-trip, verification held on screen.
+- 1:10–1:30 — evidence card + "The models advise. You decide." +
+  install line.
+
+---
+
+## What this script refuses to do
+
+Carried from the outline, restated because they're the point:
+
+- No beat records without its receipt. A missing receipt cuts the
+  beat; it never simulates it.
+- No catalog tour, no dashboard tour, no config surfaces. One
+  paved path per act.
+- No claim wider than what's on screen ("no API key" is always
+  "for subscription-backed use").
+- Each boundary crossing records as its own segment, so any beat
+  can be cut without re-shooting the story.

--- a/docs/reports/roundtable/q-demo-outline-review-001.md
+++ b/docs/reports/roundtable/q-demo-outline-review-001.md
@@ -1,0 +1,240 @@
+# Round table — demo outline review (q-demo-outline-review-001)
+
+**Thread:** `q-demo-outline-review-001` · **Date:** 2026-07-23 ·
+**Roster:** claude, antigravity, codex · **Rounds:** 1 (halted on
+convergence, D3) · **Promoted items:** #2 #3 #4 #5
+(chair-approved; ruling #6).
+
+Chair ruling (2026-07-23): apply the full amendment set A1–A8 +
+the conditional-Antigravity contingency to
+`docs/process/DEMO_10_6_0_outline.md` (revised in the same PR);
+promote this report. Unanimous: keep the demo's subject and
+structure — every seat's output was amendment-level. The one
+structural finding, hit by all three seats from different angles:
+the title promises three agents, the script delivered two — now
+resolved by the conditional third-seat beat + pre-written
+two-provider fallback.
+
+## #1 — question (chair)
+
+Review docs/process/DEMO_10_6_0_outline.md and suggest concrete
+improvements — or argue for a different demo subject if it would
+do a strictly better job. (Seats received the full outline text
+and the binding launch constraints: receipts gate, cut-don't-fake,
+single-provider-leads order, first-touch-installer audience.)
+
+## #2 — position (claude, 55s)
+
+POSITION: keep subject and structure; five improvements in value
+order. (1) ADD THE MISSING REPRODUCIBILITY BEAT: the outline shows
+Codex already wired between Acts 1-2 — the viewer never sees how
+Codex got the session_memory_* tools; a reveal you can't reproduce
+reads as staged. 20-30s beat at the top of Act 2: the one
+command/config stanza that registers attune in Codex, on screen; if
+the real path is longer, showing that honestly is MORE valuable.
+(2) REPLACE THE COLD-OPEN LINE — "the provider boundary is where
+context dies" is insider language; use "Every new AI session starts
+from zero. You are the only thing carrying context between them."
+(3) ACT 1'S 80s CAN'T HONESTLY HOLD install + real workflow —
+pre-commit the compression mechanic: jump-cut with persistent
+on-screen 4x badge + "full unedited run linked below"; pick the
+genuinely fastest workflow. (4) SHRINK THE META-BEAT TO A STINGER —
+it sits at the retention nadir (7:00+) and requires reading a doc
+on screen; one spoken line over a 3s flash of the report header,
+give the reclaimed ~40s to cross_review showing an ACTUAL finding.
+The self-planning story belongs in the article. (5) SOCIAL CUT:
+payoff in the first 5 seconds — open cold on Codex recalling
+Claude's finding, caption "Codex just remembered something Claude
+learned," context after. RISK: optimizes first-touch retention at
+the cost of the most press-worthy moment (meta-beat), and the new
+setup beat adds a receipt dependency that could force a cut if the
+marketplace sync misbehaves. QUESTION: what IS the real
+second-provider onboarding path today — demoable under 30s with a
+receipt, or does Act 2 need an honest "setup takes N minutes"
+caption?
+
+## #3 — position (antigravity, 43s)
+
+### POSITION: Antigravity Seat
+
+I support keeping the overall subject and chair-ratified narrative structure ("One Plugin, Three AI Coding Agents", single-provider quick win leading into the multi-LLM reveal). However, to maximize conversion for first-touch installers and ensure the demo honors its headline promise, I propose four concrete beat improvements:
+
+---
+
+#### Improvement 1: Fulfill the "Three Agents" Title in Act 2
+* **Current Beat (Act 2):**
+  > `- The reveal: open Codex — codex lists the same session_memory_* tools; session_memory_recall returns the finding Claude stashed. [RECEIPT: post-lift Codex canary transcript — R8 #4]`
+* **Replacement:**
+  > `- The reveal: open Codex and Antigravity side-by-side — show both agents querying the shared MCP layer (`session_memory_recall`) to pull the exact finding stashed by Claude Code. [RECEIPT: post-lift Codex canary transcript — R8 #4 & Antigravity probe]`
+* **Rationale:** The title promises *three* agents, but Act 2 currently only demonstrates a two-agent handoff (Claude → Codex) and relegates Antigravity to a post-publish probe mention in the close. Showing Codex and Antigravity concurrently inspecting Claude's stashed memory fulfills the core promise visually and unequivocally.
+
+---
+
+#### Improvement 2: Pin Act 1 to a Single High-Signal Command
+* **Current Beat (Act 1):**
+  > `- One real workflow on a real repo (bug-predict or security-audit), receipt on screen.`
+* **Replacement:**
+  > `- Run zero-setup CLI command: attune security-audit . — show the instant terminal output (rich security report with 0 API keys configured) and state: "Zero setup, immediate security audit on your existing repo."`
+* **Rationale:** Leaving the Act 1 command ambiguous ("bug-predict or security-audit") risks script drift during recording. `security-audit` produces an immediate, high-contrast visual report that communicates tangible value to first-touch installers in under 30 seconds.
+
+---
+
+#### Improvement 3: Highlight Git-State Safety in Act 3 Handoff
+* **Current Beat (Act 3):**
+  > `- In Codex: handoff_resume — the second provider verifies the handoff against the working tree before continuing, then picks up the task. [RECEIPT: live round-trip transcript]`
+* **Replacement:**
+  > `- In Codex: handoff_resume — show the `collaboration_preflight` verification receipt on screen as Codex validates clean Git refs and branch alignment before resuming: "Handoffs aren't loose prompt copies — they are Git-verified session contracts."`
+* **Rationale:** Demonstrating explicit pre-flight verification reassures senior developers that switching providers mid-session won't corrupt branch state or silently lose context.
+
+---
+
+#### Improvement 4: Preserve the On-Ramp in the 2-Minute Social Cut
+* **Current Beat (Social Cut):**
+  > `No Act 1, no meta-beat — one boundary-crossing miracle per minute.`
+* **Replacement:**
+  > `Flash 10-second Act 1 install at 0:15 (`pip install attune-ai`) → Act 2 memory reveal (0:45) → Act 3 handoff (0:40) → receipts flash + call to action (0:25).`
+* **Rationale:** Social feed scrollers lack context. Stripping Act 1 entirely leaves viewers amazed by cross-provider memory but oblivious to how effortlessly they can `pip install attune-ai` to try it themselves.
+
+---
+
+### MAIN RISK OF THIS POSITION
+
+* **Screen Density & Pacing:** Showing three active terminal/agent windows (Claude, Codex, Antigravity) in Act 2 risks visual clutter on smaller screens and adds ~15–20 seconds to the recording length, creating tighter pressure on the 9-minute target duration.
+
+---
+
+### FOLLOW-UP QUESTION FOR THE TABLE
+
+* **Question:** If Monday's post-publish Antigravity probe encounters latency during the recording window, should Act 2 fall back to a two-provider live split (Claude + Codex) with Antigravity showing as an active MCP client in the `/memory` ops view, or do we strictly trigger the cut-don't-fake rule to reduce Act 2's scope?
+
+## #4 — position (codex, 25s)
+
+POSITION
+
+1. Make the cold open demonstrate loss, not merely assert it.
+
+Change:
+
+“Split screen: a Claude Code session rich with project context; beside it a fresh Codex session that knows nothing.”
+
+To:
+
+“Claude identifies a specific repo fact: ‘The failure is in X because Y.’ Cut to fresh Codex and ask, ‘What did Claude just learn?’ Codex cannot answer. On screen: ‘The provider boundary is where context dies.’ Then: ‘Let’s cross it.’”
+
+This creates an observable before/after receipt and gives Act 2 a clean payoff.
+
+2. Replace installation footage with a first-touch success check; reduce Act 1 to 60 seconds.
+
+Change:
+
+“`pip install attune-ai` … One real workflow … receipt on screen.”
+
+To:
+
+“Show the install command completing in a short jump cut, then immediately invoke one discoverable workflow from the host UI. Show one useful finding and its transcript location. Voiceover: ‘One plugin, no API key for subscription-backed use, and a useful result in under a minute.’”
+
+Watching package installation is dead time. The audience needs to see: install → discover → useful result. Only say “no API key required” if the visible path proves the narrower subscription-backed claim.
+
+3. Make Acts 2 and 3 one continuous task, with the human explicitly authorizing every boundary crossing.
+
+Replace the separate examples with:
+
+“Claude finds the bug cause and captures it. Codex recalls that exact finding, receives a handoff tied to the current branch and diff, verifies the tree, and performs the stated next action. The operator triggers capture, recall, handoff, and resume on screen.”
+
+This turns two feature tours into one causal story and avoids implying invisible autonomous coordination. Use a persistent task card showing Finding → Branch → Changed files → Next action so viewers can track continuity.
+
+4. Demote the round-table meta-story and spend the recovered time on an Antigravity receipt.
+
+Change:
+
+“Zoom out to the round table … The product plans itself; the human stays the chair.”
+
+To:
+
+“Ask one concrete judgment question about the live diff. Show Claude’s recommendation, Codex’s objection, and Antigravity’s independent response; then show the human choosing the ruling. Close the act with: ‘The models advise. You decide.’”
+
+“The product plans itself” is both less honest than the surrounding outline and less valuable to a first-touch installer. More importantly, the headline promises three agents while the actual narrative substantially demonstrates only two. If Antigravity cannot complete a meaningful live operation, rename the demo around cross-provider Claude/Codex collaboration and mention broader adapter support only in the receipt matrix.
+
+5. Replace the rapid receipt flash with a readable claim-to-evidence close, and shorten the main cut to roughly 7:30.
+
+Change:
+
+“Flash the receipts trail … Every claim you just watched has a transcript.”
+
+To:
+
+“Hold a three-row evidence card long enough to read: Cross-provider recall — passed, Handoff/tree verification — passed, Independent review — passed; each row names provider pair, timestamp, version, and transcript link/QR. End on one CTA: ‘Install the plugin. Run one workflow. Cross providers when the task needs another seat.’”
+
+A nine-minute first-touch demo is expensive, and flashing receipts makes them decorative rather than auditable. Keep the full transcripts in companion material, but make the close legible.
+
+RISK
+
+A tighter, single-task narrative may underrepresent the breadth of 10.6.0 and could fail spectacularly if one live dependency breaks. Record each boundary as a continuous, independently usable segment so a failed Antigravity or marketplace beat can be cut without destroying the Claude→Codex story.
+
+FOLLOW-UP QUESTION
+
+Is Antigravity guaranteed to perform a meaningful memory, handoff, or review operation on screen by Tuesday, or is its current receipt only registration/probe?
+
+## #5 — synthesis (moderator)
+
+SYNTHESIS (moderator, 1 round — halted on convergence; critiques
+are complementary, no decidable split).
+
+UNANIMOUS: keep the subject and act structure — no seat proposed a
+different demo. All improvements are amendments, not rewrites.
+
+THE ONE STRUCTURAL FINDING (all three seats, different angles):
+**the demo's title promises three agents but the script delivers
+two.** Antigravity: show Codex AND Antigravity querying the shared
+memory side-by-side. Codex: if Antigravity cannot perform a
+meaningful on-screen operation by Tuesday, RENAME the demo around
+Claude/Codex collaboration and carry Antigravity in the receipt
+matrix only — more honest than a probe mention posing as
+participation. Claude seat (the reproducibility angle): the second
+provider appears pre-wired; the viewer never sees HOW Codex got the
+tools, which reads as staged. MODERATOR FACT (from the T5' probe
+record): Antigravity's receipt 6 is register+probe, sequenced
+post-publish — a meaningful live operation Tuesday is PLAUSIBLE but
+unproven until the probe runs. Resolution consistent with
+cut-don't-fake: script the Antigravity beat CONDITIONAL (record if
+the probe is green), with Codex's rename-fallback pre-written; add
+Claude's 20-30s Codex-setup beat with its own receipt (the
+marketplace re-sync canary covers it).
+
+AMENDMENT LIST (converged, in outline order):
+A1. Cold open DEMONSTRATES loss (Codex): Claude states a specific
+    repo fact; fresh Codex is asked and cannot answer; THEN the
+    caption. Replace the insider line with Claude's plain-language
+    version: "Every new AI session starts from zero. You are the
+    only thing carrying context between them."
+A2. Act 1 pinned + honest compression: pin ONE command (fastest;
+    Antigravity votes security-audit), jump-cut with persistent 4x
+    badge + "full unedited run linked", narrow the claim to "no
+    API key for subscription-backed use". Target 60s.
+A3. Act 2 opens with the reproducibility beat: the actual
+    command/stanza wiring attune into Codex (20-30s, receipted by
+    the canary). If real setup exceeds ~30s, show it honestly.
+A4. Acts 2+3 become ONE CONTINUOUS TASK (Codex): find bug → capture
+    → recall in Codex → handoff tied to branch/diff → verify tree →
+    perform the stated next action; the OPERATOR visibly triggers
+    every boundary crossing (no implied autonomy); persistent task
+    card (Finding / Branch / Changed files / Next action).
+A5. Act 3 shows the git-verification receipt on screen
+    (Antigravity): "handoffs are git-verified session contracts,
+    not loose prompt copies."
+A6. Act 4: meta-beat shrinks to a 3s stinger + one line; reclaimed
+    time goes to a CONCRETE cross_review finding on the live diff,
+    closing "The models advise. You decide." (Codex's line — more
+    honest than "the product plans itself"). Full self-planning
+    story stays in the article.
+A7. Close: replace the receipts FLASH with a readable three-row
+    evidence card (claim → provider pair → timestamp → transcript
+    link), one CTA. Tighten total runtime toward ~7:30-8:00.
+A8. Social cut: miracle in the FIRST 5 SECONDS (Codex recalling
+    Claude's finding, captioned), then context; keep a 10s
+    pip-install flash (Antigravity) so scrollers know how to try
+    it.
+CONTINGENCY (bind into production notes): record each boundary as
+an independently usable segment so a failed Antigravity or
+marketplace beat cuts cleanly without destroying the Claude→Codex
+story; pre-write the two-provider rename fallback.


### PR DESCRIPTION
Stages the launch plans nice-to-have demo item as a concrete outline:
~9-minute recorded screen demo + 2-minute social cut, released launch
week with the Tuesday 07-28 fire.

Emphasis per chair direction: the NEW 10.6.0 features carry the demo
(session_memory transport with the Codex reveal, handoff round-trip,
cross_review, the live roundtable + ruling-provenance meta-beat); the
single-provider quick win is a compressed on-ramp per the
q-user-friendliness-001 ruling. Cut-dont-fake rule binds every
[RECEIPT] beat to Mondays real transcripts.

Docs-only diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
