### PR TITLE
docs(launch): dynamic-forms demo script — rehearsal subject

### DIFF
--- a/docs/process/DEMO_DYNAMIC_FORMS_script.md
+++ b/docs/process/DEMO_DYNAMIC_FORMS_script.md
@@ -1,0 +1,170 @@
+# Dynamic Forms Demo Script — rehearsal + releasable (Patrick's voice)
+
+**Written:** 2026-07-23. **Status:** draft — this is the Thu/Fri
+CAPTURE REHEARSAL subject (chair-ruled): it exercises the full
+recording pipeline before Tuesday's 10.6.0 shoot, and the footage
+is releasable in its own right after the chair's honesty-gate
+pass. **Everything shown is live on PyPI 10.5.0 today** — no
+receipt slots to wait for; the pre-record check is just "the
+commands run on this machine." **Format:** ~4 min main cut + 60s
+social cut. Stage geometry: record on screen 1 per the
+[10.6.0 script's](DEMO_10_6_0_script.md) Stage geometry section —
+same rules, same set.
+
+Pre-record checklist:
+
+- [ ] Screen Studio mic toggle flipped + 2-second audio-track
+      test (the pending receipt from the 07-23 walkthrough)
+- [ ] `/elicit` and one pushback form rehearsed once, unrecorded
+- [ ] Do Not Disturb on; screen 1 clean set
+
+---
+
+## The journey
+
+| Segment | Time | What the viewer sees |
+|---------|------|----------------------|
+| Cold open | 0:00–0:30 | Question-by-question interrogation, live |
+| One form | 0:30–1:45 | The same scoping as a single form |
+| The pushback form | 1:45–2:45 | Disagreement as a decision, not an argument |
+| Dogfood | 2:45–3:30 | This repo's own rulings ran on these forms |
+| Close | 3:30–4:00 | The rule + the install line |
+
+---
+
+## Cold open (0:00–0:30) — the interrogation
+
+**Screen:** Claude Code, real repo. Ask for something genuinely
+ambiguous — "help me test this module."
+
+The agent asks a question. One button row. Answer it. It asks the
+next. Answer that. A third appears.
+
+**Narration:**
+
+> This is Socratic discovery, and it's the right instinct — the
+> agent scopes before it executes instead of guessing. But it's
+> one question per turn. Three decisions, three round trips, and
+> I haven't started working yet.
+
+**On-screen caption:**
+
+> The questions are right. The pacing is wrong.
+
+## One form (0:30–1:45) — the same scoping, one turn
+
+**Screen:**
+
+```text
+/elicit testing this module
+```
+
+One form renders: the independent dimensions of the decision —
+scope, focus, depth — batched into a single turn, multi-select
+where it fits, a recommended option marked. Fill it in one pass.
+Work starts.
+
+**Narration:**
+
+> Same questions. One form. The dimensions of a decision I was
+> going to make anyway — asked together, because they're
+> independent.
+>
+> And the honest part, because it's the part that makes this
+> good: there's a rule about when NOT to do this. If one answer
+> changes the next question, it stays sequential. If I already
+> said it, it's not asked. If only one thing is unknown, one
+> question is correct. The form never invents fields — it batches
+> exactly what Socratic judgment would have asked anyway.
+
+**Production:** hold on the rendered form long enough to read
+every field. This is the product shot of the video.
+
+**Narration, over the answered form:**
+
+> Under the hood this is data, not code — a declarative form,
+> validated on the way in and the way out, rendered through the
+> same tools any MCP client can call.
+
+## The pushback form (1:45–2:45) — disagreement as a decision
+
+**Screen:** a real fork: tell the agent to do something where it
+has a better alternative (use the day's genuine example — there
+is always one). The disagreement renders AS A FORM: my approach
+labeled "your approach," its alternative badged "I'd suggest
+instead," a one-line "why I'd push back."
+
+**Narration:**
+
+> This is my favorite one. When the agent disagrees with me, it
+> doesn't write me an essay — it renders the disagreement as a
+> decision. My approach, its alternative, why. I overrule with
+> one click, or I take the suggestion with one click. Either way
+> the argument is over in five seconds and the reasoning is on
+> the record.
+
+**On-screen caption:**
+
+> Pushback you can click. The human stays the chair.
+
+## Dogfood (2:45–3:30) — this repo runs on it
+
+**Screen:** a real chair-ruling form from this week's roundtable
+work (a promotion ruling — multi-select, per-item). Flash the
+promoted report it produced.
+
+**Narration:**
+
+> This isn't a feature I built and forgot. Every ruling in this
+> repository — which findings get promoted, which work ships,
+> which plans get overruled — runs through these forms. The demo
+> you're watching was scoped with one this morning.
+
+## Close (3:30–4:00)
+
+**On-screen caption:**
+
+> Ask everything at once — when the questions are independent.
+> Ask one thing — when they're not.
+
+**Narration:**
+
+> Socratic discovery that respects your time. It ships in the
+> plugin today.
+
+**Screen:** `pip install attune-ai` · attune-ai.dev
+
+---
+
+## Social cut (~60s)
+
+- 0:00–0:10 — the form, cold: `/elicit` rendering three
+  dimensions in one turn. Caption: "Every question at once —
+  when that's correct."
+- 0:10–0:25 — the interrogation it replaced (compressed, three
+  quick question-turns).
+- 0:25–0:45 — the pushback form + one-click overrule. Caption:
+  "Pushback you can click."
+- 0:45–1:00 — install line.
+
+---
+
+## Rehearsal double-duty (why this subject)
+
+This script exists to prove the Tuesday pipeline: per-segment
+takes, live narration, auto-captions off the G733, my QC pass
+per segment, the editor pass (zooms, cuts, export), and the
+LinkedIn-compression eyeball on the exported mp4. If any step
+fights back Thursday, Tuesday absorbs the lesson instead of the
+damage. The footage releasing later is the bonus, not the point —
+the chair's honesty-gate pass gates any publish, same as
+everything else.
+
+## What this script refuses to do
+
+- No mock forms — every form shown is rendered live by the
+  installed 10.5.0 plugin on this machine.
+- No claim that batching is always right — the batching rule's
+  refusals are narrated on screen, because the restraint IS the
+  feature.
+- No catalog tour, no dashboard, no config. One paved path.


### PR DESCRIPTION
Shooting script for the Thu/Fri capture rehearsal (chair-ruled
subject: dynamic forms), releasable after the honesty-gate pass.

Beats: the one-question-per-turn interrogation -> /elicit renders the
same scoping as ONE form (batching rule narrated as the honesty
beat) -> the pushback form (disagreement as a clickable decision) ->
dogfood (this repos own chair rulings run on these forms). ~4 min +
60s social cut. Every surface verified live on installed 10.5.0
(plugin/skills/elicit + 4 elicitation_* MCP tools). Stage geometry
inherited from the 10.6.0 script (screen 1).

Docs-only diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
