### PR TITLE
docs(launch): dynamic-forms demo — split-cut export resolution ruling

### DIFF
--- a/.claude/lessons.md
+++ b/.claude/lessons.md
@@ -17748,3 +17748,23 @@ def ", start_idx + 1)` for module-
     click; never reuse popover coordinates across opens. Batch
     clicks need a wait+screenshot between menu-open and item
     click.
+
+- **LinkedIn ARTICLES cannot host native video — link-embed only
+  (YouTube/Vimeo); native upload is a FEED-POST-only capability**
+  (verified 2026-07-23 for the dynamic-forms demo release plan):
+  if a demo video is meant to ride inside a LinkedIn article
+  (Draft-B style), it must be hosted on YouTube first and
+  embedded by URL; the 1920×1080 mp4 uploads natively only to a
+  feed post. Native feed video is also what LinkedIn's algorithm
+  favors — common pattern is native video in the post + YouTube
+  link in the first comment. Spec confirmation for exports:
+  recommended 1920×1080 16:9 ("1080p", NOT "dpi" — video is
+  pixel dimensions), mp4 H.264+AAC, 10-60 fps, ≤5 GB, ≤15 min
+  desktop; vertical social cut 9:16 (1080×1920) or 4:5
+  (1080×1350, currently best mobile-feed engagement). Patrick
+  ruled 07-23 evening (after pushback): SPLIT by cut — main cut
+  1920×1080 16:9 (forms stay readable; YouTube-native for the
+  article-embed path), 60s social cut 1080×1350 4:5 (that's
+  where the feed-engagement edge applies). Capture stays native
+  4K on the 16:9 screen 1; only the social cut needs the
+  per-beat crop check in the editor.

--- a/docs/process/DEMO_DYNAMIC_FORMS_script.md
+++ b/docs/process/DEMO_DYNAMIC_FORMS_script.md
@@ -17,6 +17,32 @@ Pre-record checklist:
       test (the pending receipt from the 07-23 walkthrough)
 - [ ] `/elicit` and one pushback form rehearsed once, unrecorded
 - [ ] Do Not Disturb on; screen 1 clean set
+- [ ] Recorder config verified fresh: mic = G733, system audio
+      OFF, camera off (config drifts between sessions)
+
+Capture and export settings (ruled 2026-07-23, dry-run + Patrick):
+
+- Capture: full display, screen 1 (LG HDR 4K) at native 4K —
+  identify the stage by a 5s test take + thumbnail check, never
+  by display name (names disagree across tools).
+- Export, main cut (~4 min): mp4, **1920×1080 (16:9)** — the
+  full stage, forms stay readable (the product shot is "read
+  every field"), and it is YouTube-native for the article-embed
+  path. H.264 + AAC, 10-60 fps, ≤5 GB.
+- Export, 60s social cut: mp4, **1080×1350 (4:5 portrait)** —
+  best current LinkedIn mobile-feed engagement; its beats each
+  fit a portrait crop of a single window. Verify the crop per
+  beat in the editor (one-click vertical + auto-zoom reframes,
+  but eyeball each form). The 16-18pt terminal font rule is
+  even more binding at 4:5.
+- Split ruled by Patrick 2026-07-23 (supersedes both the
+  dry-run 1080p-everything ruling and the interim
+  4:5-everything ruling). Shooting is unchanged: full 16:9
+  stage, no record-time portrait framing.
+- Hosting: native video upload = FEED POST only. A LinkedIn
+  ARTICLE cannot host native video — YouTube/Vimeo embed only.
+- After EVERY take: `cp -R` the `.screenstudio` bundle out of
+  `~/Screen Studio Projects/` before touching the app again.
 
 ---
 


### PR DESCRIPTION
Records tonight's ruling for the Thu/Fri dynamic-forms rehearsal shoot:

- **Main cut (~4 min): 1920×1080 (16:9)** — full stage, forms stay readable (the product shot is "read every field"), YouTube-native for the article-embed path.
- **60s social cut: 1080×1350 (4:5)** — best current LinkedIn mobile-feed engagement; per-beat crop check in the editor.
- Adds a capture/export settings block to the pre-record checklist: native-4K capture on screen 1, recorder-config re-verify, bundle-copy-after-every-take trap, and the LinkedIn hosting constraint (articles are embed-only — native video uploads are feed-post-only).
- Lessons entry records the verified LinkedIn specs and the ruling.

Docs-only; no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)