### PR TITLE
feat(website): video embed surface + video delivery playbook

### DIFF
--- a/.claude/lessons.md
+++ b/.claude/lessons.md
@@ -17768,3 +17768,27 @@ def ", start_idx + 1)` for module-
   where the feed-engagement edge applies). Capture stays native
   4K on the 16:9 screen 1; only the social cut needs the
   per-beat crop check in the editor.
+
+- **Worktree website dev server needs its OWN `npm ci` — a missing
+  `website/node_modules` makes Node resolution walk UP to
+  `~/node_modules` (the home-dir Next.js app) and fail with a
+  misleading error**: hit 2026-07-23 verifying the VideoEmbed
+  component. `npm run dev --prefix website` from the worktree
+  started Next 15 fine but every page 500'd with `Cannot find
+  module '@tailwindcss/postcss'` — the require stack showed
+  `/Users/patrickroebuck/node_modules/next/...`, i.e. the HOME
+  directory's Next install (the loose `~/` Next.js app), because
+  the worktree's `website/node_modules` had never been installed
+  and resolution walked up past the repo. Fix: `cd website &&
+  npm ci` in the worktree (9s, lockfile present), then restart.
+  Node-side sibling of the "worktree venv lacks extras" lesson —
+  same root cause family (worktrees share tracked files, not
+  installed deps). Related receipts from the same session:
+  (a) `.claude/launch.json` is GITIGNORED (line 262) — a
+  `website` dev-server entry added there is local convenience,
+  never PR content; (b) when browser-verifying a Next.js client
+  component, the FIRST click can land pre-hydration and no-op
+  (facade button click produced "no iframe"); re-read the page
+  and click again before diagnosing the component — verify state
+  via a DOM probe (`document.querySelector('iframe').src`), not
+  the click's success.

--- a/docs/process/DEMO_DYNAMIC_FORMS_transcript.md
+++ b/docs/process/DEMO_DYNAMIC_FORMS_transcript.md
@@ -1,0 +1,60 @@
+# Dynamic Forms Demo — transcript and receipts
+
+**Status:** template — fill after the capture; the honesty-gate
+pass reviews this page alongside the cut. **Video:** dynamic
+forms demo, main cut (~4 min), per
+[DEMO_DYNAMIC_FORMS_script.md](DEMO_DYNAMIC_FORMS_script.md).
+**Published URL:** _(YouTube link after upload)_
+
+This page is the receipt surface the video points at: every
+claim narrated on camera maps to something checkable — a live
+command, a file in this repository, or a published release.
+The `docs/` tree projects to attune-ai.dev automatically, so
+this page is linkable from the YouTube description and the
+article embed once it lands on `main`.
+
+## Transcript
+
+Verbatim narration per segment, corrected from auto-captions.
+Timestamps match the final export, not the script's estimates.
+
+### Cold open (0:00–0:30)
+
+> _(paste corrected narration here)_
+
+### One form (0:30–1:45)
+
+> _(paste corrected narration here)_
+
+### The pushback form (1:45–2:45)
+
+> _(paste corrected narration here)_
+
+### Dogfood (2:45–3:30)
+
+> _(paste corrected narration here)_
+
+### Close (3:30–4:00)
+
+> _(paste corrected narration here)_
+
+## Claims and receipts
+
+| Claim (as narrated) | Receipt |
+|---------------------|---------|
+| Socratic discovery asks one question per turn by default | Live session shown on camera; the interaction rule is in the repo's `.claude/CLAUDE.md` (Socratic Interaction Rule) |
+| `/elicit` batches the independent dimensions of a decision into one form | Rendered live by the installed plugin; skill source at `plugin/skills/elicit/` |
+| The form never invents fields — dependent questions stay sequential, answered questions aren't re-asked | Batching-restraint rules narrated on screen; _(link the governing rule/spec section)_ |
+| Forms are declarative data, validated in and out, served over MCP | `elicitation_render_form` / `elicitation_collect_response` MCP tools, listed by `list_capabilities` |
+| Pushback renders as a one-click decision, reasoning on the record | Live pushback form shown on camera; construct documented in `.claude/rules/attune/communication-grammar.md` |
+| Every chair ruling in this repo runs through these forms | The promotion-ruling form shown is from this week's roundtable work; _(link the promoted report)_ |
+| Everything shown ships today | PyPI `attune-ai` 10.5.0 — https://pypi.org/project/attune-ai/ |
+
+Rows marked with a placeholder must be resolved before publish —
+an unresolved receipt fails the honesty gate.
+
+## Capture provenance
+
+- Recorded: _(date, machine, screen 1 / LG HDR 4K)_
+- Plugin version live during capture: _(pip show attune-ai)_
+- Takes archived: _(path of the copied `.screenstudio` bundles)_

--- a/docs/process/VIDEO_DELIVERY.md
+++ b/docs/process/VIDEO_DELIVERY.md
@@ -1,0 +1,79 @@
+# Video delivery playbook
+
+**Created:** 2026-07-23. Consolidates the capture/export/hosting
+rulings from the demo-script work (dry-run + Patrick, 2026-07-23)
+into one durable, cross-video reference. Per-video scripts (e.g.
+[DEMO_DYNAMIC_FORMS_script.md](DEMO_DYNAMIC_FORMS_script.md),
+[DEMO_10_6_0_script.md](DEMO_10_6_0_script.md)) own the content;
+this page owns the pipeline. If a script and this page disagree
+on mechanics, fix the drift in the same PR.
+
+## Capture (ruled)
+
+- Full display, screen 1 (LG HDR 4K) at native 4K. Identify the
+  stage by a 5-second test take + thumbnail check — never by
+  display name (names disagree across tools).
+- Recorder config verified fresh every session: mic = G733,
+  system audio OFF, camera off. Config drifts between sessions.
+- Do Not Disturb on; screen 1 is a clean set. Terminal font
+  16–18pt minimum (binding harder for the 4:5 crop).
+- After EVERY take: `cp -R` the `.screenstudio` bundle out of
+  `~/Screen Studio Projects/` before touching the app again.
+
+## Exports (ruled)
+
+| Cut | Resolution | Why |
+|-----|------------|-----|
+| Main (~4 min) | mp4, 1920×1080 (16:9), H.264 + AAC, 10–60 fps, ≤5 GB | Full stage, forms readable; YouTube-native for the article-embed path |
+| Social (~60s) | mp4, 1080×1350 (4:5 portrait) | Best current LinkedIn mobile-feed engagement |
+
+Shooting is unchanged by the split: record the full 16:9 stage,
+no record-time portrait framing. Build the 4:5 cut in the editor
+(one-click vertical + auto-zoom reframes) and eyeball every form
+beat in the portrait crop.
+
+## Captions and transcript
+
+- Generate captions from the mic track (auto-captions off the
+  G733), then QC pass per segment — narrated claims must read
+  exactly as spoken.
+- Export an SRT sidecar from the corrected captions. Upload the
+  SAME SRT to both YouTube and the LinkedIn native video —
+  LinkedIn feed video autoplays muted, so the 4:5 cut without
+  captions loses its first three seconds.
+- Publish the corrected transcript as a per-video receipts page
+  at `docs/process/<DEMO_NAME>_transcript.md` (see
+  [DEMO_DYNAMIC_FORMS_transcript.md](DEMO_DYNAMIC_FORMS_transcript.md)
+  for the template: verbatim narration + claim→receipt table).
+  The `docs/` tree auto-projects to attune-ai.dev, so the page
+  is linkable the moment it lands on `main`.
+
+## Hosting and placement
+
+| Surface | What goes there |
+|---------|-----------------|
+| YouTube | Main 16:9 cut — the canonical hosted copy |
+| LinkedIn feed post | Native upload of the 4:5 social cut + SRT |
+| LinkedIn article | YouTube EMBED only — articles cannot host native video |
+| attune-ai.dev blog | `videoId: <youtube-id>` in the post's frontmatter renders the `VideoEmbed` facade above the content |
+
+## YouTube conventions
+
+- Upload unlisted first; flip to public only after the chair's
+  honesty-gate pass (cut + transcript page reviewed together).
+- Chapters: paste the script's journey table as timestamped
+  lines in the description — segment names, final-export times.
+- Description, first lines: one-sentence value claim, link to
+  attune-ai.dev, link to the transcript/receipts page ("every
+  claim in this video has a receipt").
+- End screen: link card back to attune-ai.dev.
+
+## Publish checklist
+
+- [ ] Honesty-gate pass on the final cut (chair)
+- [ ] Transcript page filled — no unresolved receipt rows
+- [ ] SRT uploaded on YouTube AND LinkedIn native video
+- [ ] YouTube chapters + description links in place
+- [ ] Blog post frontmatter carries `videoId`; embed verified
+      on the deployed page
+- [ ] `.screenstudio` bundles archived for every kept take

--- a/website/app/blog/[slug]/page.tsx
+++ b/website/app/blog/[slug]/page.tsx
@@ -5,6 +5,7 @@ import type { Metadata } from 'next';
 import Navigation from '@/components/Navigation';
 import Footer from '@/components/Footer';
 import Breadcrumbs from '@/components/Breadcrumbs';
+import VideoEmbed from '@/components/VideoEmbed';
 import { getPostBySlug, getAllPosts, getRelatedPosts } from '@/lib/blog';
 import { generateMetadata as generateSEOMetadata, generateStructuredData } from '@/lib/metadata';
 import ReactMarkdown from 'react-markdown';
@@ -146,8 +147,15 @@ export default async function BlogPostPage({ params }: PageProps) {
                 </div>
               </header>
 
+              {/* Demo Video (takes precedence over the cover image) */}
+              {post.videoId && (
+                <div className="mb-12">
+                  <VideoEmbed videoId={post.videoId} title={post.title} />
+                </div>
+              )}
+
               {/* Cover Image */}
-              {post.coverImage && (
+              {!post.videoId && post.coverImage && (
                 <div className="mb-12 relative aspect-video">
                   <Image
                     src={post.coverImage}

--- a/website/components/VideoEmbed.tsx
+++ b/website/components/VideoEmbed.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+import { useState } from 'react';
+
+interface VideoEmbedProps {
+  /** YouTube video ID (the 11-char ID, not the full URL). */
+  videoId: string;
+  /** Accessible title for the video (also the iframe title). */
+  title: string;
+  /** Optional poster image; defaults to the YouTube thumbnail. */
+  poster?: string;
+}
+
+/**
+ * Privacy-friendly YouTube facade: renders only a poster image and
+ * play button until clicked, then swaps in a youtube-nocookie iframe.
+ * No third-party JS or cookies load before the user opts in, and the
+ * fixed aspect ratio means no layout shift when the player mounts.
+ */
+export default function VideoEmbed({ videoId, title, poster }: VideoEmbedProps) {
+  const [playing, setPlaying] = useState(false);
+  const posterSrc = poster || `https://i.ytimg.com/vi/${videoId}/hqdefault.jpg`;
+
+  return (
+    <div className="relative aspect-video overflow-hidden rounded-lg border border-[var(--border)] bg-black">
+      {playing ? (
+        <iframe
+          src={`https://www.youtube-nocookie.com/embed/${videoId}?autoplay=1&rel=0`}
+          title={title}
+          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+          allowFullScreen
+          className="absolute inset-0 h-full w-full"
+        />
+      ) : (
+        <button
+          type="button"
+          onClick={() => setPlaying(true)}
+          aria-label={`Play video: ${title}`}
+          className="group absolute inset-0 h-full w-full cursor-pointer"
+        >
+          {/* eslint-disable-next-line @next/next/no-img-element -- remote YouTube thumbnail; avoids adding i.ytimg.com to next/image remotePatterns */}
+          <img
+            src={posterSrc}
+            alt={title}
+            loading="lazy"
+            className="absolute inset-0 h-full w-full object-cover"
+          />
+          <span className="absolute inset-0 flex items-center justify-center">
+            <span className="flex h-16 w-16 items-center justify-center rounded-full bg-black/70 transition-colors group-hover:bg-[var(--primary)]">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="28"
+                height="28"
+                viewBox="0 0 24 24"
+                fill="white"
+                aria-hidden="true"
+              >
+                <path d="M8 5v14l11-7z" />
+              </svg>
+            </span>
+          </span>
+        </button>
+      )}
+    </div>
+  );
+}

--- a/website/lib/blog.ts
+++ b/website/lib/blog.ts
@@ -12,6 +12,8 @@ export interface BlogPost {
   author: string;
   excerpt: string;
   coverImage?: string;
+  /** YouTube video ID rendered above the post content when present. */
+  videoId?: string;
   tags: string[];
   content: string;
   readingTime: string;
@@ -92,6 +94,7 @@ export function getPostBySlug(slug: string): BlogPost | null {
       author: data.author || 'Smart AI Memory Team',
       excerpt: data.excerpt || '',
       coverImage: data.coverImage,
+      videoId: data.videoId,
       tags: data.tags || [],
       content,
       readingTime: stats.text,


### PR DESCRIPTION
## What

Video enhancement groundwork for the demo videos (dynamic-forms
rehearsal capture + Tuesday's 10.6.0 shoot) — three lanes picked by
Patrick: website embed surface, captions & transcript, hosting/delivery.

- **`website/components/VideoEmbed.tsx`** — privacy-friendly YouTube
  facade: poster image + play button only, no third-party JS/cookies
  until click, then a `youtube-nocookie` iframe. Fixed `aspect-video`
  box, so no layout shift.
- **Blog wiring** — optional `videoId` frontmatter on any post renders
  the embed above the content (takes precedence over `coverImage`).
  Usable the moment a YouTube ID exists; the article/blog path is the
  ruled embed destination.
- **`docs/process/DEMO_DYNAMIC_FORMS_transcript.md`** — the
  transcript/receipts template the demo scripts promise ("every claim
  has a receipt"): verbatim narration slots + claim→receipt table.
  Auto-projects to attune-ai.dev via the framework-docs rebuild.
- **`docs/process/VIDEO_DELIVERY.md`** — cross-video delivery playbook
  consolidating the 2026-07-23 rulings: capture/export settings, SRT
  captions (LinkedIn muted autoplay), YouTube conventions, hosting
  placement matrix, publish checklist.

Deliberately deferred: feature-page/homepage video slots (dead config
until a real video ID exists) and README demo media (not picked).

## Verification

- Dev server run in the worktree (`npm ci` + `next dev`): facade
  renders with loaded poster (`naturalWidth` 480), click swaps to
  `https://www.youtube-nocookie.com/embed/<id>?autoplay=1&rel=0` —
  verified in-browser with a test `videoId` on a real post, then the
  test frontmatter reverted.
- No changelog entry: website + process-docs only, no package change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
