### PR TITLE
fix(tests): remove vestigial sys.path insert shadowing repo-root scripts package

### DIFF
--- a/tests/integration/test_llm_integration.py
+++ b/tests/integration/test_llm_integration.py
@@ -13,16 +13,12 @@ Licensed under the Apache License, Version 2.0
 """
 
 import os
-import sys
 
 import pytest
 from dotenv import load_dotenv
 
 # Load .env file if it exists
 load_dotenv()
-
-# Add paths for imports
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 from attune.llm.core import EmpathyLLM  # noqa: E402
 from attune.llm.providers.anthropic import AnthropicProvider  # noqa: E402


### PR DESCRIPTION
## Summary
QA pass 1 finding: [tests/integration/test_llm_integration.py](../blob/main/tests/integration/test_llm_integration.py) inserted `tests/` at `sys.path[0]` (vestigial — its imports come from the installed `attune` package). Once that module was collected in an xdist worker, `import scripts` in `tests/unit/scripts/` resolved to the empty `tests/scripts/` package instead of the repo-root `scripts/`, causing order-dependent collection ImportErrors on `test_collaboration_preflight.py` and `test_project_capabilities.py`.

## Receipts
- Deterministic repro pre-fix: collecting `tests/integration/test_llm_integration.py tests/unit/scripts` in one worker → 2 collection errors, 100% reproducible
- Post-fix same invocation: 236 passed, 17 skipped
- Full keyless suite (CI-faithful) surfaced the bug: 22,222 passed + these 2 errors; `tests/unit/scripts` alone: 235 passed
- Pinned black/ruff pre-flighted clean; format hook removed the now-unused `import sys`

Tests-only diff (4 deletions), Class 1 auto-merge safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)