### PR TITLE
sec(ci): add least-privilege permissions to the two workflows lacking them

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -23,6 +23,9 @@ on:
   pull_request:
     branches: [ main, develop ]
 
+permissions:
+  contents: read
+
 concurrency:
   group: integration-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/website-accuracy.yml
+++ b/.github/workflows/website-accuracy.yml
@@ -23,6 +23,9 @@ on:
       - 'scripts/audit_website_versions.py'
       - '.github/workflows/website-accuracy.yml'
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
## Summary
QA pass 2 (security) finding: `integration-tests.yml` and `website-accuracy.yml` were the only workflows without a `permissions:` block, running with repo-default token scope — GitHub code-scanning alerts #176/#177 (`actions/missing-workflow-permissions`). Both jobs only check out and run checks, so `contents: read` is sufficient.

## Receipts
- `grep -c permissions: .github/workflows/*.yml` — these were the only two at 0
- CI workflow-guard tests: `tests/unit/ci` 326 passed, 1 skipped
- Pinned `check-yaml` hook: passed on both files

6-line additive diff; alerts #176/#177 auto-close on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)