### PR TITLE
test(elicitation): pin the last two uncovered bridge.py branches

### DIFF
--- a/tests/unit/elicitation/test_batch1_characterization.py
+++ b/tests/unit/elicitation/test_batch1_characterization.py
@@ -458,3 +458,47 @@ class TestFieldHtmlRationaleHeaderDefault:
             }
         )
         assert '<span class="ae-rationale-h">Why</span>' in html
+
+
+class TestFormFromDictRecommendedTypeCheck:
+    """DECISION/PUSHBACK/PROGRESS ``recommended`` type-check — the
+    construct suites exercise a valid string and a not-in-options
+    string, but never a non-string value (bridge.py's
+    "'recommended' must be a string" branch)."""
+
+    def test_non_string_recommended_rejected(self):
+        with pytest.raises(FormValidationError) as exc:
+            form_from_dict(
+                _form(
+                    {
+                        "id": "a",
+                        "text": "A?",
+                        "type": "decision",
+                        "options": ["x"],
+                        "recommended": 123,
+                    }
+                )
+            )
+        assert exc.value.problems == ["field[0] 'recommended' must be a string"]
+
+
+class TestProgressConsistencySkippedOffProgress:
+    """``progress_items`` on a NON-progress field is parsed and carried
+    but never consistency-checked — the item/option cross-check
+    early-returns for any qtype other than PROGRESS. A quirk worth
+    pinning: a decision field with stray ``progress_items`` builds
+    cleanly instead of being rejected."""
+
+    def test_decision_with_progress_items_builds_silently(self):
+        form = form_from_dict(
+            _form(
+                {
+                    "id": "a",
+                    "text": "A?",
+                    "type": "decision",
+                    "options": ["x"],
+                    "progress_items": [{"label": "L", "status": "done"}],
+                }
+            )
+        )
+        assert form.questions[0].progress_items == [{"label": "L", "status": "done"}]


### PR DESCRIPTION
Closes the final coverage gaps in `attune.elicitation` (99% → **100%**, 478/478 statements), found via an `/elicit`-scoped coverage pass during the dynamic-forms demo rehearsal prep:

- **Non-string `recommended` rejection** ([bridge.py:163-164](src/attune/elicitation/bridge.py)) — construct suites covered a valid string and a not-in-options string, never a wrong-type value.
- **Progress-consistency early-return off-PROGRESS** ([bridge.py:268](src/attune/elicitation/bridge.py)) — pinned as a quirk: a `decision` field carrying stray `progress_items` builds silently and carries them, rather than being rejected.

Both land in `test_batch1_characterization.py` in its existing pin style. Suite: 249 passed in 0.58s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)