### PR TITLE
test(coverage): close error-path gaps in four recently-merged modules

### DIFF
--- a/.claude/lessons.md
+++ b/.claude/lessons.md
@@ -17918,3 +17918,35 @@ def ", start_idx + 1)` for module-
   --all-files`); never run a floating detect-secrets against the
   tracked baseline. Companion to the existing stash-pop baseline
   lesson — same file, different mutation vector.
+
+- **zsh does NOT word-split unquoted variables — a shell-loop
+  built command like `pytest $args` passes ONE bogus
+  space-containing arg and the run silently no-ops**: hit twice
+  in one session building per-module coverage loops
+  (`for m in "mod|paths"; do … pytest -q $args; done`): every
+  iteration printed `No data to report` while the identical
+  straight-line command worked. In zsh (this harness's shell),
+  `$args` holding "path1 path2" expands as a single word →
+  pytest collects nothing → coverage collects nothing, all
+  exit-0-quiet. Rule: in Bash-tool loops, don't accumulate
+  multi-word args in a scalar; write the commands straight-line
+  per target (or use arrays `"${arr[@]}"`). Companion to the
+  existing `=word` PATH-expansion and read-only-`status` zsh
+  lessons — same shell, different trap.
+
+- **Scoped coverage runs manufacture phantom gaps, and dotted
+  SUBMODULE `--source` args silently under-collect — measure a
+  module under its OWN full test set with `--source=<package>`
+  before calling anything a gap**: two traps in one session.
+  (1) `--source=attune.context` under only the new AST test file
+  reported compaction.py 33% / manager.py 29% — both are 88%/99%
+  under their real suites (`tests/context/` + `tests/unit/context/`);
+  a scoped run's number for sibling modules is noise, not a gap
+  (same family as the QA#6 omit-mask illusion). (2) Passing
+  dotted submodules (`--source=attune.context.skeleton
+  --source=attune.context.allocator`) collected only ONE of the
+  three named modules (or nothing at all) with just a
+  no-data-collected warning; whole-package `--source=attune.context`
+  collected everything. Rule: measure with the package-level
+  `--source` plus ALL test dirs that target the package, then read
+  per-file rows for the modules you care about.

--- a/.claude/lessons.md
+++ b/.claude/lessons.md
@@ -17950,3 +17950,35 @@ def ", start_idx + 1)` for module-
   collected everything. Rule: measure with the package-level
   `--source` plus ALL test dirs that target the package, then read
   per-file rows for the modules you care about.
+
+- **`git checkout -- <path>` is a SILENT NO-OP on UNTRACKED files —
+  the "revert to re-seed" half of a verify cycle leaves the change
+  APPLIED, and the pass count is the only tell**: 2026-07-24,
+  building the notes-search demo fixture
+  (`examples/demo_notes_search/`, deliberately seeded with one
+  failing test so the fix-test tutorial has live material). To prove
+  the seeded bug was really fixable I applied the one-line fix and
+  ran the suite (9 passed — the FIXED state), then ran `git checkout
+  -- examples/demo_notes_search/` to re-seed and re-ran: still 9
+  passed. The revert did nothing. Every file in that dir was
+  UNTRACKED (pre-first-commit) and checkout only restores paths git
+  already tracks; it exits 0 with NO output on a DIRECTORY argument
+  holding only untracked files (a bare untracked FILE path at least
+  errors `did not match any file(s) known to git` — the directory
+  form is the quiet one). Committing from there would have shipped
+  the fixture with its seeded bug already fixed, destroying the whole
+  point of the fixture. Easy to miss because this corpus hands out
+  `git checkout -- <dir>` as THE revert recipe in ~7 places (help
+  templates, generated plugin dirs, `.agents/skills/`, and the
+  "revert the src and confirm the new tests fail" loop) — every one
+  silently assumes TRACKED files, while a new fixture, a new
+  generated file, or anything before its first commit is untracked by
+  construction. Rules: (1) after a revert-to-verify cycle assert the
+  EXPECTED POST-REVERT SIGNAL, never just "the suite ran" — here
+  1 failed/8 passed = seeded and 9 passed = fixed, so a revert that
+  leaves the FIXED number IS a failed revert; (2) `git status --short
+  <path>` before trusting any revert — `??` means checkout will not
+  touch it, so use `git clean -fd <path>` or re-apply the change by
+  Edit instead; (3) a fixture README's "reset after a take"
+  instruction only becomes true once the fixture is TRACKED — say so
+  in the README, or the user's first reset is a silent no-op.

--- a/tests/unit/context/test_ast_budget.py
+++ b/tests/unit/context/test_ast_budget.py
@@ -1,5 +1,7 @@
 """Unit tests for AST-driven dynamic context budgeting."""
 
+import ast
+
 from attune.context import (
     ASTSkeletonGenerator,
     ContextInflater,
@@ -68,6 +70,36 @@ class TestASTSkeletonGenerator:
         assert generator.generate_skeleton("") == ""
         assert generator.generate_skeleton("   \n") == ""
 
+    def test_async_functions_skeletonized(self) -> None:
+        src = (
+            "async def fetch(url: str) -> str:\n"
+            '    """Fetches a URL."""\n'
+            "    data = await client.get(url)\n"
+            "    return data.text\n"
+        )
+        generator = ASTSkeletonGenerator()
+        skeleton = generator.generate_skeleton(src)
+        assert "async def fetch(url: str) -> str:" in skeleton
+        assert "await client.get" not in skeleton
+
+    def test_strip_docstrings_keeps_docstring_only_class_valid(self) -> None:
+        # A class whose entire body is its docstring must get an
+        # explicit `...` body, or the skeleton fails to unparse/reparse.
+        src = 'class Marker:\n    """Only a docstring."""\n'
+        generator = ASTSkeletonGenerator(strip_docstrings=True)
+        skeleton = generator.generate_skeleton(src)
+        assert "Only a docstring." not in skeleton
+        assert "class Marker" in skeleton
+        ast.parse(skeleton)  # still valid Python
+
+    def test_unparse_failure_passes_through(self, monkeypatch) -> None:
+        def boom(tree):
+            raise ValueError("cannot unparse")
+
+        monkeypatch.setattr("attune.context.skeleton.ast.unparse", boom)
+        generator = ASTSkeletonGenerator()
+        assert generator.generate_skeleton(SAMPLE_CODE) == SAMPLE_CODE
+
 
 class TestTokenBudgetAllocator:
     """Tests for TokenBudgetAllocator."""
@@ -133,3 +165,8 @@ class TestContextInflater:
     def test_unregistered_file_keeps_context(self) -> None:
         inflater = ContextInflater()
         assert inflater.inflate_if_requested("ghost.py", "ctx", "Edit") == "ctx"
+
+    def test_register_file_makes_source_inflatable(self) -> None:
+        inflater = ContextInflater()
+        inflater.register_file("late.py", SAMPLE_CODE)
+        assert inflater.inflate_if_requested("late.py", "skel", "Edit") == SAMPLE_CODE

--- a/tests/unit/orchestration/test_friction_matrix.py
+++ b/tests/unit/orchestration/test_friction_matrix.py
@@ -65,6 +65,29 @@ class TestBlastRadiusClassifier:
         rel = classifier._sanitize_and_relativize("src\\attune\\auth\\login.py")
         assert "\\" not in rel
 
+    def test_empty_path_minimum_risk(self) -> None:
+        classifier = BlastRadiusClassifier()
+        assert classifier.evaluate_file_path("") == 1
+
+    def test_empty_command_minimum_risk(self) -> None:
+        classifier = BlastRadiusClassifier()
+        assert classifier.evaluate_command("") == 1
+        assert classifier.evaluate_command("   ") == 1
+
+    def test_cross_drive_relpath_falls_back_to_raw_path(self, monkeypatch) -> None:
+        # On Windows, relpath raises ValueError for a path on a
+        # different drive than the workspace root; classification must
+        # fall back to the raw path instead of crashing.
+        classifier = BlastRadiusClassifier(workspace_root="/repo")
+
+        def cross_drive(path, start):
+            raise ValueError("path is on mount 'D:', start on mount 'C:'")
+
+        monkeypatch.setattr(
+            "attune.orchestration.friction.blast_radius.os.path.relpath", cross_drive
+        )
+        assert classifier.evaluate_file_path("src/attune/auth/login.py") >= 4
+
     def test_normal_file_edit(self) -> None:
         classifier = BlastRadiusClassifier()
         assert classifier.evaluate_file_path("docs/readme.md") == 1

--- a/tests/unit/orchestration/test_ghost_simulator.py
+++ b/tests/unit/orchestration/test_ghost_simulator.py
@@ -71,6 +71,30 @@ class TestGhostWorktreeManager:
         with pytest.raises(GhostWorktreeError):
             manager.create_ghost_worktree("../escape")
 
+    def test_recreate_over_existing_ghost_gives_fresh_sandbox(self, temp_repo: Path) -> None:
+        manager = GhostWorktreeManager(repo_root=str(temp_repo))
+        first = Path(manager.create_ghost_worktree("re"))
+        (first / "scratch.txt").write_text("scratch\n", encoding="utf-8")
+
+        second = Path(manager.create_ghost_worktree("re"))
+
+        assert second == first
+        assert not (second / "scratch.txt").exists()  # fresh, not reused
+        head = _git(second, "branch", "--show-current").stdout.strip()
+        assert head == "ghost-re"
+
+    def test_remove_falls_back_to_rmtree_for_non_worktree_dir(self, temp_repo: Path) -> None:
+        # A stray directory under base_dir that git doesn't know about:
+        # `git worktree remove` fails, the rmtree fallback must still
+        # clear it and report removal.
+        manager = GhostWorktreeManager(repo_root=str(temp_repo))
+        stray = Path(manager.base_dir) / "stray"
+        stray.mkdir(parents=True)
+        (stray / "junk.txt").write_text("junk\n", encoding="utf-8")
+
+        assert manager.remove_ghost_worktree("stray") is True
+        assert not stray.exists()
+
     def test_non_repo_raises_instead_of_fake_directory(self, tmp_path: Path) -> None:
         # Regression: the original silently fell back to a bare
         # directory when git failed, faking a sandbox.
@@ -111,6 +135,23 @@ class TestMultiTrajectoryRunner:
         assert results["boom"]["success"] is False
         assert "trajectory exploded" in results["boom"]["error"]
         assert results["ok"]["success"] is True
+
+    def test_sandbox_creation_failure_reported_not_fatal(self, temp_repo: Path) -> None:
+        manager = GhostWorktreeManager(repo_root=str(temp_repo))
+        runner = MultiTrajectoryRunner(manager=manager)
+
+        def ok(path: str) -> dict:
+            return {"success": True}
+
+        # "bad/id" fails ghost-id validation → sandbox creation raises;
+        # the batch must record the failure and keep running.
+        results = runner.run_trajectories({"bad/id": ok, "good": ok})
+
+        assert results["bad/id"]["success"] is False
+        assert "invalid ghost id" in results["bad/id"]["error"]
+        assert results["bad/id"]["worktree_path"] is None
+        assert results["bad/id"]["duration_seconds"] == 0.0
+        assert results["good"]["success"] is True
 
 
 class TestTrajectoryComparator:

--- a/tests/unit/telemetry/test_self_healing_traps.py
+++ b/tests/unit/telemetry/test_self_healing_traps.py
@@ -13,6 +13,7 @@ from attune.telemetry.lessons import (
     format_trap,
     process_bash_result,
 )
+from attune.telemetry.lessons.listener import MAX_DETAIL_CHARS
 
 PRECOMMIT_FAILURE = """\
 black....................................................................Failed
@@ -89,6 +90,29 @@ class TestExtractTrap:
         assert extract_trap("", PYTEST_FAILURE) is None
         assert extract_trap("pytest", "") is None
 
+    def test_more_than_five_failures_summarized(self) -> None:
+        nodes = [f"tests/unit/test_mod.py::test_case_{i}" for i in range(7)]
+        output = (
+            "=========================== short test summary info ===========================\n"
+            + "\n".join(f"FAILED {n} - AssertionError" for n in nodes)
+            + "\n============================= 7 failed in 0.20s =============================\n"
+        )
+        event = extract_trap("pytest -q", output)
+        assert event is not None
+        assert "(+2 more)" in event.detail
+
+    def test_detail_bounded_to_max_chars(self) -> None:
+        long_nodes = [f"tests/unit/{'x' * 200}_{i}.py::test_long_{i}" for i in range(6)]
+        output = (
+            "=========================== short test summary info ===========================\n"
+            + "\n".join(f"FAILED {n} - AssertionError" for n in long_nodes)
+            + "\n============================= 6 failed in 0.20s =============================\n"
+        )
+        event = extract_trap("pytest -q", output)
+        assert event is not None
+        assert len(event.detail) <= MAX_DETAIL_CHARS
+        assert event.detail.endswith("…")
+
 
 class TestFormatTrap:
     """Stash-description formatting."""
@@ -120,6 +144,41 @@ class TestRoundTrip:
 
         recalled = recall_entries("test_zone_2_routing failure", backend=backend, cwd=str(tmp_path))
         assert any("test_zone_2_routing" in str(r.get("text", "")) for r in recalled)
+
+    def test_stash_layer_exception_never_raises(self, tmp_path: Path, monkeypatch) -> None:
+        # The memory layer must never break a tool call: a stash write
+        # that blows up degrades to None instead of propagating.
+        def boom(entry, backend=None):
+            raise RuntimeError("backend exploded")
+
+        monkeypatch.setattr("attune.memory.session_stash.stash_entry", boom)
+        assert (
+            process_bash_result(
+                command="pytest tests/unit -q",
+                output=PYTEST_FAILURE,
+                session_id="sess-boom",
+                cwd=str(tmp_path),
+                backend=FileStashBackend(base_dir=tmp_path),
+            )
+            is None
+        )
+
+    def test_rejected_stash_write_returns_none(self, tmp_path: Path, monkeypatch) -> None:
+        # stash_entry returning False (PII gate / no backend) yields no
+        # signature — callers must not dedupe on an unstashed trap.
+        monkeypatch.setattr(
+            "attune.memory.session_stash.stash_entry", lambda entry, backend=None: False
+        )
+        assert (
+            process_bash_result(
+                command="pytest tests/unit -q",
+                output=PYTEST_FAILURE,
+                session_id="sess-rejected",
+                cwd=str(tmp_path),
+                backend=FileStashBackend(base_dir=tmp_path),
+            )
+            is None
+        )
 
     def test_green_output_stashes_nothing(self, tmp_path: Path) -> None:
         backend = FileStashBackend(base_dir=tmp_path)


### PR DESCRIPTION
## Summary

Gap-closing tests for the four feature modules merged in #1551–#1554. Every missed line was an error path or edge branch; each module group now measures 100% under its own test files (was 86–96%).

| Module | Before | After | What was uncovered |
|---|---|---|---|
| `orchestration/ghosts` | 92% | 100% | sandbox-creation failure telemetry, recreate-over-existing ghost, rmtree fallback when `git worktree remove` fails |
| `orchestration/friction` | 96% | 100% | empty path/command inputs, cross-drive `relpath` ValueError fallback |
| `telemetry/lessons` | 92% | 100% | >5-failure "(+N more)" summarization, `MAX_DETAIL_CHARS` bounding, stash-layer never-raises guard, rejected write → None |
| `context` (skeleton/inflater) | 91%/92% | 100% | `async def` skeletons, docstring-only class stays valid Python, unparse-failure passthrough, `register_file` |

Ghost tests stay non-mocked real-git round trips per the file's charter; the only monkeypatches are for seams unreachable on POSIX (`relpath` cross-drive ValueError, `ast.unparse` failure) and the never-raises stash guard.

## Receipts

- Serial run (`-p no:xdist`), all four files: **74 passed** (14 new) in 2.32s
- Per-module coverage re-measured from /tmp with `--source=<module>`: 107/107, 94/94, 74/74 stmts; skeleton 55/55, inflater 12/12, allocator 29/29

Tests-only diff — no production code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
