### PR TITLE
fix(elicitation): per-render unique element ids in the widget surface

### DIFF
--- a/src/attune/elicitation/widget.py
+++ b/src/attune/elicitation/widget.py
@@ -21,6 +21,7 @@ Licensed under Apache 2.0
 
 from __future__ import annotations
 
+import uuid
 from collections.abc import Callable
 from html import escape
 
@@ -504,7 +505,11 @@ def _needed_css(form: FormSchema) -> str:
     return _CSS_BASE + "".join(css for name, css in _CSS_FAMILIES if name in used)
 
 
-def form_to_widget_html(form: FormSchema, message: str = "") -> str:
+def form_to_widget_html(
+    form: FormSchema,
+    message: str = "",
+    instance_id: str | None = None,
+) -> str:
     """Render a declarative form as an inline ``show_widget`` HTML form.
 
     The S1 surface (D8). The returned HTML is self-contained (scoped
@@ -519,33 +524,45 @@ def form_to_widget_html(form: FormSchema, message: str = "") -> str:
     DOM generically by ``data-*`` attributes — so a malicious label or
     option cannot inject markup or script.
 
+    Element ids are suffixed per render so two forms shown on the same
+    page (e.g. a demo's basic + advanced beats) never collide in the
+    DOM — a duplicate id would make the second form's submit script
+    read the first form's fields.
+
     Args:
         form: The validated form to render (build it with
             :func:`form_from_dict` first).
         message: Optional prompt shown above the form.
+        instance_id: Optional alphanumeric suffix for the element ids;
+            defaults to a fresh random one per call. Pass a fixed value
+            only when a deterministic render is needed (tests, golden
+            output).
 
     Returns:
         An HTML string ready to pass straight to
         ``mcp__visualize__show_widget``.
     """
+    sfx = "".join(c for c in (instance_id or "") if c.isalnum()) or uuid.uuid4().hex[:8]
+    form_id = f"attune-elicit-form-{sfx}"
     intro = f'<p class="ae-msg">{_esc(message)}</p>' if message else ""
     desc = f'<p class="ae-desc">{_esc(form.description)}</p>' if form.description else ""
     fields = "".join(_field_html(q) for q in form.questions)
+    css = _needed_css(form).replace("#attune-elicit-form", f"#{form_id}")
 
     return f"""<h2 class="sr-only">{_esc(form.title)} — interactive form</h2>
-<form id="attune-elicit-form" data-form-title="{_esc(form.title)}">
+<form id="{form_id}" data-form-title="{_esc(form.title)}">
 <style>
-{_needed_css(form)}</style>
+{css}</style>
 <h3>{_esc(form.title)}</h3>
 {intro}{desc}
 {fields}
-<button type="button" id="ae-submit" class="ae-submit">Submit</button>
-<div id="ae-error" class="ae-error" role="alert"></div>
+<button type="button" id="ae-submit-{sfx}" class="ae-submit">Submit</button>
+<div id="ae-error-{sfx}" class="ae-error" role="alert"></div>
 <script>
 (function() {{
-  var form = document.getElementById('attune-elicit-form');
-  var btn = document.getElementById('ae-submit');
-  var err = document.getElementById('ae-error');
+  var form = document.getElementById('{form_id}');
+  var btn = document.getElementById('ae-submit-{sfx}');
+  var err = document.getElementById('ae-error-{sfx}');
   if (!form || !btn) return;
   btn.addEventListener('click', function() {{
     var answers = {{}};

--- a/tests/unit/elicitation/test_widget.py
+++ b/tests/unit/elicitation/test_widget.py
@@ -22,10 +22,40 @@ def _render(fields: list[dict], **form_extra: object) -> str:
 class TestStructure:
     def test_includes_title_and_form_shell(self):
         html = _render([{"id": "a", "text": "A?", "type": "text_input"}])
-        assert 'id="attune-elicit-form"' in html
+        assert 'id="attune-elicit-form-' in html
         assert "<h3>T</h3>" in html
         assert 'data-form-title="T"' in html
-        assert 'id="ae-submit"' in html
+        assert 'id="ae-submit-' in html
+
+    def test_element_ids_unique_per_render(self):
+        # Two forms shown on the same page must not collide in the DOM —
+        # a duplicate id would make the second submit script read the
+        # first form's fields.
+        fields = [{"id": "a", "text": "A?", "type": "text_input"}]
+        first = _render(fields)
+        second = _render(fields)
+
+        def form_id(html: str) -> str:
+            start = html.index('id="attune-elicit-form-')
+            return html[start:].split('"')[1]
+
+        assert form_id(first) != form_id(second)
+
+    def test_fixed_instance_id_is_deterministic_and_sanitized(self):
+        form = form_from_dict(
+            {"title": "T", "fields": [{"id": "a", "text": "A?", "type": "text_input"}]}
+        )
+        html = form_to_widget_html(form, instance_id="beat-2!")
+        # Non-alphanumeric chars are dropped; the suffix lands on every id
+        # the submit script looks up.
+        assert 'id="attune-elicit-form-beat2"' in html
+        assert 'id="ae-submit-beat2"' in html
+        assert 'id="ae-error-beat2"' in html
+        assert "getElementById('attune-elicit-form-beat2')" in html
+        assert html == form_to_widget_html(form, instance_id="beat-2!")
+        # The scoped CSS must follow the suffixed id.
+        assert "#attune-elicit-form-beat2 {" in html
+        assert "#attune-elicit-form " not in html
 
     def test_message_and_description_render_when_present(self):
         form = form_from_dict(

--- a/tests/unit/mcp/handlers/test_elicitation_render_widget.py
+++ b/tests/unit/mcp/handlers/test_elicitation_render_widget.py
@@ -37,7 +37,7 @@ class TestRenderWidgetHandler:
         assert out["success"] is True
         assert out["title"] == "Scope"
         assert out["field_ids"] == ["goal", "note", "n", "when"]
-        assert 'id="attune-elicit-form"' in out["html"]
+        assert 'id="attune-elicit-form-' in out["html"]
         assert "fill it" in out["html"]
         # the v2.1 rich controls render (D10 enum-honesty fix)
         assert '<input type="number"' in out["html"]


### PR DESCRIPTION
## Summary

`form_to_widget_html` emitted fixed element ids (`attune-elicit-form`, `ae-submit`, `ae-error`), so two forms rendered on the same page collided in the DOM — the second form's submit script would `getElementById` into the first form. Found live during the dynamic-forms demo rehearsal, where the basic and advanced beats are on screen together.

## Change

- Ids carry a per-render suffix — random by default, injectable via a new optional `instance_id` param (sanitized to alphanumeric) for deterministic renders.
- The scoped `<style>` block follows the suffixed id (single `.replace` at emission; the CSS family constants are unchanged).
- No answer-shape, validator, or MCP schema change. Radio groups were already scoped by their `<form>` owner.

## Receipts

- Serial run of `tests/unit/elicitation/` + the render-widget handler tests: **254 passed** (new: uniqueness across two renders, deterministic + sanitized `instance_id`, CSS-follows-id).
- Repo-wide grep: no other reference to the old fixed id outside the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
