### PR TITLE
docs(examples): notes-search tutorial demo fixture (form-scoped, frozen 07-24)

### DIFF
--- a/examples/demo_notes_search/README.md
+++ b/examples/demo_notes_search/README.md
@@ -1,0 +1,46 @@
+# Notes search — the tutorial demo fixture
+
+Demo data for attune-ai tutorials and dry runs. Every tutorial
+works on this same small, offline module so takes are repeatable
+and start from identical state.
+
+Scoped live via the dynamic-forms session on 2026-07-24
+(`resp-20260724-105201`) and **frozen that day** — change it only
+by re-scoping, not in passing cleanups.
+
+## What's here
+
+| File | What |
+|------|------|
+| `notes_search.py` | The module under demo: load, index, search notes |
+| `sample_notes.md` | Five generic notes (no real names, keys, or services) |
+| `test_notes_search.py` | The fixture's test suite |
+
+## Seeded on purpose — do not "fix" outside a tutorial
+
+- **One failing test** — `test_search_is_case_insensitive` fails
+  because `_tokenize` keeps token case (the seeded bug is marked in
+  the source). The fix-test tutorial fixes it live; the fix is one
+  line.
+- **Coverage gaps** — `remove()`, `snippet()`, and `stats()` have no
+  tests. The smart-test tutorial finds and closes them.
+
+Everything else passes and stays green.
+
+## Running it
+
+The repo's pytest config only collects `tests/`, so this suite never
+runs in CI. Run it directly:
+
+```bash
+pytest examples/demo_notes_search/test_notes_search.py -p no:cacheprovider -o addopts=
+```
+
+Expected before the tutorial: 1 failed, 8 passed. After the
+fix-test tutorial: 9 passed.
+
+## Reset after a take
+
+```bash
+git checkout -- examples/demo_notes_search/
+```

--- a/examples/demo_notes_search/notes_search.py
+++ b/examples/demo_notes_search/notes_search.py
@@ -1,0 +1,160 @@
+"""Notes search tool — the tutorial demo fixture.
+
+A small, offline notes indexing and search module. This is DEMO DATA:
+it exists so every attune-ai tutorial and dry run works on identical,
+resettable material. Scoped via the dynamic-forms session on
+2026-07-24 (resp-20260724-105201) and frozen that day.
+
+Seeded on purpose (see README.md — do not "fix" these in cleanup PRs):
+
+- One real bug that a test catches (the fix-test tutorial fixes it live).
+- Several functions with no test coverage (the smart-test tutorial
+  finds and closes them).
+
+Runs fully offline on the stdlib. No real names, keys, or services.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under Apache 2.0
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+
+#: Words too common to be worth indexing.
+STOP_WORDS = frozenset({"a", "an", "and", "in", "is", "of", "on", "the", "to"})
+
+
+@dataclass
+class Note:
+    """One note: a title, a body, and optional tags."""
+
+    note_id: int
+    title: str
+    body: str
+    tags: list[str] = field(default_factory=list)
+
+
+def _tokenize(text: str) -> list[str]:
+    """Split text into index tokens, dropping stop words.
+
+    Tokens are matched case-insensitively by search().
+    """
+    # SEEDED BUG (fix-test tutorial): tokens keep their original case,
+    # so "Redis" in a note never matches the lowercased query "redis".
+    # The fix is one line: lowercase each token here.
+    tokens = [t for t in re.split(r"[^\w]+", text) if t]
+    return [t for t in tokens if t.lower() not in STOP_WORDS]
+
+
+def load_notes(path: str | Path) -> list[Note]:
+    """Load notes from a markdown-ish file.
+
+    Format: notes separated by ``---`` lines; each note starts with a
+    ``# title`` line, an optional ``tags: a, b`` line, then the body.
+
+    Args:
+        path: Path to the notes file. Must exist and be a regular file.
+
+    Raises:
+        FileNotFoundError: If the path does not name a regular file.
+    """
+    resolved = Path(path).resolve()
+    if not resolved.is_file():
+        raise FileNotFoundError(f"notes file not found: {resolved}")
+
+    notes: list[Note] = []
+    for block in resolved.read_text(encoding="utf-8").split("\n---\n"):
+        lines = [ln for ln in block.strip().splitlines() if ln.strip()]
+        if not lines or not lines[0].startswith("# "):
+            continue
+        title = lines[0][2:].strip()
+        tags: list[str] = []
+        body_lines = lines[1:]
+        if body_lines and body_lines[0].lower().startswith("tags:"):
+            tags = [t.strip() for t in body_lines[0][5:].split(",") if t.strip()]
+            body_lines = body_lines[1:]
+        notes.append(
+            Note(
+                note_id=len(notes) + 1,
+                title=title,
+                body="\n".join(body_lines),
+                tags=tags,
+            )
+        )
+    return notes
+
+
+class NotesIndex:
+    """An in-memory inverted index over notes."""
+
+    def __init__(self) -> None:
+        self._notes: dict[int, Note] = {}
+        self._index: dict[str, set[int]] = {}
+
+    def add(self, note: Note) -> None:
+        """Add one note to the index."""
+        self._notes[note.note_id] = note
+        for token in _tokenize(f"{note.title} {note.body}"):
+            self._index.setdefault(token, set()).add(note.note_id)
+
+    def add_all(self, notes: list[Note]) -> None:
+        """Add many notes to the index."""
+        for note in notes:
+            self.add(note)
+
+    def search(self, query: str) -> list[Note]:
+        """Return notes matching the query, best match first.
+
+        Matching is case-insensitive; ranking is by how many distinct
+        query terms a note contains, ties broken by note id.
+        """
+        terms = [t.lower() for t in _tokenize(query)]
+        if not terms:
+            return []
+        scores: dict[int, int] = {}
+        for term in terms:
+            for note_id in self._index.get(term, ()):
+                scores[note_id] = scores.get(note_id, 0) + 1
+        ranked = sorted(scores.items(), key=lambda kv: (-kv[1], kv[0]))
+        return [self._notes[note_id] for note_id, _ in ranked]
+
+    def filter_by_tag(self, tag: str) -> list[Note]:
+        """Return notes carrying the tag (case-insensitive), by id."""
+        wanted = tag.strip().lower()
+        found = [n for n in self._notes.values() if any(t.lower() == wanted for t in n.tags)]
+        return sorted(found, key=lambda n: n.note_id)
+
+    # -- Functions below are the seeded coverage gaps (smart-test
+    # -- tutorial): correct, but no test exercises them yet.
+
+    def remove(self, note_id: int) -> bool:
+        """Remove a note; return True if it existed."""
+        note = self._notes.pop(note_id, None)
+        if note is None:
+            return False
+        for ids in self._index.values():
+            ids.discard(note_id)
+        self._index = {tok: ids for tok, ids in self._index.items() if ids}
+        return True
+
+    def snippet(self, note_id: int, width: int = 60) -> str:
+        """Return the start of a note's body, cut at a word boundary."""
+        note = self._notes.get(note_id)
+        if note is None:
+            return ""
+        body = " ".join(note.body.split())
+        if len(body) <= width:
+            return body
+        cut = body.rfind(" ", 0, width)
+        return body[: cut if cut > 0 else width] + "…"
+
+    def stats(self) -> dict[str, int]:
+        """Return index size counters."""
+        return {
+            "notes": len(self._notes),
+            "tokens": len(self._index),
+            "tags": len({t.lower() for n in self._notes.values() for t in n.tags}),
+        }

--- a/examples/demo_notes_search/sample_notes.md
+++ b/examples/demo_notes_search/sample_notes.md
@@ -1,0 +1,23 @@
+# Standup summary
+tags: work, meetings
+Discussed the release checklist and the Redis cache warmup.
+Action items live in the tracker.
+---
+# Grocery list
+tags: home
+Oat milk, coffee beans, rye bread, apples, olive oil.
+---
+# Reading queue
+tags: learning
+Finish the chapter on inverted indexes. Skim the paper on
+ranking functions and take notes on tokenization tradeoffs.
+---
+# Workshop ideas
+tags: work, learning
+Live-coding session on testing patterns. Bring the demo repo
+and the coverage report from last week.
+---
+# Weekend plan
+tags: home
+Bike ride if the weather holds. Otherwise: bake bread and
+sort the photo archive.

--- a/examples/demo_notes_search/test_notes_search.py
+++ b/examples/demo_notes_search/test_notes_search.py
@@ -1,0 +1,75 @@
+"""Tests for the notes-search demo fixture.
+
+One test FAILS on purpose (the seeded tokenizer bug — the fix-test
+tutorial fixes it live). The seeded coverage gaps are the functions
+this file deliberately does not touch: remove(), snippet(), stats().
+
+Run from this directory (or the repo root) with:
+    pytest examples/demo_notes_search/test_notes_search.py -p no:cacheprovider -o addopts=
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from notes_search import Note, NotesIndex, load_notes
+
+SAMPLE = Path(__file__).parent / "sample_notes.md"
+
+
+@pytest.fixture()
+def index() -> NotesIndex:
+    idx = NotesIndex()
+    idx.add_all(load_notes(SAMPLE))
+    return idx
+
+
+class TestLoadNotes:
+    def test_loads_all_notes_with_titles(self) -> None:
+        notes = load_notes(SAMPLE)
+        assert len(notes) == 5
+        assert notes[0].title == "Standup summary"
+        assert notes[0].tags == ["work", "meetings"]
+
+    def test_missing_file_raises(self, tmp_path: Path) -> None:
+        with pytest.raises(FileNotFoundError):
+            load_notes(tmp_path / "nope.md")
+
+
+class TestSearch:
+    def test_exact_case_match_found(self, index: NotesIndex) -> None:
+        hits = index.search("coffee")
+        assert [n.title for n in hits] == ["Grocery list"]
+
+    def test_search_is_case_insensitive(self, index: NotesIndex) -> None:
+        # "Redis" appears capitalized in the note body; a lowercase
+        # query must still find it. (Fails until the tokenizer bug in
+        # notes_search._tokenize is fixed.)
+        hits = index.search("redis")
+        assert [n.title for n in hits] == ["Standup summary"]
+
+    def test_multi_term_ranking(self, index: NotesIndex) -> None:
+        # "Workshop ideas" contains both terms; others contain one.
+        hits = index.search("coverage testing")
+        assert hits and hits[0].title == "Workshop ideas"
+
+    def test_no_terms_returns_empty(self, index: NotesIndex) -> None:
+        assert index.search("") == []
+        assert index.search("the of and") == []
+
+
+class TestTags:
+    def test_filter_by_tag_case_insensitive(self, index: NotesIndex) -> None:
+        titles = [n.title for n in index.filter_by_tag("WORK")]
+        assert titles == ["Standup summary", "Workshop ideas"]
+
+    def test_unknown_tag_empty(self, index: NotesIndex) -> None:
+        assert index.filter_by_tag("nope") == []
+
+
+class TestAdd:
+    def test_added_note_is_searchable(self) -> None:
+        idx = NotesIndex()
+        idx.add(Note(note_id=1, title="Solo", body="a single searchable entry"))
+        assert [n.title for n in idx.search("searchable")] == ["Solo"]


### PR DESCRIPTION
## Summary

The tutorial demo fixture, scoped live through the dynamic-forms session on 2026-07-24 (validated response `resp-20260724-105201`): a small offline notes-search module every tutorial and dry run works on, so takes are repeatable from identical state. Frozen as of today per the form's `freeze_date`.

`examples/demo_notes_search/` — module (~160 lines), five generic sample notes, test suite, README.

## Seeded on purpose (README marks them do-not-fix outside a tutorial)

| Seed | Tutorial it feeds |
|------|-------------------|
| `test_search_is_case_insensitive` fails — the tokenizer keeps token case (marked in source; the fix is one line) | fix-test, live |
| `remove()` / `snippet()` / `stats()` have no tests | smart-test coverage-gap discovery |

## Safety

- Not in the wheel: `packages.find` excludes `examples*`.
- Not collected by CI: pytest `testpaths = ["tests"]`.
- Offline, stdlib-only, no real names/keys (per the form's constraints).

## Receipts

- Seeded state: `1 failed, 8 passed`; with the one-line tokenizer fix applied: `9 passed`; re-seeded and re-verified before commit.
- Pinned black + ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
