### PR TITLE
feat(elicitation)!: forms by default — flip the surface router and the firing rule

### DIFF
--- a/.agents/skills/elicit/SKILL.md
+++ b/.agents/skills/elicit/SKILL.md
@@ -252,9 +252,11 @@ by hand. Precedence, highest first:
 2. **A `number` / `date` / `textarea` field** → widget, always. These
    have no `AskUserQuestion` control at all, so this outranks the
    opt-out and the user can never silently lose a field.
-3. **Keyboard mode on** → `AskUserQuestion`. The user's opt-out,
-   persisted per project in `attune.config.json` (`keyboard_mode`),
-   with `ATTUNE_KEYBOARD_MODE` as a session override.
+3. **Keyboard mode on** → `AskUserQuestion`. The user's opt-out, set
+   with `attune config set keyboard_mode true` and persisted per project
+   in `attune.config.json`, with `ATTUNE_KEYBOARD_MODE` as a session
+   override. If a user says forms feel like too much, point them at that
+   command rather than arguing the default.
 4. **Trivial form** → `AskUserQuestion`. Trivial is narrow and
    mechanical: exactly one `single_select`/`boolean`, ≤3 options, and
    no option label over 120 chars. A long label means tradeoffs got

--- a/.agents/skills/elicit/SKILL.md
+++ b/.agents/skills/elicit/SKILL.md
@@ -235,16 +235,43 @@ no blocked items there is nothing to ask — just narrate the report.
 
 ## Choosing a surface
 
-**Route by the form's controls first.** If **every** field is a
-select, boolean, or short text, the form renders natively on
-`AskUserQuestion` — one call, no HTML round-trip — so use that; don't
-reach for the widget. Use a rich surface (native elicitation / widget)
-**only** when at least one field is a `number`, `date`, `textarea`, or a
-`decision` / `pushback` / `progress` construct — those have no portable
-`AskUserQuestion` control. (The `needs_widget` predicate in
-`attune.elicitation` is this same check in code.) Sending an
-AskUserQuestion-eligible form to the widget costs a second tool call and
-a multi-kB HTML round-trip for no gain.
+**The widget is the default. `AskUserQuestion` is the fallback.**
+(D21 — this reverses the earlier cheapest-surface-that-fits rule.)
+Don't route on what the surface can technically express; route on how
+much of the option space the user can see at once. Folding three
+options and their tradeoffs into prose above a single-select turns a
+scan into a serial read the user has to hold in their head — that loss
+is real even though a control-type check can't see it.
+
+`select_form_surface(form, widget_capable=…, keyboard_mode=…)` in
+`attune.elicitation` is this rule in code. Call it instead of deciding
+by hand. Precedence, highest first:
+
+1. **Client can't render widgets** → `AskUserQuestion`. A constraint,
+   not a preference.
+2. **A `number` / `date` / `textarea` field** → widget, always. These
+   have no `AskUserQuestion` control at all, so this outranks the
+   opt-out and the user can never silently lose a field.
+3. **Keyboard mode on** → `AskUserQuestion`. The user's opt-out,
+   persisted per project in `attune.config.json` (`keyboard_mode`),
+   with `ATTUNE_KEYBOARD_MODE` as a session override.
+4. **Trivial form** → `AskUserQuestion`. Trivial is narrow and
+   mechanical: exactly one `single_select`/`boolean`, ≤3 options, and
+   no option label over 120 chars. A long label means tradeoffs got
+   folded into the text — that form wanted a card.
+5. **Otherwise** → widget.
+
+**Latency is not a reason to downgrade a form.** The extra tool call is
+a real cost but it is not the axis; if a form is worth asking, it is
+worth asking legibly. `needs_widget` still exists as the low-level
+"does this lose fidelity on AskUserQuestion" check, but it no longer
+owns the decision — don't route on it directly.
+
+**After the answer comes back,** collapse the form rather than leaving
+the rendered markup in the transcript: `form_response_summary(form,
+response)` returns a few lines of markdown (title + one bullet per
+answer). Use it in your narration so a long session accumulates
+summaries, not screenfuls of HTML.
 
 - **Rich / native — one call:** `elicitation_ask` renders the form as a
   native MCP elicitation dialog (supports number/date/textarea +

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -233,27 +233,52 @@ abstraction.
 
 ## Socratic Interaction Rule
 
-**ALWAYS use `AskUserQuestion` to guide users through workflow discovery and scoping. NEVER skip straight to execution.**
+**ALWAYS guide users through discovery and scoping before executing. NEVER skip straight to execution.**
 
-This is the core design principle of Attune AI's developer experience. When a user invokes `/attune` or any workflow:
+This is the core design principle of Attune AI's developer experience.
 
-1. **Initial discovery**: Use `AskUserQuestion` to understand their goal (what are you trying to accomplish?)
-2. **Scoping**: Use `AskUserQuestion` to narrow scope (which files? what test subset? what level of detail?)
-3. **Confirmation**: Use `AskUserQuestion` if there are meaningful choices before execution (approach, format, targets)
-4. **Then execute**: Only run CLI commands or tools after the user has been guided through the relevant decisions
+**Build a form; don't hand-write a question turn.** (D21 — this rule
+used to name `AskUserQuestion`, and naming a tool got it executed as
+that tool, so the communication grammar almost never fired.) Construct
+a `FormSchema` via `attune.elicitation.form_from_dict` and let
+`select_form_surface` pick the surface. The widget is the default;
+`AskUserQuestion` is one of its fallbacks, not the starting point.
 
-**Examples of when to ask:**
+**Fire a form when ANY of these holds:**
 
-- User says "run tests" → Ask: which tests? full suite, CLI only, or quick smoke test?
-- User says "security audit" → Ask: which path? src/, tests/, or full project?
-- User says "review code" → Ask: which files or area? what focus (security, quality, performance)?
-- User says "commit" → Ask: which files to stage? what kind of change is this?
+- Two or more independent dimensions must be settled — batch them into
+  ONE form, never N sequential turns. (`AskUserQuestion` caps at 4
+  options and one question per turn, so it *structurally cannot* carry
+  a batched multi-dimension ask. This is the highest-value case.)
+- Three or more alternatives, or two with tradeoffs worth stating
+  (→ `decision` construct).
+- You are recommending against something the user named
+  (→ `pushback` construct).
+- The answer is a number, a date, or free text longer than a phrase.
+- The choice changes scope, architecture, files, external state, or
+  acceptance criteria — or is hard to reverse.
+
+**A raw button-turn is correct only when ALL of these hold:** one
+dimension, ≤3 options, no tradeoffs worth stating. Plus two standing
+exceptions: the referent is already resolved and you need a bare
+confirm (the terse-vocab path — `y` / `go` / `1`), or the user is in
+keyboard mode.
+
+**Examples:**
+
+- "run tests" → one dimension, few options → button-turn is fine.
+- "security audit" → path + focus + depth → ONE form, three fields.
+- "review code" → area + focus + output shape → ONE form.
+- "commit" → files + change kind → ONE form.
 
 **Do NOT:**
 
 - Jump straight to running commands without scoping
 - Assume the user wants the broadest possible execution
-- Skip questions just because the next step seems obvious
+- Ask N sequential button-turns for what is one form
+- Pad a form with fields you don't need — ceremony is the failure mode
+  this rule is most likely to cause. If one dimension is genuinely all
+  you need, ask for one.
 
 This rule applies to ALL workflow interactions, not just `/attune`.
 

--- a/.claude/lessons.md
+++ b/.claude/lessons.md
@@ -18026,3 +18026,61 @@ def ", start_idx + 1)` for module-
   for `uses:` / `gh ` / `git push` / `github-script` and confirm every
   hit is read-only. The 2026-07-18 `persist-credentials` 403 lesson is
   the same wall hit from the other side, after the fact.
+- **A predicate with no production caller is a safe pattern until you
+  hang a SIDE EFFECT off it — then it silently measures nothing**:
+  2026-07-25, D21 (forms-by-default, PR #1652). `attune.elicitation`
+  deliberately keeps routing predicates that nothing in `src/` calls —
+  `needs_widget` has never had one. That is not a bug: the agent follows
+  the skill's prose, and the function is the executable mirror of the
+  rule, kept honest by tests. I added `select_form_surface` in the same
+  shape and put the "decay receipt" telemetry INSIDE it. Everything was
+  green — 20 tests, 99% coverage, a non-mocked route→persist→read
+  round-trip — because the tests called it directly. In the live system
+  nothing did, so `form_events.jsonl` would have stayed empty forever
+  while the PR body claimed it "measures the surface mix faithfully."
+  **Diagnostic**: after adding any observability/persistence/IO to an
+  existing pure helper, `grep -rn "<name>" --include="*.py" src/ | grep
+  -v "def <name>"` and confirm a REAL caller outside `__init__`
+  re-exports and docstrings; a passing round-trip test proves the
+  function works, never that anything invokes it. **Fix pattern**: move
+  the call to the seam that the live system actually crosses — here the
+  MCP handlers, where the tool the agent invoked *is* the datum worth
+  recording (which also upgraded the metric: `chosen` + `agreed` catch
+  the agent overriding its own router, a signal that flipping a default
+  cannot manufacture, unlike volume which rises by construction).
+  Extends "Registered ≠ working — dogfood the live loop" with the case
+  where the code was correctly architected and the DEFECT WAS
+  INTRODUCED BY INHERITING that architecture for something that needs a
+  caller.
+
+- **A behavioral-default change can invalidate a scheduled DEMO or
+  marketing artifact whose whole premise is the old behavior — grep the
+  non-code surfaces before shipping**: 2026-07-25, same PR.
+  `docs/process/DEMO_DYNAMIC_FORMS_script.md` was chair-ruled, had
+  locked specimens, and was scheduled for a Thu/Fri capture. Its arc was
+  "3 turns → 1 turn": cold-open on the agent asking three sequential
+  button questions, then `/elicit` collapsing them. D21's firing-rule
+  rewrite makes the agent batch those dimensions into one form
+  immediately — **the three-question before-state the demo depended on
+  is exactly what the change removes**. Filming it would have either
+  failed to reproduce, or reproduced only because the agent ignored its
+  own new rule. The script even said its specimens were reliable
+  *because* they were "drawn from the repo's own Socratic Interaction
+  Rule examples" — the rule I rewrote. It also carried "everything shown
+  is live on PyPI 10.5.0 today," which the change falsifies. **Rule**:
+  when changing a default or an always-loaded instruction, grep
+  `docs/process/`, `content/`, `website/`, and any blog/demo/script dirs
+  for artifacts that DEMONSTRATE the old behavior — not just docs that
+  describe it. A doc that describes old behavior is stale; a demo that
+  *performs* it is broken, and one with a capture date is urgent.
+  **Resolution worth reusing**: the fix was not to delete the beat but
+  to make it reproducible on purpose — the new opt-out
+  (`ATTUNE_KEYBOARD_MODE=1`) reproduces the old sequential experience on
+  demand, so the same prompt yields both takes deterministically. A
+  user-selectable mode is a live run, not a simulation, so it stays
+  inside the table's "curation of a live run, never simulation" ruling
+  — and it removed the script's standing reliability risk (a specimen
+  "rehearsal-verified to reliably yield ~3 sequential questions" was
+  always a hope). Pairs with "Spec-named work-scope drifts from code
+  reality" (same family: a tracked artifact goes stale against the code;
+  this one is the artifact-PERFORMS-it surface, and it has a deadline).

--- a/.help/templates/elicitation-forms/comparison.md
+++ b/.help/templates/elicitation-forms/comparison.md
@@ -3,8 +3,8 @@ type: comparison
 name: elicitation-forms-comparison
 feature: elicitation-forms
 depth: comparison
-generated_at: 2026-07-25T05:20:20.482906+00:00
-source_hash: 660990a441ecd2b722e6ade0d914a0d81e15357900f19a08cc3f511a5b9b13ff
+generated_at: 2026-07-25T05:58:04.934219+00:00
+source_hash: 9670395c7ce23f96b61ec57648f0a6c01aad19746a4f965901b5f07a5f070d2c
 status: generated
 ---
 

--- a/.help/templates/elicitation-forms/comparison.md
+++ b/.help/templates/elicitation-forms/comparison.md
@@ -3,8 +3,8 @@ type: comparison
 name: elicitation-forms-comparison
 feature: elicitation-forms
 depth: comparison
-generated_at: 2026-07-14T15:58:51.698621+00:00
-source_hash: ea2a2694719d75bff1894657cfe5e0f5c96ae71719ae4d7f00ce7252b9e9798a
+generated_at: 2026-07-25T05:20:20.482906+00:00
+source_hash: 660990a441ecd2b722e6ade0d914a0d81e15357900f19a08cc3f511a5b9b13ff
 status: generated
 ---
 

--- a/.help/templates/elicitation-forms/concept.md
+++ b/.help/templates/elicitation-forms/concept.md
@@ -3,8 +3,8 @@ type: concept
 name: elicitation-forms-concept
 feature: elicitation-forms
 depth: concept
-generated_at: 2026-07-14T15:58:51.698621+00:00
-source_hash: ea2a2694719d75bff1894657cfe5e0f5c96ae71719ae4d7f00ce7252b9e9798a
+generated_at: 2026-07-25T05:20:20.482906+00:00
+source_hash: 660990a441ecd2b722e6ade0d914a0d81e15357900f19a08cc3f511a5b9b13ff
 status: generated
 ---
 
@@ -79,7 +79,7 @@ underneath.
 
 A form renders three ways, in order of richness:
 
-- **Widget** (`form_to_widget_html` → `show_widget`) — the rich surface:
+- **Widget** (`form_to_widget_html` → `show_widget`) — **the default**:
   cards, badges, the three-bucket progress board, dissent framing. Renders
   on widget-capable clients (claude.ai / Cowork). Answers post back through
   a sentinel-marked JSON block which you validate with
@@ -92,8 +92,52 @@ A form renders three ways, in order of richness:
   form for clients with native elicitation. It does not render on Claude
   Code today and lacks multi-select, so it is not the default.
 
-The terse reply vocabulary (`y` / `go` / `1`) answers any construct on any
-surface — a form never blocks a keyboard-only user.
+### Choosing a surface
+
+`select_form_surface(form, widget_capable=…, keyboard_mode=…)` decides,
+and the rich widget is what it decides by default. The axis is **how much
+of the option space the reader can see at once**, not how many tool calls
+it costs — folding three options and their tradeoffs into prose above a
+single-select turns a scan into a serial read.
+
+Precedence, highest first:
+
+1. **Client can't render widgets** → `AskUserQuestion`. A constraint.
+2. **A `number` / `date` / `textarea` field** → widget, always. No
+   `AskUserQuestion` control exists, so this outranks the opt-out and a
+   field can never be silently dropped.
+3. **Keyboard mode on** → `AskUserQuestion`.
+4. **Trivial form** → `AskUserQuestion`. Trivial is narrow and mechanical:
+   one `single_select`/`boolean`, ≤3 options, no option label over 120
+   characters. A long label means a tradeoff was folded into the text —
+   that form wanted a card.
+5. **Otherwise** → widget.
+
+Latency is not an input. `needs_widget` still exists as the low-level
+"does this lose fidelity on `AskUserQuestion`" check, but it no longer
+owns the decision.
+
+### Keyboard mode
+
+Keyboard mode is the opt-out for people who would rather type than click.
+It persists **per project** as `keyboard_mode` in `./attune.config.json`:
+
+```json
+{ "keyboard_mode": true }
+```
+
+`ATTUNE_KEYBOARD_MODE=1` (or `0`) overrides it for one shell in either
+direction. The terse reply vocabulary (`y` / `go` / `1`) answers any
+construct on any surface regardless — a form never blocks a keyboard-only
+user.
+
+### Collapsing an answered form
+
+Once a form is submitted, the rendered markup has done its job and only
+the question/answer pairs still carry meaning.
+`form_response_summary(form, response)` returns a title line plus one
+bullet per answer, so a long session accumulates summaries instead of
+screenfuls of HTML.
 
 ### The list render variant (`list_style`)
 

--- a/.help/templates/elicitation-forms/concept.md
+++ b/.help/templates/elicitation-forms/concept.md
@@ -3,8 +3,8 @@ type: concept
 name: elicitation-forms-concept
 feature: elicitation-forms
 depth: concept
-generated_at: 2026-07-25T05:20:20.482906+00:00
-source_hash: 660990a441ecd2b722e6ade0d914a0d81e15357900f19a08cc3f511a5b9b13ff
+generated_at: 2026-07-25T05:58:04.934219+00:00
+source_hash: 9670395c7ce23f96b61ec57648f0a6c01aad19746a4f965901b5f07a5f070d2c
 status: generated
 ---
 
@@ -120,14 +120,22 @@ owns the decision.
 ### Keyboard mode
 
 Keyboard mode is the opt-out for people who would rather type than click.
-It persists **per project** as `keyboard_mode` in `./attune.config.json`:
+Turn it on with the CLI:
 
-```json
-{ "keyboard_mode": true }
+```bash
+attune config set keyboard_mode true
 ```
 
+It persists **per project** as `keyboard_mode` in `./attune.config.json`,
+so it survives restarts and stays scoped to the repo you set it in.
+`attune config show` reports the current value.
 `ATTUNE_KEYBOARD_MODE=1` (or `0`) overrides it for one shell in either
-direction. The terse reply vocabulary (`y` / `go` / `1`) answers any
+direction.
+
+Nobody has to know the setting exists to find it: after ten answered
+forms, the next submission surfaces a one-time hint pointing at the
+command (D17's usage-triggered discovery — it reaches people who have
+felt the friction, and never fires for someone already opted in). The terse reply vocabulary (`y` / `go` / `1`) answers any
 construct on any surface regardless — a form never blocks a keyboard-only
 user.
 

--- a/.help/templates/elicitation-forms/error.md
+++ b/.help/templates/elicitation-forms/error.md
@@ -3,8 +3,8 @@ type: error
 name: elicitation-forms-error
 feature: elicitation-forms
 depth: error
-generated_at: 2026-07-14T15:58:51.698621+00:00
-source_hash: ea2a2694719d75bff1894657cfe5e0f5c96ae71719ae4d7f00ce7252b9e9798a
+generated_at: 2026-07-25T05:20:20.482906+00:00
+source_hash: 660990a441ecd2b722e6ade0d914a0d81e15357900f19a08cc3f511a5b9b13ff
 status: generated
 ---
 

--- a/.help/templates/elicitation-forms/error.md
+++ b/.help/templates/elicitation-forms/error.md
@@ -3,8 +3,8 @@ type: error
 name: elicitation-forms-error
 feature: elicitation-forms
 depth: error
-generated_at: 2026-07-25T05:20:20.482906+00:00
-source_hash: 660990a441ecd2b722e6ade0d914a0d81e15357900f19a08cc3f511a5b9b13ff
+generated_at: 2026-07-25T05:58:04.934219+00:00
+source_hash: 9670395c7ce23f96b61ec57648f0a6c01aad19746a4f965901b5f07a5f070d2c
 status: generated
 ---
 

--- a/.help/templates/elicitation-forms/faq.md
+++ b/.help/templates/elicitation-forms/faq.md
@@ -3,8 +3,8 @@ type: faq
 name: elicitation-forms-faq
 feature: elicitation-forms
 depth: faq
-generated_at: 2026-07-25T05:20:20.482906+00:00
-source_hash: 660990a441ecd2b722e6ade0d914a0d81e15357900f19a08cc3f511a5b9b13ff
+generated_at: 2026-07-25T05:58:04.934219+00:00
+source_hash: 9670395c7ce23f96b61ec57648f0a6c01aad19746a4f965901b5f07a5f070d2c
 status: generated
 ---
 
@@ -91,8 +91,8 @@ answers any construct on any surface.
 ## Why did a simple question render as a full form?
 
 The widget is the default now. If you'd rather have buttons,
-turn on keyboard mode — `{"keyboard_mode": true}` in the project's
-`./attune.config.json`, or `ATTUNE_KEYBOARD_MODE=1` for one shell.
+run `attune config set keyboard_mode true` — it persists for this
+project. `ATTUNE_KEYBOARD_MODE=1` overrides it for one shell.
 
 ## Doesn't defaulting to the widget cost an extra round-trip?
 

--- a/.help/templates/elicitation-forms/faq.md
+++ b/.help/templates/elicitation-forms/faq.md
@@ -3,8 +3,8 @@ type: faq
 name: elicitation-forms-faq
 feature: elicitation-forms
 depth: faq
-generated_at: 2026-07-14T15:58:51.698621+00:00
-source_hash: ea2a2694719d75bff1894657cfe5e0f5c96ae71719ae4d7f00ce7252b9e9798a
+generated_at: 2026-07-25T05:20:20.482906+00:00
+source_hash: 660990a441ecd2b722e6ade0d914a0d81e15357900f19a08cc3f511a5b9b13ff
 status: generated
 ---
 
@@ -76,11 +76,30 @@ widget round-trip makes no Anthropic API call.
 
 ## When should a construct fire?
 
-That is a judgment call governed by the agent's decision
-routine (`.claude/rules/attune/decision-routine.md`), not by this
-subsystem — the grammar defines the *shape*, not the *when*. And a
-form never blocks a keyboard-only user: the terse reply vocabulary
-(`y` / `go` / `1`) answers any construct on any surface.
+The grammar defines the *shape*; the *when* lives in the
+agent's Socratic rule and decision routine
+(`.claude/rules/attune/decision-routine.md`). The short version:
+build a form when two or more independent dimensions need settling
+(batch them into ONE form, never N sequential turns), when there are
+three or more alternatives or two with real tradeoffs, when you are
+disagreeing with the user, or when the answer is a number, date, or
+more than a phrase of text. A raw button-turn is right only for a
+single low-stakes choice among a few options. And a form never blocks
+a keyboard-only user: the terse reply vocabulary (`y` / `go` / `1`)
+answers any construct on any surface.
+
+## Why did a simple question render as a full form?
+
+The widget is the default now. If you'd rather have buttons,
+turn on keyboard mode — `{"keyboard_mode": true}` in the project's
+`./attune.config.json`, or `ATTUNE_KEYBOARD_MODE=1` for one shell.
+
+## Doesn't defaulting to the widget cost an extra round-trip?
+
+Yes, and that is deliberate. Latency was the old routing axis
+and it made the agent quietly downgrade forms that communicated
+better; if a question is worth asking, it is worth asking legibly.
+Trivial one-off choices still go to buttons.
 
 ## Do forms cost API credits?
 

--- a/.help/templates/elicitation-forms/note.md
+++ b/.help/templates/elicitation-forms/note.md
@@ -3,8 +3,8 @@ type: note
 name: elicitation-forms-note
 feature: elicitation-forms
 depth: note
-generated_at: 2026-07-14T15:58:51.698621+00:00
-source_hash: ea2a2694719d75bff1894657cfe5e0f5c96ae71719ae4d7f00ce7252b9e9798a
+generated_at: 2026-07-25T05:20:20.482906+00:00
+source_hash: 660990a441ecd2b722e6ade0d914a0d81e15357900f19a08cc3f511a5b9b13ff
 status: generated
 ---
 
@@ -79,7 +79,7 @@ underneath.
 
 A form renders three ways, in order of richness:
 
-- **Widget** (`form_to_widget_html` → `show_widget`) — the rich surface:
+- **Widget** (`form_to_widget_html` → `show_widget`) — **the default**:
   cards, badges, the three-bucket progress board, dissent framing. Renders
   on widget-capable clients (claude.ai / Cowork). Answers post back through
   a sentinel-marked JSON block which you validate with
@@ -92,8 +92,52 @@ A form renders three ways, in order of richness:
   form for clients with native elicitation. It does not render on Claude
   Code today and lacks multi-select, so it is not the default.
 
-The terse reply vocabulary (`y` / `go` / `1`) answers any construct on any
-surface — a form never blocks a keyboard-only user.
+### Choosing a surface
+
+`select_form_surface(form, widget_capable=…, keyboard_mode=…)` decides,
+and the rich widget is what it decides by default. The axis is **how much
+of the option space the reader can see at once**, not how many tool calls
+it costs — folding three options and their tradeoffs into prose above a
+single-select turns a scan into a serial read.
+
+Precedence, highest first:
+
+1. **Client can't render widgets** → `AskUserQuestion`. A constraint.
+2. **A `number` / `date` / `textarea` field** → widget, always. No
+   `AskUserQuestion` control exists, so this outranks the opt-out and a
+   field can never be silently dropped.
+3. **Keyboard mode on** → `AskUserQuestion`.
+4. **Trivial form** → `AskUserQuestion`. Trivial is narrow and mechanical:
+   one `single_select`/`boolean`, ≤3 options, no option label over 120
+   characters. A long label means a tradeoff was folded into the text —
+   that form wanted a card.
+5. **Otherwise** → widget.
+
+Latency is not an input. `needs_widget` still exists as the low-level
+"does this lose fidelity on `AskUserQuestion`" check, but it no longer
+owns the decision.
+
+### Keyboard mode
+
+Keyboard mode is the opt-out for people who would rather type than click.
+It persists **per project** as `keyboard_mode` in `./attune.config.json`:
+
+```json
+{ "keyboard_mode": true }
+```
+
+`ATTUNE_KEYBOARD_MODE=1` (or `0`) overrides it for one shell in either
+direction. The terse reply vocabulary (`y` / `go` / `1`) answers any
+construct on any surface regardless — a form never blocks a keyboard-only
+user.
+
+### Collapsing an answered form
+
+Once a form is submitted, the rendered markup has done its job and only
+the question/answer pairs still carry meaning.
+`form_response_summary(form, response)` returns a title line plus one
+bullet per answer, so a long session accumulates summaries instead of
+screenfuls of HTML.
 
 ### The list render variant (`list_style`)
 

--- a/.help/templates/elicitation-forms/note.md
+++ b/.help/templates/elicitation-forms/note.md
@@ -3,8 +3,8 @@ type: note
 name: elicitation-forms-note
 feature: elicitation-forms
 depth: note
-generated_at: 2026-07-25T05:20:20.482906+00:00
-source_hash: 660990a441ecd2b722e6ade0d914a0d81e15357900f19a08cc3f511a5b9b13ff
+generated_at: 2026-07-25T05:58:04.934219+00:00
+source_hash: 9670395c7ce23f96b61ec57648f0a6c01aad19746a4f965901b5f07a5f070d2c
 status: generated
 ---
 
@@ -120,14 +120,22 @@ owns the decision.
 ### Keyboard mode
 
 Keyboard mode is the opt-out for people who would rather type than click.
-It persists **per project** as `keyboard_mode` in `./attune.config.json`:
+Turn it on with the CLI:
 
-```json
-{ "keyboard_mode": true }
+```bash
+attune config set keyboard_mode true
 ```
 
+It persists **per project** as `keyboard_mode` in `./attune.config.json`,
+so it survives restarts and stays scoped to the repo you set it in.
+`attune config show` reports the current value.
 `ATTUNE_KEYBOARD_MODE=1` (or `0`) overrides it for one shell in either
-direction. The terse reply vocabulary (`y` / `go` / `1`) answers any
+direction.
+
+Nobody has to know the setting exists to find it: after ten answered
+forms, the next submission surfaces a one-time hint pointing at the
+command (D17's usage-triggered discovery — it reaches people who have
+felt the friction, and never fires for someone already opted in). The terse reply vocabulary (`y` / `go` / `1`) answers any
 construct on any surface regardless — a form never blocks a keyboard-only
 user.
 

--- a/.help/templates/elicitation-forms/quickstart.md
+++ b/.help/templates/elicitation-forms/quickstart.md
@@ -3,8 +3,8 @@ type: quickstart
 name: elicitation-forms-quickstart
 feature: elicitation-forms
 depth: quickstart
-generated_at: 2026-07-14T15:58:51.698621+00:00
-source_hash: ea2a2694719d75bff1894657cfe5e0f5c96ae71719ae4d7f00ce7252b9e9798a
+generated_at: 2026-07-25T05:20:20.482906+00:00
+source_hash: 660990a441ecd2b722e6ade0d914a0d81e15357900f19a08cc3f511a5b9b13ff
 status: generated
 ---
 

--- a/.help/templates/elicitation-forms/quickstart.md
+++ b/.help/templates/elicitation-forms/quickstart.md
@@ -3,8 +3,8 @@ type: quickstart
 name: elicitation-forms-quickstart
 feature: elicitation-forms
 depth: quickstart
-generated_at: 2026-07-25T05:20:20.482906+00:00
-source_hash: 660990a441ecd2b722e6ade0d914a0d81e15357900f19a08cc3f511a5b9b13ff
+generated_at: 2026-07-25T05:58:04.934219+00:00
+source_hash: 9670395c7ce23f96b61ec57648f0a6c01aad19746a4f965901b5f07a5f070d2c
 status: generated
 ---
 

--- a/.help/templates/elicitation-forms/reference.md
+++ b/.help/templates/elicitation-forms/reference.md
@@ -3,8 +3,8 @@ type: reference
 name: elicitation-forms-reference
 feature: elicitation-forms
 depth: reference
-generated_at: 2026-07-25T05:20:20.482906+00:00
-source_hash: 660990a441ecd2b722e6ade0d914a0d81e15357900f19a08cc3f511a5b9b13ff
+generated_at: 2026-07-25T05:58:04.934219+00:00
+source_hash: 9670395c7ce23f96b61ec57648f0a6c01aad19746a4f965901b5f07a5f070d2c
 status: generated
 ---
 
@@ -23,6 +23,7 @@ status: generated
 | `select_form_surface(form, widget_capable=True, keyboard_mode=False)` | Choose the surface: `"widget"` (the default) or `"ask"`. |
 | `is_trivial_form(form)` | True when a form is small enough that buttons lose nothing: one select/boolean, ≤3 options, no label >120 chars. |
 | `keyboard_mode_enabled(project_root=None)` | Read the per-project opt-out (`keyboard_mode` in `./attune.config.json`; `ATTUNE_KEYBOARD_MODE` overrides). |
+| `set_keyboard_mode(enabled, project_root=None)` | Persist the opt-out; what `attune config set keyboard_mode` calls. Preserves other keys. |
 | `form_response_summary(form, response)` | Collapse an answered form to a compact markdown summary. |
 | `needs_widget(form)` | Low-level controls check — True if `AskUserQuestion` would lose fidelity. Does not own the surface decision. |
 | `collect_form_response(form, raw_answers, template_id="")` | Validate answers (R4) and return a `FormResponse`; raises `FormValidationError`. |

--- a/.help/templates/elicitation-forms/reference.md
+++ b/.help/templates/elicitation-forms/reference.md
@@ -3,8 +3,8 @@ type: reference
 name: elicitation-forms-reference
 feature: elicitation-forms
 depth: reference
-generated_at: 2026-07-14T15:58:51.698621+00:00
-source_hash: ea2a2694719d75bff1894657cfe5e0f5c96ae71719ae4d7f00ce7252b9e9798a
+generated_at: 2026-07-25T05:20:20.482906+00:00
+source_hash: 660990a441ecd2b722e6ade0d914a0d81e15357900f19a08cc3f511a5b9b13ff
 status: generated
 ---
 
@@ -20,6 +20,11 @@ status: generated
 | `form_to_widget_html(form, message="")` | Render the rich inline HTML form for `show_widget`. |
 | `form_to_askuserquestion(form, batch_size=4)` | Render batched `AskUserQuestion` payloads (the fallback surface). |
 | `form_to_elicitation_schema(form)` | Render a native MCP elicitation JSON schema. |
+| `select_form_surface(form, widget_capable=True, keyboard_mode=False)` | Choose the surface: `"widget"` (the default) or `"ask"`. |
+| `is_trivial_form(form)` | True when a form is small enough that buttons lose nothing: one select/boolean, ≤3 options, no label >120 chars. |
+| `keyboard_mode_enabled(project_root=None)` | Read the per-project opt-out (`keyboard_mode` in `./attune.config.json`; `ATTUNE_KEYBOARD_MODE` overrides). |
+| `form_response_summary(form, response)` | Collapse an answered form to a compact markdown summary. |
+| `needs_widget(form)` | Low-level controls check — True if `AskUserQuestion` would lose fidelity. Does not own the surface decision. |
 | `collect_form_response(form, raw_answers, template_id="")` | Validate answers (R4) and return a `FormResponse`; raises `FormValidationError`. |
 | `WIDGET_RESPONSE_MARKER` | The sentinel key the widget posts back under. |
 | `FormValidationError` | Raised for a malformed definition or answer; lists every problem. |

--- a/.help/templates/elicitation-forms/task.md
+++ b/.help/templates/elicitation-forms/task.md
@@ -3,8 +3,8 @@ type: task
 name: elicitation-forms-task
 feature: elicitation-forms
 depth: task
-generated_at: 2026-07-14T15:58:51.698621+00:00
-source_hash: ea2a2694719d75bff1894657cfe5e0f5c96ae71719ae4d7f00ce7252b9e9798a
+generated_at: 2026-07-25T05:20:20.482906+00:00
+source_hash: 660990a441ecd2b722e6ade0d914a0d81e15357900f19a08cc3f511a5b9b13ff
 status: generated
 ---
 

--- a/.help/templates/elicitation-forms/task.md
+++ b/.help/templates/elicitation-forms/task.md
@@ -3,8 +3,8 @@ type: task
 name: elicitation-forms-task
 feature: elicitation-forms
 depth: task
-generated_at: 2026-07-25T05:20:20.482906+00:00
-source_hash: 660990a441ecd2b722e6ade0d914a0d81e15357900f19a08cc3f511a5b9b13ff
+generated_at: 2026-07-25T05:58:04.934219+00:00
+source_hash: 9670395c7ce23f96b61ec57648f0a6c01aad19746a4f965901b5f07a5f070d2c
 status: generated
 ---
 

--- a/.help/templates/elicitation-forms/tip.md
+++ b/.help/templates/elicitation-forms/tip.md
@@ -3,8 +3,8 @@ type: tip
 name: elicitation-forms-tip
 feature: elicitation-forms
 depth: tip
-generated_at: 2026-07-25T05:20:20.482906+00:00
-source_hash: 660990a441ecd2b722e6ade0d914a0d81e15357900f19a08cc3f511a5b9b13ff
+generated_at: 2026-07-25T05:58:04.934219+00:00
+source_hash: 9670395c7ce23f96b61ec57648f0a6c01aad19746a4f965901b5f07a5f070d2c
 status: generated
 ---
 

--- a/.help/templates/elicitation-forms/tip.md
+++ b/.help/templates/elicitation-forms/tip.md
@@ -3,8 +3,8 @@ type: tip
 name: elicitation-forms-tip
 feature: elicitation-forms
 depth: tip
-generated_at: 2026-07-14T15:58:51.698621+00:00
-source_hash: ea2a2694719d75bff1894657cfe5e0f5c96ae71719ae4d7f00ce7252b9e9798a
+generated_at: 2026-07-25T05:20:20.482906+00:00
+source_hash: 660990a441ecd2b722e6ade0d914a0d81e15357900f19a08cc3f511a5b9b13ff
 status: generated
 ---
 

--- a/.help/templates/elicitation-forms/troubleshooting.md
+++ b/.help/templates/elicitation-forms/troubleshooting.md
@@ -3,8 +3,8 @@ type: troubleshooting
 name: elicitation-forms-troubleshooting
 feature: elicitation-forms
 depth: troubleshooting
-generated_at: 2026-07-14T15:58:51.698621+00:00
-source_hash: ea2a2694719d75bff1894657cfe5e0f5c96ae71719ae4d7f00ce7252b9e9798a
+generated_at: 2026-07-25T05:20:20.482906+00:00
+source_hash: 660990a441ecd2b722e6ade0d914a0d81e15357900f19a08cc3f511a5b9b13ff
 status: generated
 ---
 

--- a/.help/templates/elicitation-forms/troubleshooting.md
+++ b/.help/templates/elicitation-forms/troubleshooting.md
@@ -3,8 +3,8 @@ type: troubleshooting
 name: elicitation-forms-troubleshooting
 feature: elicitation-forms
 depth: troubleshooting
-generated_at: 2026-07-25T05:20:20.482906+00:00
-source_hash: 660990a441ecd2b722e6ade0d914a0d81e15357900f19a08cc3f511a5b9b13ff
+generated_at: 2026-07-25T05:58:04.934219+00:00
+source_hash: 9670395c7ce23f96b61ec57648f0a6c01aad19746a4f965901b5f07a5f070d2c
 status: generated
 ---
 

--- a/.help/templates/elicitation-forms/warning.md
+++ b/.help/templates/elicitation-forms/warning.md
@@ -3,8 +3,8 @@ type: warning
 name: elicitation-forms-warning
 feature: elicitation-forms
 depth: warning
-generated_at: 2026-07-25T05:20:20.482906+00:00
-source_hash: 660990a441ecd2b722e6ade0d914a0d81e15357900f19a08cc3f511a5b9b13ff
+generated_at: 2026-07-25T05:58:04.934219+00:00
+source_hash: 9670395c7ce23f96b61ec57648f0a6c01aad19746a4f965901b5f07a5f070d2c
 status: generated
 ---
 

--- a/.help/templates/elicitation-forms/warning.md
+++ b/.help/templates/elicitation-forms/warning.md
@@ -3,8 +3,8 @@ type: warning
 name: elicitation-forms-warning
 feature: elicitation-forms
 depth: warning
-generated_at: 2026-07-14T15:58:51.698621+00:00
-source_hash: ea2a2694719d75bff1894657cfe5e0f5c96ae71719ae4d7f00ce7252b9e9798a
+generated_at: 2026-07-25T05:20:20.482906+00:00
+source_hash: 660990a441ecd2b722e6ade0d914a0d81e15357900f19a08cc3f511a5b9b13ff
 status: generated
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,17 @@ run-record corpus that future releases learn from.
 
 ### Added
 
+- **`form_response_summary(form, response)`** — collapses an answered
+  form to a compact markdown summary (title plus one bullet per
+  answer), so a long session accumulates summaries instead of
+  screenfuls of rendered markup.
+- **Form-surface telemetry** (`attune.telemetry.form_events`) — every
+  routing decision is logged locally to
+  `~/.attune/telemetry/form_events.jsonl` with its reason, readable
+  back via `surface_mix()`. Local-only and default-on, disabled with
+  `ATTUNE_FORM_TELEMETRY=0` or `DO_NOT_TRACK`. Note it measures the
+  widget/ask *mix*, not whether a form was built at all — a hand-written
+  question turn never reaches Python.
 - **Video pointers on help surfaces.** Feature masters
   (`content/features/<feature>.md`) accept an optional `video:`
   frontmatter field (bare URL or `{url, title}`); the projector emits
@@ -108,6 +119,25 @@ run-record corpus that future releases learn from.
 
 ### Changed
 
+- **Forms by default — the rich form surface is now what you get**
+  (D21). Previously the agent routed each form to the cheapest surface
+  that could express its controls, so a multi-dimension question
+  collapsed into plain buttons and lost its cards, tradeoffs, and
+  rationale. `select_form_surface()` replaces that judgment: the
+  widget is the default and `AskUserQuestion` is an explicit fallback,
+  taken only for a client that can't render widgets, keyboard mode, or
+  a genuinely trivial form (one select/boolean, ≤3 short options).
+  `needs_widget` remains as the low-level controls check but no longer
+  owns the decision.
+- **The Socratic rule now names the artifact, not the tool.** It asked
+  agents to use `AskUserQuestion`, so they did — and the communication
+  grammar rarely fired regardless of routing. It now asks for a
+  `FormSchema`, with an explicit batching rule: independent dimensions
+  go in ONE form instead of N sequential question-turns.
+- **Keyboard mode** — the opt-out for people who'd rather type than
+  click, persisted per project as `keyboard_mode` in
+  `attune.config.json`, with `ATTUNE_KEYBOARD_MODE` as a two-way
+  session override. Ratified in D17, built here.
 - **Managed-Redis naming is platform-neutral** (#1506).
   `get_managed_redis_config` replaces the Railway-specific name;
   `get_railway_redis_config` remains as a deprecated alias.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ run-record corpus that future releases learn from.
 
 ### Added
 
+- **`attune config set` / `attune config show`** — the first project-config
+  CLI. Writes allowlisted settings to `./attune.config.json` (currently
+  `keyboard_mode`), preserving other keys; an unknown key errors rather
+  than silently persisting a setting that does nothing.
 - **`form_response_summary(form, response)`** — collapses an answered
   form to a compact markdown summary (title plus one bullet per
   answer), so a long session accumulates summaries instead of
@@ -135,9 +139,12 @@ run-record corpus that future releases learn from.
   `FormSchema`, with an explicit batching rule: independent dimensions
   go in ONE form instead of N sequential question-turns.
 - **Keyboard mode** — the opt-out for people who'd rather type than
-  click, persisted per project as `keyboard_mode` in
-  `attune.config.json`, with `ATTUNE_KEYBOARD_MODE` as a two-way
-  session override. Ratified in D17, built here.
+  click. Turn it on with `attune config set keyboard_mode true`; it
+  persists per project in `attune.config.json`, with
+  `ATTUNE_KEYBOARD_MODE` as a two-way session override. After ten
+  answered forms a one-time hint points at the command, so the opt-out
+  is discoverable without having to know it exists. Ratified in D17,
+  built here.
 - **Managed-Redis naming is platform-neutral** (#1506).
   `get_managed_redis_config` replaces the Railway-specific name;
   `get_railway_redis_config` remains as a deprecated alias.

--- a/content/features/elicitation-forms.md
+++ b/content/features/elicitation-forms.md
@@ -123,14 +123,22 @@ owns the decision.
 ### Keyboard mode
 
 Keyboard mode is the opt-out for people who would rather type than click.
-It persists **per project** as `keyboard_mode` in `./attune.config.json`:
+Turn it on with the CLI:
 
-```json
-{ "keyboard_mode": true }
+```bash
+attune config set keyboard_mode true
 ```
 
+It persists **per project** as `keyboard_mode` in `./attune.config.json`,
+so it survives restarts and stays scoped to the repo you set it in.
+`attune config show` reports the current value.
 `ATTUNE_KEYBOARD_MODE=1` (or `0`) overrides it for one shell in either
-direction. The terse reply vocabulary (`y` / `go` / `1`) answers any
+direction.
+
+Nobody has to know the setting exists to find it: after ten answered
+forms, the next submission surfaces a one-time hint pointing at the
+command (D17's usage-triggered discovery — it reaches people who have
+felt the friction, and never fires for someone already opted in). The terse reply vocabulary (`y` / `go` / `1`) answers any
 construct on any surface regardless — a form never blocks a keyboard-only
 user.
 
@@ -271,6 +279,7 @@ form = form_from_dict({
 | `select_form_surface(form, widget_capable=True, keyboard_mode=False)` | Choose the surface: `"widget"` (the default) or `"ask"`. |
 | `is_trivial_form(form)` | True when a form is small enough that buttons lose nothing: one select/boolean, ≤3 options, no label >120 chars. |
 | `keyboard_mode_enabled(project_root=None)` | Read the per-project opt-out (`keyboard_mode` in `./attune.config.json`; `ATTUNE_KEYBOARD_MODE` overrides). |
+| `set_keyboard_mode(enabled, project_root=None)` | Persist the opt-out; what `attune config set keyboard_mode` calls. Preserves other keys. |
 | `form_response_summary(form, response)` | Collapse an answered form to a compact markdown summary. |
 | `needs_widget(form)` | Low-level controls check — True if `AskUserQuestion` would lose fidelity. Does not own the surface decision. |
 | `collect_form_response(form, raw_answers, template_id="")` | Validate answers (R4) and return a `FormResponse`; raises `FormValidationError`. |
@@ -405,8 +414,8 @@ blocker or omit a real one.
   answers any construct on any surface.
 - **Q:** Why did a simple question render as a full form?
   **A:** The widget is the default now. If you'd rather have buttons,
-  turn on keyboard mode — `{"keyboard_mode": true}` in the project's
-  `./attune.config.json`, or `ATTUNE_KEYBOARD_MODE=1` for one shell.
+  run `attune config set keyboard_mode true` — it persists for this
+  project. `ATTUNE_KEYBOARD_MODE=1` overrides it for one shell.
 - **Q:** Doesn't defaulting to the widget cost an extra round-trip?
   **A:** Yes, and that is deliberate. Latency was the old routing axis
   and it made the agent quietly downgrade forms that communicated

--- a/content/features/elicitation-forms.md
+++ b/content/features/elicitation-forms.md
@@ -82,7 +82,7 @@ underneath.
 
 A form renders three ways, in order of richness:
 
-- **Widget** (`form_to_widget_html` → `show_widget`) — the rich surface:
+- **Widget** (`form_to_widget_html` → `show_widget`) — **the default**:
   cards, badges, the three-bucket progress board, dissent framing. Renders
   on widget-capable clients (claude.ai / Cowork). Answers post back through
   a sentinel-marked JSON block which you validate with
@@ -95,8 +95,52 @@ A form renders three ways, in order of richness:
   form for clients with native elicitation. It does not render on Claude
   Code today and lacks multi-select, so it is not the default.
 
-The terse reply vocabulary (`y` / `go` / `1`) answers any construct on any
-surface — a form never blocks a keyboard-only user.
+### Choosing a surface
+
+`select_form_surface(form, widget_capable=…, keyboard_mode=…)` decides,
+and the rich widget is what it decides by default. The axis is **how much
+of the option space the reader can see at once**, not how many tool calls
+it costs — folding three options and their tradeoffs into prose above a
+single-select turns a scan into a serial read.
+
+Precedence, highest first:
+
+1. **Client can't render widgets** → `AskUserQuestion`. A constraint.
+2. **A `number` / `date` / `textarea` field** → widget, always. No
+   `AskUserQuestion` control exists, so this outranks the opt-out and a
+   field can never be silently dropped.
+3. **Keyboard mode on** → `AskUserQuestion`.
+4. **Trivial form** → `AskUserQuestion`. Trivial is narrow and mechanical:
+   one `single_select`/`boolean`, ≤3 options, no option label over 120
+   characters. A long label means a tradeoff was folded into the text —
+   that form wanted a card.
+5. **Otherwise** → widget.
+
+Latency is not an input. `needs_widget` still exists as the low-level
+"does this lose fidelity on `AskUserQuestion`" check, but it no longer
+owns the decision.
+
+### Keyboard mode
+
+Keyboard mode is the opt-out for people who would rather type than click.
+It persists **per project** as `keyboard_mode` in `./attune.config.json`:
+
+```json
+{ "keyboard_mode": true }
+```
+
+`ATTUNE_KEYBOARD_MODE=1` (or `0`) overrides it for one shell in either
+direction. The terse reply vocabulary (`y` / `go` / `1`) answers any
+construct on any surface regardless — a form never blocks a keyboard-only
+user.
+
+### Collapsing an answered form
+
+Once a form is submitted, the rendered markup has done its job and only
+the question/answer pairs still carry meaning.
+`form_response_summary(form, response)` returns a title line plus one
+bullet per answer, so a long session accumulates summaries instead of
+screenfuls of HTML.
 
 ### The list render variant (`list_style`)
 
@@ -224,6 +268,11 @@ form = form_from_dict({
 | `form_to_widget_html(form, message="")` | Render the rich inline HTML form for `show_widget`. |
 | `form_to_askuserquestion(form, batch_size=4)` | Render batched `AskUserQuestion` payloads (the fallback surface). |
 | `form_to_elicitation_schema(form)` | Render a native MCP elicitation JSON schema. |
+| `select_form_surface(form, widget_capable=True, keyboard_mode=False)` | Choose the surface: `"widget"` (the default) or `"ask"`. |
+| `is_trivial_form(form)` | True when a form is small enough that buttons lose nothing: one select/boolean, ≤3 options, no label >120 chars. |
+| `keyboard_mode_enabled(project_root=None)` | Read the per-project opt-out (`keyboard_mode` in `./attune.config.json`; `ATTUNE_KEYBOARD_MODE` overrides). |
+| `form_response_summary(form, response)` | Collapse an answered form to a compact markdown summary. |
+| `needs_widget(form)` | Low-level controls check — True if `AskUserQuestion` would lose fidelity. Does not own the surface decision. |
 | `collect_form_response(form, raw_answers, template_id="")` | Validate answers (R4) and return a `FormResponse`; raises `FormValidationError`. |
 | `WIDGET_RESPONSE_MARKER` | The sentinel key the widget posts back under. |
 | `FormValidationError` | Raised for a malformed definition or answer; lists every problem. |
@@ -343,11 +392,26 @@ blocker or omit a real one.
   block and validate it with `elicitation_collect_response`. The
   widget round-trip makes no Anthropic API call.
 - **Q:** When should a construct fire?
-  **A:** That is a judgment call governed by the agent's decision
-  routine (`.claude/rules/attune/decision-routine.md`), not by this
-  subsystem — the grammar defines the *shape*, not the *when*. And a
-  form never blocks a keyboard-only user: the terse reply vocabulary
-  (`y` / `go` / `1`) answers any construct on any surface.
+  **A:** The grammar defines the *shape*; the *when* lives in the
+  agent's Socratic rule and decision routine
+  (`.claude/rules/attune/decision-routine.md`). The short version:
+  build a form when two or more independent dimensions need settling
+  (batch them into ONE form, never N sequential turns), when there are
+  three or more alternatives or two with real tradeoffs, when you are
+  disagreeing with the user, or when the answer is a number, date, or
+  more than a phrase of text. A raw button-turn is right only for a
+  single low-stakes choice among a few options. And a form never blocks
+  a keyboard-only user: the terse reply vocabulary (`y` / `go` / `1`)
+  answers any construct on any surface.
+- **Q:** Why did a simple question render as a full form?
+  **A:** The widget is the default now. If you'd rather have buttons,
+  turn on keyboard mode — `{"keyboard_mode": true}` in the project's
+  `./attune.config.json`, or `ATTUNE_KEYBOARD_MODE=1` for one shell.
+- **Q:** Doesn't defaulting to the widget cost an extra round-trip?
+  **A:** Yes, and that is deliberate. Latency was the old routing axis
+  and it made the agent quietly downgrade forms that communicated
+  better; if a question is worth asking, it is worth asking legibly.
+  Trivial one-off choices still go to buttons.
 - **Q:** Do forms cost API credits?
   **A:** No. Rendering and validation are pure local transforms — no
   model call on any surface.

--- a/docs/architecture/elicitation-forms.md
+++ b/docs/architecture/elicitation-forms.md
@@ -110,14 +110,22 @@ owns the decision.
 ### Keyboard mode
 
 Keyboard mode is the opt-out for people who would rather type than click.
-It persists **per project** as `keyboard_mode` in `./attune.config.json`:
+Turn it on with the CLI:
 
-```json
-{ "keyboard_mode": true }
+```bash
+attune config set keyboard_mode true
 ```
 
+It persists **per project** as `keyboard_mode` in `./attune.config.json`,
+so it survives restarts and stays scoped to the repo you set it in.
+`attune config show` reports the current value.
 `ATTUNE_KEYBOARD_MODE=1` (or `0`) overrides it for one shell in either
-direction. The terse reply vocabulary (`y` / `go` / `1`) answers any
+direction.
+
+Nobody has to know the setting exists to find it: after ten answered
+forms, the next submission surfaces a one-time hint pointing at the
+command (D17's usage-triggered discovery — it reaches people who have
+felt the friction, and never fires for someone already opted in). The terse reply vocabulary (`y` / `go` / `1`) answers any
 construct on any surface regardless — a form never blocks a keyboard-only
 user.
 
@@ -161,4 +169,4 @@ per-type "rejects out-of-option" test is the cheap guard that catches a
 missed validation site. Prove it with a non-mocked round-trip — render,
 submit, collect — not just unit tests.
 
-<!-- attune-generated: source_hash=660990a441ecd2b722e6ade0d914a0d81e15357900f19a08cc3f511a5b9b13ff feature=elicitation-forms kind=architecture generated_at=2026-07-25 -->
+<!-- attune-generated: source_hash=9670395c7ce23f96b61ec57648f0a6c01aad19746a4f965901b5f07a5f070d2c feature=elicitation-forms kind=architecture generated_at=2026-07-25 -->

--- a/docs/architecture/elicitation-forms.md
+++ b/docs/architecture/elicitation-forms.md
@@ -69,7 +69,7 @@ underneath.
 
 A form renders three ways, in order of richness:
 
-- **Widget** (`form_to_widget_html` → `show_widget`) — the rich surface:
+- **Widget** (`form_to_widget_html` → `show_widget`) — **the default**:
   cards, badges, the three-bucket progress board, dissent framing. Renders
   on widget-capable clients (claude.ai / Cowork). Answers post back through
   a sentinel-marked JSON block which you validate with
@@ -82,8 +82,52 @@ A form renders three ways, in order of richness:
   form for clients with native elicitation. It does not render on Claude
   Code today and lacks multi-select, so it is not the default.
 
-The terse reply vocabulary (`y` / `go` / `1`) answers any construct on any
-surface — a form never blocks a keyboard-only user.
+### Choosing a surface
+
+`select_form_surface(form, widget_capable=…, keyboard_mode=…)` decides,
+and the rich widget is what it decides by default. The axis is **how much
+of the option space the reader can see at once**, not how many tool calls
+it costs — folding three options and their tradeoffs into prose above a
+single-select turns a scan into a serial read.
+
+Precedence, highest first:
+
+1. **Client can't render widgets** → `AskUserQuestion`. A constraint.
+2. **A `number` / `date` / `textarea` field** → widget, always. No
+   `AskUserQuestion` control exists, so this outranks the opt-out and a
+   field can never be silently dropped.
+3. **Keyboard mode on** → `AskUserQuestion`.
+4. **Trivial form** → `AskUserQuestion`. Trivial is narrow and mechanical:
+   one `single_select`/`boolean`, ≤3 options, no option label over 120
+   characters. A long label means a tradeoff was folded into the text —
+   that form wanted a card.
+5. **Otherwise** → widget.
+
+Latency is not an input. `needs_widget` still exists as the low-level
+"does this lose fidelity on `AskUserQuestion`" check, but it no longer
+owns the decision.
+
+### Keyboard mode
+
+Keyboard mode is the opt-out for people who would rather type than click.
+It persists **per project** as `keyboard_mode` in `./attune.config.json`:
+
+```json
+{ "keyboard_mode": true }
+```
+
+`ATTUNE_KEYBOARD_MODE=1` (or `0`) overrides it for one shell in either
+direction. The terse reply vocabulary (`y` / `go` / `1`) answers any
+construct on any surface regardless — a form never blocks a keyboard-only
+user.
+
+### Collapsing an answered form
+
+Once a form is submitted, the rendered markup has done its job and only
+the question/answer pairs still carry meaning.
+`form_response_summary(form, response)` returns a title line plus one
+bullet per answer, so a long session accumulates summaries instead of
+screenfuls of HTML.
 
 ### The list render variant (`list_style`)
 
@@ -117,4 +161,4 @@ per-type "rejects out-of-option" test is the cheap guard that catches a
 missed validation site. Prove it with a non-mocked round-trip — render,
 submit, collect — not just unit tests.
 
-<!-- attune-generated: source_hash=ea2a2694719d75bff1894657cfe5e0f5c96ae71719ae4d7f00ce7252b9e9798a feature=elicitation-forms kind=architecture generated_at=2026-07-14 -->
+<!-- attune-generated: source_hash=660990a441ecd2b722e6ade0d914a0d81e15357900f19a08cc3f511a5b9b13ff feature=elicitation-forms kind=architecture generated_at=2026-07-25 -->

--- a/docs/how-to/elicitation-forms.md
+++ b/docs/how-to/elicitation-forms.md
@@ -120,6 +120,7 @@ form = form_from_dict({
 | `select_form_surface(form, widget_capable=True, keyboard_mode=False)` | Choose the surface: `"widget"` (the default) or `"ask"`. |
 | `is_trivial_form(form)` | True when a form is small enough that buttons lose nothing: one select/boolean, ≤3 options, no label >120 chars. |
 | `keyboard_mode_enabled(project_root=None)` | Read the per-project opt-out (`keyboard_mode` in `./attune.config.json`; `ATTUNE_KEYBOARD_MODE` overrides). |
+| `set_keyboard_mode(enabled, project_root=None)` | Persist the opt-out; what `attune config set keyboard_mode` calls. Preserves other keys. |
 | `form_response_summary(form, response)` | Collapse an answered form to a compact markdown summary. |
 | `needs_widget(form)` | Low-level controls check — True if `AskUserQuestion` would lose fidelity. Does not own the surface decision. |
 | `collect_form_response(form, raw_answers, template_id="")` | Validate answers (R4) and return a `FormResponse`; raises `FormValidationError`. |
@@ -149,4 +150,4 @@ three construct types `decision`, `pushback`, `progress` — ten in all.
 `elicitation_collect_response`, and `elicitation_ask` — the same model,
 exposed for agents that drive forms through the MCP server.
 
-<!-- attune-generated: source_hash=660990a441ecd2b722e6ade0d914a0d81e15357900f19a08cc3f511a5b9b13ff feature=elicitation-forms kind=how-to generated_at=2026-07-25 -->
+<!-- attune-generated: source_hash=9670395c7ce23f96b61ec57648f0a6c01aad19746a4f965901b5f07a5f070d2c feature=elicitation-forms kind=how-to generated_at=2026-07-25 -->

--- a/docs/how-to/elicitation-forms.md
+++ b/docs/how-to/elicitation-forms.md
@@ -117,6 +117,11 @@ form = form_from_dict({
 | `form_to_widget_html(form, message="")` | Render the rich inline HTML form for `show_widget`. |
 | `form_to_askuserquestion(form, batch_size=4)` | Render batched `AskUserQuestion` payloads (the fallback surface). |
 | `form_to_elicitation_schema(form)` | Render a native MCP elicitation JSON schema. |
+| `select_form_surface(form, widget_capable=True, keyboard_mode=False)` | Choose the surface: `"widget"` (the default) or `"ask"`. |
+| `is_trivial_form(form)` | True when a form is small enough that buttons lose nothing: one select/boolean, ≤3 options, no label >120 chars. |
+| `keyboard_mode_enabled(project_root=None)` | Read the per-project opt-out (`keyboard_mode` in `./attune.config.json`; `ATTUNE_KEYBOARD_MODE` overrides). |
+| `form_response_summary(form, response)` | Collapse an answered form to a compact markdown summary. |
+| `needs_widget(form)` | Low-level controls check — True if `AskUserQuestion` would lose fidelity. Does not own the surface decision. |
 | `collect_form_response(form, raw_answers, template_id="")` | Validate answers (R4) and return a `FormResponse`; raises `FormValidationError`. |
 | `WIDGET_RESPONSE_MARKER` | The sentinel key the widget posts back under. |
 | `FormValidationError` | Raised for a malformed definition or answer; lists every problem. |
@@ -144,4 +149,4 @@ three construct types `decision`, `pushback`, `progress` — ten in all.
 `elicitation_collect_response`, and `elicitation_ask` — the same model,
 exposed for agents that drive forms through the MCP server.
 
-<!-- attune-generated: source_hash=ea2a2694719d75bff1894657cfe5e0f5c96ae71719ae4d7f00ce7252b9e9798a feature=elicitation-forms kind=how-to generated_at=2026-07-14 -->
+<!-- attune-generated: source_hash=660990a441ecd2b722e6ade0d914a0d81e15357900f19a08cc3f511a5b9b13ff feature=elicitation-forms kind=how-to generated_at=2026-07-25 -->

--- a/docs/process/DEMO_DYNAMIC_FORMS_script.md
+++ b/docs/process/DEMO_DYNAMIC_FORMS_script.md
@@ -2,29 +2,71 @@
 
 **Written:** 2026-07-23. **Amended:** 2026-07-24, per roundtable
 thread `q-demo-scripts-review-002` (chair-ruled; caption-carried
-caveats per amended ruling). **Status:** draft — this is the Thu/Fri
-CAPTURE REHEARSAL subject (chair-ruled): it exercises the full
-recording pipeline before Tuesday's 10.6.0 shoot, and the footage
-is releasable in its own right after the chair's honesty-gate
-pass. **Everything shown is live on PyPI 10.5.0 today** — no
-receipt slots to wait for; the pre-record check is just "the
-commands run on this machine." **Format:** ~4 min main cut + 60s
-social cut. Stage geometry: record on screen 1 per the
+caveats per amended ruling). **Re-cut:** 2026-07-25, per roundtable
+thread `q-forms-default-vs-latency-001` and decisions.md D21 —
+the arc changed because the product changed (see "Why this was
+re-cut" below). **Status:** draft — this is the Thu/Fri CAPTURE
+REHEARSAL subject (chair-ruled): it exercises the full recording
+pipeline before Tuesday's 10.6.0 shoot, and the footage is
+releasable in its own right after the chair's honesty-gate pass.
+
+> **Version gate — READ BEFORE CAPTURE.** This script now shows
+> **10.6.0 behaviour, which is NOT on PyPI yet** (10.5.0 is
+> current). The forms-by-default routing and keyboard mode land in
+> 10.6.0. Capture against the branch/local build, and do not
+> publish the main cut until 10.6.0 is live. The previous version
+> of this script claimed "everything shown is live on PyPI 10.5.0
+> today" — that claim is now false and has been removed rather
+> than quietly left standing.
+
+**Format:** ~4 min main cut + 60s social cut. Stage geometry:
+record on screen 1 per the
 [10.6.0 script's](DEMO_10_6_0_script.md) Stage geometry section —
 same rules, same set.
+
+## Why this was re-cut (2026-07-25)
+
+The old arc was **"3 turns → 1 turn"**: cold-open on the agent
+asking three sequential button questions, then `/elicit` collapsing
+them into one form. That arc no longer reproduces. D21 flipped the
+default — a multi-dimension ask now renders as one form
+*immediately*, without `/elicit`, because the Socratic rule was
+rewritten to batch independent dimensions. The three-question
+interrogation the cold open depended on is the behaviour we
+removed.
+
+Rather than lose the visual proof, the re-cut makes it
+**deterministic**: keyboard mode reproduces the sequential
+experience on demand, so the same prompt gives both takes from one
+machine. This is strictly better than the old approach, which
+needed a specimen "rehearsal-verified to reliably yield ~3
+sequential questions" and could still misfire on the day.
+
+The demo's claim also gets stronger and more honest: the good
+behaviour is no longer a move the user has to know to ask for — it
+is what the product does by default.
 
 Pre-record checklist:
 
 - [ ] Screen Studio mic toggle flipped + 2-second audio-track
       test (the pending receipt from the 07-23 walkthrough)
-- [ ] `/elicit` and one pushback form rehearsed once, unrecorded
-- [ ] Cold-open prompt PRE-SELECTED: 2–3 candidate prompts
-      rehearsal-verified to reliably yield ~3 sequential
-      questions; the specimen is picked before the take, not
-      during it (table ruling, q-demo-scripts-review-002 —
-      curation of a live run, never simulation). Candidates
-      locked 2026-07-24 — see "Locked specimens" below; the
-      unrecorded live pass is what remains before ticking this.
+- [ ] Both takes and one pushback form rehearsed once, unrecorded
+- [ ] Cold-open prompt PRE-SELECTED (one prompt, two takes — see
+      "The two-take method" below). The specimen is picked before
+      the take, not during it (table ruling,
+      q-demo-scripts-review-002 — curation of a live run, never
+      simulation). Candidates locked 2026-07-24, method re-cut
+      2026-07-25; the unrecorded live pass is what remains before
+      ticking this.
+- [ ] Keyboard-mode toggle verified BOTH directions on the capture
+      machine: `ATTUNE_KEYBOARD_MODE=1` yields sequential button
+      turns, unset yields one form, on the SAME prompt. This is the
+      re-cut's load-bearing mechanism — if it doesn't flip cleanly,
+      the cold open doesn't work.
+- [ ] Running against a build that HAS D21 (forms-by-default). Check
+      with `python -c "from attune.elicitation import
+      select_form_surface; print('ok')"` — an ImportError means the
+      stage is on 10.5.0 and the whole arc reverts to the old one.
 - [ ] Pushback example LOCKED: a rehearsed, real, low-context
       disagreement whose two options fit on screen and whose
       consequence reads in one sentence. Specimen locked and
@@ -63,16 +105,28 @@ Capture and export settings (ruled 2026-07-23, dry-run + Patrick):
 
 ### Cold-open candidates (primary first)
 
-Each candidate's dimensions map onto the same scope/focus/depth
-wording the Act-1 form uses, so "same questions, one form" is
-visually provable. The candidates are drawn from the repo's own
-Socratic Interaction Rule examples (the rule text itself
-instructs these questions, which is what makes them reliable
-triggers); the final reliability check is the unrecorded
-rehearsal pass.
+**Re-cut 2026-07-25:** these are now the prompt for BOTH takes, not
+just the interrogation take. Each candidate's dimensions map onto
+the same scope/focus/depth wording, so "same questions, one form"
+is visually provable across the cut.
 
-1. **"help me test this module"** (primary — matches the Act-1
-   `/elicit testing this module` line). Expected sequence:
+The reliability problem the old note worried about is gone.
+Previously the specimen had to be "rehearsal-verified to reliably
+yield ~3 sequential questions" — a hope, since the agent chose the
+shape. Now take A gets the sequential shape because
+`ATTUNE_KEYBOARD_MODE=1` *makes* it sequential, and take B gets one
+form because that is the default. Both takes are deterministic; the
+rehearsal pass is confirming wording and pacing, not fishing for a
+behaviour.
+
+The candidates are still drawn from the repo's own Socratic
+Interaction Rule examples — note that rule was rewritten by D21, and
+its worked example (`"security audit" → path + focus + depth → ONE
+form`) is now the *batching* instruction rather than the sequential
+one.
+
+1. **"help me test this module"** (primary — typed verbatim in
+   BOTH takes). Take-A sequence, under keyboard mode:
    Q1 scope — "Which module should we test?"; Q2 focus —
    "What's the focus?" (run existing tests / find coverage
    gaps / generate new tests / coverage of changed code);
@@ -81,19 +135,23 @@ rehearsal pass.
 2. **"review my recent changes"** — Q1 scope (branch diff,
    staged, or last N commits); Q2 focus (security / quality /
    performance / tests); Q3 depth (quick pass vs multi-pass
-   deep review). If used, Act 1 becomes
-   `/elicit reviewing my recent changes`.
+   deep review).
 3. **"clean up this code"** — Q1 scope (which path); Q2 focus
    (simplify / refactor / dead code); Q3 depth (safe-only vs
-   structural). If used, Act 1 becomes
-   `/elicit cleaning up <path>`.
+   structural).
+
+Whichever candidate is used, take B types the SAME words with no
+flag and no slash command — that identity is the whole proof.
 
 ### Act-1 form (primary specimen)
 
 Dogfood-verified 2026-07-24 through the live
-`elicitation_render_form` MCP tool on the installed 10.5.0
-plugin — validates clean and batches all three fields into a
-single turn:
+`elicitation_render_form` MCP tool — validates clean and batches
+all three fields into a single turn. **Re-cut note:** this is now
+what take B renders *by default* from the plain prompt; the
+`/elicit` command is no longer needed to produce it, and the
+verification must be re-run against a D21 build (the 10.5.0 run
+proved the form validates, not that it is the default).
 
 ```json
 {
@@ -161,20 +219,39 @@ and the overrule answer round-trips
 
 | Segment | Time | What the viewer sees |
 |---------|------|----------------------|
-| Cold open | 0:00–0:30 | Question-by-question interrogation, live |
-| One form | 0:30–1:45 | The same scoping as a single form |
+| Cold open | 0:00–0:30 | Question-by-question interrogation (take A, keyboard mode) |
+| One form | 0:30–1:45 | Same prompt, one form, no command (take B, the default) |
 | The pushback form | 1:45–2:45 | Disagreement as a decision, not an argument |
 | Dogfood | 2:45–3:30 | This repo's own rulings ran on these forms |
 | Close | 3:30–4:00 | The rule + the install line |
 
 ---
 
+## The two-take method (production note — read first)
+
+Both opening acts use **one prompt and one flag**. Record take A,
+flip the flag, record take B, cut them together. Same repo, same
+prompt, same session shape — the only variable is the mode, which
+is exactly what makes the comparison honest and repeatable.
+
+```bash
+ATTUNE_KEYBOARD_MODE=1 claude    # take A — sequential button turns
+```
+
+```bash
+claude                            # take B — one form (the default)
+```
+
+Nothing is staged or simulated: take A is a real, shipping,
+user-selectable mode, not a re-enactment of an old version. That
+distinction is what keeps this inside the table's
+"curation of a live run, never simulation" ruling.
+
 ## Cold open (0:00–0:30) — the interrogation
 
-**Screen:** Claude Code, real repo. Use the PRE-SELECTED prompt
-(see checklist) — a genuinely ambiguous ask, e.g. "help me test
-this module," chosen because rehearsal showed it reliably draws
-~3 sequential questions.
+**Screen:** Claude Code, real repo, **take A**. Use the
+PRE-SELECTED prompt (see checklist) — a genuinely ambiguous ask,
+e.g. "help me test this module."
 
 The agent asks a question. One button row. Answer it. It asks the
 next. Answer that. A third appears. **Production:** the
@@ -199,30 +276,36 @@ the philosophy narration starts.
 
 ## One form (0:30–1:45) — the same scoping, one turn
 
-**Screen:**
+**Screen:** **take B** — the identical prompt, typed the same way,
+with no flag and no slash command.
 
 ```text
-/elicit testing this module
+help me test this module
 ```
 
-One form renders: the independent dimensions of the decision —
-scope, focus, depth — batched into a single turn, multi-select
-where it fits, a recommended option marked. Fill it in one pass.
-Work starts.
+One form renders immediately: the independent dimensions of the
+decision — scope, focus, depth — batched into a single turn,
+multi-select where it fits, a recommended option marked. Fill it
+in one pass. Work starts.
 
 **Narration:**
 
-> Same questions. One form. The dimensions of a decision I was
-> going to make anyway — asked together, because they're
-> independent.
+> Same prompt. Same questions. One form. I didn't ask for this —
+> I didn't type a command, I didn't opt in. The dimensions of a
+> decision I was going to make anyway, asked together, because
+> they're independent. That's just what it does now.
 
 **Production:** hold on the rendered form long enough to read
 every field, with MINIMAL narration over the hold. This is the
 product shot of the video — the viewer cannot read fields and
-parse policy by ear at the same time. Use the SAME
-scope/focus/depth wording the cold-open questions used, so "same
-questions, one form" is visually provable; a brief "3 turns →
-1 turn" caption may punctuate the transition.
+parse policy by ear at the same time. The scope/focus/depth
+wording is identical across both takes, so "same questions, one
+form" is visually provable; a "3 turns → 1 turn" caption
+punctuates the cut.
+
+**Caption (burned in over the cut between takes):**
+
+> same prompt · no command · the default changed
 
 **Narration (after the hold) — captions carry the rules (chair
 ruling, amended 2026-07-24: caveats live on screen, narration
@@ -317,13 +400,14 @@ establish the friction, resolve it, END on the pushback click.
 LinkedIn autoplays MUTED — every beat carries a burned-in caption
 that works with no audio.
 
-- 0:00–0:05 — sequential-question friction, compressed: three
-  quick question-turns with the turn-counter. Caption: "Three
-  decisions. Three round trips."
-- 0:05–0:20 — smash-cut to `/elicit`: the same three dimensions
-  as one form, with a brief 3-turns-vs-1-form contrast frame
-  (split or before/after). Caption: "Every question at once —
-  when that's correct."
+- 0:00–0:05 — sequential-question friction, compressed (take A):
+  three quick question-turns with the turn-counter. Caption:
+  "Three decisions. Three round trips."
+- 0:05–0:20 — smash-cut to take B: the SAME prompt, no command,
+  the same three dimensions as one form, with a brief
+  3-turns-vs-1-form contrast frame (split or before/after).
+  Caption: "Same prompt. Every question at once — when that's
+  correct."
 - 0:20–0:50 — the pushback form + one-click OVERRULE + the
   agent's acknowledgment (the decision receipt). Caption:
   "Pushback you can click."

--- a/docs/reference/elicitation-forms.md
+++ b/docs/reference/elicitation-forms.md
@@ -13,6 +13,7 @@
 | `select_form_surface(form, widget_capable=True, keyboard_mode=False)` | Choose the surface: `"widget"` (the default) or `"ask"`. |
 | `is_trivial_form(form)` | True when a form is small enough that buttons lose nothing: one select/boolean, ≤3 options, no label >120 chars. |
 | `keyboard_mode_enabled(project_root=None)` | Read the per-project opt-out (`keyboard_mode` in `./attune.config.json`; `ATTUNE_KEYBOARD_MODE` overrides). |
+| `set_keyboard_mode(enabled, project_root=None)` | Persist the opt-out; what `attune config set keyboard_mode` calls. Preserves other keys. |
 | `form_response_summary(form, response)` | Collapse an answered form to a compact markdown summary. |
 | `needs_widget(form)` | Low-level controls check — True if `AskUserQuestion` would lose fidelity. Does not own the surface decision. |
 | `collect_form_response(form, raw_answers, template_id="")` | Validate answers (R4) and return a `FormResponse`; raises `FormValidationError`. |
@@ -42,4 +43,4 @@ three construct types `decision`, `pushback`, `progress` — ten in all.
 `elicitation_collect_response`, and `elicitation_ask` — the same model,
 exposed for agents that drive forms through the MCP server.
 
-<!-- attune-generated: source_hash=660990a441ecd2b722e6ade0d914a0d81e15357900f19a08cc3f511a5b9b13ff feature=elicitation-forms kind=reference generated_at=2026-07-25 -->
+<!-- attune-generated: source_hash=9670395c7ce23f96b61ec57648f0a6c01aad19746a4f965901b5f07a5f070d2c feature=elicitation-forms kind=reference generated_at=2026-07-25 -->

--- a/docs/reference/elicitation-forms.md
+++ b/docs/reference/elicitation-forms.md
@@ -10,6 +10,11 @@
 | `form_to_widget_html(form, message="")` | Render the rich inline HTML form for `show_widget`. |
 | `form_to_askuserquestion(form, batch_size=4)` | Render batched `AskUserQuestion` payloads (the fallback surface). |
 | `form_to_elicitation_schema(form)` | Render a native MCP elicitation JSON schema. |
+| `select_form_surface(form, widget_capable=True, keyboard_mode=False)` | Choose the surface: `"widget"` (the default) or `"ask"`. |
+| `is_trivial_form(form)` | True when a form is small enough that buttons lose nothing: one select/boolean, ≤3 options, no label >120 chars. |
+| `keyboard_mode_enabled(project_root=None)` | Read the per-project opt-out (`keyboard_mode` in `./attune.config.json`; `ATTUNE_KEYBOARD_MODE` overrides). |
+| `form_response_summary(form, response)` | Collapse an answered form to a compact markdown summary. |
+| `needs_widget(form)` | Low-level controls check — True if `AskUserQuestion` would lose fidelity. Does not own the surface decision. |
 | `collect_form_response(form, raw_answers, template_id="")` | Validate answers (R4) and return a `FormResponse`; raises `FormValidationError`. |
 | `WIDGET_RESPONSE_MARKER` | The sentinel key the widget posts back under. |
 | `FormValidationError` | Raised for a malformed definition or answer; lists every problem. |
@@ -37,4 +42,4 @@ three construct types `decision`, `pushback`, `progress` — ten in all.
 `elicitation_collect_response`, and `elicitation_ask` — the same model,
 exposed for agents that drive forms through the MCP server.
 
-<!-- attune-generated: source_hash=ea2a2694719d75bff1894657cfe5e0f5c96ae71719ae4d7f00ce7252b9e9798a feature=elicitation-forms kind=reference generated_at=2026-07-14 -->
+<!-- attune-generated: source_hash=660990a441ecd2b722e6ade0d914a0d81e15357900f19a08cc3f511a5b9b13ff feature=elicitation-forms kind=reference generated_at=2026-07-25 -->

--- a/docs/specs/elicitation-form-surface/decisions.md
+++ b/docs/specs/elicitation-form-surface/decisions.md
@@ -795,8 +795,23 @@ became a `FormSchema` at all, regardless of how routing resolved.
   renders an answered form as title + one bullet per answer, so a long
   session accumulates summaries instead of screenfuls of markup.
 - **Decay receipt.** `attune.telemetry.form_events` logs every routing
-  decision (surface + reason) to `~/.attune/telemetry/form_events.jsonl`;
-  `surface_mix()` reads it back.
+  decision to `~/.attune/telemetry/form_events.jsonl`; `surface_mix()`
+  reads it back. The live call site is the pair of MCP elicitation
+  handlers (`_handle_elicitation_render_form` /
+  `_handle_elicitation_render_widget`), where the tool the agent invoked
+  *is* its choice — so each record carries the recommendation
+  (`surface`, `reason`), the agent's actual pick (`chosen`), and whether
+  they matched (`agreed`). `render_form` additionally returns a
+  `surface_note` nudge when it flattens a form the router wanted rich.
+
+  **Caught in review, same session:** the first cut hung the logging off
+  `select_form_surface` alone, and *nothing in `src/` called it* — the
+  predicate was exported, tested, documented, and dead in the live path
+  (the same is true of `needs_widget`, which has never had a production
+  caller; the agent follows the skill's prose, not the function). The
+  counter would have read zero forever while the PR claimed it
+  "measures the surface mix faithfully." Registered ≠ working, again.
+  Wiring the handlers is what makes it real.
 
 **Chair's value frame** (answering the Claude seat's "what would
 falsify this?"): a form/widget should *speed up knowledge intake and
@@ -804,14 +819,17 @@ increase the clarity of messages between human and AI*. Noted as the
 stated intent — it is a direction, not yet a falsifiable metric, and
 the receipt below deliberately does not claim to measure it.
 
-**Known limit of the receipt, stated plainly.** `form_events` sees
-every form that reaches the router, so it measures the widget/ask
-**mix** faithfully. It cannot see a raw `AskUserQuestion` turn written
-by hand without building a `FormSchema` — that path never enters
-Python. So it instruments **routing, not firing**, and the
-forms-vs-raw-turns ratio the table asked for stays only partly
-observable from here. Surface mix will also rise by construction once
-the default flips; that is compliance, not value.
+**Known limit of the receipt, stated plainly.** `form_events` sees every
+form that reaches an elicitation MCP tool, so it measures the widget/ask
+**mix** and the agent's **agreement rate** faithfully. It cannot see a
+raw `AskUserQuestion` turn written by hand without building a
+`FormSchema` at all — that path never enters Python. So the
+forms-vs-no-form ratio the table asked for stays only partly observable
+from here; the missing half needs transcript inspection. Surface mix
+will also rise by construction once the default flips — that is
+compliance, not value. The `agreed` field is the one signal here that
+is not self-fulfilling: it records the agent overriding its own router,
+which no amount of flipping defaults manufactures.
 
 **Dissent preserved.** Antigravity was the only seat to argue against,
 on context rather than money: rendered HTML accumulating across a long

--- a/docs/specs/elicitation-form-surface/decisions.md
+++ b/docs/specs/elicitation-form-surface/decisions.md
@@ -733,6 +733,97 @@ two design-only template sketches — `session-contract` (all-scalar) and
 needs `_substitute` to handle sole-value list slots). They bracket the
 difficulty range and belong in `design.md` when V7 designs.
 
+## D21 — forms-by-default: the routing flip and the firing rule
+
+**Date:** 2026-07-25 · **Status:** built · **owner:** patrick
+**Source:** round table `q-forms-default-vs-latency-001` (Claude,
+Antigravity, Codex; 1 round, halted on convergence).
+
+Patrick reopened D17 believing the latency-first surface default was a
+mistake. The table agreed 3/3 — and all three seats, answering blind,
+independently made the same additional point: **routing was the
+smaller half.**
+
+**What was wrong.** Two rules pulled against each other. D17 (unbuilt)
+said "Default = forms"; the shipped `needs_widget` predicate picked the
+cheapest surface that could express the form's controls, justified in
+its own docstring as saving "a second tool call plus a multi-kB HTML
+round-trip through the model FOR NO GAIN." Meanwhile the always-loaded
+Socratic rule named `AskUserQuestion` — a *tool* — so most asks never
+became a `FormSchema` at all, regardless of how routing resolved.
+
+**Decisions.**
+
+- **Routing flipped.** `select_form_surface(form, widget_capable,
+  keyboard_mode)` is the product router; the widget is the default and
+  `AskUserQuestion` is an explicit fallback. Precedence: client
+  capability → no-portable-control → keyboard mode → triviality →
+  widget. `needs_widget` survives as the low-level controls check but
+  no longer owns the decision, and the latency justification is gone
+  from its docstring — left in place it invites reversion.
+- **The axis changed, not just the default.** Route on how much of the
+  option space is visible at once, not on control-type expressibility.
+  A control-type check cannot see the loss when three options and
+  their tradeoffs get folded into prose, which is exactly why "for no
+  gain" read as reasonable.
+- **`_NO_PORTABLE_CONTROL` split from `_WIDGET_ONLY_TYPES`.**
+  `number`/`date`/`textarea` are *impossible* on AskUserQuestion; the
+  v3–v5 constructs are *lossy but expressible*. Impossible outranks
+  the keyboard-mode opt-out so the opt-out can never silently drop a
+  field; lossy yields to it.
+- **Triviality is mechanical and narrow.** One `single_select`/
+  `boolean`, ≤3 options, no option label >120 chars. The length clause
+  is the load-bearing one: when tradeoffs get smuggled into option
+  text the strings get long, so length is a testable "this wanted to
+  be a card" detector.
+- **Firing rule rewritten to name the artifact, not the tool.** The
+  Socratic rule in `.claude/CLAUDE.md` now says construct a
+  `FormSchema` and let the router choose. The batching clause carries
+  most of the value: `AskUserQuestion` caps at 4 options and one
+  question per turn, so it *structurally cannot* express a batched
+  multi-dimension ask — meaning that highest-value form already passed
+  `needs_widget` and already routed to the widget correctly. **It was
+  never routed away; it was never built.** Fixing routing without
+  firing would have fixed the smaller half.
+- **Keyboard mode built, per project.** D17 ratified the opt-out as
+  available day one and it was never built; shipping the flip without
+  it would have realised the ceremony risk rather than mitigating it.
+  Patrick ruled the preference persists **per project** —
+  `keyboard_mode` in `attune.config.json`, with
+  `ATTUNE_KEYBOARD_MODE` as a two-way session override.
+- **Collapse on submit.** `form_response_summary(form, response)`
+  renders an answered form as title + one bullet per answer, so a long
+  session accumulates summaries instead of screenfuls of markup.
+- **Decay receipt.** `attune.telemetry.form_events` logs every routing
+  decision (surface + reason) to `~/.attune/telemetry/form_events.jsonl`;
+  `surface_mix()` reads it back.
+
+**Chair's value frame** (answering the Claude seat's "what would
+falsify this?"): a form/widget should *speed up knowledge intake and
+increase the clarity of messages between human and AI*. Noted as the
+stated intent — it is a direction, not yet a falsifiable metric, and
+the receipt below deliberately does not claim to measure it.
+
+**Known limit of the receipt, stated plainly.** `form_events` sees
+every form that reaches the router, so it measures the widget/ask
+**mix** faithfully. It cannot see a raw `AskUserQuestion` turn written
+by hand without building a `FormSchema` — that path never enters
+Python. So it instruments **routing, not firing**, and the
+forms-vs-raw-turns ratio the table asked for stays only partly
+observable from here. Surface mix will also rise by construction once
+the default flips; that is compliance, not value.
+
+**Dissent preserved.** Antigravity was the only seat to argue against,
+on context rather than money: rendered HTML accumulating across a long
+session is real context pressure, and the brief's "no money at stake"
+clause did not dispose of it because tokens-in-context are not money.
+Patrick declined to promote it as a standing risk entry; the
+collapse-on-submit decision above is the partial mitigation. Full
+thread on the board (TTL 7 days) and in the ruling, message 10.
+
+**Not done.** Wiring `surface_mix()` onto the ops Health tab — the
+counter and its reader ship here, the dashboard panel does not.
+
 ## Open
 
 - **Confirm CC elicitation support** — low priority (elicitation is

--- a/plugin/help/generated/concepts/elicitation-forms.md
+++ b/plugin/help/generated/concepts/elicitation-forms.md
@@ -81,7 +81,7 @@ underneath.
 
 A form renders three ways, in order of richness:
 
-- **Widget** (`form_to_widget_html` → `show_widget`) — the rich surface:
+- **Widget** (`form_to_widget_html` → `show_widget`) — **the default**:
   cards, badges, the three-bucket progress board, dissent framing. Renders
   on widget-capable clients (claude.ai / Cowork). Answers post back through
   a sentinel-marked JSON block which you validate with
@@ -94,8 +94,52 @@ A form renders three ways, in order of richness:
   form for clients with native elicitation. It does not render on Claude
   Code today and lacks multi-select, so it is not the default.
 
-The terse reply vocabulary (`y` / `go` / `1`) answers any construct on any
-surface — a form never blocks a keyboard-only user.
+### Choosing a surface
+
+`select_form_surface(form, widget_capable=…, keyboard_mode=…)` decides,
+and the rich widget is what it decides by default. The axis is **how much
+of the option space the reader can see at once**, not how many tool calls
+it costs — folding three options and their tradeoffs into prose above a
+single-select turns a scan into a serial read.
+
+Precedence, highest first:
+
+1. **Client can't render widgets** → `AskUserQuestion`. A constraint.
+2. **A `number` / `date` / `textarea` field** → widget, always. No
+   `AskUserQuestion` control exists, so this outranks the opt-out and a
+   field can never be silently dropped.
+3. **Keyboard mode on** → `AskUserQuestion`.
+4. **Trivial form** → `AskUserQuestion`. Trivial is narrow and mechanical:
+   one `single_select`/`boolean`, ≤3 options, no option label over 120
+   characters. A long label means a tradeoff was folded into the text —
+   that form wanted a card.
+5. **Otherwise** → widget.
+
+Latency is not an input. `needs_widget` still exists as the low-level
+"does this lose fidelity on `AskUserQuestion`" check, but it no longer
+owns the decision.
+
+### Keyboard mode
+
+Keyboard mode is the opt-out for people who would rather type than click.
+It persists **per project** as `keyboard_mode` in `./attune.config.json`:
+
+```json
+{ "keyboard_mode": true }
+```
+
+`ATTUNE_KEYBOARD_MODE=1` (or `0`) overrides it for one shell in either
+direction. The terse reply vocabulary (`y` / `go` / `1`) answers any
+construct on any surface regardless — a form never blocks a keyboard-only
+user.
+
+### Collapsing an answered form
+
+Once a form is submitted, the rendered markup has done its job and only
+the question/answer pairs still carry meaning.
+`form_response_summary(form, response)` returns a title line plus one
+bullet per answer, so a long session accumulates summaries instead of
+screenfuls of HTML.
 
 ### The list render variant (`list_style`)
 

--- a/plugin/help/generated/concepts/elicitation-forms.md
+++ b/plugin/help/generated/concepts/elicitation-forms.md
@@ -122,14 +122,22 @@ owns the decision.
 ### Keyboard mode
 
 Keyboard mode is the opt-out for people who would rather type than click.
-It persists **per project** as `keyboard_mode` in `./attune.config.json`:
+Turn it on with the CLI:
 
-```json
-{ "keyboard_mode": true }
+```bash
+attune config set keyboard_mode true
 ```
 
+It persists **per project** as `keyboard_mode` in `./attune.config.json`,
+so it survives restarts and stays scoped to the repo you set it in.
+`attune config show` reports the current value.
 `ATTUNE_KEYBOARD_MODE=1` (or `0`) overrides it for one shell in either
-direction. The terse reply vocabulary (`y` / `go` / `1`) answers any
+direction.
+
+Nobody has to know the setting exists to find it: after ten answered
+forms, the next submission surfaces a one-time hint pointing at the
+command (D17's usage-triggered discovery — it reaches people who have
+felt the friction, and never fires for someone already opted in). The terse reply vocabulary (`y` / `go` / `1`) answers any
 construct on any surface regardless — a form never blocks a keyboard-only
 user.
 

--- a/plugin/help/generated/faqs/elicitation-forms.md
+++ b/plugin/help/generated/faqs/elicitation-forms.md
@@ -93,8 +93,8 @@ answers any construct on any surface.
 ## Why did a simple question render as a full form?
 
 The widget is the default now. If you'd rather have buttons,
-turn on keyboard mode — `{"keyboard_mode": true}` in the project's
-`./attune.config.json`, or `ATTUNE_KEYBOARD_MODE=1` for one shell.
+run `attune config set keyboard_mode true` — it persists for this
+project. `ATTUNE_KEYBOARD_MODE=1` overrides it for one shell.
 
 ## Doesn't defaulting to the widget cost an extra round-trip?
 

--- a/plugin/help/generated/faqs/elicitation-forms.md
+++ b/plugin/help/generated/faqs/elicitation-forms.md
@@ -78,11 +78,30 @@ widget round-trip makes no Anthropic API call.
 
 ## When should a construct fire?
 
-That is a judgment call governed by the agent's decision
-routine (`.claude/rules/attune/decision-routine.md`), not by this
-subsystem — the grammar defines the *shape*, not the *when*. And a
-form never blocks a keyboard-only user: the terse reply vocabulary
-(`y` / `go` / `1`) answers any construct on any surface.
+The grammar defines the *shape*; the *when* lives in the
+agent's Socratic rule and decision routine
+(`.claude/rules/attune/decision-routine.md`). The short version:
+build a form when two or more independent dimensions need settling
+(batch them into ONE form, never N sequential turns), when there are
+three or more alternatives or two with real tradeoffs, when you are
+disagreeing with the user, or when the answer is a number, date, or
+more than a phrase of text. A raw button-turn is right only for a
+single low-stakes choice among a few options. And a form never blocks
+a keyboard-only user: the terse reply vocabulary (`y` / `go` / `1`)
+answers any construct on any surface.
+
+## Why did a simple question render as a full form?
+
+The widget is the default now. If you'd rather have buttons,
+turn on keyboard mode — `{"keyboard_mode": true}` in the project's
+`./attune.config.json`, or `ATTUNE_KEYBOARD_MODE=1` for one shell.
+
+## Doesn't defaulting to the widget cost an extra round-trip?
+
+Yes, and that is deliberate. Latency was the old routing axis
+and it made the agent quietly downgrade forms that communicated
+better; if a question is worth asking, it is worth asking legibly.
+Trivial one-off choices still go to buttons.
 
 ## Do forms cost API credits?
 

--- a/plugin/help/generated/notes/elicitation-forms.md
+++ b/plugin/help/generated/notes/elicitation-forms.md
@@ -81,7 +81,7 @@ underneath.
 
 A form renders three ways, in order of richness:
 
-- **Widget** (`form_to_widget_html` → `show_widget`) — the rich surface:
+- **Widget** (`form_to_widget_html` → `show_widget`) — **the default**:
   cards, badges, the three-bucket progress board, dissent framing. Renders
   on widget-capable clients (claude.ai / Cowork). Answers post back through
   a sentinel-marked JSON block which you validate with
@@ -94,8 +94,52 @@ A form renders three ways, in order of richness:
   form for clients with native elicitation. It does not render on Claude
   Code today and lacks multi-select, so it is not the default.
 
-The terse reply vocabulary (`y` / `go` / `1`) answers any construct on any
-surface — a form never blocks a keyboard-only user.
+### Choosing a surface
+
+`select_form_surface(form, widget_capable=…, keyboard_mode=…)` decides,
+and the rich widget is what it decides by default. The axis is **how much
+of the option space the reader can see at once**, not how many tool calls
+it costs — folding three options and their tradeoffs into prose above a
+single-select turns a scan into a serial read.
+
+Precedence, highest first:
+
+1. **Client can't render widgets** → `AskUserQuestion`. A constraint.
+2. **A `number` / `date` / `textarea` field** → widget, always. No
+   `AskUserQuestion` control exists, so this outranks the opt-out and a
+   field can never be silently dropped.
+3. **Keyboard mode on** → `AskUserQuestion`.
+4. **Trivial form** → `AskUserQuestion`. Trivial is narrow and mechanical:
+   one `single_select`/`boolean`, ≤3 options, no option label over 120
+   characters. A long label means a tradeoff was folded into the text —
+   that form wanted a card.
+5. **Otherwise** → widget.
+
+Latency is not an input. `needs_widget` still exists as the low-level
+"does this lose fidelity on `AskUserQuestion`" check, but it no longer
+owns the decision.
+
+### Keyboard mode
+
+Keyboard mode is the opt-out for people who would rather type than click.
+It persists **per project** as `keyboard_mode` in `./attune.config.json`:
+
+```json
+{ "keyboard_mode": true }
+```
+
+`ATTUNE_KEYBOARD_MODE=1` (or `0`) overrides it for one shell in either
+direction. The terse reply vocabulary (`y` / `go` / `1`) answers any
+construct on any surface regardless — a form never blocks a keyboard-only
+user.
+
+### Collapsing an answered form
+
+Once a form is submitted, the rendered markup has done its job and only
+the question/answer pairs still carry meaning.
+`form_response_summary(form, response)` returns a title line plus one
+bullet per answer, so a long session accumulates summaries instead of
+screenfuls of HTML.
 
 ### The list render variant (`list_style`)
 

--- a/plugin/help/generated/notes/elicitation-forms.md
+++ b/plugin/help/generated/notes/elicitation-forms.md
@@ -122,14 +122,22 @@ owns the decision.
 ### Keyboard mode
 
 Keyboard mode is the opt-out for people who would rather type than click.
-It persists **per project** as `keyboard_mode` in `./attune.config.json`:
+Turn it on with the CLI:
 
-```json
-{ "keyboard_mode": true }
+```bash
+attune config set keyboard_mode true
 ```
 
+It persists **per project** as `keyboard_mode` in `./attune.config.json`,
+so it survives restarts and stays scoped to the repo you set it in.
+`attune config show` reports the current value.
 `ATTUNE_KEYBOARD_MODE=1` (or `0`) overrides it for one shell in either
-direction. The terse reply vocabulary (`y` / `go` / `1`) answers any
+direction.
+
+Nobody has to know the setting exists to find it: after ten answered
+forms, the next submission surfaces a one-time hint pointing at the
+command (D17's usage-triggered discovery — it reaches people who have
+felt the friction, and never fires for someone already opted in). The terse reply vocabulary (`y` / `go` / `1`) answers any
 construct on any surface regardless — a form never blocks a keyboard-only
 user.
 

--- a/plugin/help/generated/references/elicitation-forms.md
+++ b/plugin/help/generated/references/elicitation-forms.md
@@ -22,6 +22,11 @@ type: reference
 | `form_to_widget_html(form, message="")` | Render the rich inline HTML form for `show_widget`. |
 | `form_to_askuserquestion(form, batch_size=4)` | Render batched `AskUserQuestion` payloads (the fallback surface). |
 | `form_to_elicitation_schema(form)` | Render a native MCP elicitation JSON schema. |
+| `select_form_surface(form, widget_capable=True, keyboard_mode=False)` | Choose the surface: `"widget"` (the default) or `"ask"`. |
+| `is_trivial_form(form)` | True when a form is small enough that buttons lose nothing: one select/boolean, ≤3 options, no label >120 chars. |
+| `keyboard_mode_enabled(project_root=None)` | Read the per-project opt-out (`keyboard_mode` in `./attune.config.json`; `ATTUNE_KEYBOARD_MODE` overrides). |
+| `form_response_summary(form, response)` | Collapse an answered form to a compact markdown summary. |
+| `needs_widget(form)` | Low-level controls check — True if `AskUserQuestion` would lose fidelity. Does not own the surface decision. |
 | `collect_form_response(form, raw_answers, template_id="")` | Validate answers (R4) and return a `FormResponse`; raises `FormValidationError`. |
 | `WIDGET_RESPONSE_MARKER` | The sentinel key the widget posts back under. |
 | `FormValidationError` | Raised for a malformed definition or answer; lists every problem. |

--- a/plugin/help/generated/references/elicitation-forms.md
+++ b/plugin/help/generated/references/elicitation-forms.md
@@ -25,6 +25,7 @@ type: reference
 | `select_form_surface(form, widget_capable=True, keyboard_mode=False)` | Choose the surface: `"widget"` (the default) or `"ask"`. |
 | `is_trivial_form(form)` | True when a form is small enough that buttons lose nothing: one select/boolean, ≤3 options, no label >120 chars. |
 | `keyboard_mode_enabled(project_root=None)` | Read the per-project opt-out (`keyboard_mode` in `./attune.config.json`; `ATTUNE_KEYBOARD_MODE` overrides). |
+| `set_keyboard_mode(enabled, project_root=None)` | Persist the opt-out; what `attune config set keyboard_mode` calls. Preserves other keys. |
 | `form_response_summary(form, response)` | Collapse an answered form to a compact markdown summary. |
 | `needs_widget(form)` | Low-level controls check — True if `AskUserQuestion` would lose fidelity. Does not own the surface decision. |
 | `collect_form_response(form, raw_answers, template_id="")` | Validate answers (R4) and return a `FormResponse`; raises `FormValidationError`. |

--- a/plugin/help/generated/source_manifest.json
+++ b/plugin/help/generated/source_manifest.json
@@ -2,5916 +2,5916 @@
   "com-agents": {
     "source": "content/features/agents.md",
     "hash": "a5b1678ecf012c7b2877a6c7ecae4a6c3f14c084c13fbcbb7eee79119dce6fa3",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "com-auth-strategies": {
     "source": "src/attune/models/auth_cli.py",
     "hash": "586101ee6a646d50a06299d3c9e96f60467c65376782c191c910af6cf52ef268",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "com-bug-predict": {
     "source": "content/features/bug-predict.md",
     "hash": "6a4f420eba38e2fb884b837dd9758acb60ba60cdaf9248ec4280120b0d382b16",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "com-cli": {
     "source": "content/features/cli.md",
     "hash": "a37b4dc4f0b3706a62184b02d2be1536ad75eef39a0f22a9699db5d03b8ee050",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "com-code-quality": {
     "source": "content/features/code-quality.md",
     "hash": "ce16ac87eb92e33a08d8c2f06e86ef22e436966f47f3a28c3f4eba19060b550a",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "com-configuration": {
     "source": "content/features/configuration.md",
     "hash": "8add90392883a46899ef8b57d135b625d92c5b61231d8a5301727f8b42f8e46f",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "com-deep-review": {
     "source": "content/features/deep-review.md",
     "hash": "6a4fffc907302b4847d96097189bd8d329d3f1548d1ee46d9232f6ceecdfb450",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "com-doc-gen": {
     "source": "content/features/doc-gen.md",
     "hash": "26e02a71a523775f5bb9e371b2e563c3c858386436a73b727422f62f57de0282",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "com-elicitation-forms": {
     "source": "content/features/elicitation-forms.md",
-    "hash": "d62f3ddd16ae031e875c042d0795449de6965fecfe2caa36edddb9a5fbf1a6fd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "b7e73232af03174e0e5d50d551277a784127eb8047713cacfce1df8b19e8a8d6",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "com-fix-test": {
     "source": "content/features/fix-test.md",
     "hash": "da54b69787cc1af5c087b2d8674442afe9b8c6fc88dca37a65e99590bb84fee0",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "com-help-system": {
     "source": "content/features/help-system.md",
     "hash": "24468c8fe4f1a0e350e620098d65a3bcc007000cd5aa4dbe20a6e6c83efa87b3",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "com-hooks": {
     "source": "content/features/hooks.md",
     "hash": "5c6b8a45457387c76f628561d3baa56e9af1709bc9bd21bba9830b2c2478c8dd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "com-mcp-server": {
     "source": "content/features/mcp-server.md",
     "hash": "8e4b8c74eff980330480ae70856a1cf0393559cd22eb9ba0210b43249f9b5181",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "com-memory": {
     "source": "content/features/memory.md",
     "hash": "32b3121d9110dc9ac327bb9e838f060fbe9940a033366b0147ef34ef2efaa4dc",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "com-models": {
     "source": "content/features/models.md",
     "hash": "2117cbb0d8e863db6091870874e4ce80b48780c9ee8bb7330d8033c172ccb02b",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "com-ops-dashboard": {
     "source": "content/features/ops-dashboard.md",
     "hash": "fefc8e2b2b4a25055fcbdf96cbd8638d75278cbcacd256873b725df89544c1f6",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "com-orchestration": {
     "source": "content/features/orchestration.md",
     "hash": "4998437e04355011a7dee68dbce7e9e78bbe97f637e0b6a14c1ec972f541695c",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "com-plugin": {
     "source": "content/features/plugin.md",
     "hash": "8cc6e5702ffc8228ed63cfb74a25dd3e99e79e5335c4b1c8c134950f8b9a043d",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "com-rag-grounding": {
     "source": "content/features/rag-grounding.md",
     "hash": "3464dd78c83f06980912a7c49dc185b09830be1b1c163203f10e5aa1708fcf4e",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "com-refactor-plan": {
     "source": "content/features/refactor-plan.md",
     "hash": "8f8c684cd94fca7b2580ecaaf955ccb79924022796d576d477cdab9330df9704",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "com-release-notes": {
     "source": "content/features/release-notes.md",
     "hash": "da7101ffbec4d209fcb1cef754f01cef8a13458a6f961c3a23909edfec77e58c",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "com-release-prep": {
     "source": "content/features/release-prep.md",
     "hash": "cd77b5903fbeb7d7e0acef570bab9727b4c143181ea6be1f52b9a25bc11418bb",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "com-resilience": {
     "source": "content/features/resilience.md",
     "hash": "ae2a76f0f1ecbb9ca687e5a041acc2b4a25a5113ec57eaad550f48b8aadc4be2",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "com-security-audit": {
     "source": "content/features/security-audit.md",
     "hash": "9cce18573c827fab9a380efe8c65c2f8c5b4ada3f7e383dd71ec523a0875fb05",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "com-smart-test": {
     "source": "content/features/smart-test.md",
     "hash": "58c691c8313ddf9699deb913e6b5c50fafc684563539ddf4816a4b94a9ea3e80",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "com-spec-engine": {
     "source": "content/features/spec-engine.md",
     "hash": "c8549016aa848eeeaecbde8329f5850562f56280ab66428cb7c20887b428d81a",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "com-telemetry": {
     "source": "content/features/telemetry.md",
     "hash": "59473ab809113116a3d58d2ead3a5f13e362d6992d8cee0a89364feded5cbd50",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "com-wizards": {
     "source": "content/features/wizards.md",
     "hash": "6fe7722a026d11276ebfbdf4ea046a05112be94b560f9abf3ffee410f8637d8f",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "com-workflow-vs-wizard": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "con-agents": {
     "source": "content/features/agents.md",
     "hash": "a5b1678ecf012c7b2877a6c7ecae4a6c3f14c084c13fbcbb7eee79119dce6fa3",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "con-audience-adaptation": {
     "source": "src/attune/help/transformers.py",
     "hash": "00861e98056d93ab47c8ca43e64c941c802a1876da7faaad2ed0f825d698938c",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "con-bug-predict": {
     "source": "content/features/bug-predict.md",
     "hash": "6a4f420eba38e2fb884b837dd9758acb60ba60cdaf9248ec4280120b0d382b16",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "con-cli": {
     "source": "content/features/cli.md",
     "hash": "a37b4dc4f0b3706a62184b02d2be1536ad75eef39a0f22a9699db5d03b8ee050",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "con-code-quality": {
     "source": "content/features/code-quality.md",
     "hash": "ce16ac87eb92e33a08d8c2f06e86ef22e436966f47f3a28c3f4eba19060b550a",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "con-configuration": {
     "source": "content/features/configuration.md",
     "hash": "8add90392883a46899ef8b57d135b625d92c5b61231d8a5301727f8b42f8e46f",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "con-cross-linking": {
     "source": "scripts/build_cross_links.py",
     "hash": "f271a7146802a35388670a2541ab016e3358a78bf5aa876f30f9af1d4d4344b0",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "con-deep-review": {
     "source": "content/features/deep-review.md",
     "hash": "6a4fffc907302b4847d96097189bd8d329d3f1548d1ee46d9232f6ceecdfb450",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "con-doc-gen": {
     "source": "content/features/doc-gen.md",
     "hash": "26e02a71a523775f5bb9e371b2e563c3c858386436a73b727422f62f57de0282",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "con-elicitation-forms": {
     "source": "content/features/elicitation-forms.md",
-    "hash": "d62f3ddd16ae031e875c042d0795449de6965fecfe2caa36edddb9a5fbf1a6fd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "b7e73232af03174e0e5d50d551277a784127eb8047713cacfce1df8b19e8a8d6",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "con-feedback-loop": {
     "source": "src/attune/help/engine.py",
     "hash": "cefbd9ea62f941969da6b381754835e6994bcbece1867d76998f7199ef39265a",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "con-fix-test": {
     "source": "content/features/fix-test.md",
     "hash": "da54b69787cc1af5c087b2d8674442afe9b8c6fc88dca37a65e99590bb84fee0",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "con-help-system": {
     "source": "content/features/help-system.md",
     "hash": "24468c8fe4f1a0e350e620098d65a3bcc007000cd5aa4dbe20a6e6c83efa87b3",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "con-hooks": {
     "source": "content/features/hooks.md",
     "hash": "5c6b8a45457387c76f628561d3baa56e9af1709bc9bd21bba9830b2c2478c8dd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "con-mcp-server": {
     "source": "content/features/mcp-server.md",
     "hash": "8e4b8c74eff980330480ae70856a1cf0393559cd22eb9ba0210b43249f9b5181",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "con-memory": {
     "source": "content/features/memory.md",
     "hash": "32b3121d9110dc9ac327bb9e838f060fbe9940a033366b0147ef34ef2efaa4dc",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "con-models": {
     "source": "content/features/models.md",
     "hash": "2117cbb0d8e863db6091870874e4ce80b48780c9ee8bb7330d8033c172ccb02b",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "con-ops-dashboard": {
     "source": "content/features/ops-dashboard.md",
     "hash": "fefc8e2b2b4a25055fcbdf96cbd8638d75278cbcacd256873b725df89544c1f6",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "con-orchestration": {
     "source": "content/features/orchestration.md",
     "hash": "4998437e04355011a7dee68dbce7e9e78bbe97f637e0b6a14c1ec972f541695c",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "con-plugin": {
     "source": "content/features/plugin.md",
     "hash": "8cc6e5702ffc8228ed63cfb74a25dd3e99e79e5335c4b1c8c134950f8b9a043d",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "con-progressive-depth": {
     "source": "src/attune/help/engine.py",
     "hash": "cefbd9ea62f941969da6b381754835e6994bcbece1867d76998f7199ef39265a",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "con-rag-grounding": {
     "source": "content/features/rag-grounding.md",
     "hash": "3464dd78c83f06980912a7c49dc185b09830be1b1c163203f10e5aa1708fcf4e",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "con-refactor-plan": {
     "source": "content/features/refactor-plan.md",
     "hash": "8f8c684cd94fca7b2580ecaaf955ccb79924022796d576d477cdab9330df9704",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "con-release-notes": {
     "source": "content/features/release-notes.md",
     "hash": "da7101ffbec4d209fcb1cef754f01cef8a13458a6f961c3a23909edfec77e58c",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "con-release-prep": {
     "source": "content/features/release-prep.md",
     "hash": "cd77b5903fbeb7d7e0acef570bab9727b4c143181ea6be1f52b9a25bc11418bb",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "con-resilience": {
     "source": "content/features/resilience.md",
     "hash": "ae2a76f0f1ecbb9ca687e5a041acc2b4a25a5113ec57eaad550f48b8aadc4be2",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "con-security-audit": {
     "source": "content/features/security-audit.md",
     "hash": "9cce18573c827fab9a380efe8c65c2f8c5b4ada3f7e383dd71ec523a0875fb05",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "con-smart-test": {
     "source": "content/features/smart-test.md",
     "hash": "58c691c8313ddf9699deb913e6b5c50fafc684563539ddf4816a4b94a9ea3e80",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "con-socratic-discovery": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "con-spec-engine": {
     "source": "content/features/spec-engine.md",
     "hash": "c8549016aa848eeeaecbde8329f5850562f56280ab66428cb7c20887b428d81a",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "con-sync-paradigm": {
     "source": "scripts/generate_all.py",
     "hash": "6a3e4428fe0b789f45a226f983116d18827b19b6a12162691c522fd4861862a3",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "con-telemetry": {
     "source": "content/features/telemetry.md",
     "hash": "59473ab809113116a3d58d2ead3a5f13e362d6992d8cee0a89364feded5cbd50",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "con-template-composition": {
     "source": "src/attune/help/engine.py",
     "hash": "cefbd9ea62f941969da6b381754835e6994bcbece1867d76998f7199ef39265a",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "con-tier-routing": {
     "source": "src/attune/workflows/base.py",
-    "hash": "a2db47ce258a23dd10e151388cc8c16b9389d9f005bc5bf6e21f97e03b8d9af5",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "8651c3e2645e5ec764718119ed55284d1dc4853fa9903663925e2a0c42ff60de",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "con-tool-attune-hub": {
     "source": "plugin/skills/attune-hub/SKILL.md",
-    "hash": "6d8cb8733a4dfb798f05814226de09d60af8b45d66df5755789f380d6f234f03",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "3e8cb98c4cdae752aad8e8ddda10f55629da0906b85b407e757ff8fd9981efac",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "con-tool-bug-predict": {
     "source": "plugin/skills/bug-predict/SKILL.md",
     "hash": "992b9e6cd3452af0d31213985e5e5c607f078edd2310df76d786b95d7e6a83ce",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "con-tool-coach": {
     "source": "plugin/skills/coach/SKILL.md",
     "hash": "a1842d674325f3f1ea289e3bd7ed1dcfbb4b3301160181edab081d2b4352aeac",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "con-tool-code-quality": {
     "source": "plugin/skills/code-quality/SKILL.md",
     "hash": "769c4c885992fd1937adbdf5d97305894bd08c159c83930d7a9fb86cb4ae78b7",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "con-tool-doc-gen": {
     "source": "plugin/skills/doc-gen/SKILL.md",
     "hash": "da9a9c23727eaa9433b2c4d1dfe87d850ef560d56b855f2eb7bd0f279efc3c72",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "con-tool-fix-test": {
     "source": "plugin/skills/fix-test/SKILL.md",
     "hash": "665ff7c4978beddd72e87f3764b073e4f962b27a896bd66542d499a1a00429da",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "con-tool-memory-and-context": {
     "source": "plugin/skills/memory-and-context/SKILL.md",
-    "hash": "f1a465f47af5948c4e37d4c6a75247d71223a6d5208063be318e65e1ec475e44",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "d026a40d0c5315123672c7ed3770b643ba803a3b5d57cb994c236fcd6baa8305",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "con-tool-planning": {
     "source": "plugin/skills/planning/SKILL.md",
     "hash": "f56a42c83f514b300b4f89ea6669820ec158da952efa2894c56abb00c39eb58a",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "con-tool-rag-code-gen": {
     "source": "plugin/skills/rag-code-gen/SKILL.md",
-    "hash": "da6cb96d8150291fa8c587e756247f14fe166083add938f210747ab867a26c5e",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "0d84a32e2f89e8debd740b4343c7930b17efcca37fcb68737f342f8b6b5f6f77",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "con-tool-refactor-plan": {
     "source": "plugin/skills/refactor-plan/SKILL.md",
     "hash": "080a84b5df5dde88cd3c994ca2c2b68ec12e2cf241f2e81893f21aa9dac315f6",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "con-tool-release-prep": {
     "source": "plugin/skills/release-prep/SKILL.md",
     "hash": "8aab944ae2f53a24c94d39329bf000067a68f43b51de6657b517678bec90c67a",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "con-tool-security-audit": {
     "source": "plugin/skills/security-audit/SKILL.md",
     "hash": "f370003a809c342d35b37990da231fbb72545e75e5a37e1e1d39a27db5364761",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "con-tool-smart-test": {
     "source": "plugin/skills/smart-test/SKILL.md",
     "hash": "a5e874d1054dd123d78d9d8e9014c7c6888230f36685a203ea26176a3d649ffb",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "con-tool-spec": {
     "source": "plugin/skills/spec/SKILL.md",
-    "hash": "26f2335775e968f4625078ee9fabd15a0ad04dc0980bc37def777d5908fa2e50",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "4e1ce2c9da6fcad85ebcf7cb6b755f44c27d00608ad97b72b93a82a45e3c0186",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "con-tool-workflow-orchestration": {
     "source": "plugin/skills/workflow-orchestration/SKILL.md",
     "hash": "831c00dfb29ae4c72b35921fd3bab9e9f17affabf32b8164deb801557e031127",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "con-wizards": {
     "source": "content/features/wizards.md",
     "hash": "6fe7722a026d11276ebfbdf4ea046a05112be94b560f9abf3ffee410f8637d8f",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "con-workflow-chain-prediction": {
     "source": "src/attune/workflows/suggestions.py",
     "hash": "caa3f48a039def99a5bf58dc29129aba9548dfc74a42cc69dfb067aeb71f3200",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-adding-a-plugin-skill-has-three-enforcement-gates-not-one": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-adding-a-workspace-sibling-package-as-an-extra-can-silently": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-adding-dns-resolution-to-validate-webhook-url-breaks-tests-that": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-adding-logger-before-eager-imports-triggers-e402-in-init-py": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-after-a-pr-merges-while-youre-afk-pull-main-before-tagging": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-after-a-squash-merge-of-a-feature-branch-local-main-can-have": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-agents": {
     "source": "content/features/agents.md",
     "hash": "a5b1678ecf012c7b2877a6c7ecae4a6c3f14c084c13fbcbb7eee79119dce6fa3",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-agents-skills-must-stay-synced-with-plugin-skills": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-anchor-tag-buttons-need-text-white-no-underline": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-anthropics-built-in-prompt-caching-supersedes-custom-caching": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-any-unstaged-file-triggers-pre-commit-stash-conflicts-with-auto": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-apply-lessons-by-problem-not-by-keyword": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-attune-author-check-staleness-load-manifest-is-the-python-api": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-attune-help-re-exports-create-a-hidden-cross-package-dep-on": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-attune-helps-sidecar-schemas-dont-match-path-keyed-assumptions": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-attune-skill-names-must-not-collide-with-claude-code-built-in": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-attune-workflow-run-code-review-and-security-audit-require-a": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-b904-raise-x-from-e-is-not-auto-fixable-by-ruff": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-background-processes-from-previous-sessions-persist-across": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-bandit-b108-blocks-hardcoded-tmp-paths": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-bare-manifest-in-gitignore-silently-excludes-any-manifest": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-baseworkflow-now-provides-self-logger": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-baseworkflow-uses-class-attributes-not-constructor-params": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-bg-var-primary-bg-opacity-10-is-invisible-in-dark-mode": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-broad-gitignore-patterns-match-nested-directories": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-bug-predict": {
     "source": "content/features/bug-predict.md",
     "hash": "6a4f420eba38e2fb884b837dd9758acb60ba60cdaf9248ec4280120b0d382b16",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-bug-predict-dangerous-eval-flags-subprocess-exec": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-bugpredictionworkflow-not-bugpredictworkflow": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-changing-error-messages-breaks-tests-across-the-codebase": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-changing-the-citation-anchor-format-can-silently-regress-llm": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-changing-user-facing-output-strings-cascades-through-test": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-chicken-and-egg-for-optional-extras-in-dev": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-ci-timeout-tests-enforce-the-range-you-set": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-citation-forced-prompting-and-prompt-injection-resistance-are": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-claude-agent-sdk-is-now-a-core-dependency-of-attune-ai": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-claude-agent-sdk-systempromptpreset-as-of-0-1-63-is-claude-code": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-claude-code-plugin-is-platform-specific": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-claude-code-plugins-expect-plugin-json-inside-claude-plugin": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-claude-plugin-install-is-marketplace-only": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-cli": {
     "source": "content/features/cli.md",
     "hash": "a37b4dc4f0b3706a62184b02d2be1536ad75eef39a0f22a9699db5d03b8ee050",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-clusterfuzz-dockerfile-copies-to-src-repo-but-also-copies": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-clusterfuzzlite-no-deps-misses-transitive-imports": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-coach-is-the-user-facing-entry-point-for-the-help-system": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-code-quality": {
     "source": "content/features/code-quality.md",
     "hash": "ce16ac87eb92e33a08d8c2f06e86ef22e436966f47f3a28c3f4eba19060b550a",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-codecov-patch-0-usually-means-tests-skipped-not-failed": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-codeql-alerts-dismissible-in-bulk-via-gh-api": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-codeql-js-stored-xss-flags-jsx-even-though-react-auto-escapes": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-codeql-py-clear-text-logging-sensitive-data-traces-data-flow": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-combine-two-unreleased-changelog-drafts-into-one-version-when": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-commands-are-not-namespaced-in-plugins-skills-are": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-config-py-alongside-config-creates-a-mypy-duplicate-module": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-configuration": {
     "source": "content/features/configuration.md",
     "hash": "8add90392883a46899ef8b57d135b625d92c5b61231d8a5301727f8b42f8e46f",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-costreport-fields-are-named-not-positional": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-costreport-is-a-dataclass-not-a-dict": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-custom-mcp-stdio-loop-fails-claude-code-handshake": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-dataclassorder-true-needs-compare-false-on-list-fields": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-datetime-utcnow-datetime-nowtimezone-utc-cascades-through-the": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-dead-code-modules-with-full-test-suites-look-alive": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-dead-tests-from-monorepo-extraction-accumulate-in-packages-with": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-deep-review": {
     "source": "content/features/deep-review.md",
     "hash": "6a4fffc907302b4847d96097189bd8d329d3f1548d1ee46d9232f6ceecdfb450",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-deep-review-false-positives-verify-before-acting": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-delete-deprecated-module-is-rarely-a-simple-delete-grep-src-and": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-dependency-lower-bounds-trigger-scorecard-vulnerability-alerts": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-detect-secrets-flags-fake-as-a-secret-in-test-fixtures": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-direct-pushes-to-main-are-blocked-by-the-presence-of-required": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-dispatch-tables-hold-direct-function-references-mocks-must": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-dist-can-contain-stale-artifacts-after-version-bumps": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-doc-gen": {
     "source": "content/features/doc-gen.md",
     "hash": "26e02a71a523775f5bb9e371b2e563c3c858386436a73b727422f62f57de0282",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-dont-append-z-to-timezone-aware-isoformat": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-dry-run-candidate-golden-queries-through-the-resolver-before": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-duck-typed-test-fakes-fail-isinstance-based-collectors-silently": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-duplicate-plugins-cause-conflicting-skill-triggers": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-elicitation-forms": {
     "source": "content/features/elicitation-forms.md",
-    "hash": "d62f3ddd16ae031e875c042d0795449de6965fecfe2caa36edddb9a5fbf1a6fd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "b7e73232af03174e0e5d50d551277a784127eb8047713cacfce1df8b19e8a8d6",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-enforce-admins-false-defeats-code-review-scorecard-check": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-enforce-admins-required-reviews-blocks-solo-dev-merges": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-exclude-hard-queries-from-aggregate-p-1-metrics-in-benchmark": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-exploration-agents-fabricate-names-verify-against-source": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-f841-unused-fixture-lint-fires-when-a-test-is-refactored-to": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-fastembed-is-the-local-embeddings-path-that-passes-a-50mb": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-fix-test": {
     "source": "content/features/fix-test.md",
     "hash": "da54b69787cc1af5c087b2d8674442afe9b8c6fc88dca37a65e99590bb84fee0",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-forced-anthropic-tool-use-is-the-cleanest-path-to-guaranteed": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-forced-cite-per-claim-prompting-is-the-structural-lever-for-rag": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-formatter-strips-imports-that-are-unused-at-the-moment-you-save": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-full-coverage-runs-on-15k-test-suites-timeout-easily": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-generated-content-with-trailing-whitespace-causes-perpetual-pre": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-getattrmodule-name-none-at-call-site-is-the-clean-degradation": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-gh-api-x-patch-f-name-n-rejects-integers-as-strings": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-gh-pr-checks-json-field-names": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-gh-pr-merge-admin-is-blocked-by-in-progress-required-checks": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-gh-pr-merge-admin-prints-a-fast-forward-warning-even-when-the": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-gh-repo-create-source-path-push-is-a-one-shot-for-new-sibling": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-gh-workflow-run-file-yml-ref-tag-re-triggers-a-release-gated": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-ghost-command-references-survive-cli-renames": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-git-commit-q-can-exit-0-with-pre-commit-hook-feedback-that": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-git-pull-refuses-with-unstaged-changes-when-pull-rebase-true": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-git-rebase-root-exec-git-commit-amend-no-edit-s-re-signs-every": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-git-stash-pop-after-pre-commit-can-resurrect-stale-tool-state": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-github-actions-environment-deployment-approvals-can-be-self": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-github-copilot-autofix-pushes-commits-directly-to-pr-branches": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-github-protected-tags-cannot-be-force-updated": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-github-repos-serve-as-claude-code-marketplaces": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-gitignore-exclusions-break-ci-tests-that-read-those-files": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-glob-based-hash-computation-must-exclude-cache-dirs": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-golden-query-benchmarks-reveal-two-distinct-failure-classes": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-golden-query-test-fixtures-must-match-the-actual-corpus-layout": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-gpg-signing-fails-in-non-interactive-terminals-vscode-extension": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-hand-crafted-summary-prototype-is-the-fastest-way-to-measure-a": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-handoff-memory-option-b-proposals-are-often-wrong-re-analyze": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-hardcoded-root-paths-in-tests": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-hardcoded-strings-in-method-bodies-survive-class-attribute": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-hardcoded-user-id-defeats-ownership-checks": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-help-system": {
     "source": "content/features/help-system.md",
     "hash": "24468c8fe4f1a0e350e620098d65a3bcc007000cd5aa4dbe20a6e6c83efa87b3",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-hooks": {
     "source": "content/features/hooks.md",
     "hash": "5c6b8a45457387c76f628561d3baa56e9af1709bc9bd21bba9830b2c2478c8dd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-hot-reload-subsystem-was-1-038-lines-of-dead-code": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-import-x-inside-a-try-block-except-x-someerror-in-the-except": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-importlib-import-module-is-an-arbitrary-code-execution-vector": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-industry-terminology-wont-appear-in-llm-polished-rag-summaries": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-integration-tests-gated-by-has-api-key-can-poison-the-whole-ci": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-is-private-is-a-superset-in-python-ipaddress": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-kwargs-collides-with-explicit-params-of-the-same-name": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-lazy-imports-inside-function-bodies-cant-be-patched-with": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-linkedin-paste-use-ascii-markers-not-unicode-arrows": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-list-wizards-is-a-function-not-a-class-method": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-list-workflows-deduplication-must-keep-base-names-visible": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-llm-api-responses-lack-trailing-newlines": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-local-telemetry-trackers-need-an-autouse-conftest-fixture": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-macos-var-private-var-symlink-breaks-path-assertions": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-mcp-attune-ai-doc-orchestrator-is-a-no-op-stub": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-mcp-call-tool-wrapper-pattern": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-mcp-handler-validate-paths-before-importing-workflows": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-mcp-json-python-resolves-to-pyenv-shim-not-project-venv": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-mcp-server": {
     "source": "content/features/mcp-server.md",
     "hash": "8e4b8c74eff980330480ae70856a1cf0393559cd22eb9ba0210b43249f9b5181",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-mcp-server-process-doesnt-inherit-env-variables": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-mcp-tool-count-tests-are-hardcoded": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-mcp-tool-renames-propagate-to-skill-docs": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-mcp-workspace-root-defaults-to-os-getcwd-tests-with-tmp-path": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-memory": {
     "source": "content/features/memory.md",
     "hash": "32b3121d9110dc9ac327bb9e838f060fbe9940a033366b0147ef34ef2efaa4dc",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-metadata-can-reach-a-retriever-with-zero-signal-if-the-sidecar": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-metapathfinder-find-module-load-module-is-dead-in-python-3-12": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-mixin-classes-inherit-self-workspace-root-at-runtime-not-at": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-mkdocs-build-crashing-with-attributeerror-nonetype-object-has": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-mkdocs-strict-treats-broken-links-as-fatal-errors": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-mock-a-lazy-import-x-with-types-moduletype-patch-dictsys-modules": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-models": {
     "source": "content/features/models.md",
     "hash": "2117cbb0d8e863db6091870874e4ce80b48780c9ee8bb7330d8033c172ccb02b",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-modeltier-has-two-copies-imports-must-match": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-module-level-optional-imports-enable-clean-test-patching": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-multiple-pinentry-program-lines-in-gpg-agent-conf-first-wins": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-mutual-competition-between-polished-rag-features-is-real-and": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-mypy-437-errors-was-stale-actual-count-was-2": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-naive-suffix-strip-stemming-fails-on-english-doubling-consonant": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-never-paste-pypi-tokens-into-chat-or-logs": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-new-dataclass-fields-need-both-the-class-and-the-parser-updated": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-new-mcp-handlers-must-match-the-validation-pattern-of-adjacent": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-new-security-features-need-dedicated-tests-before-release": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-next-js-shared-data-libs-prevent-page-duplication": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-non-baseworkflow-classes-in-workflow-registry-crash-the-cli": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-noqa-f401-re-exports-break-silently-on-satellite-file-deletion": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-openssf-scorecard-alerts-2-codereviewid-3-sastid-are-process": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-ops-dashboard": {
     "source": "content/features/ops-dashboard.md",
     "hash": "fefc8e2b2b4a25055fcbdf96cbd8638d75278cbcacd256873b725df89544c1f6",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-orchestration": {
     "source": "content/features/orchestration.md",
     "hash": "4998437e04355011a7dee68dbce7e9e78bbe97f637e0b6a14c1ec972f541695c",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-orphan-help-dirs-are-deprecated-3-depth-output-adding-them-to": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-orphan-top-level-docs-directories-stay-invisible-to-readers": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-packages-attune-in-attune-ai-are-pointer-stubs-not-source": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-past-due-deprecations-are-deletion-targets-not-implementation": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-patch-requires-the-target-name-to-exist-at-module-scope-at": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-patch-the-source-module-for-from-x-import-y-in-function-bodies": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-path-cwd-at-module-level-captures-import-time-cwd": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-path-globdir-matches-directories-not-files": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-path-rename-fails-on-windows-when-target-exists": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-pip-audit-fails-on-unpublished-versions": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-platform-conditional-security-test-assertions-should-accept-any": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-plugin": {
     "source": "content/features/plugin.md",
     "hash": "8cc6e5702ffc8228ed63cfb74a25dd3e99e79e5335c4b1c8c134950f8b9a043d",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-plugin-read-skill-references-break-outside-the-plugin": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-pr-test-workflows-may-not-auto-trigger-after-close-reopen-or": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-pre-commit-auto-fix-requires-re-stage-before-retry": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-pre-commit-black-unstaged-files-re-stage-after-failure": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-pre-commit-stash-conflict-when-black-ruff-fix-files-with": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-pre-commit-stash-conflict-with-auto-fix-hooks": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-pre-commit-stash-conflicts-when-any-tracked-unstaged-file": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-pre-committed-decision-matrices-survive-contact-with-data": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-pre-flight-pre-commits-pinned-black-ruff-on-new-files-before": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-prefer-github-actions-trusted-publishing-over-local-twine-uv": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-prompt-template-word-wrap-silently-breaks-single-line-substring": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-provenance-citation-records-usually-store-short-previews-not": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-pull-main-before-merging-develop-to-avoid-merge-commits": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-pureposixpath-match-doesnt-support-in-python-3-10": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-pureposixpath-strips-trailing-slashes": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-push-specific-tags-not-tags": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-pypi-env-policies-may-whitelist-branches-only-tag-triggered": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-pypi-environment-requires-manual-approval-in-github-actions": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-pypi-renders-readme-links-relative-to-its-own-domain": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-pypi-trusted-publisher-workflow-name-field-wants-the-filename": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-pytest-importorskip-triggers-ruff-e402": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-pytest-lives-in-the-dev-extra-not-developer": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-query-fixtures-are-self-diagnostic-for-rag-corpora-even-without": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-rag-grounding": {
     "source": "content/features/rag-grounding.md",
     "hash": "3464dd78c83f06980912a7c49dc185b09830be1b1c163203f10e5aa1708fcf4e",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-re-adding-an-import-after-the-formatter-strips-it-use-function": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-re-enabling-required-reviews-kills-queued-auto-merge": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-re-export-accessibility-tests-are-scattered-across-batch-files": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-read-source-before-writing-tests-for-tricky-logic": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-real-project-files-on-disk-override-test-mocks": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-rebuild-dist-after-readme-changes": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-reclassify-unexpectedly-hard-golden-queries-up-the-difficulty": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-redisshorttermmemory-mock-injection-path": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-refactor-plan": {
     "source": "content/features/refactor-plan.md",
     "hash": "8f8c684cd94fca7b2580ecaaf955ccb79924022796d576d477cdab9330df9704",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-registry-count-assertions-are-scattered-across-test-files": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-release-branches-carry-unmerged-commits-that-feature-branches": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-release-notes": {
     "source": "content/features/release-notes.md",
     "hash": "da7101ffbec4d209fcb1cef754f01cef8a13458a6f961c3a23909edfec77e58c",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-release-prep": {
     "source": "content/features/release-prep.md",
     "hash": "cd77b5903fbeb7d7e0acef570bab9727b4c143181ea6be1f52b9a25bc11418bb",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-release-published-workflow-dispatch-both-approved-for-pypi-env": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-removing-one-workspace-dep-can-cascade-to-remove-others": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-replacing-a-mixin-based-class-scatters-test-failures-across": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-repo-merge-policy-may-restrict-merge-strategies": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-repo-root-parents-count-varies-by-file-depth": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-required-status-check-names-must-match-githubs-exact-check-names": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-research-subagents-can-hallucinate-sdk-signatures-introspect": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-resilience": {
     "source": "content/features/resilience.md",
     "hash": "ae2a76f0f1ecbb9ca687e5a041acc2b4a25a5113ec57eaad550f48b8aadc4be2",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-resultmessage-result-is-often-none-capture-assistantmessage": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-rich-live-is-output-only-use-textual-for-any-interactive-row": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-ruff-auto-fix-strips-imports-before-usage-code-exists": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-ruff-parses-pytest-ini-as-python": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-run-simplify-catches-per-file-errors-internally": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-sbin-is-a-symlink-to-usr-sbin-on-modern-ubuntu": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-scorecards-pip-parser-ignores-hash-flags-entirely": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-sdk-adapter-swallows-subagent-findings-lesson-was-wrong-adapter": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-sdk-agent-model-config-uses-stale-model-names": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-sdk-native-security-audit-workflow-swallows-subagent-findings": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-sdk-native-workflows-validate-in-execute-not-input-schema": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-security-audit": {
     "source": "content/features/security-audit.md",
     "hash": "9cce18573c827fab9a380efe8c65c2f8c5b4ada3f7e383dd71ec523a0875fb05",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-selective-hook-skip-with-skip-hookname-is-not-the-same-as-no": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-semantic-cache-70-hit-rate-claim-was-unmeasured": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-session-hooks-may-be-vestigial": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-shadow-directories-at-repo-root-break-imports": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-silent-pass-blocks-in-discovery-registry-code-hide-import": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-skill-descriptions-must-be-under-250-characters": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-skill-frontmatter-allowlist-march-2026": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-skill-frontmatter-has-a-strict-allowlist": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-smart-test": {
     "source": "content/features/smart-test.md",
     "hash": "58c691c8313ddf9699deb913e6b5c50fafc684563539ddf4816a4b94a9ea3e80",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-spec-engine": {
     "source": "content/features/spec-engine.md",
     "hash": "c8549016aa848eeeaecbde8329f5850562f56280ab66428cb7c20887b428d81a",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-squash-merge-deletes-the-remote-branch-subsequent-push-silently": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-ssrf-always-decode-urls-before-validating-hostnames": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-ssrf-in-webhook-handlers-is-easy-to-miss": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-ssrf-strip-ipv6-zone-ids-before-ip-validation": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-stacked-patch-decorators-inject-args-bottom-up": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-staleness-detection-in-attune-author-attune-ais-help-system-is": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-stop-hook-ordering-matters": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-stop-hooks-inject-stderr-not-stdout": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-stop-hooks-loop-without-a-sentinel": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-stop-hooks-missing-cd-prefix-inherit-session-cwd": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-structlog-default-output-pollutes-stdout-captured-cli-tests": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-structlog-kwargs-vs-stdlib-logger": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-tags-pushed-before-squash-merge-point-to-the-wrong-commit": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-telemetry": {
     "source": "content/features/telemetry.md",
     "hash": "59473ab809113116a3d58d2ead3a5f13e362d6992d8cee0a89364feded5cbd50",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-template-generators-overwrite-hand-written-files": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-test-mocks-must-match-imports": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-tests-for-optional-dep-code-need-pytest-importorskip-guards-in": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-text-white-on-gradient-primary-sections-gets-overridden": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-todo-counts-are-inflated-by-docstrings-and-prompt-strings": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-twine-cannot-prompt-for-tokens-in-claude-codes-non-interactive": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-two-codeql-setups-can-coexist-in-one-repo-and-deadlock-merges": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-two-parallel-help-template-generators-in-the-attune-ecosystem": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-uncommitted-claude-mcp-json-means-mcp-server-never-starts": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-untracked-scripts-break-ci-when-tests-import-them": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-unused-init-py-re-exports-become-invisible-runtime-deps": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-use-dataclass-post-init-to-coalesce-between-a-scalar-legacy": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-uv-lock-can-drift-from-pyproject-toml-on-shared-branches": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-uv-lock-may-briefly-fail-to-find-a-just-published-pypi-version": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-uv-lock-retains-editable-name-paths-after-tool-uv-sources-edits": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-uv-pip-install-e-does-not-regenerate-project-scripts-console": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-uv-pip-install-e-path-can-ship-stale-package-data-even-after": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-uv-pip-install-e-sibling-path-no-deps-is-the-clean-venv-local": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-uv-run-in-pre-commit-hooks-propagates-lockfile-errors-as-hook": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-uv-run-pip-audit-runs-the-pyenv-shim-not-the-venv": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-uv-sync-respects-existing-lockfile-pins-when-they-still-satisfy": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-uv-sync-wipes-packages-installed-via-pip-install": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-validate-file-path-needed-on-reads-too-not-just-writes": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-validate-infrastructure-against-user-value-before-extending": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-verify-mcp-tool-wiring-after-adding-new-tools": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-verify-new-dispatch-branches-with-a-known-fixture-not-just": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-verify-optional-dep-boundaries-with-a-metapathfinder-not-by": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-version-bumps-must-update-7-files-not-just-pyproject-toml": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-vs-code-extension-reads-mcp-json-at-project-root-not-claude-mcp": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-website-feature-lists-can-diverge-from-the-python-registry": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-windows-ci-encoding": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-windows-ci-runners-are-3x-slower-than-ubuntu-macos": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-windows-path-resolve-prepends-the-drive-letter-to-unix-paths": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-windows-time-time-can-return-0-0-duration-for-fast-operations": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-wizards": {
     "source": "content/features/wizards.md",
     "hash": "6fe7722a026d11276ebfbdf4ea046a05112be94b560f9abf3ffee410f8637d8f",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-wizards-call-workflows-internally-they-are-not-duplicates": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-workflowresult-constructor-mismatches-surface-only-at-runtime": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-yaml-run-block-scalars-break-on-blank-lines-inside-multi-line": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-yaml-run-values-with-colons-cause-parse-errors": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "err-zsh-has-status-as-a-read-only-builtin-variable": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-adding-a-plugin-skill-has-three-enforcement-gates-not-one": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-adding-a-workspace-sibling-package-as-an-extra-can-silently": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-adding-dns-resolution-to-validate-webhook-url-breaks-tests-that": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-adding-logger-before-eager-imports-triggers-e402-in-init-py": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-after-a-pr-merges-while-youre-afk-pull-main-before-tagging": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-after-a-squash-merge-of-a-feature-branch-local-main-can-have": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-agents": {
     "source": "content/features/agents.md",
     "hash": "a5b1678ecf012c7b2877a6c7ecae4a6c3f14c084c13fbcbb7eee79119dce6fa3",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-agents-skills-must-stay-synced-with-plugin-skills": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-anchor-tag-buttons-need-text-white-no-underline": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-anthropics-built-in-prompt-caching-supersedes-custom-caching": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-any-unstaged-file-triggers-pre-commit-stash-conflicts-with-auto": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-apply-lessons-by-problem-not-by-keyword": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-attune-author-check-staleness-load-manifest-is-the-python-api": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-attune-help-re-exports-create-a-hidden-cross-package-dep-on": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-attune-helps-sidecar-schemas-dont-match-path-keyed-assumptions": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-attune-skill-names-must-not-collide-with-claude-code-built-in": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-attune-workflow-run-code-review-and-security-audit-require-a": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-b904-raise-x-from-e-is-not-auto-fixable-by-ruff": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-background-processes-from-previous-sessions-persist-across": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-bandit-b108-blocks-hardcoded-tmp-paths": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-bare-manifest-in-gitignore-silently-excludes-any-manifest": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-baseworkflow-now-provides-self-logger": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-baseworkflow-uses-class-attributes-not-constructor-params": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-bg-var-primary-bg-opacity-10-is-invisible-in-dark-mode": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-broad-gitignore-patterns-match-nested-directories": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-bug-predict": {
     "source": "content/features/bug-predict.md",
     "hash": "6a4f420eba38e2fb884b837dd9758acb60ba60cdaf9248ec4280120b0d382b16",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-bug-predict-dangerous-eval-flags-subprocess-exec": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-bugpredictionworkflow-not-bugpredictworkflow": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-changing-error-messages-breaks-tests-across-the-codebase": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-changing-the-citation-anchor-format-can-silently-regress-llm": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-changing-user-facing-output-strings-cascades-through-test": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-chicken-and-egg-for-optional-extras-in-dev": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-ci-timeout-tests-enforce-the-range-you-set": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-citation-forced-prompting-and-prompt-injection-resistance-are": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-claude-agent-sdk-is-now-a-core-dependency-of-attune-ai": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-claude-agent-sdk-systempromptpreset-as-of-0-1-63-is-claude-code": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-claude-code-plugin-is-platform-specific": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-claude-code-plugins-expect-plugin-json-inside-claude-plugin": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-claude-plugin-install-is-marketplace-only": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-cli": {
     "source": "content/features/cli.md",
     "hash": "a37b4dc4f0b3706a62184b02d2be1536ad75eef39a0f22a9699db5d03b8ee050",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-clusterfuzz-dockerfile-copies-to-src-repo-but-also-copies": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-clusterfuzzlite-no-deps-misses-transitive-imports": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-coach-is-the-user-facing-entry-point-for-the-help-system": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-code-quality": {
     "source": "content/features/code-quality.md",
     "hash": "ce16ac87eb92e33a08d8c2f06e86ef22e436966f47f3a28c3f4eba19060b550a",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-codecov-patch-0-usually-means-tests-skipped-not-failed": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-codeql-alerts-dismissible-in-bulk-via-gh-api": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-codeql-js-stored-xss-flags-jsx-even-though-react-auto-escapes": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-codeql-py-clear-text-logging-sensitive-data-traces-data-flow": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-combine-two-unreleased-changelog-drafts-into-one-version-when": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-commands-are-not-namespaced-in-plugins-skills-are": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-config-py-alongside-config-creates-a-mypy-duplicate-module": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-configuration": {
     "source": "content/features/configuration.md",
     "hash": "8add90392883a46899ef8b57d135b625d92c5b61231d8a5301727f8b42f8e46f",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-costreport-fields-are-named-not-positional": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-costreport-is-a-dataclass-not-a-dict": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-custom-mcp-stdio-loop-fails-claude-code-handshake": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-dataclassorder-true-needs-compare-false-on-list-fields": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-datetime-utcnow-datetime-nowtimezone-utc-cascades-through-the": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-dead-code-modules-with-full-test-suites-look-alive": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-dead-tests-from-monorepo-extraction-accumulate-in-packages-with": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-deep-review": {
     "source": "content/features/deep-review.md",
     "hash": "6a4fffc907302b4847d96097189bd8d329d3f1548d1ee46d9232f6ceecdfb450",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-deep-review-false-positives-verify-before-acting": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-delete-deprecated-module-is-rarely-a-simple-delete-grep-src-and": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-dependency-lower-bounds-trigger-scorecard-vulnerability-alerts": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-detect-secrets-flags-fake-as-a-secret-in-test-fixtures": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-direct-pushes-to-main-are-blocked-by-the-presence-of-required": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-dispatch-tables-hold-direct-function-references-mocks-must": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-dist-can-contain-stale-artifacts-after-version-bumps": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-doc-gen": {
     "source": "content/features/doc-gen.md",
     "hash": "26e02a71a523775f5bb9e371b2e563c3c858386436a73b727422f62f57de0282",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-dont-append-z-to-timezone-aware-isoformat": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-dry-run-candidate-golden-queries-through-the-resolver-before": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-duck-typed-test-fakes-fail-isinstance-based-collectors-silently": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-duplicate-plugins-cause-conflicting-skill-triggers": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-elicitation-forms": {
     "source": "content/features/elicitation-forms.md",
-    "hash": "d62f3ddd16ae031e875c042d0795449de6965fecfe2caa36edddb9a5fbf1a6fd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "b7e73232af03174e0e5d50d551277a784127eb8047713cacfce1df8b19e8a8d6",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-enforce-admins-false-defeats-code-review-scorecard-check": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-enforce-admins-required-reviews-blocks-solo-dev-merges": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-exclude-hard-queries-from-aggregate-p-1-metrics-in-benchmark": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-exploration-agents-fabricate-names-verify-against-source": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-f841-unused-fixture-lint-fires-when-a-test-is-refactored-to": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-fastembed-is-the-local-embeddings-path-that-passes-a-50mb": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-fix-test": {
     "source": "content/features/fix-test.md",
     "hash": "da54b69787cc1af5c087b2d8674442afe9b8c6fc88dca37a65e99590bb84fee0",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-forced-anthropic-tool-use-is-the-cleanest-path-to-guaranteed": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-forced-cite-per-claim-prompting-is-the-structural-lever-for-rag": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-formatter-strips-imports-that-are-unused-at-the-moment-you-save": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-full-coverage-runs-on-15k-test-suites-timeout-easily": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-generated-content-with-trailing-whitespace-causes-perpetual-pre": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-getattrmodule-name-none-at-call-site-is-the-clean-degradation": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-gh-api-x-patch-f-name-n-rejects-integers-as-strings": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-gh-pr-checks-json-field-names": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-gh-pr-merge-admin-is-blocked-by-in-progress-required-checks": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-gh-pr-merge-admin-prints-a-fast-forward-warning-even-when-the": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-gh-repo-create-source-path-push-is-a-one-shot-for-new-sibling": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-gh-workflow-run-file-yml-ref-tag-re-triggers-a-release-gated": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-ghost-command-references-survive-cli-renames": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-git-commit-q-can-exit-0-with-pre-commit-hook-feedback-that": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-git-pull-refuses-with-unstaged-changes-when-pull-rebase-true": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-git-rebase-root-exec-git-commit-amend-no-edit-s-re-signs-every": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-git-stash-pop-after-pre-commit-can-resurrect-stale-tool-state": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-github-actions-environment-deployment-approvals-can-be-self": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-github-copilot-autofix-pushes-commits-directly-to-pr-branches": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-github-protected-tags-cannot-be-force-updated": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-github-repos-serve-as-claude-code-marketplaces": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-gitignore-exclusions-break-ci-tests-that-read-those-files": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-glob-based-hash-computation-must-exclude-cache-dirs": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-golden-query-benchmarks-reveal-two-distinct-failure-classes": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-golden-query-test-fixtures-must-match-the-actual-corpus-layout": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-gpg-signing-fails-in-non-interactive-terminals-vscode-extension": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-hand-crafted-summary-prototype-is-the-fastest-way-to-measure-a": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-handoff-memory-option-b-proposals-are-often-wrong-re-analyze": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-hardcoded-root-paths-in-tests": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-hardcoded-strings-in-method-bodies-survive-class-attribute": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-hardcoded-user-id-defeats-ownership-checks": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-help-system": {
     "source": "content/features/help-system.md",
     "hash": "24468c8fe4f1a0e350e620098d65a3bcc007000cd5aa4dbe20a6e6c83efa87b3",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-hooks": {
     "source": "content/features/hooks.md",
     "hash": "5c6b8a45457387c76f628561d3baa56e9af1709bc9bd21bba9830b2c2478c8dd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-hot-reload-subsystem-was-1-038-lines-of-dead-code": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-import-x-inside-a-try-block-except-x-someerror-in-the-except": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-importlib-import-module-is-an-arbitrary-code-execution-vector": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-industry-terminology-wont-appear-in-llm-polished-rag-summaries": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-integration-tests-gated-by-has-api-key-can-poison-the-whole-ci": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-is-private-is-a-superset-in-python-ipaddress": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-kwargs-collides-with-explicit-params-of-the-same-name": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-lazy-imports-inside-function-bodies-cant-be-patched-with": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-linkedin-paste-use-ascii-markers-not-unicode-arrows": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-list-wizards-is-a-function-not-a-class-method": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-list-workflows-deduplication-must-keep-base-names-visible": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-llm-api-responses-lack-trailing-newlines": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-local-telemetry-trackers-need-an-autouse-conftest-fixture": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-macos-var-private-var-symlink-breaks-path-assertions": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-mcp-attune-ai-doc-orchestrator-is-a-no-op-stub": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-mcp-call-tool-wrapper-pattern": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-mcp-handler-validate-paths-before-importing-workflows": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-mcp-json-python-resolves-to-pyenv-shim-not-project-venv": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-mcp-server": {
     "source": "content/features/mcp-server.md",
     "hash": "8e4b8c74eff980330480ae70856a1cf0393559cd22eb9ba0210b43249f9b5181",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-mcp-server-process-doesnt-inherit-env-variables": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-mcp-tool-count-tests-are-hardcoded": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-mcp-tool-renames-propagate-to-skill-docs": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-mcp-workspace-root-defaults-to-os-getcwd-tests-with-tmp-path": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-memory": {
     "source": "content/features/memory.md",
     "hash": "32b3121d9110dc9ac327bb9e838f060fbe9940a033366b0147ef34ef2efaa4dc",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-metadata-can-reach-a-retriever-with-zero-signal-if-the-sidecar": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-metapathfinder-find-module-load-module-is-dead-in-python-3-12": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-mixin-classes-inherit-self-workspace-root-at-runtime-not-at": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-mkdocs-build-crashing-with-attributeerror-nonetype-object-has": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-mkdocs-strict-treats-broken-links-as-fatal-errors": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-mock-a-lazy-import-x-with-types-moduletype-patch-dictsys-modules": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-models": {
     "source": "content/features/models.md",
     "hash": "2117cbb0d8e863db6091870874e4ce80b48780c9ee8bb7330d8033c172ccb02b",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-modeltier-has-two-copies-imports-must-match": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-module-level-optional-imports-enable-clean-test-patching": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-multiple-pinentry-program-lines-in-gpg-agent-conf-first-wins": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-mutual-competition-between-polished-rag-features-is-real-and": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-mypy-437-errors-was-stale-actual-count-was-2": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-naive-suffix-strip-stemming-fails-on-english-doubling-consonant": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-never-paste-pypi-tokens-into-chat-or-logs": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-new-dataclass-fields-need-both-the-class-and-the-parser-updated": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-new-mcp-handlers-must-match-the-validation-pattern-of-adjacent": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-new-security-features-need-dedicated-tests-before-release": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-next-js-shared-data-libs-prevent-page-duplication": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-non-baseworkflow-classes-in-workflow-registry-crash-the-cli": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-noqa-f401-re-exports-break-silently-on-satellite-file-deletion": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-openssf-scorecard-alerts-2-codereviewid-3-sastid-are-process": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-ops-dashboard": {
     "source": "content/features/ops-dashboard.md",
     "hash": "fefc8e2b2b4a25055fcbdf96cbd8638d75278cbcacd256873b725df89544c1f6",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-orchestration": {
     "source": "content/features/orchestration.md",
     "hash": "4998437e04355011a7dee68dbce7e9e78bbe97f637e0b6a14c1ec972f541695c",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-orphan-help-dirs-are-deprecated-3-depth-output-adding-them-to": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-orphan-top-level-docs-directories-stay-invisible-to-readers": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-packages-attune-in-attune-ai-are-pointer-stubs-not-source": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-past-due-deprecations-are-deletion-targets-not-implementation": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-patch-requires-the-target-name-to-exist-at-module-scope-at": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-patch-the-source-module-for-from-x-import-y-in-function-bodies": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-path-cwd-at-module-level-captures-import-time-cwd": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-path-globdir-matches-directories-not-files": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-path-rename-fails-on-windows-when-target-exists": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-pip-audit-fails-on-unpublished-versions": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-platform-conditional-security-test-assertions-should-accept-any": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-plugin": {
     "source": "content/features/plugin.md",
     "hash": "8cc6e5702ffc8228ed63cfb74a25dd3e99e79e5335c4b1c8c134950f8b9a043d",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-plugin-read-skill-references-break-outside-the-plugin": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-pr-test-workflows-may-not-auto-trigger-after-close-reopen-or": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-pre-commit-auto-fix-requires-re-stage-before-retry": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-pre-commit-black-unstaged-files-re-stage-after-failure": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-pre-commit-stash-conflict-when-black-ruff-fix-files-with": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-pre-commit-stash-conflict-with-auto-fix-hooks": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-pre-commit-stash-conflicts-when-any-tracked-unstaged-file": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-pre-committed-decision-matrices-survive-contact-with-data": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-pre-flight-pre-commits-pinned-black-ruff-on-new-files-before": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-prefer-github-actions-trusted-publishing-over-local-twine-uv": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-prompt-template-word-wrap-silently-breaks-single-line-substring": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-provenance-citation-records-usually-store-short-previews-not": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-pull-main-before-merging-develop-to-avoid-merge-commits": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-pureposixpath-match-doesnt-support-in-python-3-10": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-pureposixpath-strips-trailing-slashes": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-push-specific-tags-not-tags": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-pypi-env-policies-may-whitelist-branches-only-tag-triggered": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-pypi-environment-requires-manual-approval-in-github-actions": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-pypi-renders-readme-links-relative-to-its-own-domain": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-pypi-trusted-publisher-workflow-name-field-wants-the-filename": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-pytest-importorskip-triggers-ruff-e402": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-pytest-lives-in-the-dev-extra-not-developer": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-query-fixtures-are-self-diagnostic-for-rag-corpora-even-without": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-rag-grounding": {
     "source": "content/features/rag-grounding.md",
     "hash": "3464dd78c83f06980912a7c49dc185b09830be1b1c163203f10e5aa1708fcf4e",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-re-adding-an-import-after-the-formatter-strips-it-use-function": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-re-enabling-required-reviews-kills-queued-auto-merge": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-re-export-accessibility-tests-are-scattered-across-batch-files": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-read-source-before-writing-tests-for-tricky-logic": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-real-project-files-on-disk-override-test-mocks": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-rebuild-dist-after-readme-changes": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-reclassify-unexpectedly-hard-golden-queries-up-the-difficulty": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-redisshorttermmemory-mock-injection-path": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-refactor-plan": {
     "source": "content/features/refactor-plan.md",
     "hash": "8f8c684cd94fca7b2580ecaaf955ccb79924022796d576d477cdab9330df9704",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-registry-count-assertions-are-scattered-across-test-files": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-release-branches-carry-unmerged-commits-that-feature-branches": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-release-notes": {
     "source": "content/features/release-notes.md",
     "hash": "da7101ffbec4d209fcb1cef754f01cef8a13458a6f961c3a23909edfec77e58c",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-release-prep": {
     "source": "content/features/release-prep.md",
     "hash": "cd77b5903fbeb7d7e0acef570bab9727b4c143181ea6be1f52b9a25bc11418bb",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-release-published-workflow-dispatch-both-approved-for-pypi-env": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-removing-one-workspace-dep-can-cascade-to-remove-others": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-replacing-a-mixin-based-class-scatters-test-failures-across": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-repo-merge-policy-may-restrict-merge-strategies": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-repo-root-parents-count-varies-by-file-depth": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-required-status-check-names-must-match-githubs-exact-check-names": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-research-subagents-can-hallucinate-sdk-signatures-introspect": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-resilience": {
     "source": "content/features/resilience.md",
     "hash": "ae2a76f0f1ecbb9ca687e5a041acc2b4a25a5113ec57eaad550f48b8aadc4be2",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-resultmessage-result-is-often-none-capture-assistantmessage": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-rich-live-is-output-only-use-textual-for-any-interactive-row": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-ruff-auto-fix-strips-imports-before-usage-code-exists": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-ruff-parses-pytest-ini-as-python": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-run-simplify-catches-per-file-errors-internally": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-sbin-is-a-symlink-to-usr-sbin-on-modern-ubuntu": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-scorecards-pip-parser-ignores-hash-flags-entirely": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-sdk-adapter-swallows-subagent-findings-lesson-was-wrong-adapter": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-sdk-agent-model-config-uses-stale-model-names": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-sdk-native-security-audit-workflow-swallows-subagent-findings": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-sdk-native-workflows-validate-in-execute-not-input-schema": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-security-audit": {
     "source": "content/features/security-audit.md",
     "hash": "9cce18573c827fab9a380efe8c65c2f8c5b4ada3f7e383dd71ec523a0875fb05",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-selective-hook-skip-with-skip-hookname-is-not-the-same-as-no": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-semantic-cache-70-hit-rate-claim-was-unmeasured": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-session-hooks-may-be-vestigial": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-shadow-directories-at-repo-root-break-imports": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-silent-pass-blocks-in-discovery-registry-code-hide-import": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-skill-descriptions-must-be-under-250-characters": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-skill-frontmatter-allowlist-march-2026": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-skill-frontmatter-has-a-strict-allowlist": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-smart-test": {
     "source": "content/features/smart-test.md",
     "hash": "58c691c8313ddf9699deb913e6b5c50fafc684563539ddf4816a4b94a9ea3e80",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-spec-engine": {
     "source": "content/features/spec-engine.md",
     "hash": "c8549016aa848eeeaecbde8329f5850562f56280ab66428cb7c20887b428d81a",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-squash-merge-deletes-the-remote-branch-subsequent-push-silently": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-ssrf-always-decode-urls-before-validating-hostnames": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-ssrf-in-webhook-handlers-is-easy-to-miss": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-ssrf-strip-ipv6-zone-ids-before-ip-validation": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-stacked-patch-decorators-inject-args-bottom-up": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-staleness-detection-in-attune-author-attune-ais-help-system-is": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-stop-hook-ordering-matters": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-stop-hooks-inject-stderr-not-stdout": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-stop-hooks-loop-without-a-sentinel": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-stop-hooks-missing-cd-prefix-inherit-session-cwd": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-structlog-default-output-pollutes-stdout-captured-cli-tests": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-structlog-kwargs-vs-stdlib-logger": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-tags-pushed-before-squash-merge-point-to-the-wrong-commit": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-telemetry": {
     "source": "content/features/telemetry.md",
     "hash": "59473ab809113116a3d58d2ead3a5f13e362d6992d8cee0a89364feded5cbd50",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-template-generators-overwrite-hand-written-files": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-test-mocks-must-match-imports": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-tests-for-optional-dep-code-need-pytest-importorskip-guards-in": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-text-white-on-gradient-primary-sections-gets-overridden": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-todo-counts-are-inflated-by-docstrings-and-prompt-strings": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-twine-cannot-prompt-for-tokens-in-claude-codes-non-interactive": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-two-codeql-setups-can-coexist-in-one-repo-and-deadlock-merges": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-two-parallel-help-template-generators-in-the-attune-ecosystem": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-uncommitted-claude-mcp-json-means-mcp-server-never-starts": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-untracked-scripts-break-ci-when-tests-import-them": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-unused-init-py-re-exports-become-invisible-runtime-deps": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-use-dataclass-post-init-to-coalesce-between-a-scalar-legacy": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-uv-lock-can-drift-from-pyproject-toml-on-shared-branches": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-uv-lock-may-briefly-fail-to-find-a-just-published-pypi-version": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-uv-lock-retains-editable-name-paths-after-tool-uv-sources-edits": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-uv-pip-install-e-does-not-regenerate-project-scripts-console": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-uv-pip-install-e-path-can-ship-stale-package-data-even-after": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-uv-pip-install-e-sibling-path-no-deps-is-the-clean-venv-local": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-uv-run-in-pre-commit-hooks-propagates-lockfile-errors-as-hook": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-uv-run-pip-audit-runs-the-pyenv-shim-not-the-venv": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-uv-sync-respects-existing-lockfile-pins-when-they-still-satisfy": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-uv-sync-wipes-packages-installed-via-pip-install": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-validate-file-path-needed-on-reads-too-not-just-writes": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-validate-infrastructure-against-user-value-before-extending": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-verify-mcp-tool-wiring-after-adding-new-tools": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-verify-new-dispatch-branches-with-a-known-fixture-not-just": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-verify-optional-dep-boundaries-with-a-metapathfinder-not-by": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-version-bumps-must-update-7-files-not-just-pyproject-toml": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-vs-code-extension-reads-mcp-json-at-project-root-not-claude-mcp": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-website-feature-lists-can-diverge-from-the-python-registry": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-windows-ci-encoding": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-windows-ci-runners-are-3x-slower-than-ubuntu-macos": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-windows-path-resolve-prepends-the-drive-letter-to-unix-paths": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-windows-time-time-can-return-0-0-duration-for-fast-operations": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-wizards": {
     "source": "content/features/wizards.md",
     "hash": "6fe7722a026d11276ebfbdf4ea046a05112be94b560f9abf3ffee410f8637d8f",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-wizards-call-workflows-internally-they-are-not-duplicates": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-workflowresult-constructor-mismatches-surface-only-at-runtime": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-yaml-run-block-scalars-break-on-blank-lines-inside-multi-line": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-yaml-run-values-with-colons-cause-parse-errors": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "faq-zsh-has-status-as-a-read-only-builtin-variable": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "not-agents": {
     "source": "content/features/agents.md",
     "hash": "a5b1678ecf012c7b2877a6c7ecae4a6c3f14c084c13fbcbb7eee79119dce6fa3",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "not-bug-predict": {
     "source": "content/features/bug-predict.md",
     "hash": "6a4f420eba38e2fb884b837dd9758acb60ba60cdaf9248ec4280120b0d382b16",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "not-cli": {
     "source": "content/features/cli.md",
     "hash": "a37b4dc4f0b3706a62184b02d2be1536ad75eef39a0f22a9699db5d03b8ee050",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "not-code-quality": {
     "source": "content/features/code-quality.md",
     "hash": "ce16ac87eb92e33a08d8c2f06e86ef22e436966f47f3a28c3f4eba19060b550a",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "not-code-simplification": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "not-command-hubs": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "not-configuration": {
     "source": "content/features/configuration.md",
     "hash": "8add90392883a46899ef8b57d135b625d92c5b61231d8a5301727f8b42f8e46f",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "not-critical-rules": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "not-decision-d1-template-schemas-live-in-the-repo": {
     "source": ".claude/plans/documentation-stack-spec.md",
     "hash": "8ac207215df6d59686f456b44e76ec33e6c5b8dd6acb5d7754100c158865bd88",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "not-decision-d2-search-index-first-unified-later": {
     "source": ".claude/plans/documentation-stack-spec.md",
     "hash": "8ac207215df6d59686f456b44e76ec33e6c5b8dd6acb5d7754100c158865bd88",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "not-decision-d3-faq-sourcing-four-channels": {
     "source": ".claude/plans/documentation-stack-spec.md",
     "hash": "8ac207215df6d59686f456b44e76ec33e6c5b8dd6acb5d7754100c158865bd88",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "not-decision-d4-code-is-the-source-of-truth": {
     "source": ".claude/plans/documentation-stack-spec.md",
     "hash": "8ac207215df6d59686f456b44e76ec33e6c5b8dd6acb5d7754100c158865bd88",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "not-decision-d5-intelligent-templates-the-engine": {
     "source": ".claude/plans/documentation-stack-spec.md",
     "hash": "8ac207215df6d59686f456b44e76ec33e6c5b8dd6acb5d7754100c158865bd88",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "not-decision-d6-proof-of-concept-lessons-learned-error-templates": {
     "source": ".claude/plans/documentation-stack-spec.md",
     "hash": "8ac207215df6d59686f456b44e76ec33e6c5b8dd6acb5d7754100c158865bd88",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "not-deep-review": {
     "source": "content/features/deep-review.md",
     "hash": "6a4fffc907302b4847d96097189bd8d329d3f1548d1ee46d9232f6ceecdfb450",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "not-doc-gen": {
     "source": "content/features/doc-gen.md",
     "hash": "26e02a71a523775f5bb9e371b2e563c3c858386436a73b727422f62f57de0282",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "not-elicitation-forms": {
     "source": "content/features/elicitation-forms.md",
-    "hash": "d62f3ddd16ae031e875c042d0795449de6965fecfe2caa36edddb9a5fbf1a6fd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "b7e73232af03174e0e5d50d551277a784127eb8047713cacfce1df8b19e8a8d6",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "not-fix-test": {
     "source": "content/features/fix-test.md",
     "hash": "da54b69787cc1af5c087b2d8674442afe9b8c6fc88dca37a65e99590bb84fee0",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "not-help-system": {
     "source": "content/features/help-system.md",
     "hash": "24468c8fe4f1a0e350e620098d65a3bcc007000cd5aa4dbe20a6e6c83efa87b3",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "not-hooks": {
     "source": "content/features/hooks.md",
     "hash": "5c6b8a45457387c76f628561d3baa56e9af1709bc9bd21bba9830b2c2478c8dd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "not-markdown-formatting": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "not-mcp-server": {
     "source": "content/features/mcp-server.md",
     "hash": "8e4b8c74eff980330480ae70856a1cf0393559cd22eb9ba0210b43249f9b5181",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "not-memory": {
     "source": "content/features/memory.md",
     "hash": "32b3121d9110dc9ac327bb9e838f060fbe9940a033366b0147ef34ef2efaa4dc",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "not-models": {
     "source": "content/features/models.md",
     "hash": "2117cbb0d8e863db6091870874e4ce80b48780c9ee8bb7330d8033c172ccb02b",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "not-ops-dashboard": {
     "source": "content/features/ops-dashboard.md",
     "hash": "fefc8e2b2b4a25055fcbdf96cbd8638d75278cbcacd256873b725df89544c1f6",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "not-orchestration": {
     "source": "content/features/orchestration.md",
     "hash": "4998437e04355011a7dee68dbce7e9e78bbe97f637e0b6a14c1ec972f541695c",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "not-plugin": {
     "source": "content/features/plugin.md",
     "hash": "8cc6e5702ffc8228ed63cfb74a25dd3e99e79e5335c4b1c8c134950f8b9a043d",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "not-project-structure": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "not-rag-grounding": {
     "source": "content/features/rag-grounding.md",
     "hash": "3464dd78c83f06980912a7c49dc185b09830be1b1c163203f10e5aa1708fcf4e",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "not-refactor-plan": {
     "source": "content/features/refactor-plan.md",
     "hash": "8f8c684cd94fca7b2580ecaaf955ccb79924022796d576d477cdab9330df9704",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "not-release-notes": {
     "source": "content/features/release-notes.md",
     "hash": "da7101ffbec4d209fcb1cef754f01cef8a13458a6f961c3a23909edfec77e58c",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "not-release-prep": {
     "source": "content/features/release-prep.md",
     "hash": "cd77b5903fbeb7d7e0acef570bab9727b4c143181ea6be1f52b9a25bc11418bb",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "not-resilience": {
     "source": "content/features/resilience.md",
     "hash": "ae2a76f0f1ecbb9ca687e5a041acc2b4a25a5113ec57eaad550f48b8aadc4be2",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "not-security-audit": {
     "source": "content/features/security-audit.md",
     "hash": "9cce18573c827fab9a380efe8c65c2f8c5b4ada3f7e383dd71ec523a0875fb05",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "not-smart-test": {
     "source": "content/features/smart-test.md",
     "hash": "58c691c8313ddf9699deb913e6b5c50fafc684563539ddf4816a4b94a9ea3e80",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "not-socratic-interaction-rule": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "not-spec-engine": {
     "source": "content/features/spec-engine.md",
     "hash": "c8549016aa848eeeaecbde8329f5850562f56280ab66428cb7c20887b428d81a",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "not-telemetry": {
     "source": "content/features/telemetry.md",
     "hash": "59473ab809113116a3d58d2ead3a5f13e362d6992d8cee0a89364feded5cbd50",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "not-term-cli": {
     "source": "CLAUDE.md",
     "hash": "811c9cf90d6a42eb767f78b7fc6874a5ab0c6ae914fc1533ec40cc800f40749c",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "not-term-crew": {
     "source": "CLAUDE.md",
     "hash": "811c9cf90d6a42eb767f78b7fc6874a5ab0c6ae914fc1533ec40cc800f40749c",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "not-term-hub": {
     "source": "CLAUDE.md",
     "hash": "811c9cf90d6a42eb767f78b7fc6874a5ab0c6ae914fc1533ec40cc800f40749c",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "not-term-llm": {
     "source": "CLAUDE.md",
     "hash": "811c9cf90d6a42eb767f78b7fc6874a5ab0c6ae914fc1533ec40cc800f40749c",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "not-term-p2b": {
     "source": "CLAUDE.md",
     "hash": "811c9cf90d6a42eb767f78b7fc6874a5ab0c6ae914fc1533ec40cc800f40749c",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "not-term-progressive": {
     "source": "CLAUDE.md",
     "hash": "811c9cf90d6a42eb767f78b7fc6874a5ab0c6ae914fc1533ec40cc800f40749c",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "not-term-sdk": {
     "source": "CLAUDE.md",
     "hash": "811c9cf90d6a42eb767f78b7fc6874a5ab0c6ae914fc1533ec40cc800f40749c",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "not-term-socratic": {
     "source": "CLAUDE.md",
     "hash": "811c9cf90d6a42eb767f78b7fc6874a5ab0c6ae914fc1533ec40cc800f40749c",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "not-term-tier": {
     "source": "CLAUDE.md",
     "hash": "811c9cf90d6a42eb767f78b7fc6874a5ab0c6ae914fc1533ec40cc800f40749c",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "not-term-wizard": {
     "source": "CLAUDE.md",
     "hash": "811c9cf90d6a42eb767f78b7fc6874a5ab0c6ae914fc1533ec40cc800f40749c",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "not-wizards": {
     "source": "content/features/wizards.md",
     "hash": "6fe7722a026d11276ebfbdf4ea046a05112be94b560f9abf3ffee410f8637d8f",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "qui-agents": {
     "source": "content/features/agents.md",
     "hash": "a5b1678ecf012c7b2877a6c7ecae4a6c3f14c084c13fbcbb7eee79119dce6fa3",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "qui-browse-help": {
     "source": "src/attune/cli_commands/help_commands.py",
     "hash": "d284892c4f058b5a9d4861f08f7f2de09c8050d33766471014bb739215a83582",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "qui-bug-predict": {
     "source": "content/features/bug-predict.md",
     "hash": "6a4f420eba38e2fb884b837dd9758acb60ba60cdaf9248ec4280120b0d382b16",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "qui-check-costs": {
     "source": "src/attune/cli_minimal.py",
-    "hash": "6ecf010bd218d5d2146708b4ae24cb28ab463f17324c52a2ca6c4455569147d7",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "952eff81eb5c2a259974a8196363de82f79cbaeb5b115859b42a823100dbe974",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "qui-check-health": {
     "source": "src/attune/cli_minimal.py",
-    "hash": "6ecf010bd218d5d2146708b4ae24cb28ab463f17324c52a2ca6c4455569147d7",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "952eff81eb5c2a259974a8196363de82f79cbaeb5b115859b42a823100dbe974",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "qui-cli": {
     "source": "content/features/cli.md",
     "hash": "a37b4dc4f0b3706a62184b02d2be1536ad75eef39a0f22a9699db5d03b8ee050",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "qui-code-quality": {
     "source": "content/features/code-quality.md",
     "hash": "ce16ac87eb92e33a08d8c2f06e86ef22e436966f47f3a28c3f4eba19060b550a",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "qui-configuration": {
     "source": "content/features/configuration.md",
     "hash": "8add90392883a46899ef8b57d135b625d92c5b61231d8a5301727f8b42f8e46f",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "qui-deep-review": {
     "source": "content/features/deep-review.md",
     "hash": "6a4fffc907302b4847d96097189bd8d329d3f1548d1ee46d9232f6ceecdfb450",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "qui-doc-gen": {
     "source": "content/features/doc-gen.md",
     "hash": "26e02a71a523775f5bb9e371b2e563c3c858386436a73b727422f62f57de0282",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "qui-elicitation-forms": {
     "source": "content/features/elicitation-forms.md",
-    "hash": "d62f3ddd16ae031e875c042d0795449de6965fecfe2caa36edddb9a5fbf1a6fd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "b7e73232af03174e0e5d50d551277a784127eb8047713cacfce1df8b19e8a8d6",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "qui-fix-test": {
     "source": "content/features/fix-test.md",
     "hash": "da54b69787cc1af5c087b2d8674442afe9b8c6fc88dca37a65e99590bb84fee0",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "qui-generate-tests": {
     "source": "src/attune/cli_minimal.py",
-    "hash": "6ecf010bd218d5d2146708b4ae24cb28ab463f17324c52a2ca6c4455569147d7",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "952eff81eb5c2a259974a8196363de82f79cbaeb5b115859b42a823100dbe974",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "qui-help-system": {
     "source": "content/features/help-system.md",
     "hash": "24468c8fe4f1a0e350e620098d65a3bcc007000cd5aa4dbe20a6e6c83efa87b3",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "qui-hooks": {
     "source": "content/features/hooks.md",
     "hash": "5c6b8a45457387c76f628561d3baa56e9af1709bc9bd21bba9830b2c2478c8dd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "qui-install": {
     "source": "README.md",
-    "hash": "53198ec9cd8b2bad6330182140cc310a0635b9eee72f282a916c6dfd4c8971c0",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "29c1821d6fdff7907606b8f37c13640c6d7747a9cfd2db37fb6b4579b0c7365f",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "qui-install-plugin": {
     "source": "README.md",
-    "hash": "53198ec9cd8b2bad6330182140cc310a0635b9eee72f282a916c6dfd4c8971c0",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "29c1821d6fdff7907606b8f37c13640c6d7747a9cfd2db37fb6b4579b0c7365f",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "qui-mcp-server": {
     "source": "content/features/mcp-server.md",
     "hash": "8e4b8c74eff980330480ae70856a1cf0393559cd22eb9ba0210b43249f9b5181",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "qui-memory": {
     "source": "content/features/memory.md",
     "hash": "32b3121d9110dc9ac327bb9e838f060fbe9940a033366b0147ef34ef2efaa4dc",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "qui-models": {
     "source": "content/features/models.md",
     "hash": "2117cbb0d8e863db6091870874e4ce80b48780c9ee8bb7330d8033c172ccb02b",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "qui-ops-dashboard": {
     "source": "content/features/ops-dashboard.md",
     "hash": "fefc8e2b2b4a25055fcbdf96cbd8638d75278cbcacd256873b725df89544c1f6",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "qui-orchestration": {
     "source": "content/features/orchestration.md",
     "hash": "4998437e04355011a7dee68dbce7e9e78bbe97f637e0b6a14c1ec972f541695c",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "qui-plugin": {
     "source": "content/features/plugin.md",
     "hash": "8cc6e5702ffc8228ed63cfb74a25dd3e99e79e5335c4b1c8c134950f8b9a043d",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "qui-rag-grounding": {
     "source": "content/features/rag-grounding.md",
     "hash": "3464dd78c83f06980912a7c49dc185b09830be1b1c163203f10e5aa1708fcf4e",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "qui-refactor-plan": {
     "source": "content/features/refactor-plan.md",
     "hash": "8f8c684cd94fca7b2580ecaaf955ccb79924022796d576d477cdab9330df9704",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "qui-release-notes": {
     "source": "content/features/release-notes.md",
     "hash": "da7101ffbec4d209fcb1cef754f01cef8a13458a6f961c3a23909edfec77e58c",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "qui-release-prep": {
     "source": "content/features/release-prep.md",
     "hash": "cd77b5903fbeb7d7e0acef570bab9727b4c143181ea6be1f52b9a25bc11418bb",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "qui-resilience": {
     "source": "content/features/resilience.md",
     "hash": "ae2a76f0f1ecbb9ca687e5a041acc2b4a25a5113ec57eaad550f48b8aadc4be2",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "qui-run-code-review": {
     "source": "src/attune/cli_minimal.py",
-    "hash": "6ecf010bd218d5d2146708b4ae24cb28ab463f17324c52a2ca6c4455569147d7",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "952eff81eb5c2a259974a8196363de82f79cbaeb5b115859b42a823100dbe974",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "qui-run-security-audit": {
     "source": "src/attune/cli_minimal.py",
-    "hash": "6ecf010bd218d5d2146708b4ae24cb28ab463f17324c52a2ca6c4455569147d7",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "952eff81eb5c2a259974a8196363de82f79cbaeb5b115859b42a823100dbe974",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "qui-security-audit": {
     "source": "content/features/security-audit.md",
     "hash": "9cce18573c827fab9a380efe8c65c2f8c5b4ada3f7e383dd71ec523a0875fb05",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "qui-skill-attune-hub": {
     "source": "plugin/skills/attune-hub/SKILL.md",
-    "hash": "6d8cb8733a4dfb798f05814226de09d60af8b45d66df5755789f380d6f234f03",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "3e8cb98c4cdae752aad8e8ddda10f55629da0906b85b407e757ff8fd9981efac",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "qui-skill-bug-predict": {
     "source": "plugin/skills/bug-predict/SKILL.md",
     "hash": "992b9e6cd3452af0d31213985e5e5c607f078edd2310df76d786b95d7e6a83ce",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "qui-skill-coach": {
     "source": "plugin/skills/coach/SKILL.md",
     "hash": "a1842d674325f3f1ea289e3bd7ed1dcfbb4b3301160181edab081d2b4352aeac",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "qui-skill-code-quality": {
     "source": "plugin/skills/code-quality/SKILL.md",
     "hash": "769c4c885992fd1937adbdf5d97305894bd08c159c83930d7a9fb86cb4ae78b7",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "qui-skill-doc-gen": {
     "source": "plugin/skills/doc-gen/SKILL.md",
     "hash": "da9a9c23727eaa9433b2c4d1dfe87d850ef560d56b855f2eb7bd0f279efc3c72",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "qui-skill-fix-test": {
     "source": "plugin/skills/fix-test/SKILL.md",
     "hash": "665ff7c4978beddd72e87f3764b073e4f962b27a896bd66542d499a1a00429da",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "qui-skill-memory-and-context": {
     "source": "plugin/skills/memory-and-context/SKILL.md",
-    "hash": "f1a465f47af5948c4e37d4c6a75247d71223a6d5208063be318e65e1ec475e44",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "d026a40d0c5315123672c7ed3770b643ba803a3b5d57cb994c236fcd6baa8305",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "qui-skill-planning": {
     "source": "plugin/skills/planning/SKILL.md",
     "hash": "f56a42c83f514b300b4f89ea6669820ec158da952efa2894c56abb00c39eb58a",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "qui-skill-rag-code-gen": {
     "source": "plugin/skills/rag-code-gen/SKILL.md",
-    "hash": "da6cb96d8150291fa8c587e756247f14fe166083add938f210747ab867a26c5e",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "0d84a32e2f89e8debd740b4343c7930b17efcca37fcb68737f342f8b6b5f6f77",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "qui-skill-refactor-plan": {
     "source": "plugin/skills/refactor-plan/SKILL.md",
     "hash": "080a84b5df5dde88cd3c994ca2c2b68ec12e2cf241f2e81893f21aa9dac315f6",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "qui-skill-release-prep": {
     "source": "plugin/skills/release-prep/SKILL.md",
     "hash": "8aab944ae2f53a24c94d39329bf000067a68f43b51de6657b517678bec90c67a",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "qui-skill-security-audit": {
     "source": "plugin/skills/security-audit/SKILL.md",
     "hash": "f370003a809c342d35b37990da231fbb72545e75e5a37e1e1d39a27db5364761",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "qui-skill-smart-test": {
     "source": "plugin/skills/smart-test/SKILL.md",
     "hash": "a5e874d1054dd123d78d9d8e9014c7c6888230f36685a203ea26176a3d649ffb",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "qui-skill-spec": {
     "source": "plugin/skills/spec/SKILL.md",
-    "hash": "26f2335775e968f4625078ee9fabd15a0ad04dc0980bc37def777d5908fa2e50",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "4e1ce2c9da6fcad85ebcf7cb6b755f44c27d00608ad97b72b93a82a45e3c0186",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "qui-skill-workflow-orchestration": {
     "source": "plugin/skills/workflow-orchestration/SKILL.md",
     "hash": "831c00dfb29ae4c72b35921fd3bab9e9f17affabf32b8164deb801557e031127",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "qui-smart-test": {
     "source": "content/features/smart-test.md",
     "hash": "58c691c8313ddf9699deb913e6b5c50fafc684563539ddf4816a4b94a9ea3e80",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "qui-spec-engine": {
     "source": "content/features/spec-engine.md",
     "hash": "c8549016aa848eeeaecbde8329f5850562f56280ab66428cb7c20887b428d81a",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "qui-telemetry": {
     "source": "content/features/telemetry.md",
     "hash": "59473ab809113116a3d58d2ead3a5f13e362d6992d8cee0a89364feded5cbd50",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "qui-wizards": {
     "source": "content/features/wizards.md",
     "hash": "6fe7722a026d11276ebfbdf4ea046a05112be94b560f9abf3ffee410f8637d8f",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "ref-agents": {
     "source": "content/features/agents.md",
     "hash": "a5b1678ecf012c7b2877a6c7ecae4a6c3f14c084c13fbcbb7eee79119dce6fa3",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "ref-bug-predict": {
     "source": "content/features/bug-predict.md",
     "hash": "6a4f420eba38e2fb884b837dd9758acb60ba60cdaf9248ec4280120b0d382b16",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "ref-cli": {
     "source": "content/features/cli.md",
     "hash": "a37b4dc4f0b3706a62184b02d2be1536ad75eef39a0f22a9699db5d03b8ee050",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "ref-code-quality": {
     "source": "content/features/code-quality.md",
     "hash": "ce16ac87eb92e33a08d8c2f06e86ef22e436966f47f3a28c3f4eba19060b550a",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "ref-configuration": {
     "source": "content/features/configuration.md",
     "hash": "8add90392883a46899ef8b57d135b625d92c5b61231d8a5301727f8b42f8e46f",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "ref-deep-review": {
     "source": "content/features/deep-review.md",
     "hash": "6a4fffc907302b4847d96097189bd8d329d3f1548d1ee46d9232f6ceecdfb450",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "ref-doc-gen": {
     "source": "content/features/doc-gen.md",
     "hash": "26e02a71a523775f5bb9e371b2e563c3c858386436a73b727422f62f57de0282",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "ref-elicitation-forms": {
     "source": "content/features/elicitation-forms.md",
-    "hash": "d62f3ddd16ae031e875c042d0795449de6965fecfe2caa36edddb9a5fbf1a6fd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "b7e73232af03174e0e5d50d551277a784127eb8047713cacfce1df8b19e8a8d6",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "ref-fix-test": {
     "source": "content/features/fix-test.md",
     "hash": "da54b69787cc1af5c087b2d8674442afe9b8c6fc88dca37a65e99590bb84fee0",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "ref-help-system": {
     "source": "content/features/help-system.md",
     "hash": "24468c8fe4f1a0e350e620098d65a3bcc007000cd5aa4dbe20a6e6c83efa87b3",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "ref-hooks": {
     "source": "content/features/hooks.md",
     "hash": "5c6b8a45457387c76f628561d3baa56e9af1709bc9bd21bba9830b2c2478c8dd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "ref-mcp-server": {
     "source": "content/features/mcp-server.md",
     "hash": "8e4b8c74eff980330480ae70856a1cf0393559cd22eb9ba0210b43249f9b5181",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "ref-memory": {
     "source": "content/features/memory.md",
     "hash": "32b3121d9110dc9ac327bb9e838f060fbe9940a033366b0147ef34ef2efaa4dc",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "ref-models": {
     "source": "content/features/models.md",
     "hash": "2117cbb0d8e863db6091870874e4ce80b48780c9ee8bb7330d8033c172ccb02b",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "ref-ops-dashboard": {
     "source": "content/features/ops-dashboard.md",
     "hash": "fefc8e2b2b4a25055fcbdf96cbd8638d75278cbcacd256873b725df89544c1f6",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "ref-orchestration": {
     "source": "content/features/orchestration.md",
     "hash": "4998437e04355011a7dee68dbce7e9e78bbe97f637e0b6a14c1ec972f541695c",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "ref-plugin": {
     "source": "content/features/plugin.md",
     "hash": "8cc6e5702ffc8228ed63cfb74a25dd3e99e79e5335c4b1c8c134950f8b9a043d",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "ref-rag-grounding": {
     "source": "content/features/rag-grounding.md",
     "hash": "3464dd78c83f06980912a7c49dc185b09830be1b1c163203f10e5aa1708fcf4e",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "ref-refactor-plan": {
     "source": "content/features/refactor-plan.md",
     "hash": "8f8c684cd94fca7b2580ecaaf955ccb79924022796d576d477cdab9330df9704",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "ref-release-notes": {
     "source": "content/features/release-notes.md",
     "hash": "da7101ffbec4d209fcb1cef754f01cef8a13458a6f961c3a23909edfec77e58c",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "ref-release-prep": {
     "source": "content/features/release-prep.md",
     "hash": "cd77b5903fbeb7d7e0acef570bab9727b4c143181ea6be1f52b9a25bc11418bb",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "ref-resilience": {
     "source": "content/features/resilience.md",
     "hash": "ae2a76f0f1ecbb9ca687e5a041acc2b4a25a5113ec57eaad550f48b8aadc4be2",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "ref-security-audit": {
     "source": "content/features/security-audit.md",
     "hash": "9cce18573c827fab9a380efe8c65c2f8c5b4ada3f7e383dd71ec523a0875fb05",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "ref-skill-attune-hub": {
     "source": "plugin/skills/attune-hub/SKILL.md",
-    "hash": "6d8cb8733a4dfb798f05814226de09d60af8b45d66df5755789f380d6f234f03",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "3e8cb98c4cdae752aad8e8ddda10f55629da0906b85b407e757ff8fd9981efac",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "ref-skill-bug-predict": {
     "source": "plugin/skills/bug-predict/SKILL.md",
     "hash": "992b9e6cd3452af0d31213985e5e5c607f078edd2310df76d786b95d7e6a83ce",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "ref-skill-coach": {
     "source": "plugin/skills/coach/SKILL.md",
     "hash": "a1842d674325f3f1ea289e3bd7ed1dcfbb4b3301160181edab081d2b4352aeac",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "ref-skill-code-quality": {
     "source": "plugin/skills/code-quality/SKILL.md",
     "hash": "769c4c885992fd1937adbdf5d97305894bd08c159c83930d7a9fb86cb4ae78b7",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "ref-skill-doc-gen": {
     "source": "plugin/skills/doc-gen/SKILL.md",
     "hash": "da9a9c23727eaa9433b2c4d1dfe87d850ef560d56b855f2eb7bd0f279efc3c72",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "ref-skill-fix-test": {
     "source": "plugin/skills/fix-test/SKILL.md",
     "hash": "665ff7c4978beddd72e87f3764b073e4f962b27a896bd66542d499a1a00429da",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "ref-skill-memory-and-context": {
     "source": "plugin/skills/memory-and-context/SKILL.md",
-    "hash": "f1a465f47af5948c4e37d4c6a75247d71223a6d5208063be318e65e1ec475e44",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "d026a40d0c5315123672c7ed3770b643ba803a3b5d57cb994c236fcd6baa8305",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "ref-skill-planning": {
     "source": "plugin/skills/planning/SKILL.md",
     "hash": "f56a42c83f514b300b4f89ea6669820ec158da952efa2894c56abb00c39eb58a",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "ref-skill-rag-code-gen": {
     "source": "plugin/skills/rag-code-gen/SKILL.md",
-    "hash": "da6cb96d8150291fa8c587e756247f14fe166083add938f210747ab867a26c5e",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "0d84a32e2f89e8debd740b4343c7930b17efcca37fcb68737f342f8b6b5f6f77",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "ref-skill-refactor-plan": {
     "source": "plugin/skills/refactor-plan/SKILL.md",
     "hash": "080a84b5df5dde88cd3c994ca2c2b68ec12e2cf241f2e81893f21aa9dac315f6",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "ref-skill-release-prep": {
     "source": "plugin/skills/release-prep/SKILL.md",
     "hash": "8aab944ae2f53a24c94d39329bf000067a68f43b51de6657b517678bec90c67a",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "ref-skill-security-audit": {
     "source": "plugin/skills/security-audit/SKILL.md",
     "hash": "f370003a809c342d35b37990da231fbb72545e75e5a37e1e1d39a27db5364761",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "ref-skill-smart-test": {
     "source": "plugin/skills/smart-test/SKILL.md",
     "hash": "a5e874d1054dd123d78d9d8e9014c7c6888230f36685a203ea26176a3d649ffb",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "ref-skill-spec": {
     "source": "plugin/skills/spec/SKILL.md",
-    "hash": "26f2335775e968f4625078ee9fabd15a0ad04dc0980bc37def777d5908fa2e50",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "4e1ce2c9da6fcad85ebcf7cb6b755f44c27d00608ad97b72b93a82a45e3c0186",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "ref-skill-workflow-orchestration": {
     "source": "plugin/skills/workflow-orchestration/SKILL.md",
     "hash": "831c00dfb29ae4c72b35921fd3bab9e9f17affabf32b8164deb801557e031127",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "ref-smart-test": {
     "source": "content/features/smart-test.md",
     "hash": "58c691c8313ddf9699deb913e6b5c50fafc684563539ddf4816a4b94a9ea3e80",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "ref-spec-engine": {
     "source": "content/features/spec-engine.md",
     "hash": "c8549016aa848eeeaecbde8329f5850562f56280ab66428cb7c20887b428d81a",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "ref-telemetry": {
     "source": "content/features/telemetry.md",
     "hash": "59473ab809113116a3d58d2ead3a5f13e362d6992d8cee0a89364feded5cbd50",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "ref-tool-analyze-batch": {
     "source": "src/attune/mcp/tool_schemas.py",
     "hash": "a96c4580b9fabdd2f37ada7f8ffcd9d777c84bea9e200cbec98d76950836e07b",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "ref-tool-analyze-image": {
     "source": "src/attune/mcp/tool_schemas.py",
     "hash": "a96c4580b9fabdd2f37ada7f8ffcd9d777c84bea9e200cbec98d76950836e07b",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "ref-tool-attune-get-level": {
     "source": "src/attune/mcp/tool_schemas.py",
     "hash": "a96c4580b9fabdd2f37ada7f8ffcd9d777c84bea9e200cbec98d76950836e07b",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "ref-tool-attune-set-level": {
     "source": "src/attune/mcp/tool_schemas.py",
     "hash": "a96c4580b9fabdd2f37ada7f8ffcd9d777c84bea9e200cbec98d76950836e07b",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "ref-tool-auth-recommend": {
     "source": "src/attune/mcp/tool_schemas.py",
     "hash": "a96c4580b9fabdd2f37ada7f8ffcd9d777c84bea9e200cbec98d76950836e07b",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "ref-tool-auth-status": {
     "source": "src/attune/mcp/tool_schemas.py",
     "hash": "a96c4580b9fabdd2f37ada7f8ffcd9d777c84bea9e200cbec98d76950836e07b",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "ref-tool-bug-predict": {
     "source": "src/attune/mcp/tool_schemas.py",
     "hash": "a96c4580b9fabdd2f37ada7f8ffcd9d777c84bea9e200cbec98d76950836e07b",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "ref-tool-code-review": {
     "source": "src/attune/mcp/tool_schemas.py",
     "hash": "a96c4580b9fabdd2f37ada7f8ffcd9d777c84bea9e200cbec98d76950836e07b",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "ref-tool-context-get": {
     "source": "src/attune/mcp/tool_schemas.py",
     "hash": "a96c4580b9fabdd2f37ada7f8ffcd9d777c84bea9e200cbec98d76950836e07b",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "ref-tool-context-set": {
     "source": "src/attune/mcp/tool_schemas.py",
     "hash": "a96c4580b9fabdd2f37ada7f8ffcd9d777c84bea9e200cbec98d76950836e07b",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "ref-tool-deep-review": {
     "source": "src/attune/mcp/tool_schemas.py",
     "hash": "a96c4580b9fabdd2f37ada7f8ffcd9d777c84bea9e200cbec98d76950836e07b",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "ref-tool-dependency-check": {
     "source": "src/attune/mcp/tool_schemas.py",
     "hash": "a96c4580b9fabdd2f37ada7f8ffcd9d777c84bea9e200cbec98d76950836e07b",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "ref-tool-doc-audit": {
     "source": "src/attune/mcp/tool_schemas.py",
     "hash": "a96c4580b9fabdd2f37ada7f8ffcd9d777c84bea9e200cbec98d76950836e07b",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "ref-tool-doc-gen": {
     "source": "src/attune/mcp/tool_schemas.py",
     "hash": "a96c4580b9fabdd2f37ada7f8ffcd9d777c84bea9e200cbec98d76950836e07b",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "ref-tool-doc-orchestrator": {
     "source": "src/attune/mcp/tool_schemas.py",
     "hash": "a96c4580b9fabdd2f37ada7f8ffcd9d777c84bea9e200cbec98d76950836e07b",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "ref-tool-health-check": {
     "source": "src/attune/mcp/tool_schemas.py",
     "hash": "a96c4580b9fabdd2f37ada7f8ffcd9d777c84bea9e200cbec98d76950836e07b",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "ref-tool-memory-forget": {
     "source": "src/attune/mcp/tool_schemas.py",
     "hash": "a96c4580b9fabdd2f37ada7f8ffcd9d777c84bea9e200cbec98d76950836e07b",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "ref-tool-memory-retrieve": {
     "source": "src/attune/mcp/tool_schemas.py",
     "hash": "a96c4580b9fabdd2f37ada7f8ffcd9d777c84bea9e200cbec98d76950836e07b",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "ref-tool-memory-search": {
     "source": "src/attune/mcp/tool_schemas.py",
     "hash": "a96c4580b9fabdd2f37ada7f8ffcd9d777c84bea9e200cbec98d76950836e07b",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "ref-tool-memory-store": {
     "source": "src/attune/mcp/tool_schemas.py",
     "hash": "a96c4580b9fabdd2f37ada7f8ffcd9d777c84bea9e200cbec98d76950836e07b",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "ref-tool-performance-audit": {
     "source": "src/attune/mcp/tool_schemas.py",
     "hash": "a96c4580b9fabdd2f37ada7f8ffcd9d777c84bea9e200cbec98d76950836e07b",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "ref-tool-rag-knowledge-query": {
     "source": "src/attune/mcp/tool_schemas.py",
     "hash": "a96c4580b9fabdd2f37ada7f8ffcd9d777c84bea9e200cbec98d76950836e07b",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "ref-tool-refactor-plan": {
     "source": "src/attune/mcp/tool_schemas.py",
     "hash": "a96c4580b9fabdd2f37ada7f8ffcd9d777c84bea9e200cbec98d76950836e07b",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "ref-tool-release-prep": {
     "source": "src/attune/mcp/tool_schemas.py",
     "hash": "a96c4580b9fabdd2f37ada7f8ffcd9d777c84bea9e200cbec98d76950836e07b",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "ref-tool-research-synthesis": {
     "source": "src/attune/mcp/tool_schemas.py",
     "hash": "a96c4580b9fabdd2f37ada7f8ffcd9d777c84bea9e200cbec98d76950836e07b",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "ref-tool-secure-release": {
     "source": "src/attune/mcp/tool_schemas.py",
     "hash": "a96c4580b9fabdd2f37ada7f8ffcd9d777c84bea9e200cbec98d76950836e07b",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "ref-tool-security-audit": {
     "source": "src/attune/mcp/tool_schemas.py",
     "hash": "a96c4580b9fabdd2f37ada7f8ffcd9d777c84bea9e200cbec98d76950836e07b",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "ref-tool-simplify-code": {
     "source": "src/attune/mcp/tool_schemas.py",
     "hash": "a96c4580b9fabdd2f37ada7f8ffcd9d777c84bea9e200cbec98d76950836e07b",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "ref-tool-telemetry-stats": {
     "source": "src/attune/mcp/tool_schemas.py",
     "hash": "a96c4580b9fabdd2f37ada7f8ffcd9d777c84bea9e200cbec98d76950836e07b",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "ref-tool-test-audit": {
     "source": "src/attune/mcp/tool_schemas.py",
     "hash": "a96c4580b9fabdd2f37ada7f8ffcd9d777c84bea9e200cbec98d76950836e07b",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "ref-tool-test-gen-parallel": {
     "source": "src/attune/mcp/tool_schemas.py",
     "hash": "a96c4580b9fabdd2f37ada7f8ffcd9d777c84bea9e200cbec98d76950836e07b",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "ref-tool-test-generation": {
     "source": "src/attune/mcp/tool_schemas.py",
     "hash": "a96c4580b9fabdd2f37ada7f8ffcd9d777c84bea9e200cbec98d76950836e07b",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "ref-wizards": {
     "source": "content/features/wizards.md",
     "hash": "6fe7722a026d11276ebfbdf4ea046a05112be94b560f9abf3ffee410f8637d8f",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "tas-agents": {
     "source": "content/features/agents.md",
     "hash": "a5b1678ecf012c7b2877a6c7ecae4a6c3f14c084c13fbcbb7eee79119dce6fa3",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "tas-browse-help-docs": {
     "source": "src/attune/cli_commands/help_commands.py",
     "hash": "d284892c4f058b5a9d4861f08f7f2de09c8050d33766471014bb739215a83582",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "tas-bug-predict": {
     "source": "content/features/bug-predict.md",
     "hash": "6a4f420eba38e2fb884b837dd9758acb60ba60cdaf9248ec4280120b0d382b16",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "tas-check-auth-status": {
     "source": "src/attune/cli_minimal.py",
-    "hash": "6ecf010bd218d5d2146708b4ae24cb28ab463f17324c52a2ca6c4455569147d7",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "952eff81eb5c2a259974a8196363de82f79cbaeb5b115859b42a823100dbe974",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "tas-cli": {
     "source": "content/features/cli.md",
     "hash": "a37b4dc4f0b3706a62184b02d2be1536ad75eef39a0f22a9699db5d03b8ee050",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "tas-code-quality": {
     "source": "content/features/code-quality.md",
     "hash": "ce16ac87eb92e33a08d8c2f06e86ef22e436966f47f3a28c3f4eba19060b550a",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "tas-configuration": {
     "source": "content/features/configuration.md",
     "hash": "8add90392883a46899ef8b57d135b625d92c5b61231d8a5301727f8b42f8e46f",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "tas-deep-review": {
     "source": "content/features/deep-review.md",
     "hash": "6a4fffc907302b4847d96097189bd8d329d3f1548d1ee46d9232f6ceecdfb450",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "tas-doc-gen": {
     "source": "content/features/doc-gen.md",
     "hash": "26e02a71a523775f5bb9e371b2e563c3c858386436a73b727422f62f57de0282",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "tas-elicitation-forms": {
     "source": "content/features/elicitation-forms.md",
-    "hash": "d62f3ddd16ae031e875c042d0795449de6965fecfe2caa36edddb9a5fbf1a6fd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "b7e73232af03174e0e5d50d551277a784127eb8047713cacfce1df8b19e8a8d6",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "tas-export-telemetry": {
     "source": "src/attune/cli_minimal.py",
-    "hash": "6ecf010bd218d5d2146708b4ae24cb28ab463f17324c52a2ca6c4455569147d7",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "952eff81eb5c2a259974a8196363de82f79cbaeb5b115859b42a823100dbe974",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "tas-fix-test": {
     "source": "content/features/fix-test.md",
     "hash": "da54b69787cc1af5c087b2d8674442afe9b8c6fc88dca37a65e99590bb84fee0",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "tas-help-system": {
     "source": "content/features/help-system.md",
     "hash": "24468c8fe4f1a0e350e620098d65a3bcc007000cd5aa4dbe20a6e6c83efa87b3",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "tas-hooks": {
     "source": "content/features/hooks.md",
     "hash": "5c6b8a45457387c76f628561d3baa56e9af1709bc9bd21bba9830b2c2478c8dd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "tas-install-plugin": {
     "source": "README.md",
-    "hash": "53198ec9cd8b2bad6330182140cc310a0635b9eee72f282a916c6dfd4c8971c0",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "29c1821d6fdff7907606b8f37c13640c6d7747a9cfd2db37fb6b4579b0c7365f",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "tas-manage-lessons": {
     "source": "src/attune/cli_minimal.py",
-    "hash": "6ecf010bd218d5d2146708b4ae24cb28ab463f17324c52a2ca6c4455569147d7",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "952eff81eb5c2a259974a8196363de82f79cbaeb5b115859b42a823100dbe974",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "tas-mcp-server": {
     "source": "content/features/mcp-server.md",
     "hash": "8e4b8c74eff980330480ae70856a1cf0393559cd22eb9ba0210b43249f9b5181",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "tas-memory": {
     "source": "content/features/memory.md",
     "hash": "32b3121d9110dc9ac327bb9e838f060fbe9940a033366b0147ef34ef2efaa4dc",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "tas-models": {
     "source": "content/features/models.md",
     "hash": "2117cbb0d8e863db6091870874e4ce80b48780c9ee8bb7330d8033c172ccb02b",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "tas-ops-dashboard": {
     "source": "content/features/ops-dashboard.md",
     "hash": "fefc8e2b2b4a25055fcbdf96cbd8638d75278cbcacd256873b725df89544c1f6",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "tas-orchestration": {
     "source": "content/features/orchestration.md",
     "hash": "4998437e04355011a7dee68dbce7e9e78bbe97f637e0b6a14c1ec972f541695c",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "tas-plugin": {
     "source": "content/features/plugin.md",
     "hash": "8cc6e5702ffc8228ed63cfb74a25dd3e99e79e5335c4b1c8c134950f8b9a043d",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "tas-rag-grounding": {
     "source": "content/features/rag-grounding.md",
     "hash": "3464dd78c83f06980912a7c49dc185b09830be1b1c163203f10e5aa1708fcf4e",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "tas-refactor-plan": {
     "source": "content/features/refactor-plan.md",
     "hash": "8f8c684cd94fca7b2580ecaaf955ccb79924022796d576d477cdab9330df9704",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "tas-release-notes": {
     "source": "content/features/release-notes.md",
     "hash": "da7101ffbec4d209fcb1cef754f01cef8a13458a6f961c3a23909edfec77e58c",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "tas-release-prep": {
     "source": "content/features/release-prep.md",
     "hash": "cd77b5903fbeb7d7e0acef570bab9727b4c143181ea6be1f52b9a25bc11418bb",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "tas-resilience": {
     "source": "content/features/resilience.md",
     "hash": "ae2a76f0f1ecbb9ca687e5a041acc2b4a25a5113ec57eaad550f48b8aadc4be2",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "tas-run-doctor": {
     "source": "src/attune/cli_minimal.py",
-    "hash": "6ecf010bd218d5d2146708b4ae24cb28ab463f17324c52a2ca6c4455569147d7",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "952eff81eb5c2a259974a8196363de82f79cbaeb5b115859b42a823100dbe974",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "tas-run-workflow": {
     "source": "src/attune/cli_minimal.py",
-    "hash": "6ecf010bd218d5d2146708b4ae24cb28ab463f17324c52a2ca6c4455569147d7",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "952eff81eb5c2a259974a8196363de82f79cbaeb5b115859b42a823100dbe974",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "tas-security-audit": {
     "source": "content/features/security-audit.md",
     "hash": "9cce18573c827fab9a380efe8c65c2f8c5b4ada3f7e383dd71ec523a0875fb05",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "tas-smart-test": {
     "source": "content/features/smart-test.md",
     "hash": "58c691c8313ddf9699deb913e6b5c50fafc684563539ddf4816a4b94a9ea3e80",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "tas-spec-engine": {
     "source": "content/features/spec-engine.md",
     "hash": "c8549016aa848eeeaecbde8329f5850562f56280ab66428cb7c20887b428d81a",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "tas-telemetry": {
     "source": "content/features/telemetry.md",
     "hash": "59473ab809113116a3d58d2ead3a5f13e362d6992d8cee0a89364feded5cbd50",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "tas-use-attune-hub": {
     "source": "plugin/skills/attune-hub/SKILL.md",
-    "hash": "6d8cb8733a4dfb798f05814226de09d60af8b45d66df5755789f380d6f234f03",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "3e8cb98c4cdae752aad8e8ddda10f55629da0906b85b407e757ff8fd9981efac",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "tas-use-bug-predict": {
     "source": "plugin/skills/bug-predict/SKILL.md",
     "hash": "992b9e6cd3452af0d31213985e5e5c607f078edd2310df76d786b95d7e6a83ce",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "tas-use-coach": {
     "source": "plugin/skills/coach/SKILL.md",
     "hash": "a1842d674325f3f1ea289e3bd7ed1dcfbb4b3301160181edab081d2b4352aeac",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "tas-use-code-quality": {
     "source": "plugin/skills/code-quality/SKILL.md",
     "hash": "769c4c885992fd1937adbdf5d97305894bd08c159c83930d7a9fb86cb4ae78b7",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "tas-use-doc-gen": {
     "source": "plugin/skills/doc-gen/SKILL.md",
     "hash": "da9a9c23727eaa9433b2c4d1dfe87d850ef560d56b855f2eb7bd0f279efc3c72",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "tas-use-fix-test": {
     "source": "plugin/skills/fix-test/SKILL.md",
     "hash": "665ff7c4978beddd72e87f3764b073e4f962b27a896bd66542d499a1a00429da",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "tas-use-memory-and-context": {
     "source": "plugin/skills/memory-and-context/SKILL.md",
-    "hash": "f1a465f47af5948c4e37d4c6a75247d71223a6d5208063be318e65e1ec475e44",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "d026a40d0c5315123672c7ed3770b643ba803a3b5d57cb994c236fcd6baa8305",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "tas-use-planning": {
     "source": "plugin/skills/planning/SKILL.md",
     "hash": "f56a42c83f514b300b4f89ea6669820ec158da952efa2894c56abb00c39eb58a",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "tas-use-rag-code-gen": {
     "source": "plugin/skills/rag-code-gen/SKILL.md",
-    "hash": "da6cb96d8150291fa8c587e756247f14fe166083add938f210747ab867a26c5e",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "0d84a32e2f89e8debd740b4343c7930b17efcca37fcb68737f342f8b6b5f6f77",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "tas-use-refactor-plan": {
     "source": "plugin/skills/refactor-plan/SKILL.md",
     "hash": "080a84b5df5dde88cd3c994ca2c2b68ec12e2cf241f2e81893f21aa9dac315f6",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "tas-use-release-prep": {
     "source": "plugin/skills/release-prep/SKILL.md",
     "hash": "8aab944ae2f53a24c94d39329bf000067a68f43b51de6657b517678bec90c67a",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "tas-use-security-audit": {
     "source": "plugin/skills/security-audit/SKILL.md",
     "hash": "f370003a809c342d35b37990da231fbb72545e75e5a37e1e1d39a27db5364761",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "tas-use-smart-test": {
     "source": "plugin/skills/smart-test/SKILL.md",
     "hash": "a5e874d1054dd123d78d9d8e9014c7c6888230f36685a203ea26176a3d649ffb",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "tas-use-spec": {
     "source": "plugin/skills/spec/SKILL.md",
-    "hash": "26f2335775e968f4625078ee9fabd15a0ad04dc0980bc37def777d5908fa2e50",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "4e1ce2c9da6fcad85ebcf7cb6b755f44c27d00608ad97b72b93a82a45e3c0186",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "tas-use-workflow-orchestration": {
     "source": "plugin/skills/workflow-orchestration/SKILL.md",
     "hash": "831c00dfb29ae4c72b35921fd3bab9e9f17affabf32b8164deb801557e031127",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "tas-wizards": {
     "source": "content/features/wizards.md",
     "hash": "6fe7722a026d11276ebfbdf4ea046a05112be94b560f9abf3ffee410f8637d8f",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "tip-after-10-inspects": {
     "source": "src/attune/discovery.py",
     "hash": "81b550a4505d51c66f590eb3ea9d2c52002c0ffcab1ff3b2c013f5e34cd79c8b",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "tip-after-5-ships": {
     "source": "src/attune/discovery.py",
     "hash": "81b550a4505d51c66f590eb3ea9d2c52002c0ffcab1ff3b2c013f5e34cd79c8b",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "tip-after-bug-predict": {
     "source": "src/attune/workflows/suggestions.py",
     "hash": "caa3f48a039def99a5bf58dc29129aba9548dfc74a42cc69dfb067aeb71f3200",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "tip-after-code-review": {
     "source": "src/attune/workflows/suggestions.py",
     "hash": "caa3f48a039def99a5bf58dc29129aba9548dfc74a42cc69dfb067aeb71f3200",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "tip-after-dependency-check": {
     "source": "src/attune/workflows/suggestions.py",
     "hash": "caa3f48a039def99a5bf58dc29129aba9548dfc74a42cc69dfb067aeb71f3200",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "tip-after-first-health": {
     "source": "src/attune/discovery.py",
     "hash": "81b550a4505d51c66f590eb3ea9d2c52002c0ffcab1ff3b2c013f5e34cd79c8b",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "tip-after-first-inspect": {
     "source": "src/attune/discovery.py",
     "hash": "81b550a4505d51c66f590eb3ea9d2c52002c0ffcab1ff3b2c013f5e34cd79c8b",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "tip-after-perf-audit": {
     "source": "src/attune/workflows/suggestions.py",
     "hash": "caa3f48a039def99a5bf58dc29129aba9548dfc74a42cc69dfb067aeb71f3200",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "tip-after-refactor-plan": {
     "source": "src/attune/workflows/suggestions.py",
     "hash": "caa3f48a039def99a5bf58dc29129aba9548dfc74a42cc69dfb067aeb71f3200",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "tip-after-security-audit": {
     "source": "src/attune/workflows/suggestions.py",
     "hash": "caa3f48a039def99a5bf58dc29129aba9548dfc74a42cc69dfb067aeb71f3200",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "tip-after-simplify-code": {
     "source": "src/attune/workflows/suggestions.py",
     "hash": "caa3f48a039def99a5bf58dc29129aba9548dfc74a42cc69dfb067aeb71f3200",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "tip-after-test-gen": {
     "source": "src/attune/workflows/suggestions.py",
     "hash": "caa3f48a039def99a5bf58dc29129aba9548dfc74a42cc69dfb067aeb71f3200",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "tip-agents": {
     "source": "content/features/agents.md",
     "hash": "a5b1678ecf012c7b2877a6c7ecae4a6c3f14c084c13fbcbb7eee79119dce6fa3",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "tip-bug-predict": {
     "source": "content/features/bug-predict.md",
     "hash": "6a4f420eba38e2fb884b837dd9758acb60ba60cdaf9248ec4280120b0d382b16",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "tip-cli": {
     "source": "content/features/cli.md",
     "hash": "a37b4dc4f0b3706a62184b02d2be1536ad75eef39a0f22a9699db5d03b8ee050",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "tip-code-quality": {
     "source": "content/features/code-quality.md",
     "hash": "ce16ac87eb92e33a08d8c2f06e86ef22e436966f47f3a28c3f4eba19060b550a",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "tip-configuration": {
     "source": "content/features/configuration.md",
     "hash": "8add90392883a46899ef8b57d135b625d92c5b61231d8a5301727f8b42f8e46f",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "tip-cost-savings": {
     "source": "src/attune/discovery.py",
     "hash": "81b550a4505d51c66f590eb3ea9d2c52002c0ffcab1ff3b2c013f5e34cd79c8b",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "tip-deep-review": {
     "source": "content/features/deep-review.md",
     "hash": "6a4fffc907302b4847d96097189bd8d329d3f1548d1ee46d9232f6ceecdfb450",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "tip-doc-gen": {
     "source": "content/features/doc-gen.md",
     "hash": "26e02a71a523775f5bb9e371b2e563c3c858386436a73b727422f62f57de0282",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "tip-elicitation-forms": {
     "source": "content/features/elicitation-forms.md",
-    "hash": "d62f3ddd16ae031e875c042d0795449de6965fecfe2caa36edddb9a5fbf1a6fd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "b7e73232af03174e0e5d50d551277a784127eb8047713cacfce1df8b19e8a8d6",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "tip-fix-test": {
     "source": "content/features/fix-test.md",
     "hash": "da54b69787cc1af5c087b2d8674442afe9b8c6fc88dca37a65e99590bb84fee0",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "tip-help-system": {
     "source": "content/features/help-system.md",
     "hash": "24468c8fe4f1a0e350e620098d65a3bcc007000cd5aa4dbe20a6e6c83efa87b3",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "tip-high-tech-debt": {
     "source": "src/attune/discovery.py",
     "hash": "81b550a4505d51c66f590eb3ea9d2c52002c0ffcab1ff3b2c013f5e34cd79c8b",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "tip-hooks": {
     "source": "content/features/hooks.md",
     "hash": "5c6b8a45457387c76f628561d3baa56e9af1709bc9bd21bba9830b2c2478c8dd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "tip-mcp-server": {
     "source": "content/features/mcp-server.md",
     "hash": "8e4b8c74eff980330480ae70856a1cf0393559cd22eb9ba0210b43249f9b5181",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "tip-memory": {
     "source": "content/features/memory.md",
     "hash": "32b3121d9110dc9ac327bb9e838f060fbe9940a033366b0147ef34ef2efaa4dc",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "tip-models": {
     "source": "content/features/models.md",
     "hash": "2117cbb0d8e863db6091870874e4ce80b48780c9ee8bb7330d8033c172ccb02b",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "tip-no-patterns": {
     "source": "src/attune/discovery.py",
     "hash": "81b550a4505d51c66f590eb3ea9d2c52002c0ffcab1ff3b2c013f5e34cd79c8b",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "tip-ops-dashboard": {
     "source": "content/features/ops-dashboard.md",
     "hash": "fefc8e2b2b4a25055fcbdf96cbd8638d75278cbcacd256873b725df89544c1f6",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "tip-orchestration": {
     "source": "content/features/orchestration.md",
     "hash": "4998437e04355011a7dee68dbce7e9e78bbe97f637e0b6a14c1ec972f541695c",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "tip-plugin": {
     "source": "content/features/plugin.md",
     "hash": "8cc6e5702ffc8228ed63cfb74a25dd3e99e79e5335c4b1c8c134950f8b9a043d",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "tip-rag-grounding": {
     "source": "content/features/rag-grounding.md",
     "hash": "3464dd78c83f06980912a7c49dc185b09830be1b1c163203f10e5aa1708fcf4e",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "tip-refactor-plan": {
     "source": "content/features/refactor-plan.md",
     "hash": "8f8c684cd94fca7b2580ecaaf955ccb79924022796d576d477cdab9330df9704",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "tip-release-notes": {
     "source": "content/features/release-notes.md",
     "hash": "da7101ffbec4d209fcb1cef754f01cef8a13458a6f961c3a23909edfec77e58c",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "tip-release-prep": {
     "source": "content/features/release-prep.md",
     "hash": "cd77b5903fbeb7d7e0acef570bab9727b4c143181ea6be1f52b9a25bc11418bb",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "tip-resilience": {
     "source": "content/features/resilience.md",
     "hash": "ae2a76f0f1ecbb9ca687e5a041acc2b4a25a5113ec57eaad550f48b8aadc4be2",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "tip-security-audit": {
     "source": "content/features/security-audit.md",
     "hash": "9cce18573c827fab9a380efe8c65c2f8c5b4ada3f7e383dd71ec523a0875fb05",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "tip-smart-test": {
     "source": "content/features/smart-test.md",
     "hash": "58c691c8313ddf9699deb913e6b5c50fafc684563539ddf4816a4b94a9ea3e80",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "tip-spec-engine": {
     "source": "content/features/spec-engine.md",
     "hash": "c8549016aa848eeeaecbde8329f5850562f56280ab66428cb7c20887b428d81a",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "tip-telemetry": {
     "source": "content/features/telemetry.md",
     "hash": "59473ab809113116a3d58d2ead3a5f13e362d6992d8cee0a89364feded5cbd50",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "tip-weekly-review": {
     "source": "src/attune/discovery.py",
     "hash": "81b550a4505d51c66f590eb3ea9d2c52002c0ffcab1ff3b2c013f5e34cd79c8b",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "tip-wizards": {
     "source": "content/features/wizards.md",
     "hash": "6fe7722a026d11276ebfbdf4ea046a05112be94b560f9abf3ffee410f8637d8f",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "tro-agents": {
     "source": "content/features/agents.md",
     "hash": "a5b1678ecf012c7b2877a6c7ecae4a6c3f14c084c13fbcbb7eee79119dce6fa3",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "tro-bug-predict": {
     "source": "content/features/bug-predict.md",
     "hash": "6a4f420eba38e2fb884b837dd9758acb60ba60cdaf9248ec4280120b0d382b16",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "tro-cli": {
     "source": "content/features/cli.md",
     "hash": "a37b4dc4f0b3706a62184b02d2be1536ad75eef39a0f22a9699db5d03b8ee050",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "tro-code-quality": {
     "source": "content/features/code-quality.md",
     "hash": "ce16ac87eb92e33a08d8c2f06e86ef22e436966f47f3a28c3f4eba19060b550a",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "tro-configuration": {
     "source": "content/features/configuration.md",
     "hash": "8add90392883a46899ef8b57d135b625d92c5b61231d8a5301727f8b42f8e46f",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "tro-deep-review": {
     "source": "content/features/deep-review.md",
     "hash": "6a4fffc907302b4847d96097189bd8d329d3f1548d1ee46d9232f6ceecdfb450",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "tro-doc-gen": {
     "source": "content/features/doc-gen.md",
     "hash": "26e02a71a523775f5bb9e371b2e563c3c858386436a73b727422f62f57de0282",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "tro-elicitation-forms": {
     "source": "content/features/elicitation-forms.md",
-    "hash": "d62f3ddd16ae031e875c042d0795449de6965fecfe2caa36edddb9a5fbf1a6fd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "b7e73232af03174e0e5d50d551277a784127eb8047713cacfce1df8b19e8a8d6",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "tro-fix-test": {
     "source": "content/features/fix-test.md",
     "hash": "da54b69787cc1af5c087b2d8674442afe9b8c6fc88dca37a65e99590bb84fee0",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "tro-help-system": {
     "source": "content/features/help-system.md",
     "hash": "24468c8fe4f1a0e350e620098d65a3bcc007000cd5aa4dbe20a6e6c83efa87b3",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "tro-hooks": {
     "source": "content/features/hooks.md",
     "hash": "5c6b8a45457387c76f628561d3baa56e9af1709bc9bd21bba9830b2c2478c8dd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "tro-mcp-server": {
     "source": "content/features/mcp-server.md",
     "hash": "8e4b8c74eff980330480ae70856a1cf0393559cd22eb9ba0210b43249f9b5181",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "tro-memory": {
     "source": "content/features/memory.md",
     "hash": "32b3121d9110dc9ac327bb9e838f060fbe9940a033366b0147ef34ef2efaa4dc",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "tro-models": {
     "source": "content/features/models.md",
     "hash": "2117cbb0d8e863db6091870874e4ce80b48780c9ee8bb7330d8033c172ccb02b",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "tro-ops-dashboard": {
     "source": "content/features/ops-dashboard.md",
     "hash": "fefc8e2b2b4a25055fcbdf96cbd8638d75278cbcacd256873b725df89544c1f6",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "tro-orchestration": {
     "source": "content/features/orchestration.md",
     "hash": "4998437e04355011a7dee68dbce7e9e78bbe97f637e0b6a14c1ec972f541695c",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "tro-plugin": {
     "source": "content/features/plugin.md",
     "hash": "8cc6e5702ffc8228ed63cfb74a25dd3e99e79e5335c4b1c8c134950f8b9a043d",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "tro-rag-grounding": {
     "source": "content/features/rag-grounding.md",
     "hash": "3464dd78c83f06980912a7c49dc185b09830be1b1c163203f10e5aa1708fcf4e",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "tro-refactor-plan": {
     "source": "content/features/refactor-plan.md",
     "hash": "8f8c684cd94fca7b2580ecaaf955ccb79924022796d576d477cdab9330df9704",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "tro-release-notes": {
     "source": "content/features/release-notes.md",
     "hash": "da7101ffbec4d209fcb1cef754f01cef8a13458a6f961c3a23909edfec77e58c",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "tro-release-prep": {
     "source": "content/features/release-prep.md",
     "hash": "cd77b5903fbeb7d7e0acef570bab9727b4c143181ea6be1f52b9a25bc11418bb",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "tro-resilience": {
     "source": "content/features/resilience.md",
     "hash": "ae2a76f0f1ecbb9ca687e5a041acc2b4a25a5113ec57eaad550f48b8aadc4be2",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "tro-security-audit": {
     "source": "content/features/security-audit.md",
     "hash": "9cce18573c827fab9a380efe8c65c2f8c5b4ada3f7e383dd71ec523a0875fb05",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "tro-smart-test": {
     "source": "content/features/smart-test.md",
     "hash": "58c691c8313ddf9699deb913e6b5c50fafc684563539ddf4816a4b94a9ea3e80",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "tro-spec-engine": {
     "source": "content/features/spec-engine.md",
     "hash": "c8549016aa848eeeaecbde8329f5850562f56280ab66428cb7c20887b428d81a",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "tro-telemetry": {
     "source": "content/features/telemetry.md",
     "hash": "59473ab809113116a3d58d2ead3a5f13e362d6992d8cee0a89364feded5cbd50",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "tro-wizards": {
     "source": "content/features/wizards.md",
     "hash": "6fe7722a026d11276ebfbdf4ea046a05112be94b560f9abf3ffee410f8637d8f",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-adding-a-plugin-skill-has-three-enforcement-gates-not-one": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-adding-a-workspace-sibling-package-as-an-extra-can-silently": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-adding-logger-before-eager-imports-triggers-e402-in-init-py": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-after-a-pr-merges-while-youre-afk-pull-main-before-tagging": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-after-a-squash-merge-of-a-feature-branch-local-main-can-have": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-agents": {
     "source": "content/features/agents.md",
     "hash": "a5b1678ecf012c7b2877a6c7ecae4a6c3f14c084c13fbcbb7eee79119dce6fa3",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-agents-skills-must-stay-synced-with-plugin-skills": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-anchor-tag-buttons-need-text-white-no-underline": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-anthropics-built-in-prompt-caching-supersedes-custom-caching": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-any-unstaged-file-triggers-pre-commit-stash-conflicts-with-auto": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-attune-author-check-staleness-load-manifest-is-the-python-api": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-attune-helps-sidecar-schemas-dont-match-path-keyed-assumptions": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-attune-skill-names-must-not-collide-with-claude-code-built-in": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-b904-raise-x-from-e-is-not-auto-fixable-by-ruff": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-background-processes-from-previous-sessions-persist-across": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-bare-manifest-in-gitignore-silently-excludes-any-manifest": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-bg-var-primary-bg-opacity-10-is-invisible-in-dark-mode": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-bug-predict": {
     "source": "content/features/bug-predict.md",
     "hash": "6a4f420eba38e2fb884b837dd9758acb60ba60cdaf9248ec4280120b0d382b16",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-bug-predict-dangerous-eval-flags-subprocess-exec": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-bugpredictionworkflow-not-bugpredictworkflow": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-changing-error-messages-breaks-tests-across-the-codebase": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-changing-the-citation-anchor-format-can-silently-regress-llm": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-changing-user-facing-output-strings-cascades-through-test": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-chicken-and-egg-for-optional-extras-in-dev": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-citation-forced-prompting-and-prompt-injection-resistance-are": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-claude-code-plugin-is-platform-specific": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-claude-code-plugins-expect-plugin-json-inside-claude-plugin": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-cli": {
     "source": "content/features/cli.md",
     "hash": "a37b4dc4f0b3706a62184b02d2be1536ad75eef39a0f22a9699db5d03b8ee050",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-clusterfuzz-dockerfile-copies-to-src-repo-but-also-copies": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-clusterfuzzlite-no-deps-misses-transitive-imports": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-code-quality": {
     "source": "content/features/code-quality.md",
     "hash": "ce16ac87eb92e33a08d8c2f06e86ef22e436966f47f3a28c3f4eba19060b550a",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-codecov-patch-0-usually-means-tests-skipped-not-failed": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-codeql-alerts-dismissible-in-bulk-via-gh-api": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-combine-two-unreleased-changelog-drafts-into-one-version-when": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-commands-are-not-namespaced-in-plugins-skills-are": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-configuration": {
     "source": "content/features/configuration.md",
     "hash": "8add90392883a46899ef8b57d135b625d92c5b61231d8a5301727f8b42f8e46f",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-costreport-fields-are-named-not-positional": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-costreport-is-a-dataclass-not-a-dict": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-dataclassorder-true-needs-compare-false-on-list-fields": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-dead-code-modules-with-full-test-suites-look-alive": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-dead-tests-from-monorepo-extraction-accumulate-in-packages-with": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-deep-review": {
     "source": "content/features/deep-review.md",
     "hash": "6a4fffc907302b4847d96097189bd8d329d3f1548d1ee46d9232f6ceecdfb450",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-deep-review-false-positives-verify-before-acting": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-detect-secrets-flags-fake-as-a-secret-in-test-fixtures": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-direct-pushes-to-main-are-blocked-by-the-presence-of-required": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-dispatch-tables-hold-direct-function-references-mocks-must": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-dist-can-contain-stale-artifacts-after-version-bumps": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-doc-gen": {
     "source": "content/features/doc-gen.md",
     "hash": "26e02a71a523775f5bb9e371b2e563c3c858386436a73b727422f62f57de0282",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-dont-append-z-to-timezone-aware-isoformat": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-dry-run-candidate-golden-queries-through-the-resolver-before": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-duck-typed-test-fakes-fail-isinstance-based-collectors-silently": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-duplicate-plugins-cause-conflicting-skill-triggers": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-elicitation-forms": {
     "source": "content/features/elicitation-forms.md",
-    "hash": "d62f3ddd16ae031e875c042d0795449de6965fecfe2caa36edddb9a5fbf1a6fd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "b7e73232af03174e0e5d50d551277a784127eb8047713cacfce1df8b19e8a8d6",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-exclude-hard-queries-from-aggregate-p-1-metrics-in-benchmark": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-exploration-agents-fabricate-names-verify-against-source": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-f841-unused-fixture-lint-fires-when-a-test-is-refactored-to": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-fastembed-is-the-local-embeddings-path-that-passes-a-50mb": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-fix-test": {
     "source": "content/features/fix-test.md",
     "hash": "da54b69787cc1af5c087b2d8674442afe9b8c6fc88dca37a65e99590bb84fee0",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-forced-anthropic-tool-use-is-the-cleanest-path-to-guaranteed": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-formatter-strips-imports-that-are-unused-at-the-moment-you-save": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-generated-content-with-trailing-whitespace-causes-perpetual-pre": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-gh-api-x-patch-f-name-n-rejects-integers-as-strings": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-gh-pr-checks-json-field-names": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-gh-pr-merge-admin-is-blocked-by-in-progress-required-checks": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-gh-pr-merge-admin-prints-a-fast-forward-warning-even-when-the": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-gh-workflow-run-file-yml-ref-tag-re-triggers-a-release-gated": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-git-commit-q-can-exit-0-with-pre-commit-hook-feedback-that": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-git-pull-refuses-with-unstaged-changes-when-pull-rebase-true": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-git-rebase-root-exec-git-commit-amend-no-edit-s-re-signs-every": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-git-stash-pop-after-pre-commit-can-resurrect-stale-tool-state": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-github-actions-environment-deployment-approvals-can-be-self": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-github-copilot-autofix-pushes-commits-directly-to-pr-branches": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-github-protected-tags-cannot-be-force-updated": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-github-repos-serve-as-claude-code-marketplaces": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-gitignore-exclusions-break-ci-tests-that-read-those-files": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-glob-based-hash-computation-must-exclude-cache-dirs": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-golden-query-benchmarks-reveal-two-distinct-failure-classes": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-golden-query-test-fixtures-must-match-the-actual-corpus-layout": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-gpg-signing-fails-in-non-interactive-terminals-vscode-extension": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-hand-crafted-summary-prototype-is-the-fastest-way-to-measure-a": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-handoff-memory-option-b-proposals-are-often-wrong-re-analyze": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-hardcoded-root-paths-in-tests": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-hardcoded-strings-in-method-bodies-survive-class-attribute": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-hardcoded-user-id-defeats-ownership-checks": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-help-system": {
     "source": "content/features/help-system.md",
     "hash": "24468c8fe4f1a0e350e620098d65a3bcc007000cd5aa4dbe20a6e6c83efa87b3",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-hooks": {
     "source": "content/features/hooks.md",
     "hash": "5c6b8a45457387c76f628561d3baa56e9af1709bc9bd21bba9830b2c2478c8dd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-hot-reload-subsystem-was-1-038-lines-of-dead-code": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-import-x-inside-a-try-block-except-x-someerror-in-the-except": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-importlib-import-module-is-an-arbitrary-code-execution-vector": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-industry-terminology-wont-appear-in-llm-polished-rag-summaries": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-is-private-is-a-superset-in-python-ipaddress": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-lazy-imports-inside-function-bodies-cant-be-patched-with": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-linkedin-paste-use-ascii-markers-not-unicode-arrows": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-list-workflows-deduplication-must-keep-base-names-visible": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-llm-api-responses-lack-trailing-newlines": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-mcp-attune-ai-doc-orchestrator-is-a-no-op-stub": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-mcp-call-tool-wrapper-pattern": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-mcp-handler-validate-paths-before-importing-workflows": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-mcp-json-python-resolves-to-pyenv-shim-not-project-venv": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-mcp-server": {
     "source": "content/features/mcp-server.md",
     "hash": "8e4b8c74eff980330480ae70856a1cf0393559cd22eb9ba0210b43249f9b5181",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-mcp-tool-renames-propagate-to-skill-docs": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-memory": {
     "source": "content/features/memory.md",
     "hash": "32b3121d9110dc9ac327bb9e838f060fbe9940a033366b0147ef34ef2efaa4dc",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-metadata-can-reach-a-retriever-with-zero-signal-if-the-sidecar": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-mkdocs-build-crashing-with-attributeerror-nonetype-object-has": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-models": {
     "source": "content/features/models.md",
     "hash": "2117cbb0d8e863db6091870874e4ce80b48780c9ee8bb7330d8033c172ccb02b",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-modeltier-has-two-copies-imports-must-match": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-module-level-optional-imports-enable-clean-test-patching": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-multiple-pinentry-program-lines-in-gpg-agent-conf-first-wins": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-mutual-competition-between-polished-rag-features-is-real-and": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-mypy-437-errors-was-stale-actual-count-was-2": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-naive-suffix-strip-stemming-fails-on-english-doubling-consonant": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-never-paste-pypi-tokens-into-chat-or-logs": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-new-dataclass-fields-need-both-the-class-and-the-parser-updated": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-new-mcp-handlers-must-match-the-validation-pattern-of-adjacent": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-new-security-features-need-dedicated-tests-before-release": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-non-baseworkflow-classes-in-workflow-registry-crash-the-cli": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-noqa-f401-re-exports-break-silently-on-satellite-file-deletion": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-openssf-scorecard-alerts-2-codereviewid-3-sastid-are-process": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-ops-dashboard": {
     "source": "content/features/ops-dashboard.md",
     "hash": "fefc8e2b2b4a25055fcbdf96cbd8638d75278cbcacd256873b725df89544c1f6",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-orchestration": {
     "source": "content/features/orchestration.md",
     "hash": "4998437e04355011a7dee68dbce7e9e78bbe97f637e0b6a14c1ec972f541695c",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-orphan-help-dirs-are-deprecated-3-depth-output-adding-them-to": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-orphan-top-level-docs-directories-stay-invisible-to-readers": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-packages-attune-in-attune-ai-are-pointer-stubs-not-source": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-past-due-deprecations-are-deletion-targets-not-implementation": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-patch-requires-the-target-name-to-exist-at-module-scope-at": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-path-globdir-matches-directories-not-files": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-path-rename-fails-on-windows-when-target-exists": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-platform-conditional-security-test-assertions-should-accept-any": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-plugin": {
     "source": "content/features/plugin.md",
     "hash": "8cc6e5702ffc8228ed63cfb74a25dd3e99e79e5335c4b1c8c134950f8b9a043d",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-plugin-read-skill-references-break-outside-the-plugin": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-pre-commit-auto-fix-requires-re-stage-before-retry": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-pre-commit-black-unstaged-files-re-stage-after-failure": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-pre-commit-stash-conflict-when-black-ruff-fix-files-with": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-pre-commit-stash-conflict-with-auto-fix-hooks": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-pre-commit-stash-conflicts-when-any-tracked-unstaged-file": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-pre-committed-decision-matrices-survive-contact-with-data": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-pre-flight-pre-commits-pinned-black-ruff-on-new-files-before": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-prefer-github-actions-trusted-publishing-over-local-twine-uv": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-provenance-citation-records-usually-store-short-previews-not": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-pull-main-before-merging-develop-to-avoid-merge-commits": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-pureposixpath-match-doesnt-support-in-python-3-10": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-pureposixpath-strips-trailing-slashes": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-push-specific-tags-not-tags": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-pypi-env-policies-may-whitelist-branches-only-tag-triggered": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-pypi-renders-readme-links-relative-to-its-own-domain": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-pypi-trusted-publisher-workflow-name-field-wants-the-filename": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-pytest-importorskip-triggers-ruff-e402": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-query-fixtures-are-self-diagnostic-for-rag-corpora-even-without": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-rag-grounding": {
     "source": "content/features/rag-grounding.md",
     "hash": "3464dd78c83f06980912a7c49dc185b09830be1b1c163203f10e5aa1708fcf4e",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-re-adding-an-import-after-the-formatter-strips-it-use-function": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-re-enabling-required-reviews-kills-queued-auto-merge": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-read-source-before-writing-tests-for-tricky-logic": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-rebuild-dist-after-readme-changes": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-reclassify-unexpectedly-hard-golden-queries-up-the-difficulty": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-redisshorttermmemory-mock-injection-path": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-refactor-plan": {
     "source": "content/features/refactor-plan.md",
     "hash": "8f8c684cd94fca7b2580ecaaf955ccb79924022796d576d477cdab9330df9704",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-registry-count-assertions-are-scattered-across-test-files": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-release-branches-carry-unmerged-commits-that-feature-branches": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-release-notes": {
     "source": "content/features/release-notes.md",
     "hash": "da7101ffbec4d209fcb1cef754f01cef8a13458a6f961c3a23909edfec77e58c",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-release-prep": {
     "source": "content/features/release-prep.md",
     "hash": "cd77b5903fbeb7d7e0acef570bab9727b4c143181ea6be1f52b9a25bc11418bb",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-release-published-workflow-dispatch-both-approved-for-pypi-env": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-removing-one-workspace-dep-can-cascade-to-remove-others": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-replacing-a-mixin-based-class-scatters-test-failures-across": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-repo-merge-policy-may-restrict-merge-strategies": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-repo-root-parents-count-varies-by-file-depth": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-required-status-check-names-must-match-githubs-exact-check-names": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-research-subagents-can-hallucinate-sdk-signatures-introspect": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-resilience": {
     "source": "content/features/resilience.md",
     "hash": "ae2a76f0f1ecbb9ca687e5a041acc2b4a25a5113ec57eaad550f48b8aadc4be2",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-resultmessage-result-is-often-none-capture-assistantmessage": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-rich-live-is-output-only-use-textual-for-any-interactive-row": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-ruff-auto-fix-strips-imports-before-usage-code-exists": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-run-simplify-catches-per-file-errors-internally": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-sbin-is-a-symlink-to-usr-sbin-on-modern-ubuntu": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-sdk-adapter-swallows-subagent-findings-lesson-was-wrong-adapter": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-sdk-agent-model-config-uses-stale-model-names": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-sdk-native-workflows-validate-in-execute-not-input-schema": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-security-audit": {
     "source": "content/features/security-audit.md",
     "hash": "9cce18573c827fab9a380efe8c65c2f8c5b4ada3f7e383dd71ec523a0875fb05",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-semantic-cache-70-hit-rate-claim-was-unmeasured": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-session-hooks-may-be-vestigial": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-shadow-directories-at-repo-root-break-imports": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-silent-pass-blocks-in-discovery-registry-code-hide-import": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-skill-descriptions-must-be-under-250-characters": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-skill-frontmatter-has-a-strict-allowlist": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-smart-test": {
     "source": "content/features/smart-test.md",
     "hash": "58c691c8313ddf9699deb913e6b5c50fafc684563539ddf4816a4b94a9ea3e80",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-spec-engine": {
     "source": "content/features/spec-engine.md",
     "hash": "c8549016aa848eeeaecbde8329f5850562f56280ab66428cb7c20887b428d81a",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-squash-merge-deletes-the-remote-branch-subsequent-push-silently": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-ssrf-always-decode-urls-before-validating-hostnames": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-ssrf-strip-ipv6-zone-ids-before-ip-validation": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-stacked-patch-decorators-inject-args-bottom-up": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-staleness-detection-in-attune-author-attune-ais-help-system-is": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-stop-hooks-inject-stderr-not-stdout": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-stop-hooks-loop-without-a-sentinel": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-stop-hooks-missing-cd-prefix-inherit-session-cwd": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-structlog-default-output-pollutes-stdout-captured-cli-tests": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-structlog-kwargs-vs-stdlib-logger": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-tags-pushed-before-squash-merge-point-to-the-wrong-commit": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-telemetry": {
     "source": "content/features/telemetry.md",
     "hash": "59473ab809113116a3d58d2ead3a5f13e362d6992d8cee0a89364feded5cbd50",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-template-generators-overwrite-hand-written-files": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-test-mocks-must-match-imports": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-tests-for-optional-dep-code-need-pytest-importorskip-guards-in": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-text-white-on-gradient-primary-sections-gets-overridden": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-two-codeql-setups-can-coexist-in-one-repo-and-deadlock-merges": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-uncommitted-claude-mcp-json-means-mcp-server-never-starts": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-untracked-scripts-break-ci-when-tests-import-them": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-unused-init-py-re-exports-become-invisible-runtime-deps": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-use-dataclass-post-init-to-coalesce-between-a-scalar-legacy": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-uv-lock-can-drift-from-pyproject-toml-on-shared-branches": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-uv-lock-retains-editable-name-paths-after-tool-uv-sources-edits": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-uv-pip-install-e-path-can-ship-stale-package-data-even-after": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-uv-pip-install-e-sibling-path-no-deps-is-the-clean-venv-local": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-uv-run-in-pre-commit-hooks-propagates-lockfile-errors-as-hook": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-uv-sync-wipes-packages-installed-via-pip-install": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-validate-infrastructure-against-user-value-before-extending": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-verify-new-dispatch-branches-with-a-known-fixture-not-just": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-version-bumps-must-update-7-files-not-just-pyproject-toml": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-website-feature-lists-can-diverge-from-the-python-registry": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-windows-ci-encoding": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-windows-ci-runners-are-3x-slower-than-ubuntu-macos": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-windows-time-time-can-return-0-0-duration-for-fast-operations": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-wizards": {
     "source": "content/features/wizards.md",
     "hash": "6fe7722a026d11276ebfbdf4ea046a05112be94b560f9abf3ffee410f8637d8f",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-wizards-call-workflows-internally-they-are-not-duplicates": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-workflowresult-constructor-mismatches-surface-only-at-runtime": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-yaml-run-block-scalars-break-on-blank-lines-inside-multi-line": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-yaml-run-values-with-colons-cause-parse-errors": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   },
   "war-zsh-has-status-as-a-read-only-builtin-variable": {
     "source": ".claude/CLAUDE.md",
-    "hash": "46361f985ec79bdd79534cbfa529d18e68bce923cc6b5df3f4636d0c68a6e3cd",
-    "generated_at": "2026-07-14T22:05:26.053660+00:00"
+    "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
+    "generated_at": "2026-07-25T05:20:20.804599+00:00"
   }
 }

--- a/plugin/help/generated/source_manifest.json
+++ b/plugin/help/generated/source_manifest.json
@@ -2,5916 +2,5916 @@
   "com-agents": {
     "source": "content/features/agents.md",
     "hash": "a5b1678ecf012c7b2877a6c7ecae4a6c3f14c084c13fbcbb7eee79119dce6fa3",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "com-auth-strategies": {
     "source": "src/attune/models/auth_cli.py",
     "hash": "586101ee6a646d50a06299d3c9e96f60467c65376782c191c910af6cf52ef268",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "com-bug-predict": {
     "source": "content/features/bug-predict.md",
     "hash": "6a4f420eba38e2fb884b837dd9758acb60ba60cdaf9248ec4280120b0d382b16",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "com-cli": {
     "source": "content/features/cli.md",
     "hash": "a37b4dc4f0b3706a62184b02d2be1536ad75eef39a0f22a9699db5d03b8ee050",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "com-code-quality": {
     "source": "content/features/code-quality.md",
     "hash": "ce16ac87eb92e33a08d8c2f06e86ef22e436966f47f3a28c3f4eba19060b550a",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "com-configuration": {
     "source": "content/features/configuration.md",
     "hash": "8add90392883a46899ef8b57d135b625d92c5b61231d8a5301727f8b42f8e46f",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "com-deep-review": {
     "source": "content/features/deep-review.md",
     "hash": "6a4fffc907302b4847d96097189bd8d329d3f1548d1ee46d9232f6ceecdfb450",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "com-doc-gen": {
     "source": "content/features/doc-gen.md",
     "hash": "26e02a71a523775f5bb9e371b2e563c3c858386436a73b727422f62f57de0282",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "com-elicitation-forms": {
     "source": "content/features/elicitation-forms.md",
-    "hash": "b7e73232af03174e0e5d50d551277a784127eb8047713cacfce1df8b19e8a8d6",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "hash": "36b29d55060c78f96ed1aaf1af34338dba4a156b674b98a9f35ebfd04524d2b3",
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "com-fix-test": {
     "source": "content/features/fix-test.md",
     "hash": "da54b69787cc1af5c087b2d8674442afe9b8c6fc88dca37a65e99590bb84fee0",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "com-help-system": {
     "source": "content/features/help-system.md",
     "hash": "24468c8fe4f1a0e350e620098d65a3bcc007000cd5aa4dbe20a6e6c83efa87b3",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "com-hooks": {
     "source": "content/features/hooks.md",
     "hash": "5c6b8a45457387c76f628561d3baa56e9af1709bc9bd21bba9830b2c2478c8dd",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "com-mcp-server": {
     "source": "content/features/mcp-server.md",
     "hash": "8e4b8c74eff980330480ae70856a1cf0393559cd22eb9ba0210b43249f9b5181",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "com-memory": {
     "source": "content/features/memory.md",
     "hash": "32b3121d9110dc9ac327bb9e838f060fbe9940a033366b0147ef34ef2efaa4dc",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "com-models": {
     "source": "content/features/models.md",
     "hash": "2117cbb0d8e863db6091870874e4ce80b48780c9ee8bb7330d8033c172ccb02b",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "com-ops-dashboard": {
     "source": "content/features/ops-dashboard.md",
     "hash": "fefc8e2b2b4a25055fcbdf96cbd8638d75278cbcacd256873b725df89544c1f6",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "com-orchestration": {
     "source": "content/features/orchestration.md",
     "hash": "4998437e04355011a7dee68dbce7e9e78bbe97f637e0b6a14c1ec972f541695c",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "com-plugin": {
     "source": "content/features/plugin.md",
     "hash": "8cc6e5702ffc8228ed63cfb74a25dd3e99e79e5335c4b1c8c134950f8b9a043d",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "com-rag-grounding": {
     "source": "content/features/rag-grounding.md",
     "hash": "3464dd78c83f06980912a7c49dc185b09830be1b1c163203f10e5aa1708fcf4e",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "com-refactor-plan": {
     "source": "content/features/refactor-plan.md",
     "hash": "8f8c684cd94fca7b2580ecaaf955ccb79924022796d576d477cdab9330df9704",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "com-release-notes": {
     "source": "content/features/release-notes.md",
     "hash": "da7101ffbec4d209fcb1cef754f01cef8a13458a6f961c3a23909edfec77e58c",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "com-release-prep": {
     "source": "content/features/release-prep.md",
     "hash": "cd77b5903fbeb7d7e0acef570bab9727b4c143181ea6be1f52b9a25bc11418bb",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "com-resilience": {
     "source": "content/features/resilience.md",
     "hash": "ae2a76f0f1ecbb9ca687e5a041acc2b4a25a5113ec57eaad550f48b8aadc4be2",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "com-security-audit": {
     "source": "content/features/security-audit.md",
     "hash": "9cce18573c827fab9a380efe8c65c2f8c5b4ada3f7e383dd71ec523a0875fb05",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "com-smart-test": {
     "source": "content/features/smart-test.md",
     "hash": "58c691c8313ddf9699deb913e6b5c50fafc684563539ddf4816a4b94a9ea3e80",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "com-spec-engine": {
     "source": "content/features/spec-engine.md",
     "hash": "c8549016aa848eeeaecbde8329f5850562f56280ab66428cb7c20887b428d81a",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "com-telemetry": {
     "source": "content/features/telemetry.md",
     "hash": "59473ab809113116a3d58d2ead3a5f13e362d6992d8cee0a89364feded5cbd50",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "com-wizards": {
     "source": "content/features/wizards.md",
     "hash": "6fe7722a026d11276ebfbdf4ea046a05112be94b560f9abf3ffee410f8637d8f",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "com-workflow-vs-wizard": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "con-agents": {
     "source": "content/features/agents.md",
     "hash": "a5b1678ecf012c7b2877a6c7ecae4a6c3f14c084c13fbcbb7eee79119dce6fa3",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "con-audience-adaptation": {
     "source": "src/attune/help/transformers.py",
     "hash": "00861e98056d93ab47c8ca43e64c941c802a1876da7faaad2ed0f825d698938c",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "con-bug-predict": {
     "source": "content/features/bug-predict.md",
     "hash": "6a4f420eba38e2fb884b837dd9758acb60ba60cdaf9248ec4280120b0d382b16",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "con-cli": {
     "source": "content/features/cli.md",
     "hash": "a37b4dc4f0b3706a62184b02d2be1536ad75eef39a0f22a9699db5d03b8ee050",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "con-code-quality": {
     "source": "content/features/code-quality.md",
     "hash": "ce16ac87eb92e33a08d8c2f06e86ef22e436966f47f3a28c3f4eba19060b550a",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "con-configuration": {
     "source": "content/features/configuration.md",
     "hash": "8add90392883a46899ef8b57d135b625d92c5b61231d8a5301727f8b42f8e46f",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "con-cross-linking": {
     "source": "scripts/build_cross_links.py",
     "hash": "f271a7146802a35388670a2541ab016e3358a78bf5aa876f30f9af1d4d4344b0",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "con-deep-review": {
     "source": "content/features/deep-review.md",
     "hash": "6a4fffc907302b4847d96097189bd8d329d3f1548d1ee46d9232f6ceecdfb450",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "con-doc-gen": {
     "source": "content/features/doc-gen.md",
     "hash": "26e02a71a523775f5bb9e371b2e563c3c858386436a73b727422f62f57de0282",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "con-elicitation-forms": {
     "source": "content/features/elicitation-forms.md",
-    "hash": "b7e73232af03174e0e5d50d551277a784127eb8047713cacfce1df8b19e8a8d6",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "hash": "36b29d55060c78f96ed1aaf1af34338dba4a156b674b98a9f35ebfd04524d2b3",
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "con-feedback-loop": {
     "source": "src/attune/help/engine.py",
     "hash": "cefbd9ea62f941969da6b381754835e6994bcbece1867d76998f7199ef39265a",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "con-fix-test": {
     "source": "content/features/fix-test.md",
     "hash": "da54b69787cc1af5c087b2d8674442afe9b8c6fc88dca37a65e99590bb84fee0",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "con-help-system": {
     "source": "content/features/help-system.md",
     "hash": "24468c8fe4f1a0e350e620098d65a3bcc007000cd5aa4dbe20a6e6c83efa87b3",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "con-hooks": {
     "source": "content/features/hooks.md",
     "hash": "5c6b8a45457387c76f628561d3baa56e9af1709bc9bd21bba9830b2c2478c8dd",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "con-mcp-server": {
     "source": "content/features/mcp-server.md",
     "hash": "8e4b8c74eff980330480ae70856a1cf0393559cd22eb9ba0210b43249f9b5181",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "con-memory": {
     "source": "content/features/memory.md",
     "hash": "32b3121d9110dc9ac327bb9e838f060fbe9940a033366b0147ef34ef2efaa4dc",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "con-models": {
     "source": "content/features/models.md",
     "hash": "2117cbb0d8e863db6091870874e4ce80b48780c9ee8bb7330d8033c172ccb02b",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "con-ops-dashboard": {
     "source": "content/features/ops-dashboard.md",
     "hash": "fefc8e2b2b4a25055fcbdf96cbd8638d75278cbcacd256873b725df89544c1f6",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "con-orchestration": {
     "source": "content/features/orchestration.md",
     "hash": "4998437e04355011a7dee68dbce7e9e78bbe97f637e0b6a14c1ec972f541695c",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "con-plugin": {
     "source": "content/features/plugin.md",
     "hash": "8cc6e5702ffc8228ed63cfb74a25dd3e99e79e5335c4b1c8c134950f8b9a043d",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "con-progressive-depth": {
     "source": "src/attune/help/engine.py",
     "hash": "cefbd9ea62f941969da6b381754835e6994bcbece1867d76998f7199ef39265a",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "con-rag-grounding": {
     "source": "content/features/rag-grounding.md",
     "hash": "3464dd78c83f06980912a7c49dc185b09830be1b1c163203f10e5aa1708fcf4e",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "con-refactor-plan": {
     "source": "content/features/refactor-plan.md",
     "hash": "8f8c684cd94fca7b2580ecaaf955ccb79924022796d576d477cdab9330df9704",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "con-release-notes": {
     "source": "content/features/release-notes.md",
     "hash": "da7101ffbec4d209fcb1cef754f01cef8a13458a6f961c3a23909edfec77e58c",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "con-release-prep": {
     "source": "content/features/release-prep.md",
     "hash": "cd77b5903fbeb7d7e0acef570bab9727b4c143181ea6be1f52b9a25bc11418bb",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "con-resilience": {
     "source": "content/features/resilience.md",
     "hash": "ae2a76f0f1ecbb9ca687e5a041acc2b4a25a5113ec57eaad550f48b8aadc4be2",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "con-security-audit": {
     "source": "content/features/security-audit.md",
     "hash": "9cce18573c827fab9a380efe8c65c2f8c5b4ada3f7e383dd71ec523a0875fb05",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "con-smart-test": {
     "source": "content/features/smart-test.md",
     "hash": "58c691c8313ddf9699deb913e6b5c50fafc684563539ddf4816a4b94a9ea3e80",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "con-socratic-discovery": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "con-spec-engine": {
     "source": "content/features/spec-engine.md",
     "hash": "c8549016aa848eeeaecbde8329f5850562f56280ab66428cb7c20887b428d81a",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "con-sync-paradigm": {
     "source": "scripts/generate_all.py",
     "hash": "6a3e4428fe0b789f45a226f983116d18827b19b6a12162691c522fd4861862a3",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "con-telemetry": {
     "source": "content/features/telemetry.md",
     "hash": "59473ab809113116a3d58d2ead3a5f13e362d6992d8cee0a89364feded5cbd50",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "con-template-composition": {
     "source": "src/attune/help/engine.py",
     "hash": "cefbd9ea62f941969da6b381754835e6994bcbece1867d76998f7199ef39265a",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "con-tier-routing": {
     "source": "src/attune/workflows/base.py",
     "hash": "8651c3e2645e5ec764718119ed55284d1dc4853fa9903663925e2a0c42ff60de",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "con-tool-attune-hub": {
     "source": "plugin/skills/attune-hub/SKILL.md",
     "hash": "3e8cb98c4cdae752aad8e8ddda10f55629da0906b85b407e757ff8fd9981efac",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "con-tool-bug-predict": {
     "source": "plugin/skills/bug-predict/SKILL.md",
     "hash": "992b9e6cd3452af0d31213985e5e5c607f078edd2310df76d786b95d7e6a83ce",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "con-tool-coach": {
     "source": "plugin/skills/coach/SKILL.md",
     "hash": "a1842d674325f3f1ea289e3bd7ed1dcfbb4b3301160181edab081d2b4352aeac",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "con-tool-code-quality": {
     "source": "plugin/skills/code-quality/SKILL.md",
     "hash": "769c4c885992fd1937adbdf5d97305894bd08c159c83930d7a9fb86cb4ae78b7",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "con-tool-doc-gen": {
     "source": "plugin/skills/doc-gen/SKILL.md",
     "hash": "da9a9c23727eaa9433b2c4d1dfe87d850ef560d56b855f2eb7bd0f279efc3c72",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "con-tool-fix-test": {
     "source": "plugin/skills/fix-test/SKILL.md",
     "hash": "665ff7c4978beddd72e87f3764b073e4f962b27a896bd66542d499a1a00429da",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "con-tool-memory-and-context": {
     "source": "plugin/skills/memory-and-context/SKILL.md",
     "hash": "d026a40d0c5315123672c7ed3770b643ba803a3b5d57cb994c236fcd6baa8305",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "con-tool-planning": {
     "source": "plugin/skills/planning/SKILL.md",
     "hash": "f56a42c83f514b300b4f89ea6669820ec158da952efa2894c56abb00c39eb58a",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "con-tool-rag-code-gen": {
     "source": "plugin/skills/rag-code-gen/SKILL.md",
     "hash": "0d84a32e2f89e8debd740b4343c7930b17efcca37fcb68737f342f8b6b5f6f77",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "con-tool-refactor-plan": {
     "source": "plugin/skills/refactor-plan/SKILL.md",
     "hash": "080a84b5df5dde88cd3c994ca2c2b68ec12e2cf241f2e81893f21aa9dac315f6",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "con-tool-release-prep": {
     "source": "plugin/skills/release-prep/SKILL.md",
     "hash": "8aab944ae2f53a24c94d39329bf000067a68f43b51de6657b517678bec90c67a",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "con-tool-security-audit": {
     "source": "plugin/skills/security-audit/SKILL.md",
     "hash": "f370003a809c342d35b37990da231fbb72545e75e5a37e1e1d39a27db5364761",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "con-tool-smart-test": {
     "source": "plugin/skills/smart-test/SKILL.md",
     "hash": "a5e874d1054dd123d78d9d8e9014c7c6888230f36685a203ea26176a3d649ffb",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "con-tool-spec": {
     "source": "plugin/skills/spec/SKILL.md",
     "hash": "4e1ce2c9da6fcad85ebcf7cb6b755f44c27d00608ad97b72b93a82a45e3c0186",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "con-tool-workflow-orchestration": {
     "source": "plugin/skills/workflow-orchestration/SKILL.md",
     "hash": "831c00dfb29ae4c72b35921fd3bab9e9f17affabf32b8164deb801557e031127",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "con-wizards": {
     "source": "content/features/wizards.md",
     "hash": "6fe7722a026d11276ebfbdf4ea046a05112be94b560f9abf3ffee410f8637d8f",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "con-workflow-chain-prediction": {
     "source": "src/attune/workflows/suggestions.py",
     "hash": "caa3f48a039def99a5bf58dc29129aba9548dfc74a42cc69dfb067aeb71f3200",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-adding-a-plugin-skill-has-three-enforcement-gates-not-one": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-adding-a-workspace-sibling-package-as-an-extra-can-silently": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-adding-dns-resolution-to-validate-webhook-url-breaks-tests-that": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-adding-logger-before-eager-imports-triggers-e402-in-init-py": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-after-a-pr-merges-while-youre-afk-pull-main-before-tagging": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-after-a-squash-merge-of-a-feature-branch-local-main-can-have": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-agents": {
     "source": "content/features/agents.md",
     "hash": "a5b1678ecf012c7b2877a6c7ecae4a6c3f14c084c13fbcbb7eee79119dce6fa3",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-agents-skills-must-stay-synced-with-plugin-skills": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-anchor-tag-buttons-need-text-white-no-underline": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-anthropics-built-in-prompt-caching-supersedes-custom-caching": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-any-unstaged-file-triggers-pre-commit-stash-conflicts-with-auto": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-apply-lessons-by-problem-not-by-keyword": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-attune-author-check-staleness-load-manifest-is-the-python-api": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-attune-help-re-exports-create-a-hidden-cross-package-dep-on": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-attune-helps-sidecar-schemas-dont-match-path-keyed-assumptions": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-attune-skill-names-must-not-collide-with-claude-code-built-in": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-attune-workflow-run-code-review-and-security-audit-require-a": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-b904-raise-x-from-e-is-not-auto-fixable-by-ruff": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-background-processes-from-previous-sessions-persist-across": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-bandit-b108-blocks-hardcoded-tmp-paths": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-bare-manifest-in-gitignore-silently-excludes-any-manifest": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-baseworkflow-now-provides-self-logger": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-baseworkflow-uses-class-attributes-not-constructor-params": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-bg-var-primary-bg-opacity-10-is-invisible-in-dark-mode": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-broad-gitignore-patterns-match-nested-directories": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-bug-predict": {
     "source": "content/features/bug-predict.md",
     "hash": "6a4f420eba38e2fb884b837dd9758acb60ba60cdaf9248ec4280120b0d382b16",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-bug-predict-dangerous-eval-flags-subprocess-exec": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-bugpredictionworkflow-not-bugpredictworkflow": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-changing-error-messages-breaks-tests-across-the-codebase": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-changing-the-citation-anchor-format-can-silently-regress-llm": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-changing-user-facing-output-strings-cascades-through-test": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-chicken-and-egg-for-optional-extras-in-dev": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-ci-timeout-tests-enforce-the-range-you-set": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-citation-forced-prompting-and-prompt-injection-resistance-are": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-claude-agent-sdk-is-now-a-core-dependency-of-attune-ai": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-claude-agent-sdk-systempromptpreset-as-of-0-1-63-is-claude-code": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-claude-code-plugin-is-platform-specific": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-claude-code-plugins-expect-plugin-json-inside-claude-plugin": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-claude-plugin-install-is-marketplace-only": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-cli": {
     "source": "content/features/cli.md",
     "hash": "a37b4dc4f0b3706a62184b02d2be1536ad75eef39a0f22a9699db5d03b8ee050",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-clusterfuzz-dockerfile-copies-to-src-repo-but-also-copies": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-clusterfuzzlite-no-deps-misses-transitive-imports": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-coach-is-the-user-facing-entry-point-for-the-help-system": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-code-quality": {
     "source": "content/features/code-quality.md",
     "hash": "ce16ac87eb92e33a08d8c2f06e86ef22e436966f47f3a28c3f4eba19060b550a",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-codecov-patch-0-usually-means-tests-skipped-not-failed": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-codeql-alerts-dismissible-in-bulk-via-gh-api": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-codeql-js-stored-xss-flags-jsx-even-though-react-auto-escapes": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-codeql-py-clear-text-logging-sensitive-data-traces-data-flow": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-combine-two-unreleased-changelog-drafts-into-one-version-when": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-commands-are-not-namespaced-in-plugins-skills-are": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-config-py-alongside-config-creates-a-mypy-duplicate-module": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-configuration": {
     "source": "content/features/configuration.md",
     "hash": "8add90392883a46899ef8b57d135b625d92c5b61231d8a5301727f8b42f8e46f",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-costreport-fields-are-named-not-positional": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-costreport-is-a-dataclass-not-a-dict": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-custom-mcp-stdio-loop-fails-claude-code-handshake": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-dataclassorder-true-needs-compare-false-on-list-fields": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-datetime-utcnow-datetime-nowtimezone-utc-cascades-through-the": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-dead-code-modules-with-full-test-suites-look-alive": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-dead-tests-from-monorepo-extraction-accumulate-in-packages-with": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-deep-review": {
     "source": "content/features/deep-review.md",
     "hash": "6a4fffc907302b4847d96097189bd8d329d3f1548d1ee46d9232f6ceecdfb450",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-deep-review-false-positives-verify-before-acting": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-delete-deprecated-module-is-rarely-a-simple-delete-grep-src-and": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-dependency-lower-bounds-trigger-scorecard-vulnerability-alerts": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-detect-secrets-flags-fake-as-a-secret-in-test-fixtures": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-direct-pushes-to-main-are-blocked-by-the-presence-of-required": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-dispatch-tables-hold-direct-function-references-mocks-must": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-dist-can-contain-stale-artifacts-after-version-bumps": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-doc-gen": {
     "source": "content/features/doc-gen.md",
     "hash": "26e02a71a523775f5bb9e371b2e563c3c858386436a73b727422f62f57de0282",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-dont-append-z-to-timezone-aware-isoformat": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-dry-run-candidate-golden-queries-through-the-resolver-before": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-duck-typed-test-fakes-fail-isinstance-based-collectors-silently": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-duplicate-plugins-cause-conflicting-skill-triggers": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-elicitation-forms": {
     "source": "content/features/elicitation-forms.md",
-    "hash": "b7e73232af03174e0e5d50d551277a784127eb8047713cacfce1df8b19e8a8d6",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "hash": "36b29d55060c78f96ed1aaf1af34338dba4a156b674b98a9f35ebfd04524d2b3",
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-enforce-admins-false-defeats-code-review-scorecard-check": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-enforce-admins-required-reviews-blocks-solo-dev-merges": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-exclude-hard-queries-from-aggregate-p-1-metrics-in-benchmark": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-exploration-agents-fabricate-names-verify-against-source": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-f841-unused-fixture-lint-fires-when-a-test-is-refactored-to": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-fastembed-is-the-local-embeddings-path-that-passes-a-50mb": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-fix-test": {
     "source": "content/features/fix-test.md",
     "hash": "da54b69787cc1af5c087b2d8674442afe9b8c6fc88dca37a65e99590bb84fee0",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-forced-anthropic-tool-use-is-the-cleanest-path-to-guaranteed": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-forced-cite-per-claim-prompting-is-the-structural-lever-for-rag": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-formatter-strips-imports-that-are-unused-at-the-moment-you-save": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-full-coverage-runs-on-15k-test-suites-timeout-easily": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-generated-content-with-trailing-whitespace-causes-perpetual-pre": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-getattrmodule-name-none-at-call-site-is-the-clean-degradation": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-gh-api-x-patch-f-name-n-rejects-integers-as-strings": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-gh-pr-checks-json-field-names": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-gh-pr-merge-admin-is-blocked-by-in-progress-required-checks": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-gh-pr-merge-admin-prints-a-fast-forward-warning-even-when-the": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-gh-repo-create-source-path-push-is-a-one-shot-for-new-sibling": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-gh-workflow-run-file-yml-ref-tag-re-triggers-a-release-gated": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-ghost-command-references-survive-cli-renames": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-git-commit-q-can-exit-0-with-pre-commit-hook-feedback-that": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-git-pull-refuses-with-unstaged-changes-when-pull-rebase-true": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-git-rebase-root-exec-git-commit-amend-no-edit-s-re-signs-every": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-git-stash-pop-after-pre-commit-can-resurrect-stale-tool-state": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-github-actions-environment-deployment-approvals-can-be-self": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-github-copilot-autofix-pushes-commits-directly-to-pr-branches": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-github-protected-tags-cannot-be-force-updated": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-github-repos-serve-as-claude-code-marketplaces": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-gitignore-exclusions-break-ci-tests-that-read-those-files": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-glob-based-hash-computation-must-exclude-cache-dirs": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-golden-query-benchmarks-reveal-two-distinct-failure-classes": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-golden-query-test-fixtures-must-match-the-actual-corpus-layout": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-gpg-signing-fails-in-non-interactive-terminals-vscode-extension": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-hand-crafted-summary-prototype-is-the-fastest-way-to-measure-a": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-handoff-memory-option-b-proposals-are-often-wrong-re-analyze": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-hardcoded-root-paths-in-tests": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-hardcoded-strings-in-method-bodies-survive-class-attribute": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-hardcoded-user-id-defeats-ownership-checks": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-help-system": {
     "source": "content/features/help-system.md",
     "hash": "24468c8fe4f1a0e350e620098d65a3bcc007000cd5aa4dbe20a6e6c83efa87b3",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-hooks": {
     "source": "content/features/hooks.md",
     "hash": "5c6b8a45457387c76f628561d3baa56e9af1709bc9bd21bba9830b2c2478c8dd",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-hot-reload-subsystem-was-1-038-lines-of-dead-code": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-import-x-inside-a-try-block-except-x-someerror-in-the-except": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-importlib-import-module-is-an-arbitrary-code-execution-vector": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-industry-terminology-wont-appear-in-llm-polished-rag-summaries": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-integration-tests-gated-by-has-api-key-can-poison-the-whole-ci": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-is-private-is-a-superset-in-python-ipaddress": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-kwargs-collides-with-explicit-params-of-the-same-name": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-lazy-imports-inside-function-bodies-cant-be-patched-with": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-linkedin-paste-use-ascii-markers-not-unicode-arrows": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-list-wizards-is-a-function-not-a-class-method": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-list-workflows-deduplication-must-keep-base-names-visible": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-llm-api-responses-lack-trailing-newlines": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-local-telemetry-trackers-need-an-autouse-conftest-fixture": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-macos-var-private-var-symlink-breaks-path-assertions": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-mcp-attune-ai-doc-orchestrator-is-a-no-op-stub": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-mcp-call-tool-wrapper-pattern": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-mcp-handler-validate-paths-before-importing-workflows": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-mcp-json-python-resolves-to-pyenv-shim-not-project-venv": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-mcp-server": {
     "source": "content/features/mcp-server.md",
     "hash": "8e4b8c74eff980330480ae70856a1cf0393559cd22eb9ba0210b43249f9b5181",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-mcp-server-process-doesnt-inherit-env-variables": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-mcp-tool-count-tests-are-hardcoded": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-mcp-tool-renames-propagate-to-skill-docs": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-mcp-workspace-root-defaults-to-os-getcwd-tests-with-tmp-path": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-memory": {
     "source": "content/features/memory.md",
     "hash": "32b3121d9110dc9ac327bb9e838f060fbe9940a033366b0147ef34ef2efaa4dc",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-metadata-can-reach-a-retriever-with-zero-signal-if-the-sidecar": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-metapathfinder-find-module-load-module-is-dead-in-python-3-12": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-mixin-classes-inherit-self-workspace-root-at-runtime-not-at": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-mkdocs-build-crashing-with-attributeerror-nonetype-object-has": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-mkdocs-strict-treats-broken-links-as-fatal-errors": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-mock-a-lazy-import-x-with-types-moduletype-patch-dictsys-modules": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-models": {
     "source": "content/features/models.md",
     "hash": "2117cbb0d8e863db6091870874e4ce80b48780c9ee8bb7330d8033c172ccb02b",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-modeltier-has-two-copies-imports-must-match": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-module-level-optional-imports-enable-clean-test-patching": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-multiple-pinentry-program-lines-in-gpg-agent-conf-first-wins": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-mutual-competition-between-polished-rag-features-is-real-and": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-mypy-437-errors-was-stale-actual-count-was-2": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-naive-suffix-strip-stemming-fails-on-english-doubling-consonant": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-never-paste-pypi-tokens-into-chat-or-logs": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-new-dataclass-fields-need-both-the-class-and-the-parser-updated": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-new-mcp-handlers-must-match-the-validation-pattern-of-adjacent": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-new-security-features-need-dedicated-tests-before-release": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-next-js-shared-data-libs-prevent-page-duplication": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-non-baseworkflow-classes-in-workflow-registry-crash-the-cli": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-noqa-f401-re-exports-break-silently-on-satellite-file-deletion": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-openssf-scorecard-alerts-2-codereviewid-3-sastid-are-process": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-ops-dashboard": {
     "source": "content/features/ops-dashboard.md",
     "hash": "fefc8e2b2b4a25055fcbdf96cbd8638d75278cbcacd256873b725df89544c1f6",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-orchestration": {
     "source": "content/features/orchestration.md",
     "hash": "4998437e04355011a7dee68dbce7e9e78bbe97f637e0b6a14c1ec972f541695c",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-orphan-help-dirs-are-deprecated-3-depth-output-adding-them-to": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-orphan-top-level-docs-directories-stay-invisible-to-readers": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-packages-attune-in-attune-ai-are-pointer-stubs-not-source": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-past-due-deprecations-are-deletion-targets-not-implementation": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-patch-requires-the-target-name-to-exist-at-module-scope-at": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-patch-the-source-module-for-from-x-import-y-in-function-bodies": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-path-cwd-at-module-level-captures-import-time-cwd": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-path-globdir-matches-directories-not-files": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-path-rename-fails-on-windows-when-target-exists": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-pip-audit-fails-on-unpublished-versions": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-platform-conditional-security-test-assertions-should-accept-any": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-plugin": {
     "source": "content/features/plugin.md",
     "hash": "8cc6e5702ffc8228ed63cfb74a25dd3e99e79e5335c4b1c8c134950f8b9a043d",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-plugin-read-skill-references-break-outside-the-plugin": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-pr-test-workflows-may-not-auto-trigger-after-close-reopen-or": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-pre-commit-auto-fix-requires-re-stage-before-retry": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-pre-commit-black-unstaged-files-re-stage-after-failure": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-pre-commit-stash-conflict-when-black-ruff-fix-files-with": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-pre-commit-stash-conflict-with-auto-fix-hooks": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-pre-commit-stash-conflicts-when-any-tracked-unstaged-file": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-pre-committed-decision-matrices-survive-contact-with-data": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-pre-flight-pre-commits-pinned-black-ruff-on-new-files-before": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-prefer-github-actions-trusted-publishing-over-local-twine-uv": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-prompt-template-word-wrap-silently-breaks-single-line-substring": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-provenance-citation-records-usually-store-short-previews-not": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-pull-main-before-merging-develop-to-avoid-merge-commits": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-pureposixpath-match-doesnt-support-in-python-3-10": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-pureposixpath-strips-trailing-slashes": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-push-specific-tags-not-tags": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-pypi-env-policies-may-whitelist-branches-only-tag-triggered": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-pypi-environment-requires-manual-approval-in-github-actions": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-pypi-renders-readme-links-relative-to-its-own-domain": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-pypi-trusted-publisher-workflow-name-field-wants-the-filename": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-pytest-importorskip-triggers-ruff-e402": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-pytest-lives-in-the-dev-extra-not-developer": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-query-fixtures-are-self-diagnostic-for-rag-corpora-even-without": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-rag-grounding": {
     "source": "content/features/rag-grounding.md",
     "hash": "3464dd78c83f06980912a7c49dc185b09830be1b1c163203f10e5aa1708fcf4e",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-re-adding-an-import-after-the-formatter-strips-it-use-function": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-re-enabling-required-reviews-kills-queued-auto-merge": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-re-export-accessibility-tests-are-scattered-across-batch-files": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-read-source-before-writing-tests-for-tricky-logic": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-real-project-files-on-disk-override-test-mocks": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-rebuild-dist-after-readme-changes": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-reclassify-unexpectedly-hard-golden-queries-up-the-difficulty": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-redisshorttermmemory-mock-injection-path": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-refactor-plan": {
     "source": "content/features/refactor-plan.md",
     "hash": "8f8c684cd94fca7b2580ecaaf955ccb79924022796d576d477cdab9330df9704",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-registry-count-assertions-are-scattered-across-test-files": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-release-branches-carry-unmerged-commits-that-feature-branches": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-release-notes": {
     "source": "content/features/release-notes.md",
     "hash": "da7101ffbec4d209fcb1cef754f01cef8a13458a6f961c3a23909edfec77e58c",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-release-prep": {
     "source": "content/features/release-prep.md",
     "hash": "cd77b5903fbeb7d7e0acef570bab9727b4c143181ea6be1f52b9a25bc11418bb",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-release-published-workflow-dispatch-both-approved-for-pypi-env": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-removing-one-workspace-dep-can-cascade-to-remove-others": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-replacing-a-mixin-based-class-scatters-test-failures-across": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-repo-merge-policy-may-restrict-merge-strategies": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-repo-root-parents-count-varies-by-file-depth": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-required-status-check-names-must-match-githubs-exact-check-names": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-research-subagents-can-hallucinate-sdk-signatures-introspect": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-resilience": {
     "source": "content/features/resilience.md",
     "hash": "ae2a76f0f1ecbb9ca687e5a041acc2b4a25a5113ec57eaad550f48b8aadc4be2",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-resultmessage-result-is-often-none-capture-assistantmessage": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-rich-live-is-output-only-use-textual-for-any-interactive-row": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-ruff-auto-fix-strips-imports-before-usage-code-exists": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-ruff-parses-pytest-ini-as-python": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-run-simplify-catches-per-file-errors-internally": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-sbin-is-a-symlink-to-usr-sbin-on-modern-ubuntu": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-scorecards-pip-parser-ignores-hash-flags-entirely": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-sdk-adapter-swallows-subagent-findings-lesson-was-wrong-adapter": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-sdk-agent-model-config-uses-stale-model-names": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-sdk-native-security-audit-workflow-swallows-subagent-findings": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-sdk-native-workflows-validate-in-execute-not-input-schema": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-security-audit": {
     "source": "content/features/security-audit.md",
     "hash": "9cce18573c827fab9a380efe8c65c2f8c5b4ada3f7e383dd71ec523a0875fb05",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-selective-hook-skip-with-skip-hookname-is-not-the-same-as-no": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-semantic-cache-70-hit-rate-claim-was-unmeasured": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-session-hooks-may-be-vestigial": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-shadow-directories-at-repo-root-break-imports": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-silent-pass-blocks-in-discovery-registry-code-hide-import": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-skill-descriptions-must-be-under-250-characters": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-skill-frontmatter-allowlist-march-2026": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-skill-frontmatter-has-a-strict-allowlist": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-smart-test": {
     "source": "content/features/smart-test.md",
     "hash": "58c691c8313ddf9699deb913e6b5c50fafc684563539ddf4816a4b94a9ea3e80",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-spec-engine": {
     "source": "content/features/spec-engine.md",
     "hash": "c8549016aa848eeeaecbde8329f5850562f56280ab66428cb7c20887b428d81a",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-squash-merge-deletes-the-remote-branch-subsequent-push-silently": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-ssrf-always-decode-urls-before-validating-hostnames": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-ssrf-in-webhook-handlers-is-easy-to-miss": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-ssrf-strip-ipv6-zone-ids-before-ip-validation": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-stacked-patch-decorators-inject-args-bottom-up": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-staleness-detection-in-attune-author-attune-ais-help-system-is": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-stop-hook-ordering-matters": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-stop-hooks-inject-stderr-not-stdout": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-stop-hooks-loop-without-a-sentinel": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-stop-hooks-missing-cd-prefix-inherit-session-cwd": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-structlog-default-output-pollutes-stdout-captured-cli-tests": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-structlog-kwargs-vs-stdlib-logger": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-tags-pushed-before-squash-merge-point-to-the-wrong-commit": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-telemetry": {
     "source": "content/features/telemetry.md",
     "hash": "59473ab809113116a3d58d2ead3a5f13e362d6992d8cee0a89364feded5cbd50",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-template-generators-overwrite-hand-written-files": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-test-mocks-must-match-imports": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-tests-for-optional-dep-code-need-pytest-importorskip-guards-in": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-text-white-on-gradient-primary-sections-gets-overridden": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-todo-counts-are-inflated-by-docstrings-and-prompt-strings": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-twine-cannot-prompt-for-tokens-in-claude-codes-non-interactive": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-two-codeql-setups-can-coexist-in-one-repo-and-deadlock-merges": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-two-parallel-help-template-generators-in-the-attune-ecosystem": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-uncommitted-claude-mcp-json-means-mcp-server-never-starts": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-untracked-scripts-break-ci-when-tests-import-them": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-unused-init-py-re-exports-become-invisible-runtime-deps": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-use-dataclass-post-init-to-coalesce-between-a-scalar-legacy": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-uv-lock-can-drift-from-pyproject-toml-on-shared-branches": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-uv-lock-may-briefly-fail-to-find-a-just-published-pypi-version": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-uv-lock-retains-editable-name-paths-after-tool-uv-sources-edits": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-uv-pip-install-e-does-not-regenerate-project-scripts-console": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-uv-pip-install-e-path-can-ship-stale-package-data-even-after": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-uv-pip-install-e-sibling-path-no-deps-is-the-clean-venv-local": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-uv-run-in-pre-commit-hooks-propagates-lockfile-errors-as-hook": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-uv-run-pip-audit-runs-the-pyenv-shim-not-the-venv": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-uv-sync-respects-existing-lockfile-pins-when-they-still-satisfy": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-uv-sync-wipes-packages-installed-via-pip-install": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-validate-file-path-needed-on-reads-too-not-just-writes": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-validate-infrastructure-against-user-value-before-extending": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-verify-mcp-tool-wiring-after-adding-new-tools": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-verify-new-dispatch-branches-with-a-known-fixture-not-just": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-verify-optional-dep-boundaries-with-a-metapathfinder-not-by": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-version-bumps-must-update-7-files-not-just-pyproject-toml": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-vs-code-extension-reads-mcp-json-at-project-root-not-claude-mcp": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-website-feature-lists-can-diverge-from-the-python-registry": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-windows-ci-encoding": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-windows-ci-runners-are-3x-slower-than-ubuntu-macos": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-windows-path-resolve-prepends-the-drive-letter-to-unix-paths": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-windows-time-time-can-return-0-0-duration-for-fast-operations": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-wizards": {
     "source": "content/features/wizards.md",
     "hash": "6fe7722a026d11276ebfbdf4ea046a05112be94b560f9abf3ffee410f8637d8f",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-wizards-call-workflows-internally-they-are-not-duplicates": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-workflowresult-constructor-mismatches-surface-only-at-runtime": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-yaml-run-block-scalars-break-on-blank-lines-inside-multi-line": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-yaml-run-values-with-colons-cause-parse-errors": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "err-zsh-has-status-as-a-read-only-builtin-variable": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-adding-a-plugin-skill-has-three-enforcement-gates-not-one": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-adding-a-workspace-sibling-package-as-an-extra-can-silently": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-adding-dns-resolution-to-validate-webhook-url-breaks-tests-that": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-adding-logger-before-eager-imports-triggers-e402-in-init-py": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-after-a-pr-merges-while-youre-afk-pull-main-before-tagging": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-after-a-squash-merge-of-a-feature-branch-local-main-can-have": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-agents": {
     "source": "content/features/agents.md",
     "hash": "a5b1678ecf012c7b2877a6c7ecae4a6c3f14c084c13fbcbb7eee79119dce6fa3",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-agents-skills-must-stay-synced-with-plugin-skills": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-anchor-tag-buttons-need-text-white-no-underline": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-anthropics-built-in-prompt-caching-supersedes-custom-caching": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-any-unstaged-file-triggers-pre-commit-stash-conflicts-with-auto": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-apply-lessons-by-problem-not-by-keyword": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-attune-author-check-staleness-load-manifest-is-the-python-api": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-attune-help-re-exports-create-a-hidden-cross-package-dep-on": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-attune-helps-sidecar-schemas-dont-match-path-keyed-assumptions": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-attune-skill-names-must-not-collide-with-claude-code-built-in": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-attune-workflow-run-code-review-and-security-audit-require-a": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-b904-raise-x-from-e-is-not-auto-fixable-by-ruff": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-background-processes-from-previous-sessions-persist-across": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-bandit-b108-blocks-hardcoded-tmp-paths": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-bare-manifest-in-gitignore-silently-excludes-any-manifest": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-baseworkflow-now-provides-self-logger": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-baseworkflow-uses-class-attributes-not-constructor-params": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-bg-var-primary-bg-opacity-10-is-invisible-in-dark-mode": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-broad-gitignore-patterns-match-nested-directories": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-bug-predict": {
     "source": "content/features/bug-predict.md",
     "hash": "6a4f420eba38e2fb884b837dd9758acb60ba60cdaf9248ec4280120b0d382b16",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-bug-predict-dangerous-eval-flags-subprocess-exec": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-bugpredictionworkflow-not-bugpredictworkflow": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-changing-error-messages-breaks-tests-across-the-codebase": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-changing-the-citation-anchor-format-can-silently-regress-llm": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-changing-user-facing-output-strings-cascades-through-test": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-chicken-and-egg-for-optional-extras-in-dev": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-ci-timeout-tests-enforce-the-range-you-set": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-citation-forced-prompting-and-prompt-injection-resistance-are": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-claude-agent-sdk-is-now-a-core-dependency-of-attune-ai": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-claude-agent-sdk-systempromptpreset-as-of-0-1-63-is-claude-code": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-claude-code-plugin-is-platform-specific": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-claude-code-plugins-expect-plugin-json-inside-claude-plugin": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-claude-plugin-install-is-marketplace-only": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-cli": {
     "source": "content/features/cli.md",
     "hash": "a37b4dc4f0b3706a62184b02d2be1536ad75eef39a0f22a9699db5d03b8ee050",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-clusterfuzz-dockerfile-copies-to-src-repo-but-also-copies": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-clusterfuzzlite-no-deps-misses-transitive-imports": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-coach-is-the-user-facing-entry-point-for-the-help-system": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-code-quality": {
     "source": "content/features/code-quality.md",
     "hash": "ce16ac87eb92e33a08d8c2f06e86ef22e436966f47f3a28c3f4eba19060b550a",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-codecov-patch-0-usually-means-tests-skipped-not-failed": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-codeql-alerts-dismissible-in-bulk-via-gh-api": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-codeql-js-stored-xss-flags-jsx-even-though-react-auto-escapes": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-codeql-py-clear-text-logging-sensitive-data-traces-data-flow": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-combine-two-unreleased-changelog-drafts-into-one-version-when": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-commands-are-not-namespaced-in-plugins-skills-are": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-config-py-alongside-config-creates-a-mypy-duplicate-module": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-configuration": {
     "source": "content/features/configuration.md",
     "hash": "8add90392883a46899ef8b57d135b625d92c5b61231d8a5301727f8b42f8e46f",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-costreport-fields-are-named-not-positional": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-costreport-is-a-dataclass-not-a-dict": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-custom-mcp-stdio-loop-fails-claude-code-handshake": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-dataclassorder-true-needs-compare-false-on-list-fields": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-datetime-utcnow-datetime-nowtimezone-utc-cascades-through-the": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-dead-code-modules-with-full-test-suites-look-alive": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-dead-tests-from-monorepo-extraction-accumulate-in-packages-with": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-deep-review": {
     "source": "content/features/deep-review.md",
     "hash": "6a4fffc907302b4847d96097189bd8d329d3f1548d1ee46d9232f6ceecdfb450",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-deep-review-false-positives-verify-before-acting": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-delete-deprecated-module-is-rarely-a-simple-delete-grep-src-and": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-dependency-lower-bounds-trigger-scorecard-vulnerability-alerts": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-detect-secrets-flags-fake-as-a-secret-in-test-fixtures": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-direct-pushes-to-main-are-blocked-by-the-presence-of-required": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-dispatch-tables-hold-direct-function-references-mocks-must": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-dist-can-contain-stale-artifacts-after-version-bumps": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-doc-gen": {
     "source": "content/features/doc-gen.md",
     "hash": "26e02a71a523775f5bb9e371b2e563c3c858386436a73b727422f62f57de0282",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-dont-append-z-to-timezone-aware-isoformat": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-dry-run-candidate-golden-queries-through-the-resolver-before": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-duck-typed-test-fakes-fail-isinstance-based-collectors-silently": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-duplicate-plugins-cause-conflicting-skill-triggers": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-elicitation-forms": {
     "source": "content/features/elicitation-forms.md",
-    "hash": "b7e73232af03174e0e5d50d551277a784127eb8047713cacfce1df8b19e8a8d6",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "hash": "36b29d55060c78f96ed1aaf1af34338dba4a156b674b98a9f35ebfd04524d2b3",
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-enforce-admins-false-defeats-code-review-scorecard-check": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-enforce-admins-required-reviews-blocks-solo-dev-merges": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-exclude-hard-queries-from-aggregate-p-1-metrics-in-benchmark": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-exploration-agents-fabricate-names-verify-against-source": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-f841-unused-fixture-lint-fires-when-a-test-is-refactored-to": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-fastembed-is-the-local-embeddings-path-that-passes-a-50mb": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-fix-test": {
     "source": "content/features/fix-test.md",
     "hash": "da54b69787cc1af5c087b2d8674442afe9b8c6fc88dca37a65e99590bb84fee0",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-forced-anthropic-tool-use-is-the-cleanest-path-to-guaranteed": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-forced-cite-per-claim-prompting-is-the-structural-lever-for-rag": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-formatter-strips-imports-that-are-unused-at-the-moment-you-save": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-full-coverage-runs-on-15k-test-suites-timeout-easily": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-generated-content-with-trailing-whitespace-causes-perpetual-pre": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-getattrmodule-name-none-at-call-site-is-the-clean-degradation": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-gh-api-x-patch-f-name-n-rejects-integers-as-strings": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-gh-pr-checks-json-field-names": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-gh-pr-merge-admin-is-blocked-by-in-progress-required-checks": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-gh-pr-merge-admin-prints-a-fast-forward-warning-even-when-the": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-gh-repo-create-source-path-push-is-a-one-shot-for-new-sibling": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-gh-workflow-run-file-yml-ref-tag-re-triggers-a-release-gated": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-ghost-command-references-survive-cli-renames": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-git-commit-q-can-exit-0-with-pre-commit-hook-feedback-that": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-git-pull-refuses-with-unstaged-changes-when-pull-rebase-true": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-git-rebase-root-exec-git-commit-amend-no-edit-s-re-signs-every": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-git-stash-pop-after-pre-commit-can-resurrect-stale-tool-state": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-github-actions-environment-deployment-approvals-can-be-self": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-github-copilot-autofix-pushes-commits-directly-to-pr-branches": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-github-protected-tags-cannot-be-force-updated": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-github-repos-serve-as-claude-code-marketplaces": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-gitignore-exclusions-break-ci-tests-that-read-those-files": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-glob-based-hash-computation-must-exclude-cache-dirs": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-golden-query-benchmarks-reveal-two-distinct-failure-classes": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-golden-query-test-fixtures-must-match-the-actual-corpus-layout": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-gpg-signing-fails-in-non-interactive-terminals-vscode-extension": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-hand-crafted-summary-prototype-is-the-fastest-way-to-measure-a": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-handoff-memory-option-b-proposals-are-often-wrong-re-analyze": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-hardcoded-root-paths-in-tests": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-hardcoded-strings-in-method-bodies-survive-class-attribute": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-hardcoded-user-id-defeats-ownership-checks": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-help-system": {
     "source": "content/features/help-system.md",
     "hash": "24468c8fe4f1a0e350e620098d65a3bcc007000cd5aa4dbe20a6e6c83efa87b3",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-hooks": {
     "source": "content/features/hooks.md",
     "hash": "5c6b8a45457387c76f628561d3baa56e9af1709bc9bd21bba9830b2c2478c8dd",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-hot-reload-subsystem-was-1-038-lines-of-dead-code": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-import-x-inside-a-try-block-except-x-someerror-in-the-except": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-importlib-import-module-is-an-arbitrary-code-execution-vector": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-industry-terminology-wont-appear-in-llm-polished-rag-summaries": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-integration-tests-gated-by-has-api-key-can-poison-the-whole-ci": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-is-private-is-a-superset-in-python-ipaddress": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-kwargs-collides-with-explicit-params-of-the-same-name": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-lazy-imports-inside-function-bodies-cant-be-patched-with": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-linkedin-paste-use-ascii-markers-not-unicode-arrows": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-list-wizards-is-a-function-not-a-class-method": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-list-workflows-deduplication-must-keep-base-names-visible": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-llm-api-responses-lack-trailing-newlines": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-local-telemetry-trackers-need-an-autouse-conftest-fixture": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-macos-var-private-var-symlink-breaks-path-assertions": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-mcp-attune-ai-doc-orchestrator-is-a-no-op-stub": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-mcp-call-tool-wrapper-pattern": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-mcp-handler-validate-paths-before-importing-workflows": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-mcp-json-python-resolves-to-pyenv-shim-not-project-venv": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-mcp-server": {
     "source": "content/features/mcp-server.md",
     "hash": "8e4b8c74eff980330480ae70856a1cf0393559cd22eb9ba0210b43249f9b5181",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-mcp-server-process-doesnt-inherit-env-variables": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-mcp-tool-count-tests-are-hardcoded": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-mcp-tool-renames-propagate-to-skill-docs": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-mcp-workspace-root-defaults-to-os-getcwd-tests-with-tmp-path": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-memory": {
     "source": "content/features/memory.md",
     "hash": "32b3121d9110dc9ac327bb9e838f060fbe9940a033366b0147ef34ef2efaa4dc",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-metadata-can-reach-a-retriever-with-zero-signal-if-the-sidecar": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-metapathfinder-find-module-load-module-is-dead-in-python-3-12": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-mixin-classes-inherit-self-workspace-root-at-runtime-not-at": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-mkdocs-build-crashing-with-attributeerror-nonetype-object-has": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-mkdocs-strict-treats-broken-links-as-fatal-errors": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-mock-a-lazy-import-x-with-types-moduletype-patch-dictsys-modules": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-models": {
     "source": "content/features/models.md",
     "hash": "2117cbb0d8e863db6091870874e4ce80b48780c9ee8bb7330d8033c172ccb02b",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-modeltier-has-two-copies-imports-must-match": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-module-level-optional-imports-enable-clean-test-patching": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-multiple-pinentry-program-lines-in-gpg-agent-conf-first-wins": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-mutual-competition-between-polished-rag-features-is-real-and": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-mypy-437-errors-was-stale-actual-count-was-2": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-naive-suffix-strip-stemming-fails-on-english-doubling-consonant": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-never-paste-pypi-tokens-into-chat-or-logs": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-new-dataclass-fields-need-both-the-class-and-the-parser-updated": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-new-mcp-handlers-must-match-the-validation-pattern-of-adjacent": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-new-security-features-need-dedicated-tests-before-release": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-next-js-shared-data-libs-prevent-page-duplication": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-non-baseworkflow-classes-in-workflow-registry-crash-the-cli": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-noqa-f401-re-exports-break-silently-on-satellite-file-deletion": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-openssf-scorecard-alerts-2-codereviewid-3-sastid-are-process": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-ops-dashboard": {
     "source": "content/features/ops-dashboard.md",
     "hash": "fefc8e2b2b4a25055fcbdf96cbd8638d75278cbcacd256873b725df89544c1f6",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-orchestration": {
     "source": "content/features/orchestration.md",
     "hash": "4998437e04355011a7dee68dbce7e9e78bbe97f637e0b6a14c1ec972f541695c",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-orphan-help-dirs-are-deprecated-3-depth-output-adding-them-to": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-orphan-top-level-docs-directories-stay-invisible-to-readers": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-packages-attune-in-attune-ai-are-pointer-stubs-not-source": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-past-due-deprecations-are-deletion-targets-not-implementation": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-patch-requires-the-target-name-to-exist-at-module-scope-at": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-patch-the-source-module-for-from-x-import-y-in-function-bodies": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-path-cwd-at-module-level-captures-import-time-cwd": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-path-globdir-matches-directories-not-files": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-path-rename-fails-on-windows-when-target-exists": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-pip-audit-fails-on-unpublished-versions": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-platform-conditional-security-test-assertions-should-accept-any": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-plugin": {
     "source": "content/features/plugin.md",
     "hash": "8cc6e5702ffc8228ed63cfb74a25dd3e99e79e5335c4b1c8c134950f8b9a043d",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-plugin-read-skill-references-break-outside-the-plugin": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-pr-test-workflows-may-not-auto-trigger-after-close-reopen-or": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-pre-commit-auto-fix-requires-re-stage-before-retry": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-pre-commit-black-unstaged-files-re-stage-after-failure": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-pre-commit-stash-conflict-when-black-ruff-fix-files-with": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-pre-commit-stash-conflict-with-auto-fix-hooks": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-pre-commit-stash-conflicts-when-any-tracked-unstaged-file": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-pre-committed-decision-matrices-survive-contact-with-data": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-pre-flight-pre-commits-pinned-black-ruff-on-new-files-before": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-prefer-github-actions-trusted-publishing-over-local-twine-uv": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-prompt-template-word-wrap-silently-breaks-single-line-substring": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-provenance-citation-records-usually-store-short-previews-not": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-pull-main-before-merging-develop-to-avoid-merge-commits": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-pureposixpath-match-doesnt-support-in-python-3-10": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-pureposixpath-strips-trailing-slashes": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-push-specific-tags-not-tags": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-pypi-env-policies-may-whitelist-branches-only-tag-triggered": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-pypi-environment-requires-manual-approval-in-github-actions": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-pypi-renders-readme-links-relative-to-its-own-domain": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-pypi-trusted-publisher-workflow-name-field-wants-the-filename": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-pytest-importorskip-triggers-ruff-e402": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-pytest-lives-in-the-dev-extra-not-developer": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-query-fixtures-are-self-diagnostic-for-rag-corpora-even-without": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-rag-grounding": {
     "source": "content/features/rag-grounding.md",
     "hash": "3464dd78c83f06980912a7c49dc185b09830be1b1c163203f10e5aa1708fcf4e",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-re-adding-an-import-after-the-formatter-strips-it-use-function": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-re-enabling-required-reviews-kills-queued-auto-merge": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-re-export-accessibility-tests-are-scattered-across-batch-files": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-read-source-before-writing-tests-for-tricky-logic": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-real-project-files-on-disk-override-test-mocks": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-rebuild-dist-after-readme-changes": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-reclassify-unexpectedly-hard-golden-queries-up-the-difficulty": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-redisshorttermmemory-mock-injection-path": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-refactor-plan": {
     "source": "content/features/refactor-plan.md",
     "hash": "8f8c684cd94fca7b2580ecaaf955ccb79924022796d576d477cdab9330df9704",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-registry-count-assertions-are-scattered-across-test-files": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-release-branches-carry-unmerged-commits-that-feature-branches": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-release-notes": {
     "source": "content/features/release-notes.md",
     "hash": "da7101ffbec4d209fcb1cef754f01cef8a13458a6f961c3a23909edfec77e58c",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-release-prep": {
     "source": "content/features/release-prep.md",
     "hash": "cd77b5903fbeb7d7e0acef570bab9727b4c143181ea6be1f52b9a25bc11418bb",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-release-published-workflow-dispatch-both-approved-for-pypi-env": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-removing-one-workspace-dep-can-cascade-to-remove-others": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-replacing-a-mixin-based-class-scatters-test-failures-across": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-repo-merge-policy-may-restrict-merge-strategies": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-repo-root-parents-count-varies-by-file-depth": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-required-status-check-names-must-match-githubs-exact-check-names": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-research-subagents-can-hallucinate-sdk-signatures-introspect": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-resilience": {
     "source": "content/features/resilience.md",
     "hash": "ae2a76f0f1ecbb9ca687e5a041acc2b4a25a5113ec57eaad550f48b8aadc4be2",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-resultmessage-result-is-often-none-capture-assistantmessage": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-rich-live-is-output-only-use-textual-for-any-interactive-row": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-ruff-auto-fix-strips-imports-before-usage-code-exists": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-ruff-parses-pytest-ini-as-python": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-run-simplify-catches-per-file-errors-internally": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-sbin-is-a-symlink-to-usr-sbin-on-modern-ubuntu": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-scorecards-pip-parser-ignores-hash-flags-entirely": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-sdk-adapter-swallows-subagent-findings-lesson-was-wrong-adapter": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-sdk-agent-model-config-uses-stale-model-names": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-sdk-native-security-audit-workflow-swallows-subagent-findings": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-sdk-native-workflows-validate-in-execute-not-input-schema": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-security-audit": {
     "source": "content/features/security-audit.md",
     "hash": "9cce18573c827fab9a380efe8c65c2f8c5b4ada3f7e383dd71ec523a0875fb05",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-selective-hook-skip-with-skip-hookname-is-not-the-same-as-no": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-semantic-cache-70-hit-rate-claim-was-unmeasured": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-session-hooks-may-be-vestigial": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-shadow-directories-at-repo-root-break-imports": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-silent-pass-blocks-in-discovery-registry-code-hide-import": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-skill-descriptions-must-be-under-250-characters": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-skill-frontmatter-allowlist-march-2026": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-skill-frontmatter-has-a-strict-allowlist": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-smart-test": {
     "source": "content/features/smart-test.md",
     "hash": "58c691c8313ddf9699deb913e6b5c50fafc684563539ddf4816a4b94a9ea3e80",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-spec-engine": {
     "source": "content/features/spec-engine.md",
     "hash": "c8549016aa848eeeaecbde8329f5850562f56280ab66428cb7c20887b428d81a",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-squash-merge-deletes-the-remote-branch-subsequent-push-silently": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-ssrf-always-decode-urls-before-validating-hostnames": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-ssrf-in-webhook-handlers-is-easy-to-miss": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-ssrf-strip-ipv6-zone-ids-before-ip-validation": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-stacked-patch-decorators-inject-args-bottom-up": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-staleness-detection-in-attune-author-attune-ais-help-system-is": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-stop-hook-ordering-matters": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-stop-hooks-inject-stderr-not-stdout": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-stop-hooks-loop-without-a-sentinel": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-stop-hooks-missing-cd-prefix-inherit-session-cwd": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-structlog-default-output-pollutes-stdout-captured-cli-tests": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-structlog-kwargs-vs-stdlib-logger": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-tags-pushed-before-squash-merge-point-to-the-wrong-commit": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-telemetry": {
     "source": "content/features/telemetry.md",
     "hash": "59473ab809113116a3d58d2ead3a5f13e362d6992d8cee0a89364feded5cbd50",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-template-generators-overwrite-hand-written-files": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-test-mocks-must-match-imports": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-tests-for-optional-dep-code-need-pytest-importorskip-guards-in": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-text-white-on-gradient-primary-sections-gets-overridden": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-todo-counts-are-inflated-by-docstrings-and-prompt-strings": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-twine-cannot-prompt-for-tokens-in-claude-codes-non-interactive": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-two-codeql-setups-can-coexist-in-one-repo-and-deadlock-merges": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-two-parallel-help-template-generators-in-the-attune-ecosystem": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-uncommitted-claude-mcp-json-means-mcp-server-never-starts": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-untracked-scripts-break-ci-when-tests-import-them": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-unused-init-py-re-exports-become-invisible-runtime-deps": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-use-dataclass-post-init-to-coalesce-between-a-scalar-legacy": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-uv-lock-can-drift-from-pyproject-toml-on-shared-branches": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-uv-lock-may-briefly-fail-to-find-a-just-published-pypi-version": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-uv-lock-retains-editable-name-paths-after-tool-uv-sources-edits": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-uv-pip-install-e-does-not-regenerate-project-scripts-console": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-uv-pip-install-e-path-can-ship-stale-package-data-even-after": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-uv-pip-install-e-sibling-path-no-deps-is-the-clean-venv-local": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-uv-run-in-pre-commit-hooks-propagates-lockfile-errors-as-hook": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-uv-run-pip-audit-runs-the-pyenv-shim-not-the-venv": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-uv-sync-respects-existing-lockfile-pins-when-they-still-satisfy": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-uv-sync-wipes-packages-installed-via-pip-install": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-validate-file-path-needed-on-reads-too-not-just-writes": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-validate-infrastructure-against-user-value-before-extending": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-verify-mcp-tool-wiring-after-adding-new-tools": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-verify-new-dispatch-branches-with-a-known-fixture-not-just": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-verify-optional-dep-boundaries-with-a-metapathfinder-not-by": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-version-bumps-must-update-7-files-not-just-pyproject-toml": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-vs-code-extension-reads-mcp-json-at-project-root-not-claude-mcp": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-website-feature-lists-can-diverge-from-the-python-registry": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-windows-ci-encoding": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-windows-ci-runners-are-3x-slower-than-ubuntu-macos": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-windows-path-resolve-prepends-the-drive-letter-to-unix-paths": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-windows-time-time-can-return-0-0-duration-for-fast-operations": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-wizards": {
     "source": "content/features/wizards.md",
     "hash": "6fe7722a026d11276ebfbdf4ea046a05112be94b560f9abf3ffee410f8637d8f",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-wizards-call-workflows-internally-they-are-not-duplicates": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-workflowresult-constructor-mismatches-surface-only-at-runtime": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-yaml-run-block-scalars-break-on-blank-lines-inside-multi-line": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-yaml-run-values-with-colons-cause-parse-errors": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "faq-zsh-has-status-as-a-read-only-builtin-variable": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "not-agents": {
     "source": "content/features/agents.md",
     "hash": "a5b1678ecf012c7b2877a6c7ecae4a6c3f14c084c13fbcbb7eee79119dce6fa3",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "not-bug-predict": {
     "source": "content/features/bug-predict.md",
     "hash": "6a4f420eba38e2fb884b837dd9758acb60ba60cdaf9248ec4280120b0d382b16",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "not-cli": {
     "source": "content/features/cli.md",
     "hash": "a37b4dc4f0b3706a62184b02d2be1536ad75eef39a0f22a9699db5d03b8ee050",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "not-code-quality": {
     "source": "content/features/code-quality.md",
     "hash": "ce16ac87eb92e33a08d8c2f06e86ef22e436966f47f3a28c3f4eba19060b550a",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "not-code-simplification": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "not-command-hubs": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "not-configuration": {
     "source": "content/features/configuration.md",
     "hash": "8add90392883a46899ef8b57d135b625d92c5b61231d8a5301727f8b42f8e46f",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "not-critical-rules": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "not-decision-d1-template-schemas-live-in-the-repo": {
     "source": ".claude/plans/documentation-stack-spec.md",
     "hash": "8ac207215df6d59686f456b44e76ec33e6c5b8dd6acb5d7754100c158865bd88",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "not-decision-d2-search-index-first-unified-later": {
     "source": ".claude/plans/documentation-stack-spec.md",
     "hash": "8ac207215df6d59686f456b44e76ec33e6c5b8dd6acb5d7754100c158865bd88",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "not-decision-d3-faq-sourcing-four-channels": {
     "source": ".claude/plans/documentation-stack-spec.md",
     "hash": "8ac207215df6d59686f456b44e76ec33e6c5b8dd6acb5d7754100c158865bd88",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "not-decision-d4-code-is-the-source-of-truth": {
     "source": ".claude/plans/documentation-stack-spec.md",
     "hash": "8ac207215df6d59686f456b44e76ec33e6c5b8dd6acb5d7754100c158865bd88",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "not-decision-d5-intelligent-templates-the-engine": {
     "source": ".claude/plans/documentation-stack-spec.md",
     "hash": "8ac207215df6d59686f456b44e76ec33e6c5b8dd6acb5d7754100c158865bd88",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "not-decision-d6-proof-of-concept-lessons-learned-error-templates": {
     "source": ".claude/plans/documentation-stack-spec.md",
     "hash": "8ac207215df6d59686f456b44e76ec33e6c5b8dd6acb5d7754100c158865bd88",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "not-deep-review": {
     "source": "content/features/deep-review.md",
     "hash": "6a4fffc907302b4847d96097189bd8d329d3f1548d1ee46d9232f6ceecdfb450",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "not-doc-gen": {
     "source": "content/features/doc-gen.md",
     "hash": "26e02a71a523775f5bb9e371b2e563c3c858386436a73b727422f62f57de0282",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "not-elicitation-forms": {
     "source": "content/features/elicitation-forms.md",
-    "hash": "b7e73232af03174e0e5d50d551277a784127eb8047713cacfce1df8b19e8a8d6",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "hash": "36b29d55060c78f96ed1aaf1af34338dba4a156b674b98a9f35ebfd04524d2b3",
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "not-fix-test": {
     "source": "content/features/fix-test.md",
     "hash": "da54b69787cc1af5c087b2d8674442afe9b8c6fc88dca37a65e99590bb84fee0",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "not-help-system": {
     "source": "content/features/help-system.md",
     "hash": "24468c8fe4f1a0e350e620098d65a3bcc007000cd5aa4dbe20a6e6c83efa87b3",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "not-hooks": {
     "source": "content/features/hooks.md",
     "hash": "5c6b8a45457387c76f628561d3baa56e9af1709bc9bd21bba9830b2c2478c8dd",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "not-markdown-formatting": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "not-mcp-server": {
     "source": "content/features/mcp-server.md",
     "hash": "8e4b8c74eff980330480ae70856a1cf0393559cd22eb9ba0210b43249f9b5181",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "not-memory": {
     "source": "content/features/memory.md",
     "hash": "32b3121d9110dc9ac327bb9e838f060fbe9940a033366b0147ef34ef2efaa4dc",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "not-models": {
     "source": "content/features/models.md",
     "hash": "2117cbb0d8e863db6091870874e4ce80b48780c9ee8bb7330d8033c172ccb02b",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "not-ops-dashboard": {
     "source": "content/features/ops-dashboard.md",
     "hash": "fefc8e2b2b4a25055fcbdf96cbd8638d75278cbcacd256873b725df89544c1f6",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "not-orchestration": {
     "source": "content/features/orchestration.md",
     "hash": "4998437e04355011a7dee68dbce7e9e78bbe97f637e0b6a14c1ec972f541695c",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "not-plugin": {
     "source": "content/features/plugin.md",
     "hash": "8cc6e5702ffc8228ed63cfb74a25dd3e99e79e5335c4b1c8c134950f8b9a043d",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "not-project-structure": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "not-rag-grounding": {
     "source": "content/features/rag-grounding.md",
     "hash": "3464dd78c83f06980912a7c49dc185b09830be1b1c163203f10e5aa1708fcf4e",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "not-refactor-plan": {
     "source": "content/features/refactor-plan.md",
     "hash": "8f8c684cd94fca7b2580ecaaf955ccb79924022796d576d477cdab9330df9704",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "not-release-notes": {
     "source": "content/features/release-notes.md",
     "hash": "da7101ffbec4d209fcb1cef754f01cef8a13458a6f961c3a23909edfec77e58c",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "not-release-prep": {
     "source": "content/features/release-prep.md",
     "hash": "cd77b5903fbeb7d7e0acef570bab9727b4c143181ea6be1f52b9a25bc11418bb",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "not-resilience": {
     "source": "content/features/resilience.md",
     "hash": "ae2a76f0f1ecbb9ca687e5a041acc2b4a25a5113ec57eaad550f48b8aadc4be2",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "not-security-audit": {
     "source": "content/features/security-audit.md",
     "hash": "9cce18573c827fab9a380efe8c65c2f8c5b4ada3f7e383dd71ec523a0875fb05",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "not-smart-test": {
     "source": "content/features/smart-test.md",
     "hash": "58c691c8313ddf9699deb913e6b5c50fafc684563539ddf4816a4b94a9ea3e80",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "not-socratic-interaction-rule": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "not-spec-engine": {
     "source": "content/features/spec-engine.md",
     "hash": "c8549016aa848eeeaecbde8329f5850562f56280ab66428cb7c20887b428d81a",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "not-telemetry": {
     "source": "content/features/telemetry.md",
     "hash": "59473ab809113116a3d58d2ead3a5f13e362d6992d8cee0a89364feded5cbd50",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "not-term-cli": {
     "source": "CLAUDE.md",
     "hash": "811c9cf90d6a42eb767f78b7fc6874a5ab0c6ae914fc1533ec40cc800f40749c",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "not-term-crew": {
     "source": "CLAUDE.md",
     "hash": "811c9cf90d6a42eb767f78b7fc6874a5ab0c6ae914fc1533ec40cc800f40749c",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "not-term-hub": {
     "source": "CLAUDE.md",
     "hash": "811c9cf90d6a42eb767f78b7fc6874a5ab0c6ae914fc1533ec40cc800f40749c",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "not-term-llm": {
     "source": "CLAUDE.md",
     "hash": "811c9cf90d6a42eb767f78b7fc6874a5ab0c6ae914fc1533ec40cc800f40749c",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "not-term-p2b": {
     "source": "CLAUDE.md",
     "hash": "811c9cf90d6a42eb767f78b7fc6874a5ab0c6ae914fc1533ec40cc800f40749c",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "not-term-progressive": {
     "source": "CLAUDE.md",
     "hash": "811c9cf90d6a42eb767f78b7fc6874a5ab0c6ae914fc1533ec40cc800f40749c",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "not-term-sdk": {
     "source": "CLAUDE.md",
     "hash": "811c9cf90d6a42eb767f78b7fc6874a5ab0c6ae914fc1533ec40cc800f40749c",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "not-term-socratic": {
     "source": "CLAUDE.md",
     "hash": "811c9cf90d6a42eb767f78b7fc6874a5ab0c6ae914fc1533ec40cc800f40749c",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "not-term-tier": {
     "source": "CLAUDE.md",
     "hash": "811c9cf90d6a42eb767f78b7fc6874a5ab0c6ae914fc1533ec40cc800f40749c",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "not-term-wizard": {
     "source": "CLAUDE.md",
     "hash": "811c9cf90d6a42eb767f78b7fc6874a5ab0c6ae914fc1533ec40cc800f40749c",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "not-wizards": {
     "source": "content/features/wizards.md",
     "hash": "6fe7722a026d11276ebfbdf4ea046a05112be94b560f9abf3ffee410f8637d8f",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "qui-agents": {
     "source": "content/features/agents.md",
     "hash": "a5b1678ecf012c7b2877a6c7ecae4a6c3f14c084c13fbcbb7eee79119dce6fa3",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "qui-browse-help": {
     "source": "src/attune/cli_commands/help_commands.py",
     "hash": "d284892c4f058b5a9d4861f08f7f2de09c8050d33766471014bb739215a83582",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "qui-bug-predict": {
     "source": "content/features/bug-predict.md",
     "hash": "6a4f420eba38e2fb884b837dd9758acb60ba60cdaf9248ec4280120b0d382b16",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "qui-check-costs": {
     "source": "src/attune/cli_minimal.py",
-    "hash": "952eff81eb5c2a259974a8196363de82f79cbaeb5b115859b42a823100dbe974",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "hash": "8e78816c6a743c24afd05568ba29a5d0eec548beea557ab098a48630b1f82ac8",
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "qui-check-health": {
     "source": "src/attune/cli_minimal.py",
-    "hash": "952eff81eb5c2a259974a8196363de82f79cbaeb5b115859b42a823100dbe974",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "hash": "8e78816c6a743c24afd05568ba29a5d0eec548beea557ab098a48630b1f82ac8",
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "qui-cli": {
     "source": "content/features/cli.md",
     "hash": "a37b4dc4f0b3706a62184b02d2be1536ad75eef39a0f22a9699db5d03b8ee050",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "qui-code-quality": {
     "source": "content/features/code-quality.md",
     "hash": "ce16ac87eb92e33a08d8c2f06e86ef22e436966f47f3a28c3f4eba19060b550a",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "qui-configuration": {
     "source": "content/features/configuration.md",
     "hash": "8add90392883a46899ef8b57d135b625d92c5b61231d8a5301727f8b42f8e46f",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "qui-deep-review": {
     "source": "content/features/deep-review.md",
     "hash": "6a4fffc907302b4847d96097189bd8d329d3f1548d1ee46d9232f6ceecdfb450",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "qui-doc-gen": {
     "source": "content/features/doc-gen.md",
     "hash": "26e02a71a523775f5bb9e371b2e563c3c858386436a73b727422f62f57de0282",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "qui-elicitation-forms": {
     "source": "content/features/elicitation-forms.md",
-    "hash": "b7e73232af03174e0e5d50d551277a784127eb8047713cacfce1df8b19e8a8d6",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "hash": "36b29d55060c78f96ed1aaf1af34338dba4a156b674b98a9f35ebfd04524d2b3",
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "qui-fix-test": {
     "source": "content/features/fix-test.md",
     "hash": "da54b69787cc1af5c087b2d8674442afe9b8c6fc88dca37a65e99590bb84fee0",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "qui-generate-tests": {
     "source": "src/attune/cli_minimal.py",
-    "hash": "952eff81eb5c2a259974a8196363de82f79cbaeb5b115859b42a823100dbe974",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "hash": "8e78816c6a743c24afd05568ba29a5d0eec548beea557ab098a48630b1f82ac8",
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "qui-help-system": {
     "source": "content/features/help-system.md",
     "hash": "24468c8fe4f1a0e350e620098d65a3bcc007000cd5aa4dbe20a6e6c83efa87b3",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "qui-hooks": {
     "source": "content/features/hooks.md",
     "hash": "5c6b8a45457387c76f628561d3baa56e9af1709bc9bd21bba9830b2c2478c8dd",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "qui-install": {
     "source": "README.md",
     "hash": "29c1821d6fdff7907606b8f37c13640c6d7747a9cfd2db37fb6b4579b0c7365f",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "qui-install-plugin": {
     "source": "README.md",
     "hash": "29c1821d6fdff7907606b8f37c13640c6d7747a9cfd2db37fb6b4579b0c7365f",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "qui-mcp-server": {
     "source": "content/features/mcp-server.md",
     "hash": "8e4b8c74eff980330480ae70856a1cf0393559cd22eb9ba0210b43249f9b5181",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "qui-memory": {
     "source": "content/features/memory.md",
     "hash": "32b3121d9110dc9ac327bb9e838f060fbe9940a033366b0147ef34ef2efaa4dc",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "qui-models": {
     "source": "content/features/models.md",
     "hash": "2117cbb0d8e863db6091870874e4ce80b48780c9ee8bb7330d8033c172ccb02b",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "qui-ops-dashboard": {
     "source": "content/features/ops-dashboard.md",
     "hash": "fefc8e2b2b4a25055fcbdf96cbd8638d75278cbcacd256873b725df89544c1f6",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "qui-orchestration": {
     "source": "content/features/orchestration.md",
     "hash": "4998437e04355011a7dee68dbce7e9e78bbe97f637e0b6a14c1ec972f541695c",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "qui-plugin": {
     "source": "content/features/plugin.md",
     "hash": "8cc6e5702ffc8228ed63cfb74a25dd3e99e79e5335c4b1c8c134950f8b9a043d",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "qui-rag-grounding": {
     "source": "content/features/rag-grounding.md",
     "hash": "3464dd78c83f06980912a7c49dc185b09830be1b1c163203f10e5aa1708fcf4e",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "qui-refactor-plan": {
     "source": "content/features/refactor-plan.md",
     "hash": "8f8c684cd94fca7b2580ecaaf955ccb79924022796d576d477cdab9330df9704",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "qui-release-notes": {
     "source": "content/features/release-notes.md",
     "hash": "da7101ffbec4d209fcb1cef754f01cef8a13458a6f961c3a23909edfec77e58c",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "qui-release-prep": {
     "source": "content/features/release-prep.md",
     "hash": "cd77b5903fbeb7d7e0acef570bab9727b4c143181ea6be1f52b9a25bc11418bb",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "qui-resilience": {
     "source": "content/features/resilience.md",
     "hash": "ae2a76f0f1ecbb9ca687e5a041acc2b4a25a5113ec57eaad550f48b8aadc4be2",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "qui-run-code-review": {
     "source": "src/attune/cli_minimal.py",
-    "hash": "952eff81eb5c2a259974a8196363de82f79cbaeb5b115859b42a823100dbe974",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "hash": "8e78816c6a743c24afd05568ba29a5d0eec548beea557ab098a48630b1f82ac8",
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "qui-run-security-audit": {
     "source": "src/attune/cli_minimal.py",
-    "hash": "952eff81eb5c2a259974a8196363de82f79cbaeb5b115859b42a823100dbe974",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "hash": "8e78816c6a743c24afd05568ba29a5d0eec548beea557ab098a48630b1f82ac8",
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "qui-security-audit": {
     "source": "content/features/security-audit.md",
     "hash": "9cce18573c827fab9a380efe8c65c2f8c5b4ada3f7e383dd71ec523a0875fb05",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "qui-skill-attune-hub": {
     "source": "plugin/skills/attune-hub/SKILL.md",
     "hash": "3e8cb98c4cdae752aad8e8ddda10f55629da0906b85b407e757ff8fd9981efac",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "qui-skill-bug-predict": {
     "source": "plugin/skills/bug-predict/SKILL.md",
     "hash": "992b9e6cd3452af0d31213985e5e5c607f078edd2310df76d786b95d7e6a83ce",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "qui-skill-coach": {
     "source": "plugin/skills/coach/SKILL.md",
     "hash": "a1842d674325f3f1ea289e3bd7ed1dcfbb4b3301160181edab081d2b4352aeac",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "qui-skill-code-quality": {
     "source": "plugin/skills/code-quality/SKILL.md",
     "hash": "769c4c885992fd1937adbdf5d97305894bd08c159c83930d7a9fb86cb4ae78b7",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "qui-skill-doc-gen": {
     "source": "plugin/skills/doc-gen/SKILL.md",
     "hash": "da9a9c23727eaa9433b2c4d1dfe87d850ef560d56b855f2eb7bd0f279efc3c72",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "qui-skill-fix-test": {
     "source": "plugin/skills/fix-test/SKILL.md",
     "hash": "665ff7c4978beddd72e87f3764b073e4f962b27a896bd66542d499a1a00429da",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "qui-skill-memory-and-context": {
     "source": "plugin/skills/memory-and-context/SKILL.md",
     "hash": "d026a40d0c5315123672c7ed3770b643ba803a3b5d57cb994c236fcd6baa8305",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "qui-skill-planning": {
     "source": "plugin/skills/planning/SKILL.md",
     "hash": "f56a42c83f514b300b4f89ea6669820ec158da952efa2894c56abb00c39eb58a",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "qui-skill-rag-code-gen": {
     "source": "plugin/skills/rag-code-gen/SKILL.md",
     "hash": "0d84a32e2f89e8debd740b4343c7930b17efcca37fcb68737f342f8b6b5f6f77",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "qui-skill-refactor-plan": {
     "source": "plugin/skills/refactor-plan/SKILL.md",
     "hash": "080a84b5df5dde88cd3c994ca2c2b68ec12e2cf241f2e81893f21aa9dac315f6",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "qui-skill-release-prep": {
     "source": "plugin/skills/release-prep/SKILL.md",
     "hash": "8aab944ae2f53a24c94d39329bf000067a68f43b51de6657b517678bec90c67a",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "qui-skill-security-audit": {
     "source": "plugin/skills/security-audit/SKILL.md",
     "hash": "f370003a809c342d35b37990da231fbb72545e75e5a37e1e1d39a27db5364761",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "qui-skill-smart-test": {
     "source": "plugin/skills/smart-test/SKILL.md",
     "hash": "a5e874d1054dd123d78d9d8e9014c7c6888230f36685a203ea26176a3d649ffb",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "qui-skill-spec": {
     "source": "plugin/skills/spec/SKILL.md",
     "hash": "4e1ce2c9da6fcad85ebcf7cb6b755f44c27d00608ad97b72b93a82a45e3c0186",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "qui-skill-workflow-orchestration": {
     "source": "plugin/skills/workflow-orchestration/SKILL.md",
     "hash": "831c00dfb29ae4c72b35921fd3bab9e9f17affabf32b8164deb801557e031127",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "qui-smart-test": {
     "source": "content/features/smart-test.md",
     "hash": "58c691c8313ddf9699deb913e6b5c50fafc684563539ddf4816a4b94a9ea3e80",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "qui-spec-engine": {
     "source": "content/features/spec-engine.md",
     "hash": "c8549016aa848eeeaecbde8329f5850562f56280ab66428cb7c20887b428d81a",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "qui-telemetry": {
     "source": "content/features/telemetry.md",
     "hash": "59473ab809113116a3d58d2ead3a5f13e362d6992d8cee0a89364feded5cbd50",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "qui-wizards": {
     "source": "content/features/wizards.md",
     "hash": "6fe7722a026d11276ebfbdf4ea046a05112be94b560f9abf3ffee410f8637d8f",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "ref-agents": {
     "source": "content/features/agents.md",
     "hash": "a5b1678ecf012c7b2877a6c7ecae4a6c3f14c084c13fbcbb7eee79119dce6fa3",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "ref-bug-predict": {
     "source": "content/features/bug-predict.md",
     "hash": "6a4f420eba38e2fb884b837dd9758acb60ba60cdaf9248ec4280120b0d382b16",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "ref-cli": {
     "source": "content/features/cli.md",
     "hash": "a37b4dc4f0b3706a62184b02d2be1536ad75eef39a0f22a9699db5d03b8ee050",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "ref-code-quality": {
     "source": "content/features/code-quality.md",
     "hash": "ce16ac87eb92e33a08d8c2f06e86ef22e436966f47f3a28c3f4eba19060b550a",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "ref-configuration": {
     "source": "content/features/configuration.md",
     "hash": "8add90392883a46899ef8b57d135b625d92c5b61231d8a5301727f8b42f8e46f",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "ref-deep-review": {
     "source": "content/features/deep-review.md",
     "hash": "6a4fffc907302b4847d96097189bd8d329d3f1548d1ee46d9232f6ceecdfb450",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "ref-doc-gen": {
     "source": "content/features/doc-gen.md",
     "hash": "26e02a71a523775f5bb9e371b2e563c3c858386436a73b727422f62f57de0282",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "ref-elicitation-forms": {
     "source": "content/features/elicitation-forms.md",
-    "hash": "b7e73232af03174e0e5d50d551277a784127eb8047713cacfce1df8b19e8a8d6",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "hash": "36b29d55060c78f96ed1aaf1af34338dba4a156b674b98a9f35ebfd04524d2b3",
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "ref-fix-test": {
     "source": "content/features/fix-test.md",
     "hash": "da54b69787cc1af5c087b2d8674442afe9b8c6fc88dca37a65e99590bb84fee0",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "ref-help-system": {
     "source": "content/features/help-system.md",
     "hash": "24468c8fe4f1a0e350e620098d65a3bcc007000cd5aa4dbe20a6e6c83efa87b3",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "ref-hooks": {
     "source": "content/features/hooks.md",
     "hash": "5c6b8a45457387c76f628561d3baa56e9af1709bc9bd21bba9830b2c2478c8dd",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "ref-mcp-server": {
     "source": "content/features/mcp-server.md",
     "hash": "8e4b8c74eff980330480ae70856a1cf0393559cd22eb9ba0210b43249f9b5181",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "ref-memory": {
     "source": "content/features/memory.md",
     "hash": "32b3121d9110dc9ac327bb9e838f060fbe9940a033366b0147ef34ef2efaa4dc",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "ref-models": {
     "source": "content/features/models.md",
     "hash": "2117cbb0d8e863db6091870874e4ce80b48780c9ee8bb7330d8033c172ccb02b",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "ref-ops-dashboard": {
     "source": "content/features/ops-dashboard.md",
     "hash": "fefc8e2b2b4a25055fcbdf96cbd8638d75278cbcacd256873b725df89544c1f6",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "ref-orchestration": {
     "source": "content/features/orchestration.md",
     "hash": "4998437e04355011a7dee68dbce7e9e78bbe97f637e0b6a14c1ec972f541695c",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "ref-plugin": {
     "source": "content/features/plugin.md",
     "hash": "8cc6e5702ffc8228ed63cfb74a25dd3e99e79e5335c4b1c8c134950f8b9a043d",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "ref-rag-grounding": {
     "source": "content/features/rag-grounding.md",
     "hash": "3464dd78c83f06980912a7c49dc185b09830be1b1c163203f10e5aa1708fcf4e",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "ref-refactor-plan": {
     "source": "content/features/refactor-plan.md",
     "hash": "8f8c684cd94fca7b2580ecaaf955ccb79924022796d576d477cdab9330df9704",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "ref-release-notes": {
     "source": "content/features/release-notes.md",
     "hash": "da7101ffbec4d209fcb1cef754f01cef8a13458a6f961c3a23909edfec77e58c",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "ref-release-prep": {
     "source": "content/features/release-prep.md",
     "hash": "cd77b5903fbeb7d7e0acef570bab9727b4c143181ea6be1f52b9a25bc11418bb",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "ref-resilience": {
     "source": "content/features/resilience.md",
     "hash": "ae2a76f0f1ecbb9ca687e5a041acc2b4a25a5113ec57eaad550f48b8aadc4be2",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "ref-security-audit": {
     "source": "content/features/security-audit.md",
     "hash": "9cce18573c827fab9a380efe8c65c2f8c5b4ada3f7e383dd71ec523a0875fb05",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "ref-skill-attune-hub": {
     "source": "plugin/skills/attune-hub/SKILL.md",
     "hash": "3e8cb98c4cdae752aad8e8ddda10f55629da0906b85b407e757ff8fd9981efac",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "ref-skill-bug-predict": {
     "source": "plugin/skills/bug-predict/SKILL.md",
     "hash": "992b9e6cd3452af0d31213985e5e5c607f078edd2310df76d786b95d7e6a83ce",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "ref-skill-coach": {
     "source": "plugin/skills/coach/SKILL.md",
     "hash": "a1842d674325f3f1ea289e3bd7ed1dcfbb4b3301160181edab081d2b4352aeac",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "ref-skill-code-quality": {
     "source": "plugin/skills/code-quality/SKILL.md",
     "hash": "769c4c885992fd1937adbdf5d97305894bd08c159c83930d7a9fb86cb4ae78b7",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "ref-skill-doc-gen": {
     "source": "plugin/skills/doc-gen/SKILL.md",
     "hash": "da9a9c23727eaa9433b2c4d1dfe87d850ef560d56b855f2eb7bd0f279efc3c72",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "ref-skill-fix-test": {
     "source": "plugin/skills/fix-test/SKILL.md",
     "hash": "665ff7c4978beddd72e87f3764b073e4f962b27a896bd66542d499a1a00429da",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "ref-skill-memory-and-context": {
     "source": "plugin/skills/memory-and-context/SKILL.md",
     "hash": "d026a40d0c5315123672c7ed3770b643ba803a3b5d57cb994c236fcd6baa8305",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "ref-skill-planning": {
     "source": "plugin/skills/planning/SKILL.md",
     "hash": "f56a42c83f514b300b4f89ea6669820ec158da952efa2894c56abb00c39eb58a",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "ref-skill-rag-code-gen": {
     "source": "plugin/skills/rag-code-gen/SKILL.md",
     "hash": "0d84a32e2f89e8debd740b4343c7930b17efcca37fcb68737f342f8b6b5f6f77",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "ref-skill-refactor-plan": {
     "source": "plugin/skills/refactor-plan/SKILL.md",
     "hash": "080a84b5df5dde88cd3c994ca2c2b68ec12e2cf241f2e81893f21aa9dac315f6",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "ref-skill-release-prep": {
     "source": "plugin/skills/release-prep/SKILL.md",
     "hash": "8aab944ae2f53a24c94d39329bf000067a68f43b51de6657b517678bec90c67a",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "ref-skill-security-audit": {
     "source": "plugin/skills/security-audit/SKILL.md",
     "hash": "f370003a809c342d35b37990da231fbb72545e75e5a37e1e1d39a27db5364761",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "ref-skill-smart-test": {
     "source": "plugin/skills/smart-test/SKILL.md",
     "hash": "a5e874d1054dd123d78d9d8e9014c7c6888230f36685a203ea26176a3d649ffb",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "ref-skill-spec": {
     "source": "plugin/skills/spec/SKILL.md",
     "hash": "4e1ce2c9da6fcad85ebcf7cb6b755f44c27d00608ad97b72b93a82a45e3c0186",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "ref-skill-workflow-orchestration": {
     "source": "plugin/skills/workflow-orchestration/SKILL.md",
     "hash": "831c00dfb29ae4c72b35921fd3bab9e9f17affabf32b8164deb801557e031127",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "ref-smart-test": {
     "source": "content/features/smart-test.md",
     "hash": "58c691c8313ddf9699deb913e6b5c50fafc684563539ddf4816a4b94a9ea3e80",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "ref-spec-engine": {
     "source": "content/features/spec-engine.md",
     "hash": "c8549016aa848eeeaecbde8329f5850562f56280ab66428cb7c20887b428d81a",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "ref-telemetry": {
     "source": "content/features/telemetry.md",
     "hash": "59473ab809113116a3d58d2ead3a5f13e362d6992d8cee0a89364feded5cbd50",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "ref-tool-analyze-batch": {
     "source": "src/attune/mcp/tool_schemas.py",
     "hash": "a96c4580b9fabdd2f37ada7f8ffcd9d777c84bea9e200cbec98d76950836e07b",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "ref-tool-analyze-image": {
     "source": "src/attune/mcp/tool_schemas.py",
     "hash": "a96c4580b9fabdd2f37ada7f8ffcd9d777c84bea9e200cbec98d76950836e07b",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "ref-tool-attune-get-level": {
     "source": "src/attune/mcp/tool_schemas.py",
     "hash": "a96c4580b9fabdd2f37ada7f8ffcd9d777c84bea9e200cbec98d76950836e07b",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "ref-tool-attune-set-level": {
     "source": "src/attune/mcp/tool_schemas.py",
     "hash": "a96c4580b9fabdd2f37ada7f8ffcd9d777c84bea9e200cbec98d76950836e07b",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "ref-tool-auth-recommend": {
     "source": "src/attune/mcp/tool_schemas.py",
     "hash": "a96c4580b9fabdd2f37ada7f8ffcd9d777c84bea9e200cbec98d76950836e07b",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "ref-tool-auth-status": {
     "source": "src/attune/mcp/tool_schemas.py",
     "hash": "a96c4580b9fabdd2f37ada7f8ffcd9d777c84bea9e200cbec98d76950836e07b",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "ref-tool-bug-predict": {
     "source": "src/attune/mcp/tool_schemas.py",
     "hash": "a96c4580b9fabdd2f37ada7f8ffcd9d777c84bea9e200cbec98d76950836e07b",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "ref-tool-code-review": {
     "source": "src/attune/mcp/tool_schemas.py",
     "hash": "a96c4580b9fabdd2f37ada7f8ffcd9d777c84bea9e200cbec98d76950836e07b",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "ref-tool-context-get": {
     "source": "src/attune/mcp/tool_schemas.py",
     "hash": "a96c4580b9fabdd2f37ada7f8ffcd9d777c84bea9e200cbec98d76950836e07b",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "ref-tool-context-set": {
     "source": "src/attune/mcp/tool_schemas.py",
     "hash": "a96c4580b9fabdd2f37ada7f8ffcd9d777c84bea9e200cbec98d76950836e07b",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "ref-tool-deep-review": {
     "source": "src/attune/mcp/tool_schemas.py",
     "hash": "a96c4580b9fabdd2f37ada7f8ffcd9d777c84bea9e200cbec98d76950836e07b",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "ref-tool-dependency-check": {
     "source": "src/attune/mcp/tool_schemas.py",
     "hash": "a96c4580b9fabdd2f37ada7f8ffcd9d777c84bea9e200cbec98d76950836e07b",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "ref-tool-doc-audit": {
     "source": "src/attune/mcp/tool_schemas.py",
     "hash": "a96c4580b9fabdd2f37ada7f8ffcd9d777c84bea9e200cbec98d76950836e07b",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "ref-tool-doc-gen": {
     "source": "src/attune/mcp/tool_schemas.py",
     "hash": "a96c4580b9fabdd2f37ada7f8ffcd9d777c84bea9e200cbec98d76950836e07b",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "ref-tool-doc-orchestrator": {
     "source": "src/attune/mcp/tool_schemas.py",
     "hash": "a96c4580b9fabdd2f37ada7f8ffcd9d777c84bea9e200cbec98d76950836e07b",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "ref-tool-health-check": {
     "source": "src/attune/mcp/tool_schemas.py",
     "hash": "a96c4580b9fabdd2f37ada7f8ffcd9d777c84bea9e200cbec98d76950836e07b",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "ref-tool-memory-forget": {
     "source": "src/attune/mcp/tool_schemas.py",
     "hash": "a96c4580b9fabdd2f37ada7f8ffcd9d777c84bea9e200cbec98d76950836e07b",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "ref-tool-memory-retrieve": {
     "source": "src/attune/mcp/tool_schemas.py",
     "hash": "a96c4580b9fabdd2f37ada7f8ffcd9d777c84bea9e200cbec98d76950836e07b",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "ref-tool-memory-search": {
     "source": "src/attune/mcp/tool_schemas.py",
     "hash": "a96c4580b9fabdd2f37ada7f8ffcd9d777c84bea9e200cbec98d76950836e07b",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "ref-tool-memory-store": {
     "source": "src/attune/mcp/tool_schemas.py",
     "hash": "a96c4580b9fabdd2f37ada7f8ffcd9d777c84bea9e200cbec98d76950836e07b",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "ref-tool-performance-audit": {
     "source": "src/attune/mcp/tool_schemas.py",
     "hash": "a96c4580b9fabdd2f37ada7f8ffcd9d777c84bea9e200cbec98d76950836e07b",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "ref-tool-rag-knowledge-query": {
     "source": "src/attune/mcp/tool_schemas.py",
     "hash": "a96c4580b9fabdd2f37ada7f8ffcd9d777c84bea9e200cbec98d76950836e07b",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "ref-tool-refactor-plan": {
     "source": "src/attune/mcp/tool_schemas.py",
     "hash": "a96c4580b9fabdd2f37ada7f8ffcd9d777c84bea9e200cbec98d76950836e07b",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "ref-tool-release-prep": {
     "source": "src/attune/mcp/tool_schemas.py",
     "hash": "a96c4580b9fabdd2f37ada7f8ffcd9d777c84bea9e200cbec98d76950836e07b",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "ref-tool-research-synthesis": {
     "source": "src/attune/mcp/tool_schemas.py",
     "hash": "a96c4580b9fabdd2f37ada7f8ffcd9d777c84bea9e200cbec98d76950836e07b",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "ref-tool-secure-release": {
     "source": "src/attune/mcp/tool_schemas.py",
     "hash": "a96c4580b9fabdd2f37ada7f8ffcd9d777c84bea9e200cbec98d76950836e07b",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "ref-tool-security-audit": {
     "source": "src/attune/mcp/tool_schemas.py",
     "hash": "a96c4580b9fabdd2f37ada7f8ffcd9d777c84bea9e200cbec98d76950836e07b",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "ref-tool-simplify-code": {
     "source": "src/attune/mcp/tool_schemas.py",
     "hash": "a96c4580b9fabdd2f37ada7f8ffcd9d777c84bea9e200cbec98d76950836e07b",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "ref-tool-telemetry-stats": {
     "source": "src/attune/mcp/tool_schemas.py",
     "hash": "a96c4580b9fabdd2f37ada7f8ffcd9d777c84bea9e200cbec98d76950836e07b",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "ref-tool-test-audit": {
     "source": "src/attune/mcp/tool_schemas.py",
     "hash": "a96c4580b9fabdd2f37ada7f8ffcd9d777c84bea9e200cbec98d76950836e07b",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "ref-tool-test-gen-parallel": {
     "source": "src/attune/mcp/tool_schemas.py",
     "hash": "a96c4580b9fabdd2f37ada7f8ffcd9d777c84bea9e200cbec98d76950836e07b",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "ref-tool-test-generation": {
     "source": "src/attune/mcp/tool_schemas.py",
     "hash": "a96c4580b9fabdd2f37ada7f8ffcd9d777c84bea9e200cbec98d76950836e07b",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "ref-wizards": {
     "source": "content/features/wizards.md",
     "hash": "6fe7722a026d11276ebfbdf4ea046a05112be94b560f9abf3ffee410f8637d8f",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "tas-agents": {
     "source": "content/features/agents.md",
     "hash": "a5b1678ecf012c7b2877a6c7ecae4a6c3f14c084c13fbcbb7eee79119dce6fa3",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "tas-browse-help-docs": {
     "source": "src/attune/cli_commands/help_commands.py",
     "hash": "d284892c4f058b5a9d4861f08f7f2de09c8050d33766471014bb739215a83582",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "tas-bug-predict": {
     "source": "content/features/bug-predict.md",
     "hash": "6a4f420eba38e2fb884b837dd9758acb60ba60cdaf9248ec4280120b0d382b16",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "tas-check-auth-status": {
     "source": "src/attune/cli_minimal.py",
-    "hash": "952eff81eb5c2a259974a8196363de82f79cbaeb5b115859b42a823100dbe974",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "hash": "8e78816c6a743c24afd05568ba29a5d0eec548beea557ab098a48630b1f82ac8",
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "tas-cli": {
     "source": "content/features/cli.md",
     "hash": "a37b4dc4f0b3706a62184b02d2be1536ad75eef39a0f22a9699db5d03b8ee050",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "tas-code-quality": {
     "source": "content/features/code-quality.md",
     "hash": "ce16ac87eb92e33a08d8c2f06e86ef22e436966f47f3a28c3f4eba19060b550a",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "tas-configuration": {
     "source": "content/features/configuration.md",
     "hash": "8add90392883a46899ef8b57d135b625d92c5b61231d8a5301727f8b42f8e46f",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "tas-deep-review": {
     "source": "content/features/deep-review.md",
     "hash": "6a4fffc907302b4847d96097189bd8d329d3f1548d1ee46d9232f6ceecdfb450",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "tas-doc-gen": {
     "source": "content/features/doc-gen.md",
     "hash": "26e02a71a523775f5bb9e371b2e563c3c858386436a73b727422f62f57de0282",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "tas-elicitation-forms": {
     "source": "content/features/elicitation-forms.md",
-    "hash": "b7e73232af03174e0e5d50d551277a784127eb8047713cacfce1df8b19e8a8d6",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "hash": "36b29d55060c78f96ed1aaf1af34338dba4a156b674b98a9f35ebfd04524d2b3",
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "tas-export-telemetry": {
     "source": "src/attune/cli_minimal.py",
-    "hash": "952eff81eb5c2a259974a8196363de82f79cbaeb5b115859b42a823100dbe974",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "hash": "8e78816c6a743c24afd05568ba29a5d0eec548beea557ab098a48630b1f82ac8",
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "tas-fix-test": {
     "source": "content/features/fix-test.md",
     "hash": "da54b69787cc1af5c087b2d8674442afe9b8c6fc88dca37a65e99590bb84fee0",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "tas-help-system": {
     "source": "content/features/help-system.md",
     "hash": "24468c8fe4f1a0e350e620098d65a3bcc007000cd5aa4dbe20a6e6c83efa87b3",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "tas-hooks": {
     "source": "content/features/hooks.md",
     "hash": "5c6b8a45457387c76f628561d3baa56e9af1709bc9bd21bba9830b2c2478c8dd",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "tas-install-plugin": {
     "source": "README.md",
     "hash": "29c1821d6fdff7907606b8f37c13640c6d7747a9cfd2db37fb6b4579b0c7365f",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "tas-manage-lessons": {
     "source": "src/attune/cli_minimal.py",
-    "hash": "952eff81eb5c2a259974a8196363de82f79cbaeb5b115859b42a823100dbe974",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "hash": "8e78816c6a743c24afd05568ba29a5d0eec548beea557ab098a48630b1f82ac8",
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "tas-mcp-server": {
     "source": "content/features/mcp-server.md",
     "hash": "8e4b8c74eff980330480ae70856a1cf0393559cd22eb9ba0210b43249f9b5181",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "tas-memory": {
     "source": "content/features/memory.md",
     "hash": "32b3121d9110dc9ac327bb9e838f060fbe9940a033366b0147ef34ef2efaa4dc",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "tas-models": {
     "source": "content/features/models.md",
     "hash": "2117cbb0d8e863db6091870874e4ce80b48780c9ee8bb7330d8033c172ccb02b",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "tas-ops-dashboard": {
     "source": "content/features/ops-dashboard.md",
     "hash": "fefc8e2b2b4a25055fcbdf96cbd8638d75278cbcacd256873b725df89544c1f6",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "tas-orchestration": {
     "source": "content/features/orchestration.md",
     "hash": "4998437e04355011a7dee68dbce7e9e78bbe97f637e0b6a14c1ec972f541695c",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "tas-plugin": {
     "source": "content/features/plugin.md",
     "hash": "8cc6e5702ffc8228ed63cfb74a25dd3e99e79e5335c4b1c8c134950f8b9a043d",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "tas-rag-grounding": {
     "source": "content/features/rag-grounding.md",
     "hash": "3464dd78c83f06980912a7c49dc185b09830be1b1c163203f10e5aa1708fcf4e",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "tas-refactor-plan": {
     "source": "content/features/refactor-plan.md",
     "hash": "8f8c684cd94fca7b2580ecaaf955ccb79924022796d576d477cdab9330df9704",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "tas-release-notes": {
     "source": "content/features/release-notes.md",
     "hash": "da7101ffbec4d209fcb1cef754f01cef8a13458a6f961c3a23909edfec77e58c",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "tas-release-prep": {
     "source": "content/features/release-prep.md",
     "hash": "cd77b5903fbeb7d7e0acef570bab9727b4c143181ea6be1f52b9a25bc11418bb",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "tas-resilience": {
     "source": "content/features/resilience.md",
     "hash": "ae2a76f0f1ecbb9ca687e5a041acc2b4a25a5113ec57eaad550f48b8aadc4be2",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "tas-run-doctor": {
     "source": "src/attune/cli_minimal.py",
-    "hash": "952eff81eb5c2a259974a8196363de82f79cbaeb5b115859b42a823100dbe974",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "hash": "8e78816c6a743c24afd05568ba29a5d0eec548beea557ab098a48630b1f82ac8",
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "tas-run-workflow": {
     "source": "src/attune/cli_minimal.py",
-    "hash": "952eff81eb5c2a259974a8196363de82f79cbaeb5b115859b42a823100dbe974",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "hash": "8e78816c6a743c24afd05568ba29a5d0eec548beea557ab098a48630b1f82ac8",
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "tas-security-audit": {
     "source": "content/features/security-audit.md",
     "hash": "9cce18573c827fab9a380efe8c65c2f8c5b4ada3f7e383dd71ec523a0875fb05",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "tas-smart-test": {
     "source": "content/features/smart-test.md",
     "hash": "58c691c8313ddf9699deb913e6b5c50fafc684563539ddf4816a4b94a9ea3e80",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "tas-spec-engine": {
     "source": "content/features/spec-engine.md",
     "hash": "c8549016aa848eeeaecbde8329f5850562f56280ab66428cb7c20887b428d81a",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "tas-telemetry": {
     "source": "content/features/telemetry.md",
     "hash": "59473ab809113116a3d58d2ead3a5f13e362d6992d8cee0a89364feded5cbd50",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "tas-use-attune-hub": {
     "source": "plugin/skills/attune-hub/SKILL.md",
     "hash": "3e8cb98c4cdae752aad8e8ddda10f55629da0906b85b407e757ff8fd9981efac",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "tas-use-bug-predict": {
     "source": "plugin/skills/bug-predict/SKILL.md",
     "hash": "992b9e6cd3452af0d31213985e5e5c607f078edd2310df76d786b95d7e6a83ce",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "tas-use-coach": {
     "source": "plugin/skills/coach/SKILL.md",
     "hash": "a1842d674325f3f1ea289e3bd7ed1dcfbb4b3301160181edab081d2b4352aeac",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "tas-use-code-quality": {
     "source": "plugin/skills/code-quality/SKILL.md",
     "hash": "769c4c885992fd1937adbdf5d97305894bd08c159c83930d7a9fb86cb4ae78b7",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "tas-use-doc-gen": {
     "source": "plugin/skills/doc-gen/SKILL.md",
     "hash": "da9a9c23727eaa9433b2c4d1dfe87d850ef560d56b855f2eb7bd0f279efc3c72",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "tas-use-fix-test": {
     "source": "plugin/skills/fix-test/SKILL.md",
     "hash": "665ff7c4978beddd72e87f3764b073e4f962b27a896bd66542d499a1a00429da",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "tas-use-memory-and-context": {
     "source": "plugin/skills/memory-and-context/SKILL.md",
     "hash": "d026a40d0c5315123672c7ed3770b643ba803a3b5d57cb994c236fcd6baa8305",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "tas-use-planning": {
     "source": "plugin/skills/planning/SKILL.md",
     "hash": "f56a42c83f514b300b4f89ea6669820ec158da952efa2894c56abb00c39eb58a",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "tas-use-rag-code-gen": {
     "source": "plugin/skills/rag-code-gen/SKILL.md",
     "hash": "0d84a32e2f89e8debd740b4343c7930b17efcca37fcb68737f342f8b6b5f6f77",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "tas-use-refactor-plan": {
     "source": "plugin/skills/refactor-plan/SKILL.md",
     "hash": "080a84b5df5dde88cd3c994ca2c2b68ec12e2cf241f2e81893f21aa9dac315f6",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "tas-use-release-prep": {
     "source": "plugin/skills/release-prep/SKILL.md",
     "hash": "8aab944ae2f53a24c94d39329bf000067a68f43b51de6657b517678bec90c67a",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "tas-use-security-audit": {
     "source": "plugin/skills/security-audit/SKILL.md",
     "hash": "f370003a809c342d35b37990da231fbb72545e75e5a37e1e1d39a27db5364761",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "tas-use-smart-test": {
     "source": "plugin/skills/smart-test/SKILL.md",
     "hash": "a5e874d1054dd123d78d9d8e9014c7c6888230f36685a203ea26176a3d649ffb",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "tas-use-spec": {
     "source": "plugin/skills/spec/SKILL.md",
     "hash": "4e1ce2c9da6fcad85ebcf7cb6b755f44c27d00608ad97b72b93a82a45e3c0186",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "tas-use-workflow-orchestration": {
     "source": "plugin/skills/workflow-orchestration/SKILL.md",
     "hash": "831c00dfb29ae4c72b35921fd3bab9e9f17affabf32b8164deb801557e031127",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "tas-wizards": {
     "source": "content/features/wizards.md",
     "hash": "6fe7722a026d11276ebfbdf4ea046a05112be94b560f9abf3ffee410f8637d8f",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "tip-after-10-inspects": {
     "source": "src/attune/discovery.py",
     "hash": "81b550a4505d51c66f590eb3ea9d2c52002c0ffcab1ff3b2c013f5e34cd79c8b",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "tip-after-5-ships": {
     "source": "src/attune/discovery.py",
     "hash": "81b550a4505d51c66f590eb3ea9d2c52002c0ffcab1ff3b2c013f5e34cd79c8b",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "tip-after-bug-predict": {
     "source": "src/attune/workflows/suggestions.py",
     "hash": "caa3f48a039def99a5bf58dc29129aba9548dfc74a42cc69dfb067aeb71f3200",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "tip-after-code-review": {
     "source": "src/attune/workflows/suggestions.py",
     "hash": "caa3f48a039def99a5bf58dc29129aba9548dfc74a42cc69dfb067aeb71f3200",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "tip-after-dependency-check": {
     "source": "src/attune/workflows/suggestions.py",
     "hash": "caa3f48a039def99a5bf58dc29129aba9548dfc74a42cc69dfb067aeb71f3200",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "tip-after-first-health": {
     "source": "src/attune/discovery.py",
     "hash": "81b550a4505d51c66f590eb3ea9d2c52002c0ffcab1ff3b2c013f5e34cd79c8b",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "tip-after-first-inspect": {
     "source": "src/attune/discovery.py",
     "hash": "81b550a4505d51c66f590eb3ea9d2c52002c0ffcab1ff3b2c013f5e34cd79c8b",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "tip-after-perf-audit": {
     "source": "src/attune/workflows/suggestions.py",
     "hash": "caa3f48a039def99a5bf58dc29129aba9548dfc74a42cc69dfb067aeb71f3200",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "tip-after-refactor-plan": {
     "source": "src/attune/workflows/suggestions.py",
     "hash": "caa3f48a039def99a5bf58dc29129aba9548dfc74a42cc69dfb067aeb71f3200",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "tip-after-security-audit": {
     "source": "src/attune/workflows/suggestions.py",
     "hash": "caa3f48a039def99a5bf58dc29129aba9548dfc74a42cc69dfb067aeb71f3200",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "tip-after-simplify-code": {
     "source": "src/attune/workflows/suggestions.py",
     "hash": "caa3f48a039def99a5bf58dc29129aba9548dfc74a42cc69dfb067aeb71f3200",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "tip-after-test-gen": {
     "source": "src/attune/workflows/suggestions.py",
     "hash": "caa3f48a039def99a5bf58dc29129aba9548dfc74a42cc69dfb067aeb71f3200",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "tip-agents": {
     "source": "content/features/agents.md",
     "hash": "a5b1678ecf012c7b2877a6c7ecae4a6c3f14c084c13fbcbb7eee79119dce6fa3",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "tip-bug-predict": {
     "source": "content/features/bug-predict.md",
     "hash": "6a4f420eba38e2fb884b837dd9758acb60ba60cdaf9248ec4280120b0d382b16",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "tip-cli": {
     "source": "content/features/cli.md",
     "hash": "a37b4dc4f0b3706a62184b02d2be1536ad75eef39a0f22a9699db5d03b8ee050",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "tip-code-quality": {
     "source": "content/features/code-quality.md",
     "hash": "ce16ac87eb92e33a08d8c2f06e86ef22e436966f47f3a28c3f4eba19060b550a",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "tip-configuration": {
     "source": "content/features/configuration.md",
     "hash": "8add90392883a46899ef8b57d135b625d92c5b61231d8a5301727f8b42f8e46f",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "tip-cost-savings": {
     "source": "src/attune/discovery.py",
     "hash": "81b550a4505d51c66f590eb3ea9d2c52002c0ffcab1ff3b2c013f5e34cd79c8b",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "tip-deep-review": {
     "source": "content/features/deep-review.md",
     "hash": "6a4fffc907302b4847d96097189bd8d329d3f1548d1ee46d9232f6ceecdfb450",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "tip-doc-gen": {
     "source": "content/features/doc-gen.md",
     "hash": "26e02a71a523775f5bb9e371b2e563c3c858386436a73b727422f62f57de0282",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "tip-elicitation-forms": {
     "source": "content/features/elicitation-forms.md",
-    "hash": "b7e73232af03174e0e5d50d551277a784127eb8047713cacfce1df8b19e8a8d6",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "hash": "36b29d55060c78f96ed1aaf1af34338dba4a156b674b98a9f35ebfd04524d2b3",
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "tip-fix-test": {
     "source": "content/features/fix-test.md",
     "hash": "da54b69787cc1af5c087b2d8674442afe9b8c6fc88dca37a65e99590bb84fee0",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "tip-help-system": {
     "source": "content/features/help-system.md",
     "hash": "24468c8fe4f1a0e350e620098d65a3bcc007000cd5aa4dbe20a6e6c83efa87b3",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "tip-high-tech-debt": {
     "source": "src/attune/discovery.py",
     "hash": "81b550a4505d51c66f590eb3ea9d2c52002c0ffcab1ff3b2c013f5e34cd79c8b",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "tip-hooks": {
     "source": "content/features/hooks.md",
     "hash": "5c6b8a45457387c76f628561d3baa56e9af1709bc9bd21bba9830b2c2478c8dd",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "tip-mcp-server": {
     "source": "content/features/mcp-server.md",
     "hash": "8e4b8c74eff980330480ae70856a1cf0393559cd22eb9ba0210b43249f9b5181",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "tip-memory": {
     "source": "content/features/memory.md",
     "hash": "32b3121d9110dc9ac327bb9e838f060fbe9940a033366b0147ef34ef2efaa4dc",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "tip-models": {
     "source": "content/features/models.md",
     "hash": "2117cbb0d8e863db6091870874e4ce80b48780c9ee8bb7330d8033c172ccb02b",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "tip-no-patterns": {
     "source": "src/attune/discovery.py",
     "hash": "81b550a4505d51c66f590eb3ea9d2c52002c0ffcab1ff3b2c013f5e34cd79c8b",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "tip-ops-dashboard": {
     "source": "content/features/ops-dashboard.md",
     "hash": "fefc8e2b2b4a25055fcbdf96cbd8638d75278cbcacd256873b725df89544c1f6",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "tip-orchestration": {
     "source": "content/features/orchestration.md",
     "hash": "4998437e04355011a7dee68dbce7e9e78bbe97f637e0b6a14c1ec972f541695c",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "tip-plugin": {
     "source": "content/features/plugin.md",
     "hash": "8cc6e5702ffc8228ed63cfb74a25dd3e99e79e5335c4b1c8c134950f8b9a043d",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "tip-rag-grounding": {
     "source": "content/features/rag-grounding.md",
     "hash": "3464dd78c83f06980912a7c49dc185b09830be1b1c163203f10e5aa1708fcf4e",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "tip-refactor-plan": {
     "source": "content/features/refactor-plan.md",
     "hash": "8f8c684cd94fca7b2580ecaaf955ccb79924022796d576d477cdab9330df9704",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "tip-release-notes": {
     "source": "content/features/release-notes.md",
     "hash": "da7101ffbec4d209fcb1cef754f01cef8a13458a6f961c3a23909edfec77e58c",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "tip-release-prep": {
     "source": "content/features/release-prep.md",
     "hash": "cd77b5903fbeb7d7e0acef570bab9727b4c143181ea6be1f52b9a25bc11418bb",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "tip-resilience": {
     "source": "content/features/resilience.md",
     "hash": "ae2a76f0f1ecbb9ca687e5a041acc2b4a25a5113ec57eaad550f48b8aadc4be2",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "tip-security-audit": {
     "source": "content/features/security-audit.md",
     "hash": "9cce18573c827fab9a380efe8c65c2f8c5b4ada3f7e383dd71ec523a0875fb05",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "tip-smart-test": {
     "source": "content/features/smart-test.md",
     "hash": "58c691c8313ddf9699deb913e6b5c50fafc684563539ddf4816a4b94a9ea3e80",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "tip-spec-engine": {
     "source": "content/features/spec-engine.md",
     "hash": "c8549016aa848eeeaecbde8329f5850562f56280ab66428cb7c20887b428d81a",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "tip-telemetry": {
     "source": "content/features/telemetry.md",
     "hash": "59473ab809113116a3d58d2ead3a5f13e362d6992d8cee0a89364feded5cbd50",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "tip-weekly-review": {
     "source": "src/attune/discovery.py",
     "hash": "81b550a4505d51c66f590eb3ea9d2c52002c0ffcab1ff3b2c013f5e34cd79c8b",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "tip-wizards": {
     "source": "content/features/wizards.md",
     "hash": "6fe7722a026d11276ebfbdf4ea046a05112be94b560f9abf3ffee410f8637d8f",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "tro-agents": {
     "source": "content/features/agents.md",
     "hash": "a5b1678ecf012c7b2877a6c7ecae4a6c3f14c084c13fbcbb7eee79119dce6fa3",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "tro-bug-predict": {
     "source": "content/features/bug-predict.md",
     "hash": "6a4f420eba38e2fb884b837dd9758acb60ba60cdaf9248ec4280120b0d382b16",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "tro-cli": {
     "source": "content/features/cli.md",
     "hash": "a37b4dc4f0b3706a62184b02d2be1536ad75eef39a0f22a9699db5d03b8ee050",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "tro-code-quality": {
     "source": "content/features/code-quality.md",
     "hash": "ce16ac87eb92e33a08d8c2f06e86ef22e436966f47f3a28c3f4eba19060b550a",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "tro-configuration": {
     "source": "content/features/configuration.md",
     "hash": "8add90392883a46899ef8b57d135b625d92c5b61231d8a5301727f8b42f8e46f",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "tro-deep-review": {
     "source": "content/features/deep-review.md",
     "hash": "6a4fffc907302b4847d96097189bd8d329d3f1548d1ee46d9232f6ceecdfb450",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "tro-doc-gen": {
     "source": "content/features/doc-gen.md",
     "hash": "26e02a71a523775f5bb9e371b2e563c3c858386436a73b727422f62f57de0282",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "tro-elicitation-forms": {
     "source": "content/features/elicitation-forms.md",
-    "hash": "b7e73232af03174e0e5d50d551277a784127eb8047713cacfce1df8b19e8a8d6",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "hash": "36b29d55060c78f96ed1aaf1af34338dba4a156b674b98a9f35ebfd04524d2b3",
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "tro-fix-test": {
     "source": "content/features/fix-test.md",
     "hash": "da54b69787cc1af5c087b2d8674442afe9b8c6fc88dca37a65e99590bb84fee0",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "tro-help-system": {
     "source": "content/features/help-system.md",
     "hash": "24468c8fe4f1a0e350e620098d65a3bcc007000cd5aa4dbe20a6e6c83efa87b3",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "tro-hooks": {
     "source": "content/features/hooks.md",
     "hash": "5c6b8a45457387c76f628561d3baa56e9af1709bc9bd21bba9830b2c2478c8dd",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "tro-mcp-server": {
     "source": "content/features/mcp-server.md",
     "hash": "8e4b8c74eff980330480ae70856a1cf0393559cd22eb9ba0210b43249f9b5181",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "tro-memory": {
     "source": "content/features/memory.md",
     "hash": "32b3121d9110dc9ac327bb9e838f060fbe9940a033366b0147ef34ef2efaa4dc",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "tro-models": {
     "source": "content/features/models.md",
     "hash": "2117cbb0d8e863db6091870874e4ce80b48780c9ee8bb7330d8033c172ccb02b",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "tro-ops-dashboard": {
     "source": "content/features/ops-dashboard.md",
     "hash": "fefc8e2b2b4a25055fcbdf96cbd8638d75278cbcacd256873b725df89544c1f6",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "tro-orchestration": {
     "source": "content/features/orchestration.md",
     "hash": "4998437e04355011a7dee68dbce7e9e78bbe97f637e0b6a14c1ec972f541695c",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "tro-plugin": {
     "source": "content/features/plugin.md",
     "hash": "8cc6e5702ffc8228ed63cfb74a25dd3e99e79e5335c4b1c8c134950f8b9a043d",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "tro-rag-grounding": {
     "source": "content/features/rag-grounding.md",
     "hash": "3464dd78c83f06980912a7c49dc185b09830be1b1c163203f10e5aa1708fcf4e",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "tro-refactor-plan": {
     "source": "content/features/refactor-plan.md",
     "hash": "8f8c684cd94fca7b2580ecaaf955ccb79924022796d576d477cdab9330df9704",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "tro-release-notes": {
     "source": "content/features/release-notes.md",
     "hash": "da7101ffbec4d209fcb1cef754f01cef8a13458a6f961c3a23909edfec77e58c",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "tro-release-prep": {
     "source": "content/features/release-prep.md",
     "hash": "cd77b5903fbeb7d7e0acef570bab9727b4c143181ea6be1f52b9a25bc11418bb",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "tro-resilience": {
     "source": "content/features/resilience.md",
     "hash": "ae2a76f0f1ecbb9ca687e5a041acc2b4a25a5113ec57eaad550f48b8aadc4be2",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "tro-security-audit": {
     "source": "content/features/security-audit.md",
     "hash": "9cce18573c827fab9a380efe8c65c2f8c5b4ada3f7e383dd71ec523a0875fb05",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "tro-smart-test": {
     "source": "content/features/smart-test.md",
     "hash": "58c691c8313ddf9699deb913e6b5c50fafc684563539ddf4816a4b94a9ea3e80",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "tro-spec-engine": {
     "source": "content/features/spec-engine.md",
     "hash": "c8549016aa848eeeaecbde8329f5850562f56280ab66428cb7c20887b428d81a",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "tro-telemetry": {
     "source": "content/features/telemetry.md",
     "hash": "59473ab809113116a3d58d2ead3a5f13e362d6992d8cee0a89364feded5cbd50",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "tro-wizards": {
     "source": "content/features/wizards.md",
     "hash": "6fe7722a026d11276ebfbdf4ea046a05112be94b560f9abf3ffee410f8637d8f",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-adding-a-plugin-skill-has-three-enforcement-gates-not-one": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-adding-a-workspace-sibling-package-as-an-extra-can-silently": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-adding-logger-before-eager-imports-triggers-e402-in-init-py": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-after-a-pr-merges-while-youre-afk-pull-main-before-tagging": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-after-a-squash-merge-of-a-feature-branch-local-main-can-have": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-agents": {
     "source": "content/features/agents.md",
     "hash": "a5b1678ecf012c7b2877a6c7ecae4a6c3f14c084c13fbcbb7eee79119dce6fa3",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-agents-skills-must-stay-synced-with-plugin-skills": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-anchor-tag-buttons-need-text-white-no-underline": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-anthropics-built-in-prompt-caching-supersedes-custom-caching": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-any-unstaged-file-triggers-pre-commit-stash-conflicts-with-auto": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-attune-author-check-staleness-load-manifest-is-the-python-api": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-attune-helps-sidecar-schemas-dont-match-path-keyed-assumptions": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-attune-skill-names-must-not-collide-with-claude-code-built-in": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-b904-raise-x-from-e-is-not-auto-fixable-by-ruff": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-background-processes-from-previous-sessions-persist-across": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-bare-manifest-in-gitignore-silently-excludes-any-manifest": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-bg-var-primary-bg-opacity-10-is-invisible-in-dark-mode": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-bug-predict": {
     "source": "content/features/bug-predict.md",
     "hash": "6a4f420eba38e2fb884b837dd9758acb60ba60cdaf9248ec4280120b0d382b16",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-bug-predict-dangerous-eval-flags-subprocess-exec": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-bugpredictionworkflow-not-bugpredictworkflow": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-changing-error-messages-breaks-tests-across-the-codebase": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-changing-the-citation-anchor-format-can-silently-regress-llm": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-changing-user-facing-output-strings-cascades-through-test": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-chicken-and-egg-for-optional-extras-in-dev": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-citation-forced-prompting-and-prompt-injection-resistance-are": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-claude-code-plugin-is-platform-specific": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-claude-code-plugins-expect-plugin-json-inside-claude-plugin": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-cli": {
     "source": "content/features/cli.md",
     "hash": "a37b4dc4f0b3706a62184b02d2be1536ad75eef39a0f22a9699db5d03b8ee050",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-clusterfuzz-dockerfile-copies-to-src-repo-but-also-copies": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-clusterfuzzlite-no-deps-misses-transitive-imports": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-code-quality": {
     "source": "content/features/code-quality.md",
     "hash": "ce16ac87eb92e33a08d8c2f06e86ef22e436966f47f3a28c3f4eba19060b550a",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-codecov-patch-0-usually-means-tests-skipped-not-failed": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-codeql-alerts-dismissible-in-bulk-via-gh-api": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-combine-two-unreleased-changelog-drafts-into-one-version-when": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-commands-are-not-namespaced-in-plugins-skills-are": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-configuration": {
     "source": "content/features/configuration.md",
     "hash": "8add90392883a46899ef8b57d135b625d92c5b61231d8a5301727f8b42f8e46f",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-costreport-fields-are-named-not-positional": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-costreport-is-a-dataclass-not-a-dict": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-dataclassorder-true-needs-compare-false-on-list-fields": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-dead-code-modules-with-full-test-suites-look-alive": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-dead-tests-from-monorepo-extraction-accumulate-in-packages-with": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-deep-review": {
     "source": "content/features/deep-review.md",
     "hash": "6a4fffc907302b4847d96097189bd8d329d3f1548d1ee46d9232f6ceecdfb450",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-deep-review-false-positives-verify-before-acting": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-detect-secrets-flags-fake-as-a-secret-in-test-fixtures": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-direct-pushes-to-main-are-blocked-by-the-presence-of-required": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-dispatch-tables-hold-direct-function-references-mocks-must": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-dist-can-contain-stale-artifacts-after-version-bumps": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-doc-gen": {
     "source": "content/features/doc-gen.md",
     "hash": "26e02a71a523775f5bb9e371b2e563c3c858386436a73b727422f62f57de0282",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-dont-append-z-to-timezone-aware-isoformat": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-dry-run-candidate-golden-queries-through-the-resolver-before": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-duck-typed-test-fakes-fail-isinstance-based-collectors-silently": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-duplicate-plugins-cause-conflicting-skill-triggers": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-elicitation-forms": {
     "source": "content/features/elicitation-forms.md",
-    "hash": "b7e73232af03174e0e5d50d551277a784127eb8047713cacfce1df8b19e8a8d6",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "hash": "36b29d55060c78f96ed1aaf1af34338dba4a156b674b98a9f35ebfd04524d2b3",
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-exclude-hard-queries-from-aggregate-p-1-metrics-in-benchmark": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-exploration-agents-fabricate-names-verify-against-source": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-f841-unused-fixture-lint-fires-when-a-test-is-refactored-to": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-fastembed-is-the-local-embeddings-path-that-passes-a-50mb": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-fix-test": {
     "source": "content/features/fix-test.md",
     "hash": "da54b69787cc1af5c087b2d8674442afe9b8c6fc88dca37a65e99590bb84fee0",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-forced-anthropic-tool-use-is-the-cleanest-path-to-guaranteed": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-formatter-strips-imports-that-are-unused-at-the-moment-you-save": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-generated-content-with-trailing-whitespace-causes-perpetual-pre": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-gh-api-x-patch-f-name-n-rejects-integers-as-strings": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-gh-pr-checks-json-field-names": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-gh-pr-merge-admin-is-blocked-by-in-progress-required-checks": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-gh-pr-merge-admin-prints-a-fast-forward-warning-even-when-the": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-gh-workflow-run-file-yml-ref-tag-re-triggers-a-release-gated": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-git-commit-q-can-exit-0-with-pre-commit-hook-feedback-that": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-git-pull-refuses-with-unstaged-changes-when-pull-rebase-true": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-git-rebase-root-exec-git-commit-amend-no-edit-s-re-signs-every": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-git-stash-pop-after-pre-commit-can-resurrect-stale-tool-state": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-github-actions-environment-deployment-approvals-can-be-self": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-github-copilot-autofix-pushes-commits-directly-to-pr-branches": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-github-protected-tags-cannot-be-force-updated": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-github-repos-serve-as-claude-code-marketplaces": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-gitignore-exclusions-break-ci-tests-that-read-those-files": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-glob-based-hash-computation-must-exclude-cache-dirs": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-golden-query-benchmarks-reveal-two-distinct-failure-classes": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-golden-query-test-fixtures-must-match-the-actual-corpus-layout": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-gpg-signing-fails-in-non-interactive-terminals-vscode-extension": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-hand-crafted-summary-prototype-is-the-fastest-way-to-measure-a": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-handoff-memory-option-b-proposals-are-often-wrong-re-analyze": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-hardcoded-root-paths-in-tests": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-hardcoded-strings-in-method-bodies-survive-class-attribute": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-hardcoded-user-id-defeats-ownership-checks": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-help-system": {
     "source": "content/features/help-system.md",
     "hash": "24468c8fe4f1a0e350e620098d65a3bcc007000cd5aa4dbe20a6e6c83efa87b3",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-hooks": {
     "source": "content/features/hooks.md",
     "hash": "5c6b8a45457387c76f628561d3baa56e9af1709bc9bd21bba9830b2c2478c8dd",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-hot-reload-subsystem-was-1-038-lines-of-dead-code": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-import-x-inside-a-try-block-except-x-someerror-in-the-except": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-importlib-import-module-is-an-arbitrary-code-execution-vector": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-industry-terminology-wont-appear-in-llm-polished-rag-summaries": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-is-private-is-a-superset-in-python-ipaddress": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-lazy-imports-inside-function-bodies-cant-be-patched-with": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-linkedin-paste-use-ascii-markers-not-unicode-arrows": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-list-workflows-deduplication-must-keep-base-names-visible": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-llm-api-responses-lack-trailing-newlines": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-mcp-attune-ai-doc-orchestrator-is-a-no-op-stub": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-mcp-call-tool-wrapper-pattern": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-mcp-handler-validate-paths-before-importing-workflows": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-mcp-json-python-resolves-to-pyenv-shim-not-project-venv": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-mcp-server": {
     "source": "content/features/mcp-server.md",
     "hash": "8e4b8c74eff980330480ae70856a1cf0393559cd22eb9ba0210b43249f9b5181",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-mcp-tool-renames-propagate-to-skill-docs": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-memory": {
     "source": "content/features/memory.md",
     "hash": "32b3121d9110dc9ac327bb9e838f060fbe9940a033366b0147ef34ef2efaa4dc",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-metadata-can-reach-a-retriever-with-zero-signal-if-the-sidecar": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-mkdocs-build-crashing-with-attributeerror-nonetype-object-has": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-models": {
     "source": "content/features/models.md",
     "hash": "2117cbb0d8e863db6091870874e4ce80b48780c9ee8bb7330d8033c172ccb02b",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-modeltier-has-two-copies-imports-must-match": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-module-level-optional-imports-enable-clean-test-patching": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-multiple-pinentry-program-lines-in-gpg-agent-conf-first-wins": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-mutual-competition-between-polished-rag-features-is-real-and": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-mypy-437-errors-was-stale-actual-count-was-2": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-naive-suffix-strip-stemming-fails-on-english-doubling-consonant": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-never-paste-pypi-tokens-into-chat-or-logs": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-new-dataclass-fields-need-both-the-class-and-the-parser-updated": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-new-mcp-handlers-must-match-the-validation-pattern-of-adjacent": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-new-security-features-need-dedicated-tests-before-release": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-non-baseworkflow-classes-in-workflow-registry-crash-the-cli": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-noqa-f401-re-exports-break-silently-on-satellite-file-deletion": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-openssf-scorecard-alerts-2-codereviewid-3-sastid-are-process": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-ops-dashboard": {
     "source": "content/features/ops-dashboard.md",
     "hash": "fefc8e2b2b4a25055fcbdf96cbd8638d75278cbcacd256873b725df89544c1f6",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-orchestration": {
     "source": "content/features/orchestration.md",
     "hash": "4998437e04355011a7dee68dbce7e9e78bbe97f637e0b6a14c1ec972f541695c",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-orphan-help-dirs-are-deprecated-3-depth-output-adding-them-to": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-orphan-top-level-docs-directories-stay-invisible-to-readers": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-packages-attune-in-attune-ai-are-pointer-stubs-not-source": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-past-due-deprecations-are-deletion-targets-not-implementation": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-patch-requires-the-target-name-to-exist-at-module-scope-at": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-path-globdir-matches-directories-not-files": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-path-rename-fails-on-windows-when-target-exists": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-platform-conditional-security-test-assertions-should-accept-any": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-plugin": {
     "source": "content/features/plugin.md",
     "hash": "8cc6e5702ffc8228ed63cfb74a25dd3e99e79e5335c4b1c8c134950f8b9a043d",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-plugin-read-skill-references-break-outside-the-plugin": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-pre-commit-auto-fix-requires-re-stage-before-retry": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-pre-commit-black-unstaged-files-re-stage-after-failure": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-pre-commit-stash-conflict-when-black-ruff-fix-files-with": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-pre-commit-stash-conflict-with-auto-fix-hooks": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-pre-commit-stash-conflicts-when-any-tracked-unstaged-file": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-pre-committed-decision-matrices-survive-contact-with-data": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-pre-flight-pre-commits-pinned-black-ruff-on-new-files-before": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-prefer-github-actions-trusted-publishing-over-local-twine-uv": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-provenance-citation-records-usually-store-short-previews-not": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-pull-main-before-merging-develop-to-avoid-merge-commits": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-pureposixpath-match-doesnt-support-in-python-3-10": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-pureposixpath-strips-trailing-slashes": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-push-specific-tags-not-tags": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-pypi-env-policies-may-whitelist-branches-only-tag-triggered": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-pypi-renders-readme-links-relative-to-its-own-domain": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-pypi-trusted-publisher-workflow-name-field-wants-the-filename": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-pytest-importorskip-triggers-ruff-e402": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-query-fixtures-are-self-diagnostic-for-rag-corpora-even-without": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-rag-grounding": {
     "source": "content/features/rag-grounding.md",
     "hash": "3464dd78c83f06980912a7c49dc185b09830be1b1c163203f10e5aa1708fcf4e",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-re-adding-an-import-after-the-formatter-strips-it-use-function": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-re-enabling-required-reviews-kills-queued-auto-merge": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-read-source-before-writing-tests-for-tricky-logic": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-rebuild-dist-after-readme-changes": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-reclassify-unexpectedly-hard-golden-queries-up-the-difficulty": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-redisshorttermmemory-mock-injection-path": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-refactor-plan": {
     "source": "content/features/refactor-plan.md",
     "hash": "8f8c684cd94fca7b2580ecaaf955ccb79924022796d576d477cdab9330df9704",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-registry-count-assertions-are-scattered-across-test-files": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-release-branches-carry-unmerged-commits-that-feature-branches": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-release-notes": {
     "source": "content/features/release-notes.md",
     "hash": "da7101ffbec4d209fcb1cef754f01cef8a13458a6f961c3a23909edfec77e58c",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-release-prep": {
     "source": "content/features/release-prep.md",
     "hash": "cd77b5903fbeb7d7e0acef570bab9727b4c143181ea6be1f52b9a25bc11418bb",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-release-published-workflow-dispatch-both-approved-for-pypi-env": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-removing-one-workspace-dep-can-cascade-to-remove-others": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-replacing-a-mixin-based-class-scatters-test-failures-across": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-repo-merge-policy-may-restrict-merge-strategies": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-repo-root-parents-count-varies-by-file-depth": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-required-status-check-names-must-match-githubs-exact-check-names": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-research-subagents-can-hallucinate-sdk-signatures-introspect": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-resilience": {
     "source": "content/features/resilience.md",
     "hash": "ae2a76f0f1ecbb9ca687e5a041acc2b4a25a5113ec57eaad550f48b8aadc4be2",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-resultmessage-result-is-often-none-capture-assistantmessage": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-rich-live-is-output-only-use-textual-for-any-interactive-row": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-ruff-auto-fix-strips-imports-before-usage-code-exists": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-run-simplify-catches-per-file-errors-internally": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-sbin-is-a-symlink-to-usr-sbin-on-modern-ubuntu": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-sdk-adapter-swallows-subagent-findings-lesson-was-wrong-adapter": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-sdk-agent-model-config-uses-stale-model-names": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-sdk-native-workflows-validate-in-execute-not-input-schema": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-security-audit": {
     "source": "content/features/security-audit.md",
     "hash": "9cce18573c827fab9a380efe8c65c2f8c5b4ada3f7e383dd71ec523a0875fb05",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-semantic-cache-70-hit-rate-claim-was-unmeasured": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-session-hooks-may-be-vestigial": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-shadow-directories-at-repo-root-break-imports": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-silent-pass-blocks-in-discovery-registry-code-hide-import": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-skill-descriptions-must-be-under-250-characters": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-skill-frontmatter-has-a-strict-allowlist": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-smart-test": {
     "source": "content/features/smart-test.md",
     "hash": "58c691c8313ddf9699deb913e6b5c50fafc684563539ddf4816a4b94a9ea3e80",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-spec-engine": {
     "source": "content/features/spec-engine.md",
     "hash": "c8549016aa848eeeaecbde8329f5850562f56280ab66428cb7c20887b428d81a",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-squash-merge-deletes-the-remote-branch-subsequent-push-silently": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-ssrf-always-decode-urls-before-validating-hostnames": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-ssrf-strip-ipv6-zone-ids-before-ip-validation": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-stacked-patch-decorators-inject-args-bottom-up": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-staleness-detection-in-attune-author-attune-ais-help-system-is": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-stop-hooks-inject-stderr-not-stdout": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-stop-hooks-loop-without-a-sentinel": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-stop-hooks-missing-cd-prefix-inherit-session-cwd": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-structlog-default-output-pollutes-stdout-captured-cli-tests": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-structlog-kwargs-vs-stdlib-logger": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-tags-pushed-before-squash-merge-point-to-the-wrong-commit": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-telemetry": {
     "source": "content/features/telemetry.md",
     "hash": "59473ab809113116a3d58d2ead3a5f13e362d6992d8cee0a89364feded5cbd50",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-template-generators-overwrite-hand-written-files": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-test-mocks-must-match-imports": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-tests-for-optional-dep-code-need-pytest-importorskip-guards-in": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-text-white-on-gradient-primary-sections-gets-overridden": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-two-codeql-setups-can-coexist-in-one-repo-and-deadlock-merges": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-uncommitted-claude-mcp-json-means-mcp-server-never-starts": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-untracked-scripts-break-ci-when-tests-import-them": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-unused-init-py-re-exports-become-invisible-runtime-deps": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-use-dataclass-post-init-to-coalesce-between-a-scalar-legacy": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-uv-lock-can-drift-from-pyproject-toml-on-shared-branches": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-uv-lock-retains-editable-name-paths-after-tool-uv-sources-edits": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-uv-pip-install-e-path-can-ship-stale-package-data-even-after": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-uv-pip-install-e-sibling-path-no-deps-is-the-clean-venv-local": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-uv-run-in-pre-commit-hooks-propagates-lockfile-errors-as-hook": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-uv-sync-wipes-packages-installed-via-pip-install": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-validate-infrastructure-against-user-value-before-extending": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-verify-new-dispatch-branches-with-a-known-fixture-not-just": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-version-bumps-must-update-7-files-not-just-pyproject-toml": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-website-feature-lists-can-diverge-from-the-python-registry": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-windows-ci-encoding": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-windows-ci-runners-are-3x-slower-than-ubuntu-macos": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-windows-time-time-can-return-0-0-duration-for-fast-operations": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-wizards": {
     "source": "content/features/wizards.md",
     "hash": "6fe7722a026d11276ebfbdf4ea046a05112be94b560f9abf3ffee410f8637d8f",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-wizards-call-workflows-internally-they-are-not-duplicates": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-workflowresult-constructor-mismatches-surface-only-at-runtime": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-yaml-run-block-scalars-break-on-blank-lines-inside-multi-line": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-yaml-run-values-with-colons-cause-parse-errors": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   },
   "war-zsh-has-status-as-a-read-only-builtin-variable": {
     "source": ".claude/CLAUDE.md",
     "hash": "759be5ffcf39cb5690f7293fbd1cf6845a42f4188d6f7a61477bb05af8d968d1",
-    "generated_at": "2026-07-25T05:20:20.804599+00:00"
+    "generated_at": "2026-07-25T05:58:05.237774+00:00"
   }
 }

--- a/plugin/skills/elicit/SKILL.md
+++ b/plugin/skills/elicit/SKILL.md
@@ -237,16 +237,43 @@ no blocked items there is nothing to ask — just narrate the report.
 
 ## Choosing a surface
 
-**Route by the form's controls first.** If **every** field is a
-select, boolean, or short text, the form renders natively on
-`AskUserQuestion` — one call, no HTML round-trip — so use that; don't
-reach for the widget. Use a rich surface (native elicitation / widget)
-**only** when at least one field is a `number`, `date`, `textarea`, or a
-`decision` / `pushback` / `progress` construct — those have no portable
-`AskUserQuestion` control. (The `needs_widget` predicate in
-`attune.elicitation` is this same check in code.) Sending an
-AskUserQuestion-eligible form to the widget costs a second tool call and
-a multi-kB HTML round-trip for no gain.
+**The widget is the default. `AskUserQuestion` is the fallback.**
+(D21 — this reverses the earlier cheapest-surface-that-fits rule.)
+Don't route on what the surface can technically express; route on how
+much of the option space the user can see at once. Folding three
+options and their tradeoffs into prose above a single-select turns a
+scan into a serial read the user has to hold in their head — that loss
+is real even though a control-type check can't see it.
+
+`select_form_surface(form, widget_capable=…, keyboard_mode=…)` in
+`attune.elicitation` is this rule in code. Call it instead of deciding
+by hand. Precedence, highest first:
+
+1. **Client can't render widgets** → `AskUserQuestion`. A constraint,
+   not a preference.
+2. **A `number` / `date` / `textarea` field** → widget, always. These
+   have no `AskUserQuestion` control at all, so this outranks the
+   opt-out and the user can never silently lose a field.
+3. **Keyboard mode on** → `AskUserQuestion`. The user's opt-out,
+   persisted per project in `attune.config.json` (`keyboard_mode`),
+   with `ATTUNE_KEYBOARD_MODE` as a session override.
+4. **Trivial form** → `AskUserQuestion`. Trivial is narrow and
+   mechanical: exactly one `single_select`/`boolean`, ≤3 options, and
+   no option label over 120 chars. A long label means tradeoffs got
+   folded into the text — that form wanted a card.
+5. **Otherwise** → widget.
+
+**Latency is not a reason to downgrade a form.** The extra tool call is
+a real cost but it is not the axis; if a form is worth asking, it is
+worth asking legibly. `needs_widget` still exists as the low-level
+"does this lose fidelity on AskUserQuestion" check, but it no longer
+owns the decision — don't route on it directly.
+
+**After the answer comes back,** collapse the form rather than leaving
+the rendered markup in the transcript: `form_response_summary(form,
+response)` returns a few lines of markdown (title + one bullet per
+answer). Use it in your narration so a long session accumulates
+summaries, not screenfuls of HTML.
 
 - **Rich / native — one call:** `elicitation_ask` renders the form as a
   native MCP elicitation dialog (supports number/date/textarea +

--- a/plugin/skills/elicit/SKILL.md
+++ b/plugin/skills/elicit/SKILL.md
@@ -254,9 +254,11 @@ by hand. Precedence, highest first:
 2. **A `number` / `date` / `textarea` field** → widget, always. These
    have no `AskUserQuestion` control at all, so this outranks the
    opt-out and the user can never silently lose a field.
-3. **Keyboard mode on** → `AskUserQuestion`. The user's opt-out,
-   persisted per project in `attune.config.json` (`keyboard_mode`),
-   with `ATTUNE_KEYBOARD_MODE` as a session override.
+3. **Keyboard mode on** → `AskUserQuestion`. The user's opt-out, set
+   with `attune config set keyboard_mode true` and persisted per project
+   in `attune.config.json`, with `ATTUNE_KEYBOARD_MODE` as a session
+   override. If a user says forms feel like too much, point them at that
+   command rather than arguing the default.
 4. **Trivial form** → `AskUserQuestion`. Trivial is narrow and
    mechanical: exactly one `single_select`/`boolean`, ≤3 options, and
    no option label over 120 chars. A long label means tradeoffs got

--- a/src/attune/cli_minimal.py
+++ b/src/attune/cli_minimal.py
@@ -56,6 +56,7 @@ from __future__ import annotations
 
 import argparse
 import logging
+import os
 import sys
 
 from attune.cli_commands.cost_commands import (
@@ -254,6 +255,23 @@ def _add_gates_subparsers(subparsers: argparse._SubParsersAction) -> None:
         default=[],
         help="Changed paths for blast-radius classification",
     )
+
+
+def _add_config_subparsers(subparsers: argparse._SubParsersAction) -> None:
+    """Add project-config subcommand parsers.
+
+    Args:
+        subparsers: Parent subparsers action to attach to
+
+    """
+    config_parser = subparsers.add_parser("config", help="Project settings")
+    config_sub = config_parser.add_subparsers(dest="config_command")
+
+    set_parser = config_sub.add_parser("set", help="Set a project setting")
+    set_parser.add_argument("key", help=f"Setting name ({', '.join(sorted(_CONFIG_KEYS))})")
+    set_parser.add_argument("value", help="Value (true/false)")
+
+    config_sub.add_parser("show", help="Show current project settings")
 
 
 def _add_telemetry_subparsers(subparsers: argparse._SubParsersAction) -> None:
@@ -613,12 +631,65 @@ Documentation: https://smartaimemory.com/framework-docs/
     _add_workflow_subparsers(subparsers)
     _add_diagnose_subparser(subparsers)
     _add_gates_subparsers(subparsers)
+    _add_config_subparsers(subparsers)
     _add_telemetry_subparsers(subparsers)
     _add_costs_subparsers(subparsers)
     _add_misc_subparsers(subparsers)
     _add_ops_subparser(subparsers)
 
     return parser
+
+
+#: Settings ``attune config set`` will write. An allowlist, not a
+#: free-form key/value store — an unknown key is a typo, and silently
+#: persisting it would leave the user believing a setting took effect.
+_CONFIG_KEYS: frozenset[str] = frozenset({"keyboard_mode"})
+
+_CONFIG_TRUTHY = {"true", "1", "yes", "on"}
+_CONFIG_FALSEY = {"false", "0", "no", "off"}
+
+
+def cmd_config_set(args) -> int:
+    """Set a project setting in ./attune.config.json."""
+    from attune.elicitation import set_keyboard_mode
+
+    key = args.key.strip()
+    if key not in _CONFIG_KEYS:
+        print(f"Unknown setting: {key!r}")
+        print(f"Known settings: {', '.join(sorted(_CONFIG_KEYS))}")
+        return 1
+
+    raw = args.value.strip().lower()
+    if raw in _CONFIG_TRUTHY:
+        value = True
+    elif raw in _CONFIG_FALSEY:
+        value = False
+    else:
+        print(f"Expected true or false, got {args.value!r}")
+        return 1
+
+    try:
+        path = set_keyboard_mode(value)
+    except (OSError, ValueError) as exc:
+        print(f"Could not write the setting: {exc}")
+        return 1
+
+    print(f"{key} = {str(value).lower()}  ({path})")
+    if key == "keyboard_mode" and value:
+        print("Forms that fit a plain question will now come back as button turns.")
+    return 0
+
+
+def cmd_config_show(args) -> int:
+    """Show the current project settings."""
+    from attune.elicitation import keyboard_mode_enabled
+
+    del args
+    enabled = keyboard_mode_enabled()
+    print(f"keyboard_mode = {str(enabled).lower()}")
+    if os.environ.get("ATTUNE_KEYBOARD_MODE", "").strip():
+        print("  (overridden for this shell by ATTUNE_KEYBOARD_MODE)")
+    return 0
 
 
 _SUBCOMMAND_DISPATCH: dict[str, dict[str, object]] = {
@@ -637,6 +708,11 @@ _SUBCOMMAND_DISPATCH: dict[str, dict[str, object]] = {
     "gates": {
         "_attr": "gates_command",
         "check": cmd_gates_check,
+    },
+    "config": {
+        "_attr": "config_command",
+        "set": cmd_config_set,
+        "show": cmd_config_show,
     },
     "telemetry": {
         "_attr": "telemetry_command",

--- a/src/attune/elicitation/__init__.py
+++ b/src/attune/elicitation/__init__.py
@@ -21,6 +21,8 @@ Public surface:
 - :func:`keyboard_mode_enabled` — the user's terse/keyboard opt-out
   (D17), persisted per project in ``attune.config.json`` with
   ``ATTUNE_KEYBOARD_MODE`` as a session override.
+- :func:`set_keyboard_mode` — persist that preference (what
+  ``attune config set keyboard_mode`` calls).
 - :func:`needs_widget` — low-level *controls* check: True iff a form
   loses fidelity on ``AskUserQuestion``. No longer owns the surface
   decision — prefer :func:`select_form_surface`.
@@ -47,6 +49,7 @@ from attune.elicitation.bridge import (
     keyboard_mode_enabled,
     needs_widget,
     select_form_surface,
+    set_keyboard_mode,
 )
 from attune.elicitation.elicitation_schema import form_to_elicitation_schema
 from attune.elicitation.reference_form import EXAMPLE_ANSWERS, REFERENCE_FORM
@@ -67,4 +70,5 @@ __all__ = [
     "keyboard_mode_enabled",
     "needs_widget",
     "select_form_surface",
+    "set_keyboard_mode",
 ]

--- a/src/attune/elicitation/__init__.py
+++ b/src/attune/elicitation/__init__.py
@@ -13,9 +13,20 @@ Public surface:
   plain serializable data.
 - :func:`form_to_askuserquestion` — batched ``AskUserQuestion`` payloads
   (≤4 questions per call).
-- :func:`needs_widget` — routing predicate: True iff a form needs the
-  widget / native-elicitation surface (else it renders on
-  ``AskUserQuestion`` — one call, no HTML round-trip).
+- :func:`select_form_surface` — the surface router (D21): the widget is
+  the default; ``AskUserQuestion`` is the explicit fallback, taken only
+  for a non-widget client, keyboard mode, or a trivial form.
+- :func:`is_trivial_form` — the narrow, mechanical triviality test the
+  router uses.
+- :func:`keyboard_mode_enabled` — the user's terse/keyboard opt-out
+  (D17), persisted per project in ``attune.config.json`` with
+  ``ATTUNE_KEYBOARD_MODE`` as a session override.
+- :func:`needs_widget` — low-level *controls* check: True iff a form
+  loses fidelity on ``AskUserQuestion``. No longer owns the surface
+  decision — prefer :func:`select_form_surface`.
+- :func:`form_response_summary` — collapse an answered form to a
+  compact markdown summary, so a long session accumulates a few lines
+  per ask instead of a screenful of markup.
 - :func:`collect_form_response` — validate raw answers (required +
   option membership) and map them into a ``FormResponse`` (R4 — never
   silently accept malformed input).
@@ -30,8 +41,12 @@ from attune.elicitation.bridge import (
     FormValidationError,
     collect_form_response,
     form_from_dict,
+    form_response_summary,
     form_to_askuserquestion,
+    is_trivial_form,
+    keyboard_mode_enabled,
     needs_widget,
+    select_form_surface,
 )
 from attune.elicitation.elicitation_schema import form_to_elicitation_schema
 from attune.elicitation.reference_form import EXAMPLE_ANSWERS, REFERENCE_FORM
@@ -44,8 +59,12 @@ __all__ = [
     "FormValidationError",
     "collect_form_response",
     "form_from_dict",
+    "form_response_summary",
     "form_to_askuserquestion",
     "form_to_elicitation_schema",
     "form_to_widget_html",
+    "is_trivial_form",
+    "keyboard_mode_enabled",
     "needs_widget",
+    "select_form_surface",
 ]

--- a/src/attune/elicitation/bridge.py
+++ b/src/attune/elicitation/bridge.py
@@ -12,8 +12,11 @@ Licensed under Apache 2.0
 
 from __future__ import annotations
 
+import json
+import os
 from collections.abc import Callable
 from datetime import datetime
+from pathlib import Path
 from typing import Any
 
 from attune.meta_workflows.models import (
@@ -22,6 +25,7 @@ from attune.meta_workflows.models import (
     FormSchema,
     QuestionType,
 )
+from attune.telemetry.form_events import log_surface_decision
 
 #: The answer values accepted for a BOOLEAN question (its
 #: ``to_ask_user_format`` renders as a Yes/No single-select).
@@ -470,11 +474,11 @@ def form_from_dict(data: dict[str, Any]) -> FormSchema:
     )
 
 
-#: Question types with no portable ``AskUserQuestion`` control. A form
-#: using any of these must render on the widget or native-elicitation
-#: surface; a form using only the remaining types (single/multi-select,
-#: boolean, short text) renders natively on ``AskUserQuestion`` — one
-#: call, no HTML round-trip. See :func:`needs_widget`.
+#: Question types that lose fidelity on ``AskUserQuestion`` — either
+#: because the surface has no control for them at all
+#: (:data:`_NO_PORTABLE_CONTROL`) or because the construct's card layout
+#: flattens into prose (``decision`` / ``pushback`` / ``progress``).
+#: See :func:`needs_widget`.
 _WIDGET_ONLY_TYPES = frozenset(
     {
         QuestionType.NUMBER,
@@ -486,32 +490,246 @@ _WIDGET_ONLY_TYPES = frozenset(
     }
 )
 
+#: The strict subset with NO portable ``AskUserQuestion`` control at
+#: all. A form using any of these cannot be asked on ``AskUserQuestion``
+#: in any form — unlike the v3–v5 constructs, which are expressible but
+#: lossy (they degrade to a recommendation-first single-select). D21
+#: splits these two cases: "impossible" is a hard routing constraint,
+#: "lossy" is a fidelity preference the user may override.
+_NO_PORTABLE_CONTROL = frozenset(
+    {
+        QuestionType.NUMBER,
+        QuestionType.DATE,
+        QuestionType.TEXTAREA,
+    }
+)
+
+#: An option label longer than this is evidence the author folded
+#: tradeoffs into the label text — the thing a card renders properly.
+#: Used by :func:`is_trivial_form` as a mechanical "this wanted to be a
+#: card" detector (D21, Claude seat).
+_TRIVIAL_OPTION_LABEL_MAX = 120
+
+#: Max options a form may carry and still count as trivial. Comparison
+#: strain starts around here, and it is also ``AskUserQuestion``'s own
+#: practical ceiling for a scannable button row.
+_TRIVIAL_MAX_OPTIONS = 3
+
 
 def needs_widget(form: FormSchema) -> bool:
-    """Return True iff ``form`` needs the widget / native-elicitation surface.
+    """Return True iff ``form`` loses fidelity on ``AskUserQuestion``.
 
-    Routing predicate for surface selection. A form renders natively on
-    ``AskUserQuestion`` — a single call with no HTML round-trip — when
-    every field is a control that surface can express (single/multi-
-    select, boolean, short text). The moment any field is a rich control
-    (``number`` / ``date`` / ``textarea``) or a v3–v5 construct
-    (``decision`` / ``pushback`` / ``progress``), the form must use the
-    widget (``elicitation_render_widget`` → ``show_widget``) or native
-    elicitation instead, because those controls have no portable
-    ``AskUserQuestion`` equivalent.
+    True when any field is a rich control (``number`` / ``date`` /
+    ``textarea``) or a v3–v5 construct (``decision`` / ``pushback`` /
+    ``progress``) — the controls that either have no portable
+    ``AskUserQuestion`` equivalent or flatten into prose on it.
 
-    Sending an ``AskUserQuestion``-eligible form to the widget costs a
-    second tool call plus a multi-kB HTML round-trip through the model
-    for no gain; this predicate is the cheap check that avoids it.
+    .. note::
+       This predicate no longer owns the surface decision (D21). It is
+       the low-level *controls* check; :func:`select_form_surface` is
+       the product-level router and calls this as one input among
+       several. Prefer the selector at call sites.
+
+    Args:
+        form: The form to inspect.
+
+    Returns:
+        True if rendering on ``AskUserQuestion`` would lose fidelity.
+    """
+    return any(question.type in _WIDGET_ONLY_TYPES for question in form.questions)
+
+
+def is_trivial_form(form: FormSchema) -> bool:
+    """Return True iff ``form`` is small enough that buttons lose nothing.
+
+    Mechanical and deliberately narrow (D21): a form is trivial only
+    when it is a single low-ceremony choice with nothing to compare.
+    Every clause must hold — one question, a plain select/boolean,
+    at most :data:`_TRIVIAL_MAX_OPTIONS` options, and no option label
+    long enough to suggest a tradeoff was folded into it.
+
+    The length clause is the load-bearing one: when an author smuggles
+    tradeoffs into option text, the strings get long, and that is
+    exactly the form that wanted a card.
+
+    Args:
+        form: The form to inspect.
+
+    Returns:
+        True if the form can go to ``AskUserQuestion`` with no loss.
+    """
+    if len(form.questions) != 1:
+        return False
+    question = form.questions[0]
+    if question.type not in (QuestionType.SINGLE_SELECT, QuestionType.BOOLEAN):
+        return False
+    options = question.options or []
+    if len(options) > _TRIVIAL_MAX_OPTIONS:
+        return False
+    return all(len(str(option)) <= _TRIVIAL_OPTION_LABEL_MAX for option in options)
+
+
+def select_form_surface(
+    form: FormSchema,
+    *,
+    widget_capable: bool = True,
+    keyboard_mode: bool = False,
+) -> str:
+    """Choose the surface to render ``form`` on. Returns ``"widget"`` or ``"ask"``.
+
+    The product-level router (D21). The rich widget is the **default**;
+    ``AskUserQuestion`` is the explicit fallback. Latency is not an
+    input — the axis is how much of the option space the user can see
+    at once, not how many tool calls it costs.
+
+    Precedence, highest first:
+
+    1. **Capability floor** — a client that cannot render widgets gets
+       ``"ask"`` regardless of fidelity loss. A constraint, not a
+       preference.
+    2. **No portable control** — ``number`` / ``date`` / ``textarea``
+       have no ``AskUserQuestion`` equivalent, so the widget is forced.
+       This outranks ``keyboard_mode`` so the opt-out can never
+       silently drop a field.
+    3. **Keyboard mode** — the user's opt-out (D17). Applies only to
+       forms ``AskUserQuestion`` can actually express, which by this
+       point is all that remain.
+    4. **Triviality** — see :func:`is_trivial_form`.
+    5. Otherwise the widget, which is the default.
 
     Args:
         form: The form to route.
+        widget_capable: Whether the client can render inline HTML.
+        keyboard_mode: Whether the user opted into terse/keyboard mode.
 
     Returns:
-        True if a widget / native-elicitation surface is required; False
-        if the form can render on ``AskUserQuestion``.
+        ``"widget"`` or ``"ask"``.
     """
-    return any(question.type in _WIDGET_ONLY_TYPES for question in form.questions)
+    surface, reason = _route(form, widget_capable=widget_capable, keyboard_mode=keyboard_mode)
+    log_surface_decision(surface, reason=reason, question_count=len(form.questions))
+    return surface
+
+
+def _route(
+    form: FormSchema,
+    *,
+    widget_capable: bool,
+    keyboard_mode: bool,
+) -> tuple[str, str]:
+    """Pure routing decision + the reason, for :func:`select_form_surface`.
+
+    Split out so the reason is available to telemetry without the
+    caller-facing signature carrying it.
+    """
+    if not widget_capable:
+        return "ask", "client_not_widget_capable"
+    if any(question.type in _NO_PORTABLE_CONTROL for question in form.questions):
+        return "widget", "no_portable_control"
+    if keyboard_mode:
+        return "ask", "keyboard_mode"
+    if is_trivial_form(form):
+        return "ask", "trivial_form"
+    return "widget", "default"
+
+
+#: Values read as "on" / "off" for :func:`keyboard_mode_enabled`.
+_TRUTHY = frozenset({"1", "true", "yes", "on"})
+_FALSEY = frozenset({"0", "false", "no", "off"})
+
+#: Project-local config file the preference persists in. This is the
+#: established project-scope convention (``config/loader.py``); we read
+#: the one key directly rather than pulling the full unified-config
+#: loader into the routing path.
+_PROJECT_CONFIG = "attune.config.json"
+
+#: The key holding the preference inside :data:`_PROJECT_CONFIG`.
+_KEYBOARD_MODE_KEY = "keyboard_mode"
+
+
+def _project_keyboard_mode(project_root: Path | None = None) -> bool:
+    """Read the persisted per-project preference. False on any problem.
+
+    Best-effort: a missing file, unreadable file, malformed JSON, or
+    absent key all mean "not opted in" rather than an error. Surface
+    routing must never fail because a config file is bad.
+    """
+    base = Path(project_root) if project_root is not None else Path.cwd()
+    try:
+        raw = (base / _PROJECT_CONFIG).read_text(encoding="utf-8")
+        data = json.loads(raw)
+    except (OSError, ValueError):
+        return False
+    if not isinstance(data, dict):
+        return False
+    value = data.get(_KEYBOARD_MODE_KEY)
+    if isinstance(value, bool):
+        return value
+    return str(value).strip().lower() in _TRUTHY
+
+
+def keyboard_mode_enabled(project_root: Path | None = None) -> bool:
+    """True when the user opted into terse/keyboard mode.
+
+    D17 ratified keyboard mode as an on-demand opt-in available from day
+    one — no tenure timer, no per-user tenure state. The chair ruled
+    (2026-07-25) that the preference persists **per project**, so it
+    lives under ``keyboard_mode`` in the project-local
+    ``attune.config.json``.
+
+    ``ATTUNE_KEYBOARD_MODE`` remains a session-scoped override in both
+    directions: set it truthy to force terse mode for one shell, or
+    falsey to force rich forms even where the project opted out. Unset
+    (or unrecognised) defers to the project file.
+
+    Args:
+        project_root: Directory holding ``attune.config.json``. Defaults
+            to the current working directory.
+
+    Returns:
+        True if terse/keyboard mode is on.
+    """
+    env = os.environ.get("ATTUNE_KEYBOARD_MODE", "").strip().lower()
+    if env in _TRUTHY:
+        return True
+    if env in _FALSEY:
+        return False
+    return _project_keyboard_mode(project_root)
+
+
+def form_response_summary(form: FormSchema, response: FormResponse) -> str:
+    """Render an answered form as a compact markdown summary.
+
+    The collapse path (chair-ruled 2026-07-25, from the Antigravity
+    seat's context-bloat objection): once a form is submitted, the
+    multi-kB rendered HTML has done its job and only the question/answer
+    pairs still carry meaning. Callers substitute this summary for the
+    rendered form so a long session accumulates a few lines per ask
+    instead of a screenful of markup.
+
+    Unanswered questions are omitted — the summary reports what was
+    decided, not what was displayed. List answers (multi-select) join
+    with commas; booleans render Yes/No.
+
+    Args:
+        form: The form that was asked.
+        response: The validated response to it.
+
+    Returns:
+        A markdown summary. Title line plus one bullet per answer.
+    """
+    lines = [f"**{form.title}** — answered ({response.response_id})"]
+    for question in form.questions:
+        if question.id not in response.responses:
+            continue
+        value = response.responses[question.id]
+        if isinstance(value, bool):
+            rendered = "Yes" if value else "No"
+        elif isinstance(value, list):
+            rendered = ", ".join(str(item) for item in value) or "(none)"
+        else:
+            rendered = str(value)
+        lines.append(f"- {question.text}: **{rendered}**")
+    return "\n".join(lines)
 
 
 def form_to_askuserquestion(form: FormSchema, batch_size: int = 4) -> list[list[dict[str, Any]]]:

--- a/src/attune/elicitation/bridge.py
+++ b/src/attune/elicitation/bridge.py
@@ -574,6 +574,7 @@ def select_form_surface(
     *,
     widget_capable: bool = True,
     keyboard_mode: bool = False,
+    chosen: str | None = None,
 ) -> str:
     """Choose the surface to render ``form`` on. Returns ``"widget"`` or ``"ask"``.
 
@@ -601,12 +602,23 @@ def select_form_surface(
         form: The form to route.
         widget_capable: Whether the client can render inline HTML.
         keyboard_mode: Whether the user opted into terse/keyboard mode.
+        chosen: The surface the caller actually used, when known. The MCP
+            handlers pass this because the tool the agent invoked *is* its
+            choice, which lets the telemetry record agreement rather than
+            only the recommendation. ``None`` when the caller is asking
+            before deciding.
 
     Returns:
         ``"widget"`` or ``"ask"``.
     """
     surface, reason = _route(form, widget_capable=widget_capable, keyboard_mode=keyboard_mode)
-    log_surface_decision(surface, reason=reason, question_count=len(form.questions))
+    log_surface_decision(
+        surface,
+        reason=reason,
+        question_count=len(form.questions),
+        chosen=chosen,
+        agreed=None if chosen is None else chosen == surface,
+    )
     return surface
 
 

--- a/src/attune/elicitation/bridge.py
+++ b/src/attune/elicitation/bridge.py
@@ -708,6 +708,45 @@ def keyboard_mode_enabled(project_root: Path | None = None) -> bool:
     return _project_keyboard_mode(project_root)
 
 
+def set_keyboard_mode(enabled: bool, project_root: Path | None = None) -> Path:
+    """Persist the keyboard-mode preference for this project.
+
+    Writes ``keyboard_mode`` into the project-local ``attune.config.json``,
+    preserving any other keys already in the file. A missing file is
+    created; a malformed one raises rather than silently discarding the
+    user's other settings.
+
+    Args:
+        enabled: The preference to store.
+        project_root: Directory holding ``attune.config.json``. Defaults
+            to the current working directory.
+
+    Returns:
+        The path written.
+
+    Raises:
+        ValueError: The existing config file is not valid JSON, or holds
+            something other than a JSON object. Overwriting it would lose
+            data, so the caller must fix it first.
+    """
+    base = Path(project_root) if project_root is not None else Path.cwd()
+    path = base / _PROJECT_CONFIG
+
+    data: dict[str, Any] = {}
+    if path.exists():
+        try:
+            loaded = json.loads(path.read_text(encoding="utf-8"))
+        except ValueError as exc:
+            raise ValueError(f"{path} is not valid JSON — fix it before setting keys") from exc
+        if not isinstance(loaded, dict):
+            raise ValueError(f"{path} does not hold a JSON object")
+        data = loaded
+
+    data[_KEYBOARD_MODE_KEY] = bool(enabled)
+    path.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return path
+
+
 def form_response_summary(form: FormSchema, response: FormResponse) -> str:
     """Render an answered form as a compact markdown summary.
 

--- a/src/attune/mcp/server.py
+++ b/src/attune/mcp/server.py
@@ -869,11 +869,38 @@ class EmpathyMCPServer(MemoryHandlersMixin, WorkflowHandlersMixin):
         except FormValidationError as e:
             return {"success": False, "problems": e.problems}
 
-        return {
+        result = {
             "success": True,
             "responses": response.responses,
             "response_id": response.response_id,
         }
+        hint = self._maybe_keyboard_hint()
+        if hint:
+            result["hint"] = hint
+        return result
+
+    @staticmethod
+    def _maybe_keyboard_hint() -> str | None:
+        """Record the submission and return D17's one-time keyboard hint.
+
+        A validated submission is the only honest place to count "forms
+        the user actually answered" — rendering a form proves nothing
+        about whether they engaged with it. D17 ratified usage-triggered
+        discovery over a calendar timer precisely so the hint reaches
+        people who have felt the friction and nobody else.
+
+        Best-effort: a telemetry problem must never break the submission
+        the user just made.
+        """
+        try:
+            from attune.elicitation import keyboard_mode_enabled
+            from attune.telemetry.form_events import log_submission, maybe_keyboard_hint
+
+            log_submission()
+            return maybe_keyboard_hint(keyboard_mode=keyboard_mode_enabled())
+        except (OSError, ValueError, ImportError) as exc:
+            logger.debug("keyboard-mode hint skipped: %s", exc)
+            return None
 
     @staticmethod
     def _elicitation_session() -> tuple[Any, Any]:

--- a/src/attune/mcp/server.py
+++ b/src/attune/mcp/server.py
@@ -752,12 +752,21 @@ class EmpathyMCPServer(MemoryHandlersMixin, WorkflowHandlersMixin):
         except FormValidationError as e:
             return {"success": False, "problems": e.problems}
 
-        return {
+        recommended = self._record_surface_choice(form, chosen="ask")
+        result = {
             "success": True,
             "title": form.title,
             "description": form.description,
             "batches": form_to_askuserquestion(form),
         }
+        if recommended == "widget":
+            result["surface_note"] = (
+                "The router recommends the widget for this form (D21 — the "
+                "rich surface is the default). AskUserQuestion will flatten "
+                "it. Use elicitation_render_widget unless the client cannot "
+                "render widgets or the user is in keyboard mode."
+            )
+        return result
 
     async def _handle_elicitation_render_widget(self, args: dict[str, Any]) -> dict[str, Any]:
         """Render a declarative form as inline HTML for ``show_widget`` (S1).
@@ -789,12 +798,47 @@ class EmpathyMCPServer(MemoryHandlersMixin, WorkflowHandlersMixin):
         except FormValidationError as e:
             return {"success": False, "problems": e.problems}
 
+        self._record_surface_choice(form, chosen="widget")
         return {
             "success": True,
             "html": form_to_widget_html(form, args.get("message") or ""),
             "title": form.title,
             "field_ids": [q.id for q in form.questions],
         }
+
+    @staticmethod
+    def _record_surface_choice(form: Any, *, chosen: str) -> str | None:
+        """Run the D21 router for telemetry and return its recommendation.
+
+        The elicitation tools are the only place the live system can observe
+        a surface decision: the tool the agent invoked *is* its choice.
+        Running the router here records both the recommendation and whether
+        the agent agreed, which is what makes the decay receipt real rather
+        than a counter nothing increments.
+
+        Best-effort in every direction — a telemetry or config problem must
+        never break form rendering, so failures return ``None`` and the
+        caller proceeds.
+
+        Args:
+            form: The validated ``FormSchema``.
+            chosen: The surface this handler represents (``"ask"`` for the
+                AskUserQuestion batches, ``"widget"`` for the HTML form).
+
+        Returns:
+            The router's recommendation, or ``None`` if it could not run.
+        """
+        try:
+            from attune.elicitation import keyboard_mode_enabled, select_form_surface
+
+            return select_form_surface(
+                form,
+                keyboard_mode=keyboard_mode_enabled(),
+                chosen=chosen,
+            )
+        except (OSError, ValueError, ImportError) as exc:
+            logger.debug("surface-choice telemetry skipped: %s", exc)
+            return None
 
     async def _handle_elicitation_collect_response(self, args: dict[str, Any]) -> dict[str, Any]:
         """Validate user answers against a declarative form (R4).

--- a/src/attune/telemetry/form_events.py
+++ b/src/attune/telemetry/form_events.py
@@ -1,0 +1,124 @@
+"""Local-only log of form-surface routing decisions.
+
+The decay guard for D21 (round table ``q-forms-default-vs-latency-001``,
+Claude seat): flipping the default to the rich widget is only worth
+something if the behaviour actually changes, so record what
+:func:`attune.elicitation.select_form_surface` decided and let a later
+read answer "did the mix move?" instead of assuming it did.
+
+One event = one JSON line: ``v`` / ``ts`` / ``event`` / ``surface``
+plus optional routing context.
+
+**What this can and cannot measure.** It sees every form that reaches
+the router, so it measures the *surface mix* (widget vs ask) faithfully.
+It does NOT see a raw ``AskUserQuestion`` turn the agent wrote by hand
+without building a ``FormSchema`` — that path never enters Python. So
+this instruments routing, not firing; the forms-vs-raw-turns ratio the
+round table asked for is only partially observable from here, and the
+missing half has to come from transcript inspection.
+
+Consent model matches :mod:`attune.telemetry.memory_events`: LOCAL
+recording is default-on and nothing ever leaves the machine.
+``DO_NOT_TRACK`` or ``ATTUNE_FORM_TELEMETRY=0`` disables the log.
+Never raises — routing must not fail because telemetry did.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under Apache 2.0
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from collections import Counter
+from datetime import datetime, timezone
+from pathlib import Path
+
+_FALSEY = {"", "0", "false", "no", "off"}
+
+#: Rotate when the live file exceeds this. Mirrors ``memory_events``.
+_MAX_BYTES = 5 * 1024 * 1024
+
+
+def _enabled() -> bool:
+    """False when local form telemetry is switched off via env."""
+    if os.environ.get("ATTUNE_FORM_TELEMETRY", "1").strip().lower() in _FALSEY:
+        return False
+    dnt = os.environ.get("DO_NOT_TRACK")
+    return dnt is None or dnt.strip().lower() in _FALSEY
+
+
+def _events_path() -> Path:
+    """Resolve the live events file under ATTUNE_HOME (default ~/.attune)."""
+    home = os.environ.get("ATTUNE_HOME")
+    base = Path(home).expanduser() if home else Path.home() / ".attune"
+    return base / "telemetry" / "form_events.jsonl"
+
+
+def _rotate_if_huge(path: Path) -> None:
+    """Best-effort size backstop: rotate to a dated sibling when huge."""
+    try:
+        if path.stat().st_size < _MAX_BYTES:
+            return
+        stamp = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+        rotated = path.with_name(f"form_events.{stamp}.jsonl")
+        counter = 1
+        while rotated.exists():
+            rotated = path.with_name(f"form_events.{stamp}.{counter}.jsonl")
+            counter += 1
+        path.replace(rotated)
+    except OSError:
+        pass  # rotation is a nicety; the append below still works
+
+
+def log_surface_decision(surface: str, **fields: object) -> None:
+    """Append one surface-routing decision. Best-effort, never raises.
+
+    Args:
+        surface: The chosen surface — ``"widget"`` or ``"ask"``.
+        **fields: Routing context (e.g. ``reason``, ``question_count``).
+    """
+    try:
+        if not _enabled():
+            return
+        record: dict[str, object] = {
+            "v": "1.0",
+            "ts": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
+            "event": "form_surface",
+            "surface": str(surface)[:32],
+        }
+        record.update(fields)
+
+        path = _events_path()
+        path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+        _rotate_if_huge(path)
+        with path.open("a", encoding="utf-8") as fh:
+            json.dump(record, fh, separators=(",", ":"), default=str)
+            fh.write("\n")
+    except OSError:
+        pass  # telemetry is best-effort; never break the caller
+
+
+def surface_mix() -> dict[str, int]:
+    """Return counts per surface from the live log.
+
+    Unreadable or malformed lines are skipped rather than raising, so a
+    partially-written tail never breaks the read.
+
+    Returns:
+        A mapping of surface name to count; empty when nothing logged.
+    """
+    counts: Counter[str] = Counter()
+    path = _events_path()
+    try:
+        with path.open(encoding="utf-8") as fh:
+            for line in fh:
+                try:
+                    record = json.loads(line)
+                except ValueError:
+                    continue
+                if isinstance(record, dict) and record.get("event") == "form_surface":
+                    counts[str(record.get("surface", "(unknown)"))] += 1
+    except OSError:
+        return {}
+    return dict(counts)

--- a/src/attune/telemetry/form_events.py
+++ b/src/attune/telemetry/form_events.py
@@ -9,13 +9,19 @@ read answer "did the mix move?" instead of assuming it did.
 One event = one JSON line: ``v`` / ``ts`` / ``event`` / ``surface``
 plus optional routing context.
 
-**What this can and cannot measure.** It sees every form that reaches
-the router, so it measures the *surface mix* (widget vs ask) faithfully.
-It does NOT see a raw ``AskUserQuestion`` turn the agent wrote by hand
-without building a ``FormSchema`` — that path never enters Python. So
-this instruments routing, not firing; the forms-vs-raw-turns ratio the
-round table asked for is only partially observable from here, and the
-missing half has to come from transcript inspection.
+**What this can and cannot measure.** The live call site is the pair of
+MCP elicitation handlers, where the tool the agent invoked *is* its
+choice — so each record carries the router's recommendation (``surface``
+/ ``reason``), what the agent actually did (``chosen``), and whether
+they matched (``agreed``). That makes disagreement visible, not just
+volume.
+
+It still does NOT see a raw ``AskUserQuestion`` turn the agent wrote by
+hand without building a ``FormSchema`` at all — that path never enters
+Python. So the forms-vs-no-form ratio remains only partially observable
+from here, and the missing half has to come from transcript inspection.
+What *is* now observable is the narrower and more actionable signal:
+when a form was built and the agent then flattened it anyway.
 
 Consent model matches :mod:`attune.telemetry.memory_events`: LOCAL
 recording is default-on and nothing ever leaves the machine.

--- a/src/attune/telemetry/form_events.py
+++ b/src/attune/telemetry/form_events.py
@@ -105,6 +105,91 @@ def log_surface_decision(surface: str, **fields: object) -> None:
         pass  # telemetry is best-effort; never break the caller
 
 
+#: Form submissions before the one-time keyboard-mode hint fires. D17
+#: ratified usage-triggered discovery ("after N form submissions"), not a
+#: calendar timer — someone who never feels the friction never sees it.
+_HINT_AFTER_SUBMISSIONS = 10
+
+#: Shown to a user who has answered enough forms to have an opinion.
+_KEYBOARD_HINT = (
+    "You've answered several forms. If you'd rather answer with the "
+    "keyboard than the mouse, turn on keyboard mode — "
+    "`attune config set keyboard_mode true` — and asks that fit a plain "
+    "question will come back as button turns instead of forms."
+)
+
+
+def log_submission() -> None:
+    """Record that a user submitted a form. Best-effort, never raises."""
+    try:
+        if not _enabled():
+            return
+        path = _events_path()
+        path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+        _rotate_if_huge(path)
+        record = {
+            "v": "1.0",
+            "ts": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
+            "event": "form_submitted",
+        }
+        with path.open("a", encoding="utf-8") as fh:
+            json.dump(record, fh, separators=(",", ":"))
+            fh.write("\n")
+    except OSError:
+        pass
+
+
+def _hint_marker() -> Path:
+    """Path of the once-only marker for the keyboard-mode hint."""
+    return _events_path().with_name("keyboard_hint_shown")
+
+
+def maybe_keyboard_hint(keyboard_mode: bool = False) -> str | None:
+    """Return the keyboard-mode hint the first time it is earned, else None.
+
+    Fires at most once ever, only after the user has actually answered
+    :data:`_HINT_AFTER_SUBMISSIONS` forms, and never when they already
+    have keyboard mode on. Writes the marker before returning so a caller
+    that fires twice in one session still only shows it once.
+
+    Args:
+        keyboard_mode: Whether the user has already opted in.
+
+    Returns:
+        The hint text, or ``None``.
+    """
+    try:
+        if keyboard_mode or not _enabled():
+            return None
+        marker = _hint_marker()
+        if marker.exists():
+            return None
+        if submission_count() < _HINT_AFTER_SUBMISSIONS:
+            return None
+        marker.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+        marker.write_text("shown\n", encoding="utf-8")
+        return _KEYBOARD_HINT
+    except OSError:
+        return None
+
+
+def submission_count() -> int:
+    """Number of form submissions recorded in the live log."""
+    count = 0
+    try:
+        with _events_path().open(encoding="utf-8") as fh:
+            for line in fh:
+                try:
+                    record = json.loads(line)
+                except ValueError:
+                    continue
+                if isinstance(record, dict) and record.get("event") == "form_submitted":
+                    count += 1
+    except OSError:
+        return 0
+    return count
+
+
 def surface_mix() -> dict[str, int]:
     """Return counts per surface from the live log.
 

--- a/tests/unit/elicitation/test_select_form_surface.py
+++ b/tests/unit/elicitation/test_select_form_surface.py
@@ -1,0 +1,235 @@
+"""Tests for the D21 surface router and its inputs.
+
+Covers ``select_form_surface`` (the widget-by-default product router),
+``is_trivial_form`` (the narrow mechanical exemption),
+``keyboard_mode_enabled`` (the per-project opt-out), and
+``form_response_summary`` (the collapse path).
+
+The regression these guard: the default used to be "cheapest surface
+that fits", so a multi-dimension all-select form routed to
+``AskUserQuestion``. D21 flipped it. ``test_multi_dimension_form_*``
+below fails if that flip is ever reverted.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under Apache 2.0
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from attune.elicitation import (
+    collect_form_response,
+    form_from_dict,
+    form_response_summary,
+    is_trivial_form,
+    keyboard_mode_enabled,
+    needs_widget,
+    select_form_surface,
+)
+
+
+def _form(fields: list[dict]) -> object:
+    """Build a FormSchema from field dicts."""
+    return form_from_dict({"title": "T", "description": "d", "fields": fields})
+
+
+def _select(**options: object) -> dict:
+    """A single_select field with the given overrides."""
+    base = {"id": "a", "type": "single_select", "text": "Which?", "options": ["x", "y"]}
+    base.update(options)
+    return base
+
+
+@pytest.fixture(autouse=True)
+def _isolate_telemetry_and_env(tmp_path, monkeypatch):
+    """Keep routing telemetry and the opt-out out of the real home/cwd."""
+    monkeypatch.setenv("ATTUNE_HOME", str(tmp_path / "attune-home"))
+    monkeypatch.delenv("ATTUNE_KEYBOARD_MODE", raising=False)
+    monkeypatch.chdir(tmp_path)
+
+
+# --------------------------------------------------------------------
+# select_form_surface — the flipped default
+# --------------------------------------------------------------------
+
+
+def test_multi_dimension_form_defaults_to_widget() -> None:
+    """The D21 flip: >1 all-select field is no longer an AskUserQuestion form.
+
+    This is the exact class the old ``needs_widget``-owned routing sent
+    to buttons. If this returns ``"ask"``, the flip was reverted.
+    """
+    form = _form([_select(id="a"), _select(id="b")])
+    assert needs_widget(form) is False  # still AskUserQuestion-expressible
+    assert select_form_surface(form) == "widget"  # ...but no longer routed there
+
+
+def test_single_select_over_three_options_routes_to_widget() -> None:
+    form = _form([_select(options=["w", "x", "y", "z"])])
+    assert select_form_surface(form) == "widget"
+
+
+def test_trivial_boolean_routes_to_ask() -> None:
+    form = _form([{"id": "q", "type": "boolean", "text": "Proceed?"}])
+    assert select_form_surface(form) == "ask"
+
+
+def test_non_widget_client_falls_back_even_for_rich_form() -> None:
+    """Capability is a constraint, not a preference — it outranks everything."""
+    form = _form([{"id": "n", "type": "number", "text": "How many?"}])
+    assert select_form_surface(form, widget_capable=False) == "ask"
+
+
+def test_keyboard_mode_falls_back_for_expressible_form() -> None:
+    form = _form([_select(id="a"), _select(id="b")])
+    assert select_form_surface(form, keyboard_mode=True) == "ask"
+
+
+def test_no_portable_control_outranks_keyboard_mode() -> None:
+    """The opt-out must never silently drop a field the surface can't render."""
+    for control in ("number", "date", "textarea"):
+        form = _form([{"id": "f", "type": control, "text": "?"}])
+        assert select_form_surface(form, keyboard_mode=True) == "widget", control
+
+
+@pytest.mark.parametrize("construct", ["decision", "pushback", "progress"])
+def test_constructs_are_lossy_not_impossible(construct: str) -> None:
+    """Constructs default to the widget but yield to an explicit opt-out.
+
+    Unlike number/date/textarea they *do* have an AskUserQuestion
+    fallback (recommendation-first single-select), so keyboard mode may
+    take it.
+    """
+    field = {
+        "id": "d",
+        "type": construct,
+        "text": "Which approach?",
+        "options": ["x", "y"],
+        "recommended": "x",
+    }
+    if construct == "progress":
+        # A progress form reports items by status; the blocked subset's
+        # labels must equal ``options``.
+        field["progress_items"] = [
+            {"label": "done thing", "status": "done"},
+            {"label": "x", "status": "blocked"},
+            {"label": "y", "status": "blocked"},
+        ]
+    form = _form([field])
+    assert select_form_surface(form) == "widget"
+    assert select_form_surface(form, keyboard_mode=True) == "ask"
+
+
+# --------------------------------------------------------------------
+# is_trivial_form — the narrow exemption
+# --------------------------------------------------------------------
+
+
+def test_trivial_requires_single_question() -> None:
+    assert is_trivial_form(_form([_select(id="a")])) is True
+    assert is_trivial_form(_form([_select(id="a"), _select(id="b")])) is False
+
+
+def test_trivial_rejects_more_than_three_options() -> None:
+    assert is_trivial_form(_form([_select(options=["a", "b", "c"])])) is True
+    assert is_trivial_form(_form([_select(options=["a", "b", "c", "d"])])) is False
+
+
+def test_long_option_label_is_not_trivial() -> None:
+    """Long labels mean tradeoffs were folded into the text — that wants a card."""
+    assert is_trivial_form(_form([_select(options=["ok", "x" * 121])])) is False
+    assert is_trivial_form(_form([_select(options=["ok", "x" * 120])])) is True
+
+
+def test_multi_select_is_not_trivial() -> None:
+    field = {"id": "m", "type": "multi_select", "text": "Which?", "options": ["a"]}
+    assert is_trivial_form(_form([field])) is False
+
+
+# --------------------------------------------------------------------
+# keyboard_mode_enabled — per-project, env override
+# --------------------------------------------------------------------
+
+
+def test_keyboard_mode_defaults_off(tmp_path: Path) -> None:
+    assert keyboard_mode_enabled(tmp_path) is False
+
+
+def test_keyboard_mode_reads_project_config(tmp_path: Path) -> None:
+    (tmp_path / "attune.config.json").write_text(json.dumps({"keyboard_mode": True}))
+    assert keyboard_mode_enabled(tmp_path) is True
+
+
+def test_env_overrides_project_config_both_directions(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    (tmp_path / "attune.config.json").write_text(json.dumps({"keyboard_mode": True}))
+    monkeypatch.setenv("ATTUNE_KEYBOARD_MODE", "0")
+    assert keyboard_mode_enabled(tmp_path) is False
+    monkeypatch.setenv("ATTUNE_KEYBOARD_MODE", "1")
+    assert keyboard_mode_enabled(tmp_path) is True
+
+
+def test_malformed_project_config_is_not_an_error(tmp_path: Path) -> None:
+    """Routing must never fail because a config file is bad."""
+    (tmp_path / "attune.config.json").write_text("{not json")
+    assert keyboard_mode_enabled(tmp_path) is False
+
+
+# --------------------------------------------------------------------
+# form_response_summary — the collapse path
+# --------------------------------------------------------------------
+
+
+def test_response_summary_renders_answers_and_omits_unanswered() -> None:
+    form = _form(
+        [
+            _select(id="scope", text="Which path?", options=["src", "tests"]),
+            {
+                "id": "concerns",
+                "type": "multi_select",
+                "text": "Which concerns?",
+                "options": ["impl", "docs"],
+                "required": False,
+            },
+            {"id": "skipped", "type": "text_input", "text": "Notes?", "required": False},
+        ]
+    )
+    response = collect_form_response(form, {"scope": "src", "concerns": ["impl", "docs"]})
+    summary = form_response_summary(form, response)
+
+    assert "Which path?: **src**" in summary
+    assert "Which concerns?: **impl, docs**" in summary
+    assert "Notes?" not in summary  # unanswered questions are omitted
+    assert summary.count("\n") == 2  # title + 2 answered bullets
+
+
+# --------------------------------------------------------------------
+# the decay receipt
+# --------------------------------------------------------------------
+
+
+def test_routing_decisions_are_logged_and_readable() -> None:
+    """Non-mocked round trip: route -> persist -> read back the mix."""
+    from attune.telemetry.form_events import surface_mix
+
+    rich = _form([_select(id="a"), _select(id="b")])
+    trivial = _form([{"id": "q", "type": "boolean", "text": "Proceed?"}])
+
+    select_form_surface(rich)
+    select_form_surface(rich)
+    select_form_surface(trivial)
+
+    assert surface_mix() == {"widget": 2, "ask": 1}
+
+
+def test_telemetry_can_be_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    from attune.telemetry.form_events import surface_mix
+
+    monkeypatch.setenv("ATTUNE_FORM_TELEMETRY", "0")
+    select_form_surface(_form([_select(id="a"), _select(id="b")]))
+    assert surface_mix() == {}

--- a/tests/unit/elicitation/test_select_form_surface.py
+++ b/tests/unit/elicitation/test_select_form_surface.py
@@ -233,3 +233,92 @@ def test_telemetry_can_be_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("ATTUNE_FORM_TELEMETRY", "0")
     select_form_surface(_form([_select(id="a"), _select(id="b")]))
     assert surface_mix() == {}
+
+
+# --------------------------------------------------------------------
+# the live call site — the MCP handlers
+# --------------------------------------------------------------------
+#
+# Without these, the router is dead code: nothing in src/ called it, so
+# the telemetry above would count zero forever. These assert the wiring,
+# not just the predicate.
+
+
+def _events() -> list[dict]:
+    """Read raw telemetry records written during the test."""
+    import json
+
+    from attune.telemetry.form_events import _events_path
+
+    path = _events_path()
+    if not path.exists():
+        return []
+    return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line]
+
+
+def _run(handler_name: str, form: dict) -> dict:
+    """Invoke an elicitation MCP handler without constructing the server."""
+    import asyncio
+
+    from attune.mcp.server import EmpathyMCPServer
+
+    server = EmpathyMCPServer.__new__(EmpathyMCPServer)
+    handler = getattr(EmpathyMCPServer, handler_name)
+    return asyncio.run(handler(server, {"form": form}))
+
+
+_RICH = {
+    "title": "T",
+    "fields": [
+        {"id": "a", "type": "single_select", "text": "Scope?", "options": ["src", "tests"]},
+        {"id": "b", "type": "single_select", "text": "Depth?", "options": ["quick", "deep"]},
+    ],
+}
+_TRIVIAL = {"title": "T", "fields": [{"id": "q", "type": "boolean", "text": "Proceed?"}]}
+
+
+def test_render_widget_handler_records_the_decision() -> None:
+    result = _run("_handle_elicitation_render_widget", _RICH)
+    assert result["success"] is True
+
+    events = _events()
+    assert len(events) == 1
+    assert events[0]["chosen"] == "widget"
+    assert events[0]["surface"] == "widget"
+    assert events[0]["agreed"] is True
+
+
+def test_render_form_handler_records_disagreement_and_nudges() -> None:
+    """Agent flattened a form the router wanted rich — both must be visible."""
+    result = _run("_handle_elicitation_render_form", _RICH)
+    assert result["success"] is True
+    assert "surface_note" in result  # the nudge back toward the widget
+
+    events = _events()
+    assert len(events) == 1
+    assert events[0]["chosen"] == "ask"
+    assert events[0]["surface"] == "widget"
+    assert events[0]["agreed"] is False
+
+
+def test_render_form_handler_stays_quiet_when_ask_is_correct() -> None:
+    """A trivial form on AskUserQuestion is right — no nag, agreement logged."""
+    result = _run("_handle_elicitation_render_form", _TRIVIAL)
+    assert "surface_note" not in result
+
+    events = _events()
+    assert events[0]["agreed"] is True
+    assert events[0]["reason"] == "trivial_form"
+
+
+def test_handler_survives_broken_telemetry(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Rendering must never fail because the receipt could not be written."""
+    import attune.elicitation.bridge as bridge
+
+    def _boom(*_args: object, **_kwargs: object) -> None:
+        raise OSError("disk full")
+
+    monkeypatch.setattr(bridge, "log_surface_decision", _boom)
+    result = _run("_handle_elicitation_render_widget", _RICH)
+    assert result["success"] is True
+    assert "html" in result

--- a/tests/unit/elicitation/test_select_form_surface.py
+++ b/tests/unit/elicitation/test_select_form_surface.py
@@ -322,3 +322,93 @@ def test_handler_survives_broken_telemetry(monkeypatch: pytest.MonkeyPatch) -> N
     result = _run("_handle_elicitation_render_widget", _RICH)
     assert result["success"] is True
     assert "html" in result
+
+
+# --------------------------------------------------------------------
+# the opt-out's affordance — reachable and discoverable (D17)
+# --------------------------------------------------------------------
+#
+# The mechanism shipping without these is how D17 sat unbuilt for a
+# month: every seat called the opt-out "essential", and an opt-out
+# nobody can find is not one.
+
+
+def test_set_keyboard_mode_round_trips(tmp_path: Path) -> None:
+    from attune.elicitation import set_keyboard_mode
+
+    set_keyboard_mode(True, tmp_path)
+    assert keyboard_mode_enabled(tmp_path) is True
+    set_keyboard_mode(False, tmp_path)
+    assert keyboard_mode_enabled(tmp_path) is False
+
+
+def test_set_keyboard_mode_preserves_other_settings(tmp_path: Path) -> None:
+    """Writing one key must not eat the user's other config."""
+    from attune.elicitation import set_keyboard_mode
+
+    (tmp_path / "attune.config.json").write_text(json.dumps({"project_name": "attune", "tier": 3}))
+    set_keyboard_mode(True, tmp_path)
+
+    data = json.loads((tmp_path / "attune.config.json").read_text())
+    assert data == {"project_name": "attune", "tier": 3, "keyboard_mode": True}
+
+
+def test_set_keyboard_mode_refuses_to_clobber_bad_json(tmp_path: Path) -> None:
+    """Malformed config raises — overwriting would silently lose data."""
+    from attune.elicitation import set_keyboard_mode
+
+    (tmp_path / "attune.config.json").write_text("{not json")
+    with pytest.raises(ValueError, match="not valid JSON"):
+        set_keyboard_mode(True, tmp_path)
+
+
+def test_config_cli_sets_and_shows(tmp_path: Path, monkeypatch, capsys) -> None:
+    from attune.cli_minimal import main
+
+    monkeypatch.chdir(tmp_path)
+    assert main(["config", "set", "keyboard_mode", "true"]) == 0
+    assert json.loads((tmp_path / "attune.config.json").read_text())["keyboard_mode"] is True
+
+    capsys.readouterr()
+    assert main(["config", "show"]) == 0
+    assert "keyboard_mode = true" in capsys.readouterr().out
+
+
+def test_config_cli_rejects_unknown_key_and_bad_value(tmp_path: Path, monkeypatch) -> None:
+    """A typo must not be silently persisted as a setting that does nothing."""
+    from attune.cli_minimal import main
+
+    monkeypatch.chdir(tmp_path)
+    assert main(["config", "set", "keybord_mode", "true"]) == 1
+    assert main(["config", "set", "keyboard_mode", "maybe"]) == 1
+    assert not (tmp_path / "attune.config.json").exists()
+
+
+def test_keyboard_hint_fires_once_at_the_threshold() -> None:
+    from attune.telemetry.form_events import (
+        _HINT_AFTER_SUBMISSIONS,
+        log_submission,
+        maybe_keyboard_hint,
+    )
+
+    for _ in range(_HINT_AFTER_SUBMISSIONS - 1):
+        log_submission()
+        assert maybe_keyboard_hint() is None  # not yet earned
+
+    log_submission()
+    assert maybe_keyboard_hint() is not None  # earned
+
+    log_submission()
+    assert maybe_keyboard_hint() is None  # and never again
+
+
+def test_keyboard_hint_never_fires_for_users_already_opted_in() -> None:
+    from attune.telemetry.form_events import (
+        _HINT_AFTER_SUBMISSIONS,
+        log_submission,
+        maybe_keyboard_hint,
+    )
+
+    for _ in range(_HINT_AFTER_SUBMISSIONS + 5):
+        log_submission()
+    assert maybe_keyboard_hint(keyboard_mode=True) is None


### PR DESCRIPTION
## What and why

Two rules pulled against each other. D17 ratified **"Default = forms"** but was never built. The shipped `needs_widget` predicate picked the *cheapest surface that could express a form's controls*, justified in its own docstring as saving a round-trip **"FOR NO GAIN"**. Meanwhile the always-loaded Socratic rule named `AskUserQuestion` — a **tool** — so most asks never became a `FormSchema` at all, whatever routing decided.

Round table [`q-forms-default-vs-latency-001`](../blob/main/docs/specs/elicitation-form-surface/decisions.md) (Claude, Antigravity, Codex) converged **3/3 in one round**. All three seats, answering blind, independently made the same point: **routing was the smaller half.** `AskUserQuestion` caps at 4 options and one question per turn, so it *structurally cannot* carry a batched multi-dimension ask — that highest-value form already routed to the widget correctly. It was never routed away; **it was never built.**

## Routing

- `select_form_surface(form, widget_capable, keyboard_mode)` is the product router. Widget is the default; `AskUserQuestion` is the explicit fallback. Precedence: client capability → no-portable-control → keyboard mode → triviality → widget.
- `_NO_PORTABLE_CONTROL` splits from `_WIDGET_ONLY_TYPES`. `number`/`date`/`textarea` are *impossible* on `AskUserQuestion`; the v3–v5 constructs are *lossy but expressible*. Impossible outranks the opt-out, so a field can never be silently dropped.
- `is_trivial_form` is narrow and mechanical: one select/boolean, ≤3 options, no option label over 120 chars. The length clause detects tradeoffs smuggled into option text.
- `needs_widget` survives as the low-level controls check. The latency justification is **deleted**, not left to invite reversion.

## Firing

The Socratic rule now names the **artifact** (construct a `FormSchema`), with an explicit batching clause: independent dimensions go in ONE form, never N sequential turns.

## Also

- **`attune config set` / `attune config show`** — the first project-config CLI, added because the opt-out below shipped with no way to turn it on.
- **Keyboard mode built** (ratified in D17, never implemented) — per-project `keyboard_mode` in `attune.config.json`, `ATTUNE_KEYBOARD_MODE` as a two-way session override. Every seat named *interaction ceremony* as the risk; this is the valve, and it ships in the same change deliberately.

  The first cut shipped the valve with **no affordance** — no `attune config` command existed, so enabling it meant hand-editing JSON, and nothing surfaced the option to anyone who hadn't heard of it. An opt-out nobody can find doesn't mitigate anything, and that is exactly how D17 sat ratified-but-unbuilt for a month. Now: `attune config set keyboard_mode true` (allowlisted keys, so a typo errors rather than persisting a dead setting) plus D17's usage-triggered hint after ten *answered* forms — counting validated submissions, not renders, because rendering proves nothing about engagement.
- `form_response_summary` collapses an answered form to markdown.
- `attune.telemetry.form_events` logs routing decisions locally; `surface_mix()` reads them back. The live call site is the pair of MCP elicitation handlers, where the tool the agent invoked *is* its choice — records carry the recommendation, the agent's actual pick (`chosen`), and whether they matched (`agreed`). `render_form` nudges back toward the widget when it flattens a form the router wanted rich.

## Receipts

| Check | Result |
|---|---|
| New tests | 20, incl. a revert guard on the flip |
| Coverage | `bridge.py` 99%, `form_events.py` 81% |
| Round trip (non-mocked) | route → persist → read back `{'widget': 2, 'ask': 1}` |
| Handler wiring | 4 tests driving the real MCP handlers |
| Full suites | 1604 passed (660 elicitation+mcp after the wiring fix) |
| Doc audits | doc-import clean, docs-wiring "No findings" |
| **Live widget round-trip** | rendered via `elicitation_render_widget`, submitted by a human, validated → **`resp-20260725-013213`** |

The live receipt used the exact class that flipped: three independent all-select dimensions, which routed `widget` under the new rule and would have routed `ask` under the old one.

## Docs

Feature master re-projected (11 `.help` kinds, 4 mkdocs pages). The **demo script was re-cut** — its "3 sequential questions" cold open is precisely the behavior this PR removes, so the arc now uses keyboard mode to produce that take deterministically. Its claim *"everything shown is live on PyPI 10.5.0 today"* is now false and was replaced with a version gate rather than left standing.

`website/lib/features.ts` is deliberately **untouched** — it describes what's live on PyPI, and this lands in 10.6.0.

## Honest limits

- **The telemetry can't see a raw `AskUserQuestion` turn** written without building a `FormSchema` at all — that path never enters Python, so the forms-vs-no-form ratio stays half-observable and the rest needs transcript inspection. Surface mix also rises by construction once the default flips — that's compliance, not value. The `agreed` field is the one signal that isn't self-fulfilling: it records the agent overriding its own router.
- **The first cut of this PR shipped a dead receipt.** The logging hung off `select_form_surface`, which *nothing in `src/` called* — it would have counted zero forever while this PR body claimed it "measures the surface mix faithfully." Caught in review and fixed in `1ecacf74d`; recorded in D21 rather than quietly corrected. `needs_widget` has never had a production caller either — that's fine for a pure predicate, and not fine once a receipt hangs off it.
- **Dissent preserved.** Antigravity argued rendered HTML accumulating across a session is real *context* pressure, which "no money at stake" does not answer. `form_response_summary` is the partial mitigation.

## Merge gate

**Hold for the Windows lanes** (chair-ruled). The diff touches path handling — `attune.config.json` reads and telemetry file paths — so the ~13 min Windows matrix is load-bearing here. `auto-merge-when-green` is deliberately **not** armed.

Spec: `docs/specs/elicitation-form-surface/decisions.md` (D21)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
