### PR TITLE
docs(readme): lead with the cost model — it was teaching the wrong thing

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,30 @@ developer workflow hub; `attune-gui` is the docs hub.
 
 ---
 
+## What this costs
+
+There are two ways to run Attune, and they bill differently. Pick the
+row you're in:
+
+| How you run it | What it costs |
+| -------------- | ------------- |
+| **Plugin in Claude Code** (skills, hooks, forms) | Your Claude subscription. No API key, no extra charge. |
+| **`attune` CLI + MCP tools** | Direct Anthropic API calls — needs `ANTHROPIC_API_KEY` with **API credits**. |
+
+**The one thing people get wrong:** a Claude Pro/Max subscription does
+*not* include API credits. They are separate products. The subscription
+powers Claude Code — and therefore the plugin — but the CLI and MCP
+tools call the Anthropic API directly, so a key without pay-as-you-go
+credit returns `credit balance is too low`. If you only use the plugin,
+this never comes up.
+
+Free on either path, because they never call a model: the elicitation
+forms, the security hooks, path validation, memory storage and recall,
+and every local transform. See [API Mode](#api-mode) for keys and
+routing, and [Installation Options](#installation-options) for extras.
+
+---
+
 <!-- ROTATING SLOT: this "New in <version>" section is replaced each
      release with the headline feature; the displaced content moves to
      a permanent section below (see "Dynamic forms" for the pattern).
@@ -327,8 +351,8 @@ per-surface extras (API-mode agents, ops dashboard, Redis memory).
 | Ops dashboard (`attune ops`) — run history, cost tiles, telemetry | -- | Yes |
 
 > **Note:** Skills use your Claude subscription at no extra cost.
-> CLI and MCP tools make direct Anthropic API calls — API key
-> required. See [API Mode](#api-mode).
+> CLI and MCP tools make direct Anthropic API calls — API key with
+> credits required. See [What this costs](#what-this-costs).
 
 ---
 
@@ -547,10 +571,20 @@ spammed to the session.
 
 ## API Mode
 
+API mode is what the `attune` CLI and the MCP tools run on. **It is not
+required to use Attune** — the Claude Code plugin runs on your
+subscription and needs none of this (see
+[What this costs](#what-this-costs)). Set these up only if you want the
+CLI or MCP surfaces:
+
 ```bash
-export ANTHROPIC_API_KEY="sk-ant-..."     # Required
+export ANTHROPIC_API_KEY="sk-ant-..."     # Required *for API mode*
 export REDIS_URL="redis://localhost:6379"  # Optional
 ```
+
+The key must belong to an org with pay-as-you-go API credit. A Claude
+Pro/Max subscription does not grant it — without credit the calls
+return `credit balance is too low`.
 
 ### Model Routing
 


### PR DESCRIPTION
## Where this came from

Outside signal. Someone explored attune-ai and reached out convinced it was cloud-API-dependent and cost-prohibitive at scale. The pitch attached to that belief was generic, but **the belief itself was a measurement** — and tracing it landed on the README rather than the reader.

## What the README was teaching

| Line | What it said |
|---|---|
| 477 | "`pip install attune-ai` works out of the box" |
| 329 | Subscription-first mentioned once, as a `> Note:` inside a table |
| **551** | `export ANTHROPIC_API_KEY="sk-ant-..."     # Required` |

738 lines. The cost model first appears at 329, buried. Then 222 lines later the setup block a reader actually copies says **Required**. It sits under `## API Mode`, so it is technically scoped — but nothing upstream establishes that API mode is the *fallback* rather than the default. Someone reading toward setup learns "needs a key, pays per call."

That is precisely the misconception that came back by email.

## Changes

- **New `## What this costs`** immediately after the intro — a two-row table splitting the plugin path (your Claude subscription, no key) from the CLI/MCP path (direct API calls, needs credits), plus what costs nothing on either path (forms, hooks, path validation, memory, local transforms).
- **States the trap plainly:** a Claude Pro/Max subscription does *not* include API credits. They are separate products, and a key without pay-as-you-go credit returns `credit balance is too low`. This is a real support cost recorded in our own lessons corpus — it belongs where people will hit it.
- **`## API Mode` now opens by saying it is not required**, and the inline comment reads `# Required *for API mode*`.
- The line-329 note repoints to the new section instead of restating it.

## Scope

Docs only. **No capability or pricing claim changed** — this moves where the existing truth appears and how scoped it reads. Anchors verified to resolve; docs-wiring audit reports no findings; whitespace and brand-drift hooks pass.

## Worth doing next, separately

The same audit against the PyPI long description and attune-ai.dev — both are likelier first contact than the repo, and if they carry the same ordering they carry the same misconception.

🤖 Generated with [Claude Code](https://claude.com/claude-code)