### PR TITLE
docs(website): simplify pricing to the license fact; drop forward commitments

### DIFF
--- a/website/app/docs/page.tsx
+++ b/website/app/docs/page.tsx
@@ -40,7 +40,7 @@ const faqItems = [
   {
     question: 'Is it free? What do I need to run it?',
     answer:
-      'Fully open source under Apache 2.0 — free for personal, commercial, and enterprise use, with no license keys and no usage limits. It works on a Claude subscription or an API key, so you can run it with whichever access you already have.',
+      'Released under the Apache License 2.0 — free for personal, commercial, and enterprise use, with full source access.',
   },
   {
     question: 'What Claude Code skills are included?',

--- a/website/app/faq/page.tsx
+++ b/website/app/faq/page.tsx
@@ -69,7 +69,7 @@ const faqData: FAQCategory[] = [
     questions: [
       {
         question: 'How much does Attune AI cost?',
-        answer: 'Attune AI is completely free and open source under the Apache License 2.0. Use it in personal projects, startups, or large enterprises at no cost. No license keys, no restrictions, no hidden fees.',
+        answer: 'The software is free and open source under the Apache License 2.0 — personal, commercial, and enterprise use included. Running the CLI or MCP tools makes Anthropic API calls, which bill to your own API account.',
       },
       {
         question: 'What is the Apache 2.0 License?',
@@ -98,7 +98,7 @@ const faqData: FAQCategory[] = [
       },
       {
         question: 'Do I need an API key?',
-        answer: 'No. Attune AI works on a Claude subscription or an API key — use whichever you have. The platform is open source under Apache 2.0 with no license keys or hidden fees.',
+        answer: 'Not for the Claude Code plugin — skills, hooks, and forms run on your Claude subscription. The attune CLI and the MCP tools call the Anthropic API directly, so those need an API key with credits. A Claude subscription does not include API credits; they are separate products.',
       },
       {
         question: 'Which LLM provider is supported?',

--- a/website/app/pricing/page.tsx
+++ b/website/app/pricing/page.tsx
@@ -9,8 +9,8 @@ export const metadata: Metadata = genMeta({
   title: 'Pricing — Free & Open Source',
   description:
     'Attune-AI is the spec-driven development platform — AI workflows, ' +
-    'project memory, retrieval grounding, and verification — fully open ' +
-    'source under Apache 2.0. No paid tiers, no usage limits, no license keys.',
+    'project memory, retrieval grounding, and verification — released ' +
+    'under the Apache License 2.0.',
   url: 'https://smartaimemory.com/pricing',
 });
 
@@ -32,7 +32,6 @@ const includedItems = [
   'Retrieval grounding — attune-rag is built in',
   'Local-first project memory and lessons corpus',
   'Verification: fact-check generated content before it ships',
-  'Works on a Claude subscription or an API key',
   'Full source code access',
   'Community support on GitHub',
   'Commercial use rights (Apache 2.0)',
@@ -65,10 +64,7 @@ export default function PricingPage() {
                 The whole platform, free &amp; open source
               </h1>
               <p className="text-xl opacity-90 mb-8">
-                Turn requirements into reliable software with no paywall in
-                the way. Apache License 2.0 — no paid tiers, no usage limits,
-                no license keys. Run it on a Claude subscription or your own
-                API key.
+                Apache License 2.0 — full source, commercial use included.
               </p>
               <a
                 href="https://github.com/Smart-AI-Memory/attune-ai"
@@ -90,11 +86,11 @@ export default function PricingPage() {
                 What You Get
               </span>
               <h2 className="text-4xl font-extrabold">
-                The full platform — nothing held back
+                What&apos;s included
               </h2>
               <p className="text-[var(--text-secondary)] mt-4 max-w-2xl mx-auto">
-                Every pillar, every workflow, every tool. There&apos;s no
-                upgrade tier to unlock — {getPricingSummary().toLowerCase()}.
+                Every pillar, every workflow, every tool —{' '}
+                {getPricingSummary().toLowerCase()}.
               </p>
             </div>
 


### PR DESCRIPTION
Chair-ruled: keep `/pricing` to the Apache license, keep it simple, keep options open.

## The forward-commitment problem

> "No paid tiers, no usage limits, no license keys"

That's a promise about the future, not a fact about today. Dropping it costs nothing now and preserves room to decide later.

It appeared on **four surfaces**, not one. Per the relicense lesson — license language scatters, so grep every surface — fixing `/pricing` alone would have left three others still making the commitment and just relocated the inconsistency:

| Surface | Was |
|---|---|
| `/pricing` meta + hero + heading | "No paid tiers, no usage limits, no license keys" / "no paywall in the way" / "nothing held back" |
| `/docs` intro | "no license keys and no usage limits" |
| `/faq` ×2 | "no license keys, no restrictions, no hidden fees" |

## Two fixes beyond the simplification

Flagged explicitly so they're easy to revert independently.

**1. FAQ "Do I need an API key?" was factually wrong.**

> Was: *"**No.** Attune AI works on a Claude subscription **or** an API key — use whichever you have."*

Skills run on the subscription; the `attune` CLI and MCP tools call the Anthropic API directly and need a funded key. They are not interchangeable. A subscription-only reader who follows that answer hits `credit balance is too low` — a support cost already recorded in our lessons corpus.

**2. FAQ "How much does it cost?" said "no hidden fees"** while omitting billed API usage — which is precisely what made that cost hidden. Now names the license and the API billing in one sentence each.

Also dropped `'Works on a Claude subscription or an API key'` from the `/pricing` included-items list: an access claim sitting in a what-you-get list, carrying the same inaccuracy.

## Scope

Website only — no changelog entry per the `website_only` policy. **No capability or count claims touched**; `getPricingSummary()` and `CAPABILITIES` are untouched, so the `features.ts`-canonical rule is unaffected.

`node_modules` isn't present in this worktree so `tsc` couldn't run — diffs were reviewed by hand, the one JSX expression I introduced (`—{' '}`) is standard whitespace handling, and `getPricingSummary` is still imported and used. Worth a CI typecheck confirmation.

## Context

Third of three from one piece of outside signal: someone explored attune-ai and came away convinced it was cloud-API-dependent and cost-prohibitive. #1658 fixed the README that taught them that. PyPI needs no work — `readme = {file = "README.md"}`, so it inherits. This is the website half, where the error ran the opposite direction: not "expensive" but "free to run", with the API cost unmentioned anywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)