### PR TITLE
ci(tests): gate on the whole matrix, not just the two required lanes

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -437,6 +437,47 @@ jobs:
     - name: Security scan with Bandit
       run: bandit -c .bandit -r src/ attune_software/ --severity-level medium --confidence-level medium
 
+  # Gate on the WHOLE test matrix, not just the two required lanes.
+  #
+  # Branch protection requires `test (ubuntu-latest, 3.12)` and
+  # `test (windows-latest, 3.12)`. On a full-matrix run the other ten
+  # lanes — including windows 3.10/3.11/3.13/3.14 — report but gate
+  # nothing, so a Windows-only regression can merge green and then sit on
+  # main while every later PR shows the same red lanes that nothing
+  # blocks on. That has happened (see the "admin-merging before Windows
+  # lanes complete" and "auto-merge ignores non-required lanes" lessons).
+  #
+  # Adding those lanes to branch protection directly does NOT work: the
+  # slim matrix does not run them, and a required check that never runs
+  # reports as "missing" and blocks the PR forever. So instead this job
+  # ALWAYS runs, aggregates whatever the matrix actually did, and is the
+  # single required context. Slim run -> nothing failed -> green. Full
+  # run with a red windows 3.13 -> red, and the merge is blocked.
+  test-matrix-complete:
+    needs: [test]
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+    - name: Require every test lane that ran to have passed
+      shell: bash
+      env:
+        RESULT: ${{ needs.test.result }}
+      run: |
+        set -euo pipefail
+        echo "test matrix result: $RESULT"
+        case "$RESULT" in
+          success|skipped)
+            echo "All test lanes that ran passed (or the matrix was skipped)."
+            ;;
+          *)
+            echo "::error::One or more test lanes did not pass (result: $RESULT)."
+            echo "Check the non-required lanes too — windows 3.10/3.11/3.13/3.14"
+            echo "are exactly the ones this gate exists to catch."
+            exit 1
+            ;;
+        esac
+
   platform-compat:
     runs-on: ubuntu-latest
     timeout-minutes: 10


### PR DESCRIPTION
## The gap

Branch protection requires `test (ubuntu-latest, 3.12)` and `test (windows-latest, 3.12)`. On a **full**-matrix run the other ten lanes — including **windows 3.10 / 3.11 / 3.13 / 3.14** — report but gate nothing.

So a Windows-only regression can merge green and then sit on main while every later PR shows the same red lanes that nothing blocks on. That's not hypothetical; it's in the lessons corpus twice.

Until now the mitigation was *a person remembering to look at the non-required lanes*. That's prose, not a mechanism — the same shape as the two misses in today's mechanism-without-seam lesson. This makes it structural.

## Why not just require the lanes

Adding `test (windows-latest, 3.13)` and friends to branch protection **does not work**. The slim matrix (docs/tests-only PRs, per `docs/specs/ci-matrix-right-sizing/`) never runs them, and a required check that never runs reports as `missing` — blocking the PR forever. `tests.yml` already carries a comment warning about exactly this.

## The fix

`test-matrix-complete`:

- `needs: [test]` with `if: always()` — runs whatever the matrix did, so it can never be "missing"
- fails when the matrix result is anything other than `success` or `skipped`
- is designed to be the **one** required context covering every lane

| Scenario | Result |
|---|---|
| Slim matrix, all green | green |
| Full matrix, all green | green |
| Full matrix, windows 3.13 red | **red — merge blocked** |
| Matrix skipped entirely | green (nothing ran, nothing failed) |

## Deliberately NOT done here

**Adding `test-matrix-complete` to `required_status_checks`.** That's a repo-settings change, and it must land *after* this workflow is on main — a brand-new required context that open PRs have never run reports as `missing` and blocks them until they rebase.

Sequence:

1. Merge this PR (the job starts running, gating nothing yet)
2. Add `test-matrix-complete` to `required_status_checks`
3. Rebase any open PR so it picks up the new context

I'll do step 2 on your say-so — it changes the merge gate for every PR in the repo, so it's your call rather than mine.

## Noticed in passing, not fixed

`platform-compat` is a required check whose failure step is `continue-on-error: true` — it emits a `::warning::` and exits 0. It is required and structurally cannot fail, so it currently gates nothing. Worth a separate look; out of scope here.

## Verification

`check-yaml` passes, the YAML parses and the job's `needs`/`if` are as intended, and the 328 workflow-guard tests in `tests/unit/ci` pass. Touching `tests.yml` is itself a full-matrix trigger path, so this PR validates the change against the full matrix it's meant to gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)