### PR TITLE
ci(platform-compat): make the gate real — encoding as an error, 44 call sites fixed

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -452,21 +452,49 @@ jobs:
       id: compat
       run: |
         python scripts/check_platform_compat.py src/ --json > compat-report.json
-        python scripts/check_platform_compat.py src/ --fix
+        python scripts/check_platform_compat.py src/ --fix || true
 
     - name: Upload compatibility report
+      if: always()
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: platform-compat-report
         path: compat-report.json
 
-    - name: Fail on errors (non-blocking for now)
+    # This step USED to warn and `continue-on-error: true`, which made
+    # `platform-compat` a required check that could not fail — and even
+    # without that, no platform rule emitted `error`, so the only error
+    # severity was the scanner failing to read a file. It gated nothing.
+    #
+    # Now: `missing_encoding` is an error (a text-mode open() without
+    # encoding uses the Windows locale codepage, not UTF-8 — the
+    # highest-yield source of Windows-only breakage here), the 44
+    # pre-existing instances are fixed, and this step FAILS the build.
+    #
+    # The other categories (hardcoded home/etc/tmp paths, os.path
+    # preference) stay warnings for now and are reported below without
+    # failing — the agreed sequence is encoding first, then ratchet the
+    # rest against a baseline.
+    - name: Fail on cross-platform errors
       run: |
-        ERRORS=$(python -c "import json; r=json.load(open('compat-report.json')); print(r['summary']['errors'])")
-        if [ "$ERRORS" -gt 0 ]; then
-          echo "::warning::Found $ERRORS cross-platform compatibility errors"
-        fi
-      continue-on-error: true
+        set -euo pipefail
+        python - <<'EOF'
+        import json, sys
+        report = json.load(open("compat-report.json"))
+        summary = report["summary"]
+        errors = summary["errors"]
+        print(f"scanned {summary['files_scanned']} files: "
+              f"{errors} error(s), {summary['warnings']} warning(s)")
+        if summary["warnings"]:
+            print(f"::notice::{summary['warnings']} cross-platform warnings "
+                  "(not yet gated — see the encoding-first ratchet)")
+        if errors:
+            for issue in report.get("issues", []):
+                if issue.get("severity") == "error":
+                    print(f"::error file={issue['file']},line={issue['line']}::"
+                          f"{issue['message']}")
+            sys.exit(1)
+        EOF
 
   code-quality:
     runs-on: ubuntu-latest

--- a/scripts/check_platform_compat.py
+++ b/scripts/check_platform_compat.py
@@ -132,7 +132,15 @@ def scan_file(filepath: Path, result: ScanResult) -> None:
                             line=line_num,
                             category="missing_encoding",
                             message="open() without encoding specified",
-                            severity="warning",
+                            # ERROR, not warning: on Windows a text-mode
+                            # open() without encoding uses the locale
+                            # codepage (typically cp1252), not UTF-8 —
+                            # the highest-yield source of Windows-only
+                            # failures in this repo. Gated as of the
+                            # encoding-first ratchet; the remaining
+                            # warning categories are baselined and will
+                            # be promoted in turn.
+                            severity="error",
                             suggestion='Add encoding="utf-8" parameter',
                         ),
                     )

--- a/src/attune/cli_commands/cost_commands.py
+++ b/src/attune/cli_commands/cost_commands.py
@@ -209,7 +209,7 @@ def _export_json(tracker: CostTracker, days: int, path: Path) -> None:
 
     """
     summary = tracker.get_summary(days)
-    with path.open("w") as f:
+    with path.open("w", encoding="utf-8") as f:
         json.dump(summary, f, indent=2)
 
 
@@ -227,7 +227,7 @@ def _export_csv(tracker: CostTracker, days: int, path: Path) -> None:
     cutoff = (datetime.now() - timedelta(days=days)).strftime("%Y-%m-%d")
     daily_totals = tracker.data.get("daily_totals", {})
 
-    with path.open("w", newline="") as f:
+    with path.open("w", newline="", encoding="utf-8") as f:
         writer = csv.writer(f)
         writer.writerow(
             [

--- a/src/attune/cli_commands/telemetry_commands.py
+++ b/src/attune/cli_commands/telemetry_commands.py
@@ -142,7 +142,7 @@ def cmd_telemetry_export(args: Namespace) -> int:
         if args.format == "csv":
             import csv
 
-            with output_path.open("w", newline="") as f:
+            with output_path.open("w", newline="", encoding="utf-8") as f:
                 if data:
                     writer = csv.DictWriter(f, fieldnames=data[0].keys())
                     writer.writeheader()
@@ -150,7 +150,7 @@ def cmd_telemetry_export(args: Namespace) -> int:
             print(f"✅ Exported {len(data)} entries to {output_path}")
 
         elif args.format == "json":
-            with output_path.open("w") as f:
+            with output_path.open("w", encoding="utf-8") as f:
                 json.dump(data, f, indent=2, default=str)
             print(f"✅ Exported {len(data)} entries to {output_path}")
 

--- a/src/attune/cli_router.py
+++ b/src/attune/cli_router.py
@@ -280,7 +280,7 @@ class HybridRouter:
         }
 
         validated_path = _validate_file_path(str(self.preferences_path))
-        with open(validated_path, "w") as f:
+        with open(validated_path, "w", encoding="utf-8") as f:
             yaml.dump(data, f, default_flow_style=False)
 
     async def route(self, user_input: str, context: dict[str, Any] | None = None) -> dict[str, Any]:

--- a/src/attune/config.py
+++ b/src/attune/config.py
@@ -328,7 +328,7 @@ class AttuneConfig:
         validated_path = _validate_file_path(filepath)
         data = asdict(self)
 
-        with open(validated_path, "w") as f:
+        with open(validated_path, "w", encoding="utf-8") as f:
             yaml.dump(data, f, default_flow_style=False, sort_keys=False)
 
     def to_json(self, filepath: str, indent: int = 2) -> None:
@@ -346,7 +346,7 @@ class AttuneConfig:
         validated_path = _validate_file_path(filepath)
         data = asdict(self)
 
-        with open(validated_path, "w") as f:
+        with open(validated_path, "w", encoding="utf-8") as f:
             json.dump(data, f, indent=indent)
 
     def to_dict(self) -> dict[str, Any]:

--- a/src/attune/config/xml_config.py
+++ b/src/attune/config/xml_config.py
@@ -182,7 +182,7 @@ class EmpathyXMLConfig:
             "metrics": asdict(self.metrics),
         }
 
-        with open(validated_path, "w") as f:
+        with open(validated_path, "w", encoding="utf-8") as f:
             json.dump(data, f, indent=2)
 
     @classmethod

--- a/src/attune/cost_tracker.py
+++ b/src/attune/cost_tracker.py
@@ -278,7 +278,7 @@ class CostTracker:
         try:
             self.data["last_updated"] = datetime.now().isoformat()
             validated_path = _validate_file_path(str(self.costs_file))
-            with open(validated_path, "w") as f:
+            with open(validated_path, "w", encoding="utf-8") as f:
                 json.dump(self.data, f, indent=2)
         except (OSError, ValueError):
             pass  # Best effort - cost tracking shouldn't crash the app
@@ -295,7 +295,7 @@ class CostTracker:
         }
         try:
             validated_path = _validate_file_path(str(self.costs_summary))
-            with open(validated_path, "w") as f:
+            with open(validated_path, "w", encoding="utf-8") as f:
                 json.dump(summary_data, f, indent=2)
         except (OSError, ValueError):
             pass  # Best effort - summary is an optimization, not critical
@@ -314,7 +314,7 @@ class CostTracker:
         # Append buffered requests to JSONL file
         try:
             validated_path = _validate_file_path(str(self.costs_jsonl))
-            with open(validated_path, "a") as f:
+            with open(validated_path, "a", encoding="utf-8") as f:
                 f.writelines(json.dumps(request) + "\n" for request in self._buffer)
 
             # Update daily totals (always in memory)

--- a/src/attune/discovery.py
+++ b/src/attune/discovery.py
@@ -136,7 +136,7 @@ class DiscoveryEngine:
         """Save state to storage."""
         self.state["last_updated"] = datetime.now().isoformat()
         validated_path = _validate_file_path(str(self.stats_file))
-        with open(validated_path, "w") as f:
+        with open(validated_path, "w", encoding="utf-8") as f:
             json.dump(self.state, f, indent=2)
 
     def record_command(self, command: str) -> list:

--- a/src/attune/hooks/config.py
+++ b/src/attune/hooks/config.py
@@ -303,5 +303,5 @@ class HookConfig(BaseModel):
         config_file = _validate_file_path(str(yaml_path))
         config_file.parent.mkdir(parents=True, exist_ok=True)
 
-        with config_file.open("w") as f:
+        with config_file.open("w", encoding="utf-8") as f:
             yaml.dump(self.model_dump(), f, default_flow_style=False)

--- a/src/attune/memory/control_panel.py
+++ b/src/attune/memory/control_panel.py
@@ -377,7 +377,7 @@ class MemoryControlPanel:
             "patterns": patterns,
         }
 
-        with open(validated_path, "w") as f:
+        with open(validated_path, "w", encoding="utf-8") as f:
             json.dump(export_data, f, indent=2)
 
         return len(patterns)

--- a/src/attune/memory/redis_auto_detect.py
+++ b/src/attune/memory/redis_auto_detect.py
@@ -94,7 +94,7 @@ class RedisAutoDetector:
         try:
             self.config_path.parent.mkdir(parents=True, exist_ok=True)
             validated_path = _validate_file_path(str(self.config_path))
-            with open(validated_path, "w") as f:
+            with open(validated_path, "w", encoding="utf-8") as f:
                 yaml.safe_dump(self.config, f, default_flow_style=False)
         except (yaml.YAMLError, OSError, ValueError) as e:
             logger.error(f"Failed to save config: {e}")

--- a/src/attune/metrics/prompt_metrics.py
+++ b/src/attune/metrics/prompt_metrics.py
@@ -108,7 +108,7 @@ class MetricsTracker:
         """
         try:
             validated_path = _validate_file_path(str(self.metrics_file))
-            with open(validated_path, "a") as f:
+            with open(validated_path, "a", encoding="utf-8") as f:
                 f.write(json.dumps(metric.to_dict()) + "\n")
         except (OSError, ValueError) as e:
             logger.error(f"Failed to log metric: {e}")

--- a/src/attune/models/provider_config.py
+++ b/src/attune/models/provider_config.py
@@ -164,7 +164,7 @@ class ProviderConfig:
             path = Path.home() / ".attune" / "provider_config.json"
         path.parent.mkdir(parents=True, exist_ok=True)
         validated_path = _validate_file_path(str(path))  # type: ignore[misc]
-        with open(validated_path, "w") as f:
+        with open(validated_path, "w", encoding="utf-8") as f:
             json.dump(self.to_dict(), f, indent=2)
 
     @classmethod

--- a/src/attune/orchestration/config_store.py
+++ b/src/attune/orchestration/config_store.py
@@ -211,7 +211,7 @@ class ConfigurationStore:
         try:
             for config_file in self.storage_dir.glob("*.json"):
                 try:
-                    with config_file.open("r") as f:
+                    with config_file.open("r", encoding="utf-8") as f:
                         data = json.load(f)
                         config = AgentConfiguration.from_dict(data)
                         self._cache[config.id] = config
@@ -252,7 +252,7 @@ class ConfigurationStore:
 
         # Save to disk
         try:
-            with validated_path.open("w") as f:
+            with validated_path.open("w", encoding="utf-8") as f:
                 json.dump(config.to_dict(), f, indent=2)
 
             logger.info(f"Saved configuration {config.id} to {validated_path}")

--- a/src/attune/orchestration/pattern_learner.py
+++ b/src/attune/orchestration/pattern_learner.py
@@ -78,7 +78,7 @@ class LearningStore:
             return
 
         try:
-            with self.file_path.open("r") as f:
+            with self.file_path.open("r", encoding="utf-8") as f:
                 data = json.load(f)
 
             # Load records
@@ -121,7 +121,7 @@ class LearningStore:
 
         try:
             validated_path = _validate_file_path(str(self.file_path))
-            with validated_path.open("w") as f:
+            with validated_path.open("w", encoding="utf-8") as f:
                 json.dump(data, f, indent=2)
             self._dirty = False
             logger.info(f"Saved learning data to {validated_path}")

--- a/src/attune/pattern_persistence.py
+++ b/src/attune/pattern_persistence.py
@@ -71,7 +71,7 @@ class PatternPersistence:
 
         # Write to file
         validated_path = _validate_file_path(filepath)
-        with open(validated_path, "w") as f:
+        with open(validated_path, "w", encoding="utf-8") as f:
             json.dump(data, f, indent=2)
 
     @staticmethod

--- a/src/attune/state_manager.py
+++ b/src/attune/state_manager.py
@@ -106,7 +106,7 @@ class StateManager:
         }
 
         validated_path = _validate_file_path(str(filepath))
-        with open(validated_path, "w") as f:
+        with open(validated_path, "w", encoding="utf-8") as f:
             json.dump(data, f, indent=2)
 
     def load_state(self, user_id: str) -> CollaborationState | None:

--- a/src/attune/template_engine.py
+++ b/src/attune/template_engine.py
@@ -108,15 +108,15 @@ def scaffold_project(
             gitignore_path = target / ".gitignore"
             validated_gitignore = _validate_file_path(str(gitignore_path))
             if validated_gitignore.exists():
-                with open(validated_gitignore, "a") as f:
+                with open(validated_gitignore, "a", encoding="utf-8") as f:
                     f.write("\n" + actual_content)
             else:
-                with open(validated_gitignore, "w") as f:
+                with open(validated_gitignore, "w", encoding="utf-8") as f:
                     f.write(actual_content)
             created_files.append(".gitignore")
         else:
             validated_path = _validate_file_path(str(full_path))
-            with open(validated_path, "w") as f:
+            with open(validated_path, "w", encoding="utf-8") as f:
                 f.write(actual_content)
             created_files.append(actual_path)
 

--- a/src/attune/test_generator/__init__.py
+++ b/src/attune/test_generator/__init__.py
@@ -19,7 +19,7 @@ Usage:
     )
 
     # Write tests to file
-    with open("test_soap_note.py", "w") as f:
+    with open("test_soap_note.py", "w", encoding="utf-8") as f:
         f.write(tests["unit"])
 
 Copyright 2025 Smart AI Memory, LLC

--- a/src/attune/test_generator/cli.py
+++ b/src/attune/test_generator/cli.py
@@ -152,7 +152,7 @@ def cmd_analyze(args):
         json_output = analysis.to_dict()
         json_file = Path(f"{workflow_id}_risk_analysis.json")
         validated_json = _validate_file_path(str(json_file))
-        with open(validated_json, "w") as f:
+        with open(validated_json, "w", encoding="utf-8") as f:
             json.dump(json_output, f, indent=2)
         print(f"\n✓ JSON output written to: {validated_json}")
 

--- a/src/attune/vscode_bridge.py
+++ b/src/attune/vscode_bridge.py
@@ -112,7 +112,7 @@ def write_code_review_results(
     output_path = get_empathy_dir() / "code-review-results.json"
     validated_path = _validate_file_path(str(output_path))
 
-    with open(validated_path, "w") as f:
+    with open(validated_path, "w", encoding="utf-8") as f:
         json.dump(asdict(result), f, indent=2)
 
     return output_path

--- a/src/attune/wizards/config_driven.py
+++ b/src/attune/wizards/config_driven.py
@@ -243,7 +243,7 @@ class ConfigDrivenWizard(BaseWizard):
 
         data = self._to_dict()
         try:
-            with validated.open("w") as f:
+            with validated.open("w", encoding="utf-8") as f:
                 yaml.safe_dump(data, f, default_flow_style=False, sort_keys=False)
         except PermissionError as e:
             logger.error("Permission denied writing wizard to %s: %s", validated, e)

--- a/src/attune/wizards/registry.py
+++ b/src/attune/wizards/registry.py
@@ -123,7 +123,7 @@ def save_custom_wizard(wizard_data: dict[str, Any], base_dir: str | None = None)
     validated = _validate_file_path(str(output_path))
 
     try:
-        with validated.open("w") as f:
+        with validated.open("w", encoding="utf-8") as f:
             yaml.safe_dump(wizard_data, f, default_flow_style=False, sort_keys=False)
     except PermissionError as e:
         logger.error("Permission denied writing wizard to %s: %s", validated, e)

--- a/src/attune/workflows/batch_processing.py
+++ b/src/attune/workflows/batch_processing.py
@@ -324,7 +324,7 @@ class BatchProcessingWorkflow:
 
         path = Path(output_path)
         validated_path = _validate_file_path(str(path))
-        with open(validated_path, "w") as f:
+        with open(validated_path, "w", encoding="utf-8") as f:
             json.dump(output_data, f, indent=2)
 
         logger.info(f"Results saved to {validated_path}")

--- a/src/attune/workflows/config.py
+++ b/src/attune/workflows/config.py
@@ -447,10 +447,10 @@ class WorkflowConfig:
         if validated_path.suffix in (".yaml", ".yml"):
             if not YAML_AVAILABLE:
                 raise ImportError("PyYAML required for YAML config")
-            with open(validated_path, "w") as f:
+            with open(validated_path, "w", encoding="utf-8") as f:
                 yaml.dump(data, f, default_flow_style=False)
         else:
-            with open(validated_path, "w") as f:
+            with open(validated_path, "w", encoding="utf-8") as f:
                 json.dump(data, f, indent=2)
 
 

--- a/src/attune/workflows/health_check_tracking.py
+++ b/src/attune/workflows/health_check_tracking.py
@@ -39,7 +39,7 @@ def get_trend_comparison(
 
     # Read last score from history
     try:
-        with history_file.open("r") as f:
+        with history_file.open("r", encoding="utf-8") as f:
             lines = f.readlines()
             if len(lines) < 2:
                 return "First baseline established"
@@ -76,7 +76,7 @@ def save_tracking_history(
 
     try:
         # Append to history file (JSONL format)
-        with history_file.open("a") as f:
+        with history_file.open("a", encoding="utf-8") as f:
             entry = {
                 "timestamp": report.timestamp,
                 "mode": report.mode,
@@ -174,7 +174,7 @@ def save_health_json(
 
         # Write health.json
         validated_health_file = _validate_file_path(str(health_file))
-        with validated_health_file.open("w") as f:
+        with validated_health_file.open("w", encoding="utf-8") as f:
             json.dump(health_data, f, indent=2)
 
         logger.info("Saved health data to %s for VS Code extension", validated_health_file)

--- a/src/attune/workflows/history_utils.py
+++ b/src/attune/workflows/history_utils.py
@@ -167,7 +167,7 @@ def _save_workflow_run(
     history = history[-max_history:]
 
     validated_path = _validate_file_path(str(path))
-    with open(validated_path, "w") as f:
+    with open(validated_path, "w", encoding="utf-8") as f:
         json.dump(history, f, indent=2)
 
 

--- a/src/attune/workflows/migration.py
+++ b/src/attune/workflows/migration.py
@@ -123,7 +123,7 @@ class MigrationConfig:
         config_path = config_dir / "migration.json"
 
         try:
-            with config_path.open("w") as f:
+            with config_path.open("w", encoding="utf-8") as f:
                 json.dump(
                     {
                         "mode": self.mode,

--- a/src/attune/workflows/progress_reporters.py
+++ b/src/attune/workflows/progress_reporters.py
@@ -184,7 +184,7 @@ class JsonLinesProgressReporter:
         json_line = update.to_json()
 
         if self.output_file:
-            with open(self.output_file, "a") as f:
+            with open(self.output_file, "a", encoding="utf-8") as f:
                 f.write(json_line + "\n")
         else:
             print(json_line)

--- a/src/attune/workflows/progressive/telemetry.py
+++ b/src/attune/workflows/progressive/telemetry.py
@@ -240,7 +240,7 @@ class ProgressiveTelemetry:
                 **data,
             }
 
-            with events_file.open("a") as f:
+            with events_file.open("a", encoding="utf-8") as f:
                 f.write(json.dumps(event) + "\n")
 
         except Exception as e:  # noqa: BLE001

--- a/src/attune/workflows/tier_tracking.py
+++ b/src/attune/workflows/tier_tracking.py
@@ -297,7 +297,7 @@ class WorkflowTierTracker:
             # Save to individual pattern file
             pattern_file = self.patterns_dir / f"{progression['pattern_id']}.json"
             validated_pattern_file = _validate_file_path(str(pattern_file))
-            with open(validated_pattern_file, "w") as f:
+            with open(validated_pattern_file, "w", encoding="utf-8") as f:
                 json.dump(progression, f, indent=2)
 
             logger.info(f"💾 Saved tier progression: {validated_pattern_file}")
@@ -468,7 +468,7 @@ class WorkflowTierTracker:
 
             # Save updated file
             validated_consolidated = _validate_file_path(str(consolidated_file))
-            with open(validated_consolidated, "w") as f:
+            with open(validated_consolidated, "w", encoding="utf-8") as f:
                 json.dump(data, f, indent=2)
 
         except (OSError, ValueError, json.JSONDecodeError) as e:
@@ -477,7 +477,7 @@ class WorkflowTierTracker:
             try:
                 data = {"patterns": [progression]}
                 validated_consolidated = _validate_file_path(str(consolidated_file))
-                with open(validated_consolidated, "w") as f:
+                with open(validated_consolidated, "w", encoding="utf-8") as f:
                     json.dump(data, f, indent=2)
                 logger.info("Recreated consolidated patterns file")
             except (OSError, ValueError) as e2:


### PR DESCRIPTION
`platform-compat` was a required check that **could not fail**, twice over.

1. Its final step ended `continue-on-error: true` and emitted a `::warning::` instead of exiting non-zero.
2. And — the part that makes the obvious fix a no-op — the scanner's **only** `severity="error"` rule was `scan_error` ("could not scan file"). Every actual platform-compatibility finding was a `warning`, and the step gated on the error count.

So deleting `continue-on-error` alone would have produced a check that still only went red if the scanner *crashed*, while now **looking** enforced. A gate has two halves; repairing one while the other is broken is a downgrade, because it stops inviting scrutiny.

Meanwhile the scanner had found **66 real portability hazards** and been reporting them into a void.

## Encoding first

Per the agreed sequence — narrow gate now, ratchet the rest separately.

**Fixed all 44 `open()` calls missing an explicit encoding.** On Windows, a text-mode `open()` without `encoding=` uses the locale codepage (typically cp1252), not UTF-8. That's the highest-yield source of Windows-only breakage in this repo — same family as the `_atomic_write` LF/CRLF bug already in the lessons corpus.

All 44 were single-line text mode (zero binary), fixed by paren-matched insertion rather than a regex, and every touched file re-parsed via `ast.parse`.

**Promoted `missing_encoding` to `error`** so the rule can fail the build, and **replaced the warn-and-exit-0 step** with one that exits 1 and emits `::error file=,line=` annotations. Warnings still report as `::notice::` without failing.

## Proof it fires, not just that it's armed

Dropped a canary into `src/`:

```python
with open(path, "r") as fh:
```

| | |
|---|---|
| Canary present | **1 error** — named the exact file and line |
| Canary removed | 0 errors |

The previous version of this job would have called that canary green. That step is the difference between *armed* and *believed to be armed*.

## Receipts

- 66 → 22 warnings; **0 errors** with the rule promoted, so the gate arms clean
- **5144 tests pass** across workflows / orchestration / memory / metrics (46 min), plus 861 in ci/config/wizards and 328 workflow-guard tests
- `ruff` + pinned `black` clean; `check-yaml` passes

## Deliberately left

The remaining 22 warnings — 15 hardcoded home paths, 7 hardcoded `/etc` `/tmp` `/var/log` `/home`. They can't be mechanically cleared to zero the way encoding could, so they need **fail-on-new against a committed baseline**, not promotion. That's the follow-up ratchet PR, which lands after this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)