### PR TITLE
ci(platform-compat): ratchet the remaining warnings — fail on new, shrink on fixed

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -537,6 +537,19 @@ jobs:
             sys.exit(1)
         EOF
 
+    # The ratchet. The 22 pre-existing warnings (hardcoded home/etc/tmp
+    # paths) cannot be mechanically cleared the way the encoding errors
+    # were, so they are ACCEPTED in `.platform-compat-baseline.json` and
+    # anything beyond them fails. Keyed on file+category rather than line,
+    # so moving code never trips it — a baseline that cries wolf gets
+    # regenerated reflexively, which is the same as not having one.
+    #
+    # Fixing warnings is reported as an improvement, not a failure, with
+    # the command to shrink the baseline. CI never regenerates it: a
+    # self-updating baseline accepts every regression it exists to catch.
+    - name: No new cross-platform warnings (ratchet)
+      run: python scripts/check_platform_compat.py src/ --baseline
+
   code-quality:
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/.platform-compat-baseline.json
+++ b/.platform-compat-baseline.json
@@ -1,0 +1,16 @@
+{
+  "src/attune/config/loader.py::hardcoded_path": 3,
+  "src/attune/config/sections/persistence.py::hardcoded_path": 6,
+  "src/attune/config/sections/telemetry.py::hardcoded_path": 2,
+  "src/attune/help/session.py::hardcoded_path": 1,
+  "src/attune/hooks/scripts/worktree_path_guard.py::hardcoded_path": 1,
+  "src/attune/llm/core.py::hardcoded_path": 1,
+  "src/attune/memory/claude_memory.py::hardcoded_path": 1,
+  "src/attune/memory/redis_bootstrap.py::hardcoded_path": 1,
+  "src/attune/ops/routes/pending_writes.py::hardcoded_path": 1,
+  "src/attune/ops/session_redaction.py::hardcoded_path": 1,
+  "src/attune/platform_utils.py::hardcoded_path": 1,
+  "src/attune/roundtable/solutions.py::hardcoded_path": 1,
+  "src/attune/telemetry/usage_ping.py::hardcoded_path": 1,
+  "src/attune/workflows/rag_code_gen.py::hardcoded_path": 1
+}

--- a/scripts/check_platform_compat.py
+++ b/scripts/check_platform_compat.py
@@ -270,6 +270,58 @@ def format_json_report(result: ScanResult) -> str:
     )
 
 
+#: Default location of the accepted-warning baseline. Root-level, matching
+#: the `.secrets.baseline` convention already used here.
+DEFAULT_BASELINE = ".platform-compat-baseline.json"
+
+
+def baseline_key(issue: "Issue") -> str:
+    """Stable key for a warning: file + category, NOT line.
+
+    Line numbers shift whenever anything above them moves, so keying on
+    them would make the baseline fail on unrelated edits — noise that
+    trains people to regenerate it reflexively, which defeats the gate.
+    File+category with a count is stable under reformatting and still
+    catches "this file grew a new hardcoded path".
+    """
+    return f"{issue.file}::{issue.category}"
+
+
+def build_baseline(result: "ScanResult") -> dict[str, int]:
+    """Count current warnings per file+category."""
+    counts: dict[str, int] = {}
+    for issue in result.issues:
+        if issue.severity != "warning":
+            continue
+        counts[baseline_key(issue)] = counts.get(baseline_key(issue), 0) + 1
+    return dict(sorted(counts.items()))
+
+
+def compare_to_baseline(
+    result: "ScanResult", baseline: dict[str, int]
+) -> tuple[list[str], list[str]]:
+    """Return (regressions, improvements) against ``baseline``.
+
+    A regression is a file+category with MORE warnings than accepted, or
+    one absent from the baseline entirely. An improvement is one with
+    fewer — reported so the baseline can be shrunk and the debt actually
+    ratchets down instead of being frozen forever.
+    """
+    current = build_baseline(result)
+    regressions = []
+    for key, count in sorted(current.items()):
+        accepted = baseline.get(key, 0)
+        if count > accepted:
+            where = "new" if key not in baseline else f"was {accepted}"
+            regressions.append(f"{key}: {count} ({where})")
+    improvements = []
+    for key, accepted in sorted(baseline.items()):
+        count = current.get(key, 0)
+        if count < accepted:
+            improvements.append(f"{key}: {count} (baseline allows {accepted})")
+    return regressions, improvements
+
+
 def main() -> int:
     """Main entry point."""
     parser = argparse.ArgumentParser(
@@ -302,6 +354,21 @@ def main() -> int:
         default=[],
         help="Additional directories to exclude",
     )
+    parser.add_argument(
+        "--baseline",
+        nargs="?",
+        const=DEFAULT_BASELINE,
+        help=(
+            "Compare warnings against a baseline file and exit 1 on any "
+            f"regression (default path: {DEFAULT_BASELINE})"
+        ),
+    )
+    parser.add_argument(
+        "--update-baseline",
+        nargs="?",
+        const=DEFAULT_BASELINE,
+        help="Write the current warnings as the accepted baseline",
+    )
 
     args = parser.parse_args()
 
@@ -332,11 +399,56 @@ def main() -> int:
     else:
         print(format_text_report(result, show_suggestions=args.fix))
 
+    # Write the baseline and stop — this is the "shrink it" path, run by
+    # hand after fixing warnings, never automatically in CI (a baseline
+    # that regenerates itself accepts every regression it was meant to
+    # catch).
+    if args.update_baseline:
+        path = Path(args.update_baseline)
+        counts = build_baseline(result)
+        path.write_text(json.dumps(counts, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        total = sum(counts.values())
+        print(f"wrote {path} — {total} accepted warning(s) across {len(counts)} file/category")
+        return 0
+
+    exit_code = 0
+
+    if args.baseline:
+        path = Path(args.baseline)
+        if not path.exists():
+            print(f"Error: baseline '{path}' does not exist", file=sys.stderr)
+            print(
+                "Create it with --update-baseline once the current state is accepted.",
+                file=sys.stderr,
+            )
+            return 1
+        try:
+            baseline = json.loads(path.read_text(encoding="utf-8"))
+        except ValueError as exc:
+            print(f"Error: baseline '{path}' is not valid JSON: {exc}", file=sys.stderr)
+            return 1
+        regressions, improvements = compare_to_baseline(result, baseline)
+        if improvements:
+            print(f"\n{len(improvements)} file/category improved since the baseline:")
+            for line in improvements:
+                print(f"  - {line}")
+            print(f"Shrink it: python {sys.argv[0]} {args.path} --update-baseline")
+        if regressions:
+            print(f"\nNEW cross-platform warnings not in the baseline ({len(regressions)}):")
+            for line in regressions:
+                print(f"  - {line}")
+            print("\nFix them, or accept them deliberately with --update-baseline.")
+            exit_code = 1
+        else:
+            print("\nNo new cross-platform warnings.")
+
     # Exit code
     if args.strict and (result.errors > 0 or result.warnings > 0):
         return 1
+    if result.errors > 0:
+        return 1
 
-    return 0
+    return exit_code
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Completes the encoding-first sequence. #1663 made the gate real for `missing_encoding` by clearing all 44 instances and promoting the rule to `error`. The other **22 warnings** — 15 hardcoded home paths, 7 hardcoded `/etc` `/tmp` `/var/log` `/home` — can't be mechanically cleared to zero, so promoting them would just paint CI red. They get a baseline instead.

## How it works

- **`.platform-compat-baseline.json`** records the 22 accepted warnings across 14 file/category pairs.
- **`--baseline [path]`** exits 1 on any file/category with *more* warnings than accepted, or absent from the baseline entirely.
- **`--update-baseline [path]`** rewrites it. Run by hand, **never in CI** — a baseline that regenerates itself accepts every regression it exists to catch.
- **Fixing a warning is an improvement, not a failure.** It reports the shrink command. Without that the debt freezes at its starting size and the ratchet only turns one way.

## Why file+category, not line

Line numbers shift when anything above them moves, so a line-keyed baseline fails on unrelated edits. That noise trains people to regenerate reflexively — which is the same as having no gate. File+category with a count is stable under reformatting and still catches *"this file grew a new hardcoded path"*.

## Proof it fires

Three canaries, each reverted and the clean run re-confirmed afterward:

| Canary | Result |
|---|---|
| New file with a hardcoded path | **exit 1** — `_ratchet_canary.py::hardcoded_path: 1 (new)` |
| Extra warning in an already-baselined file | **exit 1** — `platform_utils.py::hardcoded_path: 2 (was 1)` |
| A warning **fixed** | **exit 0** + `improved since the baseline` + shrink command |

The third is the one a ratchet usually gets wrong. Re-verified clean at exit 0 after `black` reformatted the script, too — the check survives its own formatter.

## Receipts

328 workflow-guard tests pass; `ruff` + pinned `black` clean; `check-yaml` passes; the six-step `platform-compat` job parses.

## Where this leaves the gate

`platform-compat` went from a required check that **structurally could not fail** — `continue-on-error: true`, and no rule emitting `error` anyway — to one that fails on any encoding regression and any *new* hardcoded path, with a documented path to shrink the accepted debt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)