### PR TITLE
ci(platform-compat): scan code, not prose — baseline 22 → 4

### DIFF
--- a/.platform-compat-baseline.json
+++ b/.platform-compat-baseline.json
@@ -1,16 +1,6 @@
 {
-  "src/attune/config/loader.py::hardcoded_path": 3,
-  "src/attune/config/sections/persistence.py::hardcoded_path": 6,
-  "src/attune/config/sections/telemetry.py::hardcoded_path": 2,
-  "src/attune/help/session.py::hardcoded_path": 1,
-  "src/attune/hooks/scripts/worktree_path_guard.py::hardcoded_path": 1,
-  "src/attune/llm/core.py::hardcoded_path": 1,
   "src/attune/memory/claude_memory.py::hardcoded_path": 1,
-  "src/attune/memory/redis_bootstrap.py::hardcoded_path": 1,
   "src/attune/ops/routes/pending_writes.py::hardcoded_path": 1,
   "src/attune/ops/session_redaction.py::hardcoded_path": 1,
-  "src/attune/platform_utils.py::hardcoded_path": 1,
-  "src/attune/roundtable/solutions.py::hardcoded_path": 1,
-  "src/attune/telemetry/usage_ping.py::hardcoded_path": 1,
-  "src/attune/workflows/rag_code_gen.py::hardcoded_path": 1
+  "src/attune/platform_utils.py::hardcoded_path": 1
 }

--- a/scripts/check_platform_compat.py
+++ b/scripts/check_platform_compat.py
@@ -24,9 +24,12 @@ Licensed under the Apache License, Version 2.0
 """
 
 import argparse
+import ast
+import io
 import json
 import re
 import sys
+import tokenize
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -70,8 +73,77 @@ HARDCODED_PATHS = [
     (r'["\']\/tmp\/', "Hardcoded /tmp path"),
     (r'["\']\/etc\/', "Hardcoded /etc path"),
     (r'["\']\/home\/', "Hardcoded /home path"),
-    (r'["\']~\/', "Hardcoded home directory path"),
 ]
+
+#: A ``~/…`` literal is NOT a cross-platform defect on its own —
+#: ``expanduser()`` resolves it on every platform, Windows included, and
+#: ``"~/.attune/x"`` + ``.expanduser()`` is this repo's portable idiom (and
+#: was 15 of the 22 warnings the first baseline froze). It is a bug only
+#: when handed straight to a filesystem call unexpanded, which fails
+#: everywhere including Linux. So the rule fires on that COMBINATION,
+#: never on the literal.
+TILDE_LITERAL = re.compile(r'["\']~[\\/]')
+FILESYSTEM_CALL = re.compile(
+    r"\b(?:open|Path|PurePath|io\.open|os\.\w+|os\.path\.\w+|shutil\.\w+)\s*\(",
+)
+
+
+def docstring_line_numbers(content: str) -> set[int]:
+    """1-based line numbers occupied by module/class/function docstrings."""
+    try:
+        tree = ast.parse(content)
+    except (SyntaxError, ValueError):
+        return set()
+
+    numbers: set[int] = set()
+    for node in ast.walk(tree):
+        if not isinstance(
+            node,
+            (ast.Module, ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef),
+        ):
+            continue
+        body = getattr(node, "body", None)
+        if not body:
+            continue
+        first = body[0]
+        if (
+            isinstance(first, ast.Expr)
+            and isinstance(first.value, ast.Constant)
+            and isinstance(first.value.value, str)
+        ):
+            numbers.update(range(first.lineno, (first.end_lineno or first.lineno) + 1))
+    return numbers
+
+
+def code_lines(content: str) -> list[str]:
+    """Split ``content`` into lines with comments and docstrings blanked.
+
+    A scanner that matches prose reports the CODE COMMENT WARNING ABOUT a
+    hardcoded path as a hardcoded path — four of the first baseline's 22
+    entries were exactly that, including a comment explaining a Windows
+    path bug. Blanking keeps line numbers intact so reported lines still
+    point at the real source.
+    """
+    lines = content.split("\n")
+
+    try:
+        for token in tokenize.generate_tokens(io.StringIO(content).readline):
+            if token.type != tokenize.COMMENT:
+                continue
+            row, col = token.start
+            if 1 <= row <= len(lines):
+                lines[row - 1] = lines[row - 1][:col]
+    except (tokenize.TokenError, IndentationError, SyntaxError):
+        # Unparseable file — fall back to the raw lines rather than
+        # silently scanning nothing.
+        lines = content.split("\n")
+
+    for row in docstring_line_numbers(content):
+        if 1 <= row <= len(lines):
+            lines[row - 1] = ""
+
+    return lines
+
 
 OPEN_WITHOUT_ENCODING = re.compile(
     r"\bopen\s*\([^)]*\)\s*(?:as\s+\w+)?(?!\s*#.*encoding)",
@@ -90,7 +162,9 @@ def scan_file(filepath: Path, result: ScanResult) -> None:
     """Scan a single Python file for compatibility issues."""
     try:
         content = filepath.read_text(encoding="utf-8")
-        lines = content.split("\n")
+        # Comments and docstrings are prose, not code — scanning them
+        # reports discussion of a defect as the defect itself.
+        lines = code_lines(content)
         relative_path = str(filepath)
 
         # Check for hardcoded paths
@@ -107,15 +181,27 @@ def scan_file(filepath: Path, result: ScanResult) -> None:
                             suggestion="Use attune.platform_utils for platform-appropriate paths",
                         ),
                     )
+            if (
+                TILDE_LITERAL.search(line)
+                and FILESYSTEM_CALL.search(line)
+                and "expanduser" not in line
+            ):
+                result.add_issue(
+                    Issue(
+                        file=relative_path,
+                        line=line_num,
+                        category="hardcoded_path",
+                        message="Unexpanded '~' passed to a filesystem call",
+                        severity="warning",
+                        suggestion='Wrap it: Path("~/…").expanduser()',
+                    ),
+                )
 
         # Check for open() without encoding
         for line_num, line in enumerate(lines, 1):
             if "open(" in line and "encoding" not in line:
                 # Skip binary mode opens
                 if "'rb'" in line or '"rb"' in line or "'wb'" in line or '"wb"' in line:
-                    continue
-                # Skip if it's a comment
-                if line.strip().startswith("#"):
                     continue
                 # Check if it's a text mode open
                 if (

--- a/tests/unit/ci/test_platform_compat_scanner.py
+++ b/tests/unit/ci/test_platform_compat_scanner.py
@@ -1,0 +1,130 @@
+"""Regression guards for scripts/check_platform_compat.py's scan rules.
+
+The checker gates `platform-compat`, a required check. Its first baseline
+froze 22 "accepted warnings" of which 18 were false positives in three
+classes — prose (comments/docstrings) matched as code, and portable
+`~/…` + `expanduser()` literals matched as hardcoded paths. A ratchet
+whose baseline is noise trains people to ignore it, so each class gets a
+test that fails if the false positive returns, paired with a test that
+the corresponding TRUE positive still fires.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def checker():
+    """Load scripts/check_platform_compat.py as a module."""
+    repo_root = Path(__file__).resolve().parents[3]
+    script = repo_root / "scripts" / "check_platform_compat.py"
+    spec = importlib.util.spec_from_file_location("_check_platform_compat", script)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["_check_platform_compat"] = module
+    spec.loader.exec_module(module)
+    yield module
+    sys.modules.pop("_check_platform_compat", None)
+
+
+def scan_source(checker, tmp_path: Path, source: str):
+    """Scan ``source`` as a file and return the ScanResult."""
+    target = tmp_path / "sample.py"
+    target.write_text(source, encoding="utf-8")
+    result = checker.ScanResult()
+    checker.scan_file(target, result)
+    return result
+
+
+def messages(result, severity: str) -> list[str]:
+    return [i.message for i in result.issues if i.severity == severity]
+
+
+# --- Class 1: prose is not code -------------------------------------
+
+
+def test_comment_mentioning_unix_path_is_not_a_warning(checker, tmp_path: Path) -> None:
+    """A comment EXPLAINING a path bug is not the bug."""
+    result = scan_source(
+        checker,
+        tmp_path,
+        '# On Windows, Path("/etc/passwd").is_absolute() is False.\nX = 1\n',
+    )
+    assert messages(result, "warning") == []
+
+
+def test_docstring_example_is_not_a_warning(checker, tmp_path: Path) -> None:
+    """A docstring usage example is documentation, not a hardcoded path."""
+    result = scan_source(
+        checker,
+        tmp_path,
+        'def f():\n    """Configure it.\n\n    >>> f(log_dir="/var/log/empathy")\n    """\n',
+    )
+    assert messages(result, "warning") == []
+
+
+def test_trailing_comment_does_not_mask_real_code(checker, tmp_path: Path) -> None:
+    """Blanking a trailing comment must leave the code on that line scanned."""
+    result = scan_source(checker, tmp_path, 'P = "/tmp/real"  # a comment about /etc/\n')
+    assert messages(result, "warning") == ["Hardcoded /tmp path"]
+
+
+def test_real_hardcoded_path_still_warns(checker, tmp_path: Path) -> None:
+    """The rule is narrowed, not neutered."""
+    result = scan_source(checker, tmp_path, 'LOG = Path("/var/log/attune")\n')
+    assert messages(result, "warning") == ["Hardcoded /var/log path"]
+
+
+# --- Class 2: `~/` is portable when expanded ------------------------
+
+
+def test_expanded_tilde_is_not_a_warning(checker, tmp_path: Path) -> None:
+    """`Path("~/x").expanduser()` is the portable idiom, Windows included."""
+    result = scan_source(
+        checker,
+        tmp_path,
+        'F = Path("~/.attune/session.json").expanduser()\n',
+    )
+    assert messages(result, "warning") == []
+
+
+def test_tilde_config_default_is_not_a_warning(checker, tmp_path: Path) -> None:
+    """A bare `~/…` default is expanded at consumption, not here."""
+    result = scan_source(checker, tmp_path, 'memory_path: str = "~/.attune/memory"\n')
+    assert messages(result, "warning") == []
+
+
+def test_unexpanded_tilde_in_filesystem_call_warns(checker, tmp_path: Path) -> None:
+    """The true positive: `~` handed to a filesystem call fails everywhere."""
+    result = scan_source(checker, tmp_path, 'data = open("~/.attune/x", "r").read()\n')
+    assert "Unexpanded '~' passed to a filesystem call" in messages(result, "warning")
+
+
+# --- The encoding gate must survive the masking ---------------------
+
+
+def test_open_without_encoding_still_errors(checker, tmp_path: Path) -> None:
+    """Masking prose must not blank real code and hide the error gate."""
+    result = scan_source(checker, tmp_path, 'with open(p, "w") as fh:\n    fh.write("x")\n')
+    assert messages(result, "error") == ["open() without encoding specified"]
+
+
+def test_open_inside_docstring_is_not_an_error(checker, tmp_path: Path) -> None:
+    """An `open()` in a usage example is prose."""
+    result = scan_source(
+        checker,
+        tmp_path,
+        'def f():\n    """Read it.\n\n    >>> open(p, "r")\n    """\n',
+    )
+    assert messages(result, "error") == []
+
+
+def test_unparseable_file_falls_back_to_raw_lines(checker, tmp_path: Path) -> None:
+    """A syntax error must not silently disable scanning of the file."""
+    result = scan_source(checker, tmp_path, 'def broken(\nP = "/tmp/x"\n')
+    assert messages(result, "warning") == ["Hardcoded /tmp path"]


### PR DESCRIPTION
## Why

The `platform-compat` ratchet shipped in #1664 with a baseline of 22
accepted warnings. Before fixing any of them, I read all 22 — **18 are
false positives**, and "fixing" them would have made the code worse
(deleting a comment that explains a Windows bug, or rewriting the
portable `expanduser()` idiom).

A ratchet whose entire baseline is noise trains you to ignore it. That
is the same failure #1663 was written to remove.

## What changed

Two scanner defects, three false-positive classes:

**1. Prose scanned as code (4).** Comments and docstrings were matched
as source. A comment *explaining* the `Path("/etc/passwd")` Windows
bug was reported as a hardcoded `/etc` path; a docstring example was
reported as a hardcoded `/var/log` path. Comments and docstrings are
now blanked via `tokenize` + `ast` before matching, preserving line
numbers so reports still point at real source. Unparseable files fall
back to raw lines rather than silently scanning nothing.

**2. `~/` treated as non-portable (15).** It isn't — `expanduser()`
resolves `~` on every platform including Windows, and `"~/.attune/x"`
+ `.expanduser()` is this repo's portable idiom. The literal is a
defect only when handed to a filesystem call *unexpanded*, which fails
everywhere, not just on Windows. The rule now fires on that
combination rather than on the literal.

## Baseline: 22 → 4

The four that remain are genuinely deliberate Unix-specific code:

| File | Why it stays |
|---|---|
| `platform_utils.py:53` | inside the Linux branch of a platform switch |
| `session_redaction.py:123` | a regex that must literally match `/home/<user>` to redact it |
| `claude_memory.py:158` | guarded Unix-only `/etc/claude` fallback |
| `pending_writes.py:136` | tmp-prefix filter tuple, already `# nosec` |

## Receipts

- **Warnings 22 → 4; errors still 0.**
- **The gate still bites** — dropped a probe file with a hardcoded
  `/tmp` path into `src/`: exits 1 and names it as `(new)`. Probe
  removed.
- **10 regression tests** (`tests/unit/ci/test_platform_compat_scanner.py`),
  each false-positive class paired with its true positive, plus one
  asserting the masking does not blank real code and hide the
  `open()`-without-encoding **error** gate, and one that a trailing
  comment does not mask code on the same line.
- Existing `tests/core/test_platform_compat_ci.py` + `tests/unit/ci/`:
  342 passed.

No CI wiring change — the ratchet step already invokes the default
baseline path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
