### PR TITLE
docs(spec): memory-claim-verification — derive, don't store

### DIFF
--- a/docs/specs/memory-claim-verification/decisions.md
+++ b/docs/specs/memory-claim-verification/decisions.md
@@ -1,0 +1,72 @@
+# memory-claim-verification — decisions
+
+## D1 (2026-07-26): the extraction prompt is NOT the control
+
+**Ruled.** The prompt already carries a PROVENANCE rule instructing the
+model to record only what the session concluded. Both bad findings on
+2026-07-25 violated it anyway.
+
+Tightening the prompt, or making `/recall review` mandatory, were both
+considered and REJECTED as patches:
+
+- Prompt-tightening leaves an 8B model writing unverified assertions,
+  just fewer of them. The failing component cannot be its own control.
+- Mandatory review adds friction to every session to catch a minority of
+  bad records — and `/recall review` already exists and is not run, which
+  is the empirical answer to whether more optional review works.
+
+Verification must live **outside** the model, in code that resolves
+entities against ground truth.
+
+## D2 (2026-07-26): apply the claim-drift architecture, don't invent one
+
+**Ruled.** The claim-drift gate and the capability projector both refuse
+to trust a written value and derive it from a live source. Both caught
+real drift on 2026-07-25. The memory store is the last surface in the
+repo still trusting written prose about mutable state.
+
+This spec is therefore **not a new technique** — it is the existing
+derive-don't-store discipline applied to `session_stash`. Design reviews
+should check consistency with those two mechanisms before adding
+machinery.
+
+## D3 (2026-07-26): read-time annotation ships first and alone
+
+**Ruled.** P1 (refs + read-time re-resolution) is independently
+shippable, carries no write-path risk, requires no model change, and
+catches the motivating failure. Seeing `⟨pr:1666 → MERGED⟩` beside "open
+for reviewing" defeats the bad finding **without any natural-language
+understanding**.
+
+Write-time rejection (P2) is strictly more invasive and depends on OQ1.
+Do not bundle them.
+
+## D4 (2026-07-26): unreachable is never contradicted
+
+**Ruled.** A resolver that cannot reach `gh`, git, or the filesystem must
+store the finding ungrounded, never reject it. The memory layer degrades
+silently and never blocks a session — this is existing contract, restated
+here because a verification step is exactly where it would be broken.
+
+## D5 (2026-07-26): the golden set pins BOTH directions
+
+**Ruled.** The acceptance test replays all four real 2026-07-25 findings
+and requires the two bad ones to be caught **and the two good ones to
+survive**. A change that rejects everything is as wrong as one that
+accepts everything.
+
+Same discipline as `tests/unit/ci/test_platform_compat_scanner.py`, where
+each false-positive class is pinned to its true positive so a later
+re-broadening fails loudly instead of silently refilling the store.
+
+---
+
+## Open, for the chair
+
+- **OQ1** — does `llama3.1:8b` reliably emit `refs`? Measure before
+  building P2; if not, heuristic back-fill from `content` becomes the
+  permanent mechanism and R3 may not be viable.
+- **OQ2** — on contradiction, reject or demote? Proposal: demote to
+  `interpretation` with the contradiction recorded.
+- **OQ3** — should a grounded finding outlive the 30-day TTL? Changes the
+  store's character from working-memory to durable.

--- a/docs/specs/memory-claim-verification/decisions.md
+++ b/docs/specs/memory-claim-verification/decisions.md
@@ -63,10 +63,78 @@ re-broadening fails loudly instead of silently refilling the store.
 
 ## Open, for the chair
 
-- **OQ1** — does `llama3.1:8b` reliably emit `refs`? Measure before
-  building P2; if not, heuristic back-fill from `content` becomes the
-  permanent mechanism and R3 may not be viable.
+- **OQ1 — MEASURED 2026-07-26. Answer: NO, and neither does the
+  fallback.** See "OQ1 measurement" below. Awaiting a chair ruling on
+  the mechanism.
 - **OQ2** — on contradiction, reject or demote? Proposal: demote to
   `interpretation` with the contradiction recorded.
 - **OQ3** — should a grounded finding outlive the 30-day TTL? Changes the
   store's character from working-memory to durable.
+
+---
+
+## OQ1 measurement — 2026-07-26
+
+Harness: `scripts/measure_stash_refs.py`. Replays real session
+transcripts through the REAL tail extractor
+(`plugin/hooks/session_stash.py::_read_transcript_tail`) and the REAL
+Ollama call, with the shipped prompt plus a minimal `refs` clause —
+measuring the model, not prompt craft.
+
+| Metric | n=18 (>20 KB) | n=12 (>200 KB) |
+|---|---|---|
+| JSON parse ok | 100% | 100% |
+| findings WITH refs | 79.7% | 85.1% |
+| refs well-formed | 81.2% | **56.4%** |
+| refs **grounded in the tail** | **28.1%** | **21.8%** |
+| findings heuristic-backfillable | 10.1% | 8.5% |
+
+"Grounded" = the ref's value literally appears in the transcript the
+model was shown. Ungrounded means fabricated. The check is generous
+(a bare `pr:1666` scores grounded if `1666` appears anywhere).
+
+### Two findings, both decisive
+
+**1. The model emits refs enthusiastically and gets them wrong.**
+~80–85% of findings carry refs, but only ~22–28% of those refs appear
+in the source at all. Restricting to substantial transcripts made it
+WORSE, not better — well-formedness fell to 56%. This is the worst
+possible shape for R3: confident, structured, and fabricated. Verifying
+such claims would mostly verify inventions.
+
+**2. Heuristic back-fill is not a fallback either.** Only ~10% of
+findings contain an entity a regex over `content` could recover. The
+requirements assumed back-fill was the safety net if the model failed.
+It is not — it is a narrow supplement.
+
+Both mechanisms the spec named therefore fail. The premise of OQ1 —
+"if not the model, then heuristics" — was a false dichotomy.
+
+### A third mechanism the spec did not consider
+
+Refs need not come from the model OR from the finding text. The
+transcript's `tool_use` records already contain the session's real
+entities, deterministically extractable. Probed on the newest
+transcript (148 tool_use blocks):
+
+- PR numbers recovered from commands: `1578 1605 1607 1666 1667 1668`
+  — exactly the PRs that session touched, no fabrications
+- the real merge SHA `1f6553edc24d3cf7e8adebb5a853132fa1e332ef`
+- 10 distinct file paths, from `file_path` inputs
+
+These are facts about what the session DID, not prose about what a
+model thinks it did. The hook currently DISCARDS them: `_text_of`
+replaces every `tool_use`/`tool_result` block with
+`[tool output omitted]` (correct for R1 provenance — tool output is not
+speech — but it means the structured facts are thrown away before
+extraction).
+
+**Implication:** derive the session's ref-set deterministically from
+`tool_use` blocks, then attach refs to findings by matching, rather than
+asking the model to author them. This is the same derive-don't-store
+discipline as D2, applied one layer earlier than the spec proposed.
+
+Recommendation to the chair: R3 as written is not viable; replace the
+model-authored `refs` requirement with session-derived refs. The table
+should deliberate HOW findings bind to the derived ref-set, which is a
+real design fork with defensible alternatives.

--- a/docs/specs/memory-claim-verification/decisions.md
+++ b/docs/specs/memory-claim-verification/decisions.md
@@ -138,3 +138,27 @@ Recommendation to the chair: R3 as written is not viable; replace the
 model-authored `refs` requirement with session-derived refs. The table
 should deliberate HOW findings bind to the derived ref-set, which is a
 real design fork with defensible alternatives.
+
+## D6 (2026-07-26): the ref-binding question waits for the table, after the fire
+
+**Ruled (chair).** OQ1's measurement retires R3-as-written but does not
+settle its replacement. The open fork — given refs are deterministically
+derivable from `tool_use` records, how does a finding BIND to them —
+goes to the round table, convened **after** the 07-27 06:00 roundtable
+fire, not before.
+
+Reasons: the fire is the north-star receipt for `agent-round-table` and
+should not share an evening with an exploratory run; the binding question
+blocks nothing until P1 is built; and the table briefs better with a
+clean run to point at, plus the measured numbers already in this file.
+
+The three candidate bindings to put to the table:
+
+1. **Session ref-set on every finding** — cheap, deterministic,
+   imprecise (a finding inherits entities it is not about).
+2. **Per-finding matching** against the derived set — precise, lossy
+   (a finding that names nothing matchable stays ungrounded).
+3. **The SESSION is the grounded unit**, not the finding — sidesteps
+   binding entirely; changes what `grounding` in R4 means.
+
+No implementation starts before that ruling.

--- a/docs/specs/memory-claim-verification/requirements.md
+++ b/docs/specs/memory-claim-verification/requirements.md
@@ -1,6 +1,7 @@
 # memory-claim-verification
 
-**Status:** requirements draft (2026-07-26)
+**Status:** draft (2026-07-26 — requirements; OQ1 measured, R3 retired
+pending the chair ruling in D6)
 **Owner:** Patrick (chair)
 **Origin:** 2026-07-25 session — 2 of 4 auto-stashed findings were wrong
 enough that Patrick had to ask for them to be deleted.

--- a/docs/specs/memory-claim-verification/requirements.md
+++ b/docs/specs/memory-claim-verification/requirements.md
@@ -1,0 +1,211 @@
+# memory-claim-verification
+
+**Status:** requirements draft (2026-07-26)
+**Owner:** Patrick (chair)
+**Origin:** 2026-07-25 session — 2 of 4 auto-stashed findings were wrong
+enough that Patrick had to ask for them to be deleted.
+
+---
+
+## Problem
+
+`plugin/hooks/session_stash.py` runs a local `llama3.1:8b` over the
+transcript tail on every Stop, extracts ≤5 findings, and writes them to a
+30-day store as free prose. `SessionStashEntry` carries `id`,
+`session_id`, `cwd`, `timestamp`, `type`, `content`, `tags` — and **no
+link to the evidence the claim came from, and no verification of any
+kind.**
+
+Measured failure, 2026-07-25 (4 findings written, 2 deleted as wrong):
+
+| Finding | Reality |
+|---|---|
+| `9e140a08` — "PR #1666 is open for reviewing the changes" | #1666 was merged the same session |
+| `203a128d` — "the baseline … led to mistakes in the last two days" | the noisy baseline was found and fixed *before* causing any mistake |
+
+Both survived because nothing checks. `"PR #1666 is open"` and
+`"PR #1666 is merged"` are indistinguishable as strings; only one is
+checkable, and no code checks it.
+
+**Why this is worse than storing nothing.** A wrong memory is recalled
+later wearing the authority of a recorded fact, at a moment when the
+originating context is gone. The existing lesson *"a memory's
+`description:` is the RECALL SURFACE"* documents the same failure class
+in the curated tier: a stale line drove a confident, wrong
+recommendation. This spec addresses the raw tier, where the error rate is
+higher and there is no human author.
+
+### The prompt is not the lever
+
+The extraction prompt already has a PROVENANCE rule telling the model to
+record only what the session concluded. Both bad findings violated it
+anyway. **Making an 8B model more careful is not a control** — it is the
+thing that failed. This spec adds verification *outside* the model.
+
+---
+
+## The principle: derive, don't store
+
+This repo already solved this problem twice, in the same week:
+
+- **The claim-drift gate** (`tests/unit/gates/test_claim_drift.py`)
+  refuses to trust a tool count written in a README. It derives the count
+  from the live registry and fails when the written one disagrees.
+- **The capability projector** (`scripts/project_capabilities.py`) owns
+  the claim sites outright, so the number is never hand-authored.
+
+Both caught real drift on 2026-07-25 (#1605, #1607). The memory store is
+the one remaining place that trusts written prose about mutable state.
+
+**Requirement: a claim about a mutable entity must be resolvable to that
+entity's live state, at write time and again at read time.**
+
+---
+
+## Requirements
+
+### R1 — Findings carry typed entity references
+
+`SessionStashEntry` gains `refs: list[str]` — typed references to the
+entities a finding is about:
+
+```
+pr:1666   sha:1f6553edc   file:scripts/check_platform_compat.py
+spec:memory-recall-eval   branch:claude/foo   issue:1612
+```
+
+The extractor emits refs alongside content. Refs are cheap to resolve and
+are the join key between a prose claim and ground truth.
+
+### R2 — Write-time verification rejects contradicted claims
+
+Before storage, each ref resolves to live state. Where the finding also
+carries a **structured claim** about that entity (R3), a contradiction
+rejects the finding rather than storing it. Rejections increment the
+existing rejection counter (`_record_rejection`) so the rate is visible.
+
+Resolution must be cheap and offline-tolerant: `gh` for PR/issue state,
+`git` for sha/branch, filesystem for paths. **Unreachable ≠ contradicted**
+— if resolution fails, the finding is stored ungrounded (R4), never
+rejected. The memory layer must never block a session.
+
+### R3 — Verifiable claims are structured, prose is not
+
+The extractor emits an optional `claim` object for the narrow set of
+mechanically checkable assertions:
+
+```json
+{"type":"reference","content":"PR #1666 fixed the scanner",
+ "refs":["pr:1666"],
+ "claim":{"kind":"pr_state","ref":"pr:1666","value":"open"}}
+```
+
+Only `claim` is verified. `content` stays prose and is never
+NL-parsed — that would reintroduce the model as the checker.
+
+Initial `claim.kind` set (deliberately small): `pr_state`, `file_exists`,
+`count`. Extending it is a decision, not a default.
+
+### R4 — Grounded vs. interpretation is a first-class distinction
+
+Entries gain `grounding: "grounded" | "interpretation"`:
+
+- **grounded** — has ≥1 ref that resolved.
+- **interpretation** — no resolvable ref. `"the baseline led to mistakes"`
+  is an interpretation and must never carry the same authority as
+  `"baseline went 22→4 at sha 1f6553e"`.
+
+Recall labels and ranks by this. Interpretations are not banned — they
+are demoted and marked.
+
+### R5 — Read-time re-resolution
+
+`recall_entries` / `recent_entries` re-resolve refs and annotate:
+
+```
+[reference] PR #1666 fixed the scanner  ⟨pr:1666 → MERGED 2026-07-25⟩
+```
+
+This is the highest-value, lowest-cost half: it makes the 07-25 failure
+visible **without needing to understand the sentence**. A reader sees
+"open for reviewing" next to `MERGED` and discards it. Ships even if R2/R3
+are deferred.
+
+### R6 — The recall scan cap must not read as absence
+
+`recent_entries` currently logs `request cap (40) hit scanning attune;
+older records skipped`. A capped scan returning nothing is reported as
+"no hits", which is indistinguishable from "not stored" — the same
+absence-as-success failure the CI gates were rebuilt to remove. Recall
+must distinguish *no matches* from *scan truncated*.
+
+---
+
+## Acceptance — the golden-set receipt
+
+The regression test replays the four real findings from 2026-07-25:
+
+| Finding | Required outcome |
+|---|---|
+| `9e140a08` "PR #1666 is open for reviewing" | **rejected** at write (R2/R3), or flagged `MERGED` at read (R5) |
+| `203a128d` "…led to mistakes in the last two days" | stored as **interpretation**, demoted in recall (R4) |
+| `[decision]` "fix the script, not the code" | **survives, grounded** |
+| `[pattern]` "false positives from comment/docstring sensitivity" | **survives** |
+
+A change that rejects all four is as wrong as one that accepts all four.
+The test must pin both directions — this is the same discipline used in
+`tests/unit/ci/test_platform_compat_scanner.py`, where every
+false-positive class is paired with its true positive so a later
+re-broadening fails loudly.
+
+Additional receipts:
+
+- **Non-mocked round trip** — real extraction → real verification → real
+  write → real recall, per the "registered ≠ working" lesson. Mocked
+  tests will pass precisely because they mock the resolver.
+- **Offline degradation** — with `gh`/network unavailable, findings still
+  store (ungrounded) and no session is blocked.
+
+---
+
+## Non-goals
+
+- **Improving the extraction model or prompt.** Explicitly out of scope;
+  see "the prompt is not the lever".
+- **Verifying prose.** Only structured claims are checked.
+- **Touching the curated `/remember` tier.** That layer is
+  human-authored; its staleness problem is separate and already has a
+  lesson.
+- **Blocking on the memory layer.** Degrading silently stays mandatory.
+
+---
+
+## Phases
+
+**P1 — read-time annotation (R1 refs, R5, R6).** Highest value per unit
+work: catches the 07-25 failure with no model changes and no write-path
+risk. Refs can be back-filled heuristically from `content` for existing
+entries (`#\d+`, sha-like tokens, paths).
+
+**P2 — write-time verification (R2, R3).** Extractor emits `claim`;
+resolver rejects contradictions.
+
+**P3 — grounding tier (R4).** Ranking and labelling in recall.
+
+P1 is independently shippable and worth shipping alone.
+
+---
+
+## Open questions
+
+1. **Does the 8B model reliably emit refs?** If not, P1's heuristic
+   back-fill from `content` may be the permanent mechanism rather than a
+   migration step. Measure before building P2 — this determines whether
+   R3 is viable at all.
+2. **Rejection vs. demotion on contradiction.** Rejecting loses the
+   observation entirely; a contradicted claim may still indicate
+   something happened. Proposal: demote to `interpretation` with the
+   contradiction recorded, rather than drop.
+3. **TTL interaction.** Should a grounded finding whose entity still
+   resolves outlive the 30-day TTL? Probably yes, but it changes the
+   store from working-memory to something more durable — a chair call.

--- a/scripts/measure_stash_refs.py
+++ b/scripts/measure_stash_refs.py
@@ -1,0 +1,252 @@
+#!/usr/bin/env python3
+"""Measure whether the local extraction model reliably emits entity refs.
+
+Answers OQ1 of docs/specs/memory-claim-verification: if `llama3.1:8b`
+cannot reliably emit `refs` alongside a finding, then heuristic back-fill
+from `content` is the permanent mechanism rather than a migration step,
+and requirement R3 (structured, verified claims) may not be viable.
+
+This is a MEASUREMENT, not a test. It replays real session transcripts
+through the real tail-extraction path and the real Ollama call, then
+reports rates. Run it; read the number; rule on OQ1.
+
+    python scripts/measure_stash_refs.py --samples 15
+
+Copyright 2026 Smart-AI-Memory
+Licensed under the Apache License, Version 2.0
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import re
+import sys
+import time
+import urllib.error
+import urllib.request
+from dataclasses import dataclass, field
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+HOOK = REPO_ROOT / "plugin" / "hooks" / "session_stash.py"
+
+#: Entities a finding might name. These same patterns are the candidate
+#: heuristic back-fill, so the model's refs can be scored against them.
+ENTITY_PATTERNS: list[tuple[str, re.Pattern[str]]] = [
+    ("pr", re.compile(r"#(\d{2,6})\b")),
+    ("sha", re.compile(r"\b([0-9a-f]{7,40})\b")),
+    ("file", re.compile(r"\b((?:src|tests|scripts|docs|plugin)/[\w./-]+\.\w+)")),
+    ("spec", re.compile(r"docs/specs/([\w-]+)")),
+]
+
+#: The current prompt with a refs clause appended. Deliberately a MINIMAL
+#: delta from the shipped prompt — measuring the model, not prompt craft.
+REFS_CLAUSE = (
+    '- refs is a list of entities the finding is about, each "kind:value".\n'
+    "  Kinds: pr (pr:1666), sha (sha:1f6553e), file (file:src/x.py),\n"
+    "  spec (spec:memory-recall-eval). Include ONLY entities that appear\n"
+    "  in the transcript. Empty list if the finding names none.\n"
+)
+
+
+def load_hook():
+    """Load the Stop-hook module so the REAL tail extractor is used."""
+    spec = importlib.util.spec_from_file_location("_stash_hook", HOOK)
+    if spec is None or spec.loader is None:  # pragma: no cover - env guard
+        raise RuntimeError(f"cannot load {HOOK}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["_stash_hook"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def build_prompt(text: str) -> str:
+    """The shipped prompt plus the refs clause and a refs field."""
+    return (
+        "You are extracting durable memory from a coding session transcript.\n"
+        "Return ONLY JSON of the form "
+        '{"findings": [{"type": "...", "content": "...", "refs": ["..."]}]}.\n'
+        "Rules:\n"
+        "- At most 5 findings; fewer is better. Skip chit-chat and routine steps.\n"
+        "- Each finding is a single reusable insight worth recalling next session.\n"
+        "- type is one of: decision, pattern, bug, reference, note.\n"
+        "- content is one concise sentence, <= 280 chars, no secrets.\n"
+        f"{REFS_CLAUSE}"
+        "- PROVENANCE: extract only what the ASSISTANT concluded or the USER\n"
+        "  decided IN THIS SESSION.\n\n"
+        f"TRANSCRIPT TAIL:\n{text}\n"
+    )
+
+
+def call_ollama(prompt: str, model: str, timeout: int) -> tuple[dict | None, float]:
+    """Return (parsed JSON, seconds). None when unavailable or unparseable."""
+    payload = json.dumps(
+        {"model": model, "prompt": prompt, "stream": False, "format": "json"}
+    ).encode("utf-8")
+    request = urllib.request.Request(
+        "http://localhost:11434/api/generate",
+        data=payload,
+        headers={"Content-Type": "application/json"},
+    )
+    started = time.monotonic()
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            body = json.loads(response.read().decode("utf-8"))
+        return json.loads(body.get("response", "")), time.monotonic() - started
+    except (urllib.error.URLError, TimeoutError, ValueError, KeyError):
+        return None, time.monotonic() - started
+
+
+def entities_in(text: str) -> set[str]:
+    """Heuristic back-fill: the refs derivable from text alone."""
+    found: set[str] = set()
+    for kind, pattern in ENTITY_PATTERNS:
+        for match in pattern.findall(text):
+            found.add(f"{kind}:{match}")
+    return found
+
+
+@dataclass
+class Totals:
+    transcripts: int = 0
+    parse_ok: int = 0
+    parse_fail: int = 0
+    findings: int = 0
+    with_refs: int = 0
+    refs_emitted: int = 0
+    refs_wellformed: int = 0
+    refs_grounded: int = 0
+    findings_backfillable: int = 0
+    findings_model_got: int = 0
+    durations: list[float] = field(default_factory=list)
+
+
+def score(findings: list[dict], tail: str, totals: Totals) -> None:
+    """Score one transcript's findings against the transcript text."""
+    for finding in findings:
+        if not isinstance(finding, dict):
+            continue
+        content = str(finding.get("content", ""))
+        if not content:
+            continue
+        totals.findings += 1
+
+        refs = finding.get("refs")
+        refs = [str(r) for r in refs] if isinstance(refs, list) else []
+        if refs:
+            totals.with_refs += 1
+        totals.refs_emitted += len(refs)
+
+        for ref in refs:
+            if re.fullmatch(r"(pr|sha|file|spec):.+", ref):
+                totals.refs_wellformed += 1
+                # Grounded = the ref's value actually appears in the tail.
+                if ref.split(":", 1)[1] in tail:
+                    totals.refs_grounded += 1
+
+        # Could a pure regex over the CONTENT have produced a ref?
+        backfill = entities_in(content)
+        if backfill:
+            totals.findings_backfillable += 1
+            if refs:
+                totals.findings_model_got += 1
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--samples", type=int, default=15)
+    parser.add_argument(
+        "--min-bytes",
+        type=int,
+        default=20_000,
+        help="skip transcripts smaller than this (isolates substantial sessions)",
+    )
+    parser.add_argument("--model", default="llama3.1:8b")
+    parser.add_argument("--timeout", type=int, default=180)
+    parser.add_argument(
+        "--projects",
+        default=str(Path.home() / ".claude" / "projects"),
+        help="Claude Code projects dir holding transcript JSONL",
+    )
+    args = parser.parse_args()
+
+    hook = load_hook()
+    root = Path(args.projects)
+    transcripts = sorted(
+        (p for p in root.rglob("*.jsonl") if p.stat().st_size > args.min_bytes),
+        key=lambda p: p.stat().st_mtime,
+        reverse=True,
+    )[: args.samples]
+
+    if not transcripts:
+        print(f"no transcripts found under {root}", file=sys.stderr)
+        return 1
+
+    totals = Totals()
+    print(f"model={args.model}  samples={len(transcripts)}\n")
+
+    for index, path in enumerate(transcripts, 1):
+        tail = hook._read_transcript_tail(str(path))
+        if not tail.strip():
+            continue
+        totals.transcripts += 1
+        parsed, seconds = call_ollama(build_prompt(tail), args.model, args.timeout)
+        totals.durations.append(seconds)
+
+        if not isinstance(parsed, dict) or not isinstance(parsed.get("findings"), list):
+            totals.parse_fail += 1
+            print(f"  [{index:2}] PARSE_FAIL  {seconds:5.1f}s  {path.name[:40]}")
+            continue
+
+        totals.parse_ok += 1
+        findings = parsed["findings"]
+        score(findings, tail, totals)
+        refs_here = sum(1 for f in findings if isinstance(f, dict) and f.get("refs"))
+        print(
+            f"  [{index:2}] ok  {seconds:5.1f}s  findings={len(findings)} "
+            f"with_refs={refs_here}  {path.name[:40]}"
+        )
+
+    def pct(numerator: int, denominator: int) -> str:
+        return f"{100.0 * numerator / denominator:5.1f}%" if denominator else "  n/a"
+
+    print("\n" + "=" * 62)
+    print("OQ1 — does the 8B model reliably emit refs?")
+    print("=" * 62)
+    print(f"transcripts scored      {totals.transcripts}")
+    print(
+        f"JSON parse ok           {totals.parse_ok}  ({pct(totals.parse_ok, totals.transcripts)})"
+    )
+    print(f"findings extracted      {totals.findings}")
+    print(
+        f"findings WITH refs      {totals.with_refs}  "
+        f"({pct(totals.with_refs, totals.findings)})   <-- the headline"
+    )
+    print(f"refs emitted (total)    {totals.refs_emitted}")
+    print(
+        f"  well-formed           {totals.refs_wellformed}  "
+        f"({pct(totals.refs_wellformed, totals.refs_emitted)})"
+    )
+    print(
+        f"  grounded in tail      {totals.refs_grounded}  "
+        f"({pct(totals.refs_grounded, totals.refs_emitted)})  "
+        "(else: hallucinated)"
+    )
+    print(
+        f"heuristic-backfillable  {totals.findings_backfillable}  "
+        f"({pct(totals.findings_backfillable, totals.findings)} of findings)"
+    )
+    print(
+        f"  model also got those  {totals.findings_model_got}  "
+        f"({pct(totals.findings_model_got, totals.findings_backfillable)})"
+    )
+    if totals.durations:
+        print(f"mean latency            {sum(totals.durations)/len(totals.durations):.1f}s")
+    print("=" * 62)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Spec for the memory-quality problem surfaced 2026-07-25, **plus the
measurement that answers its own first open question in the negative.**

Requirements + decisions + a measurement harness. No production code.

## Origin

2 of 4 auto-stashed findings that session were wrong enough that Patrick
had to ask for them to be deleted:

| Finding | Reality |
|---|---|
| `9e140a08` — "PR #1666 is open for reviewing" | merged that same session |
| `203a128d` — "the baseline … led to mistakes" | caught *before* causing any |

## Root cause

`plugin/hooks/session_stash.py` runs a local `llama3.1:8b` over the
transcript tail and writes free prose into `SessionStashEntry` — which
has **no provenance field and no verification**. `"PR #1666 is open"` and
`"PR #1666 is merged"` are indistinguishable as strings; only one is
checkable, and nothing checks it.

A wrong memory is worse than an absent one: it is recalled later wearing
the authority of a recorded fact, when the originating context is gone.

## The approach is not new

The **claim-drift gate** refuses to trust a tool count in a README and
derives it from the live registry. The **capability projector** owns the
claim sites so the number is never hand-authored. Both caught real drift
on 07-25 (#1605, #1607). The memory store is the one remaining surface
that trusts written prose about mutable state.

## OQ1 was measured — and it retires R3 as written

`scripts/measure_stash_refs.py` replays real transcripts through the real
tail extractor and the real Ollama call.

| Metric | n=18 (>20 KB) | n=12 (>200 KB) |
|---|---|---|
| JSON parse ok | 100% | 100% |
| findings **with** refs | 79.7% | 85.1% |
| refs well-formed | 81.2% | **56.4%** |
| refs **grounded in the transcript** | **28.1%** | **21.8%** |
| findings heuristic-backfillable | 10.1% | 8.5% |

**The model emits refs enthusiastically and fabricates most of them.**
~80% of findings carry refs; only ~22–28% of those refs appear anywhere
in the text the model was shown. Restricting to substantial transcripts
made it *worse*. That is the worst possible shape for R3 — confident,
structured, invented. Verifying such claims would mostly verify
inventions.

**Heuristic back-fill is not a fallback either** (~10% recall). OQ1's
premise — "if not the model, then heuristics" — was a false dichotomy.
Both fail.

**A third mechanism exists.** The transcript's `tool_use` records already
carry the session's real entities. A probe recovered exactly the PRs that
session touched (`1578 1605 1607 1666 1667 1668`), the real merge SHA,
and 10 file paths — zero fabrications. The hook currently discards them
behind `[tool output omitted]`.

## What's ruled (decisions.md)

- **D1** the prompt is not the control — it already carries a PROVENANCE
  rule that both bad findings violated. The failing component cannot be
  its own control.
- **D3** read-time annotation ships first and alone. Rendering
  `⟨pr:1666 → MERGED⟩` beside "open for reviewing" defeats the bad
  finding with no NL understanding and no write-path risk.
- **D4** unreachable is never contradicted — the memory layer degrades
  silently and never blocks a session.
- **D5** the golden set pins both directions: the two bad findings must
  be caught *and* the two good ones must survive.
- **D6** the ref-binding fork goes to the round table **after** the 07-27
  fire. Three candidates recorded. **No implementation before that
  ruling.**

## Reading order for a cold reviewer

`requirements.md` states R3 as originally drafted; the OQ1 measurement in
`decisions.md` **retires it**. The status line says so at the top of the
file so nobody builds the retired requirement. Requirements are the
draft; decisions.md owns rulings.

## Receipts

- `tests/unit/gates/` — 152 passed (a status-line token fix; the leading
  `**Status:**` token must come from `STATUS_VOCABULARY`).
- `tests/unit/lessons/` — 26 passed.
- Harness is re-runnable: `python scripts/measure_stash_refs.py --samples 18`.
- Lessons from this measurement: #1670.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
