### PR TITLE
docs(usage-signals): US-5 before-snapshots 2026-07-25/26 (rate-limited receipts)

### DIFF
--- a/docs/specs/usage-signals/snapshots/2026-07-25.json
+++ b/docs/specs/usage-signals/snapshots/2026-07-25.json
@@ -1,0 +1,33 @@
+{
+  "attempts": [
+    {
+      "at": "2026-07-25T13:03:03.661173+00:00",
+      "captured": 0,
+      "outcome": "rate-limited"
+    }
+  ],
+  "date": "2026-07-25",
+  "github": {},
+  "manifest": {
+    "captured": [],
+    "complete": false,
+    "expected": [
+      "attune-ai",
+      "attune-rag",
+      "attune-help",
+      "attune-author",
+      "attune-verify"
+    ],
+    "missing": [
+      "attune-ai",
+      "attune-rag",
+      "attune-help",
+      "attune-author",
+      "attune-verify"
+    ],
+    "observed_at": "2026-07-25T13:03:03.661173+00:00",
+    "source": "pypistats.org/api/recent"
+  },
+  "pypi_recent": {},
+  "taken_at": "2026-07-25T13:03:03.661173+00:00"
+}

--- a/docs/specs/usage-signals/snapshots/2026-07-26.json
+++ b/docs/specs/usage-signals/snapshots/2026-07-26.json
@@ -1,0 +1,33 @@
+{
+  "attempts": [
+    {
+      "at": "2026-07-26T13:03:03.678468+00:00",
+      "captured": 0,
+      "outcome": "rate-limited"
+    }
+  ],
+  "date": "2026-07-26",
+  "github": {},
+  "manifest": {
+    "captured": [],
+    "complete": false,
+    "expected": [
+      "attune-ai",
+      "attune-rag",
+      "attune-help",
+      "attune-author",
+      "attune-verify"
+    ],
+    "missing": [
+      "attune-ai",
+      "attune-rag",
+      "attune-help",
+      "attune-author",
+      "attune-verify"
+    ],
+    "observed_at": "2026-07-26T13:03:03.678468+00:00",
+    "source": "pypistats.org/api/recent"
+  },
+  "pypi_recent": {},
+  "taken_at": "2026-07-26T13:03:03.678468+00:00"
+}


### PR DESCRIPTION
Commits the two US-5 before-snapshot JSONs from the armed launchd job
(`com.smartaimemory.attune.us5-before-snapshot`), per the Monday 07-27
runbook: (a) log read, (b) snapshot committed, (c) job disarmed.

Both fires ran on schedule (Fri 07-25 09:03, Sat 07-26 09:03) but
pypistats.org rate-limited every attempt — **0/5 packages captured on
both days**. Per usage-signals US-4, the 10.6.0 release proceeds with
the incomplete-receipt warning attached verbatim; no substitute capture
at tag time.

Docs-only (snapshot data under docs/specs/) — no changelog per policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)