### PR TITLE
release: 10.6.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "Spec-driven development for Claude Code — take an idea through requirements, design, tasks, and gated execution with an approval loop. Plus 26 auto-triggering skills: security audits, code review, test generation, release prep.",
-    "version": "10.5.0"
+    "version": "10.6.0"
   },
   "plugins": [
     {
       "name": "attune-ai",
       "description": "Spec-driven development is the core workflow: /spec carries an idea through brainstorm, requirements, design, and task execution with quality gates and your approval at each stage. Backed by 26 auto-triggering skills — security audits, code reviews, test generation, bug prediction, and release preparation. For help content tools, also install attune-help and attune-author from this marketplace.",
       "source": "./plugin",
-      "version": "10.5.0",
+      "version": "10.6.0",
       "author": {
         "name": "Smart AI Memory",
         "email": "patrick.roebuck@smartaimemory.com"

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,4 +1,4 @@
-# Attune AI Framework v10.5.0
+# Attune AI Framework v10.6.0
 
 AI-powered developer workflows with cost optimization and multi-agent orchestration.
 
@@ -307,7 +307,7 @@ attune_redis/          # Redis plugin — BUNDLED, ships in the attune-ai
 
 ---
 
-**Version:** 10.5.0 | **License:** Apache 2.0 | **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)
+**Version:** 10.6.0 | **License:** Apache 2.0 | **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)
 
 ## Lessons — core
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [10.6.0] — 2026-07-27
+
 When a workflow fails, attune can now tell you why: `attune diagnose`
 convenes a multi-model panel over the failed run's evidence and hands
 you ranked root-cause hypotheses — one click from the dashboard. The
@@ -17,6 +19,15 @@ run-record corpus that future releases learn from.
 
 ### Added
 
+- **`/memory` page over the Redis-derived index** (#1576, #1615) —
+  ops dashboard page with kind-chip filtering and an exceptions-first
+  attention header (hydration staleness, corpus drift, pending
+  threads).
+- **`handoff_create` / `handoff_resume` MCP tools** (#1605) —
+  advisory cross-provider session handoff
+  (spec cross-provider-session-handoff).
+- **`/cross-review`** (#1607) — one-seat advisory second-opinion
+  review (spec cross-review).
 - **attune-author fully absorbed — polish machinery moves upstream**
   (attune-author-consolidation T3, ruling D10). The LLM
   generator/polish machinery now lives in `attune.authoring`
@@ -81,7 +92,8 @@ run-record corpus that future releases learn from.
   term extraction for terse symptoms (#1512), origin tagging + an
   append-only closure seam (#1514), proposer role-fit + brief
   hardening (#1523), and the engine's own heal-stamped canonical run
-  record (#1524).
+  record (#1524). Verified diagnoses graduate into the lessons corpus
+  with provenance (`LessonsFilePublisher`, #1529).
 - **Multi-LLM round table** (#1450, #1451, #1462, #1464, #1466,
   #1511, #1515, #1517). `/roundtable` convenes Claude, Antigravity,
   and Codex to deliberate a question on a Redis-backed board; the
@@ -163,6 +175,9 @@ run-record corpus that future releases learn from.
 
 ### Changed
 
+- Codecov patch gate raised 50 → 80, enforcing the documented 80%
+  changed-code floor (#1531).
+
 - **Forms by default — the rich form surface is now what you get**
   (D21). Previously the agent routed each form to the cheapest surface
   that could express its controls, so a multi-dimension question
@@ -192,6 +207,11 @@ run-record corpus that future releases learn from.
   against the lessons golden-query suite (#1509).
 
 ### Fixed
+
+- Weekly help-freshness report now reports 0 stale instead of 27
+  false positives (#1562).
+- Tooltip unification completed — last `span title=` converted, with
+  a CI grep-gate against regressions (#1571).
 
 - **File-fallback memory writes no longer report false success**
   (cross-provider-memory-transport T1). `FileStashBackend.remember()`

--- a/docs/reference/API_REFERENCE.md
+++ b/docs/reference/API_REFERENCE.md
@@ -1,6 +1,6 @@
 # Attune AI API Reference
 
-**Version:** 10.5.0
+**Version:** 10.6.0
 **License:** Apache License 2.0
 **Copyright:** 2025-2026 Smart AI Memory, LLC
 
@@ -1152,5 +1152,5 @@ msg = format_error(
 
 ---
 
-**Version:** 10.5.0 | **License:** Apache 2.0
+**Version:** 10.6.0 | **License:** Apache 2.0
 **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)

--- a/plugin/.claude-plugin/marketplace.json
+++ b/plugin/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "Spec-driven development for Claude Code — /spec plans, reviews, and executes with quality gates; plus security audits, code reviews, test generation, and release prep from /attune.",
-    "version": "10.5.0"
+    "version": "10.6.0"
   },
   "plugins": [
     {
       "name": "attune-ai",
       "description": "Spec-driven development for Claude Code — /spec plans, reviews, and executes with quality gates; plus security audits, code reviews, test generation, and release prep from /attune.",
       "source": "./",
-      "version": "10.5.0",
+      "version": "10.6.0",
       "author": {
         "name": "Smart AI Memory",
         "email": "patrick.roebuck@smartaimemory.com"

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "attune-ai",
-  "version": "10.5.0",
+  "version": "10.6.0",
   "description": "Spec-driven development for Claude Code — /spec plans, reviews, and executes with quality gates; plus security audits, code reviews, test generation, and release prep from /attune.",
   "author": {
     "name": "Smart AI Memory",

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -4,7 +4,7 @@ Spec-driven development for Claude Code — turn requirements
 into reliable software. <!-- cap:skill_count -->26 auto-triggering skills<!-- /cap -->, zero
 commands: say what you need and Claude picks the right skill.
 
-**Version:** 10.5.0 | **License:** Apache 2.0
+**Version:** 10.6.0 | **License:** Apache 2.0
 
 ## Install
 

--- a/plugin/core/__init__.py
+++ b/plugin/core/__init__.py
@@ -5,4 +5,4 @@ This module provides the core workflow functionality when the full
 attune-ai package is not installed via pip.
 """
 
-__version__ = "10.5.0"
+__version__ = "10.6.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "attune-ai"
-version = "10.5.0"
+version = "10.6.0"
 description = "AI-powered developer workflows for Claude with cost optimization, multi-agent orchestration, and workflow automation."
 readme = {file = "README.md", content-type = "text/markdown"}
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -299,7 +299,7 @@ wheels = [
 
 [[package]]
 name = "attune-ai"
-version = "10.5.0"
+version = "10.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "agent-memory-client" },

--- a/website/app/page.tsx
+++ b/website/app/page.tsx
@@ -58,7 +58,7 @@ export default function Home() {
             <div className="grid lg:grid-cols-2 gap-16 items-center">
               <div className="z-10">
                 <div className="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-[var(--surface-container-high)] text-[var(--primary)] text-xs font-bold tracking-widest mb-6 uppercase">
-                  <span>v10.5.0</span>
+                  <span>v10.6.0</span>
                   <span className="w-1 h-1 rounded-full bg-[var(--primary)]"></span>
                   <span className="opacity-80">Spec-driven development platform</span>
                 </div>

--- a/website/lib/features.ts
+++ b/website/lib/features.ts
@@ -32,7 +32,7 @@ export const PRODUCTS: Product[] = [
     id: "attune-ai",
     name: "Attune AI",
     pypiName: "attune-ai",
-    version: "10.5.0",
+    version: "10.6.0",
     tagline: "Generate, maintain, and serve help from your code",
     installCommand: "pip install attune-ai",
     marketplaceInstall:
@@ -101,7 +101,7 @@ export const PRODUCTS: Product[] = [
     id: "claude-code-plugin",
     name: "Claude Code Plugin",
     pypiName: "attune-ai",
-    version: "10.5.0",
+    version: "10.6.0",
     tagline: "Progressive help right in your terminal",
     installCommand:
       "claude plugin marketplace add Smart-AI-Memory/attune-ai",


### PR DESCRIPTION
10.6.0 release PR — Monday 07-27 sitting, per the runbook.

- Version 10.5.0 → 10.6.0 across the full checklist (11 sites / 7 files) + uv.lock.
- CHANGELOG: `[Unreleased]` → `[10.6.0] — 2026-07-27` with the chair-ruled owed entries (#1529, #1531, #1562, #1571, #1576/#1615, #1605, #1607). #1574's entry rode its own squash.
- Queue lifted ahead of this PR: 7 flat + transport stack (#1593→#1598) + ops #1576/#1615. Capability projector `--check` green on final main: 26 skills / 60 registered / 49 core.
- US-4 incomplete-receipt warning attached (before-snapshots rate-limited 0/5 both days — committed in #1675; no substitute at tag time).

After merge: tag v10.6.0 from the merge SHA (bumps verified in-SHA via contents API first), approve publish `--ref main`, verify PyPI, update installed plugin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)