### PR TITLE
fix(mcp): route structlog to stderr — stdout is protocol-only

### DIFF
--- a/src/attune/mcp/server.py
+++ b/src/attune/mcp/server.py
@@ -1535,6 +1535,20 @@ def main() -> None:
         ],
     )
 
+    # stdout carries ONLY the JSON-RPC stream. structlog's default
+    # PrintLoggerFactory writes to stdout, so any structlog call inside a
+    # tool handler (e.g. the session-stash PII gate) corrupts the protocol
+    # for strict clients (Antigravity rejects the frame with "invalid
+    # trailing data"; transport receipt 6, 2026-07-27). Route structlog to
+    # stderr, which MCP clients treat as free-form logging.
+    import sys
+
+    import structlog
+
+    structlog.configure(
+        logger_factory=structlog.PrintLoggerFactory(file=sys.stderr),
+    )
+
     try:
         asyncio.run(_run_stdio())
     except KeyboardInterrupt:

--- a/tests/integration/test_mcp_stdout_purity.py
+++ b/tests/integration/test_mcp_stdout_purity.py
@@ -1,0 +1,133 @@
+"""Regression: the MCP server's stdout must carry ONLY JSON-RPC frames.
+
+Transport receipt 6 (cross-provider-memory-transport, 2026-07-27) found
+structlog's default stdout PrintLogger interleaving sanitizer debug lines
+(``pii_scrubbed`` etc.) with protocol frames during
+``session_memory_capture``. Lenient clients (Claude Code) tolerated it;
+Antigravity's strict client failed the call with "invalid trailing data
+at the end of stream". This test spawns the REAL server process, drives a
+PII-bearing capture through the real sanitizer, and fails if any stdout
+line is not valid JSON.
+"""
+
+import json
+import os
+import subprocess
+import sys
+import threading
+
+import pytest
+
+CANARY = "STDOUT-PURITY-CANARY: contact test@example.com re protocol"
+
+
+def _rpc(obj: dict) -> str:
+    return json.dumps(obj) + "\n"
+
+
+class _LineReader:
+    """Collect stdout lines on a thread so reads can time out portably."""
+
+    def __init__(self, stream) -> None:
+        self.lines: list[str] = []
+        self._stream = stream
+        self._thread = threading.Thread(target=self._run, daemon=True)
+        self._thread.start()
+
+    def _run(self) -> None:
+        for line in self._stream:
+            self.lines.append(line.rstrip("\n"))
+
+    def wait_for_id(self, rpc_id: int, timeout: float) -> dict | None:
+        deadline = threading.Event()
+        self._thread.join(timeout=0)  # ensure started
+        import time
+
+        end = time.time() + timeout
+        while time.time() < end:
+            for line in list(self.lines):
+                try:
+                    msg = json.loads(line)
+                except ValueError:
+                    continue
+                if msg.get("id") == rpc_id:
+                    return msg
+            if deadline.wait(0.1):
+                break
+        return None
+
+
+@pytest.mark.integration
+def test_session_memory_capture_keeps_stdout_json_only(tmp_path):
+    env = dict(os.environ)
+    env["ATTUNE_REDIS_REQUIRED"] = "false"
+    # Keep the file-fallback stash inside the test sandbox.
+    env["HOME"] = str(tmp_path)
+    env["PYTHONIOENCODING"] = "utf-8"
+
+    proc = subprocess.Popen(
+        [sys.executable, "-m", "attune.mcp.server"],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        encoding="utf-8",
+        env=env,
+    )
+    try:
+        reader = _LineReader(proc.stdout)
+        assert proc.stdin is not None
+        proc.stdin.write(
+            _rpc(
+                {
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "method": "initialize",
+                    "params": {
+                        "protocolVersion": "2024-11-05",
+                        "capabilities": {},
+                        "clientInfo": {"name": "stdout-purity", "version": "0"},
+                    },
+                }
+            )
+        )
+        proc.stdin.flush()
+        assert reader.wait_for_id(1, 30) is not None, "no initialize response"
+
+        proc.stdin.write(_rpc({"jsonrpc": "2.0", "method": "notifications/initialized"}))
+        proc.stdin.write(
+            _rpc(
+                {
+                    "jsonrpc": "2.0",
+                    "id": 2,
+                    "method": "tools/call",
+                    "params": {
+                        "name": "session_memory_capture",
+                        "arguments": {"content": CANARY, "type": "note"},
+                    },
+                }
+            )
+        )
+        proc.stdin.flush()
+        response = reader.wait_for_id(2, 60)
+        assert response is not None, "no tools/call response"
+
+        non_json = [line for line in reader.lines if line and not _parses(line)]
+        assert non_json == [], (
+            "stdout carried non-JSON lines alongside the protocol stream "
+            f"(strict MCP clients reject the frame): {non_json[:5]}"
+        )
+    finally:
+        proc.kill()
+        proc.wait(timeout=10)
+        for stream in (proc.stdin, proc.stdout, proc.stderr):
+            if stream is not None:
+                stream.close()
+
+
+def _parses(line: str) -> bool:
+    try:
+        json.loads(line)
+    except ValueError:
+        return False
+    return True


### PR DESCRIPTION
Transport receipt 6 (Antigravity live probe, post-10.6.0-publish) failed every `session_memory_capture` with `invalid trailing data at the end of stream`: structlog was never configured in the MCP server process, so its default stdout PrintLogger interleaved the PII-gate's debug lines (`pii_scrubbed`, `secrets_detector_*`) with the JSON-RPC stream. Claude Code's lenient client masked this; Antigravity's strict rmcp client rejects it.

- Fix: configure structlog with `PrintLoggerFactory(file=sys.stderr)` in the server entrypoint — MCP treats stderr as free-form logging.
- Regression test (`tests/integration/test_mcp_stdout_purity.py`): spawns the REAL server subprocess, runs a PII-bearing capture through the real sanitizer, asserts every stdout line parses as JSON. Verified red pre-fix (lists the exact five pollution lines), green post-fix. Keyless, redis-free, Windows-safe (explicit utf-8, thread-based read deadline).

This is the blocker for transport receipt 6 — after it ships in a patch release, the Antigravity canary can pass against PyPI distribution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)