### PR TITLE
release: 10.6.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "Spec-driven development for Claude Code — take an idea through requirements, design, tasks, and gated execution with an approval loop. Plus 26 auto-triggering skills: security audits, code review, test generation, release prep.",
-    "version": "10.6.0"
+    "version": "10.6.1"
   },
   "plugins": [
     {
       "name": "attune-ai",
       "description": "Spec-driven development is the core workflow: /spec carries an idea through brainstorm, requirements, design, and task execution with quality gates and your approval at each stage. Backed by 26 auto-triggering skills — security audits, code reviews, test generation, bug prediction, and release preparation. For help content tools, also install attune-help and attune-author from this marketplace.",
       "source": "./plugin",
-      "version": "10.6.0",
+      "version": "10.6.1",
       "author": {
         "name": "Smart AI Memory",
         "email": "patrick.roebuck@smartaimemory.com"

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,4 +1,4 @@
-# Attune AI Framework v10.6.0
+# Attune AI Framework v10.6.1
 
 AI-powered developer workflows with cost optimization and multi-agent orchestration.
 
@@ -307,7 +307,7 @@ attune_redis/          # Redis plugin — BUNDLED, ships in the attune-ai
 
 ---
 
-**Version:** 10.6.0 | **License:** Apache 2.0 | **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)
+**Version:** 10.6.1 | **License:** Apache 2.0 | **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)
 
 ## Lessons — core
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [10.6.1] — 2026-07-27
+
+### Fixed
+
+- **MCP server stdout is protocol-only** — structlog now writes to
+  stderr in the server process. Strict MCP clients (Antigravity)
+  previously failed every `session_memory_*` call with "invalid
+  trailing data at the end of stream" when the session-stash PII gate
+  logged during capture; lenient clients masked the bug. Found live by
+  transport receipt 6; regression test spawns the real server and
+  asserts a JSON-only stdout (#1681).
+
 ## [10.6.0] — 2026-07-27
 
 When a workflow fails, attune can now tell you why: `attune diagnose`

--- a/README.md
+++ b/README.md
@@ -153,6 +153,44 @@ on our dogfood store (cl100k_base).
 
 ---
 
+## Multi-LLM collaboration — three models, one repo, receipts required
+
+**Your repo stops being single-provider.** As of 10.6.0, attune
+treats Claude Code, OpenAI Codex, and Google Antigravity as seats at
+the same table — with the discipline that a claim without a receipt
+doesn't ship:
+
+- **`/roundtable`** — convene Claude, Antigravity, and Codex to
+  deliberate a question on a Redis-backed board. Seats post
+  positions independently, synthesis compiles them, and *you* chair
+  what gets promoted — nothing lands without a ruling. Headless
+  routines run the same loop on a schedule.
+- **`/cross-review`** — a one-seat advisory second opinion on a real
+  diff from a *different* model than the one that wrote it.
+  Advisory only, board-recorded.
+- **Cross-provider session handoff** — `handoff_create` /
+  `handoff_resume` MCP tools write a portable, verifiable resume
+  brief so one agent can pick up where another stopped.
+- **Provider-neutral session memory** — the `session_memory_*` MCP
+  tools give every seat the same stash/recall/forget surface over
+  the shared store, with a PII/secrets gate that redacts at rest
+  and fails closed on secrets. Verified live from a Codex session:
+  capture → recall (email stored as `[EMAIL]`) → forget →
+  gone.
+- **A projected collaboration contract** — one master file projects
+  to `AGENTS.md` and per-provider mirrors, so any agent learns the
+  repo's rules (read-only preflight, branch discipline, shared
+  memory etiquette) without Claude-specific context.
+
+Codex installs the same plugin from its marketplace
+(`codex plugin install attune-ai@attune-ai`); Antigravity connects
+over MCP. We dogfood all of it on this repository — the multi-model
+release audit for 10.6.0 ran through the roundtable itself, and
+10.6.1 exists because a cross-provider receipt probe caught a
+protocol bug the primary client silently tolerated.
+
+---
+
 ## Ecosystem
 
 | Package | Role | Install |

--- a/docs/reference/API_REFERENCE.md
+++ b/docs/reference/API_REFERENCE.md
@@ -1,6 +1,6 @@
 # Attune AI API Reference
 
-**Version:** 10.6.0
+**Version:** 10.6.1
 **License:** Apache License 2.0
 **Copyright:** 2025-2026 Smart AI Memory, LLC
 
@@ -1152,5 +1152,5 @@ msg = format_error(
 
 ---
 
-**Version:** 10.6.0 | **License:** Apache 2.0
+**Version:** 10.6.1 | **License:** Apache 2.0
 **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)

--- a/plugin/.claude-plugin/marketplace.json
+++ b/plugin/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "Spec-driven development for Claude Code — /spec plans, reviews, and executes with quality gates; plus security audits, code reviews, test generation, and release prep from /attune.",
-    "version": "10.6.0"
+    "version": "10.6.1"
   },
   "plugins": [
     {
       "name": "attune-ai",
       "description": "Spec-driven development for Claude Code — /spec plans, reviews, and executes with quality gates; plus security audits, code reviews, test generation, and release prep from /attune.",
       "source": "./",
-      "version": "10.6.0",
+      "version": "10.6.1",
       "author": {
         "name": "Smart AI Memory",
         "email": "patrick.roebuck@smartaimemory.com"

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "attune-ai",
-  "version": "10.6.0",
+  "version": "10.6.1",
   "description": "Spec-driven development for Claude Code — /spec plans, reviews, and executes with quality gates; plus security audits, code reviews, test generation, and release prep from /attune.",
   "author": {
     "name": "Smart AI Memory",

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -4,7 +4,7 @@ Spec-driven development for Claude Code — turn requirements
 into reliable software. <!-- cap:skill_count -->26 auto-triggering skills<!-- /cap -->, zero
 commands: say what you need and Claude picks the right skill.
 
-**Version:** 10.6.0 | **License:** Apache 2.0
+**Version:** 10.6.1 | **License:** Apache 2.0
 
 ## Install
 

--- a/plugin/core/__init__.py
+++ b/plugin/core/__init__.py
@@ -5,4 +5,4 @@ This module provides the core workflow functionality when the full
 attune-ai package is not installed via pip.
 """
 
-__version__ = "10.6.0"
+__version__ = "10.6.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "attune-ai"
-version = "10.6.0"
+version = "10.6.1"
 description = "AI-powered developer workflows for Claude with cost optimization, multi-agent orchestration, and workflow automation."
 readme = {file = "README.md", content-type = "text/markdown"}
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -299,7 +299,7 @@ wheels = [
 
 [[package]]
 name = "attune-ai"
-version = "10.6.0"
+version = "10.6.1"
 source = { editable = "." }
 dependencies = [
     { name = "agent-memory-client" },

--- a/website/app/page.tsx
+++ b/website/app/page.tsx
@@ -58,7 +58,7 @@ export default function Home() {
             <div className="grid lg:grid-cols-2 gap-16 items-center">
               <div className="z-10">
                 <div className="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-[var(--surface-container-high)] text-[var(--primary)] text-xs font-bold tracking-widest mb-6 uppercase">
-                  <span>v10.6.0</span>
+                  <span>v10.6.1</span>
                   <span className="w-1 h-1 rounded-full bg-[var(--primary)]"></span>
                   <span className="opacity-80">Spec-driven development platform</span>
                 </div>

--- a/website/lib/features.ts
+++ b/website/lib/features.ts
@@ -32,7 +32,7 @@ export const PRODUCTS: Product[] = [
     id: "attune-ai",
     name: "Attune AI",
     pypiName: "attune-ai",
-    version: "10.6.0",
+    version: "10.6.1",
     tagline: "Generate, maintain, and serve help from your code",
     installCommand: "pip install attune-ai",
     marketplaceInstall:
@@ -101,7 +101,7 @@ export const PRODUCTS: Product[] = [
     id: "claude-code-plugin",
     name: "Claude Code Plugin",
     pypiName: "attune-ai",
-    version: "10.6.0",
+    version: "10.6.1",
     tagline: "Progressive help right in your terminal",
     installCommand:
       "claude plugin marketplace add Smart-AI-Memory/attune-ai",


### PR DESCRIPTION
Patch release: the MCP stdout-purity fix (#1681) — unblocks transport receipt 6 (strict MCP clients / Antigravity). Bumps via `scripts/bump_version.py 10.6.1` (full site list, version tests 24/24 locally) + CHANGELOG entry.

After merge: tag v10.6.1 from the merge SHA, publish `--ref main`, verify PyPI, update local surfaces, re-run the Antigravity canary, flip receipt 6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)