### PR TITLE
fix(mcp): per-verb voice_summary on session_memory_* adapters

### DIFF
--- a/.claude/lessons.md
+++ b/.claude/lessons.md
@@ -18647,3 +18647,25 @@ def ", start_idx + 1)` for module-
   that opt-in is exactly for independent, non-branching dimensions of
   one decision (§4 batched form). Sequence that works: try
   elicitation_ask → on error, AskUserQuestion with metadata.source.
+- **The MCP voice layer stamps a GENERIC `voice_summary` over every
+  non-skipped tool response — plugin tools that phrase their own verbs
+  must set `voice_summary` in the handler, and failure signaling via
+  `ok` (not `success`) was invisible to the voicer**: receipt-4 canary
+  (2026-07-27) caught every `session_memory_*` verb answering "Here's
+  what I found." (only fits recall). Two mechanisms: (1) `call_tool`
+  in `src/attune/mcp/server.py` routes every tool NOT in
+  `_VOICE_SKIP_TOOLS` through `format_mcp_response`
+  (`src/attune/voice/formatter.py`), which stamped
+  `GREETING_SUCCESS`/`GREETING_FAILURE` unconditionally; (2) the
+  formatter reads the `success` key (default True) while the
+  session_memory handlers signal via `ok` — so `ok: False` failures
+  were voiced as success too. Fixed in PR #1684: handlers set an
+  action-appropriate `voice_summary` on EVERY return path, and
+  `format_mcp_response` now respects a pre-set `voice_summary`
+  (fallback greeting only when absent). Rule for new plugin MCP
+  tools: either add the tool to `_VOICE_SKIP_TOOLS`, or set a
+  per-verb `voice_summary` in the handler — and never assume the
+  voice layer understands your success key; it only knows `success`.
+  Canary test: `TestSessionMemoryVoiceSummaries` in
+  `attune_redis/tests/test_mcp_tools.py` asserts no verb emits the
+  generic greeting.

--- a/attune_redis/mcp_tools.py
+++ b/attune_redis/mcp_tools.py
@@ -546,6 +546,11 @@ def _stash_failure_reason(session_stash: Any) -> str:
     return str(reason) if reason else "write_failed"
 
 
+def _plural(count: int) -> str:
+    """Return "s" for non-singular counts (voice_summary phrasing)."""
+    return "" if count == 1 else "s"
+
+
 def _clamp_top_k(args: dict[str, Any]) -> int:
     """Bound recall result counts (R4: results bounded)."""
     try:
@@ -584,6 +589,7 @@ async def handle_session_memory_capture(server: Any, args: dict[str, Any]) -> di
                 "reason": "invalid_entry",
                 "error": str(exc),
                 "source": "session-stash",
+                "voice_summary": "Couldn't stash that — the entry was invalid.",
             }
         if session_stash.stash_entry(entry):
             return {
@@ -591,18 +597,31 @@ async def handle_session_memory_capture(server: Any, args: dict[str, Any]) -> di
                 "id": entry.id,
                 "type": entry.type,
                 "source": "session-stash",
+                "voice_summary": "Stashed that finding for future recall.",
             }
+        reason = _stash_failure_reason(session_stash)
         return {
             "ok": False,
-            "reason": _stash_failure_reason(session_stash),
+            "reason": reason,
             "source": "session-stash",
+            "voice_summary": f"Couldn't stash that finding ({reason}).",
         }
     except ImportError:
-        return {"ok": False, "reason": "session_stash_unavailable", "source": "session-stash"}
+        return {
+            "ok": False,
+            "reason": "session_stash_unavailable",
+            "source": "session-stash",
+            "voice_summary": "Session memory isn't available in this environment.",
+        }
     except Exception as e:  # noqa: BLE001
         # INTENTIONAL: Graceful degradation for MCP tool errors
         logger.exception("session_memory_capture failed")
-        return {"ok": False, "reason": "internal_error", "error": str(e)}
+        return {
+            "ok": False,
+            "reason": "internal_error",
+            "error": str(e),
+            "voice_summary": "Couldn't stash that finding (internal error).",
+        }
 
 
 async def handle_session_memory_recall(server: Any, args: dict[str, Any]) -> dict[str, Any]:
@@ -622,18 +641,34 @@ async def handle_session_memory_recall(server: Any, args: dict[str, Any]) -> dic
             top_k=_clamp_top_k(args),
             cwd=args.get("cwd"),
         )
+        count = len(results)
         return {
             "ok": True,
             "results": results,
-            "count": len(results),
+            "count": count,
             "source": "session-stash",
+            "voice_summary": (
+                f"Found {count} stashed finding{_plural(count)}."
+                if count
+                else "No stashed findings matched that query."
+            ),
         }
     except ImportError:
-        return {"ok": False, "reason": "session_stash_unavailable", "source": "session-stash"}
+        return {
+            "ok": False,
+            "reason": "session_stash_unavailable",
+            "source": "session-stash",
+            "voice_summary": "Session memory isn't available in this environment.",
+        }
     except Exception as e:  # noqa: BLE001
         # INTENTIONAL: Graceful degradation for MCP tool errors
         logger.exception("session_memory_recall failed")
-        return {"ok": False, "reason": "internal_error", "error": str(e)}
+        return {
+            "ok": False,
+            "reason": "internal_error",
+            "error": str(e),
+            "voice_summary": "Recall didn't work (internal error).",
+        }
 
 
 async def handle_session_memory_recent(server: Any, args: dict[str, Any]) -> dict[str, Any]:
@@ -652,18 +687,38 @@ async def handle_session_memory_recent(server: Any, args: dict[str, Any]) -> dic
             top_k=_clamp_top_k(args),
             cwd=args.get("cwd"),
         )
+        count = len(results)
         return {
             "ok": True,
             "results": results,
-            "count": len(results),
+            "count": count,
             "source": "session-stash",
+            "voice_summary": (
+                "Nothing stashed yet for this project."
+                if not count
+                else (
+                    "Here is the most recent stashed finding."
+                    if count == 1
+                    else f"Here are the {count} most recent stashed findings."
+                )
+            ),
         }
     except ImportError:
-        return {"ok": False, "reason": "session_stash_unavailable", "source": "session-stash"}
+        return {
+            "ok": False,
+            "reason": "session_stash_unavailable",
+            "source": "session-stash",
+            "voice_summary": "Session memory isn't available in this environment.",
+        }
     except Exception as e:  # noqa: BLE001
         # INTENTIONAL: Graceful degradation for MCP tool errors
         logger.exception("session_memory_recent failed")
-        return {"ok": False, "reason": "internal_error", "error": str(e)}
+        return {
+            "ok": False,
+            "reason": "internal_error",
+            "error": str(e),
+            "voice_summary": "Recall didn't work (internal error).",
+        }
 
 
 async def handle_session_memory_forget(server: Any, args: dict[str, Any]) -> dict[str, Any]:
@@ -686,6 +741,7 @@ async def handle_session_memory_forget(server: Any, args: dict[str, Any]) -> dic
                 "reason": "invalid_entry",
                 "error": "ids must be a list of record-ID strings",
                 "source": "session-stash",
+                "voice_summary": "Couldn't delete — ids must be record-ID strings.",
             }
         deleted = session_stash.forget_entries(
             ids,
@@ -698,17 +754,34 @@ async def handle_session_memory_forget(server: Any, args: dict[str, Any]) -> dic
             "deleted": deleted,
             "source": "session-stash",
         }
-        if not result["ok"]:
+        if result["ok"]:
+            result["voice_summary"] = (
+                "Nothing to delete."
+                if not ids
+                else f"Deleted {deleted} of {len(ids)} stashed record{_plural(len(ids))}."
+            )
+        else:
             result["reason"] = _stash_failure_reason(session_stash)
             if result["reason"] == "write_failed":
                 result["reason"] = "not_found"
+            result["voice_summary"] = f"Couldn't delete those records ({result['reason']})."
         return result
     except ImportError:
-        return {"ok": False, "reason": "session_stash_unavailable", "source": "session-stash"}
+        return {
+            "ok": False,
+            "reason": "session_stash_unavailable",
+            "source": "session-stash",
+            "voice_summary": "Session memory isn't available in this environment.",
+        }
     except Exception as e:  # noqa: BLE001
         # INTENTIONAL: Graceful degradation for MCP tool errors
         logger.exception("session_memory_forget failed")
-        return {"ok": False, "reason": "internal_error", "error": str(e)}
+        return {
+            "ok": False,
+            "reason": "internal_error",
+            "error": str(e),
+            "voice_summary": "Deletion didn't work (internal error).",
+        }
 
 
 async def handle_session_memory_status(server: Any, args: dict[str, Any]) -> dict[str, Any]:
@@ -731,6 +804,12 @@ async def handle_session_memory_status(server: Any, args: dict[str, Any]) -> dic
         status["backend_transport"] = status.get("transport")
         status["transport"] = "mcp"
         status["source"] = "session-stash"
+        if status.get("ok", True):
+            backend = status.get("backend") or "file"
+            status["voice_summary"] = f"Session memory is ready ({backend} backend)."
+        else:
+            reason = status.get("reason") or "unknown"
+            status["voice_summary"] = f"Session memory is unavailable ({reason})."
         return status
     except ImportError:
         return {
@@ -738,11 +817,17 @@ async def handle_session_memory_status(server: Any, args: dict[str, Any]) -> dic
             "reason": "session_stash_unavailable",
             "transport": "mcp",
             "source": "session-stash",
+            "voice_summary": "Session memory isn't available in this environment.",
         }
     except Exception as e:  # noqa: BLE001
         # INTENTIONAL: Graceful degradation for MCP tool errors
         logger.exception("session_memory_status failed")
-        return {"ok": False, "reason": "internal_error", "error": str(e)}
+        return {
+            "ok": False,
+            "reason": "internal_error",
+            "error": str(e),
+            "voice_summary": "Status check didn't work (internal error).",
+        }
 
 
 SESSION_MEMORY_TOOL_HANDLERS: dict[str, Any] = {

--- a/attune_redis/tests/test_mcp_tools.py
+++ b/attune_redis/tests/test_mcp_tools.py
@@ -494,6 +494,116 @@ class TestHandleSessionStatus:
         assert result["reachability"] == "unreachable_local"
 
 
+class TestSessionMemoryVoiceSummaries:
+    """Each verb voices its own action-appropriate summary.
+
+    Regression guard for the receipt-4 canary bug (2026-07-27): every
+    session_memory_* verb answered with the generic recall greeting
+    "Here's what I found." because the shared voice layer stamped
+    GREETING_SUCCESS over responses that carried no summary of their own.
+    """
+
+    GENERIC_GREETING = "Here's what I found."
+
+    @pytest.mark.asyncio()
+    async def test_capture_voices_stashing(self, mock_server):
+        with patch("attune.memory.session_stash.stash_entry", return_value=True):
+            result = await handle_session_memory_capture(mock_server, {"content": "a finding"})
+        assert result["voice_summary"] == "Stashed that finding for future recall."
+
+    @pytest.mark.asyncio()
+    async def test_capture_failure_voices_the_reason(self, mock_server):
+        with (
+            patch("attune.memory.session_stash.stash_entry", return_value=False),
+            patch(
+                "attune.memory.session_stash.backend_status",
+                return_value={"ok": False, "reason": "file_write_denied"},
+            ),
+        ):
+            result = await handle_session_memory_capture(mock_server, {"content": "x"})
+        assert result["voice_summary"] == "Couldn't stash that finding (file_write_denied)."
+
+    @pytest.mark.asyncio()
+    async def test_recall_voices_hit_count(self, mock_server):
+        hits = [{"id": "m1", "text": "found"}]
+        with patch("attune.memory.session_stash.recall_entries", return_value=hits):
+            result = await handle_session_memory_recall(mock_server, {"query": "parser"})
+        assert result["voice_summary"] == "Found 1 stashed finding."
+
+    @pytest.mark.asyncio()
+    async def test_recall_empty_voices_no_match(self, mock_server):
+        with patch("attune.memory.session_stash.recall_entries", return_value=[]):
+            result = await handle_session_memory_recall(mock_server, {"query": "nope"})
+        assert result["voice_summary"] == "No stashed findings matched that query."
+
+    @pytest.mark.asyncio()
+    async def test_recent_voices_singular_and_empty(self, mock_server):
+        one = [{"id": "m1"}]
+        with patch("attune.memory.session_stash.recent_entries", return_value=one):
+            result = await handle_session_memory_recent(mock_server, {})
+        assert result["voice_summary"] == "Here is the most recent stashed finding."
+
+        with patch("attune.memory.session_stash.recent_entries", return_value=[]):
+            result = await handle_session_memory_recent(mock_server, {})
+        assert result["voice_summary"] == "Nothing stashed yet for this project."
+
+    @pytest.mark.asyncio()
+    async def test_forget_voices_deletion_counts(self, mock_server):
+        with patch("attune.memory.session_stash.forget_entries", return_value=2):
+            result = await handle_session_memory_forget(mock_server, {"ids": ["a", "b"]})
+        assert result["voice_summary"] == "Deleted 2 of 2 stashed records."
+
+    @pytest.mark.asyncio()
+    async def test_forget_not_found_voices_failure(self, mock_server):
+        with (
+            patch("attune.memory.session_stash.forget_entries", return_value=0),
+            patch(
+                "attune.memory.session_stash.backend_status",
+                return_value={"ok": True, "reason": None},
+            ),
+        ):
+            result = await handle_session_memory_forget(mock_server, {"ids": ["gone"]})
+        assert result["voice_summary"] == "Couldn't delete those records (not_found)."
+
+    @pytest.mark.asyncio()
+    async def test_status_voices_backend_readiness(self, mock_server):
+        underlying = {
+            "backend": "FileStashBackend",
+            "ok": True,
+            "transport": "file",
+            "reason": None,
+        }
+        with patch("attune.memory.session_stash.backend_status", return_value=underlying):
+            result = await handle_session_memory_status(mock_server, {})
+        assert result["voice_summary"] == "Session memory is ready (FileStashBackend backend)."
+
+        underlying = {"backend": None, "ok": False, "transport": "none", "reason": "no_backend"}
+        with patch("attune.memory.session_stash.backend_status", return_value=underlying):
+            result = await handle_session_memory_status(mock_server, {})
+        assert result["voice_summary"] == "Session memory is unavailable (no_backend)."
+
+    @pytest.mark.asyncio()
+    async def test_no_verb_uses_the_generic_recall_greeting(self, mock_server):
+        """The canary assertion: no session_memory verb ever says
+        "Here's what I found." — that phrasing only fits recall, and
+        recall now phrases its own count."""
+        with patch("attune.memory.session_stash.stash_entry", return_value=True):
+            capture = await handle_session_memory_capture(mock_server, {"content": "x"})
+        with patch("attune.memory.session_stash.recall_entries", return_value=[]):
+            recall = await handle_session_memory_recall(mock_server, {"query": "q"})
+        with patch("attune.memory.session_stash.recent_entries", return_value=[]):
+            recent = await handle_session_memory_recent(mock_server, {})
+        with patch("attune.memory.session_stash.forget_entries", return_value=1):
+            forget = await handle_session_memory_forget(mock_server, {"ids": ["a"]})
+        with patch(
+            "attune.memory.session_stash.backend_status",
+            return_value={"ok": True, "backend": "FileStashBackend"},
+        ):
+            status = await handle_session_memory_status(mock_server, {})
+        for result in (capture, recall, recent, forget, status):
+            assert result["voice_summary"] != self.GENERIC_GREETING
+
+
 # =========================================================================
 # Registration integration
 # =========================================================================

--- a/src/attune/voice/formatter.py
+++ b/src/attune/voice/formatter.py
@@ -182,15 +182,17 @@ def format_mcp_response(
     if steps:
         voiced["next_steps"] = steps
 
-    # Add a one-line voice summary
-    success = response.get("success", True)
-    score = response.get("score")
-    if score is not None:
-        voiced["voice_summary"] = personality.score_commentary(score)
-    elif success:
-        voiced["voice_summary"] = personality.GREETING_SUCCESS
-    else:
-        voiced["voice_summary"] = personality.GREETING_FAILURE
+    # Add a one-line voice summary — a handler-supplied summary wins
+    # (adapters phrase their own verbs; the generic greeting is a fallback)
+    if not voiced.get("voice_summary"):
+        success = response.get("success", True)
+        score = response.get("score")
+        if score is not None:
+            voiced["voice_summary"] = personality.score_commentary(score)
+        elif success:
+            voiced["voice_summary"] = personality.GREETING_SUCCESS
+        else:
+            voiced["voice_summary"] = personality.GREETING_FAILURE
 
     return voiced
 

--- a/tests/unit/voice/test_formatter.py
+++ b/tests/unit/voice/test_formatter.py
@@ -223,6 +223,23 @@ class TestFormatMcpResponse:
         assert result["voice_summary"] == personality.GREETING_FAILURE
 
     @patch("attune.voice.formatter.get_next_steps", return_value=[])
+    def test_handler_supplied_voice_summary_wins(self, _mock):
+        """A handler-set voice_summary is preserved, not overwritten
+        with the generic greeting (session_memory_* verbs phrase their
+        own actions — capture/forget must not say "Here's what I found.")."""
+        result = format_mcp_response(
+            "session-memory-capture",
+            {"ok": True, "voice_summary": "Stashed that finding for future recall."},
+        )
+        assert result["voice_summary"] == "Stashed that finding for future recall."
+
+    @patch("attune.voice.formatter.get_next_steps", return_value=[])
+    def test_empty_voice_summary_falls_back_to_greeting(self, _mock):
+        """An empty/None summary still gets the generic fallback."""
+        result = format_mcp_response("code-review", {"success": True, "voice_summary": ""})
+        assert result["voice_summary"] == personality.GREETING_SUCCESS
+
+    @patch("attune.voice.formatter.get_next_steps", return_value=[])
     def test_skips_underscore_prefixed_keys(self, _mock):
         """Dict fallback skips _-prefixed internal keys."""
         result = format_mcp_response(


### PR DESCRIPTION
## Summary

Live receipt-4 canary (2026-07-27, spec cross-provider-memory-transport) caught `session_memory_capture` and `session_memory_forget` both answering with the generic recall greeting **"Here's what I found."** — phrasing that only fits recall.

**Root cause:** the `session_memory_*` tools aren't in `_VOICE_SKIP_TOOLS`, so the shared voice layer (`format_mcp_response` in `src/attune/voice/formatter.py`) stamped `GREETING_SUCCESS` over every response that carried no summary of its own. A second latent bug rode along: the formatter reads the `success` key (default `True`) while these handlers signal via `ok`, so even `ok: False` failures were voiced as success.

## Fix

- Each `session_memory_*` handler sets an action-appropriate `voice_summary` on **every** return path:
  - capture → "Stashed that finding for future recall." / "Couldn't stash that finding (<reason>)."
  - recall → "Found N stashed finding(s)." / "No stashed findings matched that query."
  - recent → "Here is/are the N most recent stashed finding(s)." / "Nothing stashed yet for this project."
  - forget → "Deleted N of M stashed record(s)." / "Couldn't delete those records (<reason>)."
  - status → "Session memory is ready (<backend> backend)." / "Session memory is unavailable (<reason>)."
- `format_mcp_response` now respects a handler-supplied `voice_summary`, falling back to the generic greeting only when none is present.

## Tests

- `attune_redis/tests/test_mcp_tools.py`: new `TestSessionMemoryVoiceSummaries` — per-verb assertions on success and failure paths, plus the canary assertion that no verb ever emits the generic greeting.
- `tests/unit/voice/test_formatter.py`: handler-supplied summary survives the voice layer; empty summary still gets the fallback.
- 186 tests green across `attune_redis/tests/test_mcp_tools.py`, `tests/unit/voice/`, `tests/integration/test_mcp_dispatch.py`, `tests/unit/test_mcp_memory_tools.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
