### PR TITLE
test(mcp): isolate purity test's stash from the developer's live store

### DIFF
--- a/tests/integration/test_mcp_stdout_purity.py
+++ b/tests/integration/test_mcp_stdout_purity.py
@@ -61,8 +61,13 @@ class _LineReader:
 def test_session_memory_capture_keeps_stdout_json_only(tmp_path):
     env = dict(os.environ)
     env["ATTUNE_REDIS_REQUIRED"] = "false"
-    # Keep the file-fallback stash inside the test sandbox.
+    # Keep the stash inside the test sandbox: HOME redirects the file
+    # fallback, and the dead AMS/Redis endpoints force that fallback even
+    # on machines where a real local Redis is running (otherwise the
+    # canary lands in the developer's live store — observed 2026-07-27).
     env["HOME"] = str(tmp_path)
+    env["AMS_BASE_URL"] = "http://127.0.0.1:1"
+    env["REDIS_URL"] = "redis://127.0.0.1:1/0"
     env["PYTHONIOENCODING"] = "utf-8"
 
     proc = subprocess.Popen(


### PR DESCRIPTION
The stdout-purity test's HOME sandbox only redirects the file fallback — with a live local Redis, resolve_backend picks the connected AMS backend and each run stores the canary in the developer's real store (4 leaked on 2026-07-27; deleted). Dead `AMS_BASE_URL`/`REDIS_URL` endpoints now force the file fallback. Verified: test green AND zero new canaries in the live store after a run. Test-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)