### PR TITLE
chore: weekly report 2026-07-27

### DIFF
--- a/weekly-reports/2026-07-27.md
+++ b/weekly-reports/2026-07-27.md
@@ -1,0 +1,216 @@
+# Anthropic Ecosystem Weekly — 2026-07-27
+
+## Summary
+
+Claude Opus 5 launched July 24 at the same $5/$25/MTok price as Opus 4.8, with
+thinking on by default, a 512-token prompt-cache minimum (halved from Opus 4.8),
+and one breaking change: disabling thinking with effort `xhigh` or `max` returns
+a 400 error. The stack's batch premium target (`claude-opus-4-8` in
+`anthropic_batch.py`) is a direct candidate for upgrade. Claude Code shipped
+five releases (v2.1.216–v2.1.220), fixing a severe quadratic slowdown in long
+auto-mode sessions and adding network egress controls, the `DirectoryAdded` hook,
+and `/code-review` as a non-blocking background subagent.
+
+---
+
+## Recommendations
+
+**1. Upgrade batch premium target to claude-opus-5, with corrected max_tokens
+(MEDIUM-HIGH)**
+
+`_BATCH_PREMIUM_FALLBACK = "claude-opus-4-8"` in
+`src/attune/llm/providers/anthropic_batch.py` and `ADDITIONAL_MODELS` in
+`src/attune/models/registry.py` are the two callsites. Opus 5 is a step-change
+improvement at the same price, and batch work is the main remaining use of Opus
+4.8 in the stack. Two changes required together — doing one without the other is
+a bug:
+
+- In `ADDITIONAL_MODELS`, add `claude-opus-5` with `max_tokens=128000` (not
+  8192 — thinking is ON by default and thinking tokens count against
+  `max_tokens`; the Opus 5 migration guide explicitly flags this).
+- Update `_BATCH_PREMIUM_FALLBACK` to `"claude-opus-5"`.
+- In `model_tiers.py`, add `"claude-opus-5"` to `_FABLE_FALLBACKS` (currently
+  only `claude-opus-4-8`).
+- In `models/telemetry/analytics.py:210,237`, add `"claude-opus-5"` to both
+  model-id lists so `sonnet_opus_fallback_analysis` tracks Opus 5 fallbacks.
+
+**Alternatives:** Keep Opus 4.8 as batch target indefinitely (zero risk, zero
+gain); upgrade only the interactive premium tier (Fable 5 is already used there;
+no change needed). The batch-only path is where Opus 4.8 shows up, so that is
+where the upgrade has effect.
+
+- **Applies to:** `anthropic_batch.py`, `registry.py`, `model_tiers.py`,
+  `telemetry/analytics.py`
+- **Urgency:** Medium-high — same cost, better quality, but thinking-on is a
+  real behavior change in batch context that needs `max_tokens` set correctly
+  first.
+
+---
+
+**2. Thinking-on-by-default escalates July-6 Rec #3 and #4 to HIGH (HIGH)**
+
+July-6 Rec #3 (bump `max_tokens=8192` in ADDITIONAL_MODELS for Opus 4.8) was
+medium urgency because Opus 4.8 defaulted thinking OFF. Opus 5 defaults thinking
+ON. Any batch call routed to Opus 5 with `max_tokens=8192` will allocate that
+budget across thinking tokens and response text — a 1,000-token response could
+exhaust the budget before the actual content is written. The Anthropic migration
+guide for Opus 5 is explicit: "revisit max_tokens for workloads that ran without
+thinking on Claude Opus 4.8."
+
+This isn't a hypothetical future problem if Rec #1 above is acted on. Fix before
+upgrading the batch target, not after.
+
+- **Applies to:** `src/attune/models/registry.py` (`ADDITIONAL_MODELS`),
+  `src/attune/llm/providers/anthropic_batch.py`
+- **Urgency:** High — must be resolved before any Opus 5 batch call is made.
+
+---
+
+**3. Add sandbox.network.strictAllowlist to Claude Code settings (MEDIUM)**
+
+v2.1.219 (July 24) adds `sandbox.network.strictAllowlist`. When set, sandboxed
+commands that contact non-allowlisted hosts are denied without prompting, instead
+of getting a permission dialog. The attune MCP server makes outbound calls (Redis,
+Anthropic API, etc.). This setting, added to `.claude/settings.json` with an
+explicit allowlist, would prevent unexpected egress in non-interactive sessions
+(scheduled runs like this one) without silently allowing anything that resolves.
+
+This pairs with the existing `CLAUDE_CODE_MCP_AUTO_BACKGROUND_MS` setting
+(Rec #3 from July-20).
+
+- **Applies to:** `.claude/settings.json`
+- **Urgency:** Medium — security hardening; no urgency if scheduled-run egress
+  is already constrained by infrastructure.
+
+---
+
+**4. v2.1.216 quadratic slowdown — explains past scheduled-run sluggishness
+(INFO)**
+
+Fixed in v2.1.216 (July 20): message normalization cost grew quadratically with
+turn count. A 50-turn session was 2,500× more expensive (compute time) than a
+10-turn session, causing multi-second stalls and slow resumes. This report is
+session-turn-heavy. If past scheduled runs have felt slow toward the end of long
+sessions, that is why. No code change needed; update Claude Code.
+
+---
+
+**5. DirectoryAdded hook available in v2.1.219 (LOW)**
+
+New hook type fires after `/add-dir`. If any workflow or hook needs to react to a
+directory being added to the session context (e.g., re-indexing, syncing), this
+is the trigger. The attune hook infrastructure (`src/attune/hooks/`) could use
+this without modification to the existing hook dispatcher.
+
+- **Applies to:** `.claude/settings.json` hooks configuration
+- **Urgency:** Low — no current gap, but worth knowing for future hook design.
+
+---
+
+**6. Fable fallback chain should include Opus 5 (MEDIUM)**
+
+`_FABLE_FALLBACKS = [{"model": "claude-opus-4-8"}]` in `model_tiers.py` is the
+server-side fallback list sent when Fable 5 is the primary model. With Opus 5
+now available at the same $5/$25 price and step-change better quality, this
+should be updated to `claude-opus-5` (or `claude-opus-5` first, `claude-opus-4-8`
+second). The `anthropic.llm.providers.anthropic.py:454` block also has an
+`claude-opus-4-8` entry — check that for the same update.
+
+This is separate from Rec #1 (batch); this affects the interactive premium path
+where Fable 5 encounters a refusal and falls back.
+
+- **Applies to:** `src/attune/model_tiers.py`,
+  `src/attune/llm/providers/anthropic.py`
+- **Urgency:** Medium — Fable refusals are tracked in telemetry; Opus 5 would
+  be a better fallback today.
+
+---
+
+## Carry-overs
+
+| # | First raised | Recommendation | Status |
+|---|---|---|---|
+| July-6 Rec #1 | 2026-07-06 | Fix `_OPUS_NO_SAMPLING_RE` for Sonnet 5 | **Open (HIGH)** — 7th week; Opus 5 also has sampling restrictions, same fix applies |
+| July-6 Rec #2 | 2026-07-06 | Handle `stop_reason: "refusal"` in `AnthropicProvider.generate()` | **Open (HIGH)** — 7th week; Opus 5 uses same refusal mechanism |
+| July-6 Rec #3 | 2026-07-06 | Bump `max_tokens=8192` for Opus 4.8 / Sonnet 5 | **Escalated → HIGH** — Opus 5 thinking-on-default makes this urgent (see Rec #2 above) |
+| July-6 Rec #4 | 2026-07-06 | Audit `max_tokens` call sites for adaptive thinking | **Escalated → HIGH** — same reason; now Opus 5 batch path, not just interactive |
+| July-6 Rec #5 | 2026-07-06 | Sonnet 5 intro pricing $2/$10 → expires Aug 31 | **Open (MEDIUM, 35 days)** — getting close; run the benchmark now |
+| June-29 Rec #2 | 2026-06-29 | Verify hook matchers for hyphenated MCP server names | Open (low) |
+| June-29 Rec #3 | 2026-06-29 | `autoMode.classifyAllShell` awareness | Open (low) |
+| June-22 Rec #1 | 2026-06-22 | Adjust release workflows for destructive git blocking | Open (medium) |
+| June-22 Rec #2 | 2026-06-22 | Investigate prompt caching on `_CITATION_BASE_URL` | Open |
+| June-22 Rec #3 | 2026-06-22 | `Tool(param:value)` permission rules for cost control | Open (low) |
+| June-22 Rec #4 | 2026-06-22 | Set `CLAUDE_CODE_CLIENT_PRESENCE_FILE` for scheduled runs | Open (low) |
+| June-8 Rec #4 | 2026-06-08 | Stop hooks `additionalContext` for session-stash | Open (low) |
+| July-13 Rec #1 | 2026-07-13 | Set expiry + rotation reminder on ANTHROPIC_API_KEY | Open (low) |
+| July-13 Rec #2 | 2026-07-13 | Run `/doctor` in next interactive session | Open (low) |
+| July-20 Rec #1 | 2026-07-20 | Verify hook `ask` path in auto mode post-v2.1.211 | Open (high) |
+| July-20 Rec #2 | 2026-07-20 | Confirm `Edit(tests/unit/**)` scope after v2.1.214 fix | Open (medium) |
+| July-20 Rec #3 | 2026-07-20 | Test long MCP tools with auto-background behavior | Open (medium) |
+| July-20 Rec #5 | 2026-07-20 | Scan prompts for "Claude will run /verify after changes" | Open (low) |
+
+July-6 Recs #1 and #2 are now seven weeks old at HIGH severity. The question is
+not whether Sonnet 5 is in live workflows — it is (it is the capable tier default
+in MODEL_REGISTRY). If any workflow routes there and hits a sampling restriction
+or a refusal, these fire silently or throw. Fix or close with evidence.
+
+---
+
+## Watch list
+
+- **Sonnet 5 intro pricing expires Aug 31 (35 days).** At $2/$10 now, $3/$15
+  after. If Haiku 4.5 can carry cheap-tier work that currently routes to Sonnet
+  5, now is the 5-week window to measure that. Not urgent today; urgent in two
+  weeks.
+- **Workbench retiring Aug 17 (21 days).** Legacy `platform.claude.com/workbench`
+  going dark. Export saved prompts, variables, and evals from the banner before
+  then. The experimental prompt generation APIs (`/v1/experimental/generate_prompt`,
+  `/v1/experimental/improve_prompt`, `/v1/experimental/templatize_prompt`) also
+  retire August 17.
+- **Opus 4.1 retiring August 5 (9 days).** Not in the stack's registry. Confirm
+  no call site hard-codes `claude-opus-4-1-20250805` before the 5th.
+- **Mid-conversation tool changes beta.** Adding/removing tools mid-turn while
+  preserving prompt cache (`mid-conversation-tool-changes-2026-07-01` header) is
+  live on Fable 5, Opus 4.8, and Opus 5. The attune multi-turn workflows could
+  use this to reduce re-send overhead on long sessions. Beta quality; not ready
+  to act on yet.
+- **Fallbacks "default" mode.** `fallbacks: "default"` on Fable 5 calls could
+  replace the manual `_FABLE_FALLBACKS` chain (and the `record_fable_refusal`
+  telemetry path). Still beta; worth evaluating after the Opus 5 upgrade.
+
+---
+
+## No-ops
+
+| Item | Why skipped |
+|---|---|
+| Claude Opus 5 fast mode ($10/$50/MTok) | Too expensive for batch or interactive workflows currently; revisit only if Fable 5 fast mode becomes relevant |
+| Managed Agents session seeding (`initial_events`) | Stack doesn't use Managed Agents SDK |
+| Managed Agents thread event deltas | Same — not using managed agents |
+| Managed Agents webhooks (environment, memory_store lifecycle) | Same |
+| Managed Agents `version` field optional | Same |
+| Managed Agents effort on model config | Same |
+| v2.1.217 emoji shortcode autocomplete | CLI UX only; no code change |
+| v2.1.217 subagent concurrency cap (default 20) | Passive limit; no code change unless workflows spawn >20 subagents per session |
+| v2.1.218 /ultrareview descriptive args | CLI UX improvement; no code change |
+| v2.1.218 Windows path corruption fix | Linux-only stack |
+| v2.1.220 bug fixes | Passive benefit; no action |
+
+---
+
+## Sources checked
+
+- `platform.claude.com/docs/en/release-notes/api` (July 17–24, 2026)
+- `platform.claude.com/docs/en/about-claude/models/whats-new-opus-5`
+  (full migration guide)
+- `claudeupdates.dev/version/2.1.216` (v2.1.216 detail)
+- `releasebot.io/updates/anthropic/claude-code` (v2.1.216–v2.1.220, July 20–25)
+- WebSearch: Opus 5 launch coverage (Axios, TechCrunch, Fortune)
+- Prior report: `weekly-reports/2026-07-20.md`
+- `src/attune/models/registry.py` — confirmed ADDITIONAL_MODELS has
+  `claude-opus-4-8` with `max_tokens=8192`
+- `src/attune/llm/providers/anthropic_batch.py` — confirmed
+  `_BATCH_PREMIUM_FALLBACK = "claude-opus-4-8"`
+- `src/attune/model_tiers.py` — confirmed `_FABLE_FALLBACKS` targets opus-4-8
+- `src/attune/models/telemetry/analytics.py` — confirmed model-id lists don't
+  include `claude-opus-5`

--- a/weekly-reports/2026-07-27.md
+++ b/weekly-reports/2026-07-27.md
@@ -113,7 +113,7 @@ this without modification to the existing hook dispatcher.
 server-side fallback list sent when Fable 5 is the primary model. With Opus 5
 now available at the same $5/$25 price and step-change better quality, this
 should be updated to `claude-opus-5` (or `claude-opus-5` first, `claude-opus-4-8`
-second). The `anthropic.llm.providers.anthropic.py:454` block also has an
+second). The `src/attune/llm/providers/anthropic.py:454` block also has an
 `claude-opus-4-8` entry — check that for the same update.
 
 This is separate from Rec #1 (batch); this affects the interactive premium path


### PR DESCRIPTION
# Anthropic Ecosystem Weekly — 2026-07-27

## Summary

Claude Opus 5 launched July 24 at the same $5/$25/MTok price as Opus 4.8, with
thinking on by default, a 512-token prompt-cache minimum (halved from Opus 4.8),
and one breaking change: disabling thinking with effort `xhigh` or `max` returns
a 400 error. The stack's batch premium target (`claude-opus-4-8` in
`anthropic_batch.py`) is a direct candidate for upgrade. Claude Code shipped
five releases (v2.1.216–v2.1.220), fixing a severe quadratic slowdown in long
auto-mode sessions and adding network egress controls, the `DirectoryAdded` hook,
and `/code-review` as a non-blocking background subagent.

---

## Recommendations

**1. Upgrade batch premium target to claude-opus-5, with corrected max_tokens
(MEDIUM-HIGH)**

`_BATCH_PREMIUM_FALLBACK = "claude-opus-4-8"` in
`src/attune/llm/providers/anthropic_batch.py` and `ADDITIONAL_MODELS` in
`src/attune/models/registry.py` are the two callsites. Opus 5 is a step-change
improvement at the same price, and batch work is the main remaining use of Opus
4.8 in the stack. Two changes required together — doing one without the other is
a bug:

- In `ADDITIONAL_MODELS`, add `claude-opus-5` with `max_tokens=128000` (not
  8192 — thinking is ON by default and thinking tokens count against
  `max_tokens`; the Opus 5 migration guide explicitly flags this).
- Update `_BATCH_PREMIUM_FALLBACK` to `"claude-opus-5"`.
- In `model_tiers.py`, add `"claude-opus-5"` to `_FABLE_FALLBACKS` (currently
  only `claude-opus-4-8`).
- In `models/telemetry/analytics.py:210,237`, add `"claude-opus-5"` to both
  model-id lists so `sonnet_opus_fallback_analysis` tracks Opus 5 fallbacks.

**Alternatives:** Keep Opus 4.8 as batch target indefinitely (zero risk, zero
gain); upgrade only the interactive premium tier (Fable 5 is already used there;
no change needed). The batch-only path is where Opus 4.8 shows up, so that is
where the upgrade has effect.

- **Applies to:** `anthropic_batch.py`, `registry.py`, `model_tiers.py`,
  `telemetry/analytics.py`
- **Urgency:** Medium-high — same cost, better quality, but thinking-on is a
  real behavior change in batch context that needs `max_tokens` set correctly
  first.

---

**2. Thinking-on-by-default escalates July-6 Rec #3 and #4 to HIGH (HIGH)**

July-6 Rec #3 (bump `max_tokens=8192` in ADDITIONAL_MODELS for Opus 4.8) was
medium urgency because Opus 4.8 defaulted thinking OFF. Opus 5 defaults thinking
ON. Any batch call routed to Opus 5 with `max_tokens=8192` will allocate that
budget across thinking tokens and response text — a 1,000-token response could
exhaust the budget before the actual content is written. The Anthropic migration
guide for Opus 5 is explicit: "revisit max_tokens for workloads that ran without
thinking on Claude Opus 4.8."

This isn't a hypothetical future problem if Rec #1 above is acted on. Fix before
upgrading the batch target, not after.

- **Applies to:** `src/attune/models/registry.py` (`ADDITIONAL_MODELS`),
  `src/attune/llm/providers/anthropic_batch.py`
- **Urgency:** High — must be resolved before any Opus 5 batch call is made.

---

**3. Add sandbox.network.strictAllowlist to Claude Code settings (MEDIUM)**

v2.1.219 (July 24) adds `sandbox.network.strictAllowlist`. When set, sandboxed
commands that contact non-allowlisted hosts are denied without prompting, instead
of getting a permission dialog. The attune MCP server makes outbound calls (Redis,
Anthropic API, etc.). This setting, added to `.claude/settings.json` with an
explicit allowlist, would prevent unexpected egress in non-interactive sessions
(scheduled runs like this one) without silently allowing anything that resolves.

- **Applies to:** `.claude/settings.json`
- **Urgency:** Medium — security hardening; no urgency if scheduled-run egress
  is already constrained by infrastructure.

---

**4. v2.1.216 quadratic slowdown — explains past scheduled-run sluggishness
(INFO)**

Fixed in v2.1.216 (July 20): message normalization cost grew quadratically with
turn count. A 50-turn session was 2,500× more expensive (compute time) than a
10-turn session, causing multi-second stalls and slow resumes. If past scheduled
runs felt slow toward the end of long sessions, that is why. No code change
needed; update Claude Code.

---

**5. DirectoryAdded hook available in v2.1.219 (LOW)**

New hook type fires after `/add-dir`. If any workflow or hook needs to react to a
directory being added to the session context (e.g., re-indexing, syncing), this
is the trigger. The attune hook infrastructure (`src/attune/hooks/`) could use
this without modification to the existing hook dispatcher.

- **Applies to:** `.claude/settings.json` hooks configuration
- **Urgency:** Low — no current gap, but worth knowing for future hook design.

---

**6. Fable fallback chain should include Opus 5 (MEDIUM)**

`_FABLE_FALLBACKS = [{"model": "claude-opus-4-8"}]` in `model_tiers.py` is the
server-side fallback list sent when Fable 5 is the primary model. With Opus 5
now available at the same $5/$25 price and step-change better quality, this
should be updated to `claude-opus-5` (or `claude-opus-5` first, `claude-opus-4-8`
second). The `anthropic.llm.providers.anthropic.py:454` block also has a
`claude-opus-4-8` entry — check that for the same update.

This is separate from Rec #1 (batch); this affects the interactive premium path
where Fable 5 encounters a refusal and falls back.

- **Applies to:** `src/attune/model_tiers.py`,
  `src/attune/llm/providers/anthropic.py`
- **Urgency:** Medium — Fable refusals are tracked in telemetry; Opus 5 would
  be a better fallback today.

---

## Carry-overs

| # | First raised | Recommendation | Status |
|---|---|---|---|
| July-6 Rec #1 | 2026-07-06 | Fix `_OPUS_NO_SAMPLING_RE` for Sonnet 5 | **Open (HIGH)** — 7th week; Opus 5 also has sampling restrictions |
| July-6 Rec #2 | 2026-07-06 | Handle `stop_reason: "refusal"` in `AnthropicProvider.generate()` | **Open (HIGH)** — 7th week; Opus 5 uses same refusal mechanism |
| July-6 Rec #3 | 2026-07-06 | Bump `max_tokens=8192` for Opus 4.8 / Sonnet 5 | **Escalated → HIGH** — Opus 5 thinking-on-default makes this urgent |
| July-6 Rec #4 | 2026-07-06 | Audit `max_tokens` call sites for adaptive thinking | **Escalated → HIGH** — same reason |
| July-6 Rec #5 | 2026-07-06 | Sonnet 5 intro pricing $2/$10 → expires Aug 31 | **Open (MEDIUM, 35 days)** |
| June-29 Rec #2 | 2026-06-29 | Verify hook matchers for hyphenated MCP server names | Open (low) |
| June-29 Rec #3 | 2026-06-29 | `autoMode.classifyAllShell` awareness | Open (low) |
| June-22 Rec #1 | 2026-06-22 | Adjust release workflows for destructive git blocking | Open (medium) |
| June-22 Rec #2 | 2026-06-22 | Investigate prompt caching on `_CITATION_BASE_URL` | Open |
| June-22 Rec #3 | 2026-06-22 | `Tool(param:value)` permission rules for cost control | Open (low) |
| June-22 Rec #4 | 2026-06-22 | Set `CLAUDE_CODE_CLIENT_PRESENCE_FILE` for scheduled runs | Open (low) |
| June-8 Rec #4 | 2026-06-08 | Stop hooks `additionalContext` for session-stash | Open (low) |
| July-13 Rec #1 | 2026-07-13 | Set expiry + rotation reminder on ANTHROPIC_API_KEY | Open (low) |
| July-13 Rec #2 | 2026-07-13 | Run `/doctor` in next interactive session | Open (low) |
| July-20 Rec #1 | 2026-07-20 | Verify hook `ask` path in auto mode post-v2.1.211 | Open (high) |
| July-20 Rec #2 | 2026-07-20 | Confirm `Edit(tests/unit/**)` scope after v2.1.214 fix | Open (medium) |
| July-20 Rec #3 | 2026-07-20 | Test long MCP tools with auto-background behavior | Open (medium) |
| July-20 Rec #5 | 2026-07-20 | Scan prompts for "Claude will run /verify after changes" | Open (low) |

July-6 Recs #1 and #2 are now seven weeks old at HIGH severity. Sonnet 5 is the
capable-tier default in MODEL_REGISTRY — it is in live workflows. Fix or close
with evidence.

---

## Watch list

- **Sonnet 5 intro pricing expires Aug 31 (35 days).** $2/$10 → $3/$15 after.
  Run Haiku 4.5 evals now against current Sonnet 5 workloads.
- **Workbench retiring Aug 17 (21 days).** Export saved prompts/variables/evals
  from `platform.claude.com/workbench` before shutdown. Experimental prompt
  generation APIs (`/v1/experimental/generate_prompt`, etc.) also retire Aug 17.
- **Opus 4.1 retiring August 5 (9 days).** Stack doesn't use it; confirm no
  hard-coded `claude-opus-4-1-20250805` call sites.
- **Mid-conversation tool changes beta.** Add/remove tools mid-turn while
  preserving prompt cache (`mid-conversation-tool-changes-2026-07-01` header),
  on Fable 5, Opus 4.8, Opus 5. Beta; not ready to act on yet.
- **Fallbacks "default" mode.** `fallbacks: "default"` could replace the manual
  `_FABLE_FALLBACKS` chain. Still beta; evaluate after Opus 5 upgrade settles.

---

## No-ops

| Item | Why skipped |
|---|---|
| Claude Opus 5 fast mode ($10/$50/MTok) | Too expensive for current batch/interactive use cases |
| Managed Agents session seeding, thread event deltas, webhooks | Stack doesn't use Managed Agents SDK |
| Managed Agents `version` field optional, effort on model config | Same |
| v2.1.217 emoji shortcode autocomplete | CLI UX only |
| v2.1.217 subagent concurrency cap (default 20) | Passive limit; no action unless workflows spawn >20 subagents |
| v2.1.218 /ultrareview descriptive args | CLI UX improvement |
| v2.1.218 Windows path corruption fix | Linux stack |
| v2.1.220 bug fixes and reliability improvements | Passive benefit |

---

## Sources checked

- `platform.claude.com/docs/en/release-notes/api` (July 17–24, 2026)
- `platform.claude.com/docs/en/about-claude/models/whats-new-opus-5`
- `claudeupdates.dev/version/2.1.216`
- `releasebot.io/updates/anthropic/claude-code` (v2.1.216–v2.1.220)
- WebSearch: Opus 5 launch coverage (Axios, TechCrunch, Fortune)
- Prior report: `weekly-reports/2026-07-20.md`
- `src/attune/models/registry.py` — ADDITIONAL_MODELS has `claude-opus-4-8` with `max_tokens=8192`
- `src/attune/llm/providers/anthropic_batch.py` — `_BATCH_PREMIUM_FALLBACK = "claude-opus-4-8"`
- `src/attune/model_tiers.py` — `_FABLE_FALLBACKS` targets opus-4-8 only
- `src/attune/models/telemetry/analytics.py` — model-id lists don't include `claude-opus-5`

---
_Generated by [Claude Code](https://claude.ai/code/session_01D2aTL3aD9DPpt9HCCnepiz)_