### PR TITLE
docs(spec): feature-lead-governance revision pass — rulings folded in

### DIFF
--- a/.claude/plans/feature-lead-governance.md
+++ b/.claude/plans/feature-lead-governance.md
@@ -1,6 +1,7 @@
 # Feature Lead Governance — Execution Plan
 
-**Status:** DRAFT for review; not approved for execution.
+**Status:** approved (2026-07-27) — rulings applied; execution gated
+by P1 (the cross-review usage-signal read).
 **Canonical spec:** `docs/specs/feature-lead-governance/`
 
 ## Outcome
@@ -21,10 +22,14 @@ human chair.
 
 - No permanent provider ownership.
 - No model may waive repository rules or required evidence.
-- Findings are immutable; dispositions are appended.
-- Human approval remains required for activation, transfer, scope
-  expansion, revocation, and unresolved material disputes.
-- Implementation waits for spec approval and current handoff/review APIs.
+- Findings are immutable through every governance API; dispositions
+  are appended per atomic finding; out-of-band edits are detected.
+- Chair transitions (activation, cross-provider transfer, scope
+  expansion, revocation) are evidenced by chair-merged PRs to the
+  main-tracked registry (D7) — never by an MCP-relayed confirmation.
+  Same-provider session succession is an automatic event.
+- Implementation waits for the P1 activation gate (the cross-review
+  usage-signal read) and consumes the SHIPPED handoff/board seams.
 
 ## Tasks
 

--- a/docs/specs/feature-lead-governance/decisions.md
+++ b/docs/specs/feature-lead-governance/decisions.md
@@ -1,8 +1,8 @@
 # Feature Lead Governance — Decisions
 
 **Status:** active (2026-07-27) — OPEN-1..4 + approval-evidence +
-disposition model chair-ruled; spec revision pass owed before
-execution.
+disposition model chair-ruled; revision pass APPLIED to
+requirements/design/tasks/plan the same day. Execution gated by P1.
 
 Chair rulings of 2026-07-27 come from round-table thread
 `q-feature-lead-governance-001` (3 rounds, all seats present, one

--- a/docs/specs/feature-lead-governance/design.md
+++ b/docs/specs/feature-lead-governance/design.md
@@ -1,35 +1,43 @@
 # Feature Lead Governance — Design
 
-**Status:** DRAFT for review (2026-07-26)
+**Status:** approved (2026-07-27) — revision pass applied per
+decisions.md D1–D7; execution gated by P1.
 **Slug:** `feature-lead-governance`
 
 ## Design posture
 
-This is a governance layer over the pending cross-provider handoff and
-cross-review features, not a third collaboration subsystem. The
-canonical noun is **feature lead** because authority is temporary and
-scope-bound; “lead programmer” remains acceptable UI copy.
+This is a thin governance layer over the SHIPPED handoff-packet and
+review-board seams (both T1+T2 on main since 10.6.x), not a third
+collaboration subsystem. The canonical noun is **feature lead**
+because authority is temporary and scope-bound; “lead programmer” is
+acceptable UI copy only. Governance takes no dependency on unshipped
+handoff/cross-review T3/T4 and no workflow-engine coupling until the
+registry + disposition loop is dogfooded on one real feature (D5).
 
-## D1 — branch-scoped assignment artifact
+## D1 — split persistence: main registry + branch-side records
 
-One tracked file per governed branch:
+Authority and lifecycle state live in ONE tracked file per
+assignment ON MAIN, mutated only by chair-merged PRs:
 
 ```text
-docs/assignments/<branch-slug>.yaml
+docs/assignments/<assignment-id>.yaml
 ```
 
-The file is the portable, inspectable state shared by providers. The
-first schema version is intentionally small:
+Findings and hash-chained events live BRANCH-SIDE next to the work,
+with atomic writes; the branch artifact is deleted on merge (like
+handoff files). Main is thereby the global comparison set for
+overlap rejection — a second assignment on any branch is checked
+against the registry, not against branch-local files.
+
+Registry schema (v1, intentionally small):
 
 ```yaml
 schema_version: 1
 assignment_id: flg-<stable-id>
 feature: feature-lead-governance
-branch: codex/example
 state: active
 lead:
-  provider: codex
-  session: <opaque-session-id>
+  provider: codex          # provider-level identity (D7)
 scope:
   paths:
     - src/attune/handoff/
@@ -39,13 +47,32 @@ acceptance:
     claim: Overlapping active scopes are rejected.
     probe: uv run pytest tests/unit/governance/test_assignment.py -q
 authority_profile: feature_lead_v1
-open_findings: []
-events: []
+```
+
+Branch-side event entries carry the D7 evidence block:
+
+```yaml
+event_id: <uuid>
+event_type: activate | transfer | scope_change | revoke | succession
+assignment_id: flg-<stable-id>
+approval:                    # required on the four chair transitions
+  pr_number: <int>
+  merge_commit_sha: <sha>    # merge commit on main
+  merged_by: <github-login>  # must be in the chair allowlist
+  registry_blob_sha: <sha>   # blob of the registry file AT merge_commit
+lead:
+  provider: claude | codex | antigravity
+session: <opaque-id>         # evidence only, never the authority key
+timestamp: <iso8601>
+prev_event_digest: <sha256>  # hash chain
 ```
 
 Paths are normalized, repo-contained after symlink resolution, and
-overlap-checked. Prose and event sizes are capped; oversize values are
-rejected, never silently truncated.
+overlap-checked against the registry. Prose and event sizes are
+capped; oversize values are rejected, never silently truncated.
+Writers assume SINGLE-WRITER discipline (the invoking lead session is
+the only branch-side writer in practice); the core enforces atomic
+replace-on-write and rejects a write whose base digest is stale.
 
 ## D2 — pure governance core
 
@@ -62,90 +89,129 @@ src/attune/governance/
 Public operations return structured results and never invoke a model:
 
 - `propose_assignment(...)`
-- `activate_assignment(...)`
-- `transfer_assignment(...)`
 - `record_finding(...)`
 - `dispose_finding(...)`
-- `complete_assignment(...)`
-- `revoke_assignment(...)`
+- `verify_chair_transition(...)` — the D7 probe set
+- `check_completion(...)` — terminal-state gate
 
-Provider/session invocation stays in existing adapters. This keeps the
-shared contract functional when only one provider is available.
+Chair transitions (activate / cross-provider transfer / scope-expand
+/ revoke) have NO mutating core API that asserts approval — they are
+edits to the main registry that land via chair-merged PRs; the core
+only VERIFIES them (D7). Provider/session invocation stays in
+existing adapters. The shared contract works when only one provider
+is available.
 
-## D3 — authority is policy, not prompt prose
+## D3 — authority is policy, verified against git, not prompt prose
 
 `feature_lead_v1` is a fixed, versioned policy. Validation enforces:
 
-- exactly one active lead;
+- exactly one active lead per registry file;
 - repo-contained, non-ambiguous scope;
-- human activation, transfer, scope expansion, and revocation;
-- immutable findings and append-only events;
-- completion blocked by failed required probes or unresolved
-  `chair_required` findings.
+- the four chair transitions carry D7 approval evidence that passes
+  every forgery probe:
+  1. `merge_commit_sha` is an ancestor of `origin/main`
+     (kills fabricated SHAs);
+  2. the PR resolves host-side, `merged_by` is in the repo-owned
+     chair allowlist, and the merge commit's signature verifies
+     (kills unsigned/non-chair merges);
+  3. the registry blob recomputed at the merge commit equals
+     `approval.registry_blob_sha` (kills replay against a real but
+     unrelated chair merge);
+  4. the event hash chain and the registry transition diff match the
+     event type and sequence (kills history tampering);
+- immutable findings and append-only events as APPLICATION
+  invariants, with out-of-band edits DETECTED by the
+  append-only-in-history validator (a detected mismatch leaves the
+  prior registry state authoritative);
+- completion blocked by failed required probes, unresolved
+  `chair_required` findings, or any non-terminal `rule_violation`.
 
-Prompts may explain the policy but cannot broaden it. A model-proposed
-transition returns `chair_required` when human authority is needed.
+Prompts may explain the policy but cannot broaden it. A
+model-proposed chair transition returns `chair_required` plus the
+registry-PR instructions; it never claims approval.
 
 ## D4 — finding and disposition model
 
+The finding schema is OWNED by the cross-review spec as a versioned
+board record (P2); governance consumes it. Shape:
+
 ```text
 Finding
-  id, reviewer, provider, artifact, anchor, category, severity,
-  claim, evidence, created_at
+  id, parent_comment_id?, reviewer, provider, artifact, anchor,
+  classification (rule_violation | preference_only), rule_id?,
+  severity, claim, evidence, needs_split?, created_at
 
 Disposition
-  finding_id, lead, outcome, rationale, evidence, created_at
+  finding_id, lead, outcome
+  (fixed | rejected_with_reason | deferred | accepted_advisory),
+  rationale, evidence, resolved_by_event_id?, created_at
 ```
 
-Findings are append-only. A disposition never mutates the finding.
-Mechanical validation flags missing anchors/evidence and distinguishes
-`preference_only`. The lead may reject a substantiated finding, but the
-rationale remains visible; material rejection may be escalated by the
-reviewer or human.
+- Findings are atomic and reviewer-owed at record time; the recorder
+  validates one claim + one classification and re-prompts once on a
+  mixed comment; the failed-retry fallback records the whole comment
+  as one blocking `rule_violation` with `needs_split: true`.
+- A disposition never mutates the finding; dispositions are per
+  atomic finding, never per comment.
+- `accepted` is in-progress (`open → accepted → fixed | disputed`);
+  the completion gate counts TERMINAL states of `rule_violation`
+  findings only. `preference_only` renders collapsed with a count.
+- The lead may reject a substantiated finding
+  (`rejected_with_reason`); the rationale remains visible; material
+  rejection may be escalated by the reviewer or human.
 
-## D5 — integrate handoff and cross-review by reference
+## D5 — thin module on shipped seams (ruled, replaces the draft D5)
 
-The assignment file owns governance state. Handoff frontmatter carries
-only `assignment_id`, assignment path, state, and a content digest.
-`handoff_resume` verifies the digest and reports assignment drift.
+Per the chair ruling (post-steelman, thread
+`q-feature-lead-governance-001`):
 
-`/cross-review` accepts an optional assignment path:
-
-- reviewer must differ from the authoring provider when possible;
-- the review brief includes scope, acceptance IDs, and policy summary;
-- raw findings are appended to the assignment by the moderator;
-- lead dispositions happen separately, preserving reviewer text.
-
-No governance data is duplicated into the board beyond IDs, summaries,
-and artifact pointers.
+- Governance ships as its own thin module consuming the SHIPPED
+  handoff-packet and board seams. A cross-provider transfer IS a
+  handoff packet whose frontmatter carries `assignment_id` +
+  `approval.merge_commit_sha`, checked by the already-shipped digest
+  verify — which is also the resume-tamper probe.
+- **P1 — gate inheritance:** governance activation sits behind the
+  SAME chair usage-signal read that gates cross-review T3/T4; no
+  second activation criterion exists.
+- **P2 — single schema owner:** cross-review owns the finding
+  schema; governance consumes the versioned record; hash-chain and
+  probe machinery stays single-homed.
+- No parallel assignment/approval/disposition stores; any field
+  governance needs on the packet or board is proposed as a T3
+  amendment to the owning spec, never a parallel format.
+- Cross-review's ratified posture is untouched: board-only advisory,
+  never a merge gate — a drift-guard test asserts no governance
+  state is readable by any required check.
 
 ## D6 — contract projection and UX
 
 The master collaboration contract gains a short “Feature leadership”
 section containing the R2/R3 behavioral rules and directing agents to
-the active assignment artifact. The existing projector updates
-`AGENTS.md` and `.claude/CLAUDE.md`.
+the active registry. The existing projector updates `AGENTS.md` and
+`.claude/CLAUDE.md`.
 
-Initial UX should be tool-first:
+Tool-first UX, shrunk to lead-authority actions (D7):
 
-- `assignment_create`
+- `assignment_propose`
 - `assignment_status`
-- `assignment_transfer`
 - `assignment_dispose_finding`
-- `assignment_complete`
 
-The tools report recommendations and required human decisions; they do
-not claim human approval. A later `/feature-lead` skill may make this
-more conversational after dogfood proves the state model.
+Transfer/complete/revoke REQUESTS are proposals: the tools return
+`chair_required` with the registry-PR instructions and never claim
+human approval. A later `/feature-lead` skill may make this more
+conversational after dogfood proves the state model.
 
 ## D7 — observability and privacy
 
 Structured events:
 
 - assignment proposed/activated/transferred/completed/revoked;
+- same-provider session succession;
 - finding recorded/disposed/escalated;
 - lead/reviewer unavailable;
-- assignment drift detected on resume.
+- assignment drift detected on resume;
+- forgery-probe rejection (which probe failed);
+- registry-vs-practice drift (review activity without assignment).
 
 Fields are IDs, providers, lifecycle states, disposition category,
 duration, and counts. Source text, code, prompts, and model reasoning
@@ -153,15 +219,25 @@ are excluded.
 
 ## Failure-sensitive test plan
 
-- Unit: schema/path validation, overlap matrix, transition table,
-  authority matrix, immutable findings, completion blockers.
+- Unit: schema/path validation, registry overlap matrix (including
+  the cross-branch case via the main registry), transition table,
+  authority matrix, immutable findings, terminal-state completion
+  blockers, mixed-comment split + fallback.
 - Security: traversal, symlink escape, malformed YAML, oversized
-  content, forged human-approval flag.
-- Integration: real MCP dispatch and assignment file round trip.
+  content, and one test per D3 forgery probe (fabricated SHA,
+  non-chair merger, registry-blob replay, broken hash chain).
+- History: the append-only-in-history validator fails when a prior
+  finding/event line changes relative to the git parent.
+- Integration: real MCP dispatch and registry/branch-record round
+  trip; handoff packet carrying assignment reference + digest.
 - Projection: edit master, project, then `--check` exits zero.
-- Live: one feature led by Claude and reviewed by Codex; one led by
-  Codex and reviewed by Claude; one transfer between them with a
-  deliberately introduced drift warning.
+- Live (conditional on seat availability AND distribution — the
+  Codex/Antigravity seats consume the PUBLISHED attune-ai, so the
+  matrix waits for a release carrying the governance tools): one
+  feature led by Claude and reviewed by Codex; one led by Codex and
+  reviewed by Claude; one transfer between them with a deliberately
+  introduced SCOPED drift (and an irrelevant HEAD move that must NOT
+  flag).
 
 ## Alternatives rejected
 
@@ -175,3 +251,13 @@ are excluded.
   boundaries.
 - **Board-only state:** unavailable or ephemeral at exactly the handoff
   boundary this feature must survive.
+- **Branch-scoped authority files (the draft's D1):** structurally
+  cannot enforce AC-1 across branches and cannot evidence chair
+  approval; replaced by the main registry (D4/D7 rulings).
+- **MCP-asserted human approval:** the confirmation relay transits
+  the agent and is forgeable; replaced by chair-merged registry PRs
+  verified out-of-band (D7).
+- **Governance as cross-review T3 (steelman minority):** a real
+  design (board message 14) — kept out to avoid housing authority
+  state in a spec whose ratified advisory posture is untouchable;
+  its two demonstrated advantages ship anyway as P1 and P2.

--- a/docs/specs/feature-lead-governance/requirements.md
+++ b/docs/specs/feature-lead-governance/requirements.md
@@ -1,6 +1,8 @@
 # Feature Lead Governance — Requirements
 
-**Status:** DRAFT for Patrick review (2026-07-26)
+**Status:** approved (2026-07-27) — revision pass applied per
+decisions.md D1–D7 (thread `q-feature-lead-governance-001`);
+execution gated by P1 (the cross-review usage-signal read).
 **Slug:** `feature-lead-governance`
 **Artifact tier:** Spec — cross-provider authority is a durable,
 multi-session design choice.
@@ -30,7 +32,9 @@ verification receipts, and human rulings remain authoritative.
 
 Every governed work item has one active assignment containing:
 
-- `lead`: provider/session identity, not merely a model family;
+- `lead`: a PROVIDER-level identity (D7 ruling — session ids are
+  recorded as per-event evidence, never as the authority key;
+  same-provider session resume is NOT a transfer);
 - `scope`: explicit feature slug and repo-contained paths;
 - `goal` and failure-sensitive acceptance criteria;
 - `started_at`, lifecycle state, and optional expiry;
@@ -39,8 +43,9 @@ Every governed work item has one active assignment containing:
 Assignments are opt-in for trivial and single-agent work. They are
 recommended when a feature crosses sessions/providers or when two
 models may edit the same surface. Overlapping active lead scopes are
-rejected unless a human explicitly records hierarchy or disjoint
-sub-scopes.
+rejected against the MAIN-TRACKED registry (D4 ruling — main is the
+global comparison set), unless a human explicitly records hierarchy
+or disjoint sub-scopes.
 
 ### R2 — fixed authority boundary
 
@@ -58,15 +63,21 @@ The lead may not:
   criteria;
 - overwrite unrelated user or agent changes;
 - suppress, rewrite, or misattribute reviewer findings;
-- expand scope without a human-approved assignment update;
-- merge, release, or declare disputed work complete on human authority;
+- expand scope without a chair-evidenced assignment update (R5);
+- merge, release, or declare disputed work complete on its own
+  authority — those acts require the human chair;
 - reject a finding because another provider authored it.
 
 ### R3 — evidence-based review contract
 
 Reviewers remain independent and adversarial, including when they
-review the lead's own code. Every actionable objection must name at
-least one of:
+review the lead's own code. Findings are ATOMIC and reviewer-owed at
+record time (D3 ruling): one claim, exactly one classification
+(`rule_violation` | `preference_only`), `rule_id` required iff
+`rule_violation`. A mixed comment is a schema violation → one
+re-prompt; on a failed retry the whole comment records as ONE
+blocking `rule_violation` with `needs_split: true` — fail toward
+visibility. Every `rule_violation` must name at least one of:
 
 - a violated requirement or repository rule;
 - a failing or missing failure-sensitive probe;
@@ -74,10 +85,15 @@ least one of:
 - an inconsistency with an existing public interface or ratified
   decision.
 
-Style preference without a named consequence is
-`preference_only`, not a defect. The original finding is immutable;
-the lead appends a disposition of `accepted`, `rejected`,
-`deferred`, or `chair_required`, with rationale and evidence.
+Style preference without a named consequence is `preference_only`,
+not a defect; it renders COLLAPSED with a count, never hidden (D3).
+The original finding is immutable through every governance API; the
+lead appends a per-finding disposition from the D3 vocabulary
+(`fixed` | `rejected_with_reason` | `deferred` | `accepted_advisory`;
+`accepted` alone is in-progress, never terminal), with rationale and
+evidence. The finding schema is OWNED by the cross-review spec as a
+versioned board record (D5/P2); governance consumes it and never
+forks it.
 
 ### R4 — deterministic conflict resolution
 
@@ -100,28 +116,44 @@ Assignments have these states:
 
 `proposed → active → transferred | completed | revoked`
 
-- Activation requires a human-confirmed goal, scope, lead, and
-  acceptance criteria.
-- Transfer records old/new lead identities, reason, timestamp, current
-  decisions, open findings, and verification receipts.
-- Completion requires acceptance probes and no unresolved
-  `chair_required` findings.
-- Revocation is human-only and records a reason.
-- Completion or revocation releases scope; no provider gains permanent
-  ownership of a module.
+- The four chair transitions — activation, CROSS-PROVIDER transfer,
+  scope expansion, and revocation — are each evidenced by a
+  chair-merged PR to the main-tracked registry (D7). No
+  caller-supplied flag or MCP-relayed confirmation is evidence.
+- Same-provider session succession is recorded as an automatic
+  event, not a transfer (D7) — a lead provider resuming in a new
+  session does not re-enter the chair queue.
+- Transfer records old/new lead identities, reason, timestamp,
+  current decisions, open findings, and verification receipts.
+- Completion requires passing acceptance probes, no unresolved
+  `chair_required` findings, and every `rule_violation` finding in a
+  TERMINAL state (D3 — `accepted` is not terminal; accept-and-ignore
+  cannot complete).
+- Revocation is chair-only. An urgent revocation may set an advisory
+  `revoke_pending` flag branch-side for immediacy; it carries no
+  authority until the registry PR merges (D7).
+- Scope changes may batch into one chair PR (D7 ceremony
+  mitigation).
+- Completion or revocation releases scope; no provider gains
+  permanent ownership of a module.
 
 ### R6 — integration with existing Attune features
 
-- `handoff_create`/`handoff_resume` carry the assignment ID, lead,
-  lifecycle state, open findings, and transfer history. Handoff remains
-  context, not authority; resume verifies the assignment against the
-  current tree.
+- `handoff_create`/`handoff_resume` carry REFERENCES only: the
+  assignment ID, registry path, lifecycle state, and a content
+  digest (D5 — handoffs never duplicate or establish authority
+  state). Handoff remains context, not authority; resume verifies
+  the digest and reports assignment drift.
 - `/cross-review` records the assignment and authoring provider,
-  selects a different provider where available, and returns immutable
-  findings for lead disposition.
+  selects a different provider where available, and returns
+  immutable findings which the invoking session appends for
+  separate lead disposition. Its ratified posture is untouched:
+  board-only advisory, never a merge gate until dogfooded
+  finding-quality earns it — and governance state must never be
+  readable by any required check.
 - The shared collaboration contract gains the behavioral rule; the
-  machine-readable assignment remains in one tracked branch-scoped
-  artifact.
+  machine-readable authority state lives in the main-tracked
+  registry (D4), findings/events branch-side.
 - Dynamic-team roles may consume the assignment, but role governance
   must not depend on any single provider being installed.
 
@@ -130,8 +162,12 @@ Assignments have these states:
 - If the assigned lead is unavailable, Attune reports
   `lead_unavailable`; it does not silently appoint the reviewer or
   authoring model.
-- If no independent reviewer is available, review reports `ABSENT`; it
-  never simulates cross-provider review with the lead.
+- If no independent reviewer is available, review reports `ABSENT`;
+  it never simulates cross-provider review with the lead. `ABSENT`
+  (seat missing/unauthenticated/timed out) is distinguished from
+  probe FAILURE — live cross-provider receipts are conditional on
+  seat availability and distribution lag, and degradation must be
+  deterministic and stated.
 - Read-only inspection continues without assignment writes. Mutating
   operations fail truthfully when workspace write access is denied.
 
@@ -139,28 +175,49 @@ Assignments have these states:
 
 The assignment stores decisions and receipts, not chat transcripts or
 hidden reasoning. Every event records actor, provider, role, timestamp,
-action, and artifact reference. Telemetry may count lifecycle events
-and dispositions but must not contain source code or prompt bodies.
+action, and artifact reference, hash-chained to its predecessor (D7).
+Telemetry may count lifecycle events and dispositions but must not
+contain source code or prompt bodies.
 
 ## Acceptance criteria
 
 - **AC-1:** Two active assignments with overlapping paths are rejected
-  unless a human-approved hierarchy/disjoint-scope rule exists.
-- **AC-2:** A reviewer finding cannot be deleted or rewritten; a lead
-  can only append a disposition.
-- **AC-3:** A preference-only objection is classified separately and
-  cannot block completion without a named consequence or human ruling.
-- **AC-4:** A failed required probe or unresolved `chair_required`
-  finding prevents `completed`.
+  against the main-tracked registry — including when the second
+  assignment originates on a different branch — unless a
+  chair-recorded hierarchy/disjoint-scope rule exists.
+- **AC-2:** No governance API can delete or rewrite a reviewer
+  finding; a lead can only append a disposition. Out-of-band edits
+  are DETECTED: an append-only-in-history validator fails when any
+  existing finding/event line changed relative to the git parent,
+  and a detected mismatch leaves the prior registry state
+  authoritative.
+- **AC-3:** A preference-only objection is classified separately,
+  renders collapsed with a count, and cannot block completion
+  without a named consequence or human ruling. For a split mixed
+  comment, resolving the preference child never resolves the
+  rule-violation child.
+- **AC-4:** A failed required probe, an unresolved `chair_required`
+  finding, or any `rule_violation` finding in a non-terminal state
+  prevents `completed`.
 - **AC-5:** Transfer preserves decisions, findings, receipts, and scope
-  while changing lead identity in one auditable event.
+  while changing lead identity in one auditable, chair-evidenced
+  event.
 - **AC-6:** A real Claude→Codex or Codex→Claude transfer resumes with
-  the same scope and open-finding set, then detects a deliberately
-  changed HEAD or file set.
+  the same scope and open-finding set against a recorded baseline
+  (commit, scoped-file manifest, digest), then distinguishes
+  irrelevant HEAD movement from SCOPED drift and flags only the
+  latter.
 - **AC-7:** Lead or reviewer absence is explicit; the system never
   substitutes self-review.
 - **AC-8:** The collaboration projector reports no drift after the
   behavioral rule is added to the master and projected.
+- **AC-9:** A chair-transition event whose approval evidence fails any
+  forgery probe (non-ancestor merge SHA, non-chair or unsigned
+  merger, registry-blob mismatch at the merge commit, broken event
+  hash chain) is rejected and reported.
+- **AC-10:** A branch with cross-review activity but no active
+  assignment is flagged on the board (registry-vs-practice drift
+  probe — the D7 bypass mitigation).
 
 ## Non-goals
 
@@ -171,13 +228,11 @@ and dispositions but must not contain source code or prompt bodies.
 - Autonomous merge, release, or scope expansion.
 - Storing chain-of-thought or complete transcripts.
 
-## Open decisions for review
+## Resolved decisions
 
-- **OPEN-1:** User-facing name: `feature lead` (recommended) versus
-  `lead programmer`.
-- **OPEN-2:** First surface: extend the pending handoff/cross-review
-  stack (recommended) versus ship a standalone assignment tool first.
-- **OPEN-3:** Assignment persistence: branch-scoped tracked YAML/JSON
-  artifact (recommended) versus board-only state.
-- **OPEN-4:** Whether `preference_only` findings are hidden by default
-  or shown in a collapsed section.
+OPEN-1..4 were ruled by the chair on 2026-07-27 (round-table thread
+`q-feature-lead-governance-001`) and are recorded in
+[decisions.md](decisions.md): D1 (`feature lead`), D5 (thin module +
+P1 gate inheritance + P2 schema ownership), D4 (split registry), D3
+(`preference_only` collapsed with count). D7 (approval evidence) is
+the new ruling this revision folds in throughout.

--- a/docs/specs/feature-lead-governance/tasks.md
+++ b/docs/specs/feature-lead-governance/tasks.md
@@ -1,11 +1,14 @@
 # Feature Lead Governance — Tasks
 
-**Status:** DRAFT — do not execute until requirements and OPEN-1..4 are
-chair-approved.
+**Status:** draft (2026-07-27) — OPEN-1..4 ruled and the revision
+pass applied; execution remains gated by P1 (the cross-review
+usage-signal read — decisions.md D5).
 
 Pre-execution rule: re-grep all named integration points against the
-current tree. The handoff and cross-review specs are currently moving;
-their shipped APIs, not this draft, will be authoritative.
+current tree. Handoff and cross-review T1+T2 are SHIPPED dependencies
+(consume their seams as-is); their pending T3/T4, not this draft,
+will own any new packet/board fields (propose amendments, never a
+parallel format).
 
 ## T1 — governance core
 
@@ -43,9 +46,11 @@ their shipped APIs, not this draft, will be authoritative.
 ```xml
 <task id="featurelead-t2" name="mcp-surface">
   <objective>
-    Register assignment_create/status/transfer/dispose_finding/
-    complete through the existing Attune MCP server and trusted human
-    decision boundary.
+    Register the D7-shrunk surface — assignment_propose /
+    assignment_status / assignment_dispose_finding — through the
+    existing Attune MCP server. Transfer/complete/revoke requests
+    return chair_required plus registry-PR instructions; no MCP tool
+    asserts human approval (decisions.md D7).
   </objective>
   <context>
     <depends>featurelead-t1</depends>
@@ -55,12 +60,15 @@ their shipped APIs, not this draft, will be authoritative.
     <check>read-only status works without workspace write access</check>
     <check>denied writes and unavailable leads return truthful
       structured failures</check>
+    <check>a transfer/complete/revoke request returns chair_required
+      and mutates nothing</check>
   </validation>
   <risks>
-    <risk severity="high">MCP caller identity may not prove “human”;
-      implementation must identify the existing trusted decision
-      mechanism or hold mutating transitions for explicit UI
-      confirmation.</risk>
+    <risk severity="low">RESOLVED by D7 (was: MCP caller identity may
+      not prove “human”) — chair transitions moved out of MCP into
+      chair-merged registry PRs verified by the D3 probe set;
+      residual risk is probe-implementation fidelity, covered by the
+      per-probe security tests.</risk>
   </risks>
 </task>
 ```
@@ -113,6 +121,11 @@ their shipped APIs, not this draft, will be authoritative.
     <risk severity="medium">Two successful demos do not prove reduced
       rewrite churn; retain opt-in posture until repeated use shows a
       useful signal.</risk>
+    <risk severity="medium">Distribution lag: the Codex/Antigravity
+      seats consume the PUBLISHED attune-ai, so the live matrix waits
+      for a release carrying the governance tools — schedule the
+      receipts post-publish, and record seat ABSENT (not failure)
+      when a seat is unavailable (R7).</risk>
   </risks>
 </task>
 ```


### PR DESCRIPTION
## Summary

Executes the revision pass owed by the 2026-07-27 chair rulings (decisions.md D1–D7, round-table thread `q-feature-lead-governance-001`). The spec text now matches what was ruled — every blocking defect from the review + table is resolved in text:

- **B1/D7**: chair transitions = chair-merged PRs to the main registry, four named forgery probes; MCP surface shrunk to `assignment_propose`/`status`/`dispose_finding` (T2's "MCP can't prove human" HIGH risk resolved).
- **B2/D4**: split registry — authority on main (global AC-1 comparison set), findings/events branch-side; new AC-9 (forgery rejection) and AC-10 (registry-vs-practice drift probe).
- **B3**: lead = provider; same-provider session succession is an automatic event, not a chair transfer.
- **B4**: R2's inverted "on human authority" sentence fixed.
- **D3**: atomic findings, `accepted` non-terminal, terminal-state completion gate, `needs_split` fallback; schema owned by cross-review (P2).
- **D5**: ruled thin-module + P1 gate-inheritance text in place; steelman minority preserved under alternatives rejected.
- Codex's round-1 defects folded: R6-vs-D5 payload contradiction, AC-6 HEAD-vs-scoped-drift baseline, R5-vs-D3 transfer consistency, ABSENT-vs-failure criteria; Antigravity's: atomic writes/stale-base rejection, resume digest probe.

Execution remains **gated by P1** (the cross-review usage-signal read) — tasks stay `draft`.

## Receipts

- `tests/unit/gates/test_status_line_gate.py`: 45 passed (vocabulary: approved/draft/active).
- Stale-vocabulary sweep of the spec dir (old branch-file schema, retired tool names, "moderator", session-keyed lead): zero hits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)