### PR TITLE
feat(handoff): T3 memory linkage + telemetry (D5/D6) — #1601

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   labeled a surface mix, not a fire rate: hand-written
   AskUserQuestion turns never enter Python and are invisible to the
   log (#1653).
+- **Handoff memory linkage (D5) + telemetry (D6)** — `handoff_create`
+  now stashes a topic-`handoff` pointer through the session-stash
+  helpers (same sanitized path as `session_memory_capture`), and
+  `handoff_resume` recalls pointers for the slug. Unreachable
+  backends degrade to a stated `memory: {status: skipped, reason}`
+  — never an error, never a silent omission. Both tools' structlog
+  events now carry the real memory outcome
+  (spec: cross-provider-session-handoff T3, #1601).
 
 ## [10.6.1] — 2026-07-27
 

--- a/docs/specs/cross-provider-session-handoff/receipts.md
+++ b/docs/specs/cross-provider-session-handoff/receipts.md
@@ -1,0 +1,31 @@
+# Cross-Provider Session Handoff — Receipts
+
+Evidence ledger (R6 discipline): rows record probes actually run,
+dated, with results verbatim. UNPROBED rows stay honest until the
+named client runs.
+
+## 2026-07-27 — T3 memory linkage: suite + live local canary
+
+- **Suite receipt** — `tests/unit/handoff/` +
+  `tests/integration/test_mcp_dispatch_handoff.py` run SERIALLY
+  (`-p no:xdist`): `35 passed`. Includes the unreachable-backend
+  path asserting `memory == {status: skipped, reason: no_backend}`
+  with `ok` staying true, and the real-dispatch linkage test
+  (capture through the real sanitizer, recall through the real
+  dispatch chain).
+- **Live local canary (Claude side)** — temp fixture repo,
+  real backend resolution (`AMSMemoryBackend`, local Redis AMS):
+  `handoff_create` → `memory.status=captured`
+  (id `6ddf8227-cb74-4fc3-8a44-0c69ace07483`), `handoff_resume` →
+  `memory.status=recalled` with the pointer id among results;
+  canary then forgotten via `forget_entries` (deleted=1). Structlog
+  events observed with the real memory outcome:
+  `handoff_create … memory=captured`,
+  `handoff_resume … memory=recalled` (D6).
+
+## R6 live cross-provider receipt — UNPROBED
+
+- **Claude Code → Codex resume** — UNPROBED. Packet created in
+  Claude Code, resumed in a live Codex session (post-distribution;
+  10.6.1 is on PyPI and the marketplaces, so this row is runnable).
+  T4 owns filling it with the session id + verbatim tool results.

--- a/src/attune/handoff/__init__.py
+++ b/src/attune/handoff/__init__.py
@@ -15,16 +15,13 @@ from typing import Any
 
 import structlog
 
+from attune.handoff import memory_link as _memory_link
 from attune.handoff import packet as _packet
 from attune.handoff import verify as _verify
 
 logger = structlog.get_logger(__name__)
 
 __all__ = ["handoff_create", "handoff_resume"]
-
-#: R3 memory linkage lands in T3; until then the report says so
-#: explicitly rather than omitting the key (stable report shape).
-_MEMORY_NOT_WIRED = {"status": "skipped", "reason": "not_implemented"}
 
 
 def handoff_create(
@@ -68,13 +65,20 @@ def handoff_create(
     slug = _verify.slugify_branch(meta["branch"] or "detached")
     sections = _packet.assemble_sections(fields)
     result = _packet.write_packet(root, slug, meta, sections)
+    memory: dict[str, Any] = {"status": "skipped", "reason": "packet_not_written"}
+    if result.get("ok"):
+        # D5: stash a topic-`handoff` pointer via the session-stash
+        # helpers; failures are reported, never raised.
+        memory = _memory_link.link_create(
+            slug, goal=goal, path=result["path"], cwd=str(root.resolve())
+        )
     logger.info(
         "handoff_create",
         slug=slug,
         ok=result.get("ok"),
         reason=result.get("reason"),
         duration_ms=round((time.monotonic() - started) * 1000),
-        memory=_MEMORY_NOT_WIRED["status"],
+        memory=memory["status"],
     )
     if not result.get("ok"):
         return result
@@ -83,7 +87,7 @@ def handoff_create(
         "path": result["path"],
         "slug": slug,
         "packet": {"verified": meta, "asserted": sections},
-        "memory": dict(_MEMORY_NOT_WIRED),
+        "memory": memory,
     }
 
 
@@ -122,12 +126,14 @@ def handoff_resume(
 
     packet_rel = f"docs/handoffs/{slug}.md"
     warnings = _verify.drift(meta, root, ignore_paths=(packet_rel,))
+    # D5: recall handoff pointers for the slug; skips are stated.
+    memory = _memory_link.link_resume(slug, cwd=str(root.resolve()))
     logger.info(
         "handoff_resume",
         slug=slug,
         warning_codes=[w["code"] for w in warnings],
         duration_ms=round((time.monotonic() - started) * 1000),
-        memory=_MEMORY_NOT_WIRED["status"],
+        memory=memory["status"],
     )
     return {
         "ok": True,
@@ -136,5 +142,5 @@ def handoff_resume(
         "verified": meta,
         "warnings": warnings,
         "asserted": sections,
-        "memory": dict(_MEMORY_NOT_WIRED),
+        "memory": memory,
     }

--- a/src/attune/handoff/memory_link.py
+++ b/src/attune/handoff/memory_link.py
@@ -1,0 +1,108 @@
+"""D5 memory linkage — session-stash handoff pointers, degrade-silent.
+
+``handoff_create`` stashes a topic-``handoff`` pointer through the same
+session-stash helpers the ``session_memory_capture`` MCP handler wraps;
+``handoff_resume`` recalls pointers for the slug. Every failure path
+returns ``{"status": "skipped", "reason": <stable code>}`` — the
+``memory`` report key is always present and this module never raises
+(R3: degrade silently, but say so). Spec:
+docs/specs/cross-provider-session-handoff/ (D5).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+#: Pointers are recall aids, not the packet — keep resume results short.
+RECALL_TOP_K = 3
+
+#: Keys surfaced from backend-shaped recall records (bounded report).
+#: Matches the searchable backends' search() shape (file tier: id/text/
+#: topics/cwd/session_id/score); volatile keys are dropped.
+_RESULT_KEYS = ("id", "text", "content", "topics", "score")
+
+
+def _skip_reason(session_stash: Any) -> str:
+    """Stable machine-readable reason for a failed write (never raises)."""
+    try:
+        status = session_stash.backend_status()
+        reason = status.get("reason") if isinstance(status, dict) else None
+        return str(reason) if reason else "write_failed"
+    except Exception:  # noqa: BLE001
+        # INTENTIONAL: reason lookup is best-effort; the skip itself is
+        # already truthful.
+        return "write_failed"
+
+
+def link_create(slug: str, *, goal: str, path: str, cwd: str) -> dict[str, Any]:
+    """Stash a handoff pointer for ``slug``; report the outcome.
+
+    Args:
+        slug: Packet slug (branch with ``/`` as ``-``).
+        goal: Caller-asserted goal, quoted in the pointer content.
+        path: Written packet path (the pointer's referent).
+        cwd: Repo root at create time (cwd-scoped recall).
+
+    Returns:
+        ``{"status": "captured", "id": ...}`` on a durable write, else
+        ``{"status": "skipped", "reason": <stable code>}``.
+    """
+    try:
+        from attune.memory import session_stash
+    except Exception as exc:  # noqa: BLE001
+        # INTENTIONAL: memory linkage must never break packet creation.
+        logger.debug("handoff memory link unavailable: %s", exc)
+        return {"status": "skipped", "reason": "session_stash_unavailable"}
+    try:
+        content = f"Handoff packet {slug}: {goal or 'no goal recorded'} ({path})"
+        entry = session_stash.SessionStashEntry.create(
+            session_id="handoff",
+            cwd=cwd,
+            type="reference",
+            content=content,
+            tags=["handoff", f"slug:{slug}"],
+        )
+        if session_stash.stash_entry(entry):
+            return {"status": "captured", "id": entry.id}
+        return {"status": "skipped", "reason": _skip_reason(session_stash)}
+    except Exception as exc:  # noqa: BLE001
+        # INTENTIONAL: a backend/sanitizer error is a skip, not a failure
+        # of handoff_create itself.
+        logger.warning("handoff memory link failed: %s", exc)
+        return {"status": "skipped", "reason": "stash_error"}
+
+
+def link_resume(slug: str, *, cwd: str) -> dict[str, Any]:
+    """Recall handoff pointers for ``slug``; report the outcome.
+
+    Returns:
+        ``{"status": "recalled", "count": N, "results": [...]}`` when a
+        backend answered (``count`` may be 0 — an honest empty recall),
+        else ``{"status": "skipped", "reason": <stable code>}``.
+    """
+    try:
+        from attune.memory import session_stash
+    except Exception as exc:  # noqa: BLE001
+        # INTENTIONAL: memory linkage must never break packet resume.
+        logger.debug("handoff memory link unavailable: %s", exc)
+        return {"status": "skipped", "reason": "session_stash_unavailable"}
+    try:
+        # recall_entries returns [] both for "no backend" and "no hits";
+        # distinguish them so an unreachable backend is a stated skip,
+        # not a silent empty recall.
+        status = session_stash.backend_status()
+        if not (isinstance(status, dict) and status.get("ok")):
+            reason = status.get("reason") if isinstance(status, dict) else None
+            return {"status": "skipped", "reason": str(reason or "no_backend")}
+        results = session_stash.recall_entries(f"handoff {slug}", top_k=RECALL_TOP_K, cwd=cwd)
+        trimmed = [
+            {k: r[k] for k in _RESULT_KEYS if k in r} for r in results if isinstance(r, dict)
+        ]
+        return {"status": "recalled", "count": len(trimmed), "results": trimmed}
+    except Exception as exc:  # noqa: BLE001
+        # INTENTIONAL: recall is best-effort; the report stays truthful.
+        logger.warning("handoff memory recall failed: %s", exc)
+        return {"status": "skipped", "reason": "recall_error"}

--- a/tests/integration/test_mcp_dispatch_handoff.py
+++ b/tests/integration/test_mcp_dispatch_handoff.py
@@ -39,6 +39,54 @@ def _git(repo: Path, *args: str) -> str:
     return result.stdout.strip()
 
 
+class _MemBackend:
+    """Searchable backend double at the session_stash boundary (T3).
+
+    Dispatch, handlers, the real handoff core, and the REAL PII
+    sanitizer all run; only the storage service is substituted.
+    """
+
+    is_fallback = False
+
+    def __init__(self) -> None:
+        self.records: dict[str, dict] = {}
+
+    def is_connected(self) -> bool:
+        return True
+
+    def remember(self, content, *, memory_id=None, session_id=None, topics=None) -> bool:
+        self.records[memory_id] = {
+            "id": memory_id,
+            "text": content,
+            "session_id": session_id,
+            "topics": list(topics or []),
+        }
+        return True
+
+    def search(self, query, limit=10):
+        return [dict(r) for r in list(self.records.values())[:limit]]
+
+    def stash(self, *args, **kwargs) -> bool:
+        return True
+
+
+@pytest.fixture(autouse=True)
+def memory_offline():
+    """Default every dispatch test to no memory backend (hermetic).
+
+    The D5 linkage then degrades to a stated skip; the linkage test
+    below opts into `_MemBackend` explicitly.
+    """
+    with (
+        patch("attune.memory.session_stash.resolve_backend", return_value=None),
+        patch(
+            "attune.memory.session_stash.backend_status",
+            return_value={"ok": False, "backend": None, "reason": "no_backend"},
+        ),
+    ):
+        yield
+
+
 @pytest.fixture
 def repo(tmp_path: Path) -> Path:
     root = tmp_path / "repo"
@@ -92,7 +140,36 @@ class TestHandoffDispatch:
         assert report["verified"]["provider"] == "test-suite"
         assert report["asserted"]["goal"] == "Dispatch round trip"
         assert report["warnings"] == []
-        assert report["memory"]["status"] == "skipped"
+        assert report["memory"] == {"status": "skipped", "reason": "no_backend"}
+
+    @pytest.mark.asyncio
+    async def test_memory_linkage_through_real_dispatch(
+        self, server: EmpathyMCPServer, repo: Path
+    ) -> None:
+        """T3/D5: create stashes a handoff pointer, resume recalls it —
+        through the real dispatch chain and the real sanitizer."""
+        backend = _MemBackend()
+        with (
+            patch("attune.memory.session_stash.resolve_backend", return_value=backend),
+            patch(
+                "attune.memory.session_stash.backend_status",
+                return_value={"ok": True, "backend": "_MemBackend", "reason": None},
+            ),
+        ):
+            created = await server.call_tool(
+                "handoff_create", {"goal": "Linkage receipt", "provider": "test-suite"}
+            )
+            assert created["memory"]["status"] == "captured"
+            pointer_id = created["memory"]["id"]
+            stored = backend.records[pointer_id]
+            assert "Linkage receipt" in stored["text"]
+            assert "handoff" in stored["topics"]
+            assert "slug:feature-hand" in stored["topics"]
+
+            report = await server.call_tool("handoff_resume", {})
+            assert report["memory"]["status"] == "recalled"
+            assert report["memory"]["count"] == 1
+            assert report["memory"]["results"][0]["id"] == pointer_id
 
     @pytest.mark.asyncio
     async def test_resume_missing_packet_truthful(self, server: EmpathyMCPServer) -> None:

--- a/tests/unit/handoff/conftest.py
+++ b/tests/unit/handoff/conftest.py
@@ -7,6 +7,24 @@ from pathlib import Path
 
 import pytest
 
+from attune.memory import session_stash
+
+
+@pytest.fixture(autouse=True)
+def memory_offline(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Handoff unit tests never touch a real memory backend.
+
+    Defaults every test to the unreachable-backend state so the D5
+    linkage degrades to a stated skip; tests that want a backend
+    override with a fake (see ``test_memory_link.backend``).
+    """
+    monkeypatch.setattr(session_stash, "resolve_backend", lambda b=None: None)
+    monkeypatch.setattr(
+        session_stash,
+        "backend_status",
+        lambda: {"ok": False, "backend": None, "reason": "no_backend"},
+    )
+
 
 def git(repo: Path, *args: str) -> str:
     """Run git in the fixture repo with signing/hooks disabled."""

--- a/tests/unit/handoff/test_memory_link.py
+++ b/tests/unit/handoff/test_memory_link.py
@@ -1,0 +1,132 @@
+"""T3 memory linkage: D5 pointer stash/recall, degrade-silent with reason."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from attune.handoff import handoff_create, handoff_resume
+from attune.memory import session_stash
+
+
+class FakeBackend:
+    """Searchable backend double: records writes, serves canned recalls."""
+
+    def __init__(self, results: list[dict[str, Any]] | None = None) -> None:
+        self.remembered: list[dict[str, Any]] = []
+        self.results = results or []
+
+    def remember(self, content: str, **kwargs: Any) -> bool:
+        self.remembered.append({"content": content, **kwargs})
+        return True
+
+    def stash(self, *args: Any, **kwargs: Any) -> bool:  # pragma: no cover
+        return True
+
+    def search(self, query: str, limit: int = 5) -> list[dict[str, Any]]:
+        return self.results[:limit]
+
+
+@pytest.fixture()
+def backend(monkeypatch: pytest.MonkeyPatch) -> FakeBackend:
+    """Resolve the session stash to a recording fake backend."""
+    fake = FakeBackend()
+    monkeypatch.setattr(session_stash, "resolve_backend", lambda b=None: fake)
+    monkeypatch.setattr(
+        session_stash,
+        "backend_status",
+        lambda: {"ok": True, "backend": "FakeBackend", "reason": None},
+    )
+    return fake
+
+
+class TestCreateLinkage:
+    def test_create_stashes_handoff_pointer(self, repo: Path, backend: FakeBackend) -> None:
+        result = handoff_create(repo, goal="Ship the thing", base_ref="main")
+        assert result["ok"] is True
+        assert result["memory"]["status"] == "captured"
+        assert result["memory"]["id"]
+        assert len(backend.remembered) == 1
+        write = backend.remembered[0]
+        assert "Ship the thing" in write["content"]
+        assert "handoff" in write["topics"]
+        assert "slug:feature-x" in write["topics"]
+
+    def test_unreachable_backend_skips_with_reason_ok_stays_true(self, repo: Path) -> None:
+        # The conftest `memory_offline` autouse fixture is the
+        # unreachable-backend state; no override here.
+        result = handoff_create(repo, goal="g", base_ref="main")
+        assert result["ok"] is True
+        assert result["memory"] == {"status": "skipped", "reason": "no_backend"}
+
+    def test_backend_error_skips_without_raising(
+        self, repo: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def boom(*args: Any, **kwargs: Any) -> bool:
+            raise RuntimeError("backend exploded")
+
+        monkeypatch.setattr(session_stash, "stash_entry", boom)
+        result = handoff_create(repo, goal="g", base_ref="main")
+        assert result["ok"] is True
+        assert result["memory"] == {"status": "skipped", "reason": "stash_error"}
+
+    def test_rejected_packet_never_reaches_the_stash(
+        self, repo: Path, backend: FakeBackend
+    ) -> None:
+        from attune.handoff import packet as packet_mod
+
+        result = handoff_create(repo, goal="x" * (packet_mod.FIELD_CAP_BYTES + 1), base_ref="main")
+        assert result["ok"] is False
+        assert backend.remembered == []
+
+
+class TestResumeLinkage:
+    def test_resume_recalls_pointers_for_slug(
+        self, repo: Path, backend: FakeBackend, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        handoff_create(repo, goal="g", base_ref="main")
+        backend.results = [
+            {
+                "id": "abc123",
+                "text": "Handoff packet feature-x: g",
+                "topics": ["handoff", "slug:feature-x"],
+                "score": 2.5,
+                "session_id": "dropped-from-report",
+            }
+        ]
+        result = handoff_resume(repo)
+        assert result["ok"] is True
+        memory = result["memory"]
+        assert memory["status"] == "recalled"
+        assert memory["count"] == 1
+        assert memory["results"][0]["id"] == "abc123"
+        assert memory["results"][0]["text"] == "Handoff packet feature-x: g"
+        assert "session_id" not in memory["results"][0]
+
+    def test_resume_empty_recall_is_honest_not_skipped(
+        self, repo: Path, backend: FakeBackend
+    ) -> None:
+        handoff_create(repo, goal="g", base_ref="main")
+        result = handoff_resume(repo)
+        assert result["memory"] == {"status": "recalled", "count": 0, "results": []}
+
+    def test_resume_unreachable_backend_skips_with_reason(self, repo: Path) -> None:
+        handoff_create(repo, goal="g", base_ref="main")
+        result = handoff_resume(repo)
+        assert result["ok"] is True
+        assert result["memory"] == {"status": "skipped", "reason": "no_backend"}
+
+    def test_resume_recall_error_skips_without_raising(
+        self, repo: Path, backend: FakeBackend, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        handoff_create(repo, goal="g", base_ref="main")
+
+        def boom(*args: Any, **kwargs: Any) -> list[dict[str, Any]]:
+            raise RuntimeError("recall exploded")
+
+        monkeypatch.setattr(session_stash, "recall_entries", boom)
+        result = handoff_resume(repo)
+        assert result["ok"] is True
+        assert result["memory"] == {"status": "skipped", "reason": "recall_error"}


### PR DESCRIPTION
T3 of docs/specs/cross-provider-session-handoff/ — the remainder reconciled as UNBLOCKED on [#1601](https://github.com/Smart-AI-Memory/attune-ai/issues/1601) (2026-07-27 gate note).

## What

- **D5 memory linkage** — `handoff_create` stashes a topic-`handoff` pointer through `attune.memory.session_stash` (the same sanitized path the `session_memory_capture` handler wraps); `handoff_resume` recalls pointers for the slug (`top_k=3`, cwd-scoped).
- **Degrade-silent, stated** — unreachable backend → `memory: {status: skipped, reason: no_backend}`; backend errors → `stash_error`/`recall_error`; `ok` stays true. An empty recall is honestly `{status: recalled, count: 0}`, not a skip.
- **D6 telemetry** — the existing `handoff_create`/`handoff_resume` structlog events now carry the real memory outcome instead of the T1 placeholder.
- **Test hygiene** — handoff unit + dispatch tests were hitting the REAL resolved backend (live writes to the local AMS tier during test runs). Both suites now default to an autouse offline-backend fixture; linkage tests opt into a recording fake.

## Receipts

- **Suite (serial):** `tests/unit/handoff/ + tests/integration/test_mcp_dispatch_handoff.py` → `35 passed` (`-p no:xdist`), incl. the unreachable-backend path (skip WITH reason, ok true) and a real-dispatch linkage test through the real sanitizer.
- **Live local canary (real backend):** `AMSMemoryBackend` — create → `memory.status=captured`, resume → `recalled` with the pointer id among results, canary forgotten (deleted=1). Logged in the new `docs/specs/cross-provider-session-handoff/receipts.md`.
- **Remaining scope on #1601 is T4 only** (docs, ledger, R6 live Codex receipt — the receipts.md row stays honestly UNPROBED).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
