### PR TITLE
feat(ops): elicitation surface-mix panel on the Health tab (#1653)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Elicitation surface mix on the Health tab** — the ops dashboard's
+  `/health` page now reads `telemetry/form_events.jsonl` live and
+  shows which surface rendered each Python-routed form. Honestly
+  labeled a surface mix, not a fire rate: hand-written
+  AskUserQuestion turns never enter Python and are invisible to the
+  log (#1653).
+
 ## [10.6.1] — 2026-07-27
 
 ### Fixed

--- a/src/attune/ops/routes/health_library.py
+++ b/src/attune/ops/routes/health_library.py
@@ -45,6 +45,7 @@ from fastapi.responses import (
 
 from attune.ops import data, health_snapshot
 from attune.ops.security import require_client_token
+from attune.telemetry import form_events
 
 logger = logging.getLogger(__name__)
 
@@ -85,6 +86,11 @@ async def health_library_page(request: Request) -> HTMLResponse:
     stale = health_snapshot.is_stale(snapshot)
     _maybe_kick_refresh(request, snapshot)
 
+    # Live read of the routing log (#1653) — deliberately NOT the
+    # in-memory interaction counters: routing happens in the MCP/agent
+    # process, so only the JSONL sees these events.
+    surface_mix = form_events.surface_mix(home=cfg.attune_home)
+
     templates = request.app.state.templates
     return templates.TemplateResponse(
         request,
@@ -97,6 +103,8 @@ async def health_library_page(request: Request) -> HTMLResponse:
             stale_after_hours=health_snapshot.DEFAULT_STALE_AFTER_HOURS,
             latest_report=health_snapshot.latest_llm_report(cfg.project_root),
             env=data.env_health(cfg),
+            surface_mix=surface_mix,
+            surface_mix_total=sum(surface_mix.values()),
         ),
     )
 

--- a/src/attune/ops/templates/health_library.html
+++ b/src/attune/ops/templates/health_library.html
@@ -202,6 +202,34 @@
    previously stranded in {% block scripts %}, which base.html
    renders AFTER </main> — the section escaped the centered page
    container entirely (Patrick, 2026-07-21). #}
+{# Elicitation surface mix (#1653) — a live read of
+   telemetry/form_events.jsonl, independent of the snapshot. Honest
+   framing: this is the SURFACE MIX of Python-routed forms, not a fire
+   rate — a hand-written AskUserQuestion turn never enters Python and
+   is invisible here. #}
+<section style="margin-top: 2rem;">
+  <h2>Elicitation surface mix</h2>
+  <p class="page-sub">
+    Which surface rendered each Python-routed form, read live from
+    <code>telemetry/form_events.jsonl</code>. Surface mix only, not a
+    fire rate &mdash; a hand-written AskUserQuestion turn never enters
+    Python, so it is invisible here.
+  </p>
+  {% if surface_mix %}
+    <table class="data-table">
+      <thead><tr><th>Surface</th><th class="num">Forms routed</th></tr></thead>
+      <tbody>
+        {% for surface, count in surface_mix | dictsort(by='value', reverse=true) %}
+          <tr><td><code>{{ surface }}</code></td><td class="num">{{ count }}</td></tr>
+        {% endfor %}
+        <tr><th>total</th><td class="num">{{ surface_mix_total }}</td></tr>
+      </tbody>
+    </table>
+  {% else %}
+    <p class="page-sub">No form routing events recorded yet.</p>
+  {% endif %}
+</section>
+
 <section style="margin-top: 2rem;">
   <h2>Environment</h2>
   <p class="page-sub">Environment + state file presence (formerly the standalone Health page).</p>

--- a/src/attune/telemetry/form_events.py
+++ b/src/attune/telemetry/form_events.py
@@ -54,11 +54,17 @@ def _enabled() -> bool:
     return dnt is None or dnt.strip().lower() in _FALSEY
 
 
-def _events_path() -> Path:
-    """Resolve the live events file under ATTUNE_HOME (default ~/.attune)."""
-    home = os.environ.get("ATTUNE_HOME")
-    base = Path(home).expanduser() if home else Path.home() / ".attune"
-    return base / "telemetry" / "form_events.jsonl"
+def _events_path(home: Path | None = None) -> Path:
+    """Resolve the live events file under ``home`` (an attune-home base).
+
+    Defaults to ATTUNE_HOME (or ``~/.attune``) — the write path. Readers
+    with their own configured home (the ops dashboard) pass it
+    explicitly so they read the store they display, not the process env.
+    """
+    if home is None:
+        env = os.environ.get("ATTUNE_HOME")
+        home = Path(env).expanduser() if env else Path.home() / ".attune"
+    return Path(home) / "telemetry" / "form_events.jsonl"
 
 
 def _rotate_if_huge(path: Path) -> None:
@@ -233,17 +239,21 @@ def inference_rate() -> dict[str, float | int]:
     }
 
 
-def surface_mix() -> dict[str, int]:
+def surface_mix(home: Path | None = None) -> dict[str, int]:
     """Return counts per surface from the live log.
 
     Unreadable or malformed lines are skipped rather than raising, so a
     partially-written tail never breaks the read.
 
+    Args:
+        home: Optional attune-home base to read from; defaults to the
+            process's own (ATTUNE_HOME or ``~/.attune``).
+
     Returns:
         A mapping of surface name to count; empty when nothing logged.
     """
     counts: Counter[str] = Counter()
-    path = _events_path()
+    path = _events_path(home)
     try:
         with path.open(encoding="utf-8") as fh:
             for line in fh:

--- a/tests/unit/ops/test_health_library_route.py
+++ b/tests/unit/ops/test_health_library_route.py
@@ -290,6 +290,49 @@ def test_health_page_includes_environment_section(client):
     assert "attune-home" in resp.text
 
 
+class TestSurfaceMixPanel:
+    """Elicitation surface-mix panel (#1653) — reads the JSONL under the
+    dashboard's configured attune-home (NOT the in-memory interaction
+    counters, which live in the wrong process)."""
+
+    def _write_events(self, cfg: Config, lines: list[str]) -> None:
+        path = cfg.attune_home / "telemetry" / "form_events.jsonl"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("".join(line + "\n" for line in lines), encoding="utf-8")
+
+    def test_no_events_renders_empty_state(self, client: TestClient) -> None:
+        resp = client.get("/health")
+        assert resp.status_code == 200
+        assert "Elicitation surface mix" in resp.text
+        assert "No form routing events recorded yet." in resp.text
+
+    def test_renders_counts_from_jsonl(self, client: TestClient, cfg: Config) -> None:
+        self._write_events(
+            cfg,
+            [
+                '{"event":"form_surface","surface":"widget"}',
+                '{"event":"form_surface","surface":"widget"}',
+                '{"event":"form_surface","surface":"ask"}',
+                '{"event":"form_submitted"}',  # not a surface event
+                "{not json",  # malformed tail must not break the page
+            ],
+        )
+        resp = client.get("/health")
+        assert resp.status_code == 200
+        assert "<code>widget</code>" in resp.text
+        assert "<code>ask</code>" in resp.text
+        # widget=2, ask=1, total=3 (form_submitted + malformed excluded)
+        assert '<td class="num">2</td>' in resp.text
+        assert '<td class="num">3</td>' in resp.text
+
+    def test_panel_is_labeled_as_mix_not_fire_rate(self, client: TestClient) -> None:
+        """#1653's honest-framing requirement: the panel must say it
+        measures the surface mix, not the fire rate."""
+        resp = client.get("/health")
+        flattened = " ".join(resp.text.split())
+        assert "Surface mix only, not a fire rate" in flattened
+
+
 class TestServeLlmReport:
     """/docs/reports/{name} — the link-QA fix (2026-07-21): the Health
     page links the latest narrative report; nothing served it."""

--- a/tests/unit/telemetry/test_form_events.py
+++ b/tests/unit/telemetry/test_form_events.py
@@ -144,6 +144,23 @@ class TestSurfaceMixErrorPaths:
         )
         assert surface_mix() == {"widget": 1}
 
+    def test_explicit_home_overrides_process_env(
+        self, _isolated_home: Path, tmp_path: Path
+    ) -> None:
+        """A reader with its own configured home (the ops dashboard,
+        #1653) reads THAT store, not the process's ATTUNE_HOME."""
+        other_home = tmp_path / "other-home"
+        path = other_home / "telemetry" / "form_events.jsonl"
+        path.parent.mkdir(parents=True)
+        path.write_text(
+            '{"event":"form_surface","surface":"widget"}\n'
+            '{"event":"form_surface","surface":"ask"}\n'
+            '{"event":"form_surface","surface":"widget"}\n',
+            encoding="utf-8",
+        )
+        assert surface_mix(home=other_home) == {"widget": 2, "ask": 1}
+        assert surface_mix() == {}  # env-scoped home is still empty
+
 
 class TestSubmissionPathsErrorArms:
     def test_log_submission_oserror_swallowed(self, _isolated_home: Path) -> None:


### PR DESCRIPTION
Closes [#1653](https://github.com/Smart-AI-Memory/attune-ai/issues/1653).

## What

- New **Elicitation surface mix** section on `/health` — a live read of `telemetry/form_events.jsonl` via `surface_mix()`, rendered as a surface→count table with total.
- Per the issue: deliberately **not** `interaction_counters` (in-memory, per-dashboard-process — routing happens in the MCP/agent process and never reaches it).
- `surface_mix()` / `_events_path()` gain an optional `home=` so the dashboard reads its **configured** attune-home, not the process env (also makes route tests hermetic).
- **Honest framing** baked into the copy and locked by a test: "Surface mix only, not a fire rate — a hand-written AskUserQuestion turn never enters Python, so it is invisible here."

## Receipts

- **Suite (serial):** `tests/unit/ops/test_health_library_route.py + tests/unit/telemetry/test_form_events.py` → 43 passed, incl. empty state, JSONL-derived counts (malformed tail skipped), the honest-label lock, and the explicit-home override.
- **Live-fire:** restarted the running ops dashboard from this branch — the panel renders `widget 1 / total 1`, matching the real `~/.attune/telemetry/form_events.jsonl` (1 `form_surface` event).

Note: touches CHANGELOG [Unreleased] like #1694 — whichever merges second may need a trivial conflict rebase; I am watching both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
