### PR TITLE
test(handoff): cover memory_link defensive arms — 82% → 100%

### DIFF
--- a/.claude/lessons.md
+++ b/.claude/lessons.md
@@ -18669,3 +18669,38 @@ def ", start_idx + 1)` for module-
   Canary test: `TestSessionMemoryVoiceSummaries` in
   `attune_redis/tests/test_mcp_tools.py` asserts no verb emits the
   generic greeting.
+
+- **Tests of any module that calls the session-stash helpers hit the
+  REAL entry-point-resolved backend — a green "unit" suite silently
+  writes to the user's live memory tier; default the test dir offline
+  via an autouse fixture**: 2026-07-27, handoff T3 (#1694). The
+  pre-T3 handoff unit AND real-dispatch integration tests ran
+  `handoff_create` with no backend patching; the moment T3 wired the
+  D5 linkage, every test run stashed pointers into the live local AMS.
+  Tells: `memory=captured` in a unit test's captured structlog, and a
+  T1-era test asserting the `not_implemented` placeholder failing
+  with `captured` — the failure was the live-write leak surfacing.
+  Root cause: `session_stash.resolve_backend()` resolves from the
+  `attune.memory_backends` entry point at CALL time, so any code path
+  touching `stash_entry`/`recall_entries` is a live-write surface in
+  tests unless explicitly severed. Fix shape: an autouse fixture in
+  the test dir's conftest patching `session_stash.resolve_backend` →
+  `None` and `backend_status` → `{ok: False, reason: "no_backend"}`;
+  tests that need a backend override AFTER it (autouse fixtures
+  instantiate first, so a later fake-backend fixture's patch wins).
+  Bonus: the offline default exercises the degrade-silent skip arm
+  for free. Apply the same at-the-boundary patching in real-dispatch
+  integration files (in-memory double at the session_stash seam —
+  the `_InMemorySearchableBackend` pattern). Pairs with "Registered ≠
+  working" (dogfood separately proves the LIVE path — a deliberate
+  canary with a forget at the end, not an accidental test write).
+
+- **`auto-merge-when-green` label not armed after ~1 min → arm
+  natively with `gh pr merge <n> --auto --squash`**: 2026-07-27,
+  #1695 — label applied, `autoMergeRequest` still null a minute
+  later (the arming workflow can be inert; see the existing
+  labeled-events-don't-replay lesson). The direct command arms
+  GitHub-native auto-merge with the same no-admin-bypass semantics
+  (waits on required checks + review) and takes effect instantly.
+  Either way the arm-check post-condition stands: DONE only when
+  `gh pr view <n> --json autoMergeRequest` is non-null.

--- a/tests/unit/handoff/test_memory_link.py
+++ b/tests/unit/handoff/test_memory_link.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -9,6 +10,20 @@ import pytest
 
 from attune.handoff import handoff_create, handoff_resume
 from attune.memory import session_stash
+
+
+def _make_session_stash_unimportable(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Make ``from attune.memory import session_stash`` raise ImportError.
+
+    Both the package attribute (bound by earlier imports) and the
+    ``sys.modules`` entry must go: the attribute would satisfy the
+    ``from`` import directly, and a ``None`` module entry makes the
+    fallback submodule import raise.
+    """
+    import attune.memory
+
+    monkeypatch.delattr(attune.memory, "session_stash", raising=False)
+    monkeypatch.setitem(sys.modules, "attune.memory.session_stash", None)
 
 
 class FakeBackend:
@@ -72,6 +87,34 @@ class TestCreateLinkage:
         assert result["ok"] is True
         assert result["memory"] == {"status": "skipped", "reason": "stash_error"}
 
+    def test_create_unimportable_session_stash_skips(
+        self, repo: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The packet still writes when the memory layer can't import."""
+        _make_session_stash_unimportable(monkeypatch)
+        result = handoff_create(repo, goal="g", base_ref="main")
+        assert result["ok"] is True
+        assert Path(result["path"]).exists()
+        assert result["memory"] == {
+            "status": "skipped",
+            "reason": "session_stash_unavailable",
+        }
+
+    def test_status_probe_error_falls_back_to_write_failed(
+        self, repo: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A failed write whose reason lookup ALSO fails still reports a
+        stable skip code — never an exception."""
+        monkeypatch.setattr(session_stash, "stash_entry", lambda entry: False)
+
+        def boom() -> dict[str, Any]:
+            raise RuntimeError("status probe exploded")
+
+        monkeypatch.setattr(session_stash, "backend_status", boom)
+        result = handoff_create(repo, goal="g", base_ref="main")
+        assert result["ok"] is True
+        assert result["memory"] == {"status": "skipped", "reason": "write_failed"}
+
     def test_rejected_packet_never_reaches_the_stash(
         self, repo: Path, backend: FakeBackend
     ) -> None:
@@ -117,6 +160,18 @@ class TestResumeLinkage:
         result = handoff_resume(repo)
         assert result["ok"] is True
         assert result["memory"] == {"status": "skipped", "reason": "no_backend"}
+
+    def test_resume_unimportable_session_stash_skips(
+        self, repo: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        handoff_create(repo, goal="g", base_ref="main")
+        _make_session_stash_unimportable(monkeypatch)
+        result = handoff_resume(repo)
+        assert result["ok"] is True
+        assert result["memory"] == {
+            "status": "skipped",
+            "reason": "session_stash_unavailable",
+        }
 
     def test_resume_recall_error_skips_without_raising(
         self, repo: Path, backend: FakeBackend, monkeypatch: pytest.MonkeyPatch


### PR DESCRIPTION
Follow-up to #1694 — Codecov flagged patch coverage 84% (8 lines missing in `src/attune/handoff/memory_link.py`).

Three new tests cover the defensive arms: the `_skip_reason` exception fallback (`write_failed`), and the session_stash-unimportable paths on both create and resume (`session_stash_unavailable`, packet still written).

**Receipt:** `memory_link.py` measured 82% → **100%** locally; 33 handoff unit tests serial-green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
