### PR TITLE
feat(fact-check): T2 resolver fold-in — shared authoritative resolver (#1586)

### DIFF
--- a/docs/specs/attune-author-consolidation/decisions.md
+++ b/docs/specs/attune-author-consolidation/decisions.md
@@ -225,14 +225,27 @@ in-repo projector goldens cover rendering. Scripts and the
 aggregator test were left untouched — they are held PR #1562's
 surface. **T4 is now unblocked** per D12.
 
+## 2026-07-27 — Resolver fold-in EXECUTED (spec T2 / #1191, issue #1586)
+
+**Built** (post-#1561 lift, per the build-slot order). New shared
+`fact_check/imports.py` owns the authoritative import verdict:
+`find_repo_root` + `ensure_src_on_path` (repo `src/` first on
+`sys.path` — the audit script's mechanism, extracted), plus the
+resolution primitives (`resolve_import_statement` moved verbatim from
+`audit_doc_imports.py::_resolve`; `try_import` / `resolve_attr` /
+`resolve_dotted` moved from `python_refs.py`). `python_refs.check()`
+now preps the checked repo's src before resolving (kills the line-115
+false-positive class for fresh processes; a `sys.path` insert cannot
+rebind already-imported modules — documented limit). The audit
+script's `_resolve` delegates lazily (its `main()` bootstrap stays —
+it must run before any attune import). Regression test:
+`tests/unit/authoring/fact_check/test_imports.py::TestLine115Regression`
+— a symbol existing ONLY in the checked repo's src resolves, with a
+no-repo-layout negative control. 127 fact_check + audit-gate tests
+serial-green.
+
 ## Open
 
 - **T4 execution** (post-T3, per D12): drop `[author]` extra,
   retire CLI invocation paths, archive GitHub repo, set PyPI
   archived status. No new decision needed — D12 is the ruling.
-- **Resolver fold-in (spec T2 / #1191)** — extract `audit_doc_imports.py`'s
-  `src`-on-`sys.path` resolver into a shared `fact_check/imports.py` and
-  repoint the absorbed `python_refs.py` at it (kills the line-115 false
-  positive). Split OUT of T2a to keep the staleness absorb focused; it
-  touches disjoint files (`fact_check/`, `scripts/`) with its own
-  regression test. Tracked as its own follow-up.

--- a/scripts/audit_doc_imports.py
+++ b/scripts/audit_doc_imports.py
@@ -190,34 +190,16 @@ def _import_statements(body: str) -> list[tuple[int, str]]:
 def _resolve(statement: str) -> str | None:
     """Return an error message if the import does not resolve, else None.
 
-    Import-only and in-process: imports the module and checks each name
-    with ``hasattr``. Never executes fence bodies.
+    Delegates to the shared authoritative resolver
+    (``attune.authoring.fact_check.imports``, #1586) so this gate and
+    the master fact-check produce one import verdict. Imported lazily:
+    ``main()`` puts the in-repo ``src`` on ``sys.path`` first, so the
+    script keeps working in a checkout where the package isn't
+    installed. Never executes fence bodies.
     """
-    try:
-        if statement.startswith("import "):
-            mod = statement[len("import ") :].split(" as ")[0].strip()
-            importlib.import_module(mod)
-            return None
-        # from MOD import A, B as C, ...
-        head, _, tail = statement.partition(" import ")
-        mod = head[len("from ") :].strip()
-        module = importlib.import_module(mod)
-        missing = []
-        for piece in tail.split(","):
-            name = piece.strip().split(" as ")[0].strip()
-            if name and name != "*" and not hasattr(module, name):
-                missing.append(name)
-        if missing:
-            return f"{mod} has no attribute(s): {', '.join(missing)}"
-        return None
-    except ModuleNotFoundError as e:
-        return f"ModuleNotFoundError: {e}"
-    except ImportError as e:
-        return f"ImportError: {e}"
-    except Exception as e:  # noqa: BLE001
-        # INTENTIONAL: a doc import that blows up any other way (e.g. a
-        # module-level error) is still a broken fence the reader would hit.
-        return f"{type(e).__name__}: {e}"
+    from attune.authoring.fact_check.imports import resolve_import_statement
+
+    return resolve_import_statement(statement)
 
 
 # --- G4 deep checks (kwargs/attrs + MCP module paths) ----------------------

--- a/src/attune/authoring/fact_check/imports.py
+++ b/src/attune/authoring/fact_check/imports.py
@@ -1,0 +1,147 @@
+"""Shared authoritative import resolver for doc fact-checking.
+
+The single import-verdict implementation behind BOTH doc gates
+(consolidation spec Step 2 / #1191 T1, tracked by #1586):
+
+- ``scripts/audit_doc_imports.py`` (the CI doc-import gate) delegates
+  its statement resolution here after preparing ``sys.path``.
+- ``fact_check/python_refs.py`` (the master fact-check) resolves its
+  code-fence imports and prose dotted paths through the same
+  primitives.
+
+The authority mechanism is ``ensure_src_on_path``: resolving against
+the repo's own ``src/`` tree first, immune to the editable-install
+MAPPING trap where the active venv points ``attune`` at a different
+checkout (the "line-115" false-positive class — a symbol present in
+the repo being checked reported as unresolvable because the venv
+resolved a stale sibling checkout). Note the inherent limit: a
+``sys.path`` insert cannot rebind modules ALREADY imported into the
+running process — fresh processes (the audit script, authoring CLI
+runs) get the full guarantee; long-lived processes keep their loaded
+modules.
+
+Resolution is import-only: modules are imported and attributes checked
+with ``hasattr``/``getattr``; fence bodies are never executed.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+
+
+def find_repo_root(start: Path) -> Path | None:
+    """Walk up from ``start`` to the enclosing repo root, if any.
+
+    A repo root is a directory holding both ``pyproject.toml`` and a
+    ``src/`` directory — the layout whose in-repo source should win
+    import resolution. Returns ``None`` when no such ancestor exists.
+    """
+    node = start.resolve()
+    if node.is_file():
+        node = node.parent
+    for candidate in (node, *node.parents):
+        if (candidate / "pyproject.toml").is_file() and (candidate / "src").is_dir():
+            return candidate
+    return None
+
+
+def ensure_src_on_path(repo_root: Path | None) -> None:
+    """Put ``<repo_root>/src`` first on ``sys.path`` (idempotent).
+
+    Call BEFORE resolving imports so not-yet-loaded modules resolve
+    against the repo's own source rather than whatever the active
+    venv's editable mapping points at. A no-op when ``repo_root`` is
+    ``None`` or has no ``src/`` directory.
+    """
+    if repo_root is None:
+        return
+    src = repo_root / "src"
+    if src.is_dir() and str(src) not in sys.path:
+        sys.path.insert(0, str(src))
+
+
+def resolve_import_statement(statement: str) -> str | None:
+    """Return an error message if ``statement`` does not resolve, else None.
+
+    Handles ``import MOD [as A]`` and ``from MOD import A, B as C``.
+    Import-only and in-process: imports the module and checks each name
+    with ``hasattr``.
+    """
+    try:
+        if statement.startswith("import "):
+            mod = statement[len("import ") :].split(" as ")[0].strip()
+            importlib.import_module(mod)
+            return None
+        # from MOD import A, B as C, ...
+        head, _, tail = statement.partition(" import ")
+        mod = head[len("from ") :].strip()
+        module = importlib.import_module(mod)
+        missing = []
+        for piece in tail.split(","):
+            name = piece.strip().split(" as ")[0].strip()
+            if name and name != "*" and not hasattr(module, name):
+                missing.append(name)
+        if missing:
+            return f"{mod} has no attribute(s): {', '.join(missing)}"
+        return None
+    except ModuleNotFoundError as e:
+        return f"ModuleNotFoundError: {e}"
+    except ImportError as e:
+        return f"ImportError: {e}"
+    except Exception as e:  # noqa: BLE001
+        # INTENTIONAL: a doc import that blows up any other way (e.g. a
+        # module-level error) is still a broken fence the reader would hit.
+        return f"{type(e).__name__}: {e}"
+
+
+def try_import(module: str) -> bool:
+    """Best-effort import test. Returns True if importable."""
+    try:
+        importlib.import_module(module)
+    except Exception:  # noqa: BLE001
+        # INTENTIONAL: any failure (ImportError, syntax error in a
+        # broken dep, ValueError on a bad dotted path) means the
+        # reference is unresolvable — exactly what the doc author
+        # needs surfaced.
+        return False
+    return True
+
+
+def resolve_attr(module_path: str, attr: str) -> bool:
+    """Import ``module_path`` and verify ``attr`` exists on it."""
+    try:
+        module = importlib.import_module(module_path)
+    except Exception:  # noqa: BLE001
+        # INTENTIONAL: unimportable module == unresolvable attribute.
+        return False
+    return hasattr(module, attr)
+
+
+def resolve_dotted(path: str) -> bool:
+    """Resolve a full dotted path like ``attune.ops._readers.Foo``.
+
+    Walks from longest module prefix down: tries to import each
+    prefix; if a prefix imports, checks that the suffix attribute
+    chain exists on the resulting object.
+    """
+    parts = path.split(".")
+    # Try progressively shorter module prefixes.
+    for split in range(len(parts), 0, -1):
+        module_path = ".".join(parts[:split])
+        try:
+            obj = importlib.import_module(module_path)
+        except Exception:  # noqa: BLE001
+            # INTENTIONAL: a shorter prefix may still import; keep walking.
+            continue
+        # Walk remaining attributes.
+        ok = True
+        for attr in parts[split:]:
+            if not hasattr(obj, attr):
+                ok = False
+                break
+            obj = getattr(obj, attr)
+        if ok:
+            return True
+    return False

--- a/src/attune/authoring/fact_check/python_refs.py
+++ b/src/attune/authoring/fact_check/python_refs.py
@@ -1,18 +1,21 @@
 """Check Python import statements and dotted-path references.
 
-Resolves each candidate against the active venv via
-``importlib.import_module`` — see spec §1.3, "catches the
-``attune.ops._readers`` class of bug where the path parses fine
-but doesn't actually exist."
+Resolves each candidate through the shared authoritative resolver
+(``fact_check/imports.py``, #1586): the repo's own ``src/`` is put
+first on ``sys.path`` before resolution, so a symbol that exists in
+the checked repo resolves even when the active venv's editable
+mapping points at a different checkout (the line-115 false-positive
+class). Catches the ``attune.ops._readers`` class of bug where the
+path parses fine but doesn't actually exist (spec §1.3).
 """
 
 from __future__ import annotations
 
 import ast
-import importlib
 import re
 from pathlib import Path
 
+from . import imports as _imports
 from .report import CHECK_PYTHON_REFS, Finding
 
 #: Match prose references like ``attune.ops._readers.Foo`` or
@@ -49,53 +52,11 @@ def _extract_code_fences(text: str) -> list[tuple[int, str]]:
     return fences
 
 
-def _try_import(module: str) -> bool:
-    """Best-effort import test. Returns True if importable."""
-    try:
-        importlib.import_module(module)
-    except Exception:  # noqa: BLE001
-        # INTENTIONAL: any failure (ImportError, syntax error in a
-        # broken dep, ValueError on a bad dotted path) means the
-        # reference is unresolvable from the active venv — exactly
-        # what we want to surface to the doc author.
-        return False
-    return True
-
-
-def _resolve_attr(module_path: str, attr: str) -> bool:
-    """Import ``module_path`` and verify ``attr`` exists on it."""
-    try:
-        module = importlib.import_module(module_path)
-    except Exception:  # noqa: BLE001
-        return False
-    return hasattr(module, attr)
-
-
-def _resolve_dotted(path: str) -> bool:
-    """Resolve a full dotted path like ``attune.ops._readers.Foo``.
-
-    Walks from longest module prefix down: tries to import each
-    prefix; if a prefix imports, checks that the suffix attribute
-    chain exists on the resulting object.
-    """
-    parts = path.split(".")
-    # Try progressively shorter module prefixes.
-    for split in range(len(parts), 0, -1):
-        module_path = ".".join(parts[:split])
-        try:
-            obj = importlib.import_module(module_path)
-        except Exception:  # noqa: BLE001
-            continue
-        # Walk remaining attributes.
-        ok = True
-        for attr in parts[split:]:
-            if not hasattr(obj, attr):
-                ok = False
-                break
-            obj = getattr(obj, attr)
-        if ok:
-            return True
-    return False
+# Resolution primitives live in the shared authoritative resolver
+# (one import verdict for this checker AND the CI doc-import gate).
+_try_import = _imports.try_import
+_resolve_attr = _imports.resolve_attr
+_resolve_dotted = _imports.resolve_dotted
 
 
 def check(polished_path: Path) -> list[Finding]:
@@ -104,6 +65,10 @@ def check(polished_path: Path) -> list[Finding]:
     Returns findings for unresolvable imports inside python code
     fences and for unresolvable dotted paths in prose.
     """
+    # Authoritative resolution (#1586): the checked repo's own src/
+    # wins over the venv's editable mapping for anything not yet
+    # imported into this process.
+    _imports.ensure_src_on_path(_imports.find_repo_root(polished_path))
     text = polished_path.read_text(encoding="utf-8")
     findings: list[Finding] = []
     seen: set[tuple[str, str]] = set()

--- a/tests/unit/authoring/fact_check/test_imports.py
+++ b/tests/unit/authoring/fact_check/test_imports.py
@@ -1,0 +1,102 @@
+"""Shared authoritative resolver (#1586) — incl. the line-115 regression."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+from attune.authoring.fact_check import imports as fc_imports
+from attune.authoring.fact_check import python_refs
+
+_MASTER_BODY = (
+    "```python\n"
+    "from attune_tdemo import MARKER\n"
+    "```\n"
+    "\n"
+    "See `attune_tdemo.MARKER` for details.\n"
+)
+
+
+def _make_repo(tmp_path: Path) -> tuple[Path, Path]:
+    """A repo whose src/ defines a package the active venv has never
+    heard of, plus a master doc referencing it."""
+    repo = tmp_path / "repo"
+    pkg = repo / "src" / "attune_tdemo"
+    pkg.mkdir(parents=True)
+    (pkg / "__init__.py").write_text("MARKER = 'here'\n", encoding="utf-8")
+    (repo / "pyproject.toml").write_text('[project]\nname = "tdemo"\n', encoding="utf-8")
+    docs = repo / "content" / "features"
+    docs.mkdir(parents=True)
+    master = docs / "demo.md"
+    master.write_text(_MASTER_BODY, encoding="utf-8")
+    return repo, master
+
+
+@pytest.fixture(autouse=True)
+def _restore_import_state(monkeypatch: pytest.MonkeyPatch):
+    """Undo sys.path inserts and demo-module imports after each test."""
+    monkeypatch.setattr(sys, "path", list(sys.path))
+    yield
+    sys.modules.pop("attune_tdemo", None)
+
+
+class TestRepoRootDiscovery:
+    def test_finds_root_above_master(self, tmp_path: Path) -> None:
+        repo, master = _make_repo(tmp_path)
+        assert fc_imports.find_repo_root(master) == repo
+
+    def test_none_outside_a_repo_layout(self, tmp_path: Path) -> None:
+        loose = tmp_path / "loose.md"
+        loose.write_text("x\n", encoding="utf-8")
+        assert fc_imports.find_repo_root(loose) is None
+
+    def test_ensure_src_on_path_is_idempotent(self, tmp_path: Path) -> None:
+        repo, _ = _make_repo(tmp_path)
+        fc_imports.ensure_src_on_path(repo)
+        fc_imports.ensure_src_on_path(repo)
+        assert sys.path.count(str(repo / "src")) == 1
+        fc_imports.ensure_src_on_path(None)  # must be a no-op, not a crash
+
+
+class TestResolveImportStatement:
+    def test_clean_statements_resolve(self) -> None:
+        assert fc_imports.resolve_import_statement("import attune") is None
+        assert (
+            fc_imports.resolve_import_statement("from attune.authoring.fact_check import imports")
+            is None
+        )
+
+    def test_missing_attribute_named(self) -> None:
+        msg = fc_imports.resolve_import_statement(
+            "from attune.authoring.fact_check.imports import not_a_real_name"
+        )
+        assert msg is not None
+        assert "no attribute" in msg
+        assert "not_a_real_name" in msg
+
+    def test_missing_module_named(self) -> None:
+        msg = fc_imports.resolve_import_statement("import attune.nope_xyz")
+        assert msg is not None
+        assert "ModuleNotFoundError" in msg
+
+
+class TestLine115Regression:
+    def test_repo_src_symbol_resolves_authoritatively(self, tmp_path: Path) -> None:
+        """The #1586 regression: a symbol that exists ONLY in the checked
+        repo's src/ must resolve — the venv's (absent) view of the
+        package must not produce a false 'not importable'."""
+        _, master = _make_repo(tmp_path)
+        findings = python_refs.check(master)
+        assert findings == []
+
+    def test_same_doc_without_repo_layout_still_fails(self, tmp_path: Path) -> None:
+        """Negative control: with no repo src/ to resolve against, the
+        same references are honestly unresolvable — proving the pass
+        above came from repo-src resolution, not ambient state."""
+        loose = tmp_path / "demo.md"
+        loose.write_text(_MASTER_BODY, encoding="utf-8")
+        findings = python_refs.check(loose)
+        assert findings, "expected unresolvable-reference findings"
+        assert any("attune_tdemo" in f.message for f in findings)


### PR DESCRIPTION
Closes [#1586](https://github.com/Smart-AI-Memory/attune-ai/issues/1586) — second item in the binding build-slot order, unblocked by the #1561 lift today.

## What (spec: attune-author-consolidation, Step 2 / #1191 T1)

- New shared `src/attune/authoring/fact_check/imports.py`: `find_repo_root` + `ensure_src_on_path` (the audit script's src-on-sys.path mechanism, extracted) plus the resolution primitives (`resolve_import_statement` verbatim from the audit script; `try_import`/`resolve_attr`/`resolve_dotted` from python_refs).
- `python_refs.check()` preps the checked repo's `src/` before resolving — the line-115 false-positive class (venv editable mapping pointing at a different checkout) is gone for fresh-process runs; the inherent already-imported-modules limit is documented.
- `scripts/audit_doc_imports.py::_resolve` now delegates lazily to the shared helper (its `main()` bootstrap stays — it must run before any attune import). G4 deep layer untouched.
- decisions.md: execution entry added, Open bullet retired.

## Receipts

- **Regression test** `TestLine115Regression`: a symbol existing ONLY in the checked repo's src resolves; a no-repo-layout negative control proves the pass comes from repo-src resolution, not ambient state.
- **Suite (serial):** `tests/unit/authoring/fact_check/ + tests/unit/scripts/test_audit_doc_imports.py` → **127 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
