### PR TITLE
feat(website): multi-LLM pillar + live-registry count corrections (launch fire)

### DIFF
--- a/website/app/docs/page.tsx
+++ b/website/app/docs/page.tsx
@@ -45,7 +45,7 @@ const faqItems = [
   {
     question: 'What Claude Code skills are included?',
     answer:
-      '25 auto-invoking skills: security audit, smart test, code quality, bug prediction, doc generation, refactor planning, release prep, planning, spec-driven development, fix-test, workflow orchestration, RAG-grounded code generation, content verification, cross-session recall, memory and context, personal memory, image analysis, batch processing, capability catalog, discovery sweep, form-driven elicitation, the coach help system, the attune hub router, single-source feature-page authoring, and the multi-LLM round table.',
+      '26 auto-invoking skills: security audit, smart test, code quality, bug prediction, doc generation, refactor planning, release prep, planning, spec-driven development, fix-test, workflow orchestration, RAG-grounded code generation, content verification, cross-session recall, memory and context, personal memory, image analysis, batch processing, capability catalog, discovery sweep, form-driven elicitation, the coach help system, the attune hub router, single-source feature-page authoring, cross-model diff review, and the multi-LLM round table.',
   },
   {
     question: 'Where do I install attune-help from?',
@@ -165,7 +165,7 @@ export default function DocsPage() {
                   <p className="text-sm text-[var(--text-secondary)] mb-5 flex-1">
                     The whole platform: spec engine, AI workflows, project
                     memory, retrieval grounding, and verification.
-                    20 workflows, 25 skills, 47 MCP tools.
+                    19 workflows, 26 skills, 49 MCP tools.
                   </p>
                   <div className="bg-[#213145] text-white/90 rounded-xl font-mono text-xs p-3">
                     <span className="text-white/50">$ </span>pip install attune-ai
@@ -452,7 +452,7 @@ export default function DocsPage() {
               </h2>
               <p className="text-center text-[var(--text-secondary)] mb-12 max-w-2xl mx-auto">
                 Install from the marketplace. Progressive help, project
-                bootstrapping, and 25 skills right in your terminal.
+                bootstrapping, and 26 skills right in your terminal.
               </p>
 
               <div className="bg-[var(--background)] border-2 border-[var(--border)] rounded-lg p-8 mb-8">
@@ -518,9 +518,9 @@ export default function DocsPage() {
                 Workflows &amp; Skills
               </h2>
               <p className="text-center text-[var(--text-secondary)] mb-12 max-w-2xl mx-auto">
-                The build half of the loop: 20 workflows,
-                25 auto-triggering Claude Code skills,
-                and an MCP server with 47 registered tools — review, tests,
+                The build half of the loop: 19 workflows,
+                26 auto-triggering Claude Code skills,
+                and an MCP server with 49 registered tools — review, tests,
                 bug prediction, refactor, and release prep.
               </p>
 

--- a/website/app/faq/page.tsx
+++ b/website/app/faq/page.tsx
@@ -30,11 +30,11 @@ const faqData: FAQCategory[] = [
       },
       {
         question: 'What is Attune AI built on?',
-        answer: 'Memory is the pillar: project memory carries cross-session findings and a retrievable lessons corpus, surfaced at the moment a prompt needs them. Around it ship four supporting capabilities, each real and shipped: dynamic forms (structured human/AI turns), AI workflows (20 workflows for review, tests, bug prediction, and refactors), retrieval grounding (citations back to your source via attune-rag), and verification (fact-checking generated content before it reaches main).',
+        answer: 'Memory is the pillar: project memory carries cross-session findings and a retrievable lessons corpus, surfaced at the moment a prompt needs them. Around it ship four supporting capabilities, each real and shipped: dynamic forms (structured human/AI turns), AI workflows (19 workflows for review, tests, bug prediction, and refactors), retrieval grounding (citations back to your source via attune-rag), and verification (fact-checking generated content before it reaches main).',
       },
       {
         question: 'What can Attune AI do, in numbers?',
-        answer: 'Attune AI ships 20 workflows, 47 MCP tools, 25 auto-triggering skills, 5 wizards, and 15 template kinds. The spec engine runs via /spec, progressive help via /coach, and cross-session recall via /recall.',
+        answer: 'Attune AI ships 19 workflows, 49 MCP tools, 26 auto-triggering skills, 5 wizards, and 15 template kinds. The spec engine runs via /spec, progressive help via /coach, and cross-session recall via /recall.',
       },
       {
         question: "What's the difference between attune-ai and attune-gui?",

--- a/website/app/page.tsx
+++ b/website/app/page.tsx
@@ -451,7 +451,7 @@ export default function Home() {
               </div>
               <h3 className="text-xl font-bold mb-3">attune-ai</h3>
               <p className="text-[var(--text-secondary)] leading-relaxed text-sm">
-                Full framework. Workflows, staleness detection, MCP server, and 25 auto-triggering skills for Claude Code.
+                Full framework. Workflows, staleness detection, MCP server, and 26 auto-triggering skills for Claude Code.
               </p>
             </div>
 

--- a/website/lib/features.ts
+++ b/website/lib/features.ts
@@ -46,8 +46,8 @@ export const PRODUCTS: Product[] = [
       "Generate concept, task, and reference templates",
       "Staleness detection via source hashing",
       "Auto-regeneration of stale templates",
-      "25 Claude Code skills included",
-      "MCP server with 47 registered tools",
+      "26 Claude Code skills included",
+      "MCP server with 49 registered tools",
     ],
   },
   {
@@ -117,7 +117,7 @@ export const PRODUCTS: Product[] = [
       "/coach status — check template freshness",
       "/coach maintain — regenerate stale templates",
       "Auto-triggers on natural language (help, explain, learn)",
-      "25 auto-triggering skills (security, testing, review, etc.)",
+      "26 auto-triggering skills (security, testing, review, etc.)",
     ],
   },
 ];
@@ -268,7 +268,7 @@ export const DIFFERENTIATORS: Differentiator[] = [
  * and no page consumed them.)
  */
 export const CAPABILITIES = {
-  workflows: 20,
+  workflows: 19,
   skills: 26,
   mcpTools: 49,
   templateKinds: 15,
@@ -311,7 +311,7 @@ export const RELIABILITY_LOOP: LoopStage[] = [
     n: "03",
     name: "Build",
     description:
-      "20 workflows: review, tests, bug prediction, refactor.",
+      "19 workflows: review, tests, bug prediction, refactor.",
   },
   {
     n: "04",
@@ -362,6 +362,26 @@ export const PILLARS: Pillar[] = [
     icon: "🧠",
     color: "secondary",
   },
+  // 10.6.0 multi-LLM wave (launch plan; wording aligned with the
+  // shipped README "Multi-LLM collaboration" section).
+  {
+    id: "multi-llm",
+    tag: "Multi-LLM",
+    title: "Three AI agents, one project brain",
+    description:
+      "Claude Code, Codex, and Antigravity share the same project " +
+      "memory, hand off work with git-verified packets, and give " +
+      "each other second opinions on real diffs. The round table " +
+      "lets them deliberate a question — you chair what gets " +
+      "adopted.",
+    points: [
+      "Shared session memory via MCP — same tools in every agent",
+      "Handoffs re-verified against the actual git tree on resume",
+      "Cross-model review and deliberation — advisory; you decide",
+    ],
+    icon: "🤝",
+    color: "accent",
+  },
   {
     id: "communication",
     tag: "Dynamic forms",
@@ -387,7 +407,7 @@ export const PILLARS: Pillar[] = [
     tag: "AI workflows",
     title: "Specialist teams, not one prompt",
     description:
-      "20 workflows run teams of 2–6 Claude subagents to " +
+      "19 workflows run teams of 2–6 Claude subagents to " +
       "review code, surface vulnerabilities, generate tests, and plan " +
       "refactors — with cost-tiered model routing.",
     points: [


### PR DESCRIPTION
## Summary

Applies the 10.6.0 launch plan's staged website work (Tuesday fire, step 3a), corrected against the live registries — the staged `website/multi-llm-launch` branch's 10.7.0 hand-bumps are **superseded** per the starter's instruction and this PR replaces it.

- **New Multi-LLM pillar** on the homepage pillar band, wording aligned with the shipped README **Multi-LLM collaboration** section (roundtable / cross-review / handoff / shared session memory).
- **Counts re-verified against live registries** (website-content-accuracy rule):
  - workflows **20 → 19** (`list_workflows()` stage-filtered; secure-release + 2 health checks have no stages)
  - skills **25 → 26** (`plugin/skills/` dir count — cross-review added in 10.6.0)
  - MCP tools **47 → 49** (`tool_schemas` `get_*_tools()` total)
  - fixed in `features.ts` product bullets + CAPABILITIES, homepage, FAQ, and docs page
- docs-page skill enumeration gains **cross-model diff review** (was missing; count said 25 while naming 25 of 26).
- Versions were already correct at 10.6.1 on main (bump_version.py covered them).

Website-only change — no changelog entry per website/CLAUDE.md policy.

## Receipts

- `vitest run` 28/28 with `ATTUNE_PYTHON` set, so the capabilities-accuracy registry assertions ran **live** (not skipped)
- `eslint` clean, `tsc --noEmit` clean
- residue grep for 20-workflows/25-skills/47-tools: zero hits

🤖 Generated with [Claude Code](https://claude.com/claude-code)