### PR TITLE
docs(readme): fix stale capability counts against live registries

### DIFF
--- a/README.md
+++ b/README.md
@@ -445,7 +445,7 @@ per-surface extras (API-mode agents, ops dashboard, Redis memory).
 
 ## MCP Tools
 
-47 tools organized into 6 categories:
+49 tools organized into 7 categories:
 
 ### Workflow (22)
 
@@ -482,6 +482,10 @@ per-surface extras (API-mode agents, ops dashboard, Redis memory).
 
 `elicitation_ask` `elicitation_render_form`
 `elicitation_collect_response` `elicitation_render_widget`
+
+### Handoff (2)
+
+`handoff_create` `handoff_resume`
 
 ---
 
@@ -525,10 +529,10 @@ from retrieval. Full methodology:
 
 | | Attune AI | Static Docs | Agent Frameworks | Coding CLIs |
 | --- | --- | --- | --- | --- |
-| **Ready-to-use workflows** | 22 built-in | None | Build from scratch | None |
+| **Ready-to-use workflows** | 20 built-in | None | Build from scratch | None |
 | **Multi-agent teams** | 2–6 agents per workflow | None | Yes | No |
-| **MCP integration** | 47 native tools | None | No | No |
-| **Auto-triggering skills** | 23 skills, natural language | None | None | None |
+| **MCP integration** | 49 native tools | None | No | No |
+| **Auto-triggering skills** | 26 skills, natural language | None | None | None |
 | **Socratic discovery** | Questions before execution | None | None | None |
 | **Portable security hooks** | PreToolUse + PostToolUse | None | No | No |
 


### PR DESCRIPTION
## Summary

README side of the live-registry count corrections (website side shipped in #1703). Fixes the ungated claim sites that drifted:

- **MCP Tools section**: "47 tools organized into 6 categories" → **49 tools / 7 categories** (`tool_schemas` `get_*_tools()` total), and adds the missing **Handoff (2)** category (`handoff_create` `handoff_resume`) to the enumeration.
- **Why Attune? table**: 22 built-in workflows → **20**, 47 native tools → **49**, 23 skills → **26** (`plugin/skills/` dir count — cross-review added in 10.6.0).

### Workflow count is 20 (ratified)

The spawning task suggested 19 (the stage-filtered `list_workflows()` figure #1703 briefly used on the website), but the ratified definition is claim-drift-gates D4: distinct workflow classes = `len(set(discover_workflows().values()))` = **20** (release-prep/release-gate are a deliberate alias pair). The 19-yielding stage-filtered counter was a divergent duplicate guard, realigned in #1704 — so 20 is the single convention and matches the README's G1-gated hero claim.

## Receipts

- G1 claim-drift gate ran before the change: **14/14 pass** — confirming the stale sites were all ungated; re-ran after: **14/14 pass**.
- Live derivations: `tool_schemas` = 49 tools in 7 category fns; `plugin/skills/*/SKILL.md` = 26; `discover_workflows()` = 20 distinct classes / 22 slugs.
- Residue grep for `47 tools|6 categories|23 skills|22 built-in|47 native`: zero hits.
- Gated `cap:`-marked rows (60 MCP tools, 26 skills, 20-workflow hero) untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
