### PR TITLE
docs(rules): fix website-accuracy verification commands to match D4 + guards

### DIFF
--- a/.claude/rules/attune/website-content-accuracy.md
+++ b/.claude/rules/attune/website-content-accuracy.md
@@ -22,12 +22,49 @@ code**.
 
 ## Required Verification Commands
 
+One command per key in `CAPABILITIES` (`website/lib/features.ts`).
+Each is the same derivation the CI guard asserts — if a command here
+and the guard disagree, the guard wins and this table is the bug.
+
 | Claim | Verification |
 |-------|-------------|
-| Workflow count / names | `python -c "from attune.workflows import list_workflows; [print(w['name']) for w in list_workflows() if w.get('stages')]"` |
-| Wizard count / names | `python -c "from attune.wizards import WizardRegistry; r = WizardRegistry(); print(r.list_wizards())"` |
-| Agent templates | Check `src/attune/agents/` for registered templates |
+| `workflows` | `python -c "from attune.workflows import discover_workflows; print(len(set(discover_workflows().values())))"` |
+| `skills` | `ls -d plugin/skills/*/ \| wc -l` |
+| `mcpTools` | `python -c "from attune.mcp import tool_schemas as t; print(sum(len(getattr(t, n)()) for n in dir(t) if n.startswith('get_') and n.endswith('_tools')))"` |
+| `templateKinds` | `python -c "from attune_author.generator import _ALL_TEMPLATE_NAMES as a; print(len(a))"` |
+| `wizards` | `python -c "from attune.wizards import list_wizards; print(len(list_wizards()))"` |
 | Version number | `python -c "from attune import __version__; print(__version__)"` |
+
+**`workflows` counts distinct classes, never `stages`.** D4
+(claim-drift-gates, ratified 2026-07-12) chose
+`len(set(discover_workflows().values()))` and explicitly *rejected*
+`list_workflows()` filtered on a truthy `stages` field. Almost every
+workflow sets some `stages` value, so that filter counts nearly all of
+them while implying they are multi-stage — only three actually declare
+more than one stage. `release-prep`/`release-gate` and
+`orchestrated-health-check`/`health-check` are deliberate alias pairs
+and count once each.
+
+---
+
+## The website-only CI gap
+
+Website-only PRs (nothing changed outside `website/`) **skip the Python
+test suite** — the `changes` job in `.github/workflows/tests.yml` emits
+`website_only=true` and the full-suite jobs report green without running
+pytest (see `website/CLAUDE.md`).
+
+`tests/unit/test_website_version_accuracy.py` — the guard that owns
+these counts — is therefore **not enforced on the PRs most likely to
+change them**. The failure surfaces later, on whatever unrelated
+full-suite PR merges next.
+
+So on a website-only PR, running the commands above is not belt-and-
+braces. It is the only check that will run. To force the guard locally:
+
+```bash
+python -m pytest tests/unit/test_website_version_accuracy.py -q
+```
 
 ---
 
@@ -40,6 +77,21 @@ None existed in the Python registry.
 
 This was discovered only when a user noticed the discrepancy.
 
+### 2026-07-28 — this rule caused the regression it exists to prevent
+
+PR #1703 changed `CAPABILITIES.workflows` from 20 to 19, citing the
+"stage-filtered registry" — the derivation D4 had rejected sixteen days
+earlier. The number came from following the command in this table,
+which was never updated when D4 landed. Because #1703 was website-only,
+the guard that would have caught it never ran; `main` went red on the
+next full-suite PR and stayed red until #1704.
+
+Two failure modes stacked: a stale verification command, and a CI gap
+that hid the result. Both are addressed above. The durable lesson is
+that a rule doc prescribing a command is load-bearing — when a decision
+changes a derivation, the doc that teaches it has to change in the same
+breath, or it keeps handing out the old answer with full authority.
+
 ---
 
 ## Apply This Rule When
@@ -49,6 +101,8 @@ This was discovered only when a user noticed the discrepancy.
   `components/Navigation.tsx`
 - Writing blog posts that reference specific workflow or wizard names
 - Creating comparison pages that list Attune AI capabilities
+- Writing launch copy, release announcements, or README prose that
+  repeats a capability count
 
 ---
 


### PR DESCRIPTION
## Why

[#1704](https://github.com/Smart-AI-Memory/attune-ai/pull/1704) fixed the counts that reddened `main`. This fixes the doc that produced the wrong count in the first place.

`.claude/rules/attune/website-content-accuracy.md` still prescribed the **stage-filtered** derivation for the workflow count — the one D4 (claim-drift-gates, ratified 2026-07-12) explicitly *rejected*. #1703 followed the rule correctly and got 19; the guard enforces D4's distinct-class count of 20. Because #1703 was website-only the guard never ran, so `main` only went red on the next full-suite PR.

The rule doc was never updated when D4 landed, so it kept handing out the pre-D4 answer with full authority.

## What changed

Verified **every** command in the table against the live registries, not just the one that broke. Two were wrong:

| Row | Before | After |
|---|---|---|
| `workflows` | `list_workflows()` filtered on truthy `stages` — D4-rejected | `len(set(discover_workflows().values()))` per D4 |
| `wizards` | `WizardRegistry` — raises `ImportError`, no longer exists | `list_wizards()` |
| Agent templates | pointed at `src/attune/agents/` | dropped — `CAPABILITIES` lost `agentTemplates` 2026-06-11 |
| `skills`, `mcpTools`, `templateKinds` | absent | added |

The table is now one row per `CAPABILITIES` key, and states that if a command here and the CI guard disagree, the guard wins and the table is the bug.

Also documents **the website-only CI gap** that hid the failure: the `changes` job emits `website_only=true` and the full-suite jobs report green without running pytest, so `test_website_version_accuracy.py` — the guard that owns these counts — is not enforced on exactly the PRs most likely to change them. On a website-only PR, running these commands is the only check that will run.

## Receipts

All five `CAPABILITIES` values re-derived from the live registries and matched `main`:

| Key | features.ts | Live |
|---|---|---|
| workflows | 20 | 20 |
| skills | 26 | 26 |
| mcpTools | 49 | 49 |
| templateKinds | 15 | 15 |
| wizards | 5 | 5 |

- `TestCapabilityCountsSync` **5/5 PASSED**, including `test_workflows_count_matches_registry` — the exact test that reddened `main`
- `tests/unit/rules/` + `tests/unit/test_website_version_accuracy.py` — **19 passed, 0 skipped**
- Each replacement command executed as written before being pasted into the table; the two removed commands were confirmed broken (`WizardRegistry` → `ImportError`) or stale

Docs-only change — no runtime code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
