### PR TITLE
docs(launch): article says 10.6.1 on PyPI, not 10.6.0

### DIFF
--- a/docs/process/LAUNCH_10_6_0_article_draft.md
+++ b/docs/process/LAUNCH_10_6_0_article_draft.md
@@ -10,10 +10,19 @@ unfilled slot is forbidden (no claim without a receipt).
 Pre-publish checklist:
 
 - [ ] All `[RECEIPT: …]` slots filled with real transcript excerpts
-- [ ] Version/date claims match the actual v10.6.0 tag + PyPI 200
+- [ ] Version/date claims re-checked against **live PyPI**, not the
+      tag this draft was written against. 10.6.0 names the release;
+      **10.6.1** is the same-day patch and is what `pip install`
+      resolves to today — it carries the README "Multi-LLM
+      collaboration" section this article describes. Verify with
+      `curl -s https://pypi.org/pypi/attune-ai/json` before firing;
+      a later patch moves this number again.
 - [ ] Chair honesty-gate pass (same ruling session as Draft B)
-- [ ] Counts ("five tools", "26 skills") re-verified against the
-      merged registries, not this draft
+- [x] Counts re-verified against the merged registries (2026-07-28):
+      "five `session_memory_*` tools" = 5, names match
+      (`attune_redis.mcp_tools.SESSION_MEMORY_TOOL_DEFINITIONS`).
+      No other capability count appears in the body — the earlier
+      "26 skills" item checked a claim this draft does not make.
 
 ---
 
@@ -140,7 +149,8 @@ it gets a seat at the table and a key to the memory, not a fork.
 pip install attune-ai
 ```
 
-10.6.0 is on PyPI now. The round table is open.
+10.6.1 is on PyPI now — 10.6.0 plus a same-day patch. The round
+table is open.
 
 ---
 


### PR DESCRIPTION
## Why

The launch article fires today. It closed with:

> `10.6.0 is on PyPI now. The round table is open.`

**PyPI latest is 10.6.1** — the same-day patch that carries the README **Multi-LLM collaboration** section *this article is about*. A reader who installs on the strength of the piece and goes looking for that section needs 10.6.1; 10.6.0 doesn't have it.

## What changed

**The closing line** — now `10.6.1 is on PyPI now — 10.6.0 plus a same-day patch.`

`10.6.0` still names the release in the title and body. That's correct and untouched. Only the install-time claim moved.

**Checklist item 2** could not have caught this. Written 2026-07-22, it said:

> - [ ] Version/date claims match the actual v10.6.0 tag + PyPI 200

Following it as written *confirms the wrong version* — it encodes a fact from before the patch existed. Rewritten to check live PyPI with the command, and to flag that a later patch moves the number again. Same stale-check shape as the rule doc in [#1706](https://github.com/Smart-AI-Memory/attune-ai/pull/1706).

**Checklist item 4** resolved rather than reworded. Swept all three launch surfaces for capability counts:

| Surface | Capability-count claims |
|---|---|
| `LAUNCH_10_6_0_article_draft.md` | one — "five `session_memory_*` MCP tools" |
| `RELEASE_10_6_0_drafts.md` | none (PR numbers and process refs only) |
| `.claude/plans/launch-10-6-0-multi-llm.md` | none |

The one live claim verifies: **5**, names matching the article's list (capture, recall, recent, forget, status). The item's "26 skills" was checking a claim the draft doesn't make.

## Receipts

- `curl -s https://pypi.org/pypi/attune-ai/json` → `10.6.1`
- `SESSION_MEMORY_TOOL_DEFINITIONS` → len 5, names match the article
- `git grep` for capability counts across all three launch surfaces → only the checklist line and the "five tools" sentence

## Note for the honesty gate

Worth knowing, though the article is clean on it: `mcpTools: 49` in `features.ts` counts **core `tool_schemas` only**. `attune_redis` adds 11 more (the 5 `session_memory_*` plus 6 `redis_*`), zero overlap — so the surface is **60 registered / 49 core**, matching the projector figure in the launch plan. If any copy pairs "49 MCP tools" with "five session_memory tools", those come from different registries and the five are *not* inside the 49. The article never says 49, so no change needed here.

Draft copy only — no runtime code, no published surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
