### PR TITLE
fix(release): resolve MODEL_CONFIG lazily; drop the conftest import-time scrub

### DIFF
--- a/.claude/lessons.md
+++ b/.claude/lessons.md
@@ -18980,7 +18980,28 @@ def ", start_idx + 1)` for module-
   constant — a module-level `X = f(env)` is the tell. Exclude vars other
   fixtures own (`ATTUNE_HOME`): scrubbing it pointed the default
   telemetry store at the real `~/.attune` and the existing RC-4
-  `test_suite_isolation_drift_guard` caught it instantly. The
+  `test_suite_isolation_drift_guard` caught it instantly.
+  **SUPERSEDED IN PART (2026-07-28, same day): prefer REMOVING the
+  import-time capture over scrubbing earlier.** Measuring the codebase
+  settled it — 61 `ATTUNE_*` reads at call time, 0 at import, and
+  exactly ONE module-level binding freezing a resolver result
+  (`release_models.MODEL_CONFIG`). So the de-facto contract was already
+  "observable after import" and that one line was the sole violation: a
+  4-reference fix, not the `src/`-wide lazy-evaluation migration a
+  round-table seat proposed on the strength of the same symptom.
+  Making it lazy let the conftest import-time scrub be DELETED
+  (18955 passed / 0 failed under the fully poisoned env, both with and
+  without it). Two reasons the deletion is better than defence in
+  depth: (a) the import-time scrub deletes vars before `load_dotenv()`
+  runs at module level, and dotenv only injects names that do NOT
+  exist — so the scrub ARMS a `.env` injection path that a shell export
+  had been shadowing; (b) with no scrub, a future import-time freeze
+  fails LOUDLY instead of being masked by the very thing hiding it.
+  The diagnostic above still stands unchanged; what changed is the
+  remedy ranking — fix `src/`, then check whether the test-side
+  workaround is still needed at all. A static guard
+  (`test_no_module_level_binding_freezes_a_resolver_result`) keeps the
+  count at zero; verified red/green by reintroducing a freeze. The
   ANTHROPIC_API_KEY-leaks-into-pytest lesson is the same family, so
   treat "reads process env" as a standing test-isolation trigger, not
   a one-off; (2) when two runs of the same routine disagree, **diff

--- a/.claude/lessons.md
+++ b/.claude/lessons.md
@@ -19041,3 +19041,53 @@ def ", start_idx + 1)` for module-
   path and the editable-install MAPPING lessons; this is the
   VERIFICATION surface of that family, where the cost is misdirected
   debugging rather than a misplaced file.
+
+- **A reviewer proposing an architecture-wide refactor from ONE observed
+  symptom is making a scope claim — take a census of conforming vs
+  violating sites before accepting it. The census usually shrinks the
+  work by an order of magnitude** (2026-07-28, round table
+  `q-conftest-env-scrub-001`): one seat's position was that `src/`
+  should be refactored to lazy environment evaluation, possibly
+  migrating to a Pydantic `BaseSettings` model, because
+  `release_models.MODEL_CONFIG` resolved a model tier at import and
+  froze it. Reasoning from the one site everyone could see, that is a
+  coherent conclusion — and it was wrong about scope. A 20-line AST
+  census answered it: **61 `ATTUNE_*` reads at call time, 0 at import,
+  exactly ONE module-level binding freezing a resolver result.** The
+  codebase's contract was already "observable after import"; the fix
+  was 4 references (two imports, one usage, one re-export), not a
+  migration. Two more things the census bought: it collapsed a
+  three-way seat disagreement into one chair decision (a second seat
+  had refused to rule on `src/` without first settling the lifecycle
+  contract — the census settled it), and fixing the single violation
+  made a test-side workaround shipped hours earlier DELETABLE, which no
+  seat predicted. **Rule: when any reviewer — human or LLM — proposes
+  "refactor X across the codebase" from a symptom you found in one
+  place, write the query that counts conformers before costing the
+  work.** `ast.parse` + walking `tree.body` for module-level `Assign`
+  nodes is usually enough and takes minutes. The failure mode this
+  prevents is real and expensive: a plausible generalization from a
+  sample of one, arriving with enough architectural vocabulary
+  (anti-pattern, settings object, dependency injection) to sound
+  settled. Corollary worth keeping: turn the census into a static
+  guard so the count stays at zero — the guard is cheaper than the
+  migration and fails loudly on the next violation.
+
+- **Calibration on LLM reviewer claims: the most speculative-sounding
+  claim can be the live one, and the most confidently structural claim
+  can be the false one — probe by CHECKABILITY, not by confidence**
+  (2026-07-28, same thread): a seat closed with two caveats framed as
+  "things I suspect were not considered." The hedged, mechanism-heavy
+  one — *deleting env vars lets `load_dotenv` inject from `.env`,
+  because dotenv only writes names that do not already exist, so the
+  scrub could OPEN a hole* — verified as a **live armed mechanism**
+  (`load_dotenv()` at module level in `workflows/base.py`, `.env` files
+  present; latent only because no dotenv file names an `ATTUNE_*` var
+  today). The flatly-stated structural one — *a repo-root `conftest.py`
+  loads before `tests/conftest.py` and would defeat the fix* — was
+  **refuted in one `ls`**: no repo-root conftest exists. Seats are
+  text-in/text-out (R1) and cannot run anything, so every claim they
+  make is reasoning; rank them for verification by how cheap they are
+  to falsify, never by how sure they sound. Recording the verdicts
+  (CONFIRMED / REFUTED / unverified) beside each claim in the promoted
+  report is what keeps a deliberation from hardening into folklore.

--- a/src/attune/agents/release/base_agent.py
+++ b/src/attune/agents/release/base_agent.py
@@ -24,10 +24,10 @@ from attune.models.registry import TIER_PRICING
 from .release_models import (
     ANTHROPIC_AVAILABLE,
     LLM_MODE,
-    MODEL_CONFIG,
     ReleaseAgentResult,
     Tier,
     anthropic,
+    get_model_config,
 )
 
 logger = logging.getLogger(__name__)
@@ -177,7 +177,7 @@ class ReleaseAgent:
         if not self.llm_client:
             return "", {"model": "rule_based", "cost": 0.0}
 
-        model = MODEL_CONFIG[tier.value]
+        model = get_model_config()[tier.value]
 
         try:
             # Premium tier resolves to fable — the helper routes fable

--- a/src/attune/agents/release/release_models.py
+++ b/src/attune/agents/release/release_models.py
@@ -46,14 +46,43 @@ except ImportError:
 # Configuration
 # =============================================================================
 
-# NOTE: the premium entry resolves through attune.model_tiers at IMPORT
-# time (this dict is read directly by base_agent/release_prep_team).
-# Set ATTUNE_MODEL_PREMIUM before importing to override it.
-MODEL_CONFIG = {
-    "cheap": "claude-haiku-4-5",
-    "capable": "claude-sonnet-5",
-    "premium": resolve_model("premium"),
-}
+#: Tiers whose model id is fixed (no env override path).
+_STATIC_MODELS = {"cheap": "claude-haiku-4-5", "capable": "claude-sonnet-5"}
+
+
+def get_model_config() -> dict[str, str]:
+    """Resolve the tier -> model-id map, reading env at CALL time.
+
+    The premium entry resolves through :mod:`attune.model_tiers`, which
+    honors ``ATTUNE_MODEL_PREMIUM``. Resolving here rather than at import
+    keeps this consistent with the rest of the codebase: every other
+    ``ATTUNE_*`` read in ``src/`` happens inside a function (61 sites),
+    and this dict was the single module-level binding that froze a
+    resolver result at import.
+
+    That freeze was a real defect, not just a testing nuisance — a
+    long-lived process (MCP server, ops dashboard) could not observe a
+    changed override without a restart, the effective value depended on
+    import order, and a consumer doing ``from … import MODEL_CONFIG``
+    captured a snapshot that ``importlib.reload`` could not refresh.
+    Ruled 2026-07-28 (round table ``q-conftest-env-scrub-001``):
+    ``ATTUNE_*`` overrides are observable after import.
+    """
+    return {**_STATIC_MODELS, "premium": resolve_model("premium")}
+
+
+def __getattr__(name: str) -> object:
+    """Keep ``release_models.MODEL_CONFIG`` working, resolved fresh.
+
+    Attribute access re-resolves; it is no longer a frozen module global.
+    Note that ``from … import MODEL_CONFIG`` still binds a snapshot at
+    the importing module's import time — call :func:`get_model_config`
+    instead when the value must track the environment.
+    """
+    if name == "MODEL_CONFIG":
+        return get_model_config()
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
 
 # LLM mode: "real" uses API calls, "simulated" uses rule-based analysis
 LLM_MODE = os.getenv("RELEASE_LLM_MODE", "simulated")

--- a/src/attune/agents/release/release_prep_team.py
+++ b/src/attune/agents/release/release_prep_team.py
@@ -57,13 +57,13 @@ from .release_models import (  # noqa: F401
     ANTHROPIC_AVAILABLE,
     DEFAULT_QUALITY_GATES,
     LLM_MODE,
-    MODEL_CONFIG,
     REDIS_AVAILABLE,
     QualityGate,
     ReleaseAgentResult,
     ReleaseReadinessReport,
     Tier,
     anthropic,
+    get_model_config,
     redis_lib,
 )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,23 +34,6 @@ import pytest
 _SUITE_MANAGED_ENV = frozenset({"ATTUNE_HOME", "ATTUNE_HELP_TELEMETRY"})
 
 
-# Scrub at conftest IMPORT time, before any test module (and therefore any
-# `attune.*` module) is imported. Several defaults are resolved once at
-# import and captured by other modules — e.g. release_models.MODEL_CONFIG
-# resolves the premium tier through attune.model_tiers at import, and
-# base_agent binds that dict, so a per-test fixture is far too late to
-# undo an exported ATTUNE_MODEL_PREMIUM. Clearing here makes the suite
-# hermetic for both import-time and call-time reads; the fixture below
-# then keeps it that way for anything set mid-session.
-def _scrub_attune_env_at_import() -> None:
-    """Drop ambient ``ATTUNE_*`` overrides before any attune module loads."""
-    for name in [k for k in os.environ if k.startswith("ATTUNE_")]:
-        if name not in _SUITE_MANAGED_ENV:
-            del os.environ[name]
-
-
-_scrub_attune_env_at_import()
-
 # =============================================================================
 # Redis host guard — literal loopback, never a resolvable name
 # (windows-exit139-segfault spec)

--- a/tests/unit/agents/release/test_base_agent_coverage.py
+++ b/tests/unit/agents/release/test_base_agent_coverage.py
@@ -195,25 +195,15 @@ class TestCallLlmWithClient:
         assert text == ""
         assert meta["model"] != "fallback"
 
-    def test_premium_routes_via_beta_namespace(self, monkeypatch):
+    def test_premium_routes_via_beta_namespace(self):
         """Premium tier resolves to fable -> create_with_fable beta path.
 
-        The beta-namespace route is reached BECAUSE premium resolves to
-        fable, and that resolution happens at IMPORT time, so an exported
-        ``ATTUNE_MODEL_PREMIUM`` genuinely changes production routing —
-        the old failure here was a real behavior difference, not a bad
-        assertion. Clear the override and reload so the test exercises
-        the default routing deterministically, the same way
-        test_release_models.py::test_model_config_uses_current_model_ids
-        does for the literal ids.
+        Resolution is call-time since 2026-07-28, so the autouse env
+        scrub suffices and this needs no reload choreography.
         """
-        import importlib
+        from attune.agents.release.release_models import Tier, get_model_config
 
-        import attune.agents.release.release_models as rm
-
-        monkeypatch.delenv("ATTUNE_MODEL_PREMIUM", raising=False)
-        importlib.reload(rm)
-        MODEL_CONFIG, Tier = rm.MODEL_CONFIG, rm.Tier
+        MODEL_CONFIG = get_model_config()
 
         assert "fable" in MODEL_CONFIG["premium"]  # task 6 wiring
         resp = self._response("premium answer")

--- a/tests/unit/agents/release/test_release_models.py
+++ b/tests/unit/agents/release/test_release_models.py
@@ -382,28 +382,21 @@ class TestModuleConstants:
         assert "capable" in MODEL_CONFIG
         assert "premium" in MODEL_CONFIG
 
-    def test_model_config_uses_current_model_ids(self, monkeypatch):
-        """MODEL_CONFIG uses non-deprecated model IDs.
+    def test_model_config_uses_current_model_ids(self):
+        """The tier map uses non-deprecated model IDs.
 
-        ``MODEL_CONFIG["premium"]`` resolves through ``attune.model_tiers``
-        at IMPORT time (documented in release_models.py), so the autouse
-        env scrub cannot reach it — the module may already be imported
-        with a developer's ``ATTUNE_MODEL_PREMIUM`` baked in. Clear the
-        tier overrides and reload, so this asserts the real DEFAULT
-        rather than whatever the ambient shell happened to export.
+        Resolution happens at CALL time, so the autouse env scrub is
+        sufficient — no reload choreography. (Before the 2026-07-28 lazy
+        fix this froze at import and needed importlib.reload.)
         """
-        import importlib
+        from attune.agents.release.release_models import get_model_config
 
-        import attune.agents.release.release_models as rm
-
-        for var in ("ATTUNE_MODEL_PREMIUM", "ATTUNE_MODEL_CAPABLE", "ATTUNE_MODEL_CHEAP"):
-            monkeypatch.delenv(var, raising=False)
-        module = importlib.reload(rm)
+        config = get_model_config()
 
         # Prevent regression to deprecated model IDs
-        assert module.MODEL_CONFIG["cheap"] == "claude-haiku-4-5"
-        assert module.MODEL_CONFIG["capable"] == "claude-sonnet-5"
-        assert module.MODEL_CONFIG["premium"] == "claude-fable-5"
+        assert config["cheap"] == "claude-haiku-4-5"
+        assert config["capable"] == "claude-sonnet-5"
+        assert config["premium"] == "claude-fable-5"
 
     def test_default_quality_gates_keys(self):
         """DEFAULT_QUALITY_GATES has expected keys."""

--- a/tests/unit/test_env_isolation_guard.py
+++ b/tests/unit/test_env_isolation_guard.py
@@ -39,14 +39,60 @@ def test_suite_managed_vars_survive_the_scrub():
     assert "ATTUNE_HOME" in _SUITE_MANAGED_ENV
 
 
-def test_import_time_override_does_not_reach_module_constants():
-    """An exported override must not survive into import-time constants.
+def test_no_module_level_binding_freezes_a_resolver_result():
+    """No module global may freeze an env-reading resolver at import.
 
-    ``release_models.MODEL_CONFIG`` resolves the premium tier at IMPORT
-    time and ``base_agent`` binds that dict, so a per-test fixture is too
-    late — the scrub has to run before the first ``attune`` import. This
-    spawns a real subprocess with the override set, which is the only way
-    to prove the ordering holds.
+    This is the invariant that lets the per-test scrub be sufficient. A
+    module-level ``X = resolve_something()`` captures the ambient env at
+    import, before any fixture can run, and any consumer doing
+    ``from … import X`` then holds a snapshot that ``importlib.reload``
+    cannot refresh.
+
+    Ruled 2026-07-28 (round table ``q-conftest-env-scrub-001``):
+    ``ATTUNE_*`` overrides are observable after import. At that ruling
+    the codebase had 61 call-time reads, 0 import-time reads, and
+    exactly ONE violation — ``release_models.MODEL_CONFIG`` — which was
+    made lazy. This guard keeps that at zero; a new violation should
+    fail HERE, loudly, rather than be masked by scrubbing env before
+    the first import.
+    """
+    import ast
+
+    resolvers = {
+        "resolve_model",
+        "get_max_budget_usd",
+        "get_model_config",
+        "get_cache_ttl",
+        "keyboard_mode_enabled",
+        "get_auto_approve_max",
+    }
+    repo_root = Path(__file__).resolve().parents[2]
+    frozen = []
+    for path in (repo_root / "src" / "attune").rglob("*.py"):
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8", errors="ignore"))
+        except SyntaxError:  # pragma: no cover - unparseable file
+            continue
+        for node in tree.body:  # module level only
+            if isinstance(node, ast.Assign | ast.AnnAssign):
+                src = ast.unparse(node)
+                if any(f"{r}(" in src for r in resolvers):
+                    frozen.append(f"{path.relative_to(repo_root)}:{node.lineno}")
+    assert not frozen, (
+        "module-level binding(s) freeze a resolver result at import: "
+        f"{frozen}. Make the value lazy (a function, or module __getattr__) "
+        "so it observes the environment at call time."
+    )
+
+
+def test_import_time_override_does_not_reach_module_constants():
+    """An exported override must not change resolved model ids in a test.
+
+    Complements the static guard above with a live check: spawn a real
+    subprocess with the override set and assert the default-asserting
+    test still passes. Before the 2026-07-28 lazy fix this required
+    scrubbing env before the first ``attune`` import; it now passes on
+    the strength of the per-test fixture alone.
     """
     env = {**os.environ, "ATTUNE_MODEL_PREMIUM": "claude-opus-5", "ANTHROPIC_API_KEY": ""}
     # Absolute node id + explicit cwd: lanes do not all invoke pytest from


### PR DESCRIPTION
Acts on the round table's ruling (`q-conftest-env-scrub-001`, promoted in #1713): **`ATTUNE_*` overrides are observable after import.**

## Measuring settled the seats' disagreement

| | Count |
|---|---|
| `ATTUNE_*` reads at **call time** | **61** |
| `ATTUNE_*` reads at **import time** | **0** |
| Module-level bindings **freezing** a resolver result | **1** |

The contract already existed in the code; `release_models.MODEL_CONFIG` was the sole violation. That makes this a **4-reference fix**, not the `src/`-wide lazy-evaluation / Pydantic `BaseSettings` migration one seat proposed from the same symptom. The table's largest proposed work item evaporated on measurement.

## The change

`MODEL_CONFIG` → `get_model_config()`, plus a module `__getattr__` so attribute access keeps working and re-resolves. `base_agent` calls it at call time; `release_prep_team` re-exports the function.

## The experiment: the conftest import-time scrub is now deletable

Removed it and re-ran the fully poisoned sweep — **18955 passed / 0 failed**. Deleting beats keeping it as defence in depth, for two reasons:

1. **It armed a hole.** The scrub deleted vars before `load_dotenv()` runs at module level in `workflows/base.py:34`, and dotenv only injects names that do *not* exist — so it made `.env` injectable where a shell export had been shadowing it. That's the latent inversion the table predicted and the moderator confirmed; removing the scrub closes it at the root instead of guarding it.
2. **It masked the defect class.** Without it, a future import-time freeze fails loudly rather than being hidden by the very mechanism hiding this one.

## Guard

New static check keeps module-level resolver freezes at zero — **verified red/green** by reintroducing a freeze and watching it fail with the offending file:line. The two release tests drop their `importlib.reload` choreography; that gymnastics was the symptom, not the fix.

## Receipts

- poisoned env, **without** the import-time scrub: 18955 passed / 0 failed
- clean env: 18955 passed / 0 failed
- guard: 4 passed (incl. red/green probe); release suite: 130 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)