### PR TITLE
docs(launch): article PUBLISHED — carry the URL into Draft B-v2

### DIFF
--- a/docs/process/LAUNCH_10_6_0_article_draft.md
+++ b/docs/process/LAUNCH_10_6_0_article_draft.md
@@ -3,9 +3,15 @@
 **Written:** 2026-07-22 (launch plan item 1 —
 `.claude/plans/launch-10-6-0-multi-llm.md`). **Fires:** Tuesday
 2026-07-28, AFTER the lift + live receipts (chair-ratified timing).
-**Venue:** LinkedIn article. **Status:** draft — `[RECEIPT: …]`
-slots fill from Monday's real transcripts; publishing with an
-unfilled slot is forbidden (no claim without a receipt).
+**Venue:** LinkedIn article. **Status: PUBLISHED 2026-07-28** —
+<https://www.linkedin.com/posts/patrick-roebuck-attune-ai_this-article-talk-about-the-multi-llm-memory-activity-7487899197329993729-pGPN>
+
+All four `[RECEIPT: …]` slots were filled from real transcripts before
+firing; the no-claim-without-a-receipt rule held end to end. This file
+is now the archival source for a shipped article — the published copy
+differs only in that its one JSON block was reflowed to prose for
+LinkedIn's editor, which has no code-block primitive. Every value in
+that reflow was fact-checked against the raw receipt.
 
 Pre-publish checklist:
 
@@ -34,8 +40,11 @@ Pre-publish checklist:
       sentence → replacement APPLIED; every claim in that paragraph
       now traces to the linked report. (3) Closing variant → **(c)**
       APPLIED, layered after the install line.
-- [ ] **Publish**, then paste the article URL into Draft B-v2's
-      `[LINK: launch article]` — the last remaining step.
+- [x] **PUBLISHED 2026-07-28** —
+      https://www.linkedin.com/posts/patrick-roebuck-attune-ai_this-article-talk-about-the-multi-llm-memory-activity-7487899197329993729-pGPN
+      URL carried into Draft B-v2's `[LINK: launch article]`.
+      Pre-publish checklist fully discharged; this draft is now
+      the archival source for a shipped article.
 - [x] Counts re-verified against the merged registries (2026-07-28):
       "five `session_memory_*` tools" = 5, names match
       (`attune_redis.mcp_tools.SESSION_MEMORY_TOOL_DEFINITIONS`).

--- a/docs/process/RELEASE_10_6_0_drafts.md
+++ b/docs/process/RELEASE_10_6_0_drafts.md
@@ -199,7 +199,7 @@ backlog item).
 > The models deliberate; I decide. Free and open source,
 > Apache 2.0: `pip install attune-ai`
 >
-> Full story with the transcripts: [LINK: launch article]
+> Full story with the transcripts: https://www.linkedin.com/posts/patrick-roebuck-attune-ai_this-article-talk-about-the-multi-llm-memory-activity-7487899197329993729-pGPN
 
 ### Honesty checklist on Draft B-v2 (chair rules at post time)
 
@@ -241,7 +241,9 @@ backlog item).
       2026-07-28. Transport receipt 6 PASSED live 2026-07-27 against
       PyPI 10.6.1 (`agy --print`, four legs clean, PII redacted at
       rest from the Antigravity seat). No reword needed.
-- [ ] [LINK: launch article] filled with the published URL.
+- [x] [LINK: launch article] filled with the published URL
+      (2026-07-28). Article is LIVE; the post body above now carries
+      the real link. **Every item on this checklist is now closed.**
 - [x] v1 anecdote removed — nothing in v2 claims a self-healing
       diagnosis occurred.
 


### PR DESCRIPTION
The launch article is **live**: <https://www.linkedin.com/posts/patrick-roebuck-attune-ai_this-article-talk-about-the-multi-llm-memory-activity-7487899197329993729-pGPN>

Both documents' checklists are now fully discharged — **zero unchecked boxes** across the article draft and the release drafts.

- Draft B-v2's post body carries the real link in place of `[LINK: launch article]`, and its final checklist item closes.
- The article draft's header flips from `draft` to **PUBLISHED** with the URL.

One difference recorded rather than glossed: the published copy reflowed its single JSON block to prose, because LinkedIn's article editor has no code-block primitive and a fence would have pasted as unstyled text. Every value in that reflow — both SHAs, the `head_moved` string, the diverged filename, the packet's empty `changed_files` — was fact-checked against the raw `handoff-r6.json` receipt rather than retyped. The in-repo draft keeps the fence, which renders correctly here and is the better archival form.

The no-claim-without-a-receipt rule held end to end. All four `[RECEIPT: …]` slots were filled from real transcripts before firing, including the handoff round-trip that had to be closed live the same morning after the original Codex path auto-cancelled.

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)