### PR TITLE
docs(transport): flip to shipped — discharges the CHAIR_REQUIRED receipt

### DIFF
--- a/docs/specs/cross-provider-memory-transport/decisions.md
+++ b/docs/specs/cross-provider-memory-transport/decisions.md
@@ -113,3 +113,37 @@ rule). The semantics gap is real and the verdict stands:
   prove the real boundary.
 - **Falsified if:** a provider cannot be run. Record an honest unsupported or
   unprobed receipt; never substitute a synthetic pass.
+
+## 2026-07-28 — Status flipped to `shipped`; CHAIR_REQUIRED discharged
+
+Chair-ruled on promotion of round-table thread
+`routine-clean-run-20260728-1020` (report:
+`docs/reports/roundtable/routine-clean-run-20260728-1020.md`). That
+thread's appendix triaged this spec as item 1; two of three seats read
+it as CLOSE-as-shipped, and the third's hold was traced to reading the
+declared status string rather than PR/receipt state — the stale label
+this entry retires.
+
+**Evidence the flip rests on** (verified at flip time, not inferred):
+
+| Receipt | Result |
+|---|---|
+| 1 File-write-failure regression | PASS |
+| 2 Real MCP dispatch | PASS |
+| 3 AMS round-trip + PII canary | PASS (live) |
+| 4 Codex live MCP canary | PASS (live) |
+| 5 Claude Code hook canary | PASS (live) |
+| 6 Antigravity/Gemini probe | PASS (live, 10.6.1) |
+
+Held stack lifted 2026-07-27: T1 #1593, T2 #1594, T3 #1596, T5 #1598 —
+all MERGED, each re-targeted to main before its base branch was
+deleted, per the tasks.md procedure.
+
+The `chair-review:cross-provider-memory-transport` ledger entry is a
+soft (exit 1) boundary marker, not a technical blocker — this status
+flip is what discharges it.
+
+**Correction to the appendix's framing:** it referred to "the five
+phase files." Only THREE carry a `**Status:**` line (`requirements.md`,
+`design.md`, `tasks.md`); `decisions.md` and `receipts.md` have none by
+construction. All three are flipped.

--- a/docs/specs/cross-provider-memory-transport/design.md
+++ b/docs/specs/cross-provider-memory-transport/design.md
@@ -1,6 +1,13 @@
 # Cross-Provider Memory Transport — Design
 
-**Status:** APPROVED — implementation authorized 2026-07-22.
+**Status:** shipped (2026-07-28) — all six R8 boundary receipts
+PASS (4 of them live), and the full stack merged 2026-07-27:
+T1 #1593, T2 #1594, T3 #1596, T5 #1598. Shipped to PyPI in
+10.6.0 and hardened same-day in 10.6.1 (#1681 stdout purity,
+which receipt 6 caught). Flipped on the chair's promotion of
+round-table thread `routine-clean-run-20260728-1020`, whose
+appendix identified this status as the stale label; that flip
+discharges the `CHAIR_REQUIRED` receipt.
 
 ## Transport flows
 

--- a/docs/specs/cross-provider-memory-transport/requirements.md
+++ b/docs/specs/cross-provider-memory-transport/requirements.md
@@ -1,6 +1,13 @@
 # Cross-Provider Memory Transport — Requirements
 
-**Status:** APPROVED — implementation authorized 2026-07-22.
+**Status:** shipped (2026-07-28) — all six R8 boundary receipts
+PASS (4 of them live), and the full stack merged 2026-07-27:
+T1 #1593, T2 #1594, T3 #1596, T5 #1598. Shipped to PyPI in
+10.6.0 and hardened same-day in 10.6.1 (#1681 stdout purity,
+which receipt 6 caught). Flipped on the chair's promotion of
+round-table thread `routine-clean-run-20260728-1020`, whose
+appendix identified this status as the stale label; that flip
+discharges the `CHAIR_REQUIRED` receipt.
 **Slug:** `cross-provider-memory-transport`
 
 ## Problem

--- a/docs/specs/cross-provider-memory-transport/tasks.md
+++ b/docs/specs/cross-provider-memory-transport/tasks.md
@@ -1,11 +1,11 @@
 # Cross-Provider Memory Transport — Tasks
 
-**Status:** approved (2026-07-22 consolidation — in execution; T1–T3
-BUILT, held as a stacked draft queue: T1 #1593 → T2 #1594 → T3 #1596,
-label `hold-until-07-27`; at the lift, merge each and re-target the next
-to main BEFORE deleting its base branch). Execution evidence and the
-live AMS receipt are recorded in `decisions.md` (D3 execution evidence
-section).
+**Status:** shipped (2026-07-28) — the held stack lifted as planned on
+2026-07-27: T1 #1593, T2 #1594, T3 #1596, T5 #1598 all MERGED, each
+re-targeted to main before its base branch was deleted. All six R8
+boundary receipts PASS (4 live) — see `receipts.md`. Execution evidence
+and the live AMS receipt remain in `decisions.md` (D3 execution
+evidence section).
 
 Remaining work was re-measured against the built state on 2026-07-22 and
 consolidated: most of T4-as-written was already satisfied by T1–T3 (hooks


### PR DESCRIPTION
Item 1 from the round-table appendix promoted in #1716. The spec's files still read `APPROVED — in execution; T1–T3 BUILT, held as a stacked draft queue` while that stack had merged the day before.

## Evidence, verified at flip time rather than inferred

| Receipt | Result |
|---|---|
| 1 File-write-failure regression | PASS |
| 2 Real MCP dispatch | PASS |
| 3 AMS round-trip + PII canary | PASS (live) |
| 4 Codex live MCP canary | PASS (live) |
| 5 Claude Code hook canary | PASS (live) |
| 6 Antigravity/Gemini probe | PASS (live, 10.6.1) |

All four PRs confirmed MERGED on 2026-07-27 via `gh`: #1593, #1594, #1596, #1598. Shipped in 10.6.0 and hardened same-day in 10.6.1 by #1681 — the stdout-purity fix that **receipt 6 itself caught**, which is a decent argument that these receipts were doing real work rather than rubber-stamping.

## One correction to the appendix

It referred to "the five phase files." Only **three** carry a `**Status:**` line — `requirements.md`, `design.md`, `tasks.md`. `decisions.md` and `receipts.md` have none by construction. All three are flipped, and the discrepancy is recorded in `decisions.md` so the next reader doesn't go hunting for two files that were never there.

The `chair-review:cross-provider-memory-transport` ledger entry is a soft (exit 1) boundary marker, not a technical blocker — this flip is what discharges it. That reading was the one the appendix's third seat got wrong, by trusting the declared status string over PR/receipt state.

Status-line gate: **45 passed** (`shipped` is in `STATUS_VOCABULARY`) — worth running locally on any status edit, since one bad token reddens every unit-suite-bearing lane on unrelated PRs.

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)