### PR TITLE
docs(specs): rule OPEN-1..3, kill the usage-read gate, ratify the baseline line

### DIFF
--- a/docs/specs/agent-round-table/decisions.md
+++ b/docs/specs/agent-round-table/decisions.md
@@ -545,3 +545,41 @@ Two independent environment faults, both now recorded in
    in `tests/unit/test_env_isolation_guard.py`.
 
 Neither fault was visible to CI, which exports none of these.
+
+## 2026-07-28 — Baseline numbers: RULED as a report line, not a ledger
+
+Chair ruling on action 3 of the weekly clean-run digest
+(`routine-clean-run-20260728-1020`): the claude seat proposed recording
+pass/skip/xfail/duration weekly so the next run has a diff, and
+pre-committed to withdrawing it rather than growing machinery.
+
+**GREEN-LIT — but as a required line in the promoted routine report,
+NOT a new ledger file.**
+
+The gap the seats named is real and was verified, not assumed: of the
+three promoted routine reports in `docs/reports/roundtable/`, the two
+older ones carry **no pass count at all**. So "absolutes without a
+prior baseline cannot distinguish stable from slowly eroding" is not
+hypothetical here — skip and xfail counts could drift upward for months
+and every weekly run would still read HEALTHY, because a growing skip
+list renders identically to a passing one.
+
+But a new ledger file is the wrong shape, and the proposing seat's
+instinct against machinery was right. **The four numbers already exist
+in every digest thread** — they are in the check output the seats are
+briefed with. They simply evaporate with the 7-day TTL unless the
+thread is promoted. So the fix is not a new artifact; it is making the
+numbers a required line in the report that promotion already produces.
+
+**Convention, effective now:** every promoted `routine-clean-run-*`
+report states pass / skip / xfail / duration in its health-verdict
+section. `routine-clean-run-20260728-1020.md` already does
+(19,001 passed / 63 skipped / 7 xfailed) and is the template.
+
+Cost: zero new files, zero new code, zero new schedule.
+
+**Accepted tradeoff, stated rather than hidden:** an unpromoted week
+loses its numbers. That is deliberate — a week not worth promoting is
+not worth baselining, and the alternative (a routine that writes to a
+tracked file on every headless fire) is exactly the machinery the
+proposing seat withdrew from.

--- a/docs/specs/cross-review/decisions.md
+++ b/docs/specs/cross-review/decisions.md
@@ -54,3 +54,58 @@ no code surface yet (skill text only). Receipts on the PR: 19 new
 tests, roundtable 175 serial-green, plugins 148 serial-green,
 mutating-git grep clean. T3 dogfooding remains gated on the
 OPEN-1..3 rulings.
+
+## 2026-07-28 — OPEN-1..3 RULED; the usage-read gate is KILLED
+
+Chair ruling. The gate held OPEN-1..3 for "the 07-27 usage read."
+That read is retired as a gate — not deferred — on three findings, each
+verified rather than argued.
+
+**1. The corpus cannot answer the question.** OPEN-3 needs "frequency
+and typical diff size" of cross-review runs. `usage-signals` snapshots
+measure PyPI/GitHub adoption:
+
+```json
+{"attempts": [{"captured": 0, "outcome": "rate-limited"}],
+ "github": {}, "pypi_recent": {}, "manifest": {"complete": false}}
+```
+
+Zero occurrences of `cross-review`, `roundtable`, or `invocation` in
+the snapshot corpus. The newest snapshot (2026-07-26) captured nothing
+at all — rate-limited, zero rows.
+
+**2. The gate is circular.** OPEN-3 wants usage data → usage data comes
+from T3's five dogfood runs → T3 `<depends>` names "OPEN-1..3 ruled."
+Waiting cannot satisfy this gate; it can only expire.
+
+**3. The gate protects nothing.** `DEFAULT_SEAT = "codex"` and
+`DIFF_CAP_CHARS = 60_000` are live in shipped 10.6.1
+(`src/attune/roundtable/review.py:35-36`) — provisional values are in
+users' hands today. Withholding the ruling withheld the label, not the
+behavior.
+
+### Rulings
+
+- **OPEN-1 — default reviewer seat: FIXED default, `codex`** (the
+  shipped value) for v1. Rotation is not ruled out; it needs T3
+  evidence. Carry into that evidence the finding recorded in
+  `docs/reports/roundtable/routine-clean-run-20260728-1020.md`: in that
+  appendix the antigravity seat diverged on all four triage items by
+  reasoning from lifecycle labels and declared status rather than
+  PR/receipt state. That is a seat-behavior signal relevant to who
+  should review by default.
+- **OPEN-2 — invocation ergonomics: MANUAL-ONLY for v1.** No suggested
+  cadence, no reminder. Auto-trigger was already a v1 non-goal; this
+  makes the whole surface manual until dogfooding shows demand.
+- **OPEN-3 — diff budget: RATIFY the shipped `60_000` chars as the v1
+  cap**, explicitly provisional. T3's five runs produce the real
+  frequency and diff-size distribution; OPEN-3 is **re-ruled from that
+  evidence**, which is the data the original gate wanted and could
+  never have obtained by waiting.
+
+**T3 is UNBLOCKED.** Its `<depends>` is satisfied by this entry.
+
+Binding posture is unchanged and not reopened: board-only advisory,
+never a merge gate until dogfooded finding-quality earns it. A
+low-finding-quality outcome remains a VALID result that rules the
+advisory posture permanent (dogfood-or-remove).

--- a/docs/specs/cross-review/requirements.md
+++ b/docs/specs/cross-review/requirements.md
@@ -1,8 +1,9 @@
 # Cross Review — Requirements
 
-**Status:** APPROVED (chair, 2026-07-22; OPEN-1..3 held for the
-07-27 usage read) — implementation staged post-lift, SECOND after
-cross-provider-session-handoff.
+**Status:** approved (chair, 2026-07-22) — **OPEN-1..3 RULED
+2026-07-28** and the usage-read gate KILLED as unanswerable and
+circular (see `decisions.md`). T1+T2 shipped in 10.6.1; **T3 is
+unblocked**; T4 follows T3.
 **Slug:** `cross-review`
 **Provenance:** roundtable `q-multi-llm-obvious-win-001` (chair
 same-day amendment: committed, not usage-gated) — see

--- a/docs/specs/feature-lead-governance/decisions.md
+++ b/docs/specs/feature-lead-governance/decisions.md
@@ -144,3 +144,32 @@ active assignment.
 The round-1 defect register (12 classified items) was declined for
 promotion by the chair; it informs the revision pass via the
 moderator's session review and expires with the board thread.
+
+## 2026-07-28 — P1 gate DISCHARGED by inheritance
+
+Chair ruling. D5's P1 says governance activation "sits behind the SAME
+chair usage-signal read that gates cross-review T3/T4. No second
+activation criterion is invented; one chair read ungates or kills
+both."
+
+That read was **killed as a gate** on 2026-07-28 — it could not answer
+its own question (the `usage-signals` corpus measures PyPI/GitHub
+adoption, not feature invocation; its newest snapshot captured zero
+rows), and it was circular (the data it wanted comes from the dogfood
+runs it was blocking). Full reasoning and receipts:
+`docs/specs/cross-review/decisions.md`, 2026-07-28 entry.
+
+**By the inheritance clause, that ruling discharges P1 here.** No
+second activation criterion is invented — the clause is honored
+exactly: one chair decision resolved both, which is what it was written
+to guarantee.
+
+Also settles the artifact conflict the round table's appendix raised
+(item 4): the bucket read `approved-not-shipped` while the internal
+status token read `draft (2026-07-27)`. The appendix's antigravity seat
+concluded chair approval was missing; the other two seats read it as an
+un-run gate, not absent sign-off, and the recorded design agrees —
+P1 *inherits* cross-review's gate. It was a **label mismatch, not a
+re-approval trigger**, and this entry is the one line that fixes it.
+Re-running approval would have re-litigated approved design and
+multiplied chair work for nothing.


### PR DESCRIPTION
Two chair rulings, both acting on the round-table digest promoted in #1716.

## 1. Cross-review OPEN-1..3 ruled; the usage-read gate **killed**, not deferred

Three findings, each verified rather than argued:

**The corpus cannot answer the question.** OPEN-3 needs "frequency and typical diff size" of cross-review runs. The `usage-signals` snapshots measure PyPI/GitHub adoption — zero occurrences of `cross-review`, `roundtable`, or `invocation`. The newest one captured nothing at all:

```json
{"attempts": [{"captured": 0, "outcome": "rate-limited"}],
 "github": {}, "pypi_recent": {}, "manifest": {"complete": false}}
```

**The gate is circular.** OPEN-3 wants usage data → that data comes from T3's five dogfood runs → T3's `<depends>` reads "OPEN-1..3 ruled." Waiting cannot satisfy this gate; it can only expire.

**It protects nothing.** `DEFAULT_SEAT = "codex"` and `DIFF_CAP_CHARS = 60_000` have been live in shipped 10.6.1 (`review.py:35-36`) since 07-27. Withholding the ruling withheld the label, not the behavior.

Ruled: **OPEN-1** fixed default `codex` for v1 (rotation not ruled out — needs T3 evidence); **OPEN-2** manual-only; **OPEN-3** ratify the shipped 60k cap as explicitly provisional, **re-ruled from T3's evidence** — the very data the gate wanted. **T3 is unblocked.** Advisory-only posture untouched and not reopened.

By D5's inheritance clause ("one chair read ungates or kills both"), the same ruling **discharges feature-lead-governance P1**. That also settles the appendix's item 4 as a label mismatch rather than a missing approval — re-running approval would have re-litigated approved design for nothing.

## 2. Four-numbers baseline: green-lit as a **report line**, not a ledger file

The gap is real and I verified it rather than taking the seats' word: of the three promoted routine reports, **the two older ones carry no pass count at all**. Skip/xfail erosion would read identically to health — a growing skip list looks exactly like a passing one.

But the numbers already exist in every digest thread; they only evaporate with the 7-day TTL. So the fix is promotion-shaped, not machinery-shaped: every promoted `routine-clean-run-*` report states pass / skip / xfail / duration. This week's already does and is the template.

Zero new files, code, or schedule — which honors the proposing seat's own self-limit. The tradeoff is stated rather than hidden: **an unpromoted week loses its numbers**, deliberately, since a week not worth promoting isn't worth baselining.

Status-line gate: 45 passed. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)