### PR TITLE
release: 11.0.0 — retire attune-author invocation paths

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "Spec-driven development for Claude Code — take an idea through requirements, design, tasks, and gated execution with an approval loop. Plus 26 auto-triggering skills: security audits, code review, test generation, release prep.",
-    "version": "10.6.1"
+    "version": "11.0.0"
   },
   "plugins": [
     {
       "name": "attune-ai",
       "description": "Spec-driven development is the core workflow: /spec carries an idea through brainstorm, requirements, design, and task execution with quality gates and your approval at each stage. Backed by 26 auto-triggering skills — security audits, code reviews, test generation, bug prediction, and release preparation. For help content tools, also install attune-help and attune-author from this marketplace.",
       "source": "./plugin",
-      "version": "10.6.1",
+      "version": "11.0.0",
       "author": {
         "name": "Smart AI Memory",
         "email": "patrick.roebuck@smartaimemory.com"

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,4 +1,4 @@
-# Attune AI Framework v10.6.1
+# Attune AI Framework v11.0.0
 
 AI-powered developer workflows with cost optimization and multi-agent orchestration.
 
@@ -307,7 +307,7 @@ attune_redis/          # Redis plugin — BUNDLED, ships in the attune-ai
 
 ---
 
-**Version:** 10.6.1 | **License:** Apache 2.0 | **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)
+**Version:** 11.0.0 | **License:** Apache 2.0 | **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)
 
 ## Lessons — core
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [11.0.0] — 2026-07-28
+
+Retires the last `attune-author` invocation paths. One breaking change,
+plus the cross-provider handoff and memory work that landed after
+10.6.1.
+
+### Removed
+
+- **BREAKING: the `[author]` install extra** — `pip install
+  'attune-ai[author]'` no longer resolves. It existed to pull in
+  `attune-author`, which was archived after its capability was absorbed
+  into this repo (author-consolidation T4, D12). Drop the extra from
+  your requirements; plain `pip install attune-ai` is unchanged and no
+  runtime API was removed. The `attune-help` pin moved to `[dev]`.
+- **BREAKING: the ops help-regeneration surface** — `help_regen.py`,
+  the `/api/help/regen*` routes, and the Admin-page regen UI are gone.
+  `/help/admin` is now report-only and points at `/coach maintain`,
+  which owns documentation regeneration (#1689).
+
+
 ### Added
 
 - **Elicitation surface mix on the Health tab** — the ops dashboard's
@@ -23,6 +43,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   — never an error, never a silent omission. Both tools' structlog
   events now carry the real memory outcome
   (spec: cross-provider-session-handoff T3, #1601).
+
+### Fixed
+
+- **`session_memory_*` tools answer per verb** — capture, forget, and
+  the rest returned the same generic "Here's what I found." summary
+  regardless of what they did. Each verb now reports its own outcome
+  (#1684). Surfaced by the live Codex and Antigravity receipt probes.
+- **Release model tier resolves at call time** — `MODEL_CONFIG`
+  resolved the premium tier once at import and froze it, so a
+  long-lived process could not observe a changed `ATTUNE_MODEL_PREMIUM`
+  without a restart, and the effective value depended on import order.
+  It is now resolved per call (#1714).
+
+### Changed
+
+- **Fact-check resolver is shared and authoritative** — the T2 resolver
+  fold-in gives fact-checking a single source of truth instead of a
+  parallel implementation (#1586).
 
 ## [10.6.1] — 2026-07-27
 

--- a/README.md
+++ b/README.md
@@ -85,19 +85,28 @@ routing, and [Installation Options](#installation-options) for extras.
      a permanent section below (see "Dynamic forms" for the pattern).
      Don't stack a second "New in" section here. -->
 
-## New in 10.0.0 — one memory architecture, no legacy layer
+## New in 11.0.0 — attune-author invocation paths retired
 
-Major version, one breaking change: the legacy memory-graph API
-(`attune.memory.MemoryGraph` and its node/edge types) is removed.
-Curated memory has been plain `.md` files served from Redis since
-9.6.0 — the graph was the layer nothing living called, confirmed by
-a usage audit before deletion (receipts in
-`docs/specs/archive/memorygraph-value-gate/`). If you never imported
-`MemoryGraph` — telemetry says that's everyone — nothing changes:
-same install, same memory loop, same measured economics below.
-Accessing a removed name raises an error naming the successor, and
-there is no data migration because the graph store was already
-retired.
+Major version, one breaking change: the **`[author]` install extra is
+removed**, along with the ops dashboard's help-regeneration surface
+(`/api/help/regen*` and the Admin-page regen UI). `/help/admin` is now
+report-only and points at `/coach maintain`, which is where
+documentation regeneration lives.
+
+**Are you affected?** Only if you install with
+`pip install 'attune-ai[author]'` — that extra no longer resolves, so
+drop it from your requirements. Plain `pip install attune-ai` is
+unchanged, and no runtime API was removed. The extra existed to pull in
+`attune-author`, which was archived after its capability was absorbed
+here; keeping an extra that points at an archived package would have been
+the dishonest option.
+
+Also in this release: handoff packets now carry memory linkage and
+report a real memory outcome instead of silence; the Health tab shows
+which surface rendered each Python-routed form; `session_memory_*` tools
+answer with per-verb summaries rather than a generic line; and the
+release model tier resolves at call time, so a changed override is
+observed without a restart.
 
 ## The memory suite — out of the box, measured
 

--- a/docs/reference/API_REFERENCE.md
+++ b/docs/reference/API_REFERENCE.md
@@ -1,6 +1,6 @@
 # Attune AI API Reference
 
-**Version:** 10.6.1
+**Version:** 11.0.0
 **License:** Apache License 2.0
 **Copyright:** 2025-2026 Smart AI Memory, LLC
 
@@ -1152,5 +1152,5 @@ msg = format_error(
 
 ---
 
-**Version:** 10.6.1 | **License:** Apache 2.0
+**Version:** 11.0.0 | **License:** Apache 2.0
 **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)

--- a/plugin/.claude-plugin/marketplace.json
+++ b/plugin/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "Spec-driven development for Claude Code — /spec plans, reviews, and executes with quality gates; plus security audits, code reviews, test generation, and release prep from /attune.",
-    "version": "10.6.1"
+    "version": "11.0.0"
   },
   "plugins": [
     {
       "name": "attune-ai",
       "description": "Spec-driven development for Claude Code — /spec plans, reviews, and executes with quality gates; plus security audits, code reviews, test generation, and release prep from /attune.",
       "source": "./",
-      "version": "10.6.1",
+      "version": "11.0.0",
       "author": {
         "name": "Smart AI Memory",
         "email": "patrick.roebuck@smartaimemory.com"

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "attune-ai",
-  "version": "10.6.1",
+  "version": "11.0.0",
   "description": "Spec-driven development for Claude Code — /spec plans, reviews, and executes with quality gates; plus security audits, code reviews, test generation, and release prep from /attune.",
   "author": {
     "name": "Smart AI Memory",

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -4,7 +4,7 @@ Spec-driven development for Claude Code — turn requirements
 into reliable software. <!-- cap:skill_count -->26 auto-triggering skills<!-- /cap -->, zero
 commands: say what you need and Claude picks the right skill.
 
-**Version:** 10.6.1 | **License:** Apache 2.0
+**Version:** 11.0.0 | **License:** Apache 2.0
 
 ## Install
 

--- a/plugin/core/__init__.py
+++ b/plugin/core/__init__.py
@@ -5,4 +5,4 @@ This module provides the core workflow functionality when the full
 attune-ai package is not installed via pip.
 """
 
-__version__ = "10.6.1"
+__version__ = "11.0.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "attune-ai"
-version = "10.6.1"
+version = "11.0.0"
 description = "AI-powered developer workflows for Claude with cost optimization, multi-agent orchestration, and workflow automation."
 readme = {file = "README.md", content-type = "text/markdown"}
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -299,7 +299,7 @@ wheels = [
 
 [[package]]
 name = "attune-ai"
-version = "10.6.1"
+version = "11.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "agent-memory-client" },

--- a/website/app/page.tsx
+++ b/website/app/page.tsx
@@ -58,7 +58,7 @@ export default function Home() {
             <div className="grid lg:grid-cols-2 gap-16 items-center">
               <div className="z-10">
                 <div className="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-[var(--surface-container-high)] text-[var(--primary)] text-xs font-bold tracking-widest mb-6 uppercase">
-                  <span>v10.6.1</span>
+                  <span>v11.0.0</span>
                   <span className="w-1 h-1 rounded-full bg-[var(--primary)]"></span>
                   <span className="opacity-80">Spec-driven development platform</span>
                 </div>

--- a/website/lib/features.ts
+++ b/website/lib/features.ts
@@ -32,7 +32,7 @@ export const PRODUCTS: Product[] = [
     id: "attune-ai",
     name: "Attune AI",
     pypiName: "attune-ai",
-    version: "10.6.1",
+    version: "11.0.0",
     tagline: "Generate, maintain, and serve help from your code",
     installCommand: "pip install attune-ai",
     marketplaceInstall:
@@ -101,7 +101,7 @@ export const PRODUCTS: Product[] = [
     id: "claude-code-plugin",
     name: "Claude Code Plugin",
     pypiName: "attune-ai",
-    version: "10.6.1",
+    version: "11.0.0",
     tagline: "Progressive help right in your terminal",
     installCommand:
       "claude plugin marketplace add Smart-AI-Memory/attune-ai",


### PR DESCRIPTION
Cuts **11.0.0**. Major bump because the removal is genuinely breaking, not because a major was scheduled.

## Why major, not the 10.7.0 originally planned

`pip install 'attune-ai[author]'` no longer resolves, and the ops `/api/help/regen*` routes plus the Admin regen UI are gone. Anyone with that extra pinned breaks on upgrade — that is what a major is for. The counter-argument (attune-author was archived, so the extra pointed at a dead package) is real but doesn't change the mechanical break.

## The changelog needed writing, not just promoting

`[Unreleased]` held **2 entries for 6 shipped changes**, and the breaking change had none at all. Added:

| Missing entry | Commit |
|---|---|
| **BREAKING** — `[author]` extra + ops regen surface removed | #1689 |
| Shared authoritative fact-check resolver | #1586 |
| Per-verb `voice_summary` on `session_memory_*` | #1684 |
| Lazy `MODEL_CONFIG` resolution | #1714 |

Shipping a major with an undocumented breaking change would have been the worst of those four omissions.

## README

Replaced the stale **"New in 10.0.0"** section with **"New in 11.0.0"**, in the same shape as its predecessor: name the break, say plainly who is affected, say what to do. `plugin/README.md`'s version line is hand-bumped as always (the claim-drift gate catches it otherwise).

## Verification before commit

- `bump_version.py` covered **9 sites**; `test_all_versions_match` passes
- **153/153** gate tests pass (claim-drift + status-line)
- README MCP counts (22/5/4/4/8) **re-verified against the live registry** — no drift
- `uv.lock` diff is **exactly one line** — no dependency cascade
- Pinned black/ruff/detect-secrets clean on all 13 touched files

Step 7 of the release procedure (`attune-author regenerate`) is **obsolete as written** — this release is what retires that invocation path. Used the check-only freshness path instead; no LLM spend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)