### PR TITLE
docs(rules): lead the Socratic rule with the one case that fires most

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -269,10 +269,22 @@ confirm** because prose is faster to write.
 ### Fire a form when ANY of these holds
 
 - **Two or more independent dimensions must be settled** — batch them
-  into ONE form, never N sequential turns. (`AskUserQuestion` caps at 4
-  options and one question per turn, so it *structurally cannot* carry
-  a batched multi-dimension ask. This is the highest-value case, and
-  it is the headline above.)
+  into ONE form, never N sequential turns. This is the highest-value
+  case, and it is the headline above.
+
+  Build the `FormSchema` even when the surface ends up being
+  `AskUserQuestion`. It is a portable, validated artifact that renders
+  to every surface — `form_to_widget_html`, `form_to_elicitation_schema`,
+  and `form_to_askuserquestion` ("render a form to BATCHED
+  `AskUserQuestion` payloads"). Hand-writing the turn skips the
+  validation and pins you to one surface.
+
+  Actual limits, so you size the form rather than guess: **2–4 options
+  per question, 1–4 questions per call.** A batch of >1 question is
+  blocked by default by `ask_question_format_guard.py` and opts in via
+  `metadata.source` containing "form" (e.g. `"elicit-form"`) — a policy
+  default with a documented hatch, NOT a structural cap. Beyond 4
+  dimensions, split into a two-tier picker.
 - Three or more alternatives, or two with tradeoffs worth stating
   (→ `decision` construct).
 - You are recommending against something the user named

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -233,9 +233,13 @@ abstraction.
 
 ## Socratic Interaction Rule
 
-**ALWAYS guide users through discovery and scoping before executing. NEVER skip straight to execution.**
+**Asking for more than one thing? That is a form. Build it before you
+write the sentence.**
 
-This is the core design principle of Attune AI's developer experience.
+Everything below elaborates that line. If you only remember one thing,
+remember that one — it is the case that fires most often and the case
+I most often get wrong, because prose is cheap to emit and a form costs
+a beat.
 
 **Build a form; don't hand-write a question turn.** (D21 — this rule
 used to name `AskUserQuestion`, and naming a tool got it executed as
@@ -244,12 +248,31 @@ a `FormSchema` via `attune.elicitation.form_from_dict` and let
 `select_form_surface` pick the surface. The widget is the default;
 `AskUserQuestion` is one of its fallbacks, not the starting point.
 
-**Fire a form when ANY of these holds:**
+### Two grammars, two directions — not a ranking
 
-- Two or more independent dimensions must be settled — batch them into
-  ONE form, never N sequential turns. (`AskUserQuestion` caps at 4
+They are not competing methods and neither is "primary". They serve
+opposite directions of the same exchange:
+
+| Direction | Grammar | When |
+|---|---|---|
+| I ask | a form | something genuinely needs settling |
+| You answer | terse vocab (`y` / `go` / `1` / `→ X`) | it is already settled |
+
+A bare confirm is **not an ask** — it is you closing a loop I opened.
+Putting a form in front of `go` adds friction to the highest-frequency
+interaction in the loop. Do not do it.
+
+The failure mode this rule guards is not "used terse vocab where a form
+belonged." It is **mis-classifying a multi-dimension ask as a bare
+confirm** because prose is faster to write.
+
+### Fire a form when ANY of these holds
+
+- **Two or more independent dimensions must be settled** — batch them
+  into ONE form, never N sequential turns. (`AskUserQuestion` caps at 4
   options and one question per turn, so it *structurally cannot* carry
-  a batched multi-dimension ask. This is the highest-value case.)
+  a batched multi-dimension ask. This is the highest-value case, and
+  it is the headline above.)
 - Three or more alternatives, or two with tradeoffs worth stating
   (→ `decision` construct).
 - You are recommending against something the user named
@@ -258,11 +281,14 @@ a `FormSchema` via `attune.elicitation.form_from_dict` and let
 - The choice changes scope, architecture, files, external state, or
   acceptance criteria — or is hard to reverse.
 
-**A raw button-turn is correct only when ALL of these hold:** one
-dimension, ≤3 options, no tradeoffs worth stating. Plus two standing
-exceptions: the referent is already resolved and you need a bare
-confirm (the terse-vocab path — `y` / `go` / `1`), or the user is in
-keyboard mode.
+### A raw button-turn is correct only when ALL of these hold
+
+One dimension, ≤3 options, no tradeoffs worth stating. Plus one
+standing exception: the user is in keyboard mode.
+
+(The terse-vocab path is not an exception here — see "two grammars"
+above. A bare confirm of a resolved referent is not a question turn at
+all, so this test never applies to it.)
 
 **Examples:**
 


### PR DESCRIPTION
The rule opened with **five conditions** to evaluate against a turn not yet written. That is expensive at exactly the moment of least willingness to spend — which is why the multi-dimension case kept losing to prose. It now opens with one line and everything else elaborates it:

> **Asking for more than one thing? That is a form. Build it before you write the sentence.**

## The framing fix

Patrick raised that the terse-vocab rule (`y` / `go` / `1`) predates dynamic forms and reads like a competing method, and asked whether forms should be made primary instead.

They don't compete — they're opposite directions of one exchange:

| Direction | Grammar | When |
|---|---|---|
| agent asks | a form | something genuinely needs settling |
| user answers | terse vocab | it is already settled |

A bare confirm **is not an ask**, so the form test never applied to it. That lets the old "standing exception" for terse vocab be deleted — it was never an exception, it was a category error, and framing it as a carve-out invited precisely the mis-classification the rule guards against: treating a multi-dimension ask as a bare confirm because prose is faster to emit.

Net effect on terse vocab is **stronger** footing, not weaker. Making forms "primary" would have put a form in front of `go`, adding friction to the highest-frequency interaction in the loop — the ceremony failure the rule itself warns is its most likely.

## Cost, accepted knowingly

**53 → 76 lines in an always-loaded file.** The examples block is what disambiguates "one dimension" from "two," which is the judgment actually being missed, so it stays for now. Trim if the weight shows.

Receipts: rules-residency budget 4 passed; form engine 29 passed; pre-commit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)