### PR TITLE
fix(mcp): per-verb voice_summary on handoff_create/handoff_resume

### DIFF
--- a/src/attune/mcp/handoff_handlers.py
+++ b/src/attune/mcp/handoff_handlers.py
@@ -2,6 +2,10 @@
 
 Thin async wrappers over :mod:`attune.handoff` — all behavior
 (git-derived truth, caps, drift matrix) lives in the core module.
+The wrappers own the ``voice_summary`` phrasing: the core functions
+are voice-free, and without a handler-supplied summary the shared
+voice layer stamps the generic recall greeting over every response
+(same class as the session_memory_* fix, #1684).
 Spec: docs/specs/cross-provider-session-handoff/ (T2).
 """
 
@@ -12,13 +16,18 @@ from typing import Any
 from attune.handoff import handoff_create, handoff_resume
 
 
+def _plural(count: int) -> str:
+    """Return "s" for non-singular counts (voice_summary phrasing)."""
+    return "" if count == 1 else "s"
+
+
 class HandoffHandlersMixin:
     """Dispatch-table handlers for ``handoff_create``/``handoff_resume``."""
 
     _workspace_root: str
 
     async def _handle_handoff_create(self, args: dict[str, Any]) -> dict[str, Any]:
-        return handoff_create(
+        result = handoff_create(
             self._workspace_root,
             goal=str(args.get("goal", "")),
             acceptance_criteria=str(args.get("acceptance_criteria", "")),
@@ -28,10 +37,30 @@ class HandoffHandlersMixin:
             verification=args.get("verification"),
             provider=str(args.get("provider", "unspecified")),
         )
+        if result.get("ok"):
+            result["voice_summary"] = f"Wrote the handoff packet for {result['slug']}."
+        else:
+            reason = result.get("reason", "unknown")
+            result["voice_summary"] = f"Couldn't write the handoff packet ({reason})."
+        return result
 
     async def _handle_handoff_resume(self, args: dict[str, Any]) -> dict[str, Any]:
         slug = args.get("slug")
-        return handoff_resume(
+        result = handoff_resume(
             self._workspace_root,
             slug=str(slug) if slug is not None else None,
         )
+        if result.get("ok"):
+            count = len(result.get("warnings", []))
+            memory = result.get("memory", {})
+            memory_status = (
+                memory.get("status", "skipped") if isinstance(memory, dict) else "skipped"
+            )
+            result["voice_summary"] = (
+                f"Verified the {result['slug']} handoff packet — "
+                f"{count} warning{_plural(count)}, memory {memory_status}."
+            )
+        else:
+            reason = result.get("reason", "unknown")
+            result["voice_summary"] = f"Couldn't resume the handoff ({reason})."
+        return result

--- a/tests/unit/handoff/test_mcp_handlers.py
+++ b/tests/unit/handoff/test_mcp_handlers.py
@@ -1,0 +1,90 @@
+"""MCP handoff adapters voice their own verbs (voice_summary).
+
+Regression guard for the 11.0.0 canary finding (2026-07-28): both
+handoff tools answered with the generic recall greeting "Here's what
+I found." because the shared voice layer stamps GREETING_SUCCESS over
+any response that carries no summary of its own — the same class of
+bug fixed for the session_memory_* adapters in #1684.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from attune.handoff import packet as packet_mod
+from attune.mcp.handoff_handlers import HandoffHandlersMixin
+from attune.voice.personality import GREETING_SUCCESS
+
+
+class _Server(HandoffHandlersMixin):
+    """Minimal host for the mixin — just the workspace root."""
+
+    def __init__(self, root: Path) -> None:
+        self._workspace_root = str(root)
+
+
+class TestHandoffCreateVoice:
+    @pytest.mark.asyncio
+    async def test_create_voices_the_slug(self, repo: Path) -> None:
+        result = await _Server(repo)._handle_handoff_create({"goal": "Ship it"})
+        assert result["ok"] is True
+        assert result["voice_summary"] == "Wrote the handoff packet for feature-x."
+
+    @pytest.mark.asyncio
+    async def test_create_failure_voices_the_reason(self, repo: Path) -> None:
+        over_cap = "x" * (packet_mod.FIELD_CAP_BYTES + 1)
+        result = await _Server(repo)._handle_handoff_create({"goal": over_cap})
+        assert result["ok"] is False
+        assert result["voice_summary"] == "Couldn't write the handoff packet (field_over_cap)."
+
+
+class TestHandoffResumeVoice:
+    @pytest.mark.asyncio
+    async def test_resume_voices_warnings_and_memory(self, repo: Path) -> None:
+        server = _Server(repo)
+        await server._handle_handoff_create({"goal": "Ship it"})
+        result = await server._handle_handoff_resume({})
+        assert result["ok"] is True
+        assert result["warnings"] == []
+        assert result["voice_summary"] == (
+            "Verified the feature-x handoff packet — 0 warnings, memory skipped."
+        )
+
+    @pytest.mark.asyncio
+    async def test_resume_singular_warning_phrasing(self, repo: Path) -> None:
+        server = _Server(repo)
+        await server._handle_handoff_create({"goal": "Ship it"})
+        # One drift warning: an uncommitted file → dirty_tree.
+        (repo / "scratch.txt").write_text("wip\n", encoding="utf-8")
+        result = await server._handle_handoff_resume({})
+        assert result["ok"] is True
+        assert [w["code"] for w in result["warnings"]] == ["dirty_tree"]
+        assert result["voice_summary"] == (
+            "Verified the feature-x handoff packet — 1 warning, memory skipped."
+        )
+
+    @pytest.mark.asyncio
+    async def test_resume_missing_packet_voices_the_reason(self, repo: Path) -> None:
+        result = await _Server(repo)._handle_handoff_resume({})
+        assert result["ok"] is False
+        assert result["voice_summary"] == "Couldn't resume the handoff (packet_not_found)."
+
+
+class TestNoGenericGreeting:
+    """The canary assertion: neither handoff verb ever says
+    "Here's what I found." on its own — that greeting only fits recall."""
+
+    @pytest.mark.asyncio
+    async def test_no_handoff_verb_uses_the_generic_recall_greeting(self, repo: Path) -> None:
+        server = _Server(repo)
+        create = await server._handle_handoff_create({"goal": "Ship it"})
+        resume = await server._handle_handoff_resume({})
+        create_fail = await server._handle_handoff_create(
+            {"goal": "x" * (packet_mod.FIELD_CAP_BYTES + 1)}
+        )
+        resume_fail = await server._handle_handoff_resume({"slug": "../evil"})
+        for result in (create, resume, create_fail, resume_fail):
+            assert result["voice_summary"]
+            assert result["voice_summary"] != GREETING_SUCCESS


### PR DESCRIPTION
## Summary

Both `handoff_create` and `handoff_resume` MCP tools answered with the generic recall greeting "Here's what I found." (`GREETING_SUCCESS`, `src/attune/voice/personality.py:20`) — observed live in the 2026-07-28 11.0.0 testing session. The `session_memory_*` adapters got per-verb `voice_summary` in #1684; this closes the same gap for the handoff tools.

Root cause (same class as #1684): the handoff tools aren't in `_VOICE_SKIP_TOOLS`, so `format_mcp_response` stamps the generic greeting over any response without a handler-supplied summary — including `ok: False` failures, since the formatter reads the `success` key while these handlers signal via `ok`.

## Fix

In the MCP adapter layer (`src/attune/mcp/handoff_handlers.py`) — the core `attune.handoff` functions stay voice-free:

- `handoff_create` → `"Wrote the handoff packet for <slug>."`; failures → `"Couldn't write the handoff packet (<reason>)."`
- `handoff_resume` → `"Verified the <slug> handoff packet — N warnings, memory <status>."` (singular/plural aware); failures → `"Couldn't resume the handoff (<reason>)."`

## Tests

`tests/unit/handoff/test_mcp_handlers.py` — placed under the handoff conftest so the autouse `memory_offline` fixture keeps these tests off the live session stash (the known fixture-pollution chip):

- create success voices the slug; over-cap failure voices `field_over_cap`
- resume voices warning count (0 and singular-1 via a real `dirty_tree` drift) and memory status; missing packet voices `packet_not_found`
- canary assertion mirroring #1684: no handoff verb ever returns the generic greeting

Receipts: `tests/unit/handoff/` 39 passed; `tests/unit/voice/ tests/unit/mcp/` 513 passed; pinned black/ruff pre-flighted clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
