### PR TITLE
test(handoff): live-backend isolation guard for handoff unit tests

### DIFF
--- a/tests/unit/handoff/test_packet.py
+++ b/tests/unit/handoff/test_packet.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from attune.handoff import handoff_create, handoff_resume
 from attune.handoff import packet as packet_mod
 
@@ -119,3 +121,35 @@ class TestRoundTrip:
         result = handoff_resume(repo)
         assert result["ok"] is False
         assert result["reason"] == "packet_not_found"
+
+
+class TestMemoryIsolationGuard:
+    """No handoff test may write a reachable live backend (2026-07-28).
+
+    The D5 linkage is degrade-silent, so before the ``memory_offline``
+    autouse fixture landed (#1694) these tests stashed real pointers
+    into the developer's live AMS. This guard trips if that isolation
+    ever drifts — fixture removed, ``memory_link`` bypassing the
+    ``session_stash`` seam, or ``stash_entry`` no longer routing through
+    the patched ``resolve_backend``.
+    """
+
+    def test_create_cannot_reach_live_backend(self, repo: Path) -> None:
+        result = handoff_create(repo, goal="isolation-guard sentinel", base_ref="main")
+        assert result["ok"] is True
+        memory = result["memory"]
+        if memory.get("status") == "captured":
+            from attune.memory import session_stash
+
+            # Best-effort: remove the pointer this very test just leaked
+            # before failing loudly.
+            session_stash.forget_entries([memory["id"]], source="test-isolation-guard")
+            pytest.fail(
+                "handoff_create wrote to a real memory backend from a unit "
+                "test; the memory_offline autouse fixture in "
+                "tests/unit/handoff/conftest.py no longer isolates the "
+                "session_stash seam"
+            )
+        # reason pins the skip to the fixture's patched backend_status —
+        # an error-path skip (stash_error) would mask broken isolation.
+        assert memory == {"status": "skipped", "reason": "no_backend"}


### PR DESCRIPTION
## Summary
- The D5 memory linkage (`src/attune/handoff/memory_link.py`) is degrade-silent, so handoff unit tests that ran before the `memory_offline` autouse fixture landed (#1694) stashed real pytest fixture-repo pointers into the developer's live AMS backend.
- Live cleanup done as part of this task: **8** debris entries ("Handoff packet feature-x/feature-hand" with pytest tmp-dir cwds, all created 2026-07-28 01:34–01:35 UTC, i.e. before the fixture commit at 02:28 UTC) deleted via `session_memory_forget` and verified gone — the two ids named in the report plus six more of the same class.
- Adds `TestMemoryIsolationGuard` to `tests/unit/handoff/test_packet.py`: fails loudly (and best-effort forgets its own leaked pointer) if `handoff_create` ever reaches a reachable live backend again — fixture removed, `memory_link` bypassing the `session_stash` seam, or `stash_entry` no longer routing through the patched `resolve_backend`. Asserting `reason == "no_backend"` pins the skip to the fixture, so an error-path skip can't mask broken isolation.

## Receipts
- `tests/unit/handoff` + `tests/integration/test_mcp_dispatch_handoff.py` run serially (worktree src on PYTHONPATH) against a **reachable live AMS**: 39 passed, and a before/after `session_memory_recall` diff showed **zero** new stash entries.
- Pinned black/ruff pre-flighted clean before staging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)