### PR TITLE
feat(roundtable): P2 gate-triage inbox + P4 role telemetry

### DIFF
--- a/docs/specs/roundtable-triage/decisions.md
+++ b/docs/specs/roundtable-triage/decisions.md
@@ -153,3 +153,32 @@ download), that is NEW scope needing its own approval.
 Queued follow-ons from q-briefing-triage-002 are now ALL closed:
 item 1 #1511, item 2 #1512 (D17), item 3 #1514 (D18), item 4 this
 entry.
+
+## 2026-07-29 — P2 gate-triage inbox built here (issue #1587)
+
+The P2 build ruled 2026-07-21 (thread q-roundtable-extensions-001;
+V1 shape recorded in docs/specs/spec-lifecycle-gates/decisions.md)
+lands in this spec's lineage per the issue's 2026-07-28 re-scoping
+(agent-round-table is shipped; this spec carries active triage
+work). Implementation: `attune.roundtable.gate_triage` — read-only
+grouping of `unresolved_chair_required()` ledger rows by
+(target, gate_id); convene threshold N>=3 pending OR oldest >48h;
+one D3-capped mini-table (3 invocations); closed disposition enum
+(uphold | waive | revise | defer, malformed -> no-recommendation,
+never laundered); single chair digest; triaged-receipt dedup in
+`~/.attune/ops/gates/triage_state.json`; RR-4 eligibility via
+`LADDER_GATES` with ineligible receipts NAMED in the digest; P3
+skeptic dissents routed in as duck-typed records (no import
+coupling on the skeptic module). Below threshold: no board writes,
+no seat spend — the anti-ceremony guard the ruling demands.
+
+P4 role telemetry (record-only) starts recording with this launch:
+`attune.roundtable.role_telemetry` appends seat/digest events to
+`~/.attune/ops/roundtable/role_telemetry.jsonl`;
+`record_chair_ruling()` + `chair_latency_seconds()` derive chair
+latency at read time. Nothing consumes it (the ruled record-only
+posture).
+
+Pre-build drift check (the issue's mandate): `verdicts.jsonl` IS
+emitting — 7 live rows at build time; `unresolved_chair_required()`
+verified as the consumption seam.

--- a/src/attune/roundtable/gate_triage.py
+++ b/src/attune/roundtable/gate_triage.py
@@ -1,0 +1,409 @@
+"""Gate-triage inbox — round-table P2 (issue #1587).
+
+Ruled 2026-07-21 (thread ``q-roundtable-extensions-001``, chair:
+Patrick; recorded in docs/specs/spec-lifecycle-gates/decisions.md).
+V1 shape, verbatim from the ruling:
+
+- **READ-ONLY** over the G1 verdict ledger — groups unresolved
+  ``CHAIR_REQUIRED`` receipts by ``(target, gate_id)``. Never
+  appends to the ledger, never alters gate state (RR-2).
+- Convenes **ONE D3-capped mini-table** ONLY past a threshold
+  (``N >= 3`` pending OR oldest ``> 48h``). Below threshold the
+  inbox is a quiet grouped listing with **no board writes** — the
+  ruled failure mode is inbox ceremony: a meeting queue noisier
+  than the raw ledger.
+- Emits **one disposition per shortfall group** from a CLOSED enum
+  (:data:`TRIAGE_DISPOSITIONS`); a reply that names none records as
+  ``no-recommendation`` — TAC-4, never laundered into a
+  recommendation.
+- Appends a **single chair digest**; marks deliberated receipts
+  triaged in its own state file (**dedup mandatory** — a triaged
+  ``receipt_id`` is never re-deliberated).
+- **RR-4 risk tiers govern eligibility from day one**: only
+  receipts whose ``gate_id`` is in the known inventory
+  (``LADDER_GATES``, the RR-4 superset) are deliberation-eligible;
+  unknown gates are NAMED for the chair, never silently dropped.
+- **P3 skeptic dissents route into this digest** (one chair inbox)
+  as duck-typed mappings — no import of the skeptic module.
+
+P4 role telemetry (record-only) starts recording with this launch:
+each pass records seat invocations and the digest post, giving
+chair-latency its start timestamp.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under Apache 2.0
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import json
+import logging
+import os
+import re
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from attune.gates.lifecycle.ledger import unresolved_chair_required
+from attune.gates.lifecycle.protocol import GateReceipt
+from attune.roundtable import role_telemetry
+from attune.roundtable.rotation import CANONICAL_SEATS
+
+logger = logging.getLogger(__name__)
+
+#: Convene threshold (the ruling, verbatim): N pending receipts …
+THRESHOLD_PENDING = 3
+#: … OR the oldest pending receipt is older than this.
+THRESHOLD_OLDEST_HOURS = 48
+
+#: D3 — up to 3 invocations for the one mini-table sitting
+#: (agent-round-table D3; same ceiling semantic as the P3 skeptic).
+TABLE_MAX_INVOCATIONS = 3
+
+#: CLOSED disposition enum — one per shortfall group. Extending it
+#: is a spec amendment (the gate-protocol STATES discipline).
+TRIAGE_DISPOSITIONS: tuple[str, ...] = ("uphold", "waive", "revise", "defer")
+
+#: The recorded value when the table sat but named no valid
+#: disposition for a group — chair-visible, never a member of the
+#: enum, never laundered.
+NO_RECOMMENDATION = "no-recommendation"
+
+_DISPOSITION_RE = re.compile(
+    r"^\s*DISPOSITION:\s*(?P<target>[^:]+?)\s*::\s*(?P<gate>[^:]+?)"
+    r"\s*::\s*(?P<disposition>[a-z-]+)\s*$",
+    re.MULTILINE,
+)
+
+
+@dataclass(frozen=True)
+class Shortfall:
+    """One deliberation unit: every pending receipt for a spec+gate."""
+
+    target: str
+    gate_id: str
+    receipts: tuple[GateReceipt, ...]
+
+    @property
+    def oldest(self) -> str:
+        return min(r.timestamp for r in self.receipts)
+
+
+@dataclass
+class TriageRecord:
+    """One complete inbox pass — everything the chair digest needs."""
+
+    shortfalls: list[Shortfall] = field(default_factory=list)
+    ineligible: list[GateReceipt] = field(default_factory=list)
+    dispositions: dict[tuple[str, str], str] = field(default_factory=dict)
+    dissents: list[Mapping[str, object]] = field(default_factory=list)
+    outcome: str = "pending"
+    seat: str | None = None
+    invocations: int = 0
+    thread: str = ""
+
+
+def state_path() -> Path:
+    """``<ATTUNE_HOME|~/.attune>/ops/gates/triage_state.json``."""
+    home = os.environ.get("ATTUNE_HOME")
+    attune_dir = Path(home).expanduser() if home else Path.home() / ".attune"
+    return attune_dir / "ops" / "gates" / "triage_state.json"
+
+
+def load_triaged(*, path: Path | None = None) -> dict[str, dict[str, str]]:
+    """``receipt_id -> {thread, at, disposition}`` for every triaged receipt."""
+    src = path or state_path()
+    if not src.is_file():
+        return {}
+    try:
+        data = json.loads(src.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        logger.warning("gate-triage: unreadable state %s: %s — treating as empty", src, exc)
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def mark_triaged(entries: Mapping[str, dict[str, str]], *, path: Path | None = None) -> Path:
+    """Merge ``entries`` into the triage state file (dedup ledger)."""
+    dest = path or state_path()
+    state = load_triaged(path=dest)
+    state.update({k: dict(v) for k, v in entries.items()})
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    dest.write_text(json.dumps(state, indent=2) + "\n", encoding="utf-8")
+    return dest
+
+
+def eligible_gate_ids() -> tuple[str, ...]:
+    """The RR-4 gate inventory that governs triage eligibility."""
+    from attune.gates.lifecycle.activation import LADDER_GATES
+
+    return LADDER_GATES
+
+
+def collect_shortfalls(
+    *,
+    ledger_path: Path | None = None,
+    triage_state_path: Path | None = None,
+) -> tuple[list[Shortfall], list[GateReceipt]]:
+    """Group unresolved, untriaged CHAIR_REQUIRED receipts (read-only).
+
+    Returns ``(shortfalls, ineligible)`` — a receipt whose gate is
+    outside the RR-4 inventory is returned separately so the digest
+    can NAME it for the chair rather than silently dropping it.
+    """
+    triaged = load_triaged(path=triage_state_path)
+    known = set(eligible_gate_ids())
+    groups: dict[tuple[str, str], list[GateReceipt]] = {}
+    ineligible: list[GateReceipt] = []
+    for receipt in unresolved_chair_required(path=ledger_path):
+        if receipt.receipt_id in triaged:
+            continue  # dedup mandatory — never re-deliberate
+        if receipt.gate_id not in known:
+            ineligible.append(receipt)
+            continue
+        groups.setdefault((receipt.target, receipt.gate_id), []).append(receipt)
+    shortfalls = [
+        Shortfall(target=t, gate_id=g, receipts=tuple(rs)) for (t, g), rs in sorted(groups.items())
+    ]
+    return shortfalls, ineligible
+
+
+def past_threshold(shortfalls: Sequence[Shortfall], now: _dt.datetime | None = None) -> bool:
+    """The ruled convene test: N >= 3 pending OR oldest > 48h."""
+    pending = sum(len(s.receipts) for s in shortfalls)
+    if pending == 0:
+        return False
+    if pending >= THRESHOLD_PENDING:
+        return True
+    now = now or _dt.datetime.now(_dt.timezone.utc)
+    oldest = min(s.oldest for s in shortfalls)
+    try:
+        oldest_at = _dt.datetime.fromisoformat(oldest)
+    except ValueError:
+        return True  # unparseable age reads as stale, never as fresh
+    if oldest_at.tzinfo is None:
+        oldest_at = oldest_at.replace(tzinfo=_dt.timezone.utc)
+    return (now - oldest_at) > _dt.timedelta(hours=THRESHOLD_OLDEST_HOURS)
+
+
+def build_table_brief(shortfalls: Sequence[Shortfall]) -> str:
+    """The R1 text-only brief for the one mini-table sitting."""
+    blocks = []
+    for s in shortfalls:
+        findings = "\n".join(f"- {f}" for r in s.receipts for f in r.findings) or "- (none)"
+        blocks.append(
+            f"### {s.target} :: {s.gate_id} "
+            f"({len(s.receipts)} receipt(s), oldest {s.oldest})\n{findings}"
+        )
+    choices = " | ".join(TRIAGE_DISPOSITIONS)
+    return (
+        "You are one seat of a gate-triage mini-table. The shortfall "
+        "groups below are unresolved CHAIR_REQUIRED gate receipts. "
+        "For EACH group, recommend exactly one disposition for the "
+        "chair. You never alter gate state; the chair rules.\n\n"
+        "Reply with one line per group, EXACTLY:\n\n"
+        f"DISPOSITION: <target> :: <gate_id> :: <{choices}>\n"
+        "REASON: <one line>\n\n"
+        "Calibration: an evidence-free 'waive' is rubber-stamp decay; "
+        "a 'defer' on every group is inbox ceremony. Ground each "
+        "recommendation in the group's findings. Text only.\n\n" + "\n\n".join(blocks)
+    )
+
+
+def parse_dispositions(text: str, shortfalls: Sequence[Shortfall]) -> dict[tuple[str, str], str]:
+    """One disposition per shortfall group, from the closed enum.
+
+    Groups the reply skips, misnames, or grades outside the enum
+    record :data:`NO_RECOMMENDATION` — visible to the chair, never
+    invented and never laundered.
+    """
+    named: dict[tuple[str, str], str] = {}
+    for m in _DISPOSITION_RE.finditer(text):
+        key = (m.group("target").strip(), m.group("gate").strip())
+        disposition = m.group("disposition").strip()
+        if disposition in TRIAGE_DISPOSITIONS:
+            named[key] = disposition
+    return {
+        (s.target, s.gate_id): named.get((s.target, s.gate_id), NO_RECOMMENDATION)
+        for s in shortfalls
+    }
+
+
+def run_triage(
+    board: object | None = None,
+    invoke_seat: Callable[[Sequence[str], str], tuple[int, str]] | None = None,
+    seat_recipes: Sequence[tuple[str, tuple[str, ...]]] | None = None,
+    dissents: Sequence[Mapping[str, object]] = (),
+    thread: str | None = None,
+    ledger_path: Path | None = None,
+    triage_state_path: Path | None = None,
+    telemetry_path: Path | None = None,
+    now: _dt.datetime | None = None,
+) -> TriageRecord:
+    """Run ONE inbox pass; return the record.
+
+    Below threshold: read-only grouping, NO board writes, no seat
+    spend. Past threshold: one D3-capped mini-table, one digest,
+    receipts marked triaged. Never alters gate state (RR-2/R8).
+    ``dissents`` are duck-typed P3 skeptic dissent records
+    (mappings with ``spec``/``cite``/``reason``) routed into the
+    same digest.
+    """
+    record = TriageRecord(dissents=list(dissents))
+    record.shortfalls, record.ineligible = collect_shortfalls(
+        ledger_path=ledger_path, triage_state_path=triage_state_path
+    )
+    stamp = (now or _dt.datetime.now(_dt.timezone.utc)).strftime("%Y%m%d-%H%M")
+    record.thread = thread or f"gate-triage-{stamp}"
+
+    if not past_threshold(record.shortfalls, now=now) and not record.dissents:
+        record.outcome = "below-threshold"
+        return record
+
+    if record.shortfalls and not _convene(record, board, invoke_seat, seat_recipes, telemetry_path):
+        return record
+
+    _mark_deliberated(record, triage_state_path)
+    _post(board, record.thread, "moderator", "synthesis", digest(record))
+    role_telemetry.record(
+        "moderator", "moderator", record.thread, "digest-posted", path=telemetry_path
+    )
+    if record.outcome == "pending":
+        record.outcome = "digested"
+    return record
+
+
+def _convene(
+    record: TriageRecord,
+    board: object | None,
+    invoke_seat: Callable[[Sequence[str], str], tuple[int, str]] | None,
+    seat_recipes: Sequence[tuple[str, tuple[str, ...]]] | None,
+    telemetry_path: Path | None,
+) -> bool:
+    """The ONE mini-table sitting — returns False when no seat sat."""
+    from attune.roundtable.routine import SEAT_RECIPES, default_invoke_seat
+
+    invoke = invoke_seat or default_invoke_seat
+    recipes = dict(seat_recipes or SEAT_RECIPES)
+    brief = build_table_brief(record.shortfalls)
+    _post(board, record.thread, "moderator", "question", brief)
+
+    for seat in [s for s in CANONICAL_SEATS if s in recipes]:
+        if record.invocations >= TABLE_MAX_INVOCATIONS:
+            break
+        record.invocations += 1
+        role_telemetry.record("triage-seat", seat, record.thread, "invoked", path=telemetry_path)
+        code, reply = invoke(recipes[seat], brief)
+        if code != 0 or not reply.strip():
+            _post(
+                board,
+                record.thread,
+                seat,
+                "position",
+                f"ABSENT — exit {code}: {reply[:200]}",
+                absent=True,
+            )
+            role_telemetry.record("triage-seat", seat, record.thread, "absent", path=telemetry_path)
+            continue
+        record.seat = seat
+        record.dispositions = parse_dispositions(reply, record.shortfalls)
+        _post(board, record.thread, seat, "position", reply)
+        role_telemetry.record("triage-seat", seat, record.thread, "replied", path=telemetry_path)
+        break
+
+    if record.seat is None:
+        record.outcome = "table-absent"
+        _post(
+            board,
+            record.thread,
+            "moderator",
+            "halt",
+            "no triage seat reachable; receipts stay pending; chair reviews unassisted",
+        )
+        return False
+    record.outcome = "deliberated"
+    return True
+
+
+def _mark_deliberated(record: TriageRecord, triage_state_path: Path | None) -> None:
+    """Mark every deliberated receipt triaged (dedup — never re-deliberate)."""
+    if record.seat is None or not record.dispositions:
+        return
+    at = _dt.datetime.now(_dt.timezone.utc).isoformat()
+    entries = {
+        r.receipt_id: {
+            "thread": record.thread,
+            "at": at,
+            "disposition": record.dispositions[(s.target, s.gate_id)],
+        }
+        for s in record.shortfalls
+        for r in s.receipts
+    }
+    mark_triaged(entries, path=triage_state_path)
+
+
+def digest(record: TriageRecord) -> str:
+    """The single chair digest for one pass."""
+    lines = [f"Gate-triage digest ({record.thread}): outcome={record.outcome}"]
+    for s in record.shortfalls:
+        disposition = record.dispositions.get((s.target, s.gate_id), "pending")
+        lines.append(
+            f"{s.target} :: {s.gate_id} — {len(s.receipts)} receipt(s), "
+            f"recommended: {disposition}"
+        )
+    if record.ineligible:
+        named = "; ".join(f"{r.target}::{r.gate_id}" for r in record.ineligible)
+        lines.append(f"ineligible (gate outside the RR-4 inventory — chair-only): {named}")
+    for d in record.dissents:
+        lines.append(
+            f"P3 skeptic DISSENT on {d.get('spec', '?')!r}: cite={d.get('cite', '?')}; "
+            f"reason={d.get('reason', '(none)')}"
+        )
+    lines.append("Chair rules; this pass never alters gate state (RR-2/R8).")
+    return "\n".join(lines)
+
+
+def _post(
+    board: object | None, thread: str, seat: str, kind: str, body: str, **fields: object
+) -> None:
+    """Post to the board when one is wired; print otherwise."""
+    if board is None:
+        print(f"[{thread}] {seat}/{kind}: {body[:160]}", flush=True)
+        return
+    board.post_message(thread, seat, kind, body, **fields)  # type: ignore[attr-defined]
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """CLI: ``python -m attune.roundtable.gate_triage [--dry-run]``.
+
+    ``--dry-run`` prints the grouped inbox and threshold verdict
+    without any board write or seat invocation.
+    """
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Gate-triage inbox pass over unresolved CHAIR_REQUIRED receipts (P2)."
+    )
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args(argv)
+
+    shortfalls, ineligible = collect_shortfalls()
+    if args.dry_run:
+        convene = past_threshold(shortfalls)
+        print(f"pending shortfall groups: {len(shortfalls)}; convene={convene}")
+        for s in shortfalls:
+            print(f"  {s.target} :: {s.gate_id} — {len(s.receipts)} receipt(s), oldest {s.oldest}")
+        for r in ineligible:
+            print(f"  ineligible: {r.target} :: {r.gate_id} (outside RR-4 inventory)")
+        return 0
+
+    from attune.roundtable.board import Board
+
+    record = run_triage(board=Board())
+    print(f"gate-triage pass complete: outcome={record.outcome}")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/src/attune/roundtable/role_telemetry.py
+++ b/src/attune/roundtable/role_telemetry.py
@@ -1,0 +1,118 @@
+"""Role telemetry — round-table P4, RECORD-ONLY (issue #1587).
+
+Ruled 2026-07-21 (thread ``q-roundtable-extensions-001``, chair:
+Patrick; build order P3 → P2 → P4-recording): role telemetry starts
+recording when the P2 gate-triage inbox launches. Record-only means
+exactly that — this module appends events and computes read-side
+derivations; NOTHING consumes it for behavior. Dissent hit-rate and
+chair-latency dashboards come later, if the chair ever asks.
+
+Events are appended to
+``<ATTUNE_HOME|~/.attune>/ops/roundtable/role_telemetry.jsonl`` —
+the same home-resolution idiom as the G1 verdict ledger, so the
+suite's isolation fixture redirects writes automatically.
+
+Chair latency is derived, never stored: the seconds between a
+thread's ``digest-posted`` event and its ``chair-ruled`` event.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under Apache 2.0
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+def telemetry_path() -> Path:
+    """``<ATTUNE_HOME|~/.attune>/ops/roundtable/role_telemetry.jsonl``."""
+    home = os.environ.get("ATTUNE_HOME")
+    attune_dir = Path(home).expanduser() if home else Path.home() / ".attune"
+    return attune_dir / "ops" / "roundtable" / "role_telemetry.jsonl"
+
+
+def record(
+    role: str,
+    seat: str,
+    thread: str,
+    event: str,
+    *,
+    path: Path | None = None,
+    **fields: object,
+) -> Path:
+    """Append one role event (append-only; never deletes, never blocks).
+
+    A telemetry write failure is logged and swallowed — recording is
+    an observation surface, not a dependency of the pass it observes.
+    """
+    dest = path or telemetry_path()
+    row = {
+        "role": role,
+        "seat": seat,
+        "thread": thread,
+        "event": event,
+        "at": datetime.now(timezone.utc).isoformat(),
+        **fields,
+    }
+    try:
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        with dest.open("a", encoding="utf-8") as f:
+            f.write(json.dumps(row) + "\n")
+    except OSError as exc:
+        logger.warning("role-telemetry: write failed (%s); event dropped", exc)
+    return dest
+
+
+def record_chair_ruling(thread: str, *, path: Path | None = None, **fields: object) -> Path:
+    """Record the chair's ruling touch on a thread (the latency endpoint)."""
+    return record("chair", "chair", thread, "chair-ruled", path=path, **fields)
+
+
+def _rows(path: Path | None) -> list[dict[str, object]]:
+    src = path or telemetry_path()
+    if not src.is_file():
+        return []
+    out: list[dict[str, object]] = []
+    try:
+        lines = src.read_text(encoding="utf-8").splitlines()
+    except OSError as exc:
+        logger.warning("role-telemetry: unreadable %s: %s", src, exc)
+        return []
+    for line in lines:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            out.append(json.loads(line))
+        except json.JSONDecodeError:
+            logger.warning("role-telemetry: skipping malformed line")
+    return out
+
+
+def chair_latency_seconds(thread: str, *, path: Path | None = None) -> float | None:
+    """Seconds from a thread's ``digest-posted`` to its ``chair-ruled``.
+
+    Derived at read time from the first matching pair; ``None`` when
+    either endpoint is missing (an unruled digest has no latency —
+    that absence IS the P4 signal, never coerced to a number).
+    """
+    posted: datetime | None = None
+    for row in _rows(path):
+        if row.get("thread") != thread:
+            continue
+        stamp = str(row.get("at", ""))
+        try:
+            at = datetime.fromisoformat(stamp)
+        except ValueError:
+            continue
+        if row.get("event") == "digest-posted" and posted is None:
+            posted = at
+        elif row.get("event") == "chair-ruled" and posted is not None:
+            return (at - posted).total_seconds()
+    return None

--- a/tests/unit/roundtable/test_gate_triage.py
+++ b/tests/unit/roundtable/test_gate_triage.py
@@ -1,0 +1,381 @@
+"""Gate-triage inbox tests (round-table P2, issue #1587).
+
+Real ledger/state/telemetry files in tmp — no mocked persistence
+(the read-only ledger seam is the point). Seat invocations and the
+board are injected fakes; the ruled governance (read-only ledger,
+threshold gating, closed enum, dedup, RR-4 eligibility, dissent
+routing, R8 never-promotes) is asserted from the pass record plus
+posted messages.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under Apache 2.0
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import json
+
+import pytest
+
+from attune.gates.lifecycle.ledger import append
+from attune.gates.lifecycle.protocol import GateReceipt
+from attune.roundtable import role_telemetry
+from attune.roundtable.gate_triage import (
+    NO_RECOMMENDATION,
+    THRESHOLD_PENDING,
+    TRIAGE_DISPOSITIONS,
+    build_table_brief,
+    collect_shortfalls,
+    load_triaged,
+    parse_dispositions,
+    past_threshold,
+    run_triage,
+)
+from attune.roundtable.rotation import CANONICAL_SEATS
+
+
+class FakeBoard:
+    def __init__(self):
+        self.posts = []
+
+    def post_message(self, thread, seat, kind, body, **fields):
+        self.posts.append({"thread": thread, "seat": seat, "kind": kind, "body": body, **fields})
+        return len(self.posts)
+
+
+RECIPES = tuple((seat, (f"seat-{seat}",)) for seat in CANONICAL_SEATS)
+
+
+def invoker(replies):
+    def invoke(recipe, brief):
+        seat = recipe[0].removeprefix("seat-")
+        return replies.get(seat, (1, ""))
+
+    return invoke
+
+
+def receipt(target="demo-spec", gate="symbol-reality", state="CHAIR_REQUIRED", **kw):
+    return GateReceipt(gate_id=gate, phase="tasks", target=target, state=state, **kw)
+
+
+@pytest.fixture
+def paths(tmp_path):
+    return {
+        "ledger_path": tmp_path / "verdicts.jsonl",
+        "triage_state_path": tmp_path / "triage_state.json",
+        "telemetry_path": tmp_path / "role_telemetry.jsonl",
+    }
+
+
+def seed(paths, *receipts):
+    for r in receipts:
+        append(r, path=paths["ledger_path"])
+
+
+def reply_for(*groups, disposition="uphold"):
+    return "\n".join(
+        f"DISPOSITION: {t} :: {g} :: {disposition}\nREASON: grounded in findings"
+        for (t, g) in groups
+    )
+
+
+class TestCollectShortfalls:
+    def test_groups_by_target_and_gate(self, paths):
+        seed(
+            paths,
+            receipt(findings=["a"]),
+            receipt(findings=["b"]),
+            receipt(target="other-spec", gate="falsifiability"),
+        )
+        shortfalls, ineligible = collect_shortfalls(
+            ledger_path=paths["ledger_path"], triage_state_path=paths["triage_state_path"]
+        )
+        keys = [(s.target, s.gate_id) for s in shortfalls]
+        assert keys == [("demo-spec", "symbol-reality"), ("other-spec", "falsifiability")]
+        assert len(shortfalls[0].receipts) == 2
+        assert ineligible == []
+
+    def test_non_chair_required_excluded(self, paths):
+        seed(paths, receipt(state="PASS"), receipt(state="BLOCKED"))
+        shortfalls, _ = collect_shortfalls(
+            ledger_path=paths["ledger_path"], triage_state_path=paths["triage_state_path"]
+        )
+        assert shortfalls == []
+
+    def test_rr4_unknown_gate_named_not_dropped(self, paths):
+        seed(paths, receipt(gate="invented-gate"))
+        shortfalls, ineligible = collect_shortfalls(
+            ledger_path=paths["ledger_path"], triage_state_path=paths["triage_state_path"]
+        )
+        assert shortfalls == []
+        assert [r.gate_id for r in ineligible] == ["invented-gate"]
+
+    def test_triaged_receipts_never_recollected(self, paths):
+        r = receipt()
+        seed(paths, r)
+        paths["triage_state_path"].write_text(
+            json.dumps({r.receipt_id: {"thread": "t", "at": "x", "disposition": "uphold"}})
+        )
+        shortfalls, _ = collect_shortfalls(
+            ledger_path=paths["ledger_path"], triage_state_path=paths["triage_state_path"]
+        )
+        assert shortfalls == []
+
+
+class TestThreshold:
+    def _shortfalls(self, paths, *receipts):
+        seed(paths, *receipts)
+        shortfalls, _ = collect_shortfalls(
+            ledger_path=paths["ledger_path"], triage_state_path=paths["triage_state_path"]
+        )
+        return shortfalls
+
+    def test_below_both_arms_is_quiet(self, paths):
+        shortfalls = self._shortfalls(paths, receipt(), receipt(target="b"))
+        assert past_threshold(shortfalls) is False
+
+    def test_count_arm(self, paths):
+        rs = [receipt(target=f"s{i}") for i in range(THRESHOLD_PENDING)]
+        assert past_threshold(self._shortfalls(paths, *rs)) is True
+
+    def test_age_arm(self, paths):
+        old = (dt.datetime.now(dt.timezone.utc) - dt.timedelta(hours=49)).isoformat()
+        shortfalls = self._shortfalls(paths, receipt(timestamp=old))
+        assert past_threshold(shortfalls) is True
+
+    def test_empty_is_never_past(self, paths):
+        assert past_threshold([]) is False
+
+
+class TestParseDispositions:
+    def test_one_per_group_from_closed_enum(self, paths):
+        seed(paths, receipt(), receipt(target="other-spec", gate="falsifiability"))
+        shortfalls, _ = collect_shortfalls(
+            ledger_path=paths["ledger_path"], triage_state_path=paths["triage_state_path"]
+        )
+        text = reply_for(("demo-spec", "symbol-reality"), disposition="waive")
+        parsed = parse_dispositions(text, shortfalls)
+        assert parsed[("demo-spec", "symbol-reality")] == "waive"
+        assert parsed[("other-spec", "falsifiability")] == NO_RECOMMENDATION
+
+    def test_out_of_enum_grade_is_no_recommendation(self, paths):
+        seed(paths, receipt())
+        shortfalls, _ = collect_shortfalls(
+            ledger_path=paths["ledger_path"], triage_state_path=paths["triage_state_path"]
+        )
+        text = "DISPOSITION: demo-spec :: symbol-reality :: rubber-stamp\nREASON: x"
+        parsed = parse_dispositions(text, shortfalls)
+        assert parsed[("demo-spec", "symbol-reality")] == NO_RECOMMENDATION
+
+    def test_enum_is_closed(self):
+        assert NO_RECOMMENDATION not in TRIAGE_DISPOSITIONS
+
+
+class TestRunTriage:
+    def _run(self, paths, replies=None, dissents=(), receipts=None, board=None):
+        if receipts is None:
+            receipts = [receipt(target=f"s{i}", findings=[f"finding-{i}"]) for i in range(3)]
+        seed(paths, *receipts)
+        board = board if board is not None else FakeBoard()
+        record = run_triage(
+            board=board,
+            invoke_seat=invoker(replies or {}),
+            seat_recipes=RECIPES,
+            dissents=dissents,
+            thread="t-triage",
+            now=dt.datetime.now(dt.timezone.utc),
+            **paths,
+        )
+        return record, board
+
+    def test_below_threshold_no_board_writes_no_spend(self, paths):
+        record, board = self._run(paths, receipts=[receipt()])
+        assert record.outcome == "below-threshold"
+        assert record.invocations == 0
+        assert board.posts == []
+
+    def test_deliberated_path_marks_triaged_and_digests(self, paths):
+        reply = reply_for(*[(f"s{i}", "symbol-reality") for i in range(3)])
+        record, board = self._run(paths, replies={"claude": (0, reply)})
+        assert record.outcome == "deliberated"
+        assert record.seat == "claude"
+        assert all(d == "uphold" for d in record.dispositions.values())
+        kinds = [p["kind"] for p in board.posts]
+        assert kinds == ["question", "position", "synthesis"]
+        triaged = load_triaged(path=paths["triage_state_path"])
+        assert len(triaged) == 3
+        assert all(v["disposition"] == "uphold" for v in triaged.values())
+
+    def test_second_pass_is_quiet_dedup(self, paths):
+        reply = reply_for(*[(f"s{i}", "symbol-reality") for i in range(3)])
+        self._run(paths, replies={"claude": (0, reply)})
+        record2 = run_triage(
+            board=FakeBoard(),
+            invoke_seat=invoker({"claude": (0, reply)}),
+            seat_recipes=RECIPES,
+            thread="t-2",
+            **paths,
+        )
+        assert record2.outcome == "below-threshold"
+        assert record2.shortfalls == []
+
+    def test_malformed_reply_records_no_recommendation(self, paths):
+        record, _ = self._run(paths, replies={"claude": (0, "LGTM, ship it all")})
+        assert record.outcome == "deliberated"
+        assert set(record.dispositions.values()) == {NO_RECOMMENDATION}
+        triaged = load_triaged(path=paths["triage_state_path"])
+        assert all(v["disposition"] == NO_RECOMMENDATION for v in triaged.values())
+
+    def test_absent_fallback_then_reply(self, paths):
+        reply = reply_for(*[(f"s{i}", "symbol-reality") for i in range(3)])
+        record, board = self._run(paths, replies={"claude": (1, ""), "antigravity": (0, reply)})
+        assert record.seat == "antigravity"
+        assert record.invocations == 2
+        assert len([p for p in board.posts if p.get("absent")]) == 1
+
+    def test_all_absent_stays_pending_not_triaged(self, paths):
+        record, board = self._run(paths, replies={})
+        assert record.outcome == "table-absent"
+        assert load_triaged(path=paths["triage_state_path"]) == {}
+        assert any(p["kind"] == "halt" for p in board.posts)
+
+    def test_never_alters_gate_state(self, paths):
+        receipts = [receipt(target=f"s{i}") for i in range(3)]
+        seed(paths, *receipts)
+        before = paths["ledger_path"].read_bytes()
+        reply = reply_for(*[(f"s{i}", "symbol-reality") for i in range(3)])
+        run_triage(
+            board=FakeBoard(),
+            invoke_seat=invoker({"claude": (0, reply)}),
+            seat_recipes=RECIPES,
+            thread="t-ro",
+            **paths,
+        )
+        assert paths["ledger_path"].read_bytes() == before
+
+    def test_skeptic_dissents_route_into_digest(self, paths):
+        dissent = {"spec": "some-spec", "cite": "smoke :: pytest -q", "reason": "tail shows fail"}
+        record, board = self._run(
+            paths,
+            replies={"claude": (0, reply_for(*[(f"s{i}", "symbol-reality") for i in range(3)]))},
+            dissents=[dissent],
+        )
+        synthesis = [p for p in board.posts if p["kind"] == "synthesis"][0]["body"]
+        assert "P3 skeptic DISSENT on 'some-spec'" in synthesis
+        assert "smoke :: pytest -q" in synthesis
+
+    def test_dissents_alone_digest_without_table(self, paths):
+        dissent = {"spec": "s", "cite": "c", "reason": "r"}
+        record, board = self._run(paths, receipts=[], dissents=[dissent])
+        assert record.outcome == "digested"
+        assert record.invocations == 0
+        assert [p["kind"] for p in board.posts] == ["synthesis"]
+
+    def test_ineligible_named_in_digest(self, paths):
+        receipts = [receipt(target=f"s{i}") for i in range(3)]
+        receipts.append(receipt(target="odd", gate="invented-gate"))
+        reply = reply_for(*[(f"s{i}", "symbol-reality") for i in range(3)])
+        record, board = self._run(paths, replies={"claude": (0, reply)}, receipts=receipts)
+        synthesis = [p for p in board.posts if p["kind"] == "synthesis"][0]["body"]
+        assert "ineligible" in synthesis and "odd::invented-gate" in synthesis
+
+    def test_never_promotes(self, paths):
+        reply = reply_for(*[(f"s{i}", "symbol-reality") for i in range(3)])
+        _, board = self._run(paths, replies={"claude": (0, reply)})
+        assert all(p["kind"] != "ruling" for p in board.posts)
+        synthesis = [p for p in board.posts if p["kind"] == "synthesis"][0]["body"]
+        assert "never alters gate state" in synthesis
+
+
+class TestBrief:
+    def test_brief_carries_findings_and_enum(self, paths):
+        seed(paths, receipt(findings=["symbol X missing"]))
+        shortfalls, _ = collect_shortfalls(
+            ledger_path=paths["ledger_path"], triage_state_path=paths["triage_state_path"]
+        )
+        brief = build_table_brief(shortfalls)
+        assert "symbol X missing" in brief
+        for d in TRIAGE_DISPOSITIONS:
+            assert d in brief
+        assert "inbox ceremony" in brief
+
+
+class TestMain:
+    def test_dry_run_prints_grouping_no_spend(self, tmp_path, monkeypatch, capsys):
+        from attune.roundtable.gate_triage import main
+
+        monkeypatch.setenv("ATTUNE_HOME", str(tmp_path))
+        append(receipt(findings=["x"]), path=tmp_path / "ops" / "gates" / "verdicts.jsonl")
+        append(
+            receipt(target="odd", gate="invented-gate"),
+            path=tmp_path / "ops" / "gates" / "verdicts.jsonl",
+        )
+        code = main(["--dry-run"])
+        out = capsys.readouterr().out
+        assert code == 0
+        assert "convene=False" in out
+        assert "demo-spec :: symbol-reality" in out
+        assert "ineligible: odd :: invented-gate" in out
+
+
+class TestRoleTelemetry:
+    def test_pass_records_seat_and_digest_events(self, paths):
+        reply = "DISPOSITION: s0 :: symbol-reality :: defer\nREASON: needs context"
+        seed(paths, *[receipt(target=f"s{i}") for i in range(3)])
+        run_triage(
+            board=FakeBoard(),
+            invoke_seat=invoker({"claude": (0, reply)}),
+            seat_recipes=RECIPES,
+            thread="t-telemetry",
+            **paths,
+        )
+        rows = [
+            json.loads(line)
+            for line in paths["telemetry_path"].read_text().splitlines()
+            if line.strip()
+        ]
+        events = [(r["role"], r["event"]) for r in rows]
+        assert ("triage-seat", "invoked") in events
+        assert ("triage-seat", "replied") in events
+        assert ("moderator", "digest-posted") in events
+
+    def test_chair_latency_derives_from_ruling(self, paths):
+        p = paths["telemetry_path"]
+        role_telemetry.record("moderator", "moderator", "t-x", "digest-posted", path=p)
+        role_telemetry.record_chair_ruling("t-x", path=p)
+        latency = role_telemetry.chair_latency_seconds("t-x", path=p)
+        assert latency is not None and latency >= 0
+
+    def test_unruled_digest_has_no_latency(self, paths):
+        p = paths["telemetry_path"]
+        role_telemetry.record("moderator", "moderator", "t-y", "digest-posted", path=p)
+        assert role_telemetry.chair_latency_seconds("t-y", path=p) is None
+
+    def test_write_failure_never_raises(self, tmp_path):
+        blocked = tmp_path / "file-not-dir" / "t.jsonl"
+        blocked.parent.write_text("a file, not a directory")
+        role_telemetry.record("r", "s", "t", "e", path=blocked)  # must not raise
+
+    def test_default_paths_resolve_under_attune_home(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("ATTUNE_HOME", str(tmp_path))
+        assert role_telemetry.telemetry_path() == (
+            tmp_path / "ops" / "roundtable" / "role_telemetry.jsonl"
+        )
+        role_telemetry.record("r", "s", "t-home", "digest-posted")
+        assert role_telemetry.chair_latency_seconds("t-home") is None
+
+    def test_missing_file_reads_empty(self, tmp_path):
+        assert role_telemetry.chair_latency_seconds("t", path=tmp_path / "absent.jsonl") is None
+
+    def test_malformed_lines_skipped(self, tmp_path):
+        p = tmp_path / "t.jsonl"
+        p.write_text('not json\n\n{"thread": "t-z", "event": "digest-posted", "at": "junk"}\n')
+        # malformed JSON and unparseable timestamps never raise
+        assert role_telemetry.chair_latency_seconds("t-z", path=p) is None
+
+    def test_other_threads_ignored(self, tmp_path):
+        p = tmp_path / "t.jsonl"
+        role_telemetry.record("moderator", "moderator", "t-a", "digest-posted", path=p)
+        role_telemetry.record_chair_ruling("t-b", path=p)
+        assert role_telemetry.chair_latency_seconds("t-a", path=p) is None


### PR DESCRIPTION
## What

Builds the P2 gate-triage inbox ruled 2026-07-21 (`q-roundtable-extensions-001`, build order P3 → P2 → P4-recording), per #1587's re-scoping into the roundtable-triage lineage. P4 role telemetry starts recording in the same PR, as the issue directs.

**Flow:** `unresolved_chair_required()` ledger rows → grouped by (target, gate_id), triaged-receipt dedup applied → threshold test (N≥3 pending OR oldest >48h) → past threshold only: ONE D3-capped mini-table (3 invocations, rotation order, absent fallback) → one disposition per shortfall from the closed enum `uphold | waive | revise | defer` (malformed → `no-recommendation`, never laundered) → single chair digest → deliberated receipts marked triaged in `ops/gates/triage_state.json`.

**Governance (substrate-enforced):**

- READ-ONLY: never appends to `verdicts.jsonl`, never alters gate state (byte-compare test)
- Below threshold: no board writes, no seat spend — the anti-ceremony guard (the ruling's named failure mode)
- RR-4 eligibility via `LADDER_GATES`; ineligible receipts NAMED in the digest, never silently dropped
- P3 skeptic dissents route into the same digest as duck-typed records — no import coupling on #1559
- Dedup mandatory: a triaged receipt_id is never re-deliberated (second-pass test)
- R8: never promotes, never rules

**P4 telemetry (record-only):** `role_telemetry.py` appends seat/digest events to `ops/roundtable/role_telemetry.jsonl`; `record_chair_ruling()` + `chair_latency_seconds()` derive chair latency at read time. Nothing consumes it.

**Pre-build drift check (the issue's mandate): PASS** — `verdicts.jsonl` is emitting (7 live rows at build time).

## Receipts

- 32 tests in `tests/unit/roundtable/test_gate_triage.py`, real tmp ledger/state/telemetry files (no mocked persistence), serial pass
- Trees: roundtable + quality + gates = 360+ pass CI-style (keyless, xdist)
- Coverage on new modules: gate_triage 93%, role_telemetry 95%
- radon: all functions ≤ B(10) — under the complexity ratchet
- Build record: `docs/specs/roundtable-triage/decisions.md` 2026-07-29 entry

Closes #1587.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
