### PR TITLE
feat(gates): append-only discharge path for chair-ruled ledger receipts

### DIFF
--- a/src/attune/gates/lifecycle/__init__.py
+++ b/src/attune/gates/lifecycle/__init__.py
@@ -26,7 +26,7 @@ from .activation import (
     waived,
 )
 from .baseline import falsifiability_gate, format_lint_gate, symbol_reality_gate
-from .ledger import append, latest_for, ledger_path, unresolved_chair_required
+from .ledger import append, discharge, latest_for, ledger_path, unresolved_chair_required
 from .protocol import PHASES, STATES, GateReceipt
 from .runner import exit_code, run_boundary
 from .status_line import RESUME_TRIGGER_CLAUSE, status_line_gate
@@ -52,6 +52,7 @@ __all__ = [
     "run_boundary",
     "status_line_gate",
     "symbol_reality_gate",
+    "discharge",
     "unresolved_chair_required",
     "waived",
 ]

--- a/src/attune/gates/lifecycle/ledger.py
+++ b/src/attune/gates/lifecycle/ledger.py
@@ -69,5 +69,78 @@ def latest_for(target: str, *, path: Path | None = None) -> list[GateReceipt]:
 
 
 def unresolved_chair_required(*, path: Path | None = None) -> list[GateReceipt]:
-    """CHAIR_REQUIRED receipts not yet cited by any ruling."""
-    return [r for r in _rows(path) if r.state == "CHAIR_REQUIRED" and r.decisions_ref is None]
+    """CHAIR_REQUIRED receipts not yet cited by any ruling.
+
+    Rows are superseded per ``receipt_id`` (later rows win — the
+    same discipline :func:`latest_for` applies per gate), so a
+    receipt discharged via :func:`discharge` no longer reports as
+    unresolved even though its original row remains in the
+    append-only history.
+    """
+    latest: dict[str, GateReceipt] = {}
+    for receipt in _rows(path):
+        latest[receipt.receipt_id] = receipt  # later rows supersede
+    return [r for r in latest.values() if r.state == "CHAIR_REQUIRED" and r.decisions_ref is None]
+
+
+def discharge(
+    receipt_id: str, decisions_ref: str, *, path: Path | None = None
+) -> GateReceipt | None:
+    """Cite a chair ruling on an existing receipt — append-only.
+
+    Appends a superseding copy of the receipt's latest row with
+    ``decisions_ref`` set; the original row is never touched (G1:
+    the ledger never deletes). Returns the appended receipt, or
+    ``None`` when no row carries ``receipt_id`` (nothing is
+    written — an invented discharge must fail loudly at the
+    caller, never fabricate history).
+    """
+    if not decisions_ref.strip():
+        raise ValueError("decisions_ref must name the ruling that discharges the receipt")
+    target: GateReceipt | None = None
+    for receipt in _rows(path):
+        if receipt.receipt_id == receipt_id:
+            target = receipt  # later rows supersede
+    if target is None:
+        return None
+    cited = GateReceipt(
+        gate_id=target.gate_id,
+        phase=target.phase,
+        target=target.target,
+        state=target.state,
+        findings=list(target.findings),
+        evidence_refs=list(target.evidence_refs),
+        proposed_disposition=target.proposed_disposition,
+        waived=target.waived,
+        receipt_id=target.receipt_id,
+        timestamp=target.timestamp,
+        decisions_ref=decisions_ref,
+    )
+    append(cited, path=path)
+    return cited
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI: ``python -m attune.gates.lifecycle.ledger discharge <receipt_id> <decisions_ref>``."""
+    import argparse
+
+    parser = argparse.ArgumentParser(description="G1 verdict-ledger maintenance (append-only).")
+    sub = parser.add_subparsers(dest="command", required=True)
+    d = sub.add_parser("discharge", help="cite a chair ruling on an existing receipt")
+    d.add_argument("receipt_id")
+    d.add_argument("decisions_ref", help="e.g. docs/specs/<slug>/decisions.md#<entry>")
+    args = parser.parse_args(argv)
+
+    cited = discharge(args.receipt_id, args.decisions_ref)
+    if cited is None:
+        print(f"no ledger row carries receipt_id {args.receipt_id!r}; nothing written")
+        return 1
+    print(
+        f"discharged {cited.receipt_id} ({cited.target} :: {cited.gate_id}) "
+        f"citing {cited.decisions_ref}"
+    )
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tests/unit/gates/test_lifecycle_gates.py
+++ b/tests/unit/gates/test_lifecycle_gates.py
@@ -20,6 +20,7 @@ from attune.gates.lifecycle import (
     active_gates,
     append,
     blast_radius,
+    discharge,
     exit_code,
     falsifiability_gate,
     latest_for,
@@ -89,6 +90,63 @@ class TestLedger:
         append(open_r, path=f)
         append(cited, path=f)
         assert [r.gate_id for r in unresolved_chair_required(path=f)] == ["a"]
+
+    def test_discharge_supersedes_and_preserves_history(self, tmp_path):
+        f = tmp_path / "verdicts.jsonl"
+        r = GateReceipt(gate_id="chair-review", phase="tasks", target="s", state="CHAIR_REQUIRED")
+        append(r, path=f)
+        raw_before = f.read_text()
+        cited = discharge(r.receipt_id, "docs/specs/s/decisions.md#ruling", path=f)
+        assert cited is not None and cited.decisions_ref == "docs/specs/s/decisions.md#ruling"
+        assert cited.receipt_id == r.receipt_id
+        # append-only: the original row is still in the raw history
+        assert raw_before in f.read_text()
+        assert len(f.read_text().splitlines()) == 2
+        # unresolved no longer reports the discharged receipt
+        assert unresolved_chair_required(path=f) == []
+        # latest_for serves the cited version
+        (latest,) = latest_for("s", path=f)
+        assert latest.decisions_ref == "docs/specs/s/decisions.md#ruling"
+
+    def test_discharge_unknown_receipt_writes_nothing(self, tmp_path):
+        f = tmp_path / "verdicts.jsonl"
+        append(GateReceipt(gate_id="g", phase="design", target="s", state="PASS"), path=f)
+        before = f.read_text()
+        assert discharge("does-not-exist", "ref", path=f) is None
+        assert f.read_text() == before
+
+    def test_discharge_empty_ref_rejected(self, tmp_path):
+        f = tmp_path / "verdicts.jsonl"
+        r = GateReceipt(gate_id="g", phase="design", target="s", state="CHAIR_REQUIRED")
+        append(r, path=f)
+        with pytest.raises(ValueError, match="decisions_ref"):
+            discharge(r.receipt_id, "  ", path=f)
+
+    def test_unresolved_uses_last_row_per_receipt(self, tmp_path):
+        f = tmp_path / "verdicts.jsonl"
+        open_r = GateReceipt(gate_id="a", phase="design", target="s", state="CHAIR_REQUIRED")
+        append(open_r, path=f)
+        discharge(open_r.receipt_id, "ref-1", path=f)
+        other = GateReceipt(gate_id="b", phase="design", target="s", state="CHAIR_REQUIRED")
+        append(other, path=f)
+        assert [r.gate_id for r in unresolved_chair_required(path=f)] == ["b"]
+
+    def test_discharge_cli_round_trip(self, tmp_path, monkeypatch, capsys):
+        from attune.gates.lifecycle.ledger import main
+
+        monkeypatch.setenv("ATTUNE_HOME", str(tmp_path))
+        r = GateReceipt(gate_id="chair-review", phase="tasks", target="s", state="CHAIR_REQUIRED")
+        append(r)
+        assert main(["discharge", r.receipt_id, "docs/specs/s/decisions.md#x"]) == 0
+        assert "discharged" in capsys.readouterr().out
+        assert unresolved_chair_required() == []
+
+    def test_discharge_cli_unknown_exits_1(self, tmp_path, monkeypatch, capsys):
+        from attune.gates.lifecycle.ledger import main
+
+        monkeypatch.setenv("ATTUNE_HOME", str(tmp_path))
+        assert main(["discharge", "nope", "ref"]) == 1
+        assert "nothing written" in capsys.readouterr().out
 
     def test_default_path_is_isolated_from_real_home(self):
         """Drift guard: the suite must never touch the real ledger."""


### PR DESCRIPTION
Found by the gate-triage inbox's first live pass (dogfood, leg-3 lineage): receipt `b05d58094d8b` (cross-provider-memory-transport :: chair-review) was chair-discharged 2026-07-28 but still reported unresolved — the G1 ledger had no code path to cite a ruling on an existing row.

**Mechanism (append-only honored):** `discharge(receipt_id, decisions_ref)` appends a superseding copy of the receipt's latest row with `decisions_ref` set; the original row is never touched. `unresolved_chair_required()` now supersedes per `receipt_id` — the same later-rows-win discipline `latest_for` already applies. Unknown receipt_id → `None`, nothing written; empty ref → ValueError. Module CLI: `python -m attune.gates.lifecycle.ledger discharge <id> <ref>`.

**Receipts:**
- 33 tests in `test_lifecycle_gates.py` (discharge round-trip, history preservation byte-check, supersede semantics, unknown-id refusal, CLI both exits), 419 across gates + roundtable + quality trees CI-style
- radon all A/B
- **Live backfill executed and verified:** `b05d58094d8b` discharged citing the 07-28 decisions entry; the gate-triage `--dry-run` ineligible line is gone; live ledger 7→8 rows (append-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)