### PR TITLE
test(agents): release_prep_team orchestration pass 78% → 100%

### DIFF
--- a/docs/COVERAGE_BUG_LOG.md
+++ b/docs/COVERAGE_BUG_LOG.md
@@ -1,3 +1,26 @@
+## 2026-07-29 — release_prep_team.py orchestration pass (coverage push, Fable 5)
+
+`src/attune/agents/release/release_prep_team.py` 78% → 100% via net-new
+`tests/unit/agents/test_release_prep_team_orchestration.py` (10 tests:
+assess_readiness fan-out with stub agents, confidence tiers, Redis-optional
+init branches with a fake redis_lib). One finding, flagged not fixed:
+
+- **Candidate bug (silent wrong result, class 1-adjacent — no crash):
+  a FAILED security agent passes the Security gate via the -1
+  sentinel.** `_evaluate_quality_gates` records `critical_issues = -1`
+  when the security result has `success=False`, and `-1 <=
+  max_critical_issues (0)` evaluates the gate as PASSED — greenest
+  outcome on the exact path where the auditor never ran. Partial
+  mitigation: `_identify_issues` adds a blocker when the failed
+  result's findings carry an `"error"` key — but `_execute_tier`
+  failure shapes vary per agent, so a failure without that key
+  approves the release with a green Security row (actual=-1.0 is the
+  only visible tell). NOT fixed in this pass: hardening the gate
+  (sentinel → failed) changes release-gate semantics and needs a
+  ruling; the current behavior is pinned by
+  `test_failed_security_agent_sentinel_passes_gate` with a comment
+  telling the fixer to rewrite it deliberately. Flagged as a chip.
+
 ## 2026-07-24 — elicitation/widget.py fixed element ids (dogfood, Fable 5)
 
 `src/attune/elicitation/widget.py` (`form_to_widget_html`). Found by
@@ -1441,4 +1464,4 @@ describes the 18 classes-1–4 coverage-push finds. (The class 5 row was
 missing from this table until 2026-07-24 — it was recorded in the
 session-49f snapshot above but never propagated here.)
 
-Modules at 100%: 81 (cumulative across all sessions).
+Modules at 100%: 82 (cumulative across all sessions).

--- a/tests/unit/agents/test_release_prep_team_orchestration.py
+++ b/tests/unit/agents/test_release_prep_team_orchestration.py
@@ -1,0 +1,189 @@
+"""Orchestration tests for ReleasePrepTeam (test-quality-program #1569).
+
+Covers the seams the existing suites skip: the ``assess_readiness``
+async fan-out (parallel agent execution → gates → blockers →
+approval → confidence → report assembly), the Redis-optional
+``__init__`` branches (fake redis_lib — no live server), and the
+failed-security-agent sentinel branch in gate evaluation.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under Apache 2.0
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from typing import Any
+
+import pytest
+
+from attune.agents.release import release_prep_team as rpt
+from attune.agents.release.release_models import ReleaseAgentResult, Tier
+
+
+def result(
+    role: str,
+    findings: dict[str, Any],
+    success: bool = True,
+    score: float = 9.0,
+    cost: float = 0.25,
+) -> ReleaseAgentResult:
+    return ReleaseAgentResult(
+        agent_id=role.lower().replace(" ", "-"),
+        agent_role=role,
+        success=success,
+        tier_used=Tier.CHEAP,
+        findings=findings,
+        score=score,
+        confidence=0.9,
+        cost=cost,
+        execution_time_ms=5,
+        escalated=False,
+    )
+
+
+GREEN = {
+    "Security Auditor": {"critical_issues": 0},
+    "Test Coverage": {"coverage_percent": 92.0},
+    "Code Quality": {"quality_score": 9.1},
+    "Documentation": {"coverage_percent": 88.0},
+}
+
+
+@dataclass
+class StubAgent:
+    """Stands in for a ReleaseAgent: records the path it was given."""
+
+    reply: ReleaseAgentResult
+    total_cost: float = 0.25
+    seen_paths: list[str] = field(default_factory=list)
+
+    def process(self, codebase_path: str) -> ReleaseAgentResult:
+        self.seen_paths.append(codebase_path)
+        return self.reply
+
+
+def team_with(replies: dict[str, dict[str, Any]], **result_kw: Any) -> rpt.ReleasePrepTeam:
+    """A ReleasePrepTeam whose four agents are stubs (no subprocess, no LLM)."""
+    team = rpt.ReleasePrepTeam(redis_url=None)
+    team.agents = [  # type: ignore[assignment]
+        StubAgent(reply=result(role, findings, **result_kw)) for role, findings in replies.items()
+    ]
+    return team
+
+
+class TestAssessReadiness:
+    def test_all_green_approves_with_high_confidence(self):
+        team = team_with(GREEN)
+        report = asyncio.run(team.assess_readiness("some/path"))
+        assert report.approved is True
+        assert report.confidence == "high"
+        assert report.blockers == [] and report.warnings == []
+        assert [g.passed for g in report.quality_gates] == [True, True, True, True]
+        assert "RELEASE APPROVED" in report.summary
+        assert report.total_duration >= 0
+        assert report.total_cost == pytest.approx(1.0)  # 4 stub agents x 0.25
+        # every agent was fanned the same codebase path
+        assert [a.seen_paths for a in team.agents] == [["some/path"]] * 4
+
+    def test_noncritical_doc_failure_is_medium_confidence(self):
+        replies = dict(GREEN)
+        replies["Documentation"] = {"coverage_percent": 10.0}
+        report = asyncio.run(team_with(replies).assess_readiness())
+        assert report.approved is True  # doc gate is non-critical
+        assert report.confidence == "medium"
+        assert len(report.warnings) == 1 and "Documentation" in report.warnings[0]
+        assert report.blockers == []
+
+    def test_critical_coverage_failure_blocks_with_low_confidence(self):
+        replies = dict(GREEN)
+        replies["Test Coverage"] = {"coverage_percent": 12.0}
+        report = asyncio.run(team_with(replies).assess_readiness())
+        assert report.approved is False
+        assert report.confidence == "low"
+        assert any("Test Coverage" in b for b in report.blockers)
+        assert "RELEASE NOT APPROVED" in report.summary
+
+    def test_agent_error_surfaces_as_blocker(self):
+        replies = dict(GREEN)
+        team = team_with(replies)
+        team.agents[1] = StubAgent(  # type: ignore[index]
+            reply=result(
+                "Test Coverage",
+                {"coverage_percent": 95.0, "error": "pytest crashed"},
+                success=False,
+            )
+        )
+        report = asyncio.run(team.assess_readiness())
+        assert report.approved is False
+        assert any("pytest crashed" in b for b in report.blockers)
+
+    def test_failed_security_agent_sentinel_passes_gate(self):
+        # CURRENT behavior, asserted deliberately: a security agent that
+        # FAILED (success=False, no error key) records the -1 sentinel,
+        # and -1 <= max_critical_issues(0) means the Security gate
+        # PASSES while the auditor never ran. Logged in
+        # docs/COVERAGE_BUG_LOG.md — if this assertion breaks because
+        # the sentinel now fails the gate, that fix is intentional:
+        # update this test to the new contract.
+        replies = dict(GREEN)
+        team = team_with(replies)
+        team.agents[0] = StubAgent(  # type: ignore[index]
+            reply=result("Security Auditor", {}, success=False)
+        )
+        report = asyncio.run(team.assess_readiness())
+        security_gate = next(g for g in report.quality_gates if g.name == "Security")
+        assert security_gate.actual == -1.0
+        assert security_gate.passed is True
+        assert report.approved is True
+
+
+class FakeRedisClient:
+    def __init__(self, alive: bool = True):
+        self.alive = alive
+
+    def ping(self):
+        if not self.alive:
+            raise ConnectionError("no redis here")
+        return True
+
+
+class TestRedisOptionalInit:
+    def test_redis_url_connects_and_reaches_agents(self, monkeypatch):
+        client = FakeRedisClient()
+        fake_lib = type("L", (), {"from_url": staticmethod(lambda url: client)})
+        monkeypatch.setattr(rpt, "REDIS_AVAILABLE", True)
+        monkeypatch.setattr(rpt, "redis_lib", fake_lib)
+        team = rpt.ReleasePrepTeam(redis_url="redis://example:6379/0")
+        assert team.redis is client
+        assert all(agent.redis is client for agent in team.agents)
+
+    def test_redis_url_ping_failure_degrades_to_none(self, monkeypatch):
+        fake_lib = type(
+            "L", (), {"from_url": staticmethod(lambda url: FakeRedisClient(alive=False))}
+        )
+        monkeypatch.setattr(rpt, "REDIS_AVAILABLE", True)
+        monkeypatch.setattr(rpt, "redis_lib", fake_lib)
+        team = rpt.ReleasePrepTeam(redis_url="redis://example:6379/0")
+        assert team.redis is None
+
+    def test_no_url_tries_localhost(self, monkeypatch):
+        client = FakeRedisClient()
+        fake_lib = type("L", (), {"Redis": staticmethod(lambda **kw: client)})
+        monkeypatch.setattr(rpt, "REDIS_AVAILABLE", True)
+        monkeypatch.setattr(rpt, "redis_lib", fake_lib)
+        team = rpt.ReleasePrepTeam()
+        assert team.redis is client
+
+    def test_no_url_localhost_down_degrades_to_none(self, monkeypatch):
+        fake_lib = type("L", (), {"Redis": staticmethod(lambda **kw: FakeRedisClient(False))})
+        monkeypatch.setattr(rpt, "REDIS_AVAILABLE", True)
+        monkeypatch.setattr(rpt, "redis_lib", fake_lib)
+        team = rpt.ReleasePrepTeam()
+        assert team.redis is None
+
+    def test_redis_unavailable_stays_none(self, monkeypatch):
+        monkeypatch.setattr(rpt, "REDIS_AVAILABLE", False)
+        team = rpt.ReleasePrepTeam(redis_url="redis://example:6379/0")
+        assert team.redis is None


### PR DESCRIPTION
test-quality-program pass (#1569), playbook loop. The issue's two named candidates (agent_coordination, agent_tracking) closed yesterday at 100%, so this pass baselined fresh: telemetry 98% / roundtable 92% / gates 95% are mined out; `attune.agents` surfaced `release_prep_team.py` at 78% with its CORE path uncovered.

**What the new suite covers** (`test_release_prep_team_orchestration.py`, 10 tests):
- `assess_readiness` async fan-out end-to-end with stub agents: approval, all three confidence tiers, blocker/warning surfacing, cost summation, per-agent path wiring
- Redis-optional `__init__` branches via a fake `redis_lib` (url ping ok/fail, localhost ok/fail, unavailable) — no live server
- The failed-security-agent sentinel branch — **asserted as current behavior and logged in `docs/COVERAGE_BUG_LOG.md` as a candidate silent-wrong-result bug**: a security agent that fails without an `error` key passes the Security gate (`-1 <= 0`) on the exact path where the auditor never ran. Fix needs a gate-semantics ruling; flagged separately.

**Receipts:** module 78% → **100%** (measured with the full `tests/unit/agents` tree via the worktree workaround); 230 agents tests pass; pinned black/ruff clean. Tests+docs only — Class 1 lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)