### PR TITLE
fix(agents): failed security auditor fails the Security gate + agents to 100%

### DIFF
--- a/docs/COVERAGE_BUG_LOG.md
+++ b/docs/COVERAGE_BUG_LOG.md
@@ -21,6 +21,17 @@ init branches with a fake redis_lib). One finding, flagged not fixed:
   `test_failed_security_agent_sentinel_passes_gate` with a comment
   telling the fixer to rewrite it deliberately. Flagged as a chip.
 
+  **DISPOSITION (same day, chair-ruled "go fix it"):** hardened —
+  a failed OR absent security result now fails the Security gate
+  (`security_ran and …`; the -1 sentinel stays as the display
+  value), and `_identify_issues` blocks on EVERY failed agent with
+  a fallback reason when no `error` key exists (the bug's other
+  half: a failure with no diagnostic must not read quieter than
+  one with). Pinned test rewritten to the new contract
+  (`test_failed_security_agent_fails_gate_and_blocks`) plus a
+  missing-result case. Class 1 (silent wrong result on a
+  never-exercised path), counted as a coverage-push find.
+
 ## 2026-07-24 — elicitation/widget.py fixed element ids (dogfood, Fable 5)
 
 `src/attune/elicitation/widget.py` (`form_to_widget_html`). Found by
@@ -1464,4 +1475,4 @@ describes the 18 classes-1–4 coverage-push finds. (The class 5 row was
 missing from this table until 2026-07-24 — it was recorded in the
 session-49f snapshot above but never propagated here.)
 
-Modules at 100%: 82 (cumulative across all sessions).
+Modules at 100%: 85 (cumulative across all sessions).

--- a/src/attune/agents/release/release_prep_team.py
+++ b/src/attune/agents/release/release_prep_team.py
@@ -215,9 +215,13 @@ class ReleasePrepTeam:
         quality = next((r for r in results if "Quality" in r.agent_role), None)
         docs = next((r for r in results if "Documentation" in r.agent_role), None)
 
-        # Security gate: no critical issues
-        critical_issues = 0
-        if security and security.success:
+        # Security gate: no critical issues. A FAILED (or absent)
+        # auditor can never satisfy the gate — unknown is not clean;
+        # the -1 sentinel stays as the display value so the gates
+        # table shows the auditor never produced a count.
+        security_ran = bool(security and security.success)
+        critical_issues = -1
+        if security_ran:
             critical_issues = security.findings.get("critical_issues", 0)
         elif security:
             critical_issues = security.findings.get("critical_issues", -1)
@@ -227,7 +231,8 @@ class ReleasePrepTeam:
                 name="Security",
                 threshold=float(self.quality_gates["max_critical_issues"]),
                 actual=float(critical_issues),
-                passed=critical_issues <= self.quality_gates["max_critical_issues"],
+                passed=security_ran
+                and critical_issues <= self.quality_gates["max_critical_issues"],
                 critical=True,
             ),
         )
@@ -308,8 +313,12 @@ class ReleasePrepTeam:
                     warnings.append(f"{gate.name} below threshold: {gate.message}")
 
         for result in results:
-            if not result.success and result.findings.get("error"):
-                blockers.append(f"Agent {result.agent_role} failed: {result.findings['error']}")
+            if not result.success:
+                # A failed agent ALWAYS blocks — a failure that carries
+                # no diagnostic must not read as quieter than one that
+                # does (the -1-sentinel bug's other half).
+                reason = result.findings.get("error") or "failed without diagnostic output"
+                blockers.append(f"Agent {result.agent_role} failed: {reason}")
 
         return blockers, warnings
 

--- a/tests/unit/agents/test_release_agent_analysis_branches.py
+++ b/tests/unit/agents/test_release_agent_analysis_branches.py
@@ -1,0 +1,114 @@
+"""Branch coverage for the release agents' analysis seams (#1569).
+
+The three modules' uncovered regions were all the same shapes: the
+LLM-enhancement branch (guarded by ``llm_client`` + ``LLM_MODE ==
+"real"`` — stubbed here, no real provider), the ruff score ladder,
+and the defensive paths (unparseable source files, analysis
+exceptions). No subprocess runs: ``_run_command`` is patched at
+each module seam.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under Apache 2.0
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from attune.agents.release import documentation_agent as doc_mod
+from attune.agents.release import quality_agent as q_mod
+from attune.agents.release import security_agent as sec_mod
+from attune.agents.release.release_models import Tier
+
+
+def ruff_stats(n: int) -> str:
+    """Ruff --statistics stdout reporting exactly ``n`` violations."""
+    return f"{n} E501 Line too long"
+
+
+class TestQualityScoreLadder:
+    @pytest.mark.parametrize(
+        ("violations", "expected"),
+        [(0, 10.0), (5, 9.0), (20, 8.0), (50, 7.0), (150, 5.0), (400, 3.0)],
+    )
+    def test_score_tiers(self, violations, expected):
+        agent = q_mod.CodeQualityAgent(redis_client=None)
+        stdout = ruff_stats(violations) if violations else ""
+        findings = agent._parse_ruff_output(stdout, returncode=0)
+        assert findings["quality_score"] == expected
+        assert findings["total_violations"] == violations
+
+
+class TestQualityLlmEnhancement:
+    def _agent(self, monkeypatch, llm_reply: str):
+        agent = q_mod.CodeQualityAgent(redis_client=None)
+        monkeypatch.setattr(q_mod, "_run_command", lambda *a, **k: (0, ruff_stats(5), ""))
+        monkeypatch.setattr(q_mod, "LLM_MODE", "real")
+        agent.llm_client = object()
+        monkeypatch.setattr(agent, "_call_llm", lambda *a, **k: (llm_reply, {}))
+        return agent
+
+    def test_llm_quality_score_overrides_rule_based(self, monkeypatch):
+        agent = self._agent(monkeypatch, '{"quality_score": 9.5}')
+        success, findings = agent._execute_tier(".", Tier.CHEAP)
+        assert findings["quality_score"] == 9.5
+        assert findings["score"] == 9.5
+        assert findings["mode"] == "llm"
+        assert success is True  # 9.5 >= min_quality_score
+
+    def test_empty_llm_reply_keeps_rule_based_score(self, monkeypatch):
+        agent = self._agent(monkeypatch, "")
+        _, findings = agent._execute_tier(".", Tier.CHEAP)
+        assert findings["quality_score"] == 9.0  # 5 violations -> rule-based tier
+        assert findings["mode"] == "llm"  # client present, mode reflects it
+
+    def test_llm_reply_without_score_keeps_rule_based(self, monkeypatch):
+        agent = self._agent(monkeypatch, '{"notes": "looks fine"}')
+        _, findings = agent._execute_tier(".", Tier.CHEAP)
+        assert findings["quality_score"] == 9.0
+
+
+class TestSecurityLlmEnhancement:
+    def test_llm_findings_merge_into_bandit_results(self, monkeypatch):
+        agent = sec_mod.SecurityAuditorAgent(redis_client=None)
+        monkeypatch.setattr(sec_mod, "_run_command", lambda *a, **k: (0, '{"results": []}', ""))
+        monkeypatch.setattr(sec_mod, "LLM_MODE", "real")
+        agent.llm_client = object()
+        monkeypatch.setattr(agent, "_call_llm", lambda *a, **k: ('{"critical_issues": 2}', {}))
+        _, findings = agent._execute_tier(".", Tier.CHEAP)
+        assert findings["critical_issues"] == 2  # LLM enhancement merged
+        assert findings["mode"] == "llm"
+        assert findings["tier"] == "cheap"
+
+    def test_empty_llm_reply_keeps_bandit_findings(self, monkeypatch):
+        agent = sec_mod.SecurityAuditorAgent(redis_client=None)
+        monkeypatch.setattr(sec_mod, "_run_command", lambda *a, **k: (0, '{"results": []}', ""))
+        monkeypatch.setattr(sec_mod, "LLM_MODE", "real")
+        agent.llm_client = object()
+        monkeypatch.setattr(agent, "_call_llm", lambda *a, **k: ("", {}))
+        _, findings = agent._execute_tier(".", Tier.CHEAP)
+        assert findings["critical_issues"] == 0
+        assert findings["mode"] == "llm"
+
+
+class TestDocumentationDefensivePaths:
+    def test_unparseable_file_skipped_not_fatal(self, tmp_path):
+        (tmp_path / "good.py").write_text('def documented():\n    """Doc."""\n')
+        (tmp_path / "broken.py").write_text("def broken(:\n")
+        agent = doc_mod.DocumentationAgent(redis_client=None)
+        success, findings = agent._execute_tier(str(tmp_path), Tier.CHEAP)
+        # the broken file is skipped; the good one fully documented
+        assert findings["total_functions"] == 1
+        assert findings["coverage_percent"] == 100.0
+        assert success is True
+
+    def test_analysis_exception_returns_error_findings(self, monkeypatch):
+        def boom(*a, **k):
+            raise RuntimeError("fs exploded")
+
+        monkeypatch.setattr(doc_mod, "Path", boom)
+        agent = doc_mod.DocumentationAgent(redis_client=None)
+        success, findings = agent._execute_tier(".", Tier.CHEAP)
+        assert success is False
+        assert findings["error"] == "fs exploded"
+        assert findings["coverage_percent"] == 0.0

--- a/tests/unit/agents/test_release_prep_team_orchestration.py
+++ b/tests/unit/agents/test_release_prep_team_orchestration.py
@@ -119,14 +119,13 @@ class TestAssessReadiness:
         assert report.approved is False
         assert any("pytest crashed" in b for b in report.blockers)
 
-    def test_failed_security_agent_sentinel_passes_gate(self):
-        # CURRENT behavior, asserted deliberately: a security agent that
-        # FAILED (success=False, no error key) records the -1 sentinel,
-        # and -1 <= max_critical_issues(0) means the Security gate
-        # PASSES while the auditor never ran. Logged in
-        # docs/COVERAGE_BUG_LOG.md — if this assertion breaks because
-        # the sentinel now fails the gate, that fix is intentional:
-        # update this test to the new contract.
+    def test_failed_security_agent_fails_gate_and_blocks(self):
+        # The 2026-07-29 gate-hardening contract (chair-ruled): a
+        # security agent that FAILED (success=False, even with no
+        # error key) can never satisfy the Security gate — unknown is
+        # not clean. The -1 sentinel stays as the DISPLAY value, the
+        # gate fails, and the failed agent blocks with a fallback
+        # reason even without diagnostic output.
         replies = dict(GREEN)
         team = team_with(replies)
         team.agents[0] = StubAgent(  # type: ignore[index]
@@ -135,8 +134,19 @@ class TestAssessReadiness:
         report = asyncio.run(team.assess_readiness())
         security_gate = next(g for g in report.quality_gates if g.name == "Security")
         assert security_gate.actual == -1.0
-        assert security_gate.passed is True
-        assert report.approved is True
+        assert security_gate.passed is False
+        assert report.approved is False
+        assert report.confidence == "low"
+        assert any("failed without diagnostic output" in b for b in report.blockers)
+
+    def test_missing_security_result_fails_gate(self):
+        # No security result at all is the same unknown — the gate
+        # cannot pass on absence.
+        replies = {k: v for k, v in GREEN.items() if k != "Security Auditor"}
+        report = asyncio.run(team_with(replies).assess_readiness())
+        security_gate = next(g for g in report.quality_gates if g.name == "Security")
+        assert security_gate.passed is False
+        assert report.approved is False
 
 
 class FakeRedisClient:


### PR DESCRIPTION
Chair-ruled fix of the sentinel bug logged this morning (`COVERAGE_BUG_LOG.md` 2026-07-29 entry, found by the #1740 coverage pass):

**Gate hardening:**
- A failed **or absent** security result can no longer satisfy the Security gate — `passed` requires the auditor actually ran (`security_ran and …`). The `-1` sentinel stays as the display value so the gates table shows the auditor produced no count.
- `_identify_issues` now blocks on **every** failed agent, with a fallback reason when the failure carries no `error` key — the bug's other half (a failure with no diagnostic must not read quieter than one with).
- The deliberately-pinned test rewritten to the new contract (`test_failed_security_agent_fails_gate_and_blocks`) + a missing-result case; bug-log disposition updated (Class 1, coverage-push find).

**Coverage sweep per the same ruling (target ≥90%):** quality_agent 84→**100%**, security_agent 88→**100%**, documentation_agent 89→**100%** via `test_release_agent_analysis_branches.py` — LLM-enhancement branches stubbed at module seams (no provider), ruff score ladder parametrized, unparseable-source skip, analysis exception path.

**Receipts:** 271 tests across agents + quality + release-prep-execute trees CI-style; all four release modules at 100% (306/306 statements); radon ≤ C(16); pinned black/ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)