### PR TITLE
chore(coverage): omit-audit pass 2 — convert 8 mislabeled entries, drop dead glob

### DIFF
--- a/docs/specs/test-quality-program/omit-audit.md
+++ b/docs/specs/test-quality-program/omit-audit.md
@@ -109,3 +109,41 @@ misreports spec_from_file_location-loaded modules" and the fix in
 **Caveat:** this audit covers the "claims-untestable" entries, not the
 hook scripts or every `__init__`. Tier-2 alone is ~2,000 statements of
 currently-unmeasured, testable code.
+
+---
+
+## Pass 2 — 2026-07-29 (#1569, chair-directed)
+
+**Method:** one scoped coverage run over each candidate's own test
+files (subset lower bound — a module clearing the bar in subset is
+proven; more tests only raise it). 1027 tests, keyless, serial.
+
+**Converted (removed from omit — measured, labels were false):**
+
+| Entry | Claimed reason | Measured |
+|-------|----------------|----------|
+| `agents/release/release_prep_team.py` | "Requires LLM API calls" | 100% (#1740/#1741 suites) |
+| `monitoring/otel_backend.py` | "Requires OpenTelemetry SDK" | 100% (3 dedicated suites) |
+| `orchestration/execution_strategies.py` | "Requires live agents" | 94% (unit consumers) |
+| `meta_workflows/cli_commands/config_commands.py` | "Interactive" | 100% |
+| `meta_workflows/cli_commands/memory_commands.py` | "Interactive" | 100% |
+| `meta_workflows/cli_commands/template_commands.py` | "Interactive" | 100% |
+| `meta_workflows/cli_commands/analytics_commands.py` | "Interactive" | 99% |
+| `meta_workflows/cli_commands/agent_commands.py` | "Interactive... live Claude agent loop" | 99% |
+
+**Removed as dead:** `*/memory/cross_session.py` — the glob matches
+no file on disk (real module: `memory/short_term/cross_session.py`).
+
+**Kept omitted with honest state (measured low — need tests first):**
+
+| Entry | Measured | Note |
+|-------|----------|------|
+| `orchestration/_strategies/base.py` | 46% | Label corrected to justified-other; QA-pass candidate |
+| `project_index/index.py` | 18% | Comment's "(integration-tested)" claim stands; unit gap real |
+| `project_index/scanner_parallel.py` | 17% | Same |
+
+Not probed this pass (bounded scope): `core_modules/short_term_memory.py`
+(integration-only evidence), `memory/short_term/sessions.py`,
+`memory/control_panel_api.py`, the hook scripts, and the init/entry
+excludes. Net effect: ~930 statements of ~99%-covered production code
+re-enter the measured denominator — the project total RISES.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -723,25 +723,29 @@ omit = [
     # Infrastructure requiring external deps
     # Deleted in v2.9.0: cli/, cli_unified.py, security/, pattern modules
     # Memory modules requiring Redis server
-    "*/memory/cross_session.py",  # Requires Redis server
+    # cross_session.py entry removed 2026-07-29 (#1569 omit-audit
+    # pass 2): dead glob — no file matches */memory/cross_session.py
+    # (the real module lives under memory/short_term/).
     "*/memory/control_panel_api.py",  # FastAPI REST server
     "*/memory/short_term/sessions.py",  # Requires Redis server
     # claude_memory.py omit entry removed 2026-07-21 (#1569): its
     # Requires-Claude-API label was false — pure file I/O, keyless
     # 60-test suite, measures ~100% covered.
-    # Agent modules requiring live LLM
-    "*/agents/release/release_prep_team.py",  # Requires LLM API calls
-    # OpenTelemetry backend (requires otel infrastructure)
-    "*/monitoring/otel_backend.py",  # Requires OpenTelemetry SDK
-    # Orchestration execution (requires external services)
-    "*/orchestration/execution_strategies.py",  # Requires live agents
-    "*/orchestration/_strategies/base.py",  # Abstract base strategies
-    # Meta-workflow CLI commands (interactive)
+    # release_prep_team.py entry removed 2026-07-29 (#1569 omit-audit
+    # pass 2): its Requires-LLM label was false — 100% suite lives in
+    # tests/unit/agents/ (#1740/#1741).
+    # otel_backend.py entry removed 2026-07-29 (same pass): three
+    # dedicated suites in tests/unit/monitoring/ measure it 100%.
+    # execution_strategies.py entry removed 2026-07-29 (same pass):
+    # measures 94% from existing unit consumers — no live agents used.
+    # Orchestration strategy base (undertested — convert after a QA pass)
+    "*/orchestration/_strategies/base.py",  # justified-other: 46% measured, needs tests before conversion
+    # Meta-workflow CLI commands
     "*/meta_workflows/cli_meta_workflows.py",  # CLI entry
-    "*/meta_workflows/cli_commands/analytics_commands.py",  # Interactive analytics
-    "*/meta_workflows/cli_commands/template_commands.py",  # Interactive templates
-    "*/meta_workflows/cli_commands/config_commands.py",  # Interactive config
-    "*/meta_workflows/cli_commands/memory_commands.py",  # Interactive memory
+    # The five cli_commands modules below were removed from this list
+    # 2026-07-29 (#1569 omit-audit pass 2): their Interactive labels
+    # were false — dedicated suites in tests/unit/meta_workflows/
+    # measure them 99-100% keylessly.
     # Hook scripts (run as standalone processes via Claude Code)
     "*/hooks/scripts/evaluate_session.py",  # Standalone hook
     "*/hooks/scripts/first_time_init.py",  # Standalone hook
@@ -766,7 +770,6 @@ omit = [
     # Models main entry
     "*/models/__main__.py",  # Models CLI entry point
     "*/hooks/scripts/help_freshness_nudge.py",  # Standalone hook script (not importable via pytest)
-    "*/meta_workflows/cli_commands/agent_commands.py",  # Interactive agent CLI (requires live Claude agent loop)
     "*/attune/config.py",  # Shadowed by attune/config/ package — unreachable import
 ]
 branch = true


### PR DESCRIPTION
Chair-directed continuation of the QA #6 omit audit (`docs/specs/test-quality-program/omit-audit.md` — pass-2 section added with the full table).

**Converted (removed from omit — measured with a scoped run over each candidate's own suites, 1027 tests keyless; subset = lower bound, so these are proven):**

| Entry | Claimed reason | Measured |
|---|---|---|
| `release_prep_team.py` | "Requires LLM API calls" | **100%** (today's #1740/#1741 suites) |
| `otel_backend.py` | "Requires OpenTelemetry SDK" | **100%** (3 dedicated suites) |
| `execution_strategies.py` | "Requires live agents" | **94%** |
| 5× `meta_workflows/cli_commands/*` | "Interactive" | **99–100%** each |

**Dead glob removed:** `*/memory/cross_session.py` matches no file on disk.

**Kept omitted, honest labels:** `_strategies/base.py` (46%, relabeled justified-other), `project_index/index.py` (18%), `scanner_parallel.py` (17%) — QA-pass candidates, not conversions.

**Net effect:** ~930 statements of ~99%-covered production code re-enter the measured denominator — the project coverage total rises; the coverage lane verifies live on this PR. Omit-documentation pre-commit check passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)