### PR TITLE
feat(collab): feature-lead pilot — lead rule projected, base.py to 100%, first delegated lane

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -57,6 +57,29 @@ attune_redis/          # Redis plugin — bundled in the attune-ai wheel
 - Keep provider-specific setup in adapters. The shared contract must
   still work when only one provider is available.
 
+### Lead programmer and delegation
+
+- The project has a **lead programmer: Claude**, global by default.
+  A per-feature lead may be set via the feature-lead-governance
+  spec's mechanism; where one is set, it overrides the global
+  default for that feature only (feature lead, not permanent model
+  owner — its D1).
+- The lead owns integration, synthesis, central receipt re-runs,
+  and the final recommendation below the chair. Other seats work
+  ADVISORY: their findings and drafts route through the lead, and
+  they should expect the lead to integrate, amend, or decline with
+  a recorded reason. Only the chair promotes (R8).
+- **Receipt-declared delegation is binding for cross-provider
+  lanes**: every delegated lane names its receipt type(s) at
+  launch (suite / behavioral / live-fire / metric /
+  evidence-chain), and the lead re-runs the receipts centrally
+  before work reaches the chair. A seat's self-report is never
+  the receipt.
+- Delegated runs during the feature-lead pilot are recorded in the
+  cross-review R5 dogfood ledger
+  (`docs/specs/cross-review/receipts.md`) — they are the evidence
+  P1 activation waits on.
+
 ### Artifact selection
 
 - Match the artifact to the work before non-trivial implementation and

--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -69,6 +69,12 @@ attune_redis/          # Redis plugin — bundled in the attune-ai wheel
   ADVISORY: their findings and drafts route through the lead, and
   they should expect the lead to integrate, amend, or decline with
   a recorded reason. Only the chair promotes (R8).
+- **Single-provider fallback:** when the lead's provider is absent
+  from a session, lead duties devolve to the CHAIR (integration and
+  final recommendation), the active provider works
+  advisory-to-the-chair, and receipt re-runs fall to whatever
+  provider is present. The contract stays executable with one
+  provider; the lead role resumes when its provider returns.
 - **Receipt-declared delegation is binding for cross-provider
   lanes**: every delegated lane names its receipt type(s) at
   launch (suite / behavioral / live-fire / metric /

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -62,6 +62,12 @@ See `docs/reference/cli-reference.md`.
   ADVISORY: their findings and drafts route through the lead, and
   they should expect the lead to integrate, amend, or decline with
   a recorded reason. Only the chair promotes (R8).
+- **Single-provider fallback:** when the lead's provider is absent
+  from a session, lead duties devolve to the CHAIR (integration and
+  final recommendation), the active provider works
+  advisory-to-the-chair, and receipt re-runs fall to whatever
+  provider is present. The contract stays executable with one
+  provider; the lead role resumes when its provider returns.
 - **Receipt-declared delegation is binding for cross-provider
   lanes**: every delegated lane names its receipt type(s) at
   launch (suite / behavioral / live-fire / metric /

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -50,6 +50,29 @@ See `docs/reference/cli-reference.md`.
 - Keep provider-specific setup in adapters. The shared contract must
   still work when only one provider is available.
 
+### Lead programmer and delegation
+
+- The project has a **lead programmer: Claude**, global by default.
+  A per-feature lead may be set via the feature-lead-governance
+  spec's mechanism; where one is set, it overrides the global
+  default for that feature only (feature lead, not permanent model
+  owner — its D1).
+- The lead owns integration, synthesis, central receipt re-runs,
+  and the final recommendation below the chair. Other seats work
+  ADVISORY: their findings and drafts route through the lead, and
+  they should expect the lead to integrate, amend, or decline with
+  a recorded reason. Only the chair promotes (R8).
+- **Receipt-declared delegation is binding for cross-provider
+  lanes**: every delegated lane names its receipt type(s) at
+  launch (suite / behavioral / live-fire / metric /
+  evidence-chain), and the lead re-runs the receipts centrally
+  before work reaches the chair. A seat's self-report is never
+  the receipt.
+- Delegated runs during the feature-lead pilot are recorded in the
+  cross-review R5 dogfood ledger
+  (`docs/specs/cross-review/receipts.md`) — they are the evidence
+  P1 activation waits on.
+
 ### Artifact selection
 
 - Match the artifact to the work before non-trivial implementation and

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,6 +57,29 @@ attune_redis/          # Redis plugin — bundled in the attune-ai wheel
 - Keep provider-specific setup in adapters. The shared contract must
   still work when only one provider is available.
 
+### Lead programmer and delegation
+
+- The project has a **lead programmer: Claude**, global by default.
+  A per-feature lead may be set via the feature-lead-governance
+  spec's mechanism; where one is set, it overrides the global
+  default for that feature only (feature lead, not permanent model
+  owner — its D1).
+- The lead owns integration, synthesis, central receipt re-runs,
+  and the final recommendation below the chair. Other seats work
+  ADVISORY: their findings and drafts route through the lead, and
+  they should expect the lead to integrate, amend, or decline with
+  a recorded reason. Only the chair promotes (R8).
+- **Receipt-declared delegation is binding for cross-provider
+  lanes**: every delegated lane names its receipt type(s) at
+  launch (suite / behavioral / live-fire / metric /
+  evidence-chain), and the lead re-runs the receipts centrally
+  before work reaches the chair. A seat's self-report is never
+  the receipt.
+- Delegated runs during the feature-lead pilot are recorded in the
+  cross-review R5 dogfood ledger
+  (`docs/specs/cross-review/receipts.md`) — they are the evidence
+  P1 activation waits on.
+
 ### Artifact selection
 
 - Match the artifact to the work before non-trivial implementation and

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,6 +69,12 @@ attune_redis/          # Redis plugin — bundled in the attune-ai wheel
   ADVISORY: their findings and drafts route through the lead, and
   they should expect the lead to integrate, amend, or decline with
   a recorded reason. Only the chair promotes (R8).
+- **Single-provider fallback:** when the lead's provider is absent
+  from a session, lead duties devolve to the CHAIR (integration and
+  final recommendation), the active provider works
+  advisory-to-the-chair, and receipt re-runs fall to whatever
+  provider is present. The contract stays executable with one
+  provider; the lead role resumes when its provider returns.
 - **Receipt-declared delegation is binding for cross-provider
   lanes**: every delegated lane names its receipt type(s) at
   launch (suite / behavioral / live-fire / metric /

--- a/content/collaboration/contract.md
+++ b/content/collaboration/contract.md
@@ -29,6 +29,29 @@ hand-edit its projected blocks or the handoff template.
 - Keep provider-specific setup in adapters. The shared contract must
   still work when only one provider is available.
 
+### Lead programmer and delegation
+
+- The project has a **lead programmer: Claude**, global by default.
+  A per-feature lead may be set via the feature-lead-governance
+  spec's mechanism; where one is set, it overrides the global
+  default for that feature only (feature lead, not permanent model
+  owner — its D1).
+- The lead owns integration, synthesis, central receipt re-runs,
+  and the final recommendation below the chair. Other seats work
+  ADVISORY: their findings and drafts route through the lead, and
+  they should expect the lead to integrate, amend, or decline with
+  a recorded reason. Only the chair promotes (R8).
+- **Receipt-declared delegation is binding for cross-provider
+  lanes**: every delegated lane names its receipt type(s) at
+  launch (suite / behavioral / live-fire / metric /
+  evidence-chain), and the lead re-runs the receipts centrally
+  before work reaches the chair. A seat's self-report is never
+  the receipt.
+- Delegated runs during the feature-lead pilot are recorded in the
+  cross-review R5 dogfood ledger
+  (`docs/specs/cross-review/receipts.md`) — they are the evidence
+  P1 activation waits on.
+
 ### Artifact selection
 
 - Match the artifact to the work before non-trivial implementation and

--- a/content/collaboration/contract.md
+++ b/content/collaboration/contract.md
@@ -41,6 +41,12 @@ hand-edit its projected blocks or the handoff template.
   ADVISORY: their findings and drafts route through the lead, and
   they should expect the lead to integrate, amend, or decline with
   a recorded reason. Only the chair promotes (R8).
+- **Single-provider fallback:** when the lead's provider is absent
+  from a session, lead duties devolve to the CHAIR (integration and
+  final recommendation), the active provider works
+  advisory-to-the-chair, and receipt re-runs fall to whatever
+  provider is present. The contract stays executable with one
+  provider; the lead role resumes when its provider returns.
 - **Receipt-declared delegation is binding for cross-provider
   lanes**: every delegated lane names its receipt type(s) at
   launch (suite / behavioral / live-fire / metric /

--- a/docs/specs/cross-review/receipts.md
+++ b/docs/specs/cross-review/receipts.md
@@ -14,6 +14,7 @@ ids recorded per T3's live-fire check. Dispositions ruled by Patrick
 | 2026-07-29 | codex | branch vs merge-base cd55f3839 (origin/main) — lessons docs diff | 1 sent / 0 omitted | 1 (findings) | dismissed — dated context by design |
 | 2026-07-29 | antigravity | branch vs merge-base cd55f3839 (origin/main) — lessons docs diff | 1 sent / 0 omitted | 0 (clean) | clean |
 | 2026-07-29 | codex | branch vs merge-base e7fa7e088 (origin/main) — feature-page docs branch | 23 sent / 7 omitted | 3 (findings) | stale-branch — carry only if revived |
+| 2026-07-29 | codex | branch vs merge-base 51bc7550f (origin/main) — feature-lead PILOT diff (contract lead rule + base.py QA) | 6 sent / 0 omitted | 1 (findings) | real — accepted and fixed in-branch (single-provider lead fallback) |
 
 Board threads (live-fire check): `review-detached-20260729-0036`,
 `review-detached-20260729-0037`,

--- a/docs/specs/feature-lead-governance/decisions.md
+++ b/docs/specs/feature-lead-governance/decisions.md
@@ -226,3 +226,29 @@ receipt-declared delegation rule is BINDING for cross-LLM lanes:
 every delegated lane names its receipt type at launch and the lead
 re-runs receipts centrally — a seat's self-report is never the
 receipt. Both land as the pilot's first tasks.
+
+## 2026-07-29 — Pilot FIRED; first delegated lane complete (lead record)
+
+Chair fired the D8 pilot the same evening. Receipts:
+
+- **Task A (substrate):** lead-programmer + receipt-declared
+  delegation clauses landed in the contract master and projected to
+  all three provider surfaces (AGENTS.md, .agents/AGENTS.md,
+  .claude/CLAUDE.md).
+- **Task B (pilot module):** `orchestration/_strategies/base.py`
+  46% → 100% (net-new `test_execution_strategy_base.py`, 13 tests,
+  serial pass); omit entry converted per its convert-after-QA note.
+- **Task C (delegated lane):** codex seat reviewed the REAL pilot
+  diff (6 files sent, 0 omitted; board thread
+  `review-pilot-feature-lead-base-strategies-20260729-1420`).
+  ONE high finding — the lead clause contradicted the contract's
+  single-provider requirement. **Lead disposition: ACCEPTED, fixed
+  in-branch** (single-provider fallback: lead duties devolve to the
+  chair; contract stays one-provider-executable). Ledger row
+  appended to the R5 dogfood ledger (feeds P1) with disposition
+  `real`.
+
+Pilot observation for the P1 evidence stream: the delegated seat's
+first finding was a real defect in the lead's OWN work — the
+different-model review caught what the author could not. That is
+the accepted-vs-rejected signal the gate measures, seeded run 1.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -738,8 +738,9 @@ omit = [
     # dedicated suites in tests/unit/monitoring/ measure it 100%.
     # execution_strategies.py entry removed 2026-07-29 (same pass):
     # measures 94% from existing unit consumers — no live agents used.
-    # Orchestration strategy base (undertested — convert after a QA pass)
-    "*/orchestration/_strategies/base.py",  # justified-other: 46% measured, needs tests before conversion
+    # _strategies/base.py entry removed 2026-07-29 (feature-lead
+    # pilot QA pass): 46% -> 100% via
+    # tests/unit/orchestration/test_execution_strategy_base.py.
     # Meta-workflow CLI commands
     "*/meta_workflows/cli_meta_workflows.py",  # CLI entry
     # The five cli_commands modules below were removed from this list

--- a/tests/unit/orchestration/test_execution_strategy_base.py
+++ b/tests/unit/orchestration/test_execution_strategy_base.py
@@ -1,0 +1,221 @@
+"""ExecutionStrategy base seams (feature-lead pilot QA pass, #1569).
+
+Covers `_execute_agent`'s real-tool dispatch table — every branch
+maps an agent id/role to a Real* analyzer and reshapes its report
+into the workflow-facing output dict — plus the exception fallback
+and `_aggregate_results`. The Real* classes are stubbed at their
+import site (`attune.orchestration.real_tools`); no subprocess, no
+filesystem scans.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under Apache 2.0
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from attune.orchestration import real_tools
+from attune.orchestration._strategies.base import ExecutionStrategy
+
+
+class OneShot(ExecutionStrategy):
+    """Minimal concrete strategy — the ABC needs execute() defined."""
+
+    async def execute(self, agents, context):  # pragma: no cover - unused
+        raise NotImplementedError
+
+
+def agent(agent_id: str, role: str = "generic role") -> SimpleNamespace:
+    return SimpleNamespace(id=agent_id, role=role)
+
+
+def run(agent_stub, context: dict[str, Any] | None = None):
+    return asyncio.run(OneShot()._execute_agent(agent_stub, context or {}))
+
+
+def analyzer_returning(report):
+    """A Real*-shaped class whose analyze/audit returns ``report``."""
+
+    class Fake:
+        def __init__(self, project_root):
+            self.project_root = project_root
+
+        def audit(self, target):
+            return report
+
+        def analyze(self, target=None):
+            return report
+
+    return Fake
+
+
+class TestDispatchBranches:
+    def test_security_branch_maps_report(self, monkeypatch):
+        report = SimpleNamespace(
+            total_issues=3,
+            critical_count=1,
+            high_count=1,
+            medium_count=1,
+            passed=False,
+            issues_by_file={"a.py": 3},
+        )
+        monkeypatch.setattr(real_tools, "RealSecurityAuditor", analyzer_returning(report))
+        result = run(agent("security_auditor", "Security Auditor"))
+        assert result.success is False
+        assert result.output["critical_issues"] == 1
+        assert result.output["total_issues"] == 3
+        assert result.confidence == 0.7  # issues present
+
+    def test_security_clean_run_full_confidence_via_role(self, monkeypatch):
+        report = SimpleNamespace(
+            total_issues=0,
+            critical_count=0,
+            high_count=0,
+            medium_count=0,
+            passed=True,
+            issues_by_file={},
+        )
+        monkeypatch.setattr(real_tools, "RealSecurityAuditor", analyzer_returning(report))
+        # role-based dispatch: unknown id, "security" in role
+        result = run(agent("custom-1", "App Security Reviewer"))
+        assert result.success is True
+        assert result.confidence == 1.0
+
+    def test_coverage_branch_thresholds(self, monkeypatch):
+        report = SimpleNamespace(total_coverage=72.0, files_analyzed=10, uncovered_files=["x.py"])
+        monkeypatch.setattr(real_tools, "RealCoverageAnalyzer", analyzer_returning(report))
+        result = run(agent("test_coverage_analyzer", "Coverage"))
+        assert result.success is False  # < 80
+        assert result.output["coverage_percent"] == 72.0
+        assert result.confidence == pytest.approx(0.72)
+
+    def test_quality_branch(self, monkeypatch):
+        report = SimpleNamespace(
+            quality_score=8.5, ruff_issues=2, mypy_issues=0, total_files=5, passed=True
+        )
+        monkeypatch.setattr(real_tools, "RealCodeQualityAnalyzer", analyzer_returning(report))
+        result = run(agent("code_reviewer", "Quality Reviewer"))
+        assert result.success is True
+        assert result.output["quality_score"] == 8.5
+        assert result.confidence == pytest.approx(0.85)
+
+    def test_documentation_branch(self, monkeypatch):
+        report = SimpleNamespace(
+            completeness_percentage=90.0,
+            total_functions=10,
+            documented_functions=9,
+            total_classes=2,
+            documented_classes=2,
+            missing_docstrings=["f"],
+            passed=True,
+        )
+        monkeypatch.setattr(real_tools, "RealDocumentationAnalyzer", analyzer_returning(report))
+        result = run(agent("documentation_writer", "Documentation"))
+        assert result.output["coverage_percent"] == 90.0  # release-prep field alias
+        assert result.confidence == pytest.approx(0.9)
+
+    def test_performance_branch(self, monkeypatch):
+        report = SimpleNamespace(
+            score=6.0,
+            total_files=4,
+            functions_analyzed=40,
+            high_complexity=["f1"],
+            large_functions=["f2", "f3"],
+            passed=False,
+        )
+        monkeypatch.setattr(real_tools, "RealPerformanceProfiler", analyzer_returning(report))
+        result = run(agent("performance_optimizer", "Performance"))
+        assert result.success is False
+        assert result.output["high_complexity_count"] == 1
+        assert result.output["large_functions_count"] == 2
+        assert result.confidence == pytest.approx(0.6)
+
+    def test_architecture_branch(self, monkeypatch):
+        report = SimpleNamespace(
+            score=9.0,
+            total_modules=30,
+            total_packages=6,
+            max_depth=4,
+            circular_imports=[],
+            high_coupling=["m"],
+            passed=True,
+        )
+        monkeypatch.setattr(real_tools, "RealArchitectureAnalyzer", analyzer_returning(report))
+        result = run(agent("architecture_analyst", "Architecture"))
+        assert result.output["circular_imports"] == 0
+        assert result.output["high_coupling_count"] == 1
+        assert result.confidence == pytest.approx(0.9)
+
+    def test_test_generator_placeholder(self):
+        result = run(agent("test_generator", "Test Generator"))
+        assert result.success is True
+        assert "manual invocation" in result.output["message"]
+        assert result.confidence == 0.8
+
+    def test_unknown_agent_placeholder(self):
+        result = run(agent("mystery", "Mystery Role"))
+        assert result.success is True
+        assert result.output["agent_id"] == "mystery"
+        assert result.confidence == 0.5
+
+    def test_context_paths_reach_the_analyzer(self, monkeypatch):
+        seen = {}
+
+        class Probe:
+            def __init__(self, project_root):
+                seen["root"] = project_root
+
+            def audit(self, target):
+                seen["target"] = target
+                return SimpleNamespace(
+                    total_issues=0,
+                    critical_count=0,
+                    high_count=0,
+                    medium_count=0,
+                    passed=True,
+                    issues_by_file={},
+                )
+
+        monkeypatch.setattr(real_tools, "RealSecurityAuditor", Probe)
+        run(agent("security_auditor"), {"project_root": "/repo", "target_path": "pkg"})
+        assert seen == {"root": "/repo", "target": "pkg"}
+
+    def test_analyzer_exception_becomes_failed_result(self, monkeypatch):
+        class Boom:
+            def __init__(self, project_root):
+                raise RuntimeError("tool exploded")
+
+        monkeypatch.setattr(real_tools, "RealSecurityAuditor", Boom)
+        result = run(agent("security_auditor"))
+        assert result.success is False
+        assert result.error == "tool exploded"
+        assert result.confidence == 0.0
+        assert result.output["error_details"] == "tool exploded"
+        assert result.duration_seconds >= 0
+
+
+class TestAggregateResults:
+    def test_aggregates_success_and_confidence(self):
+        results = [
+            SimpleNamespace(success=True, confidence=1.0, output={"a": 1}),
+            SimpleNamespace(success=False, confidence=0.5, output={"b": 2}),
+        ]
+        agg = OneShot()._aggregate_results(results)
+        assert agg["num_agents"] == 2
+        assert agg["all_succeeded"] is False
+        assert agg["avg_confidence"] == pytest.approx(0.75)
+        assert agg["outputs"] == [{"a": 1}, {"b": 2}]
+
+    def test_empty_results_zero_confidence(self):
+        agg = OneShot()._aggregate_results([])
+        assert agg == {
+            "num_agents": 0,
+            "all_succeeded": True,
+            "avg_confidence": 0.0,
+            "outputs": [],
+        }


### PR DESCRIPTION
The D8/D9 pilot, executed end-to-end (record: feature-lead-governance decisions.md, 2026-07-29 pilot entry):

- **Substrate**: lead-programmer + receipt-declared-delegation clauses in the contract master, projected to all three provider surfaces — stateless seats now carry the role structurally.
- **Pilot module QA**: `_strategies/base.py` 46% → **100%** (13 behavioral tests at the real_tools seam); omit entry converted per its own convert-after-QA note.
- **First delegated lane**: codex reviewed the real pilot diff (6 files, 0 omitted, board-posted). Its ONE high finding was a real defect in the lead's own work — the lead clause contradicted the contract's single-provider requirement. Accepted and fixed in-branch (single-provider fallback: lead duties devolve to the chair). R5 ledger row appended with disposition `real` — the pilot's first accepted-finding signal for the P1 evidence stream.

Receipts: 606 orchestration+quality tests CI-style; contract projection check green; omit checker green; commits signed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)