### PR TITLE
fix(patterns): persist outcome + graph in PersistentPatternLibrary; pilot lane 2 records

### DIFF
--- a/.claude/lessons.md
+++ b/.claude/lessons.md
@@ -19429,3 +19429,24 @@ def ", start_idx + 1)` for module-
   runs lie") is the same fact used in the other direction — a
   subset number is a valid floor and an invalid ceiling. Pick
   targets from FULL baselines; prove conversions with SCOPED runs.
+
+- **Persistence-by-override subclasses must cover EVERY base
+  mutator — audit the base class's mutation surface, not just the
+  method you came for (2026-07-29, pilot lane 2)**:
+  `PersistentPatternLibrary` overrode `contribute_pattern` to stash
+  on write, but `record_pattern_outcome` and `link_patterns` were
+  inherited unpersisted — outcomes and links survived only for the
+  life of the process, so cross-session `success_rate` was always
+  0.0 and the pattern graph reset on every reload. Unit tests all
+  passed (they exercised one process); the gap only showed in a
+  TWO-PROCESS round-trip probe (A: usage=2 → B: usage=0). Rules:
+  (1) when a subclass adds persistence by overriding mutators,
+  enumerate ALL base methods that mutate state and cover or
+  explicitly exempt each; (2) the receipt for "persists across
+  sessions" is a two-process probe, never a same-process
+  save-then-read; (3) serializer round-trip fields (here
+  usage/success/failure counts were already serialized) can mask
+  the gap — the WRITE path, not the schema, is where these bugs
+  live. Pairs with "registered ≠ working" (same family: the
+  mocked/single-process test passes precisely where the live loop
+  fails).

--- a/docs/specs/feature-lead-governance/decisions.md
+++ b/docs/specs/feature-lead-governance/decisions.md
@@ -252,3 +252,42 @@ Pilot observation for the P1 evidence stream: the delegated seat's
 first finding was a real defect in the lead's OWN work — the
 different-model review caught what the author could not. That is
 the accepted-vs-rejected signal the gate measures, seeded run 1.
+
+## 2026-07-29 — Pilot lane 2: PatternLibrary persistence verdict + P1 signal store wired (lead record)
+
+Queued chair directive: round-trip `PatternLibrary` persistence
+FIRST; wire lead finding-dispositions into
+`record_pattern_outcome()` as the P1 accepted/rejected signal store
+if patterns survive across sessions, else log the verdict and keep
+the R5 ledger as the store.
+
+**Probe verdict (two-process receipt): MIXED.** Contributions
+survive across sessions (`PersistentPatternLibrary` stashes on
+`contribute_pattern`), but outcome recordings did NOT — the
+subclass never overrode `record_pattern_outcome`, so process A's
+`usage=2 success=1` reloaded in process B as `usage=0 success=0`.
+Links (`link_patterns`) had the same defect. Cross-session
+`success_rate` was fiction — exactly the field the P1 signal needs.
+
+**Lead action (bug-fix authority + scope-widening initiative):**
+persisted both mutators in `src/attune/pattern_review.py`
+(re-stash after `record_pattern_outcome`; graph stashed under a
+dedicated `pattern_graph` key and restored in `_load`), with
+regression tests. Post-fix probe: `usage=2 success=1` survives
+reload. With the fix, the directive's wire-up condition genuinely
+holds.
+
+**Wiring (one wheel):** seeded the live store (AMS/Redis backend)
+with pattern `cross_review_delegated_lane` — each lead disposition
+of a delegated-lane finding records `accepted=success` /
+`rejected=failure`; `success_rate` IS the P1 accepted-rate signal.
+Run 1 (codex lane, ACCEPTED) recorded: fresh-process read shows
+`usage=1 success=1 rate=1.00`. The R5 ledger stays the
+human-readable narrative receipt; the pattern store is the
+machine-readable counter — same events, one corpus each side, no
+second memory system.
+
+**Known residual (flagged, not built):** dispositions are recorded
+by the lead at disposition time (procedural); no automation fires
+`record_pattern_outcome` from ledger edits. Acceptable at pilot
+scale; revisit at P1 activation if manual recording drifts.

--- a/docs/specs/feature-lead-governance/principles-section-draft.md
+++ b/docs/specs/feature-lead-governance/principles-section-draft.md
@@ -1,0 +1,125 @@
+# DRAFT — Principles section for the collaboration contract master
+
+**Status:** DRAFT for chair review — NOT ruled, NOT projected.
+**Author:** lead (2026-07-29 session), per the queued chair float
+("expand a principles document") and the lead counter-shape: every
+principle CITES its enforcer; anything without one is marked
+**aspirational** so the gap is visible instead of implied.
+**Target on approval:** a `### Principles` section in
+`content/collaboration/contract.md` (the projector master), landed
+via `scripts/project_collaboration_contract.py` so all three
+provider surfaces carry it.
+
+---
+
+## Proposed section text
+
+### Principles
+
+Every principle below names its enforcer — the ratchet, gate, hook,
+or drift-guard test that makes it true without anyone remembering
+it. A principle marked **aspirational** has no mechanical enforcer
+yet: treat it as binding discipline, and treat adding its enforcer
+as pickable work.
+
+1. **The receipt beats the promise.** "Configured", "registered",
+   and "exited 0" are claims; evidence of the user-visible behavior
+   is the receipt. Delegated lanes declare their receipt type at
+   launch and the lead re-runs receipts centrally.
+   *Enforcer: **aspirational** (ruled discipline —
+   `decision-routine.md` delegation receipts + this contract's
+   Verification receipts section; no mechanical gate).*
+
+2. **The code is the contract; spec text is a hypothesis.** Before
+   executing any spec-named scope, grep the code for the property
+   the phase targets and execute against THAT set.
+   *Enforcer: **aspirational** (lessons-core rule; no gate can
+   check intent — partially backstopped by drift guards below).*
+
+3. **One source, projected — never hand-edited twins.** Skills,
+   the collaboration contract, help pages, and docs feature pages
+   are projections; edit the master and re-project.
+   *Enforcers: `tests/unit/plugins/test_sync_agents_skills.py`
+   (skills mirror), `tests/unit/scripts/
+   test_project_collaboration_contract.py` (contract blocks),
+   `tests/unit/lessons/test_core_mirror.py` (lessons core),
+   `tests/unit/authoring/test_projection_drift.py` (authored
+   projections) — all fail CI on drift.*
+
+4. **Dangerous constructs are blocked, not discouraged.** No
+   `eval`/`exec`, no unvalidated file paths, no bare `except`.
+   *Enforcers: `src/attune/hooks/scripts/security_guard.py`
+   (PreToolUse block on eval/exec), pre-commit detect-secrets,
+   security tests required for file-op code (reviewed, not
+   gated — that half is **aspirational**).*
+
+5. **Coverage is a floor, not a goal.** Changed code carries
+   ≥80% coverage; the local bar is 85%.
+   *Enforcers: codecov project+patch gates (80%),
+   `tests/unit/ci/test_workflow_yaml.py::
+   test_coverage_threshold_is_at_least_80` (the threshold itself
+   is drift-guarded).*
+
+6. **CI spends attention, never money.** Per-push/PR workflows run
+   keyless (`ANTHROPIC_API_KEY: ""`); the real secret lives only in
+   scheduled, budget-capped jobs.
+   *Enforcer: **aspirational** (ruled after the 2026-06-10 burn;
+   workflow YAML is tested for timeouts/pinning/concurrency in
+   `tests/unit/ci/test_workflow_yaml.py`, but no test yet asserts
+   the keyless invariant — candidate enforcer to add).*
+
+7. **A failed gatekeeper fails the gate.** A security auditor that
+   errors or goes missing fails the Security gate — absence is not
+   a pass.
+   *Enforcer: sentinel semantics pinned by
+   `tests/unit/agents/test_release_prep_team_orchestration.py`
+   (chair-ruled 2026-07-29).*
+
+8. **Docs may not cite fiction.** A doc that names a symbol which
+   no longer imports fails CI.
+   *Enforcers: `doc-import-audit` CI job +
+   `tests/unit/test_generated_doc_import_drift.py`; wiring claims
+   checked by the `wiring-audit` job.*
+
+9. **Identity and brand drift are ratcheted.** Legacy identifiers
+   and retired framing cannot re-enter the tree.
+   *Enforcers: G5 brand-drift pre-commit gate +
+   `tests/unit/gates/test_brand_drift.py`,
+   `tests/unit/gates/test_claim_drift.py`.*
+
+10. **Context is budgeted.** Always-loaded rule bodies fit a
+    byte budget; everything else is JIT-recalled via the index.
+    *Enforcer: `tests/unit/rules/test_rules_residency_budget.py`.*
+
+11. **Seats advise; the chair promotes; the lead integrates.**
+    Cross-provider seats are advisory, the integrating lead owns
+    synthesis and central receipt re-runs below the chair, and only
+    the chair promotes (R8).
+    *Enforcer: **aspirational** (governance ruling, D8/D9 +
+    R8 — carried by this contract's text on all provider surfaces;
+    inherently procedural).*
+
+12. **Memory is derived, never authored in the serving layer.**
+    Durable findings land in the tracked corpus (lessons, spec
+    decisions, handoffs); Redis indexes are hydrated projections.
+    *Enforcer: **aspirational** (contract text; hydration
+    overwrites hand-written keys on the next run, which is a
+    ratchet-by-reconstruction, but nothing blocks the direct
+    write).*
+
+---
+
+## Notes for the chair (not part of the section)
+
+- Two principles surfaced **enforcer gaps** worth pickable-work
+  rows: (a) a workflow-YAML test asserting per-push/PR jobs pin
+  provider API-key secrets (`ANTHROPIC_API_KEY` et al.) to `""`
+  (principle 6);
+  (b) a path-validation gate for file-op code (principle 4's
+  second half).
+- Deliberately NOT included: style rules (black/ruff enforce
+  themselves), and anything that is one session's preference
+  rather than a cross-provider invariant.
+- If approved, the section lands in the master + one projector
+  run; the draft file is then deleted (single-source rule,
+  principle 3, applied to itself).

--- a/docs/specs/feature-lead-governance/principles-section-draft.md
+++ b/docs/specs/feature-lead-governance/principles-section-draft.md
@@ -62,11 +62,11 @@ as pickable work.
 
 6. **CI spends attention, never money.** Per-push/PR workflows run
    keyless (`ANTHROPIC_API_KEY: ""`); the real secret lives only in
-   scheduled, budget-capped jobs.
-   *Enforcer: **aspirational** (ruled after the 2026-06-10 burn;
-   workflow YAML is tested for timeouts/pinning/concurrency in
-   `tests/unit/ci/test_workflow_yaml.py`, but no test yet asserts
-   the keyless invariant — candidate enforcer to add).*
+   allowlisted, manually-dispatched or budget-capped jobs.
+   *Enforcers: `tests/unit/ci/test_ci_spend_guard.py` (secret refs
+   allowlisted, non-allowlisted assignments must be `""`),
+   `tests/unit/ci/test_workflow_yaml.py`
+   (timeouts/pinning/concurrency).*
 
 7. **A failed gatekeeper fails the gate.** A security auditor that
    errors or goes missing fails the Security gate — absence is not
@@ -111,12 +111,12 @@ as pickable work.
 
 ## Notes for the chair (not part of the section)
 
-- Two principles surfaced **enforcer gaps** worth pickable-work
-  rows: (a) a workflow-YAML test asserting per-push/PR jobs pin
-  provider API-key secrets (`ANTHROPIC_API_KEY` et al.) to `""`
-  (principle 6);
-  (b) a path-validation gate for file-op code (principle 4's
-  second half).
+- One principle surfaced an **enforcer gap** worth a pickable-work
+  row: a path-validation gate for file-op code (principle 4's
+  second half). A second suspected gap (keyless-CI invariant)
+  turned out to be already enforced by
+  `tests/unit/ci/test_ci_spend_guard.py` — the grep-for-existing-
+  enforcer rule caught it before a duplicate was built.
 - Deliberately NOT included: style rules (black/ruff enforce
   themselves), and anything that is one session's preference
   rather than a cross-provider invariant.

--- a/src/attune/pattern_review.py
+++ b/src/attune/pattern_review.py
@@ -297,3 +297,12 @@ class PersistentPatternLibrary(PatternLibrary):
         """Validate + add in memory (base behaviour), then persist to the backend."""
         PatternLibrary.contribute_pattern(self, agent_id, pattern)
         self._backend.stash(ACTIVE_PREFIX + pattern.id, _pattern_to_dict(pattern))
+
+    def record_pattern_outcome(self, pattern_id: str, success: bool) -> None:
+        """Record the outcome (base behaviour), then re-persist the pattern.
+
+        Without the re-stash, usage/success/failure counts survive only for
+        the life of the process and every reload resets ``success_rate``.
+        """
+        PatternLibrary.record_pattern_outcome(self, pattern_id, success)
+        self._backend.stash(ACTIVE_PREFIX + pattern_id, _pattern_to_dict(self.patterns[pattern_id]))

--- a/src/attune/pattern_review.py
+++ b/src/attune/pattern_review.py
@@ -34,6 +34,10 @@ logger = logging.getLogger(__name__)
 STAGED_PREFIX = "staged_pattern:"
 #: Key prefix for active (promoted) library patterns in the same store.
 ACTIVE_PREFIX = "pattern:"
+#: Key holding the persisted pattern relation graph (outside the
+#: ``pattern:*`` glob, so :meth:`PersistentPatternLibrary._load` never
+#: tries to parse it as a pattern).
+GRAPH_KEY = "pattern_graph"
 #: Env var gating opt-in review routing of contributed patterns (R7).
 REVIEW_ENABLED_ENV = "ATTUNE_PATTERN_REVIEW"
 #: Truthy spellings that turn review routing on.
@@ -292,6 +296,11 @@ class PersistentPatternLibrary(PatternLibrary):
             except ValueError:
                 # Duplicate id already loaded — skip the redundant copy.
                 continue
+        stored_graph = self._backend.retrieve(GRAPH_KEY)
+        if isinstance(stored_graph, dict):
+            for pid, related in stored_graph.items():
+                if pid in self.patterns and isinstance(related, list):
+                    self.pattern_graph[pid] = [r for r in related if r in self.patterns]
 
     def contribute_pattern(self, agent_id: str, pattern: Pattern) -> None:
         """Validate + add in memory (base behaviour), then persist to the backend."""
@@ -306,3 +315,8 @@ class PersistentPatternLibrary(PatternLibrary):
         """
         PatternLibrary.record_pattern_outcome(self, pattern_id, success)
         self._backend.stash(ACTIVE_PREFIX + pattern_id, _pattern_to_dict(self.patterns[pattern_id]))
+
+    def link_patterns(self, pattern_id_1: str, pattern_id_2: str) -> None:
+        """Create the bidirectional link (base behaviour), then persist the graph."""
+        PatternLibrary.link_patterns(self, pattern_id_1, pattern_id_2)
+        self._backend.stash(GRAPH_KEY, dict(self.pattern_graph))

--- a/tests/unit/test_pattern_review.py
+++ b/tests/unit/test_pattern_review.py
@@ -168,6 +168,34 @@ class TestPersistentLibrary:
         assert got.success_count == 1
         assert got.failure_count == 1
 
+    def test_link_patterns_persists_graph_across_reload(self, tmp_path):
+        # Regression: links used to live only in the in-memory pattern_graph.
+        lib = PersistentPatternLibrary(backend=FileStashBackend(base_dir=str(tmp_path)))
+        for pid in ("p1", "p2"):
+            lib.contribute_pattern(
+                "a1",
+                Pattern(
+                    id=pid, agent_id="a1", pattern_type="behavioral", name="n", description="d"
+                ),
+            )
+        lib.link_patterns("p1", "p2")
+        reloaded = PersistentPatternLibrary(backend=FileStashBackend(base_dir=str(tmp_path)))
+        assert reloaded.pattern_graph["p1"] == ["p2"]
+        assert reloaded.pattern_graph["p2"] == ["p1"]
+
+    def test_load_drops_graph_edges_to_missing_patterns(self, tmp_path):
+        be = FileStashBackend(base_dir=str(tmp_path))
+        lib = PersistentPatternLibrary(backend=be)
+        lib.contribute_pattern(
+            "a1",
+            Pattern(id="p1", agent_id="a1", pattern_type="behavioral", name="n", description="d"),
+        )
+        # Stored graph references a pattern that no longer exists in the store.
+        be.stash("pattern_graph", {"p1": ["ghost"], "ghost": ["p1"]})
+        reloaded = PersistentPatternLibrary(backend=FileStashBackend(base_dir=str(tmp_path)))
+        assert reloaded.pattern_graph["p1"] == []
+        assert "ghost" not in reloaded.pattern_graph
+
     def test_record_outcome_absent_id_raises_and_persists_nothing(self, tmp_path):
         be = FileStashBackend(base_dir=str(tmp_path))
         lib = PersistentPatternLibrary(backend=be)

--- a/tests/unit/test_pattern_review.py
+++ b/tests/unit/test_pattern_review.py
@@ -152,6 +152,29 @@ class TestPersistentLibrary:
         assert "p9" in reloaded.patterns
         assert queue.get("p9") is None
 
+    def test_record_outcome_persists_across_reload(self, tmp_path):
+        # Regression: outcomes used to mutate only the in-memory Pattern, so
+        # a reloaded library reset usage/success counts to zero.
+        lib = PersistentPatternLibrary(backend=FileStashBackend(base_dir=str(tmp_path)))
+        lib.contribute_pattern(
+            "a1",
+            Pattern(id="p1", agent_id="a1", pattern_type="behavioral", name="n", description="d"),
+        )
+        lib.record_pattern_outcome("p1", success=True)
+        lib.record_pattern_outcome("p1", success=False)
+        reloaded = PersistentPatternLibrary(backend=FileStashBackend(base_dir=str(tmp_path)))
+        got = reloaded.patterns["p1"]
+        assert got.usage_count == 2
+        assert got.success_count == 1
+        assert got.failure_count == 1
+
+    def test_record_outcome_absent_id_raises_and_persists_nothing(self, tmp_path):
+        be = FileStashBackend(base_dir=str(tmp_path))
+        lib = PersistentPatternLibrary(backend=be)
+        with pytest.raises(ValueError):
+            lib.record_pattern_outcome("ghost", success=True)
+        assert be.retrieve(ACTIVE_PREFIX + "ghost") is None
+
     def test_load_skips_unparseable_active_entry(self, tmp_path):
         be = FileStashBackend(base_dir=str(tmp_path))
         lib = PersistentPatternLibrary(backend=be)


### PR DESCRIPTION
## Summary

Pilot lane 2 (chair-queued): PatternLibrary persistence dogfood + P1 signal-store wiring, plus the principles-section draft for chair review.

- **fix(patterns):** `PersistentPatternLibrary` persisted only `contribute_pattern`; `record_pattern_outcome` and `link_patterns` mutated in-memory state that vanished on reload (two-process probe: A `usage=2 success=1` → B `usage=0 success=0`). Both mutators now re-stash; graph stored under a dedicated `pattern_graph` key. Regression tests added (25 pass serially; 76 across the four pattern suites).
- **Wiring:** live store seeded with `cross_review_delegated_lane`; run-1 codex-lane ACCEPTED disposition recorded (fresh-process read: `usage=1 success=1 rate=1.00`). R5 ledger stays the narrative receipt; the pattern store is the machine-readable P1 counter.
- **docs(spec):** lane-2 record in feature-lead-governance decisions.md; principles-section draft (every principle cites its enforcer; keyless-CI gap turned out already enforced by `test_ci_spend_guard.py`).
- **docs(lessons):** persistence-by-override subclasses must cover every base mutator (session batch).

## Receipts

- Suite (serial): `tests/unit/test_pattern_review.py` 25 passed; pattern suites 76 passed.
- Live-fire: two-process round-trip probe pre-fix (fails) and post-fix (survives); fresh-process read of the seeded live AMS store.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
