### PR TITLE
docs(spec)+test(gates): principles draft amended — self-enforcing citations + codex lane 3 fixes

### DIFF
--- a/docs/specs/cross-review/receipts.md
+++ b/docs/specs/cross-review/receipts.md
@@ -15,6 +15,7 @@ ids recorded per T3's live-fire check. Dispositions ruled by Patrick
 | 2026-07-29 | antigravity | branch vs merge-base cd55f3839 (origin/main) — lessons docs diff | 1 sent / 0 omitted | 0 (clean) | clean |
 | 2026-07-29 | codex | branch vs merge-base e7fa7e088 (origin/main) — feature-page docs branch | 23 sent / 7 omitted | 3 (findings) | stale-branch — carry only if revived |
 | 2026-07-29 | codex | branch vs merge-base 51bc7550f (origin/main) — feature-lead PILOT diff (contract lead rule + base.py QA) | 6 sent / 0 omitted | 1 (findings) | real — accepted and fixed in-branch (single-provider lead fallback) |
+| 2026-07-29 | codex | branch vs merge-base db48a3bf2 (origin/main) — pilot lane 3: principles draft + citations guard | 2 sent / 0 omitted | 2 (findings) | real — both accepted and fixed in-branch (path-scope widened; def/class-anchored name check); verify-it-fires receipts re-run |
 
 Board threads (live-fire check): `review-detached-20260729-0036`,
 `review-detached-20260729-0037`,

--- a/docs/specs/feature-lead-governance/principles-section-draft.md
+++ b/docs/specs/feature-lead-governance/principles-section-draft.md
@@ -27,8 +27,9 @@ as pickable work.
    is the receipt. Delegated lanes declare their receipt type at
    launch and the lead re-runs receipts centrally.
    *Enforcer: **aspirational** (ruled discipline —
-   `decision-routine.md` delegation receipts + this contract's
-   Verification receipts section; no mechanical gate).*
+   `.claude/rules/attune/decision-routine.md` delegation receipts
+   + this contract's Verification receipts section; no mechanical
+   gate).*
 
 2. **The code is the contract; spec text is a hypothesis.** Before
    executing any spec-named scope, grep the code for the property
@@ -55,7 +56,7 @@ as pickable work.
 
 5. **Coverage is a floor, not a goal.** Changed code carries
    ≥80% coverage; the local bar is 85%.
-   *Enforcers: codecov project+patch gates (80%),
+   *Enforcers: `codecov.yml` project+patch gates (80%),
    `tests/unit/ci/test_workflow_yaml.py::
    test_coverage_threshold_is_at_least_80` (the threshold itself
    is drift-guarded).*
@@ -107,19 +108,57 @@ as pickable work.
     ratchet-by-reconstruction, but nothing blocks the direct
     write).*
 
+13. **Simpler is better.** Three clear lines beat one clever
+    abstraction: flatten nested conditionals, inline one-use
+    helpers, prefer stdlib over custom abstractions, and review
+    every change for complexity it didn't need.
+    *Enforcer: **aspirational** (ratified design philosophy,
+    carried in every provider surface's instructions; simplicity
+    is judged in review, not gated).*
+
+14. **A handoff is context, not authority.** The receiving agent
+    verifies a handoff against the current Git state and tests
+    before continuing; the current worktree, Git state, and test
+    results are the shared truth, never hidden chat context.
+    *Enforcer: **aspirational** (contract text — Shared truth +
+    Handoffs sections; inherently procedural, since the check IS
+    the receiving agent's first action).*
+
+15. **Degrade gracefully around the memory layer.** When Redis or
+    the memory index is unreachable, skip recall and proceed —
+    work is never blocked on the memory layer, and recalled
+    results are context to verify, not authority.
+    *Enforcers: `tests/unit/memory/test_session_stash.py` (backend
+    resolution failure degrades to None, never raises),
+    `tests/unit/test_mcp_memory_tools.py` (memory tools degrade
+    gracefully when the layer is absent). The SessionStart hydrate
+    hook's own fail-open path is untested — the remaining
+    **aspirational** half.*
+
 ---
 
 ## Notes for the chair (not part of the section)
 
-- One principle surfaced an **enforcer gap** worth a pickable-work
-  row: a path-validation gate for file-op code (principle 4's
-  second half). A second suspected gap (keyless-CI invariant)
-  turned out to be already enforced by
-  `tests/unit/ci/test_ci_spend_guard.py` — the grep-for-existing-
-  enforcer rule caught it before a duplicate was built.
+- **The section enforces itself:**
+  `tests/unit/gates/test_principles_citations.py` parses the
+  numbered principles, extracts every backtick-cited repo path
+  (including `path::test_name` forms), and fails if any cited
+  enforcer no longer exists — principle 3 applied recursively. On
+  ratification the test's target constant moves from this draft
+  file to the contract master (one-line change, noted in the
+  test).
+- Enforcer gaps worth pickable-work rows: (a) a path-validation
+  gate for file-op code (principle 4's second half — chip filed);
+  (b) a fail-open test for the SessionStart hydrate hook
+  (principle 15's second half). Two suspected gaps turned out
+  already enforced (`test_ci_spend_guard.py` for keyless CI;
+  `test_session_stash.py` for memory-layer degradation) — the
+  grep-for-existing-enforcer rule caught both before duplicates
+  were built.
 - Deliberately NOT included: style rules (black/ruff enforce
   themselves), and anything that is one session's preference
   rather than a cross-provider invariant.
 - If approved, the section lands in the master + one projector
   run; the draft file is then deleted (single-source rule,
-  principle 3, applied to itself).
+  principle 3, applied to itself) and the citations test is
+  re-pointed at the master in the same PR.

--- a/tests/unit/gates/test_principles_citations.py
+++ b/tests/unit/gates/test_principles_citations.py
@@ -1,0 +1,84 @@
+"""Drift guard: every enforcer cited in the Principles section exists.
+
+The principles document's whole claim is that each principle names a real
+ratchet/gate/hook/drift-guard. This test keeps that claim true: it parses
+the numbered principles, extracts every backtick-cited repo path (including
+``path::test_name`` forms), and fails if a cited enforcer file no longer
+exists or a cited test name no longer appears in its file.
+
+TARGET note: while the section is a draft under chair review it lives in
+the feature-lead-governance spec; on ratification the section moves into
+``content/collaboration/contract.md`` and TARGET must be re-pointed there
+in the same PR (the draft file is deleted).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parents[3]
+TARGET = REPO_ROOT / "docs/specs/feature-lead-governance/principles-section-draft.md"
+
+#: A collapsed backtick span that looks like a repo file path.
+_PATH_RE = re.compile(r"^[\w./-]+\.(?:py|yml|yaml|md)$")
+
+
+def _principles_text() -> str:
+    text = TARGET.read_text(encoding="utf-8")
+    # Anchor to the heading at line start — the literal string also appears
+    # inside a backtick span in the draft's preamble.
+    match = re.search(r"^### Principles$", text, re.MULTILINE)
+    assert match, f"no '### Principles' heading in {TARGET}"
+    # The numbered list ends at the horizontal rule before the chair notes.
+    end = text.index("\n---", match.start())
+    return text[match.start() : end]
+
+
+def _cited_enforcers() -> list[str]:
+    """Backtick spans that collapse to a repo path (or path::test_name)."""
+    spans = re.findall(r"`([^`]+)`", _principles_text(), re.DOTALL)
+    cited = []
+    for span in spans:
+        collapsed = re.sub(r"\s+", "", span)
+        path_part = collapsed.split("::")[0]
+        if _PATH_RE.match(path_part):
+            cited.append(collapsed)
+    return cited
+
+
+def test_target_document_exists():
+    assert TARGET.exists(), (
+        f"{TARGET} is gone. If the Principles section was ratified into the "
+        "contract master, re-point TARGET at content/collaboration/contract.md."
+    )
+
+
+def test_extraction_is_not_vacuous():
+    # A regex regression that extracts nothing must fail loudly, not pass.
+    assert len(_cited_enforcers()) >= 10
+
+
+def test_every_cited_enforcer_path_exists():
+    missing = []
+    for citation in _cited_enforcers():
+        path_part = citation.split("::")[0]
+        if not (REPO_ROOT / path_part).exists():
+            missing.append(citation)
+    assert not missing, (
+        f"Principles section cites enforcers that no longer exist: {missing}. "
+        "Fix the citation or restore the enforcer — the section may not cite "
+        "fiction (its own principle 8)."
+    )
+
+
+def test_every_cited_test_name_exists_in_its_file():
+    stale = []
+    for citation in _cited_enforcers():
+        if "::" not in citation:
+            continue
+        path_part, test_name = citation.split("::", 1)
+        enforcer = REPO_ROOT / path_part
+        if enforcer.exists() and test_name not in enforcer.read_text(encoding="utf-8"):
+            stale.append(citation)
+    assert not stale, f"Principles section cites test names absent from their files: {stale}"

--- a/tests/unit/gates/test_principles_citations.py
+++ b/tests/unit/gates/test_principles_citations.py
@@ -20,8 +20,16 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).parents[3]
 TARGET = REPO_ROOT / "docs/specs/feature-lead-governance/principles-section-draft.md"
 
-#: A collapsed backtick span that looks like a repo file path.
-_PATH_RE = re.compile(r"^[\w./-]+\.(?:py|yml|yaml|md)$")
+#: A collapsed backtick span that looks like a repo file path: any known
+#: config/code/doc extension, or a slash-containing path (covers shell
+#: scripts, extensionless hooks, and directories). Dotted module names
+#: (no slash, unknown extension) stay excluded.
+_PATH_RE = re.compile(r"^[\w./-]+\.(?:py|yml|yaml|md|toml|json|sh|cfg|ini|txt)$")
+_DIR_RE = re.compile(r"^[\w.-]+(?:/[\w.-]+)+/?$")
+
+
+def _is_repo_path(token: str) -> bool:
+    return bool(_PATH_RE.match(token) or _DIR_RE.match(token))
 
 
 def _principles_text() -> str:
@@ -42,7 +50,7 @@ def _cited_enforcers() -> list[str]:
     for span in spans:
         collapsed = re.sub(r"\s+", "", span)
         path_part = collapsed.split("::")[0]
-        if _PATH_RE.match(path_part):
+        if _is_repo_path(path_part):
             cited.append(collapsed)
     return cited
 
@@ -79,6 +87,15 @@ def test_every_cited_test_name_exists_in_its_file():
             continue
         path_part, test_name = citation.split("::", 1)
         enforcer = REPO_ROOT / path_part
-        if enforcer.exists() and test_name not in enforcer.read_text(encoding="utf-8"):
+        if not enforcer.exists():
+            continue  # already reported by the path-existence test
+        # A real def/class at line start — a stale name surviving in a
+        # comment or docstring must not count (codex lane 3 finding).
+        defined = re.search(
+            rf"^\s*(?:def|class)\s+{re.escape(test_name)}\b",
+            enforcer.read_text(encoding="utf-8"),
+            re.MULTILINE,
+        )
+        if not defined:
             stale.append(citation)
     assert not stale, f"Principles section cites test names absent from their files: {stale}"


### PR DESCRIPTION
## Summary

Principles draft amended per chair review + delegated codex lane 3 (feeds R5/P1).

- **Draft amendments (chair review verdict: sufficient in form, three gaps):** 3 missing principles added (Simpler is better; handoff-is-context-not-authority; degrade-gracefully-around-memory), codecov citation made a real path, and principle 15's enforcer corrected after grep-first found fail-open partially pinned already.
- **Self-enforcement:** new `tests/unit/gates/test_principles_citations.py` — parses the numbered principles, validates every backtick-cited enforcer path (incl. wrapped `path::test_name` forms), fails on fiction. Re-pointed at the contract master on ratification.
- **Codex lane 3 (pilot):** 2 medium findings on the guard itself, both accepted + fixed (path scope widened to toml/json/sh/dirs; `::name` check anchored to `def`/`class`). Ledger row appended, disposition `real`; P1 signal store now `usage=3 success=3`.

## Receipts

- Suite (serial): `tests/unit/gates/test_principles_citations.py` 4 passed.
- Verify-it-fires: broken-path, missing-directory, and substring-only-name probes all fail the guard.
- Evidence-chain: both codex findings re-verified centrally before disposition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
