### PR TITLE
test(ops): deflake test_run_busy_returns_409 with event-gated busy window

### DIFF
--- a/tests/unit/ops/test_runner.py
+++ b/tests/unit/ops/test_runner.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import asyncio
 import json
 import sys
+import threading
 
 import pytest
 
@@ -106,14 +107,25 @@ def test_workflows_page_hides_run_buttons_when_disabled(tmp_path, monkeypatch):
 
 
 def test_run_busy_returns_409(tmp_path, monkeypatch):
-    """Second POST while a run is in flight returns 409."""
+    """Second POST while a run is in flight returns 409.
 
-    async def slow_executor(run):
+    The first run's executor blocks on a release event the test only
+    sets AFTER the 409 assertions, so the busy window provably spans
+    the second POST — no timer race (a 0.5s sleep flaked on the
+    Windows 3.13 lane when the run finished before the probe landed).
+    ``threading.Event`` (not ``asyncio.Event``) because the test
+    thread sets it while the executor polls it from TestClient's
+    event loop.
+    """
+    release = threading.Event()
+
+    async def gated_executor(run):
         from datetime import datetime, timezone
 
         run.status = "running"
         run.started_at = datetime.now(timezone.utc)
-        await asyncio.sleep(0.5)
+        while not release.is_set():
+            await asyncio.sleep(0.01)
         run.mark_done(0)
 
     app, _ = _make_app(
@@ -121,15 +133,20 @@ def test_run_busy_returns_409(tmp_path, monkeypatch):
         monkeypatch,
         allow_run=True,
         command_builder=lambda _: ("noop",),
-        executor=slow_executor,
+        executor=gated_executor,
     )
     with TestClient(app) as client:
-        first = client.post("/workflows/x/run")
-        assert first.status_code == 201
-        second = client.post("/workflows/x/run")
-    assert second.status_code == 409
-    detail = second.json()["detail"]
-    assert detail["current_run_id"] == first.json()["run_id"]
+        try:
+            first = client.post("/workflows/x/run")
+            assert first.status_code == 201
+            second = client.post("/workflows/x/run")
+            assert second.status_code == 409
+            detail = second.json()["detail"]
+            assert detail["current_run_id"] == first.json()["run_id"]
+        finally:
+            # Release before lifespan shutdown so the gated run can't
+            # outlive the client, even when an assertion fails.
+            release.set()
 
 
 def test_run_relative_scope_resolves_against_project_root_not_cwd(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

Deflakes `tests/unit/ops/test_runner.py::test_run_busy_returns_409`, which flaked on the Windows 3.13 lane (PR #1748, run 30463898729) with `assert 201 == 409` — the 0.5s `slow_executor` sleep finished before the second POST landed, so the server was no longer busy.

## Change

- The executor now blocks on a `threading.Event` (`release`) instead of a timer; the test sets it only **after** the 409 assertions, so the first run provably stays in flight while the busy probe runs. No timing assumption remains.
- `threading.Event` (polled with a 10ms async sleep) rather than `asyncio.Event`, because the sync test thread sets it while the executor runs on TestClient's event loop.
- `release.set()` is in a `finally` inside the client context so a failing assertion can't leave the gated run alive across lifespan shutdown.
- 409 detail assertions kept (`current_run_id` matches the first run's id).

## Verification

- Serial: `pytest tests/unit/ops/test_runner.py::test_run_busy_returns_409 -p no:xdist` — passed, 10/10 repeats.
- xdist: full `tests/unit/ops/test_runner.py -n auto` — 26 passed.
- Pinned black/ruff pre-flighted clean.

Windows lanes are the sensitive environment — worth letting the full matrix (including the ~13 min Windows lanes) finish before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
