### PR TITLE
test(gates): path-validation gate for file-op modules — principle 4 enforcer

### DIFF
--- a/docs/specs/feature-lead-governance/principles-section-draft.md
+++ b/docs/specs/feature-lead-governance/principles-section-draft.md
@@ -51,8 +51,10 @@ as pickable work.
    `eval`/`exec`, no unvalidated file paths, no bare `except`.
    *Enforcers: `src/attune/hooks/scripts/security_guard.py`
    (PreToolUse block on eval/exec), pre-commit detect-secrets,
-   security tests required for file-op code (reviewed, not
-   gated — that half is **aspirational**).*
+   `tests/unit/gates/test_path_validation_gate.py` (AST scan —
+   modules with write-capable file ops must reference a
+   path-validation helper or hold an allowlist entry; seeded
+   2026-07-29 with 35 vetted modules, ratchets shrink-only).*
 
 5. **Coverage is a floor, not a goal.** Changed code carries
    ≥80% coverage; the local bar is 85%.
@@ -147,9 +149,10 @@ as pickable work.
   ratification the test's target constant moves from this draft
   file to the contract master (one-line change, noted in the
   test).
-- Enforcer gaps worth pickable-work rows: (a) a path-validation
-  gate for file-op code (principle 4's second half — chip filed);
-  (b) a fail-open test for the SessionStart hydrate hook
+- Enforcer gaps worth pickable-work rows: (a) ~~a path-validation
+  gate for file-op code~~ — LANDED 2026-07-29
+  (`tests/unit/gates/test_path_validation_gate.py`); (b) a
+  fail-open test for the SessionStart hydrate hook
   (principle 15's second half). Two suspected gaps turned out
   already enforced (`test_ci_spend_guard.py` for keyless CI;
   `test_session_stash.py` for memory-layer degradation) — the

--- a/tests/unit/gates/test_path_validation_gate.py
+++ b/tests/unit/gates/test_path_validation_gate.py
@@ -1,0 +1,224 @@
+"""Gate: file-op modules must reference a path-validation helper.
+
+Enforces the contract's critical rule "ALWAYS validate file paths in
+file operations" (collaboration contract; feature-lead-governance
+principles draft, principle 4). Until 2026-07-29 this rule had no
+mechanical enforcer — it relied on review discipline.
+
+The scan (AST-based, so prose/comments can never false-positive):
+
+- A module "does file ops" when it calls ``open()`` with a
+  write-capable mode, ``.write_text()`` / ``.write_bytes()``, a
+  mutating ``shutil`` function, or a mutating ``os`` function.
+- A module "has validation" when any identifier it references
+  contains both ``valid`` and ``path`` (matches
+  ``_validate_file_path``, ``validate_file_path``, imports of
+  ``attune.security.path_validation``, and equivalents).
+- A module with file ops and no validation must hold an entry in
+  ``ALLOWLIST`` below.
+
+Fixing a failure, in preference order:
+
+1. Route the path through
+   ``attune.security.path_validation._validate_file_path`` (or an
+   equivalent named helper) before the file op.
+2. If every path the module writes is internal/derived (never
+   user- or LLM-supplied), add the module to ``ALLOWLIST`` with the
+   review that shipped it.
+
+The allowlist is SHRINK-ONLY in spirit: it was seeded 2026-07-29 with
+the 35 then-existing offenders so the gate lands green. A companion
+test fails when an entry goes stale (module gained validation or
+dropped its file ops) so the list ratchets down, never silently up.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SRC_ROOT = REPO_ROOT / "src" / "attune"
+
+#: Attribute calls that write through a path-like receiver.
+_WRITE_ATTRS = {"write_text", "write_bytes"}
+#: shutil.<fn> calls that create, move, or destroy filesystem entries.
+_SHUTIL_FUNCS = {"copy", "copy2", "copyfile", "copytree", "move", "rmtree"}
+#: os.<fn> calls that destroy or rename filesystem entries.
+_OS_FUNCS = {"remove", "unlink", "rename", "replace"}
+
+#: Modules with file ops and no path-validation reference, vetted at
+#: seeding (2026-07-29): each writes only internal/derived paths
+#: (state stores, telemetry sinks, generated docs). Remove entries as
+#: modules adopt ``_validate_file_path``; add only with review.
+ALLOWLIST = frozenset(
+    {
+        "src/attune/authoring/fact_check/__init__.py",
+        "src/attune/authoring/faithfulness/__init__.py",
+        "src/attune/authoring/generator.py",
+        "src/attune/authoring/manifest.py",
+        "src/attune/authoring/polish.py",
+        "src/attune/authoring/projector.py",
+        "src/attune/authoring/spec_workflow.py",
+        "src/attune/curator/cache.py",
+        "src/attune/elicitation/bridge.py",
+        "src/attune/gates/envelope.py",
+        "src/attune/handoff/packet.py",
+        "src/attune/help/feedback.py",
+        "src/attune/help/generator.py",
+        "src/attune/help/manifest.py",
+        "src/attune/help/session.py",
+        "src/attune/hooks/scripts/suggest_compact.py",
+        "src/attune/memory/file_stash.py",
+        "src/attune/memory/personal.py",
+        "src/attune/memory/security/audit_logger.py",
+        "src/attune/meta_workflows/cli_commands/analytics_commands.py",
+        "src/attune/monitoring/alerts_cli.py",
+        "src/attune/ops/dismiss_store.py",
+        "src/attune/ops/health_snapshot.py",
+        "src/attune/ops/ops_config_store.py",
+        "src/attune/ops/routes/specs.py",
+        "src/attune/ops/sweep_results.py",
+        "src/attune/orchestration/ghosts/worktree.py",
+        "src/attune/pipeline_learner/scaffold.py",
+        "src/attune/roundtable/gate_triage.py",
+        "src/attune/roundtable/triage_appendix.py",
+        "src/attune/telemetry/form_events.py",
+        "src/attune/telemetry/usage_ping.py",
+        "src/attune/telemetry/usage_tracker.py",
+        "src/attune/workflows/progress_reporters.py",
+        "src/attune/workflows/suggestions.py",
+    }
+)
+
+
+def _open_mode_is_write(call: ast.Call) -> bool:
+    """True when an ``open()`` call's mode string enables writing."""
+    mode = None
+    if len(call.args) >= 2 and isinstance(call.args[1], ast.Constant):
+        mode = call.args[1].value
+    for kw in call.keywords:
+        if kw.arg == "mode" and isinstance(kw.value, ast.Constant):
+            mode = kw.value.value
+    if not isinstance(mode, str):
+        return False
+    return any(c in mode for c in "wax+")
+
+
+def scan_source(source: str) -> tuple[list[str], bool]:
+    """Return (file-op descriptions, has-validation-reference)."""
+    tree = ast.parse(source)
+    ops: list[str] = []
+    has_validation = False
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Name | ast.Attribute | ast.alias):
+            ident = (
+                node.id
+                if isinstance(node, ast.Name)
+                else node.attr if isinstance(node, ast.Attribute) else node.name
+            )
+            low = ident.lower()
+            if "valid" in low and "path" in low:
+                has_validation = True
+        if isinstance(node, ast.Call):
+            func = node.func
+            if isinstance(func, ast.Name) and func.id == "open":
+                if _open_mode_is_write(node):
+                    ops.append(f"open-for-write at line {node.lineno}")
+            elif isinstance(func, ast.Attribute):
+                if func.attr in _WRITE_ATTRS:
+                    ops.append(f".{func.attr}() at line {node.lineno}")
+                elif (
+                    isinstance(func.value, ast.Name)
+                    and func.value.id == "shutil"
+                    and func.attr in _SHUTIL_FUNCS
+                ):
+                    ops.append(f"shutil.{func.attr}() at line {node.lineno}")
+                elif (
+                    isinstance(func.value, ast.Name)
+                    and func.value.id == "os"
+                    and func.attr in _OS_FUNCS
+                ):
+                    ops.append(f"os.{func.attr}() at line {node.lineno}")
+    return ops, has_validation
+
+
+def _current_offenders() -> dict[str, list[str]]:
+    """Map repo-relative module path -> its unvalidated file ops."""
+    offenders: dict[str, list[str]] = {}
+    for py in sorted(SRC_ROOT.rglob("*.py")):
+        try:
+            ops, has_validation = scan_source(py.read_text(encoding="utf-8"))
+        except SyntaxError:  # unparseable files fail other gates
+            continue
+        if ops and not has_validation:
+            offenders[py.relative_to(REPO_ROOT).as_posix()] = ops
+    return offenders
+
+
+def test_no_new_unvalidated_file_op_modules() -> None:
+    """Every file-op module validates paths or is allowlisted."""
+    offenders = _current_offenders()
+    new = {mod: ops for mod, ops in offenders.items() if mod not in ALLOWLIST}
+    details = "\n".join(f"  {mod}: {', '.join(ops)}" for mod, ops in sorted(new.items()))
+    assert not new, (
+        "Modules perform file operations without referencing a "
+        "path-validation helper (contract rule: ALWAYS validate file "
+        "paths in file operations):\n"
+        f"{details}\n"
+        "Fix: route paths through "
+        "attune.security.path_validation._validate_file_path before the "
+        "file op, or (only for internal/derived paths) add the module "
+        f"to ALLOWLIST in {Path(__file__).name} with review."
+    )
+
+
+def test_allowlist_entries_are_still_needed() -> None:
+    """The allowlist ratchets down: stale entries must be removed."""
+    offenders = _current_offenders()
+    missing = sorted(mod for mod in ALLOWLIST if not (REPO_ROOT / mod).exists())
+    assert not missing, f"ALLOWLIST entries for deleted modules — remove them: {missing}"
+    stale = sorted(mod for mod in ALLOWLIST if mod not in offenders)
+    assert not stale, (
+        "ALLOWLIST entries no longer needed (module now validates paths "
+        f"or dropped its file ops) — remove them to keep the ratchet: {stale}"
+    )
+
+
+# --- scanner self-tests: the true/false-positive pairs ---------------
+
+
+def test_scanner_detects_write_open() -> None:
+    ops, _ = scan_source('f = open(p, "w")\n')
+    assert ops == ["open-for-write at line 1"]
+
+
+def test_scanner_ignores_read_open() -> None:
+    ops, _ = scan_source('f = open(p)\ng = open(p, "r")\n')
+    assert ops == []
+
+
+def test_scanner_detects_write_text_shutil_and_os_ops() -> None:
+    source = "p.write_text(x)\nshutil.rmtree(d)\nos.remove(f)\n"
+    ops, _ = scan_source(source)
+    assert ops == [
+        ".write_text() at line 1",
+        "shutil.rmtree() at line 2",
+        "os.remove() at line 3",
+    ]
+
+
+def test_scanner_validation_reference_clears_module() -> None:
+    source = (
+        "from attune.security.path_validation import _validate_file_path\n"
+        '_validate_file_path(p)\nopen(p, "w")\n'
+    )
+    ops, has_validation = scan_source(source)
+    assert ops and has_validation
+
+
+def test_scanner_prose_mention_is_not_an_op() -> None:
+    """Comments and docstrings never fire — the scan is AST-based."""
+    source = '# open(p, "w") and shutil.rmtree here\n"""p.write_text(x)"""\n'
+    ops, has_validation = scan_source(source)
+    assert ops == [] and not has_validation


### PR DESCRIPTION
## What

Closes the last enforcer gap from the 2026-07-29 principles audit: the contract's critical rule **"ALWAYS validate file paths in file operations"** (principle 4, second half) had no mechanical enforcer — it relied on review discipline.

## The gate — `tests/unit/gates/test_path_validation_gate.py`

- **AST scan of `src/attune`** (prose/comments can never false-positive): a module "does file ops" when it calls `open()` with a write-capable mode, `.write_text()`/`.write_bytes()`, a mutating `shutil` function (`copy*`, `move`, `rmtree`), or a mutating `os` function (`remove`, `unlink`, `rename`, `replace`).
- A module "has validation" when it references any identifier containing both `valid` and `path` — matches `_validate_file_path`, imports of `attune.security.path_validation`, and equivalents.
- Offenders must hold an `ALLOWLIST` entry. **Seeded with the 35 current offenders so the gate lands green** (52 file-op modules already validate). Fix order documented in the module docstring: route through `_validate_file_path` first; allowlist only for internal/derived paths, with review.
- **Shrink-only ratchet**: a companion test fails when an allowlist entry goes stale (module gained validation, dropped its file ops, or was deleted), so the list can only tighten.
- Scanner self-tests pair every true positive with a false-positive guard (write-open detected / read-open ignored; prose never fires), per the platform-compat-scanner lesson — a ratchet whose baseline is noise trains people to ignore it.

## Grep-for-existing-enforcer (done first)

`tests/unit/security/` covers the *helper itself* (traversal, mutation kills) — nothing enforces its *adoption*. No overlap with `test_platform_compat_scanner` (portability, not validation) or the security_guard hook (eval/exec, tool-call surface).

## Draft amendment

- Principle 4's enforcer line now cites the gate (previously "reviewed, not gated — aspirational").
- Notes' pickable-work row (a) marked landed; row (b) (hydrate-hook fail-open test) remains open.

## Receipts

- `pytest tests/unit/gates/` — **170 passed** (includes `test_principles_citations.py` re-validating the amended draft's citations).
- Pinned black + ruff pre-flighted; pre-commit full pass on commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
