### PR TITLE
docs(lessons): EOD batch 4 — pinned-ruff rule-set skew; mutation output as blocked-read answer

### DIFF
--- a/.claude/lessons.md
+++ b/.claude/lessons.md
@@ -19481,3 +19481,37 @@ def ", start_idx + 1)` for module-
   there is nothing to clobber). Reusing an agent branch after its
   PR merged hits this every time; expect it and don't retry the
   lease.
+
+- **Bare `uv run ruff check <f>` is NOT the pinned ruff — the
+  pre-commit pin (v0.8.4) enforces rules REMOVED from modern ruff,
+  so the bare check passes where the commit-time hook fails
+  (2026-07-29, path-validation gate PR)**: pre-flighted the new
+  gate test with `uv run ruff check` ("All checks passed", project
+  ruff 0.15.21), then the commit-time pinned ruff hook failed
+  UP038 (`isinstance(x, (A, B))` → `A | B`) — UP038 was
+  deprecated-then-removed in modern ruff, so ONLY the old pinned
+  version can flag it, and no bare invocation of the project's
+  ruff will ever reproduce the failure. The existing pre-flight
+  lesson names `uv run ruff check <f>` for non-autofixable lint —
+  that is insufficient for version-skewed rule sets. Amended rule:
+  pre-flight ruff the same way as black, through the pinned hook —
+  `uv run --with pre-commit pre-commit run ruff --files <f>` —
+  and treat any bare-tool green as unverified until the pinned
+  hook agrees. Same family as "pinned black reformats what .venv
+  black left alone", opposite direction: the PIN is older than the
+  venv tool, enforcing a rule the new tool deleted.
+
+- **When the auto-mode classifier blocks read-only branch-existence
+  checks, a user-authorized `git push origin --delete` is
+  self-verifying — "remote ref does not exist" IS the answer
+  (2026-07-29)**: after merging PR #1753, both probes for whether
+  the head branch survived (`git ls-remote --heads origin <b>` and
+  `gh api repos/.../branches/<b>`) were classifier-blocked, oddly
+  while destructive-but-authorized ops passed. Instead of fighting
+  for a read path, the requested deletion itself settled it: the
+  push-delete errored `remote ref does not exist`, proving the
+  merge lane had already deleted the branch. Pattern: when a
+  read is blocked but the user has authorized the mutating action
+  the read was gating, run the mutation — its error/success output
+  carries the state you wanted to read. Don't loop retrying
+  blocked reads first.


### PR DESCRIPTION
## What

End-of-session lessons batch (one PR per the ratified EOD default) from the path-validation-gate session (#1753). Two entries appended to `.claude/lessons.md`:

1. **Pinned pre-commit ruff (v0.8.4) enforces rules removed from modern ruff** — bare `uv run ruff check` (0.15.21) passed while the commit-time pinned hook failed UP038, a rule that no longer exists in the project's ruff. Amends the pre-flight lesson: run ruff through the pinned hook (`uv run --with pre-commit pre-commit run ruff --files <f>`), same as black.
2. **A user-authorized mutation's output answers a classifier-blocked read** — with branch-existence probes blocked, the requested `git push origin --delete` errored `remote ref does not exist`, proving the branch was already gone.

Docs-only diff; lessons.md ships via the label lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)