### PR TITLE
feat(roundtable): D11c hardened skeptic countersign of lead receipt re-runs

### DIFF
--- a/docs/specs/cross-review/receipts.md
+++ b/docs/specs/cross-review/receipts.md
@@ -21,6 +21,17 @@ tags let the ledger passively accumulate evidence of which
 principles the review lanes actually exercise (the aspirational
 principles are measurable nowhere else).
 
+Countersign tokens (D11c, 2026-07-29): a row claiming the lead's
+central receipt re-run was skeptic-countersigned carries the full
+citable token `countersign: <seat> :: <label> :: sha256:<16+ hex>`
+(dissents: same grammar, `dissent:` prefix), produced only by
+`attune.roundtable.countersign` from an executor-written,
+digest-verified artifact. Enforced by
+`tests/unit/gates/test_ledger_countersign_format.py`, which imports
+the grammar from the module — a bare "countersign:" claim without
+the artifact digest is exactly the lead-narrated form D11c rejects,
+and it fails the gate.
+
 | Date | Seat | Target | Files | Findings | Disposition |
 |---|---|---|---|---|---|
 | 2026-07-29 | codex | branch vs merge-base 94e8459c5 (origin/main) — #1559 skeptic diff | 3 sent / 0 omitted | 5 (findings) | carry-to-#1559 |

--- a/docs/specs/feature-lead-governance/decisions.md
+++ b/docs/specs/feature-lead-governance/decisions.md
@@ -392,3 +392,41 @@ now; the third held:
 Also standing from the same exchange, NOT yet ruled: the
 enforcer-touch check (diff ∩ cited enforcers) as D11b's mechanical
 governance-trigger predicate — parked in the starter queue.
+
+## 2026-07-29 — D11c implemented: hardened countersign shipped (lead record)
+
+Implementation evidence for the D11c ruling above (design addendum
+in design.md, same date). The evidence path is executor → artifact
+→ skeptic, as ruled — the rejected lead-narrated form is not
+reachable through the shipped API:
+
+- `src/attune/roundtable/countersign.py`:
+  `rerun_receipts_to_artifact` (the executing process streams an
+  append-only, hash-chained JSONL artifact — one entry per receipt
+  as it completes; existing paths refused), `load_receipt_artifact`
+  (fail-closed: missing file, symlink, unparseable line, broken
+  chain, digest/tail mismatch, bad sequence, and zero receipts all
+  refuse), `run_countersign_pass` (brief built mechanically from
+  the verified artifact; rotation-picked NON-LEAD seat via
+  `skeptic_for`; CITE validated against executed receipt labels; a
+  token is emitted from exactly one path), and
+  `format_countersign_token` + `COUNTERSIGN_TOKEN_RE` (the citable
+  ledger grammar, single-sourced).
+- Ledger gate: `tests/unit/gates/test_ledger_countersign_format.py`
+  imports the module regex and fails any R5 row claiming a
+  countersign/dissent without the full token (fires-on-violation
+  self-test included). Grammar documented in the ledger header.
+- Receipts: 33 new tests (tamper both ways — naive edit breaks the
+  entry digest, recomputed-digest edit breaks the tail hash or
+  chain; refusal outcomes; different-model rule; absent fallback;
+  CLI round trip); roundtable + gates suites 458 passed serially;
+  module coverage 91%.
+- R8 intact: the pass never flips a status, never promotes; a
+  refusal produces NO token, so an uncountersigned row stays
+  visibly uncountersigned for the chair.
+
+Recorded honest limit (design addendum): the hardening is
+evidentiary, not cryptographic — single-machine process
+attestation is out of scope, same posture as D3's forgery probes.
+Next evidence step: first live delegated lane whose lead re-run
+ships with an artifact + countersign token in its R5 row.

--- a/docs/specs/feature-lead-governance/design.md
+++ b/docs/specs/feature-lead-governance/design.md
@@ -261,3 +261,88 @@ are excluded.
   design (board message 14) — kept out to avoid housing authority
   state in a spec whose ratified advisory posture is untouchable;
   its two demonstrated advantages ship anyway as P1 and P2.
+
+## Addendum (2026-07-29) — D11c design: hardened skeptic countersign
+
+Implements the D11c ruling (decisions.md 2026-07-29, roundtable
+`q-lead-verification-gap-001`): the lead's central receipt re-runs
+are countersigned by the #1559 skeptic, in the HARDENED form only.
+The rejected naive form — the skeptic judging receipts the lead
+narrates inside its own session — is "self-verification with
+another prompt attached" (codex). The design forces the evidence
+path executor → artifact → skeptic; the lead never authors the
+evidence the skeptic reads.
+
+### Evidence path
+
+1. **Executor produces the artifact.** The process that actually
+   executes the receipt commands (the isolated scratch-worktree
+   re-run machinery, same execution semantics as
+   `attune.roundtable.solutions.validate`: serial, fixed argv,
+   never a shell, 127/124 mapping, tail truncation) appends one
+   JSONL entry per receipt AS IT COMPLETES — never a summary
+   written after the fact. The artifact is append-only and
+   hash-chained: each entry carries `prev_digest` and its own
+   `entry_digest` (sha256 over the canonical entry), and a header
+   entry pins the repo commit the re-run validated. The writer
+   refuses to open an existing path (no overwrite, no append to a
+   foreign file).
+2. **Skeptic consumes ONLY the artifact.** The countersign pass
+   loads the artifact, re-verifies the full digest chain, and
+   builds the seat brief mechanically from the verified entries.
+   No free-text receipt summary enters the brief. The seat is
+   rotation-picked and never the lead (`skeptic_for` with the lead
+   as author — the different-model rule verbatim). Verdicts parse
+   through `parse_skeptic_verdict` with `valid_labels` drawn from
+   the artifact, so an invented CITE is malformed, never valid.
+3. **Countersign lands as a citable ledger token.** A verified
+   COUNTERSIGN renders as a fixed-grammar token carrying the seat,
+   the cited receipt label, and the artifact digest:
+
+   ```text
+   countersign: <seat> :: <label> :: sha256:<16+ hex>
+   dissent: <seat> :: <label> :: sha256:<16+ hex>
+   ```
+
+   The token goes in the R5 ledger row's disposition cell next to
+   the D11a material. `tests/unit/gates/test_ledger_countersign_format.py`
+   sweeps the ledger and fails on any token that does not match
+   the grammar — the regex is imported from the module (one
+   source, per the self-enforcing-citations principle). The digest
+   makes the row auditable: the chair can re-verify the named
+   artifact byte-for-byte.
+
+### Fail-closed contract
+
+The module can emit a countersign token from exactly one path: a
+digest-verified artifact plus a parsed COUNTERSIGN whose CITE
+names an executed receipt. Everything else is a recorded refusal,
+never a pass-through:
+
+- missing artifact → `no-artifact`;
+- unparseable JSON, broken chain, digest mismatch, bad sequence,
+  or zero receipt entries → `bad-artifact`;
+- no reachable non-lead seat → `skeptic-absent`;
+- unparseable or uncited verdict → `malformed-verdict` (TAC-4:
+  recorded as such for the chair, never laundered).
+
+A refusal outcome produces NO token; the ledger row then simply
+lacks a countersign, which is itself visible to the chair.
+
+### Honest limits (recorded, not solved)
+
+Single-machine trust boundary: a lead session could in principle
+run the writer against fabricated commands. The hardening is
+evidentiary, not cryptographic — fixed-argv execution, an
+append-only chain that makes post-hoc editing loud, a mechanical
+brief, and a chair-auditable digest. Process attestation is out of
+scope (same posture as D3's forgery probes: verify what git and
+hashes can verify, name what they cannot).
+
+### Placement
+
+New module `src/attune/roundtable/countersign.py` (the skeptic
+module keeps its staged-closure concern; countersign reuses its
+rotation, verdict parsing, and brief conventions). R8 intact: the
+pass never flips a status, never promotes, and the ledger token is
+advisory evidence for the chair.

--- a/src/attune/roundtable/countersign.py
+++ b/src/attune/roundtable/countersign.py
@@ -1,0 +1,554 @@
+"""Hardened skeptic countersign of lead receipt re-runs — D11c.
+
+Ruled 2026-07-29 (feature-lead-governance decisions.md D11c, via
+roundtable ``q-lead-verification-gap-001``): the lead re-runs every
+seat's receipts centrally, but nobody mechanically verifies the
+lead's own re-runs. This module closes that gap in the HARDENED
+form the table converged on — the naive form (skeptic judging
+receipts the lead narrates in its own session) was rejected as
+"self-verification with another prompt attached" (codex).
+
+Evidence path: **executor → artifact → skeptic**.
+
+1. :func:`rerun_receipts_to_artifact` executes the declared
+   receipt commands in an isolated scratch worktree (same
+   execution semantics as :func:`attune.roundtable.solutions.
+   validate` — serial, fixed argv, never a shell) and appends one
+   hash-chained JSONL entry per receipt AS IT COMPLETES. The
+   writer refuses existing paths: append-only, no overwrite.
+2. :func:`load_receipt_artifact` re-verifies the full digest
+   chain and FAILS CLOSED — missing file, unparseable line,
+   broken chain, or zero receipts is a :class:`CountersignError`,
+   never a partial read.
+3. :func:`run_countersign_pass` builds the seat brief
+   mechanically from the verified artifact, rotation-picks a
+   NON-LEAD seat (different-model rule, reusing
+   :func:`attune.roundtable.skeptic.skeptic_for`), and parses the
+   verdict with ``valid_labels`` drawn from the artifact — an
+   invented CITE is malformed, never valid.
+4. A verified COUNTERSIGN renders as a fixed-grammar ledger token
+   (:func:`format_countersign_token`) carrying the seat, cited
+   label, and artifact digest; the R5 ledger gate imports
+   :data:`COUNTERSIGN_TOKEN_RE` so grammar and gate cannot drift.
+
+The module can emit a token from exactly one path: verified
+artifact + parsed COUNTERSIGN citing an executed receipt. Every
+other outcome is a recorded refusal (TAC-4 — never laundered).
+R8 intact: never flips a status, never promotes.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under Apache 2.0
+"""
+
+from __future__ import annotations
+
+import datetime
+import hashlib
+import json
+import re
+import shlex
+import subprocess  # nosec B404 — fixed argv git commands, never shell=True
+import tempfile
+import uuid
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from attune.roundtable.rotation import CANONICAL_SEATS
+from attune.roundtable.skeptic import (
+    MAX_RECEIPT_CMDS,
+    SkepticVerdict,
+    parse_skeptic_verdict,
+    skeptic_for,
+)
+from attune.roundtable.solutions import Candidate, CheckReceipt, discard, validate
+
+#: The ledger-citable token grammar — imported by
+#: tests/unit/gates/test_ledger_countersign_format.py (one source).
+COUNTERSIGN_TOKEN_RE = re.compile(
+    r"(?P<kind>countersign|dissent): (?P<seat>[a-z][a-z0-9-]*) :: "
+    r"(?P<label>[^:]+?) :: sha256:(?P<digest>[0-9a-f]{16,64})"
+)
+
+_ARTIFACT_VERSION = 1
+
+_GIT_TIMEOUT = 120
+
+
+class CountersignError(ValueError):
+    """An artifact or invocation this module refuses to countersign."""
+
+
+@dataclass(frozen=True)
+class ReceiptArtifact:
+    """A digest-verified receipt artifact — the skeptic's only input."""
+
+    path: Path
+    commit: str
+    receipts: list[CheckReceipt]
+    sha256: str  # digest of the artifact file bytes — the citable id
+
+
+@dataclass
+class CountersignPass:
+    """One complete countersign pass — everything the chair needs."""
+
+    lead: str
+    artifact_sha256: str | None = None
+    skeptic: str | None = None
+    verdict: SkepticVerdict | None = None
+    outcome: str = "pending"
+    token: str | None = None
+    receipts: list[CheckReceipt] = field(default_factory=list)
+
+
+def _entry_digest(entry: Mapping[str, object]) -> str:
+    """Canonical digest of one artifact entry (minus its own digest)."""
+    material = {k: v for k, v in entry.items() if k != "entry_digest"}
+    return hashlib.sha256(
+        json.dumps(material, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
+
+
+def _append_entry(handle, entry: dict, prev_digest: str) -> str:
+    """Chain, digest, write, and flush one entry; return its digest."""
+    entry["prev_digest"] = prev_digest
+    entry["entry_digest"] = _entry_digest(entry)
+    handle.write(json.dumps(entry, sort_keys=True, separators=(",", ":")) + "\n")
+    handle.flush()
+    return str(entry["entry_digest"])
+
+
+def rerun_receipts_to_artifact(
+    repo: Path,
+    checks: list[tuple[str, list[str]]],
+    artifact_path: Path,
+    base_ref: str = "HEAD",
+    scratch_root: Path | None = None,
+) -> ReceiptArtifact:
+    """Execute receipt commands isolated, streaming the artifact.
+
+    This IS the executor: each :class:`CheckReceipt` is appended to
+    the artifact the moment its command completes, by the same
+    process that ran it — the lead never gets a window to narrate.
+    Execution reuses :func:`attune.roundtable.solutions.validate`
+    one check at a time (serial, fixed argv, tail truncation,
+    127/124 mapping) inside a detached scratch worktree that is
+    always discarded.
+
+    Raises:
+        CountersignError: ``artifact_path`` already exists (the
+            artifact is append-only — never overwrite), no checks
+            declared, or more than the cheap-receipt cap.
+        RuntimeError: Scratch worktree creation failed.
+    """
+    if artifact_path.exists() or artifact_path.is_symlink():
+        raise CountersignError(f"artifact path already exists (append-only): {artifact_path}")
+    if not checks:
+        raise CountersignError("no receipt commands to execute")
+    if len(checks) > MAX_RECEIPT_CMDS:
+        raise CountersignError(
+            f"{len(checks)} receipt commands — cheap receipts are capped at {MAX_RECEIPT_CMDS}"
+        )
+    for label, _ in checks:
+        # Labels flow into the ledger token grammar; a colon would
+        # make the eventual countersign unrenderable — refuse at the
+        # executor end, not after the seat has already voted.
+        if not label or ":" in label:
+            raise CountersignError(f"receipt label unusable in token grammar: {label!r}")
+    resolved = subprocess.run(  # nosec B603 — fixed argv, shell=False
+        ["git", "-C", str(repo), "rev-parse", base_ref],
+        capture_output=True,
+        text=True,
+        timeout=_GIT_TIMEOUT,
+    )
+    if resolved.returncode != 0:
+        raise CountersignError(f"cannot resolve {base_ref!r}: {resolved.stderr.strip()[:300]}")
+    commit = resolved.stdout.strip()
+
+    root = scratch_root or Path(tempfile.gettempdir())
+    worktree = root / f"rt-countersign-{uuid.uuid4().hex[:12]}"
+    created = subprocess.run(  # nosec B603 — fixed argv, shell=False
+        ["git", "-C", str(repo), "worktree", "add", "--detach", str(worktree), base_ref],
+        capture_output=True,
+        text=True,
+        timeout=_GIT_TIMEOUT,
+    )
+    if created.returncode != 0:
+        raise RuntimeError(f"worktree add failed: {created.stderr.strip()[:300]}")
+
+    candidate = Candidate(worktree=worktree, files=[])
+    artifact_path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        with artifact_path.open("x", encoding="utf-8") as handle:
+            prev = _append_entry(
+                handle,
+                {
+                    "seq": 0,
+                    "kind": "header",
+                    "version": _ARTIFACT_VERSION,
+                    "commit": commit,
+                    "declared": [[label, list(argv)] for label, argv in checks],
+                    "started_at": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+                },
+                prev_digest="",
+            )
+            for seq, (label, argv) in enumerate(checks, start=1):
+                validate(candidate, [(label, argv)])
+                receipt = candidate.receipts[-1]
+                prev = _append_entry(
+                    handle,
+                    {
+                        "seq": seq,
+                        "kind": "receipt",
+                        "label": receipt.label,
+                        "argv": receipt.argv,
+                        "exit_code": receipt.exit_code,
+                        "tail": receipt.tail,
+                        "tail_sha256": hashlib.sha256(receipt.tail.encode("utf-8")).hexdigest(),
+                    },
+                    prev_digest=prev,
+                )
+    finally:
+        discard(candidate)
+    return ReceiptArtifact(
+        path=artifact_path,
+        commit=commit,
+        receipts=list(candidate.receipts),
+        sha256=hashlib.sha256(artifact_path.read_bytes()).hexdigest(),
+    )
+
+
+def load_receipt_artifact(artifact_path: Path) -> ReceiptArtifact:
+    """Load and digest-verify an artifact — FAIL CLOSED.
+
+    Every failure mode is a :class:`CountersignError`: missing
+    file, symlink, unparseable line, wrong header, broken hash
+    chain, per-entry digest mismatch, tail digest mismatch, bad
+    sequence, or zero receipt entries. There is no partial read.
+
+    Raises:
+        CountersignError: Any of the above.
+    """
+    if artifact_path.is_symlink():
+        raise CountersignError(f"artifact is a symlink (refused): {artifact_path}")
+    if not artifact_path.is_file():
+        raise CountersignError(f"artifact missing: {artifact_path}")
+    raw = artifact_path.read_bytes()
+    lines = raw.decode("utf-8", errors="strict").splitlines() if raw else []
+    if not lines:
+        raise CountersignError(f"artifact empty: {artifact_path}")
+
+    entries: list[dict] = []
+    for n, line in enumerate(lines):
+        try:
+            entry = json.loads(line)
+        except json.JSONDecodeError as exc:
+            raise CountersignError(f"artifact line {n} unparseable: {exc}") from exc
+        if not isinstance(entry, dict):
+            raise CountersignError(f"artifact line {n} is not an object")
+        entries.append(entry)
+
+    header = entries[0]
+    if header.get("kind") != "header" or header.get("seq") != 0:
+        raise CountersignError("artifact does not start with a header entry")
+    if header.get("version") != _ARTIFACT_VERSION:
+        raise CountersignError(f"unsupported artifact version: {header.get('version')!r}")
+
+    prev = ""
+    receipts: list[CheckReceipt] = []
+    for n, entry in enumerate(entries):
+        if entry.get("prev_digest") != prev:
+            raise CountersignError(f"hash chain broken at entry {n}")
+        if _entry_digest(entry) != entry.get("entry_digest"):
+            raise CountersignError(f"entry digest mismatch at entry {n}")
+        prev = str(entry["entry_digest"])
+        if n == 0:
+            continue
+        if entry.get("kind") != "receipt" or entry.get("seq") != n:
+            raise CountersignError(f"bad sequence at entry {n}")
+        tail = entry.get("tail")
+        if not isinstance(tail, str) or not isinstance(entry.get("label"), str):
+            raise CountersignError(f"malformed receipt entry {n}")
+        if hashlib.sha256(tail.encode("utf-8")).hexdigest() != entry.get("tail_sha256"):
+            raise CountersignError(f"tail digest mismatch at entry {n}")
+        argv = entry.get("argv")
+        if not isinstance(argv, list) or not all(isinstance(a, str) for a in argv):
+            raise CountersignError(f"malformed argv at entry {n}")
+        receipts.append(
+            CheckReceipt(
+                label=entry["label"],
+                argv=list(argv),
+                exit_code=int(entry.get("exit_code", -1)),
+                tail=tail,
+            )
+        )
+    if not receipts:
+        raise CountersignError("artifact carries no receipt entries")
+    return ReceiptArtifact(
+        path=artifact_path,
+        commit=str(header.get("commit", "")),
+        receipts=receipts,
+        sha256=hashlib.sha256(raw).hexdigest(),
+    )
+
+
+def format_countersign_token(kind: str, seat: str, label: str, sha256: str) -> str:
+    """Render the citable ledger token; round-trips the grammar.
+
+    Raises:
+        CountersignError: The rendered token does not match
+            :data:`COUNTERSIGN_TOKEN_RE` (bad seat, label, or
+            digest) — a token that the gate would flag is never
+            produced in the first place.
+    """
+    token = f"{kind}: {seat} :: {label} :: sha256:{sha256[:16]}"
+    if not COUNTERSIGN_TOKEN_RE.fullmatch(token):
+        raise CountersignError(f"token does not match grammar: {token!r}")
+    return token
+
+
+def _format_receipts(receipts: Sequence[CheckReceipt]) -> str:
+    blocks = []
+    for r in receipts:
+        status = "PASS" if r.passed else f"FAIL (exit {r.exit_code})"
+        blocks.append(f"### {r.label}: {status}\n$ {shlex.join(r.argv)}\n{r.tail}")
+    return "\n\n".join(blocks)
+
+
+def build_countersign_brief(lead: str, artifact: ReceiptArtifact) -> str:
+    """Build the seat brief MECHANICALLY from the verified artifact.
+
+    No lead-authored text enters the brief — the evidence is the
+    artifact's receipts, identified by commit and digest so the
+    seat's verdict is anchored to auditable bytes.
+    """
+    return (
+        "You are the rotating SKEPTIC seat at a three-model round "
+        f"table. The LEAD ({lead}) re-ran delegated-lane receipts "
+        "centrally; the append-only artifact below was written by "
+        "the executing process and its digest chain verified. Judge "
+        "ONLY from this evidence — do not run tools or invent "
+        "checks that were not run.\n\n"
+        f"Artifact sha256: {artifact.sha256}\n"
+        f"Validated commit: {artifact.commit}\n\n"
+        "Reply with EXACTLY one verdict block:\n\n"
+        "VERDICT: COUNTERSIGN\n"
+        "CITE: <label> :: <the command you weight most>\n\n"
+        "or\n\n"
+        "VERDICT: DISSENT\n"
+        "CITE: <label> :: <the failing command>\n"
+        "REASON: <one line, grounded in that command's output "
+        "tail>\n\n"
+        "Calibration: a countersign you did not check for is "
+        "rubber-stamp decay; a failing receipt the lead's claim "
+        "depends on earns a DISSENT. Text only.\n\n"
+        f"## Re-run receipts (from artifact)\n{_format_receipts(artifact.receipts)}"
+    )
+
+
+def run_countersign_pass(
+    artifact_path: Path,
+    lead: str,
+    board: object | None = None,
+    invoke_seat: Callable[[Sequence[str], str], tuple[int, str]] | None = None,
+    seat_recipes: Sequence[tuple[str, tuple[str, ...]]] | None = None,
+    prior_records: Sequence[Mapping[str, object]] = (),
+    thread: str | None = None,
+) -> CountersignPass:
+    """Countersign the lead's receipt re-run from its artifact.
+
+    Fail-closed: a token is emitted from exactly one path —
+    digest-verified artifact + parsed COUNTERSIGN citing an
+    executed receipt. Refusals (``no-artifact``, ``bad-artifact``,
+    ``skeptic-absent``, ``malformed-verdict``) and DISSENT are
+    recorded outcomes without a countersign token (a dissent gets
+    a dissent token — equally citable, opposite meaning). Never
+    flips a status, never promotes (R8).
+
+    Raises:
+        CountersignError: Unknown lead seat (caller error, not an
+            artifact refusal).
+    """
+    from attune.roundtable.routine import SEAT_RECIPES, default_invoke_seat
+
+    if lead not in CANONICAL_SEATS:
+        raise CountersignError(f"unknown lead seat: {lead!r}")
+    invoke = invoke_seat or default_invoke_seat
+    recipes = dict(seat_recipes or SEAT_RECIPES)
+    record = CountersignPass(lead=lead)
+    thread = thread or (f"countersign-{lead}-{datetime.datetime.now().strftime('%Y%m%d-%H%M')}")
+
+    try:
+        artifact = load_receipt_artifact(artifact_path)
+    except CountersignError as exc:
+        record.outcome = "no-artifact" if not artifact_path.is_file() else "bad-artifact"
+        _post(board, thread, "moderator", "halt", f"countersign refused: {exc}")
+        return record
+    record.artifact_sha256 = artifact.sha256
+    record.receipts = list(artifact.receipts)
+
+    brief = build_countersign_brief(lead, artifact)
+    _post(board, thread, "moderator", "question", brief, countersign_for=lead)
+
+    first = skeptic_for(lead, prior_records)
+    start = CANONICAL_SEATS.index(first)
+    ordered = [
+        CANONICAL_SEATS[(start + i) % len(CANONICAL_SEATS)] for i in range(len(CANONICAL_SEATS))
+    ]
+    eligible = [seat for seat in ordered if seat != lead and seat in recipes]
+    for seat in eligible[:2]:  # picked seat + one absent fallback
+        code, reply = invoke(recipes[seat], brief)
+        if code != 0 or not reply.strip():
+            _post(
+                board,
+                thread,
+                seat,
+                "position",
+                f"ABSENT — exit {code}: {reply[:200]}",
+                absent=True,
+                countersign_for=lead,
+            )
+            continue
+        record.skeptic = seat
+        record.verdict = parse_skeptic_verdict(
+            reply, valid_labels=[r.label for r in artifact.receipts]
+        )
+        _post(board, thread, seat, "position", reply, countersign_for=lead)
+        break
+
+    if record.skeptic is None:
+        record.outcome = "skeptic-absent"
+        _post(
+            board,
+            thread,
+            "moderator",
+            "halt",
+            f"no eligible skeptic seat reachable to countersign {lead!r}'s re-run",
+        )
+        return record
+
+    verdict = record.verdict
+    assert verdict is not None  # nosec B101 — set with record.skeptic above
+    if verdict.kind in ("countersign", "dissent"):
+        record.outcome = f"{verdict.kind}ed"
+        label = (verdict.cite or "").split("::", 1)[0].strip()
+        record.token = format_countersign_token(
+            verdict.kind, record.skeptic, label, artifact.sha256
+        )
+    else:
+        record.outcome = "malformed-verdict"
+
+    _post(board, thread, "moderator", "synthesis", _digest(record), countersign_for=lead)
+    return record
+
+
+def _digest(record: CountersignPass) -> str:
+    """Compact chair-facing summary of one countersign pass."""
+    lines = [
+        f"Countersign pass for lead {record.lead!r}: outcome={record.outcome}",
+        f"skeptic={record.skeptic or 'ABSENT'} "
+        f"artifact={record.artifact_sha256[:16] if record.artifact_sha256 else 'NONE'}",
+        "receipts: "
+        + "; ".join(
+            f"{r.label}={'PASS' if r.passed else f'FAIL({r.exit_code})'}" for r in record.receipts
+        ),
+    ]
+    if record.token:
+        lines.append(f"ledger token: {record.token}")
+    else:
+        lines.append("NO ledger token (fail-closed refusal or malformed verdict)")
+    lines.append("Chair rules; this pass never flips a status (R8).")
+    return "\n".join(lines)
+
+
+def _post(
+    board: object | None, thread: str, seat: str, kind: str, body: str, **fields: object
+) -> None:
+    """Post to the board when one is wired; print otherwise."""
+    if board is None:
+        print(f"[{thread}] {seat}/{kind}: {body[:160]}", flush=True)
+        return
+    board.post_message(thread, seat, kind, body, **fields)  # type: ignore[attr-defined]
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """CLI for the two ends of the evidence path.
+
+    ``rerun``: the executor end — re-run declared receipts and
+    stream the artifact.  ``pass``: the skeptic end — verify the
+    artifact and seek the countersign.  ``verify``: chair audit —
+    verify a named artifact's chain and print its digest.
+    """
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="D11c hardened countersign of lead receipt re-runs (R8: chair promotes)."
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_rerun = sub.add_parser("rerun", help="execute receipts, streaming the artifact")
+    p_rerun.add_argument("artifact", help="artifact path to create (must not exist)")
+    p_rerun.add_argument(
+        "--check",
+        action="append",
+        required=True,
+        metavar="LABEL::CMD",
+        help="receipt as 'label :: command' (repeatable)",
+    )
+    p_rerun.add_argument("--repo", default=".")
+
+    p_pass = sub.add_parser("pass", help="verify artifact and seek the countersign")
+    p_pass.add_argument("artifact")
+    p_pass.add_argument("--lead", required=True, choices=sorted(CANONICAL_SEATS))
+
+    p_verify = sub.add_parser("verify", help="chair audit: verify chain, print digest")
+    p_verify.add_argument("artifact")
+
+    args = parser.parse_args(argv)
+    artifact_path = Path(args.artifact)
+
+    if args.command == "rerun":
+        checks: list[tuple[str, list[str]]] = []
+        for raw in args.check:
+            label, sep, cmd = raw.partition("::")
+            if not sep or not label.strip() or not cmd.strip():
+                print(f"bad --check (want 'label :: command'): {raw!r}")
+                return 2
+            try:
+                checks.append((label.strip(), shlex.split(cmd)))
+            except ValueError as exc:
+                print(f"unparseable command in {raw!r}: {exc}")
+                return 2
+        try:
+            artifact = rerun_receipts_to_artifact(Path(args.repo).resolve(), checks, artifact_path)
+        except (CountersignError, RuntimeError) as exc:
+            print(f"countersign rerun: {exc}")
+            return 2
+        print(f"artifact written: {artifact.path} sha256:{artifact.sha256}")
+        return 0
+
+    if args.command == "verify":
+        try:
+            artifact = load_receipt_artifact(artifact_path)
+        except CountersignError as exc:
+            print(f"countersign verify: FAIL — {exc}")
+            return 2
+        print(f"artifact OK: {len(artifact.receipts)} receipt(s) sha256:{artifact.sha256}")
+        return 0
+
+    from attune.roundtable.board import Board
+
+    try:
+        record = run_countersign_pass(artifact_path, args.lead, board=Board())
+    except CountersignError as exc:
+        print(f"countersign: {exc}")
+        return 2
+    print(f"countersign pass complete: outcome={record.outcome}")
+    if record.token:
+        print(f"ledger token: {record.token}")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/src/attune/roundtable/countersign.py
+++ b/src/attune/roundtable/countersign.py
@@ -219,6 +219,58 @@ def rerun_receipts_to_artifact(
     )
 
 
+def _parse_artifact_lines(artifact_path: Path) -> tuple[bytes, list[dict]]:
+    """Read the artifact and parse one JSON object per line — FAIL CLOSED."""
+    if artifact_path.is_symlink():
+        raise CountersignError(f"artifact is a symlink (refused): {artifact_path}")
+    if not artifact_path.is_file():
+        raise CountersignError(f"artifact missing: {artifact_path}")
+    raw = artifact_path.read_bytes()
+    lines = raw.decode("utf-8", errors="strict").splitlines() if raw else []
+    if not lines:
+        raise CountersignError(f"artifact empty: {artifact_path}")
+    entries: list[dict] = []
+    for n, line in enumerate(lines):
+        try:
+            entry = json.loads(line)
+        except json.JSONDecodeError as exc:
+            raise CountersignError(f"artifact line {n} unparseable: {exc}") from exc
+        if not isinstance(entry, dict):
+            raise CountersignError(f"artifact line {n} is not an object")
+        entries.append(entry)
+    return raw, entries
+
+
+def _validate_header(entries: list[dict]) -> dict:
+    """The artifact must open with a supported-version header entry."""
+    header = entries[0]
+    if header.get("kind") != "header" or header.get("seq") != 0:
+        raise CountersignError("artifact does not start with a header entry")
+    if header.get("version") != _ARTIFACT_VERSION:
+        raise CountersignError(f"unsupported artifact version: {header.get('version')!r}")
+    return header
+
+
+def _receipt_from_entry(entry: dict, n: int) -> CheckReceipt:
+    """Validate one receipt entry and build its CheckReceipt — FAIL CLOSED."""
+    if entry.get("kind") != "receipt" or entry.get("seq") != n:
+        raise CountersignError(f"bad sequence at entry {n}")
+    tail = entry.get("tail")
+    if not isinstance(tail, str) or not isinstance(entry.get("label"), str):
+        raise CountersignError(f"malformed receipt entry {n}")
+    if hashlib.sha256(tail.encode("utf-8")).hexdigest() != entry.get("tail_sha256"):
+        raise CountersignError(f"tail digest mismatch at entry {n}")
+    argv = entry.get("argv")
+    if not isinstance(argv, list) or not all(isinstance(a, str) for a in argv):
+        raise CountersignError(f"malformed argv at entry {n}")
+    return CheckReceipt(
+        label=entry["label"],
+        argv=list(argv),
+        exit_code=int(entry.get("exit_code", -1)),
+        tail=tail,
+    )
+
+
 def load_receipt_artifact(artifact_path: Path) -> ReceiptArtifact:
     """Load and digest-verify an artifact — FAIL CLOSED.
 
@@ -230,30 +282,8 @@ def load_receipt_artifact(artifact_path: Path) -> ReceiptArtifact:
     Raises:
         CountersignError: Any of the above.
     """
-    if artifact_path.is_symlink():
-        raise CountersignError(f"artifact is a symlink (refused): {artifact_path}")
-    if not artifact_path.is_file():
-        raise CountersignError(f"artifact missing: {artifact_path}")
-    raw = artifact_path.read_bytes()
-    lines = raw.decode("utf-8", errors="strict").splitlines() if raw else []
-    if not lines:
-        raise CountersignError(f"artifact empty: {artifact_path}")
-
-    entries: list[dict] = []
-    for n, line in enumerate(lines):
-        try:
-            entry = json.loads(line)
-        except json.JSONDecodeError as exc:
-            raise CountersignError(f"artifact line {n} unparseable: {exc}") from exc
-        if not isinstance(entry, dict):
-            raise CountersignError(f"artifact line {n} is not an object")
-        entries.append(entry)
-
-    header = entries[0]
-    if header.get("kind") != "header" or header.get("seq") != 0:
-        raise CountersignError("artifact does not start with a header entry")
-    if header.get("version") != _ARTIFACT_VERSION:
-        raise CountersignError(f"unsupported artifact version: {header.get('version')!r}")
+    raw, entries = _parse_artifact_lines(artifact_path)
+    header = _validate_header(entries)
 
     prev = ""
     receipts: list[CheckReceipt] = []
@@ -263,26 +293,8 @@ def load_receipt_artifact(artifact_path: Path) -> ReceiptArtifact:
         if _entry_digest(entry) != entry.get("entry_digest"):
             raise CountersignError(f"entry digest mismatch at entry {n}")
         prev = str(entry["entry_digest"])
-        if n == 0:
-            continue
-        if entry.get("kind") != "receipt" or entry.get("seq") != n:
-            raise CountersignError(f"bad sequence at entry {n}")
-        tail = entry.get("tail")
-        if not isinstance(tail, str) or not isinstance(entry.get("label"), str):
-            raise CountersignError(f"malformed receipt entry {n}")
-        if hashlib.sha256(tail.encode("utf-8")).hexdigest() != entry.get("tail_sha256"):
-            raise CountersignError(f"tail digest mismatch at entry {n}")
-        argv = entry.get("argv")
-        if not isinstance(argv, list) or not all(isinstance(a, str) for a in argv):
-            raise CountersignError(f"malformed argv at entry {n}")
-        receipts.append(
-            CheckReceipt(
-                label=entry["label"],
-                argv=list(argv),
-                exit_code=int(entry.get("exit_code", -1)),
-                tail=tail,
-            )
-        )
+        if n > 0:
+            receipts.append(_receipt_from_entry(entry, n))
     if not receipts:
         raise CountersignError("artifact carries no receipt entries")
     return ReceiptArtifact(

--- a/tests/unit/gates/test_ledger_countersign_format.py
+++ b/tests/unit/gates/test_ledger_countersign_format.py
@@ -1,0 +1,69 @@
+"""D11c guard: countersign claims in the R5 ledger are citable.
+
+The lead's central receipt re-runs are countersigned by a non-lead
+skeptic seat from an executor-produced, digest-verified artifact
+(feature-lead-governance D11c, 2026-07-29). A ledger row that claims
+a countersign (or a dissent) must carry the full citable token —
+seat, cited receipt label, and artifact digest — so the chair can
+audit the named artifact instead of trusting the lead's word:
+
+    countersign: <seat> :: <label> :: sha256:<16+ hex>
+    dissent: <seat> :: <label> :: sha256:<16+ hex>
+
+The grammar is IMPORTED from the producing module
+(:data:`attune.roundtable.countersign.COUNTERSIGN_TOKEN_RE`) — one
+source, so the gate and the token formatter cannot drift apart. A
+bare "countersign:" without the artifact digest is exactly the
+lead-narrated claim D11c exists to reject; this gate fails on it.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from attune.roundtable.countersign import COUNTERSIGN_TOKEN_RE
+
+REPO_ROOT = Path(__file__).parents[3]
+LEDGER = REPO_ROOT / "docs/specs/cross-review/receipts.md"
+
+_CLAIM = re.compile(r"\b(?:countersign|dissent):", re.IGNORECASE)
+
+
+def _ledger_rows() -> list[str]:
+    rows = [
+        line
+        for line in LEDGER.read_text(encoding="utf-8").splitlines()
+        if re.match(r"^\| \d{4}-\d{2}-\d{2} \|", line)
+    ]
+    assert rows, f"no ledger rows found in {LEDGER} — table format changed?"
+    return rows
+
+
+def _uncited_claims(row: str) -> list[str]:
+    """Claim markers in the row not covered by a full citable token."""
+    stripped = COUNTERSIGN_TOKEN_RE.sub("", row)
+    return [m.group(0) for m in _CLAIM.finditer(stripped)]
+
+
+def test_countersign_claims_carry_full_token():
+    bad = [row for row in _ledger_rows() if _uncited_claims(row)]
+    assert not bad, (
+        "R5 ledger rows claim a countersign/dissent without the citable "
+        "token 'countersign: <seat> :: <label> :: sha256:<hex>' "
+        f"(D11c): {bad}"
+    )
+
+
+def test_gate_fires_on_bare_claim():
+    # Fires-on-violation receipt: a lead-narrated claim without the
+    # artifact digest must be caught, a full token must pass.
+    bare = "| 2026-07-29 | codex | t | 1 | 1 | real — countersigned by codex |"
+    assert not _uncited_claims(bare)  # 'countersigned by' is prose, not a claim marker
+    claim = "| 2026-07-29 | codex | t | 1 | 1 | real — countersign: codex said fine |"
+    assert _uncited_claims(claim)
+    full = (
+        "| 2026-07-29 | codex | t | 1 | 1 | real — "
+        "countersign: antigravity :: unit-suite :: sha256:0123456789abcdef |"
+    )
+    assert not _uncited_claims(full)

--- a/tests/unit/roundtable/test_countersign.py
+++ b/tests/unit/roundtable/test_countersign.py
@@ -1,0 +1,391 @@
+"""D11c hardened-countersign tests.
+
+Real git repos and worktrees in tmp for the executor end — no
+mocked git (the executor→artifact seam is the point). Seat
+invocations and the board are injected fakes; the fail-closed
+contract (missing/tampered artifacts refuse, tokens only from
+verified evidence, different-model rule, R8 never-promotes) is
+asserted from the pass record and posted messages.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under Apache 2.0
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import subprocess
+import sys
+
+import pytest
+
+from attune.roundtable.countersign import (
+    COUNTERSIGN_TOKEN_RE,
+    CountersignError,
+    build_countersign_brief,
+    format_countersign_token,
+    load_receipt_artifact,
+    main,
+    rerun_receipts_to_artifact,
+    run_countersign_pass,
+)
+from attune.roundtable.rotation import CANONICAL_SEATS
+
+
+@pytest.fixture
+def repo(tmp_path):
+    """A tiny real git repo with one committed file."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+
+    def git(*args):
+        subprocess.run(["git", "-C", str(repo), *args], check=True, capture_output=True, text=True)
+
+    git("init", "-q")
+    git("config", "user.email", "t@example.com")
+    git("config", "user.name", "t")
+    git("config", "commit.gpgsign", "false")
+    (repo / "hello.py").write_text('GREETING = "hello"\n')
+    git("add", "hello.py")
+    git("commit", "-q", "-m", "seed")
+    return repo
+
+
+PASS_CHECK = ("greet", [sys.executable, "-c", "print('ok')"])
+FAIL_CHECK = ("boom", [sys.executable, "-c", "raise SystemExit(3)"])
+
+
+@pytest.fixture
+def artifact(repo, tmp_path):
+    """An executor-produced artifact with one pass and one fail."""
+    path = tmp_path / "receipts.jsonl"
+    rerun_receipts_to_artifact(repo, [PASS_CHECK, FAIL_CHECK], path)
+    return path
+
+
+class FakeBoard:
+    """Collects posts; exposes no promote path (R8 by construction)."""
+
+    def __init__(self):
+        self.posts = []
+
+    def post_message(self, thread, seat, kind, body, **fields):
+        self.posts.append({"thread": thread, "seat": seat, "kind": kind, "body": body, **fields})
+
+
+def _invoke_countersign(recipe, brief):
+    return 0, "VERDICT: COUNTERSIGN\nCITE: greet :: print ok"
+
+
+def _invoke_dissent(recipe, brief):
+    return 0, "VERDICT: DISSENT\nCITE: boom :: exit 3\nREASON: receipt failed"
+
+
+RECIPES = tuple((seat, (seat, "--stub")) for seat in CANONICAL_SEATS)
+
+
+# ---------------------------------------------------------------- executor
+
+
+class TestRerunToArtifact:
+    def test_streams_verifiable_artifact(self, repo, tmp_path):
+        path = tmp_path / "a.jsonl"
+        produced = rerun_receipts_to_artifact(repo, [PASS_CHECK, FAIL_CHECK], path)
+        loaded = load_receipt_artifact(path)
+        assert [r.label for r in loaded.receipts] == ["greet", "boom"]
+        assert loaded.receipts[0].passed and loaded.receipts[0].tail == "ok"
+        assert loaded.receipts[1].exit_code == 3
+        assert loaded.sha256 == produced.sha256
+        head = subprocess.run(
+            ["git", "-C", str(repo), "rev-parse", "HEAD"],
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
+        assert loaded.commit == head
+
+    def test_refuses_existing_path(self, repo, tmp_path):
+        path = tmp_path / "a.jsonl"
+        path.write_text("occupied")
+        with pytest.raises(CountersignError, match="append-only"):
+            rerun_receipts_to_artifact(repo, [PASS_CHECK], path)
+
+    def test_refuses_empty_and_capped_checks(self, repo, tmp_path):
+        with pytest.raises(CountersignError, match="no receipt"):
+            rerun_receipts_to_artifact(repo, [], tmp_path / "a.jsonl")
+        many = [(f"c{i}", ["true"]) for i in range(9)]
+        with pytest.raises(CountersignError, match="capped"):
+            rerun_receipts_to_artifact(repo, many, tmp_path / "b.jsonl")
+
+    def test_refuses_label_breaking_token_grammar(self, repo, tmp_path):
+        with pytest.raises(CountersignError, match="label"):
+            rerun_receipts_to_artifact(repo, [("a:b", ["true"])], tmp_path / "a.jsonl")
+
+    def test_refuses_bad_ref(self, repo, tmp_path):
+        with pytest.raises(CountersignError, match="cannot resolve"):
+            rerun_receipts_to_artifact(repo, [PASS_CHECK], tmp_path / "a.jsonl", base_ref="nope")
+
+    def test_scratch_worktree_discarded(self, repo, tmp_path):
+        scratch = tmp_path / "scratch"
+        rerun_receipts_to_artifact(repo, [PASS_CHECK], tmp_path / "a.jsonl", scratch_root=scratch)
+        assert not scratch.exists() or not any(scratch.iterdir())
+
+
+# ------------------------------------------------------- fail-closed loads
+
+
+class TestLoadFailsClosed:
+    def test_missing_file(self, tmp_path):
+        with pytest.raises(CountersignError, match="missing"):
+            load_receipt_artifact(tmp_path / "nope.jsonl")
+
+    def test_symlink_refused(self, artifact, tmp_path):
+        link = tmp_path / "link.jsonl"
+        link.symlink_to(artifact)
+        with pytest.raises(CountersignError, match="symlink"):
+            load_receipt_artifact(link)
+
+    def test_empty_file(self, tmp_path):
+        path = tmp_path / "empty.jsonl"
+        path.write_text("")
+        with pytest.raises(CountersignError, match="empty"):
+            load_receipt_artifact(path)
+
+    def test_garbage_line(self, artifact):
+        artifact.write_text(artifact.read_text() + "not json\n")
+        with pytest.raises(CountersignError, match="unparseable"):
+            load_receipt_artifact(artifact)
+
+    def test_missing_header(self, artifact):
+        lines = artifact.read_text().splitlines()
+        artifact.write_text("\n".join(lines[1:]) + "\n")
+        with pytest.raises(CountersignError, match="header|chain"):
+            load_receipt_artifact(artifact)
+
+    def test_naive_tail_tamper_breaks_entry_digest(self, artifact):
+        lines = artifact.read_text().splitlines()
+        entry = json.loads(lines[1])
+        entry["tail"] = "doctored"
+        lines[1] = json.dumps(entry, sort_keys=True, separators=(",", ":"))
+        artifact.write_text("\n".join(lines) + "\n")
+        with pytest.raises(CountersignError, match="digest mismatch"):
+            load_receipt_artifact(artifact)
+
+    def test_recomputed_digest_tamper_breaks_chain_or_tail_hash(self, artifact):
+        # A sophisticated tamper on the LAST entry recomputes the entry
+        # digest; the stale tail_sha256 still betrays it.
+        lines = artifact.read_text().splitlines()
+        entry = json.loads(lines[-1])
+        entry["tail"] = "doctored"
+        del entry["entry_digest"]
+        digest = hashlib.sha256(
+            json.dumps(entry, sort_keys=True, separators=(",", ":")).encode()
+        ).hexdigest()
+        entry["entry_digest"] = digest
+        lines[-1] = json.dumps(entry, sort_keys=True, separators=(",", ":"))
+        artifact.write_text("\n".join(lines) + "\n")
+        with pytest.raises(CountersignError, match="tail digest"):
+            load_receipt_artifact(artifact)
+
+    def test_dropped_entry_breaks_chain(self, artifact):
+        lines = artifact.read_text().splitlines()
+        artifact.write_text("\n".join([lines[0], lines[2]]) + "\n")
+        with pytest.raises(CountersignError, match="chain|sequence"):
+            load_receipt_artifact(artifact)
+
+    def test_header_only_refused(self, artifact):
+        lines = artifact.read_text().splitlines()
+        artifact.write_text(lines[0] + "\n")
+        with pytest.raises(CountersignError, match="no receipt"):
+            load_receipt_artifact(artifact)
+
+
+# ---------------------------------------------------------------- tokens
+
+
+class TestToken:
+    def test_round_trips_grammar(self):
+        token = format_countersign_token("countersign", "codex", "greet", "a" * 64)
+        m = COUNTERSIGN_TOKEN_RE.fullmatch(token)
+        assert m and m.group("seat") == "codex" and m.group("digest") == "a" * 16
+
+    def test_bad_pieces_refused(self):
+        with pytest.raises(CountersignError):
+            format_countersign_token("countersign", "codex", "has:colon", "a" * 64)
+        with pytest.raises(CountersignError):
+            format_countersign_token("countersign", "codex", "greet", "short")
+
+
+# ---------------------------------------------------------------- passes
+
+
+class TestCountersignPass:
+    def test_countersign_emits_citable_token(self, artifact):
+        board = FakeBoard()
+        record = run_countersign_pass(
+            artifact,
+            lead="claude",
+            board=board,
+            invoke_seat=_invoke_countersign,
+            seat_recipes=RECIPES,
+        )
+        assert record.outcome == "countersigned"
+        assert record.token and COUNTERSIGN_TOKEN_RE.fullmatch(record.token)
+        assert record.artifact_sha256[:16] in record.token
+        assert record.skeptic != "claude"
+
+    def test_dissent_emits_dissent_token(self, artifact):
+        record = run_countersign_pass(
+            artifact,
+            lead="claude",
+            board=FakeBoard(),
+            invoke_seat=_invoke_dissent,
+            seat_recipes=RECIPES,
+        )
+        assert record.outcome == "dissented"
+        assert record.token.startswith("dissent: ")
+
+    def test_invented_cite_is_malformed_no_token(self, artifact):
+        record = run_countersign_pass(
+            artifact,
+            lead="claude",
+            board=FakeBoard(),
+            invoke_seat=lambda r, b: (0, "VERDICT: COUNTERSIGN\nCITE: invented :: x"),
+            seat_recipes=RECIPES,
+        )
+        assert record.outcome == "malformed-verdict"
+        assert record.token is None
+
+    def test_uncited_countersign_is_malformed(self, artifact):
+        record = run_countersign_pass(
+            artifact,
+            lead="claude",
+            board=FakeBoard(),
+            invoke_seat=lambda r, b: (0, "VERDICT: COUNTERSIGN"),
+            seat_recipes=RECIPES,
+        )
+        assert record.outcome == "malformed-verdict"
+        assert record.token is None
+
+    def test_missing_artifact_refuses_without_invoking(self, tmp_path):
+        calls = []
+
+        def invoke(recipe, brief):
+            calls.append(recipe)
+            return 0, "VERDICT: COUNTERSIGN\nCITE: greet :: x"
+
+        record = run_countersign_pass(
+            tmp_path / "nope.jsonl",
+            lead="claude",
+            board=FakeBoard(),
+            invoke_seat=invoke,
+            seat_recipes=RECIPES,
+        )
+        assert record.outcome == "no-artifact"
+        assert record.token is None and not calls
+
+    def test_tampered_artifact_refuses_without_invoking(self, artifact):
+        artifact.write_text(artifact.read_text() + "junk\n")
+        record = run_countersign_pass(
+            artifact,
+            lead="claude",
+            board=FakeBoard(),
+            invoke_seat=lambda r, b: (0, "VERDICT: COUNTERSIGN\nCITE: greet :: x"),
+            seat_recipes=RECIPES,
+        )
+        assert record.outcome == "bad-artifact"
+        assert record.token is None
+
+    def test_lead_never_invoked_as_skeptic(self, artifact):
+        seats = []
+
+        def invoke(recipe, brief):
+            seats.append(recipe[0])
+            return 1, ""  # everyone absent — walk the whole rotation
+
+        record = run_countersign_pass(
+            artifact,
+            lead="codex",
+            board=FakeBoard(),
+            invoke_seat=invoke,
+            seat_recipes=RECIPES,
+        )
+        assert "codex" not in seats
+        assert record.outcome == "skeptic-absent"
+        assert record.token is None
+
+    def test_absent_first_seat_falls_back_once(self, artifact):
+        seats = []
+
+        def invoke(recipe, brief):
+            seats.append(recipe[0])
+            if len(seats) == 1:
+                return 1, "unreachable"
+            return 0, "VERDICT: COUNTERSIGN\nCITE: greet :: x"
+
+        record = run_countersign_pass(
+            artifact,
+            lead="claude",
+            board=FakeBoard(),
+            invoke_seat=invoke,
+            seat_recipes=RECIPES,
+        )
+        assert record.outcome == "countersigned"
+        assert record.skeptic == seats[1] != "claude"
+
+    def test_unknown_lead_raises(self, artifact):
+        with pytest.raises(CountersignError, match="unknown lead"):
+            run_countersign_pass(artifact, lead="gpt", seat_recipes=RECIPES)
+
+    def test_brief_is_built_from_artifact_only(self, artifact):
+        loaded = load_receipt_artifact(artifact)
+        brief = build_countersign_brief("claude", loaded)
+        assert loaded.sha256 in brief
+        assert "### greet: PASS" in brief and "### boom: FAIL (exit 3)" in brief
+
+    def test_synthesis_posted_for_chair(self, artifact):
+        board = FakeBoard()
+        run_countersign_pass(
+            artifact,
+            lead="claude",
+            board=board,
+            invoke_seat=_invoke_countersign,
+            seat_recipes=RECIPES,
+        )
+        synth = [p for p in board.posts if p["kind"] == "synthesis"]
+        assert synth and "never flips a status (R8)" in synth[0]["body"]
+
+
+# ------------------------------------------------------------------- CLI
+
+
+class TestCli:
+    def test_rerun_then_verify(self, repo, tmp_path, capsys):
+        path = tmp_path / "a.jsonl"
+        code = main(
+            [
+                "rerun",
+                str(path),
+                "--repo",
+                str(repo),
+                "--check",
+                f"greet :: {sys.executable} -c \"print('ok')\"",
+            ]
+        )
+        assert code == 0
+        assert "sha256:" in capsys.readouterr().out
+        assert main(["verify", str(path)]) == 0
+        path.write_text(path.read_text() + "junk\n")
+        assert main(["verify", str(path)]) == 2
+
+    def test_rerun_bad_check_spec(self, repo, tmp_path):
+        assert (
+            main(["rerun", str(tmp_path / "a.jsonl"), "--repo", str(repo), "--check", "nolabel"])
+            == 2
+        )
+
+    def test_rerun_refuses_existing_artifact(self, repo, tmp_path):
+        path = tmp_path / "a.jsonl"
+        path.write_text("occupied")
+        assert main(["rerun", str(path), "--repo", str(repo), "--check", "c :: true"]) == 2


### PR DESCRIPTION
Implements **D11c** (feature-lead-governance decisions.md, ruled 2026-07-29 via roundtable `q-lead-verification-gap-001`, shipped in #1751): the lead's central receipt re-runs are countersigned by the #1559 skeptic — **hardened form only**. The naive form (skeptic judging lead-narrated receipts in the lead's session) was rejected by the table as "self-verification with another prompt attached"; this design makes that form unreachable through the shipped API.

## Evidence path: executor → artifact → skeptic

- **`src/attune/roundtable/countersign.py`**
  - `rerun_receipts_to_artifact` — the executing process (isolated scratch worktree, reusing `solutions.validate` semantics: serial, fixed argv, never a shell) streams an **append-only, hash-chained JSONL artifact**, one entry per receipt as it completes. Existing paths refused (no overwrite); labels that would break the token grammar refused at the executor end.
  - `load_receipt_artifact` — **fail-closed**: missing file, symlink, unparseable line, wrong header, broken chain, per-entry digest mismatch, tail-hash mismatch, bad sequence, zero receipts → `CountersignError`. No partial reads.
  - `run_countersign_pass` — brief built **mechanically** from the verified artifact (no lead-authored text); rotation-picked **non-lead** seat via `skeptic_for` (different-model rule); verdict parsed with `parse_skeptic_verdict(valid_labels=…)` so an invented CITE is malformed. A token is emitted from exactly one path: verified artifact + parsed verdict citing an executed receipt. Refusals (`no-artifact` / `bad-artifact` / `skeptic-absent` / `malformed-verdict`) produce **no token** — an uncountersigned ledger row stays visibly uncountersigned. R8 intact.
  - `format_countersign_token` + `COUNTERSIGN_TOKEN_RE` — the citable ledger grammar `countersign: <seat> :: <label> :: sha256:<16+ hex>` (dissent: same), single-sourced.
  - CLI: `rerun` (executor end), `pass` (skeptic end), `verify` (chair audit: re-verify chain, print digest).
- **Gate**: `tests/unit/gates/test_ledger_countersign_format.py` — D11a-style sweep of the R5 ledger, **importing the module regex** (grammar and gate cannot drift); fires-on-violation self-test included. A bare `countersign:` claim without the artifact digest fails.
- **Spec**: design addendum in `docs/specs/feature-lead-governance/design.md` (evidence path, fail-closed contract, honest limits — hardening is evidentiary, not cryptographic; attestation out of scope, same posture as D3); dated implementation-evidence entry in decisions.md (ruling text untouched); countersign convention documented in the ledger header.

## Receipts

- 33 new tests: tamper both ways (naive edit breaks the entry digest; recomputed-digest edit breaks the tail hash or chain), all refusal outcomes, different-model rule (lead never invoked as skeptic), absent-seat fallback, CLI round trip — real git repos/worktrees, no mocked git.
- `tests/unit/roundtable/ + tests/unit/gates/`: **458 passed** serially post-rebase (includes #1751's D11a gate).
- Module coverage **91%** (serial, /tmp coverage dance).

Next evidence step (recorded in decisions.md): first live delegated lane whose lead re-run ships with an artifact + countersign token in its R5 row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
