### PR TITLE
docs: refresh stale version claims across living docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,7 @@ integration and spends most time in code.
 
 | Name | What |
 |------|------|
-| **attune-ai** | AI dev workflows, v5.0.0 |
+| **attune-ai** | AI dev workflows |
 | **Phase 2** | Profiling, caching, generators |
 
 ## Preferences

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -4,7 +4,7 @@ description: Attune AI - Architecture Overview: System architecture overview wit
 
 # Attune AI - Architecture Overview
 
-**Last Updated:** April 23, 2026
+**Last Updated:** July 29, 2026
 **Status:** Living Document
 
 ---
@@ -111,28 +111,30 @@ Tier 5 — Entry Points
      cli_router ←── commands ──→ wizards
 ```
 
-### Codebase Metrics (v5.0.2)
+### Codebase Metrics (v11.0.0)
 
 | Metric | Value |
 |--------|-------|
-| Python files | 683 |
-| Lines of code | 178,974 |
-| Functions | 4,622 |
-| Classes | 1,188 |
-| Subpackages | 40 |
-| Tests | 10,860+ passing |
+| Python files | 731 |
+| Lines of code | 189,910 |
+| Functions (incl. methods) | 5,154 |
+| Classes | 889 |
+| Subpackages | 50 |
+| Tests | 23,597 collected |
 
-### Key Coupling Metrics (v5.0.2)
+### Key Coupling Metrics (v11.0.0)
+
+Dependents = files under `src/attune/` importing the module.
 
 | Module | Dependents | Role |
 |--------|-----------|------|
-| security/path_validation | 77+ | Path traversal guard |
-| config | 6 | Legacy config (decoupled) |
-| models | 14 | Model registry, tiers |
-| memory | 23 | Unified storage API |
-| meta_workflows | 25 | Orchestration hub |
-| workflows | 16 | Workflow engine |
-| mcp | 25+ tools | Claude Code integration |
+| security/path_validation | 77 | Path traversal guard |
+| config | 26 | Configuration |
+| models | 52 | Model registry, tiers |
+| memory | 53 | Unified storage API |
+| meta_workflows | 31 | Orchestration hub |
+| workflows | 59 | Workflow engine |
+| mcp | 49 core tools | Claude Code integration |
 
 ---
 

--- a/docs/ORCHESTRATION_API.md
+++ b/docs/ORCHESTRATION_API.md
@@ -4,8 +4,8 @@ description: Orchestration API Reference — agent templates, execution strategi
 
 # Orchestration API Reference
 
-**Version:** 8.0.1
-**Last Updated:** June 9, 2026
+**Version:** 11.0.0
+**Last Updated:** July 29, 2026
 
 ---
 

--- a/docs/ORCHESTRATION_USER_GUIDE.md
+++ b/docs/ORCHESTRATION_USER_GUIDE.md
@@ -4,8 +4,8 @@ description: Orchestration User Guide: Step-by-step tutorial with examples, best
 
 # Orchestration User Guide
 
-**Version:** 8.0.1
-**Last Updated:** June 9, 2026
+**Version:** 11.0.0
+**Last Updated:** July 29, 2026
 **Status:** Production Ready
 
 ---

--- a/docs/reference/multi-agent.md
+++ b/docs/reference/multi-agent.md
@@ -70,9 +70,11 @@ print(f"Collaboration efficiency: {stats['collaboration_efficiency']:.0%}")
     [CHANGELOG](https://github.com/Smart-AI-Memory/attune-ai/blob/main/CHANGELOG.md)).
     They had no internal callers in attune-ai and were blocking Redis-free
     installs. If you depended on these classes, pin
-    `attune-ai<6.8.0` or copy them from the v6.7.x source tree. A future
-    `attune-redis` plugin will re-introduce coordination primitives with
-    a proper API once it lands on PyPI.
+    `attune-ai<6.8.0` or copy them from the v6.7.x source tree. The Redis
+    plugin now ships bundled inside the attune-ai wheel (there is no
+    separate `attune-redis` package on PyPI); its
+    `attune_redis.signals.RedisSignalBus` provides the cross-agent
+    signaling primitive.
 
 ---
 


### PR DESCRIPTION
Mechanical staleness pass ahead of the next release (tech-debt sweep, evening 2026-07-29):

| File | Was | Now |
|---|---|---|
| `docs/ARCHITECTURE.md` | metrics labeled v5.0.2 (six majors stale) | regenerated at v11.0.0 — 731 files, 189,910 LOC, 889 classes, 23,597 tests collected; coupling dependents recounted with a stated definition |
| `docs/ORCHESTRATION_USER_GUIDE.md` / `docs/ORCHESTRATION_API.md` | `Version: 8.0.1` headers | 11.0.0 — content already covers WorkflowAgent/AgentTeam; only headers rotted |
| `docs/reference/multi-agent.md` | "a future attune-redis plugin… once it lands on PyPI" | plugin ships bundled in the attune-ai wheel; `RedisSignalBus` is the live primitive |
| `CLAUDE.md` (root) | "AI dev workflows, v5.0.0" | version dropped — prose versions rot, pyproject owns it |

CI-gated freshness surfaces (help templates, doc-import drift) verified clean before the pass — these edits are the gaps no gate reaches. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)