### PR TITLE
fix(tests): skip chmod-based countersign worktree test on Windows

### DIFF
--- a/tests/unit/roundtable/test_countersign.py
+++ b/tests/unit/roundtable/test_countersign.py
@@ -456,6 +456,7 @@ class TestLoadFailsClosedBranches:
 
 
 class TestExecutorWorktreeFailure:
+    @pytest.mark.skipif(sys.platform == "win32", reason="chmod not reliable on Windows")
     def test_unwritable_scratch_root_raises_runtime_error(self, repo, tmp_path):
         ro_root = tmp_path / "ro"
         ro_root.mkdir()


### PR DESCRIPTION
## Problem

Since the D11c countersign suite landed (#1757/#1758), **all 5 Windows lanes fail deterministically on every PR** (see #1766's checks):

```
FAILED tests/unit/roundtable/test_countersign.py::TestExecutorWorktreeFailure::test_unwritable_scratch_root_raises_runtime_error - Failed: DID NOT RAISE RuntimeError
```

`chmod(0o555)` cannot make a directory unwritable on Windows, so `git worktree add` into the "read-only" scratch root succeeds and the expected `RuntimeError` never raises.

## Fix

`@pytest.mark.skipif(sys.platform == "win32", ...)` matching the repo's existing "chmod not reliable on Windows" convention (`tests/unit/models/test_config_load_observability.py`). The POSIX lanes keep exercising the failure path.

## Receipts

- Local (macOS): `pytest tests/unit/roundtable/test_countersign.py::TestExecutorWorktreeFailure` → 1 passed.
- Windows lanes on this PR are the live-fire receipt — hold merge until they're green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)