### PR TITLE
test(roundtable): skip chmod-based unwritable-scratch-root test on Windows

### DIFF
--- a/tests/unit/roundtable/test_countersign.py
+++ b/tests/unit/roundtable/test_countersign.py
@@ -456,6 +456,7 @@ class TestLoadFailsClosedBranches:
 
 
 class TestExecutorWorktreeFailure:
+    @pytest.mark.skipif(sys.platform == "win32", reason="chmod not reliable on Windows")
     def test_unwritable_scratch_root_raises_runtime_error(self, repo, tmp_path):
         ro_root = tmp_path / "ro"
         ro_root.mkdir()


### PR DESCRIPTION
**Unblocks the merge train.** `test_unwritable_scratch_root_raises_runtime_error` (landed via #1757/#1758 before Windows lanes ran) uses `chmod(0o555)` for directory write-protection — a no-op on Windows, so `git worktree add` succeeds and the expected RuntimeError never raises. First full-matrix run against new main (#1759, docs-only) failed `test (windows-latest, 3.12)` → `test-matrix-complete` → every PR blocked.

Fix: `skipif(sys.platform == "win32")` with the suite's standing idiom; POSIX lanes keep the branch coverage. Verified locally (serial pass). The `auto-merge-when-green` label is safe here because `test-matrix-complete` is required and only passes once the Windows lanes actually pass this diff.

After merge: #1759, #1763, #1766 need fresh runs against updated main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)