### PR TITLE
fix(bulletin): serialize Windows appends with msvcrt lock; assert zero loss

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Bulletin file backend: concurrent Windows writers no longer lose
+  entries** — the CRT's `O_APPEND` is seek-to-end + write (not
+  atomic), so two processes could overwrite each other's records; up
+  to 15% loss was tolerated and a CI run still rolled 19%. Appends on
+  Windows now serialize on a cross-process `msvcrt.locking`
+  sentinel-byte mutex (stdlib, no new dependency), degrading to the
+  old unlocked append on lock timeout since the bulletin is advisory.
+  The concurrency test now asserts exact zero loss on every platform.
+
 ## [11.1.0] — 2026-07-30
 
 Roundtable verification hardening and the governance layer that

--- a/src/attune/bulletin/file_backend.py
+++ b/src/attune/bulletin/file_backend.py
@@ -12,9 +12,18 @@ file opened in append mode are atomic. Our entries are well under
 that limit (~250-400B). This avoids the cross-platform pitfalls of
 ``fcntl`` (POSIX-only) while keeping the bulletin advisory-safe.
 
-Readers tolerate malformed lines — if a Windows race produced an
-interleaved write, the bad line is skipped and the rest of the log
-is still usable.
+On Windows, the CRT implements ``O_APPEND`` as seek-to-end + write —
+two non-atomic steps — so two processes can seek to the same EOF and
+overwrite each other's records. Appends there serialize on a
+cross-process ``msvcrt.locking`` mutex: a single sentinel byte far
+past any real data (Windows region locks are mandatory, so locking
+live data would fail concurrent readers). If the lock can't be
+acquired within a short timeout the append proceeds unlocked — the
+pre-lock behavior — because the bulletin is advisory.
+
+Readers tolerate malformed lines — if a race on the degraded Windows
+path produced an interleaved write, the bad line is skipped and the
+rest of the log is still usable.
 
 If the bulletin directory is unwritable, ``append`` logs at WARN and
 returns silently. The bulletin is advisory; it must not gate the
@@ -26,6 +35,8 @@ from __future__ import annotations
 import json
 import logging
 import os
+import sys
+import time
 from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
 
@@ -36,6 +47,14 @@ logger = logging.getLogger(__name__)
 # Maximum line length (sanity bound — entries should be ~250-400B).
 # Any line longer than this on read is treated as corrupted.
 _MAX_LINE_BYTES = 16_384
+
+# Windows append lock: a sentinel byte locked far past any real data
+# (region locks are mandatory on Windows — locking live bytes would
+# fail concurrent readers; daily rotation keeps the log nowhere near
+# this offset). Lock waits cap at the timeout, then the append runs
+# unlocked — the bulletin is advisory and must not block workflows.
+_WIN32_LOCK_OFFSET = 0x7FFF_FFFE
+_WIN32_LOCK_TIMEOUT_S = 5.0
 
 
 class FileBulletinBackend:
@@ -89,17 +108,63 @@ class FileBulletinBackend:
             return
 
         try:
-            # O_APPEND ensures atomic appends ≤ PIPE_BUF on POSIX.
-            # On Windows the same call works but atomicity isn't
-            # formally guaranteed; reads tolerate malformed lines.
-            flags = os.O_WRONLY | os.O_CREAT | os.O_APPEND
-            fd = os.open(str(self.active_path), flags, 0o644)
-            try:
-                os.write(fd, line)
-            finally:
-                os.close(fd)
+            if sys.platform == "win32":
+                self._append_win32(line)
+            else:
+                # O_APPEND ensures atomic appends ≤ PIPE_BUF on POSIX.
+                flags = os.O_WRONLY | os.O_CREAT | os.O_APPEND
+                fd = os.open(str(self.active_path), flags, 0o644)
+                try:
+                    os.write(fd, line)
+                finally:
+                    os.close(fd)
         except OSError as e:
             logger.warning("bulletin: append failed: %s", e)
+
+    def _append_win32(self, line: bytes) -> None:  # pragma: no cover
+        """Append under a cross-process lock (win32 only).
+
+        The CRT's ``O_APPEND`` is seek-to-end + write, which is not
+        atomic across processes, so appends serialize on a mandatory
+        ``msvcrt.locking`` region lock at ``_WIN32_LOCK_OFFSET``. On
+        lock timeout the write proceeds unlocked (pre-lock behavior).
+
+        Not coverage-measured: coverage uploads from the Linux lane
+        only; the receipt is the Windows CI lane's zero-loss
+        concurrency test.
+        """
+        import msvcrt
+
+        flags = os.O_WRONLY | os.O_CREAT | os.O_APPEND | os.O_BINARY
+        fd = os.open(str(self.active_path), flags, 0o644)
+        try:
+            locked = self._win32_try_lock(fd)
+            try:
+                os.lseek(fd, 0, os.SEEK_END)
+                os.write(fd, line)
+            finally:
+                if locked:
+                    os.lseek(fd, _WIN32_LOCK_OFFSET, os.SEEK_SET)
+                    msvcrt.locking(fd, msvcrt.LK_UNLCK, 1)
+        finally:
+            os.close(fd)
+
+    @staticmethod
+    def _win32_try_lock(fd: int) -> bool:  # pragma: no cover
+        """Acquire the sentinel-byte append lock; False on timeout."""
+        import msvcrt
+
+        os.lseek(fd, _WIN32_LOCK_OFFSET, os.SEEK_SET)
+        deadline = time.monotonic() + _WIN32_LOCK_TIMEOUT_S
+        while True:
+            try:
+                msvcrt.locking(fd, msvcrt.LK_NBLCK, 1)
+                return True
+            except OSError:
+                if time.monotonic() >= deadline:
+                    logger.warning("bulletin: append lock timed out; writing unlocked")
+                    return False
+                time.sleep(0.001)
 
     # ------------------------------------------------------------------
     # Read path

--- a/tests/unit/bulletin/test_file_backend.py
+++ b/tests/unit/bulletin/test_file_backend.py
@@ -173,23 +173,20 @@ def _writer_task(args: tuple[str, str, int]) -> None:
 
 class TestConcurrency:
     def test_two_concurrent_writers_dont_lose_entries(self, tmp_path: Path) -> None:
-        """Concurrent appends from two processes survive correctly.
+        """Concurrent appends from two processes lose nothing, exactly.
 
         On POSIX, ``O_APPEND`` guarantees atomic appends for writes
         ≤ ``PIPE_BUF`` (typically 4096B); our ~250-400B entries are
-        well under that so the assertion is exact (zero entries lost).
+        well under that.
 
-        On Windows, ``O_APPEND`` doesn't carry the same formal
-        atomicity guarantee. Reads tolerate malformed lines, so the
-        observed failure mode is "occasional skipped entry on
-        contention" — empirically <10% in the common case but
-        boundary runs at exactly 10/100 have been seen in CI (e.g.
-        PR #488's lane). The Windows branch asserts the loss rate
-        stays AT or below 15% — a slack-bounded version of the
-        documented contract (advisory accuracy, not strict delivery)
-        that absorbs Windows scheduling variance without inviting
-        true regressions through. Switching to the Redis Streams
-        backend (Phase 3) eliminates this entirely.
+        On Windows, the CRT's ``O_APPEND`` is seek-to-end + write —
+        not atomic — so appends serialize on the backend's
+        ``msvcrt.locking`` sentinel-byte mutex. Before that lock
+        existed this branch tolerated a 15% loss rate and still
+        flaked (a 2026-07-30 CI run rolled 19/100 lost); with the
+        lock the assertion is exact on every platform. If this ever
+        fails on the Windows lane again, the lock is broken — that
+        is a real regression, not scheduling variance.
         """
         root = tmp_path / "bulletin"
         per_writer = 50
@@ -210,21 +207,87 @@ class TestConcurrency:
             f"actor-B-{i}" for i in range(per_writer)
         }
         missing = expected - run_ids
+        assert len(missing) == 0, f"lost {len(missing)} entries: {sorted(missing)[:5]}..."
 
-        if sys.platform == "win32":
-            # Advisory: occasional skipped lines OK, drift = regression.
-            # Threshold is 15% (not 10%) to absorb Windows scheduling
-            # variance — boundary runs at exactly 10/100 = 10.0% are
-            # within normal observed range, not regressions.
-            loss_rate = len(missing) / len(expected)
-            assert loss_rate <= 0.15, (
-                f"Windows loss rate {loss_rate:.1%} exceeds 15% — "
-                f"lost {len(missing)}/{len(expected)} entries: "
-                f"{sorted(missing)[:5]}..."
-            )
-        else:
-            # POSIX: O_APPEND atomicity should be exact.
-            assert len(missing) == 0, f"lost {len(missing)} entries: {sorted(missing)[:5]}..."
+
+class _FakeMsvcrt:
+    """Records locking() calls; optionally refuses non-blocking locks."""
+
+    LK_NBLCK = 1
+    LK_UNLCK = 2
+
+    def __init__(self, *, refuse_locks: bool = False) -> None:
+        self.refuse_locks = refuse_locks
+        self.calls: list[tuple[int, int, int]] = []  # (mode, offset, nbytes)
+
+    def locking(self, fd: int, mode: int, nbytes: int) -> None:
+        offset = os.lseek(fd, 0, os.SEEK_CUR)
+        self.calls.append((mode, offset, nbytes))
+        if self.refuse_locks and mode == self.LK_NBLCK:
+            raise OSError("region locked by another process")
+
+
+class TestWin32AppendChoreography:
+    """Pin _append_win32's lock choreography with a fake msvcrt.
+
+    Real mandatory-lock semantics only exist on Windows — the Windows
+    CI lane's exact-zero concurrency test above is that receipt. These
+    tests run on every platform and pin the choreography instead:
+    lock and unlock happen at the same sentinel offset around the
+    write, and a lock timeout degrades to an unlocked append rather
+    than dropping the entry.
+    """
+
+    @pytest.fixture()
+    def _posix_o_binary(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # os.O_BINARY only exists on Windows; give POSIX a no-op value
+        # (on Windows this reassigns the real value — a no-op).
+        monkeypatch.setattr(os, "O_BINARY", getattr(os, "O_BINARY", 0), raising=False)
+
+    def _line(self, run_id: str) -> bytes:
+        return (json.dumps(_entry(run_id=run_id).to_dict()) + "\n").encode("utf-8")
+
+    @pytest.mark.usefixtures("_posix_o_binary")
+    def test_locks_writes_then_unlocks_at_same_offset(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from attune.bulletin.file_backend import _WIN32_LOCK_OFFSET
+
+        fake = _FakeMsvcrt()
+        monkeypatch.setitem(sys.modules, "msvcrt", fake)
+        backend = FileBulletinBackend(tmp_path / "bulletin")
+        backend.active_path.parent.mkdir(parents=True, exist_ok=True)
+
+        backend._append_win32(self._line("locked-run"))
+
+        # Entry landed and reads back.
+        assert {e.run_id for e in backend.read_active()} == {"locked-run"}
+        # Exactly one lock + one unlock, both single-byte, both at the
+        # sentinel offset (unlocking elsewhere would leak the lock).
+        assert [(m, n) for m, o, n in fake.calls] == [
+            (fake.LK_NBLCK, 1),
+            (fake.LK_UNLCK, 1),
+        ]
+        assert [o for _m, o, _n in fake.calls] == [_WIN32_LOCK_OFFSET, _WIN32_LOCK_OFFSET]
+
+    @pytest.mark.usefixtures("_posix_o_binary")
+    def test_lock_timeout_degrades_to_unlocked_append(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from attune.bulletin import file_backend as fb
+
+        fake = _FakeMsvcrt(refuse_locks=True)
+        monkeypatch.setitem(sys.modules, "msvcrt", fake)
+        monkeypatch.setattr(fb, "_WIN32_LOCK_TIMEOUT_S", 0.01)
+        backend = FileBulletinBackend(tmp_path / "bulletin")
+        backend.active_path.parent.mkdir(parents=True, exist_ok=True)
+
+        backend._append_win32(self._line("degraded-run"))
+
+        # Entry still landed (advisory: never blocked on the lock)...
+        assert {e.run_id for e in backend.read_active()} == {"degraded-run"}
+        # ...and no unlock was attempted for a lock never acquired.
+        assert all(m == fake.LK_NBLCK for m, _o, _n in fake.calls)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

`tests/unit/bulletin/test_file_backend.py::TestConcurrency::test_two_concurrent_writers_dont_lose_entries` tolerated a 15% entry-loss rate on Windows and still flaked — a 2026-07-30 CI run rolled 19/100 lost entries and failed the release PR's windows-3.10 lane. Two defects:

1. **The flake** — a threshold test over a real race rolls over its tolerance periodically.
2. **The behavior** — losing up to 15% of concurrent writes on Windows was tolerated, not fixed.

## Root cause

The MS CRT implements `O_APPEND` as **seek-to-end + write** — two non-atomic steps. Two processes can seek to the same EOF and overwrite each other's records (full entry loss, not just interleaving). POSIX `O_APPEND` is atomic for writes ≤ `PIPE_BUF`, which is why only the Windows lane hurt.

## Fix

- **win32 appends serialize on a cross-process `msvcrt.locking` mutex** (stdlib — no new dependency, no portalocker). The lock byte is a sentinel at `0x7FFF_FFFE`, far past any real data, because Windows region locks are *mandatory* — locking live bytes would fail concurrent readers. Daily rotation keeps the log nowhere near that offset.
- **Lock timeout (5s) degrades to the old unlocked append** — the bulletin is advisory and must never block a workflow. Worst case under pathological contention is exactly today's behavior.
- **POSIX path unchanged** (already atomic).

## Test changes

- The concurrency test now asserts **exact zero loss on every platform** — the 15% Windows branch is gone. If it ever fails on the Windows lane again, the lock is broken; that's a real regression, not scheduling variance.
- Two new cross-platform choreography tests (fake `msvcrt`) pin: lock → write → unlock at the same sentinel offset, and timeout → degraded unlocked append that still lands the entry.
- Win32-only bodies carry `pragma: no cover` (coverage uploads from the Linux lane only); the real-lock receipt is the Windows CI lane running the tightened test.

## Receipts

- 46/46 bulletin unit tests pass locally (POSIX).
- Pinned black + ruff pre-flighted clean.
- `tests/unit/gates/test_path_validation_gate.py` 7/7.
- Windows lanes on this PR are the live-fire receipt for the lock itself — **hold merge until the full Windows matrix is green** (per the admin-merge-before-Windows-lanes lesson).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
