### PR TITLE
content(blog): comparison-post tag 'AI frameworks' → 'AI Workflow-harness'

### DIFF
--- a/content/blog/attune-ai-vs-crewai-vs-langchain.md
+++ b/content/blog/attune-ai-vs-crewai-vs-langchain.md
@@ -3,7 +3,7 @@ title: "Attune AI vs CrewAI vs LangChain: Which AI Agent Framework Should You Ch
 date: "2026-03-07"
 author: "Patrick Roebuck"
 excerpt: "A developer's honest comparison of Attune AI, CrewAI, and LangChain for building AI agents and workflows. We compare architecture, cost, ease of use, and real-world performance."
-tags: ["comparison", "CrewAI", "LangChain", "AI frameworks", "AI Workflow-harness", "Attune AI"]
+tags: ["comparison", "CrewAI", "LangChain", "AI Workflow-harness", "Attune AI"]
 published: true
 ---
 


### PR DESCRIPTION
One-line tag swap in the CrewAI/LangChain comparison post, aligning it
with the ratified "AI Workflow-harness" term. Rescued from the main
checkout's working tree, where it sat uncommitted; the local edit's
typo ("Worflow") is fixed here.

Website-only content change — no changelog entry per policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)