### PR TITLE
test(diagnosis): cluster edge coverage — six modules to 100% (#1569 lane 2)

### DIFF
--- a/tests/unit/cli_commands/test_diagnosis_gates_commands.py
+++ b/tests/unit/cli_commands/test_diagnosis_gates_commands.py
@@ -1,0 +1,216 @@
+"""Tests for the diagnose and gates-check CLI command handlers.
+
+Both handlers lazy-import their engines at call time, so the engine
+seams are patched at their source modules and the handlers exercised
+through the real argparse ``Namespace`` contract: exit codes and the
+rendered stdout are the receipts.
+"""
+
+from __future__ import annotations
+
+from argparse import Namespace
+from types import SimpleNamespace
+
+import pytest
+
+from attune.cli_commands.diagnosis_commands import cmd_diagnose
+from attune.cli_commands.gates_commands import cmd_gates_check
+from attune.models.telemetry.data_models import DiagnosisRecord
+
+
+def _record(**overrides: object) -> DiagnosisRecord:
+    base: dict[str, object] = {
+        "diagnosis_id": "d1",
+        "source_run_id": "r1",
+        "workflow_name": "code-review",
+        "created_at": "2026-07-30T12:00:00+00:00",
+        "symptom": "boom",
+    }
+    base.update(overrides)
+    return DiagnosisRecord(**base)  # type: ignore[arg-type]
+
+
+class TestCmdDiagnose:
+    def test_success_renders_receipted_summary(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        import attune.diagnosis.engine as engine_mod
+
+        seen: list[tuple[str, str]] = []
+
+        def _fake_diagnose(run_id: str, origin: str = "operational") -> DiagnosisRecord:
+            seen.append((run_id, origin))
+            return _record(
+                prior_lessons=["lesson-a", "lesson-b"],
+                panel={"seats_invoked": ["codex"], "absences": [], "invocations": 3},
+                synthesis="Root cause: stale mapping.",
+                dissent=["codex disagrees on scope"],
+            )
+
+        monkeypatch.setattr(engine_mod, "diagnose", _fake_diagnose)
+        rc = cmd_diagnose(Namespace(run_id="r1", origin="dogfood"))
+
+        assert rc == 0
+        assert seen == [("r1", "dogfood")]
+        out = capsys.readouterr().out
+        assert "diagnosis d1 for run r1" in out
+        assert "workflow: code-review" in out
+        assert "symptom:  boom" in out
+        assert "priors:   2 lesson(s) recalled" in out
+        assert "panel:    1 seat(s), 0 absent, 3 invocation(s)" in out
+        assert "Root cause: stale mapping." in out
+        assert "1 unresolved dissent line(s) retained" in out
+        assert "persisted to the canonical diagnosis stream" in out
+
+    def test_origin_defaults_when_absent(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        import attune.diagnosis.engine as engine_mod
+
+        seen: list[str] = []
+
+        def _fake_diagnose(run_id: str, origin: str = "unset") -> DiagnosisRecord:
+            seen.append(origin)
+            return _record(priors_degraded="recall-failed: ConnectionError")
+
+        monkeypatch.setattr(engine_mod, "diagnose", _fake_diagnose)
+        rc = cmd_diagnose(Namespace(run_id="r1"))
+
+        assert rc == 0
+        assert seen == ["operational"]
+        out = capsys.readouterr().out
+        # Degraded priors render the reason, not a lesson count.
+        assert "priors:   degraded (recall-failed: ConnectionError)" in out
+
+    def test_source_error_exits_1(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        import attune.diagnosis.engine as engine_mod
+
+        def _fail(run_id: str, origin: str = "operational") -> DiagnosisRecord:
+            raise engine_mod.DiagnosisSourceError("run r1 not found in any stream")
+
+        monkeypatch.setattr(engine_mod, "diagnose", _fail)
+        rc = cmd_diagnose(Namespace(run_id="r1"))
+
+        assert rc == 1
+        assert "cannot diagnose: run r1 not found" in capsys.readouterr().out
+
+    def test_unexpected_error_exits_2(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        import attune.diagnosis.engine as engine_mod
+
+        def _explode(run_id: str, origin: str = "operational") -> DiagnosisRecord:
+            raise RuntimeError("panel melted")
+
+        monkeypatch.setattr(engine_mod, "diagnose", _explode)
+        rc = cmd_diagnose(Namespace(run_id="r1"))
+
+        assert rc == 2
+        assert "diagnosis failed unexpectedly: RuntimeError: panel melted" in (
+            capsys.readouterr().out
+        )
+
+
+def _receipt(
+    state: str = "PASS",
+    *,
+    waived: bool = False,
+    findings: list[str] | None = None,
+    proposed_disposition: str = "",
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        state=state,
+        waived=waived,
+        gate_id="G5-brand",
+        target="docs/page.md",
+        phase="tasks",
+        receipt_id="rcpt-1",
+        findings=findings or [],
+        proposed_disposition=proposed_disposition,
+    )
+
+
+def _gates_args(**overrides: object) -> Namespace:
+    base: dict[str, object] = {
+        "phase": "tasks",
+        "spec": "my-spec",
+        "tier": None,
+        "changed": None,
+    }
+    base.update(overrides)
+    return Namespace(**base)
+
+
+class TestCmdGatesCheck:
+    def _patch(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        receipts: list[SimpleNamespace],
+        code: int,
+    ) -> list[tuple]:
+        import attune.gates.lifecycle as lifecycle_mod
+
+        calls: list[tuple] = []
+
+        def _fake_run_boundary(phase: str, spec: str, **kwargs: object) -> list[SimpleNamespace]:
+            calls.append((phase, spec, kwargs))
+            return receipts
+
+        monkeypatch.setattr(lifecycle_mod, "run_boundary", _fake_run_boundary)
+        monkeypatch.setattr(lifecycle_mod, "exit_code", lambda _receipts: code)
+        return calls
+
+    def test_no_applicable_gates(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        calls = self._patch(monkeypatch, [], code=0)
+        rc = cmd_gates_check(_gates_args())
+
+        assert rc == 0
+        assert "no gates applicable at the tasks boundary for my-spec" in (capsys.readouterr().out)
+        # ``changed: None`` normalizes to an empty list at the seam.
+        assert calls[0][2]["changed_paths"] == []
+
+    def test_receipts_rendered_with_findings_and_disposition(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        receipts = [
+            _receipt(
+                "PASS",
+                waived=True,
+                findings=["stale claim in docs/page.md"],
+                proposed_disposition="re-run projector",
+            )
+        ]
+        self._patch(monkeypatch, receipts, code=0)
+        rc = cmd_gates_check(_gates_args(changed=["docs/page.md"]))
+
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "[PASS (waived)] G5-brand — docs/page.md @ tasks (rcpt-1)" in out
+        assert "    - stale claim in docs/page.md" in out
+        assert "    → re-run projector" in out
+        assert "BLOCKED" not in out
+        assert "CHAIR_REQUIRED" not in out
+
+    def test_hard_block_exits_2(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        self._patch(monkeypatch, [_receipt("BLOCKED")], code=2)
+        rc = cmd_gates_check(_gates_args())
+
+        assert rc == 2
+        assert "BLOCKED: this boundary cannot advance (G5 hard block)." in (capsys.readouterr().out)
+
+    def test_soft_block_exits_1(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        self._patch(monkeypatch, [_receipt("CHAIR_REQUIRED")], code=1)
+        rc = cmd_gates_check(_gates_args())
+
+        assert rc == 1
+        assert "CHAIR_REQUIRED: proceed only with an explicit chair acknowledgment" in (
+            capsys.readouterr().out
+        )

--- a/tests/unit/diagnosis/test_engine_triage_edges.py
+++ b/tests/unit/diagnosis/test_engine_triage_edges.py
@@ -1,0 +1,307 @@
+"""Edge coverage for engine source-run resolution and triage plumbing.
+
+Targets ``find_source_run``'s malformed-stream defenses and ops-store
+fallback (``_source_from_ops_record``), and ``run_triage``'s board
+posting plus the manual ``main()`` entry point. All keyless: the
+diagnose step is always stubbed and ``ATTUNE_HOME`` is redirected to
+tmp so no real corpus is read or written.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from attune.diagnosis.engine import _source_from_ops_record, find_source_run
+from attune.diagnosis.triage import main, run_triage, select_failed_runs
+from attune.models.telemetry.data_models import DiagnosisHypothesis, DiagnosisRecord
+
+
+def _run_line(run_id: str, *, success: bool = False, **extra: object) -> str:
+    data: dict[str, object] = {
+        "run_id": run_id,
+        "workflow_name": "code-review",
+        "started_at": "2026-07-20T12:00:00+00:00",
+        "trigger": "manual",
+        "success": success,
+        "error": "boom",
+    }
+    data.update(extra)
+    return json.dumps(data)
+
+
+def _diagnosis(diagnosis_id: str, source: str) -> DiagnosisRecord:
+    return DiagnosisRecord(
+        diagnosis_id=diagnosis_id,
+        source_run_id=source,
+        workflow_name="code-review",
+        created_at="2026-07-20T12:00:00+00:00",
+        symptom="boom",
+        hypotheses=[DiagnosisHypothesis(statement="stale mapping", confidence="high")],
+    )
+
+
+@pytest.fixture
+def attune_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    home = tmp_path / "attune-home"
+    home.mkdir()
+    monkeypatch.setenv("ATTUNE_HOME", str(home))
+    return home
+
+
+class TestFindSourceRunStreamEdges:
+    def test_unreadable_stream_returns_none(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        stream = tmp_path / "runs.jsonl"
+        stream.write_text(_run_line("r1") + "\n", encoding="utf-8")
+
+        def _boom(self: Path, *args: object, **kwargs: object) -> str:
+            raise OSError("permission denied")
+
+        monkeypatch.setattr(Path, "read_text", _boom)
+        assert find_source_run("r1", stream=stream) is None
+
+    def test_invalid_json_line_containing_id_skipped(self, tmp_path: Path) -> None:
+        stream = tmp_path / "runs.jsonl"
+        stream.write_text('{"run_id": "r1" broken\n', encoding="utf-8")
+        assert find_source_run("r1", stream=stream) is None
+
+    def test_matching_line_with_missing_fields_skipped(self, tmp_path: Path) -> None:
+        # run_id matches but required record fields are absent, so
+        # from_dict raises and the line is skipped, not fatal.
+        stream = tmp_path / "runs.jsonl"
+        stream.write_text(json.dumps({"run_id": "r1"}) + "\n", encoding="utf-8")
+        assert find_source_run("r1", stream=stream) is None
+
+
+class TestOpsRecordFallback:
+    def _write_ops_run(self, home: Path, run_id: str, data: object) -> Path:
+        runs_dir = home / "ops" / "runs" / "2026-07-30"
+        runs_dir.mkdir(parents=True, exist_ok=True)
+        target = runs_dir / f"{run_id}.json"
+        content = data if isinstance(data, str) else json.dumps(data)
+        target.write_text(content, encoding="utf-8")
+        return target
+
+    def test_no_ops_store_returns_none(self, attune_home: Path) -> None:
+        assert _source_from_ops_record("abc123") is None
+
+    def test_invalid_json_skipped(self, attune_home: Path) -> None:
+        self._write_ops_run(attune_home, "abc123", "{broken")
+        assert _source_from_ops_record("abc123") is None
+
+    def test_non_dict_payload_skipped(self, attune_home: Path) -> None:
+        self._write_ops_run(attune_home, "abc123", [1, 2])
+        assert _source_from_ops_record("abc123") is None
+
+    def test_completed_run_synthesized(self, attune_home: Path) -> None:
+        self._write_ops_run(
+            attune_home,
+            "abc123",
+            {
+                "workflow": "code-review",
+                "started_at": "2026-07-30T10:00:00+00:00",
+                "trigger": "manual",
+                "status": "completed",
+                "exit_code": 0,
+            },
+        )
+        record = _source_from_ops_record("abc123")
+        assert record is not None
+        assert record.run_id == "abc123"
+        assert record.workflow_name == "code-review"
+        assert record.success is True
+        assert "exit 0" in (record.error or "")
+
+    def test_failed_run_uses_sdk_stderr(self, attune_home: Path) -> None:
+        self._write_ops_run(
+            attune_home,
+            "abc123",
+            {
+                "workflow": "code-review",
+                "started_at": "2026-07-30T10:00:00+00:00",
+                "status": "failed",
+                "exit_code": 1,
+                "sdk_stderr": "Traceback: boom",
+                "trigger": 42,  # non-str trigger normalizes to None
+            },
+        )
+        record = _source_from_ops_record("abc123")
+        assert record is not None
+        assert record.success is False
+        assert record.error == "Traceback: boom"
+        assert record.trigger is None
+
+    def test_find_source_run_falls_back_to_ops(self, attune_home: Path) -> None:
+        # No canonical stream under ATTUNE_HOME — the ops record is
+        # the only source, and the default-stream path must reach it.
+        self._write_ops_run(
+            attune_home,
+            "abc123",
+            {
+                "workflow": "code-review",
+                "started_at": "2026-07-30T10:00:00+00:00",
+                "status": "failed",
+                "exit_code": 1,
+            },
+        )
+        record = find_source_run("abc123")
+        assert record is not None
+        assert record.workflow_name == "code-review"
+
+
+class TestSelectFailedRunsEdges:
+    def test_malformed_lines_skipped(self, tmp_path: Path) -> None:
+        stream = tmp_path / "runs.jsonl"
+        stream.write_text(
+            "\n".join(
+                [
+                    "",  # blank
+                    "{not json",
+                    json.dumps({"run_id": "r-missing-fields", "success": False}),
+                    json.dumps({"run_id": 42, "success": False}),
+                    _run_line("r-good"),
+                ]
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        selected = select_failed_runs(stream, limit=5, already_diagnosed=lambda _rid: False)
+        assert [r.run_id for r in selected] == ["r-good"]
+
+    def test_unreadable_stream_returns_empty(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        stream = tmp_path / "runs.jsonl"
+        stream.write_text(_run_line("r1") + "\n", encoding="utf-8")
+
+        def _boom(self: Path, *args: object, **kwargs: object) -> str:
+            raise OSError("permission denied")
+
+        monkeypatch.setattr(Path, "read_text", _boom)
+        assert select_failed_runs(stream, limit=5, already_diagnosed=lambda _rid: False) == []
+
+    def test_default_diagnosed_predicate_reads_store(
+        self, attune_home: Path, tmp_path: Path
+    ) -> None:
+        # No already_diagnosed injected: the default predicate queries
+        # the (empty, ATTUNE_HOME-redirected) diagnosis store.
+        stream = tmp_path / "runs.jsonl"
+        stream.write_text(_run_line("r1") + "\n", encoding="utf-8")
+        selected = select_failed_runs(stream, limit=5)
+        assert [r.run_id for r in selected] == ["r1"]
+
+
+class _FakeBoard:
+    posts: list[tuple[str, str, str, str]] = []
+
+    def post_message(self, thread: str, author: str, kind: str, body: str) -> None:
+        _FakeBoard.posts.append((thread, author, kind, body))
+
+
+class _ExplodingBoard:
+    def __init__(self) -> None:
+        raise RuntimeError("board down")
+
+
+class TestRunTriageBoardPost:
+    def test_digest_posted_with_date_stamped_thread(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import attune.roundtable as roundtable
+
+        _FakeBoard.posts = []
+        monkeypatch.setattr(roundtable, "Board", _FakeBoard)
+        stream = tmp_path / "runs.jsonl"
+        stream.write_text(_run_line("r1") + "\n", encoding="utf-8")
+
+        digest = run_triage(
+            stream=stream,
+            diagnose_fn=lambda run_id, config: _diagnosis("d1", run_id),
+            now=datetime(2026, 7, 30, 12, 0, tzinfo=timezone.utc),
+        )
+
+        assert len(_FakeBoard.posts) == 1
+        thread, author, kind, body = _FakeBoard.posts[0]
+        assert thread == "routine-failed-run-triage-2026-07-30"
+        assert (author, kind) == ("moderator", "synthesis")
+        assert body == digest
+        assert "1 run(s) diagnosed" in digest
+
+    def test_board_failure_never_loses_digest(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import attune.roundtable as roundtable
+
+        monkeypatch.setattr(roundtable, "Board", _ExplodingBoard)
+        stream = tmp_path / "runs.jsonl"
+        stream.write_text(_run_line("r1") + "\n", encoding="utf-8")
+
+        digest = run_triage(
+            stream=stream,
+            diagnose_fn=lambda run_id, config: _diagnosis("d1", run_id),
+        )
+        assert "1 run(s) diagnosed" in digest
+
+    def test_no_diagnoses_skips_board(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import attune.roundtable as roundtable
+
+        _FakeBoard.posts = []
+        monkeypatch.setattr(roundtable, "Board", _FakeBoard)
+        stream = tmp_path / "runs.jsonl"
+        stream.write_text("", encoding="utf-8")
+
+        run_triage(stream=stream, diagnose_fn=lambda run_id, config: _diagnosis("d1", run_id))
+        assert _FakeBoard.posts == []
+
+
+class TestMainEntryPoint:
+    def test_dry_run_prints_batch_without_diagnosing(
+        self,
+        attune_home: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        stream_dir = attune_home / "telemetry"
+        stream_dir.mkdir(parents=True)
+        (stream_dir / "workflow_runs.jsonl").write_text(_run_line("r1") + "\n", encoding="utf-8")
+
+        rc = main(["--dry-run"])
+
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "would diagnose 1 run(s):" in out
+        assert "- r1 (code-review): boom" in out
+
+    def test_dry_run_with_empty_corpus(
+        self, attune_home: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        rc = main(["--dry-run"])
+        assert rc == 0
+        assert "would diagnose 0 run(s):" in capsys.readouterr().out
+
+    def test_limit_overrides_batch_cap_and_digest_printed(
+        self,
+        attune_home: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        import attune.diagnosis.triage as triage_mod
+
+        seen_caps: list[int] = []
+
+        def _fake_run_triage(config: object) -> str:
+            seen_caps.append(config.triage_batch_max)
+            return "DIGEST-SENTINEL"
+
+        monkeypatch.setattr(triage_mod, "run_triage", _fake_run_triage)
+        rc = main(["--limit", "2"])
+
+        assert rc == 0
+        assert seen_caps == [2]
+        assert "DIGEST-SENTINEL" in capsys.readouterr().out

--- a/tests/unit/diagnosis/test_store_priors_edges.py
+++ b/tests/unit/diagnosis/test_store_priors_edges.py
@@ -1,0 +1,228 @@
+"""Edge coverage for the diagnosis store and priors recall.
+
+Targets the drop-counting paths in ``attune.diagnosis.store`` (every
+``DiagnosisLoadStats`` counter, unreadable stream, last-wins
+supersede) and the degrade paths in ``attune.diagnosis.priors``
+(missing redis package, client construction from ``REDIS_URL``,
+transport failure, and FT.SEARCH reply-shape defenses). All keyless
+and network-free.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from datetime import timezone
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from attune.diagnosis.priors import (
+    _parse_search_reply,
+    extract_error_terms,
+    recall_priors,
+)
+from attune.diagnosis.store import (
+    _parse_created_at,
+    load_diagnoses,
+    records_for_run,
+)
+from attune.pipeline_learner.corpus import FIXTURE_NAMES
+
+_ELIGIBLE_AT = "2026-07-21T00:00:00+00:00"
+
+
+def _record_line(
+    diagnosis_id: str = "d1",
+    *,
+    source_run_id: str = "r1",
+    workflow_name: str = "code-review",
+    created_at: str = _ELIGIBLE_AT,
+    symptom: str = "boom",
+    **extra: object,
+) -> str:
+    data: dict[str, object] = {
+        "diagnosis_id": diagnosis_id,
+        "source_run_id": source_run_id,
+        "workflow_name": workflow_name,
+        "created_at": created_at,
+        "symptom": symptom,
+    }
+    data.update(extra)
+    return json.dumps(data)
+
+
+class TestParseCreatedAt:
+    def test_non_string(self) -> None:
+        assert _parse_created_at(None) is None
+        assert _parse_created_at(12345) is None
+        assert _parse_created_at("") is None
+
+    def test_invalid_iso(self) -> None:
+        assert _parse_created_at("not-a-date") is None
+
+    def test_naive_timestamp_gets_utc(self) -> None:
+        parsed = _parse_created_at("2026-07-21T00:00:00")
+        assert parsed is not None
+        assert parsed.tzinfo is timezone.utc
+
+
+class TestLoadDiagnosesDrops:
+    def test_every_drop_counter_fires(self, tmp_path: Path) -> None:
+        fixture_name = sorted(FIXTURE_NAMES)[0]
+        stream = tmp_path / "diagnosis_records.jsonl"
+        stream.write_text(
+            "\n".join(
+                [
+                    _record_line("d-good"),
+                    "",  # blank — skipped entirely, not counted
+                    "{not json",  # malformed JSON
+                    json.dumps([1, 2]),  # not a dict
+                    json.dumps({"workflow_name": "", "created_at": _ELIGIBLE_AT}),
+                    _record_line("d-fix", workflow_name=fixture_name),
+                    _record_line("d-old", created_at="2026-01-01T00:00:00+00:00"),
+                    # Required fields missing -> from_dict raises TypeError.
+                    json.dumps({"workflow_name": "w", "created_at": _ELIGIBLE_AT}),
+                ]
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+
+        records, stats = load_diagnoses(stream)
+
+        assert [r.diagnosis_id for r in records] == ["d-good"]
+        assert stats.total_lines == 7  # blank line never counted
+        assert stats.eligible == 1
+        assert stats.dropped_malformed == 4
+        assert stats.dropped_fixture == 1
+        assert stats.dropped_pre_cutover == 1
+        assert stats.dropped_superseded == 0
+
+    def test_last_wins_supersede_counted(self, tmp_path: Path) -> None:
+        stream = tmp_path / "diagnosis_records.jsonl"
+        stream.write_text(
+            _record_line("d1", symptom="first")
+            + "\n"
+            + _record_line("d1", symptom="second")
+            + "\n",
+            encoding="utf-8",
+        )
+        records, stats = load_diagnoses(stream)
+        assert len(records) == 1
+        assert records[0].symptom == "second"
+        assert stats.eligible == 1
+        assert stats.dropped_superseded == 1
+
+    def test_missing_file(self, tmp_path: Path) -> None:
+        records, stats = load_diagnoses(tmp_path / "absent.jsonl")
+        assert records == []
+        assert stats.total_lines == 0
+
+    def test_unreadable_stream_degrades(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        stream = tmp_path / "diagnosis_records.jsonl"
+        stream.write_text(_record_line() + "\n", encoding="utf-8")
+
+        def _boom(self: Path, *args: object, **kwargs: object) -> str:
+            raise OSError("permission denied")
+
+        monkeypatch.setattr(Path, "read_text", _boom)
+        records, stats = load_diagnoses(stream)
+        assert records == []
+        assert stats.total_lines == 0
+
+    def test_records_for_run_filters(self, tmp_path: Path) -> None:
+        stream = tmp_path / "diagnosis_records.jsonl"
+        stream.write_text(
+            _record_line("d1", source_run_id="r1")
+            + "\n"
+            + _record_line("d2", source_run_id="r2")
+            + "\n",
+            encoding="utf-8",
+        )
+        matched = records_for_run("r2", stream)
+        assert [r.diagnosis_id for r in matched] == ["d2"]
+
+
+class TestExtractErrorTermsFallback:
+    def test_fallback_respects_limit(self) -> None:
+        # No error-shape pattern matches terse lowercase prose, so the
+        # stopword-filtered plain-word fallback supplies terms and must
+        # stop at the limit.
+        text = "gadget frobnicator melted badly quickly slowly loudly"
+        terms = extract_error_terms(text, limit=3)
+        assert terms == ["gadget", "frobnicator", "melted"]
+
+
+class _FakeRedisClient:
+    def __init__(self, reply: object = None, error: Exception | None = None) -> None:
+        self.reply = reply
+        self.error = error
+        self.commands: list[tuple] = []
+
+    def execute_command(self, *args: object) -> object:
+        self.commands.append(args)
+        if self.error is not None:
+            raise self.error
+        return self.reply
+
+
+class TestRecallPriorsClientConstruction:
+    def test_redis_package_missing_degrades(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # A None entry in sys.modules makes ``import redis`` raise
+        # ImportError without touching the real package.
+        monkeypatch.setitem(sys.modules, "redis", None)
+        result = recall_priors(["ValueError"])
+        assert result.lessons == []
+        assert result.degraded == "redis-package-not-installed"
+
+    def test_client_built_from_redis_url_and_transport_error_degrades(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        seen_urls: list[str] = []
+        failing = _FakeRedisClient(error=ConnectionError("down"))
+
+        class _FakeRedis:
+            @staticmethod
+            def from_url(url: str, **kwargs: object) -> _FakeRedisClient:
+                seen_urls.append(url)
+                return failing
+
+        monkeypatch.setitem(sys.modules, "redis", SimpleNamespace(Redis=_FakeRedis))
+        monkeypatch.setenv("REDIS_URL", "redis://example.invalid:7000/3")
+
+        result = recall_priors(["ValueError", "path|traversal"])
+        assert seen_urls == ["redis://example.invalid:7000/3"]
+        assert result.degraded == "recall-failed: ConnectionError"
+        # Pipe characters inside a term are sanitized before OR-joining.
+        assert failing.commands[0][2] == "ValueError|path traversal"
+
+    def test_no_terms_short_circuits(self) -> None:
+        assert recall_priors([]).degraded == "no-terms-extracted"
+
+
+class TestParseSearchReply:
+    def test_non_list_reply(self) -> None:
+        assert _parse_search_reply("nope") == []
+
+    def test_too_short_reply(self) -> None:
+        assert _parse_search_reply([0]) == []
+
+    def test_non_list_fields_entry_skipped(self) -> None:
+        raw = [1, "key:a", "not-a-field-list"]
+        assert _parse_search_reply(raw) == []
+
+    def test_empty_name_and_description_skipped(self) -> None:
+        raw = [1, "key:a", ["name", "", "description", ""]]
+        assert _parse_search_reply(raw) == []
+
+    def test_bytes_fields_decoded(self) -> None:
+        raw = [1, b"key:a", [b"name", b"lesson-x", b"description", b"why it fires"]]
+        assert _parse_search_reply(raw) == ["lesson-x — why it fires"]
+
+    def test_name_only_entry_stripped(self) -> None:
+        raw = [1, "key:a", ["name", "lesson-x", "description", ""]]
+        assert _parse_search_reply(raw) == ["lesson-x"]


### PR DESCRIPTION
## What

Lane 2 from `docs/reports/modules-needing-work-2026-07-30.md` (test-quality program #1569): the **diagnosis cluster** — `diagnosis/{triage,engine,priors,store}.py` plus `cli_commands/{diagnosis,gates}_commands.py`, which included the two lowest-covered modules in the entire tree.

Tests-only: 44 new keyless tests in three files. No production code touched.

| Module | Codecov main | Now |
|---|---|---|
| `cli_commands/gates_commands.py` | 18.2% | **100%** |
| `cli_commands/diagnosis_commands.py` | 34.6% | **100%** |
| `diagnosis/triage.py` | 68.3% | **100%** |
| `diagnosis/engine.py` | 78.6% | **100%** |
| `diagnosis/priors.py` | 79.7% | **100%** |
| `diagnosis/store.py` | 80.0% | **100%** |

## Coverage targets

- **store** — every `DiagnosisLoadStats` drop counter (malformed / fixture / pre-cutover / superseded), last-wins supersede semantics, unreadable stream degrade, `created_at` parsing edges.
- **priors** — redis-package-absent and client-from-`REDIS_URL` construction paths (fake module injected via `sys.modules`), transport-error degrade, pipe-sanitized OR-join query, term-extraction fallback limit, `FT.SEARCH` reply-shape defenses incl. bytes decoding.
- **engine** — `find_source_run` malformed-stream defenses (unreadable, invalid JSON containing the id, matching line with missing fields) and the full ops-store fallback (`_source_from_ops_record`): synthesis of completed and failed runs, `sdk_stderr` preference, non-str trigger normalization, default-stream fallback reach.
- **triage** — selection edge cases, the default diagnosed-predicate (store-backed), board post success/failure/skip (digest never lost), and the manual `main()` entry point: `--dry-run` with and without corpus, `--limit` cap override.
- **CLI handlers** — `cmd_diagnose` exit codes 0/1/2 with the rendered receipt summary (degraded vs recalled priors, panel counts, dissent); `cmd_gates_check` G5 exit-code mapping (0/1/2), waived-receipt rendering, findings/disposition lines, `changed: None` normalization.

## Receipts (declared at launch: suite + metric)

- **suite** (serial, no xdist): new files **44 passed** in 0.16s; full `tests/unit/diagnosis/` + `tests/unit/cli_commands/` **424 passed** in 5.23s, zero failures.
- **metric** (worktree-safe coverage recipe, all six modules as `--source`): **380 stmts, 0 miss, 100%**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
