### PR TITLE
test(ops): data-layer cluster edge coverage — four modules to 100% (#1569 lane 3)

### DIFF
--- a/tests/unit/ops/test_cache_pending_writes_edges.py
+++ b/tests/unit/ops/test_cache_pending_writes_edges.py
@@ -1,0 +1,286 @@
+"""Edge coverage for the session-summary cache and pending-writes helpers.
+
+Targets the I/O-failure and malformed-record branches the round-trip
+suites skip: cache load validation (shape, key, field coercion),
+atomic-save failure cleanup, journal parsing, PID liveness probes,
+and the git-status / transient-path heuristics. All keyless; every
+"failure" is injected via monkeypatch or crafted files.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from attune.ops import session_summary_cache as cache
+from attune.ops.routes import pending_writes as pw
+from attune.ops.session_summary_cache import (
+    CacheKey,
+    _hash_tail,
+    _suppress_oserror,
+    cache_path_for,
+    compute_cache_key,
+    load,
+    save,
+)
+
+
+def _write_cache_record(attune_home: Path, session_id: str, record: object) -> Path:
+    path = cache_path_for(attune_home, session_id)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    content = record if isinstance(record, str) else json.dumps(record)
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+def _key(**overrides: object) -> CacheKey:
+    base: dict[str, object] = {"filename": "s.jsonl", "mtime_ns": 123, "sha256": "abc"}
+    base.update(overrides)
+    return CacheKey(**base)  # type: ignore[arg-type]
+
+
+class TestHashTailFailures:
+    def test_missing_file_returns_none(self, tmp_path: Path) -> None:
+        assert _hash_tail(tmp_path / "absent.jsonl") is None
+
+    def test_open_failure_returns_none(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        target = tmp_path / "s.jsonl"
+        target.write_text("data\n", encoding="utf-8")
+
+        def _boom(self: Path, *args: object, **kwargs: object) -> None:
+            raise OSError("permission denied")
+
+        monkeypatch.setattr(Path, "open", _boom)
+        assert _hash_tail(target) is None
+
+    def test_compute_cache_key_none_when_digest_fails(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        target = tmp_path / "s.jsonl"
+        target.write_text("data\n", encoding="utf-8")
+        monkeypatch.setattr(cache, "_hash_tail", lambda p: None)
+        assert compute_cache_key(target) is None
+
+
+class TestLoadValidation:
+    def test_read_failure_returns_none(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _write_cache_record(tmp_path, "s1", {"key": {}})
+
+        def _boom(self: Path, *args: object, **kwargs: object) -> str:
+            raise OSError("permission denied")
+
+        monkeypatch.setattr(Path, "read_text", _boom)
+        assert load(tmp_path, "s1", _key()) is None
+
+    def test_non_dict_payload_returns_none(self, tmp_path: Path) -> None:
+        _write_cache_record(tmp_path, "s1", [1, 2, 3])
+        assert load(tmp_path, "s1", _key()) is None
+
+    def test_non_dict_key_returns_none(self, tmp_path: Path) -> None:
+        _write_cache_record(tmp_path, "s1", {"key": "not-a-dict"})
+        assert load(tmp_path, "s1", _key()) is None
+
+    def test_missing_key_field_returns_none(self, tmp_path: Path) -> None:
+        _write_cache_record(tmp_path, "s1", {"key": {"filename": "s.jsonl"}})
+        assert load(tmp_path, "s1", _key()) is None
+
+    def test_uncoercible_mtime_returns_none(self, tmp_path: Path) -> None:
+        _write_cache_record(
+            tmp_path,
+            "s1",
+            {"key": {"filename": "s.jsonl", "mtime_ns": "not-int", "sha256": "abc"}},
+        )
+        assert load(tmp_path, "s1", _key()) is None
+
+    def test_matching_key_but_missing_summary_returns_none(self, tmp_path: Path) -> None:
+        _write_cache_record(
+            tmp_path,
+            "s1",
+            {"key": {"filename": "s.jsonl", "mtime_ns": 123, "sha256": "abc"}},
+        )
+        assert load(tmp_path, "s1", _key()) is None
+
+    def test_hit_defaults_optional_fields(self, tmp_path: Path) -> None:
+        _write_cache_record(
+            tmp_path,
+            "s1",
+            {
+                "key": {"filename": "s.jsonl", "mtime_ns": 123, "sha256": "abc"},
+                "summary": "the summary",
+            },
+        )
+        hit = load(tmp_path, "s1", _key())
+        assert hit is not None
+        assert hit.source == "cached"
+        assert (hit.tokens_in, hit.tokens_out, hit.cost_usd) == (0, 0, 0.0)
+        assert hit.created_at == ""
+
+
+class TestSaveFailureCleanup:
+    def test_replace_failure_raises_and_cleans_temp(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def _boom(self: Path, target: Path) -> None:
+            raise OSError("disk full")
+
+        monkeypatch.setattr(Path, "replace", _boom)
+        with pytest.raises(OSError, match="disk full"):
+            save(
+                tmp_path,
+                "s1",
+                key=_key(),
+                summary="x",
+                tokens_in=1,
+                tokens_out=2,
+                cost_usd=0.01,
+            )
+        cache_dir = cache_path_for(tmp_path, "s1").parent
+        assert list(cache_dir.glob("*.tmp")) == []
+
+    def test_suppress_oserror_contextmanager(self) -> None:
+        with _suppress_oserror():
+            raise OSError("swallowed")
+        with pytest.raises(ValueError, match="propagates"), _suppress_oserror():
+            raise ValueError("propagates")
+
+
+class TestLoadJournalEntries:
+    def test_read_failure_returns_empty(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        journal = tmp_path / "pending_writes.jsonl"
+        journal.write_text('{"ok": 1}\n', encoding="utf-8")
+
+        def _boom(self: Path, *args: object, **kwargs: object) -> str:
+            raise OSError("permission denied")
+
+        monkeypatch.setattr(Path, "read_text", _boom)
+        assert pw._load_journal_entries(journal) == []
+
+    def test_blank_and_corrupt_lines_skipped(self, tmp_path: Path) -> None:
+        journal = tmp_path / "pending_writes.jsonl"
+        journal.write_text('\n   \n{broken\n{"ok": 1}\n', encoding="utf-8")
+        assert pw._load_journal_entries(journal) == [{"ok": 1}]
+
+
+class TestIsDashboardRunning:
+    def test_non_positive_pid(self) -> None:
+        assert pw._is_dashboard_running(0) is False
+        assert pw._is_dashboard_running(-5) is False
+
+    @pytest.mark.parametrize(
+        ("exc", "expected"),
+        [
+            (ProcessLookupError(), False),
+            (PermissionError(), True),
+            (OSError("odd"), False),
+        ],
+    )
+    def test_kill_probe_outcomes(
+        self, monkeypatch: pytest.MonkeyPatch, exc: OSError, expected: bool
+    ) -> None:
+        def _kill(pid: int, sig: int) -> None:
+            raise exc
+
+        monkeypatch.setattr(os, "kill", _kill)
+        assert pw._is_dashboard_running(12345) is expected
+
+    def test_alive_pid(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(os, "kill", lambda pid, sig: None)
+        assert pw._is_dashboard_running(12345) is True
+
+
+class TestIsFileCommitted:
+    def test_missing_project_root(self, tmp_path: Path) -> None:
+        assert pw._is_file_committed(tmp_path / "f.py", tmp_path / "absent") is None
+
+    def test_file_outside_root(self, tmp_path: Path) -> None:
+        root = tmp_path / "root"
+        root.mkdir()
+        outside = tmp_path / "elsewhere.py"
+        assert pw._is_file_committed(outside, root) is None
+
+    def test_git_failure_returns_none(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def _boom(*args: object, **kwargs: object) -> None:
+            raise subprocess.TimeoutExpired(cmd="git", timeout=5)
+
+        monkeypatch.setattr(pw.subprocess, "run", _boom)
+        assert pw._is_file_committed(tmp_path / "f.py", tmp_path) is None
+
+    def test_nonzero_exit_returns_none(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            pw.subprocess,
+            "run",
+            lambda *a, **k: SimpleNamespace(returncode=128, stdout=""),
+        )
+        assert pw._is_file_committed(tmp_path / "f.py", tmp_path) is None
+
+    def test_clean_and_dirty_outputs(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            pw.subprocess,
+            "run",
+            lambda *a, **k: SimpleNamespace(returncode=0, stdout="\n"),
+        )
+        assert pw._is_file_committed(tmp_path / "f.py", tmp_path) is True
+        monkeypatch.setattr(
+            pw.subprocess,
+            "run",
+            lambda *a, **k: SimpleNamespace(returncode=0, stdout=" M f.py\n"),
+        )
+        assert pw._is_file_committed(tmp_path / "f.py", tmp_path) is False
+
+
+class TestIsRealEntry:
+    def test_missing_or_non_string_root_rejected(self) -> None:
+        assert pw._is_real_entry({}) is False
+        assert pw._is_real_entry({"project_root": ""}) is False
+        assert pw._is_real_entry({"project_root": 42}) is False
+
+    def test_tmp_prefixed_root_rejected(self) -> None:
+        assert pw._is_real_entry({"project_root": "/tmp/pytest-of-x/proj"}) is False
+
+    def test_nonexistent_root_rejected(self) -> None:
+        # Not under a tmp prefix, but gone from disk.
+        assert pw._is_real_entry({"project_root": "/nonexistent-root-xyz/proj"}) is False
+
+    def test_is_dir_error_rejected(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        def _boom(self: Path) -> bool:
+            raise OSError("stat failed")
+
+        monkeypatch.setattr(Path, "is_dir", _boom)
+        assert pw._is_real_entry({"project_root": "/somewhere/real"}) is False
+
+    def test_real_repo_root_accepted(self) -> None:
+        # The test file's own repo directory: exists and is not under
+        # any transient-path prefix.
+        repo_dir = str(Path(__file__).resolve().parent)
+        if any(repo_dir.startswith(p) for p in pw._TMP_PATH_PREFIXES):
+            pytest.skip("test checkout itself lives under a tmp prefix")
+        assert pw._is_real_entry({"project_root": repo_dir}) is True
+
+
+class TestEnrichEdges:
+    def test_bad_timestamp_and_missing_paths(self) -> None:
+        enriched = pw._enrich(
+            {"ts": "not-a-date", "dashboard_pid": "not-an-int"},
+            now=datetime.now(timezone.utc),
+        )
+        assert enriched["age_seconds"] is None
+        assert enriched["dashboard_still_running"] is False
+        assert enriched["current_disk_sha256"] is None
+        assert enriched["matches_journal"] is False
+        assert enriched["is_committed"] is None

--- a/tests/unit/ops/test_data_layer_edges.py
+++ b/tests/unit/ops/test_data_layer_edges.py
@@ -1,0 +1,404 @@
+"""Edge coverage for the collab-inbox and memory-page data layers.
+
+Existing suites mock ``_connect``/``connect`` and drive happy paths;
+these tests cover the raw seams those mocks skip: real client
+construction (via ``sys.modules`` fakes, never a live Redis), the
+read-only git allowlist, packet-frontmatter parsing, and every
+degrade branch in the memory readers. All keyless and network-free.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from attune.ops import collab_data, memory_data
+from attune.ops.collab_data import read_inbox, read_thread
+from attune.ops.memory_data import (
+    MEMORY_KEY_PREFIX,
+    _build_row,
+    _edge_preview,
+    _first_line,
+    node_count,
+    read_attention,
+    read_node,
+    read_overview,
+)
+
+from .test_memory_page import FakeRedis
+
+
+class _FakePingableClient:
+    def __init__(self, fail_ping: bool = False) -> None:
+        self.fail_ping = fail_ping
+
+    def ping(self) -> bool:
+        if self.fail_ping:
+            raise ConnectionError("refused")
+        return True
+
+
+def _fake_redis_module(client: _FakePingableClient) -> SimpleNamespace:
+    class _FakeRedisCls:
+        @staticmethod
+        def from_url(url: str, **kwargs: object) -> _FakePingableClient:
+            return client
+
+    return SimpleNamespace(Redis=_FakeRedisCls)
+
+
+class TestCollabConnect:
+    def test_success_returns_client(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        client = _FakePingableClient()
+        monkeypatch.setitem(sys.modules, "redis", _fake_redis_module(client))
+        assert collab_data._connect("redis://example.invalid:6379/0") is client
+
+    def test_ping_failure_degrades_to_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        client = _FakePingableClient(fail_ping=True)
+        monkeypatch.setitem(sys.modules, "redis", _fake_redis_module(client))
+        assert collab_data._connect() is None
+
+    def test_missing_package_degrades_to_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setitem(sys.modules, "redis", None)
+        assert collab_data._connect() is None
+
+
+class _ThreadScanClient:
+    """Minimal board client driving _pending_threads directly."""
+
+    def __init__(
+        self,
+        threads: dict[str, list[str]],
+        meta: dict[str, dict[str, str]] | None = None,
+        ttls: dict[str, int] | None = None,
+        extra_keys: list[str] | None = None,
+    ) -> None:
+        self._threads = threads
+        self._meta = meta or {}
+        self._ttls = ttls or {}
+        self._extra = extra_keys or []
+
+    def scan_iter(self, match: str, count: int = 10):
+        yield from list(self._threads) + list(self._meta) + self._extra
+
+    def hgetall(self, key: str) -> dict[str, str]:
+        return dict(self._meta.get(key, {}))
+
+    def llen(self, key: str) -> int:
+        if key not in self._threads:
+            raise TypeError("WRONGTYPE")
+        return len(self._threads[key])
+
+    def ttl(self, key: str) -> int:
+        return self._ttls.get(key, -1)
+
+
+def _thread_key(thread: str) -> str:
+    return collab_data.THREAD_PREFIX + thread
+
+
+class TestPendingThreadFilters:
+    def test_diagnostic_promoted_and_wrongtype_keys_skipped(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        client = _ThreadScanClient(
+            threads={
+                _thread_key("q-real-001"): ["m1", "m2"],
+                _thread_key("test-canary"): ["m1"],
+                _thread_key("routine-test-canary"): ["m1"],
+                _thread_key("q-promoted-001"): ["m1"],
+            },
+            meta={
+                _thread_key("q-promoted-001") + ":meta": {"status": "promoted"},
+            },
+            ttls={_thread_key("q-real-001"): 7200},
+            # A non-list key inside the namespace: llen raises, row skipped.
+            extra_keys=[_thread_key("q-wrongtype-001")],
+        )
+        monkeypatch.setattr(collab_data, "_connect", lambda url=None: client)
+
+        inbox = read_inbox(tmp_path)
+
+        assert inbox.board_reachable is True
+        assert [(r.thread, r.messages, r.ttl_hours) for r in inbox.threads] == [
+            ("q-real-001", 2, 2.0)
+        ]
+        # One actionable thread only — canaries and promoted excluded.
+        assert inbox.action_count == 1
+
+    def test_scan_failure_marks_board_unreachable(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        class _Exploding:
+            def scan_iter(self, match: str, count: int = 10):
+                raise ConnectionError("dropped mid-scan")
+
+        monkeypatch.setattr(collab_data, "_connect", lambda url=None: _Exploding())
+        inbox = read_inbox(tmp_path)
+        assert inbox.board_reachable is False
+        assert inbox.threads == []
+
+
+class TestGitAllowlist:
+    def test_disallowed_verb_returns_none(self, tmp_path: Path) -> None:
+        assert collab_data._git(tmp_path, "push", "origin", "main") is None
+        assert collab_data._git(tmp_path) is None
+
+    def test_oserror_and_timeout_return_none(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def _oserror(*args: object, **kwargs: object) -> None:
+            raise OSError("git missing")
+
+        monkeypatch.setattr(collab_data.subprocess, "run", _oserror)
+        assert collab_data._git(tmp_path, "rev-parse", "HEAD") is None
+
+        def _timeout(*args: object, **kwargs: object) -> None:
+            raise subprocess.TimeoutExpired(cmd="git", timeout=10)
+
+        monkeypatch.setattr(collab_data.subprocess, "run", _timeout)
+        assert collab_data._git(tmp_path, "rev-parse", "HEAD") is None
+
+    def test_nonzero_exit_returns_none(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            collab_data.subprocess,
+            "run",
+            lambda *a, **k: SimpleNamespace(returncode=128, stdout="fatal\n"),
+        )
+        assert collab_data._git(tmp_path, "rev-parse", "HEAD") is None
+
+    def test_success_strips_stdout(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            collab_data.subprocess,
+            "run",
+            lambda *a, **k: SimpleNamespace(returncode=0, stdout="abc123\n"),
+        )
+        assert collab_data._git(tmp_path, "rev-parse", "HEAD") == "abc123"
+
+
+class TestPacketBranch:
+    def test_unreadable_path_returns_empty(self, tmp_path: Path) -> None:
+        # A directory raises OSError on read_text on every platform.
+        assert collab_data._packet_branch(tmp_path) == ""
+
+    def test_frontmatter_terminator_stops_scan(self, tmp_path: Path) -> None:
+        packet = tmp_path / "p.md"
+        packet.write_text('---\nslug: x\n---\nbranch: "late"\n', encoding="utf-8")
+        assert collab_data._packet_branch(packet) == ""
+
+    def test_bad_json_value_returns_empty(self, tmp_path: Path) -> None:
+        packet = tmp_path / "p.md"
+        packet.write_text("---\nbranch: not-json\n---\n", encoding="utf-8")
+        assert collab_data._packet_branch(packet) == ""
+
+    def test_valid_branch_parsed(self, tmp_path: Path) -> None:
+        packet = tmp_path / "p.md"
+        packet.write_text('---\nbranch: "feat/x"\n---\n', encoding="utf-8")
+        assert collab_data._packet_branch(packet) == "feat/x"
+
+
+class TestStaleHandoffs:
+    def _project_with_packet(self, tmp_path: Path, branch: str = "feat/x") -> Path:
+        handoffs = tmp_path / "docs" / "handoffs"
+        handoffs.mkdir(parents=True)
+        (handoffs / "feat-x.md").write_text(f'---\nbranch: "{branch}"\n---\n', encoding="utf-8")
+        return tmp_path
+
+    def test_missing_branch_flagged(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        root = self._project_with_packet(tmp_path)
+        monkeypatch.setattr(collab_data, "_git", lambda repo, *args: None)
+        rows = collab_data._stale_handoffs(root)
+        assert [(r.slug, r.reason) for r in rows] == [("feat-x", "branch missing")]
+
+    def test_merged_branch_flagged(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        root = self._project_with_packet(tmp_path)
+        # rev-parse resolves (branch exists), merge-base succeeds (merged).
+        monkeypatch.setattr(collab_data, "_git", lambda repo, *args: "ok")
+        rows = collab_data._stale_handoffs(root)
+        assert [(r.slug, r.reason) for r in rows] == [
+            ("feat-x", "branch merged — packet should be deleted")
+        ]
+
+    def test_live_branch_not_flagged(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        root = self._project_with_packet(tmp_path)
+
+        def _git(repo: Path, *args: str) -> str | None:
+            return "ok" if args[0] == "rev-parse" else None
+
+        monkeypatch.setattr(collab_data, "_git", _git)
+        assert collab_data._stale_handoffs(root) == []
+
+    def test_packet_without_branch_skipped(self, tmp_path: Path) -> None:
+        handoffs = tmp_path / "docs" / "handoffs"
+        handoffs.mkdir(parents=True)
+        (handoffs / "no-branch.md").write_text("# just notes\n", encoding="utf-8")
+        assert collab_data._stale_handoffs(tmp_path) == []
+
+
+class TestReadThreadEdges:
+    def test_whitespace_thread_rejected(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            collab_data, "_connect", lambda url=None: pytest.fail("must not connect")
+        )
+        assert read_thread("has space") is None
+        assert read_thread("") is None
+
+    def test_lrange_failure_returns_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        class _Client:
+            def lrange(self, key: str, start: int, stop: int) -> list[str]:
+                raise ConnectionError("dropped")
+
+        monkeypatch.setattr(collab_data, "_connect", lambda url=None: _Client())
+        assert read_thread("q-a-001") is None
+
+    def test_bad_items_skipped(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        class _Client:
+            def lrange(self, key: str, start: int, stop: int) -> list[Any]:
+                return ["{not json", '"a-string"', '{"author": "codex"}', None]
+
+        monkeypatch.setattr(collab_data, "_connect", lambda url=None: _Client())
+        assert read_thread("q-a-001") == [{"author": "codex"}]
+
+
+class TestMemoryConnect:
+    def test_missing_package_degrades(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setitem(sys.modules, "redis", None)
+        assert memory_data.connect() is None
+
+    def test_ping_failure_degrades(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        client = _FakePingableClient(fail_ping=True)
+        monkeypatch.setitem(sys.modules, "redis", _fake_redis_module(client))
+        assert memory_data.connect() is None
+
+    def test_success_returns_client(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        client = _FakePingableClient()
+        monkeypatch.setitem(sys.modules, "redis", _fake_redis_module(client))
+        assert memory_data.connect("redis://example.invalid:6379/9") is client
+
+
+class _ExplodingScanClient:
+    def ping(self) -> bool:
+        return True
+
+    def scan_iter(self, match: str, count: int = 10):
+        raise ConnectionError("dropped mid-read")
+
+    def get(self, key: str) -> str:
+        raise ConnectionError("dropped")
+
+    def type(self, key: str) -> str:
+        raise ConnectionError("dropped")
+
+
+class TestMemoryDegradePaths:
+    def test_read_overview_mid_read_failure(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(memory_data, "connect", lambda url=None: _ExplodingScanClient())
+        assert read_overview() is None
+
+    def test_read_node_unreachable(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(memory_data, "connect", lambda url=None: None)
+        assert read_node(MEMORY_KEY_PREFIX + "node:x") is None
+
+    def test_read_node_mid_read_failure(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(memory_data, "connect", lambda url=None: _ExplodingScanClient())
+        assert read_node(MEMORY_KEY_PREFIX + "node:x") is None
+
+    def test_node_count_unreachable_and_mid_read(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(memory_data, "connect", lambda url=None: None)
+        assert node_count() is None
+        monkeypatch.setattr(memory_data, "connect", lambda url=None: _ExplodingScanClient())
+        assert node_count() is None
+
+    def test_read_attention_get_failure(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(memory_data, "connect", lambda url=None: _ExplodingScanClient())
+        assert read_attention(tmp_path) is None
+
+    def test_pending_threads_scan_failure_counts_zero(self) -> None:
+        assert memory_data._pending_threads(_ExplodingScanClient()) == 0
+
+
+class TestMemoryValueShapes:
+    def test_set_and_unknown_shaped_keys_render(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        store: dict[str, object] = {
+            MEMORY_KEY_PREFIX + "markers:seen": {"a", "b", "c"},
+            MEMORY_KEY_PREFIX + "weird:num": 42,  # shape "none" -> unknown
+        }
+        monkeypatch.setattr(memory_data, "connect", lambda url=None: FakeRedis(store))
+        overview = read_overview()
+        assert overview is not None
+        by_kind = {row.kind: row for row in overview.rows}
+        assert by_kind["set"].description == "a, b, c"
+        assert by_kind["set"].size == "3 members"
+        assert by_kind["unknown"].description == ""
+        assert overview.kind_counts == {"set": 1, "unknown": 1}
+
+    def test_read_node_list_and_set_dispatch(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        store: dict[str, object] = {
+            MEMORY_KEY_PREFIX + "edges:x": ['{"target": "y"}', '{"target": "z"}'],
+            MEMORY_KEY_PREFIX + "markers:seen": {"b", "a"},
+        }
+        monkeypatch.setattr(memory_data, "connect", lambda url=None: FakeRedis(store))
+        edges = read_node(MEMORY_KEY_PREFIX + "edges:x")
+        assert edges == {"edge 1": '{"target": "y"}', "edge 2": '{"target": "z"}'}
+        members = read_node(MEMORY_KEY_PREFIX + "markers:seen")
+        assert members == {"members": "a\nb"}
+
+    def test_read_node_unsupported_type_renders_note(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        class _ZsetClient:
+            def type(self, key: str) -> str:
+                return "zset"
+
+        monkeypatch.setattr(memory_data, "connect", lambda url=None: _ZsetClient())
+        fields = read_node(MEMORY_KEY_PREFIX + "scores:x")
+        assert fields == {"type": "zset", "note": "unsupported value type for display"}
+
+    def test_pending_threads_skips_non_meta_keys(self) -> None:
+        class _MixedClient:
+            def scan_iter(self, match: str, count: int = 10):
+                yield "attune:roundtable:thread:q-real-001"  # no :meta suffix
+                yield "attune:roundtable:thread:q-real-001:meta"
+
+            def hgetall(self, key: str) -> dict[str, str]:
+                return {"status": "open"}
+
+        assert memory_data._pending_threads(_MixedClient()) == 1
+
+
+class TestMemoryRowHelpers:
+    def test_first_line_all_blank(self) -> None:
+        assert _first_line("\n   \n\t\n") == ""
+
+    def test_human_size_kilobyte_branch(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        big_text = "x" * 2048
+        store: dict[str, object] = {MEMORY_KEY_PREFIX + "lesson:big": {"text": big_text}}
+        monkeypatch.setattr(memory_data, "connect", lambda url=None: FakeRedis(store))
+        overview = read_overview()
+        assert overview is not None
+        assert overview.rows[0].size == "2.0 KB"
+
+    def test_edge_preview_skips_bad_json(self) -> None:
+        preview = _edge_preview(["{broken", '{"target": "t1", "type": "REL"}'])
+        assert preview == "→ t1 (REL)"
+
+    def test_edge_preview_without_type(self) -> None:
+        assert _edge_preview(['{"target": "t1"}']) == "→ t1"
+
+    def test_build_row_exception_result_cleared(self) -> None:
+        row = _build_row(
+            MEMORY_KEY_PREFIX + "node:x",
+            "hash",
+            RuntimeError("WRONGTYPE"),
+            hash_kinds={},
+        )
+        assert row.description == ""
+        assert row.size == ""
+        assert row.kind == "node"


### PR DESCRIPTION
## What

Lane 3 from `docs/reports/modules-needing-work-2026-07-30.md` (test-quality program #1569): the **ops dashboard data layer** — the user-facing surface cluster.

Tests-only: 68 new keyless tests in two files. No production code touched.

| Module | Codecov main | Now |
|---|---|---|
| `ops/routes/pending_writes.py` | 74.5% | **100%** |
| `ops/collab_data.py` | 77.0% | **100%** |
| `ops/session_summary_cache.py` | 77.5% | **100%** |
| `ops/memory_data.py` | 82.2% | **100%** |

## Coverage targets

The existing ops suites mock `_connect`/`connect` and drive happy paths; these tests cover the raw seams the mocks skip:

- **collab_data** — real `_connect` construction and degrade (via `sys.modules` fakes, never live Redis), thread-scan filters (diagnostic canaries, promoted, WRONGTYPE keys), the read-only git allowlist (disallowed verbs, OSError/timeout, nonzero exit), packet-frontmatter parsing (`---` terminator, bad JSON, unreadable path), stale-handoff classification (missing vs merged vs live branch), `read_thread` guards and item defenses.
- **memory_data** — `connect` degrade paths, mid-read connection drops in `read_overview`/`read_node`/`node_count`/`read_attention`, set- and unknown-shaped value rendering, `read_node` list/set/unsupported-type dispatch, edge-preview JSON defenses, the KB `_human_size` branch, pending-thread meta filters.
- **session_summary_cache** — `_hash_tail`/`compute_cache_key` I/O failures, every `load` validation rejection (non-dict payload/key, missing fields, uncoercible mtime, missing summary) plus optional-field defaulting on a hit, atomic-save failure cleanup (temp file removed, error propagated), the `_suppress_oserror` contract.
- **pending_writes helpers** — journal read failure and corrupt-line skipping, `_is_dashboard_running` probe outcomes (ProcessLookupError/PermissionError/OSError), `_is_file_committed` (missing root, outside-root, git failure, clean vs dirty), `_is_real_entry` transient-path and existence filters, `_enrich` bad-timestamp/missing-path edges.

## Receipts (declared at launch: suite + metric)

- **suite** (serial, no xdist): new files **68 passed** in 0.70s; full `tests/unit/ops/` **1596 passed** in 23.98s, zero failures.
- **metric** (worktree-safe coverage recipe, all four modules as `--source`): **613 stmts, 0 miss, 100%**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
