### PR TITLE
test(coverage): omit-audit pass 3 — un-omit sessions.py + cli_meta_workflows.py (#1569)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -724,7 +724,9 @@ omit = [
     # pass 2): dead glob — no file matches */memory/cross_session.py
     # (the real module lives under memory/short_term/).
     "*/memory/control_panel_api.py",  # FastAPI REST server
-    "*/memory/short_term/sessions.py",  # Requires Redis server
+    # memory/short_term/sessions.py entry removed 2026-07-30 (#1569
+    # omit-audit pass 3): its Requires-Redis label was false —
+    # tests/unit/memory/short_term/ measures it 100% keylessly.
     # claude_memory.py omit entry removed 2026-07-21 (#1569): its
     # Requires-Claude-API label was false — pure file I/O, keyless
     # 60-test suite, measures ~100% covered.
@@ -739,7 +741,10 @@ omit = [
     # pilot QA pass): 46% -> 100% via
     # tests/unit/orchestration/test_execution_strategy_base.py.
     # Meta-workflow CLI commands
-    "*/meta_workflows/cli_meta_workflows.py",  # CLI entry
+    # cli_meta_workflows.py entry removed 2026-07-30 (#1569
+    # omit-audit pass 3): its CLI-entry label was false — the module
+    # is a pure re-export shim, covered 100% by the import-contract
+    # test in tests/unit/meta_workflows/.
     # The five cli_commands modules below were removed from this list
     # 2026-07-29 (#1569 omit-audit pass 2): their Interactive labels
     # were false — dedicated suites in tests/unit/meta_workflows/

--- a/tests/unit/meta_workflows/test_cli_meta_workflows_reexports.py
+++ b/tests/unit/meta_workflows/test_cli_meta_workflows_reexports.py
@@ -1,0 +1,23 @@
+"""Contract test for the cli_meta_workflows backward-compat shim.
+
+The module exists only to re-export the cli_commands package's
+public surface under the legacy import path. The contract: every
+name in ``__all__`` resolves, and each is the SAME object the
+package exports — a drifted or dropped re-export would silently
+break legacy imports.
+"""
+
+from __future__ import annotations
+
+from attune.meta_workflows import cli_commands, cli_meta_workflows
+
+
+def test_all_reexports_resolve_to_package_objects() -> None:
+    assert cli_meta_workflows.__all__  # non-empty by contract
+    for name in cli_meta_workflows.__all__:
+        shim_obj = getattr(cli_meta_workflows, name)
+        assert shim_obj is getattr(cli_commands, name), name
+
+
+def test_typer_app_is_exported() -> None:
+    assert "meta_workflow_app" in cli_meta_workflows.__all__


### PR DESCRIPTION
## What

Pick-order item 4 from `docs/reports/modules-needing-work-2026-07-30.md` (test-quality program #1569): **omit-audit pass 3** over the three highest-yield production omit entries. Two more labels fall; the running total of falsified omit labels goes from 10 to 12.

| Entry | Stated reason | Probe result | Action |
|---|---|---|---|
| `mcp/server.py` | Infrastructure server | Already un-omitted on main by #1787; measures **97%** (495 stmts) from `tests/unit/mcp/` | none needed — probe confirmed |
| `memory/short_term/sessions.py` | Requires Redis server | **FALSE** — `tests/unit/memory/short_term/` measures it **100%** (63 stmts) keylessly | entry removed |
| `meta_workflows/cli_meta_workflows.py` | CLI entry | **FALSE** — it's a pure re-export shim, not a CLI | entry removed + import-contract test added |

## Changes

- `pyproject.toml`: two omit entries removed, each with the dated removal comment per the established convention (the `Check coverage omit entries are documented` hook passes).
- `tests/unit/meta_workflows/test_cli_meta_workflows_reexports.py`: new contract test — every `__all__` name on the shim resolves to the SAME object the `cli_commands` package exports, so a drifted or dropped legacy re-export fails loudly.

Coverage effect: adds 65 fully-covered statements (plus server.py's 495 at 97%, already live via #1787) to the measured set — total project coverage moves up, not down.

## Receipts (declared at launch: metric + suite)

- **metric** (worktree-safe recipe): `sessions.py` 63 stmts, 0 miss, **100%**; `cli_meta_workflows.py` 2 stmts, 0 miss, **100%**; `mcp/server.py` 495 stmts, 13 miss, **97%**.
- **suite** (serial, no xdist): `tests/unit/meta_workflows/` + `tests/unit/memory/short_term/` **686 passed** in 3m25s; new re-export test 2 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
