### PR TITLE
fix(ops): un-shadow the lazy Config re-export + Tier 3 shim tests (#1569)

### DIFF
--- a/docs/COVERAGE_BUG_LOG.md
+++ b/docs/COVERAGE_BUG_LOG.md
@@ -1,3 +1,28 @@
+## 2026-07-30 — Tier 3 shim corrections (coverage push, Fable 5)
+
+`src/attune/coordination.py` 0% → 100% (shim contract test),
+`src/attune/ops/__main__.py` 0% → 100% (entry-binding test),
+`src/attune/ops/__init__.py` 50% → 100% (lazy-delegation tests).
+One production bug found and fixed:
+
+- **Class 2-adjacent (dead lazy branch shadowed by its own
+  placeholder): `from attune.ops import Config` silently imported
+  `None`.** The package bound `Config = None` at module scope "for
+  static export" while the PEP 562 `__getattr__` carried the real
+  lazy `attune.ops.config.Config` resolution — but module
+  `__getattr__` only fires for MISSING attributes, so the
+  placeholder always won and the resolver branch was dead code
+  (masked from coverage by its own `pragma: no cover`). Any
+  consumer doing `from attune.ops import Config` got `None` and a
+  deferred `TypeError: 'NoneType' object is not callable` at first
+  use; a grep found no internal consumers, so the trap was armed
+  but unfired. Fix: the placeholder line deleted, `__getattr__` now
+  reachable; `test_config_getattr_resolves_real_class` pins the
+  contract. Detection note for the class: a `pragma: no cover` on
+  a PEP 562 `__getattr__` hides exactly this shadowing failure —
+  when a module defines both a placeholder AND a `__getattr__`
+  branch for the same name, one of them is dead by construction.
+
 ## 2026-07-29 — release_prep_team.py orchestration pass (coverage push, Fable 5)
 
 `src/attune/agents/release/release_prep_team.py` 78% → 100% via net-new

--- a/src/attune/ops/__init__.py
+++ b/src/attune/ops/__init__.py
@@ -10,8 +10,11 @@ release status, and environment health. It reads attune state from
 
 __all__ = ["create_app", "build_config", "Config"]
 
-# Define export at module scope; actual object is still lazy-resolved in __getattr__.
-Config = None
+# ``Config`` is deliberately NOT bound at module scope: PEP 562
+# ``__getattr__`` only fires for missing attributes, so a module-level
+# ``Config = None`` placeholder shadowed the lazy resolver and every
+# ``from attune.ops import Config`` silently imported ``None``
+# (caught 2026-07-30, Tier 3 corrections — see COVERAGE_BUG_LOG.md).
 
 
 def create_app(*args, **kwargs):

--- a/tests/unit/ops/test_lazy_exports.py
+++ b/tests/unit/ops/test_lazy_exports.py
@@ -1,0 +1,45 @@
+"""Contract tests for the ops package's lazy re-export layer.
+
+``attune.ops`` deliberately avoids importing FastAPI at package
+import (the dashboard deps are heavy); ``__main__`` is the
+``python -m attune.ops`` entry. The contract: the lazy wrappers
+delegate to the real factories with arguments intact, and the
+``__main__`` module binds the real CLI entry point.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import attune.ops as ops_pkg
+
+
+def test_main_module_binds_cli_entry() -> None:
+    main_mod = importlib.import_module("attune.ops.__main__")
+    from attune.ops.cli import main as cli_main
+
+    assert main_mod.main is cli_main
+
+
+def test_create_app_delegates_lazily(monkeypatch) -> None:
+    import attune.ops.server as server_mod
+
+    seen: list[tuple] = []
+    monkeypatch.setattr(server_mod, "create_app", lambda *a, **k: seen.append((a, k)) or "APP")
+    assert ops_pkg.create_app("cfg", flag=True) == "APP"
+    assert seen == [(("cfg",), {"flag": True})]
+
+
+def test_build_config_delegates_lazily(monkeypatch) -> None:
+    import attune.ops.config as config_mod
+
+    seen: list[tuple] = []
+    monkeypatch.setattr(config_mod, "build_config", lambda *a, **k: seen.append((a, k)) or "CFG")
+    assert ops_pkg.build_config(port=1234) == "CFG"
+    assert seen == [((), {"port": 1234})]
+
+
+def test_config_getattr_resolves_real_class() -> None:
+    from attune.ops.config import Config as real_config
+
+    assert ops_pkg.Config is real_config

--- a/tests/unit/test_coordination_shim.py
+++ b/tests/unit/test_coordination_shim.py
@@ -1,0 +1,30 @@
+"""Contract tests for the ``attune.coordination`` deprecation shim.
+
+The module was removed in v6.8.0 (redis-decoupling P1); what ships
+is a PEP 562 shim whose whole job is a helpful ImportError. The
+contract: every removed name raises ImportError with the pinned
+guidance, anything else raises plain AttributeError, and importing
+the shim itself stays side-effect free.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import attune.coordination as coordination
+
+
+def test_every_removed_name_raises_helpful_import_error() -> None:
+    assert coordination._REMOVED_NAMES  # non-empty by contract
+    for name in coordination._REMOVED_NAMES:
+        with pytest.raises(ImportError, match="removed in v6.8.0") as excinfo:
+            getattr(coordination, name)
+        message = str(excinfo.value)
+        assert name in message
+        assert "attune-ai<6.8.0" in message
+        assert "docs/specs/redis-decoupling/" in message
+
+
+def test_unknown_attribute_raises_attribute_error() -> None:
+    with pytest.raises(AttributeError, match="no attribute 'NotAThing'"):
+        coordination.NotAThing  # noqa: B018 — attribute access IS the test


### PR DESCRIPTION
## What

Tier 3 corrections from `docs/reports/modules-needing-work-2026-07-30.md` (#1569 pick-order item 5, the final item) — and the probe surfaced a **real production bug**, now fixed.

## The bug

`from attune.ops import Config` silently imported **`None`**. The package bound `Config = None` at module scope ("for static export") while the PEP 562 `__getattr__` carried the real lazy `attune.ops.config.Config` resolution — but module `__getattr__` only fires for *missing* attributes, so the placeholder always shadowed the resolver. The dead branch was masked from coverage by its own `pragma: no cover`. Any consumer would have gotten `None` and a deferred `TypeError` at first use; a grep found no internal consumers, so the trap was armed but unfired. Logged in `docs/COVERAGE_BUG_LOG.md` (class 2-adjacent, with a detection note: placeholder + `__getattr__` branch for the same name means one of them is dead by construction).

**Fix:** the shadowing line is deleted (one line, plus an explanatory comment); `test_config_getattr_resolves_real_class` pins the contract.

## Tests added

| Module | Was | Now |
|---|---|---|
| `coordination.py` (deprecation shim) | 0% | **100%** — every removed name raises the pinned ImportError guidance; unknown names raise AttributeError |
| `ops/__init__.py` (lazy re-exports) | 50% | **100%** — create_app/build_config delegation with args intact; Config resolves to the real class |
| `ops/__main__.py` | 0% | **fully covered** — entry-binding test; the `if __name__` block is `exclude_lines`'d |

## Receipts (declared at launch: suite + metric)

- **suite** (serial): new files **6 passed** in 0.16s; full `tests/unit/ops/` **1600 passed** in 18.45s (includes the new tests).
- **metric** (worktree-safe recipe): `coordination.py` 7 stmts, 0 miss, 100%; `ops/__init__.py` 7 stmts, 0 miss, 100%; `ops/__main__.py` sole "miss" is the excluded guard body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
