### PR TITLE
feat(scripts): standing modules-needing-work generator + parallel lane briefs

### DIFF
--- a/docs/reports/modules-needing-work.md
+++ b/docs/reports/modules-needing-work.md
@@ -1,0 +1,132 @@
+# Modules needing work
+
+**Generated:** 2026-07-30 20:16 UTC by `scripts/modules_needing_work.py` — regenerate in place, don't hand-edit (the dated 2026-07-30 report is the historical first edition).
+
+**Source:** Codecov main — project total 94.57% across 699 files. Candidate list for coverage lanes (test-quality program #1569).
+
+## Tier 1 — measured below the 85% bar (53 modules)
+
+### Clusters by miss volume
+
+| Cluster | Modules | Missed lines |
+|---|---|---|
+| `workflows` | 9 | 135 |
+| `authoring` | 6 | 131 |
+| `memory` | 6 | 127 |
+| `monitoring` | 4 | 38 |
+| `telemetry` | 1 | 29 |
+| `(top-level)` | 2 | 28 |
+| `commands` | 2 | 28 |
+| `roundtable` | 1 | 27 |
+| `cli_commands` | 2 | 26 |
+| `learning` | 1 | 25 |
+| `config` | 2 | 23 |
+| `mcp` | 1 | 23 |
+| `context` | 1 | 23 |
+| `ops` | 4 | 20 |
+| `hooks` | 1 | 20 |
+| `llm` | 2 | 18 |
+| `agents_md` | 1 | 14 |
+| `help` | 1 | 8 |
+| `models` | 1 | 7 |
+| `gates` | 1 | 6 |
+| `pipeline_learner` | 1 | 6 |
+| `agents` | 1 | 4 |
+| `orchestration` | 1 | 2 |
+| `wizards` | 1 | 2 |
+
+### Full list (ascending coverage)
+
+| Cover | Lines | Miss | Module |
+|---|---|---|---|
+| 0.00% | 7 | 7 | `src/attune/coordination.py` |
+| 0.00% | 1 | 1 | `src/attune/ops/__main__.py` |
+| 50.00% | 8 | 4 | `src/attune/ops/__init__.py` |
+| 58.49% | 53 | 17 | `src/attune/memory/short_term/patterns.py` |
+| 68.68% | 99 | 20 | `src/attune/workflows/context_proxy_mixin.py` |
+| 68.75% | 96 | 21 | `src/attune/redis_config.py` |
+| 69.09% | 55 | 11 | `src/attune/memory/file_session_patterns.py` |
+| 69.23% | 26 | 6 | `src/attune/authoring/ground_truth/cli_help.py` |
+| 70.58% | 34 | 7 | `src/attune/models/telemetry/run_context.py` |
+| 71.23% | 73 | 15 | `src/attune/authoring/fact_check/numeric_refs.py` |
+| 71.26% | 87 | 19 | `src/attune/authoring/ground_truth/dataclass_refs.py` |
+| 71.42% | 7 | 2 | `src/attune/memory/short_term/__init__.py` |
+| 74.07% | 27 | 6 | `src/attune/config/__init__.py` |
+| 74.44% | 90 | 18 | `src/attune/authoring/fact_check/cli_refs.py` |
+| 75.20% | 121 | 22 | `src/attune/authoring/ground_truth/public_api.py` |
+| 75.40% | 305 | 51 | `src/attune/authoring/source_introspection.py` |
+| 77.41% | 93 | 20 | `src/attune/hooks/executor.py` |
+| 77.47% | 111 | 22 | `src/attune/memory/file_session.py` |
+| 77.50% | 40 | 7 | `src/attune/monitoring/metrics.py` |
+| 77.96% | 59 | 6 | `src/attune/cli_commands/curator.py` |
+| 78.85% | 227 | 29 | `src/attune/telemetry/approval_gates.py` |
+| 79.16% | 192 | 33 | `src/attune/memory/cross_session/coordinator.py` |
+| 79.27% | 111 | 22 | `src/attune/workflows/dependency_check_report.py` |
+| 79.54% | 44 | 6 | `src/attune/gates/lifecycle/runner.py` |
+| 80.21% | 91 | 14 | `src/attune/agents_md/parser.py` |
+| 80.46% | 215 | 42 | `src/attune/memory/short_term/facade.py` |
+| 80.72% | 192 | 25 | `src/attune/learning/storage.py` |
+| 80.76% | 52 | 9 | `src/attune/workflows/post_simplification_mixin.py` |
+| 80.88% | 136 | 15 | `src/attune/workflows/bug_predict_patterns.py` |
+| 81.03% | 58 | 5 | `src/attune/llm/security.py` |
+| 81.19% | 117 | 10 | `src/attune/workflows/test_gen/ast_analyzer.py` |
+| 81.25% | 112 | 17 | `src/attune/config/loader.py` |
+| 81.25% | 16 | 2 | `src/attune/orchestration/_strategies/__init__.py` |
+| 81.48% | 162 | 24 | `src/attune/workflows/dependency_check_parsers.py` |
+| 81.48% | 54 | 4 | `src/attune/ops/routes/runs_history.py` |
+| 81.57% | 76 | 12 | `src/attune/monitoring/multi_backend.py` |
+| 81.75% | 137 | 16 | `src/attune/commands/parser.py` |
+| 81.77% | 192 | 27 | `src/attune/roundtable/triage_appendix.py` |
+| 81.81% | 132 | 15 | `src/attune/workflows/discovery_sweep/sources/pattern_scan.py` |
+| 81.92% | 83 | 12 | `src/attune/monitoring/notifications.py` |
+| 82.35% | 102 | 12 | `src/attune/commands/loader.py` |
+| 82.45% | 57 | 4 | `src/attune/agents/release/coverage_agent.py` |
+| 82.55% | 86 | 8 | `src/attune/help/staleness.py` |
+| 82.73% | 168 | 23 | `src/attune/mcp/memory_handlers.py` |
+| 83.06% | 189 | 23 | `src/attune/context/compaction.py` |
+| 83.33% | 126 | 20 | `src/attune/cli_commands/cost_commands.py` |
+| 83.33% | 90 | 7 | `src/attune/workflows/doc_orch_scout.py` |
+| 83.33% | 84 | 13 | `src/attune/llm/providers/anthropic_batch.py` |
+| 83.83% | 99 | 13 | `src/attune/workflows/services/parsing_service.py` |
+| 83.87% | 31 | 2 | `src/attune/wizards/builtin/debug_wizard.py` |
+| 84.09% | 88 | 11 | `src/attune/ops/routes/curator.py` |
+| 84.09% | 44 | 6 | `src/attune/pipeline_learner/scaffold.py` |
+| 84.12% | 63 | 7 | `src/attune/monitoring/validators.py` |
+
+## Tier 2 — omitted from measurement (un-omit-audit candidates)
+
+Production entries still in the `pyproject.toml` omit list. Every stated reason is a hypothesis until probed — 12 labels have been falsified so far.
+
+- `*/agent_factory/crews/*` — CrewAI deprecated - use meta-workflows
+- `*/agent_factory/adapters/autogen_adapter.py` — Deprecated adapter
+- `*/agent_factory/adapters/crewai_adapter.py` — CrewAI deprecated
+- `*/agent_factory/adapters/haystack_adapter.py` — Deprecated adapter
+- `*/agent_factory/adapters/langchain_adapter.py` — Use native adapter
+- `*/agent_factory/memory_integration.py` — Optional integration module
+- `*/agent_factory/resilient.py` — Optional resilience module
+- `*/wizards/technology_wizard.py` — Example wizard
+- `*/wizards/customer_support_wizard.py` — Example wizard
+- `*/workflows/progress_server.py` — Progress streaming server
+- `*/models/auth_cli.py` — Interactive auth setup
+- `*/monitoring/alerts_cli.py` — Monitoring CLI
+- `attune_software/cli/*.py` — Plugin CLI subcommands
+- `*/memory/control_panel_api.py` — FastAPI REST server
+- `*/hooks/scripts/evaluate_session.py` — Standalone hook
+- `*/hooks/scripts/first_time_init.py` — Standalone hook
+- `*/hooks/scripts/session_end.py` — Standalone hook
+- `*/hooks/scripts/session_start.py` — Standalone hook
+- `*/hooks/scripts/suggest_compact.py` — Standalone hook
+- `*/hooks/scripts/telemetry_hook.py` — Standalone hook
+- `*/core_modules/interaction.py` — Interaction stubs
+- `*/core_modules/short_term_memory.py` — Memory stubs
+- `*/mcp/__init__.py` — MCP package init
+- `*/commands/__init__.py` — Commands package init
+- `*/memory/storage/__init__.py` — Storage package init
+- `*/core_modules/__init__.py` — Core modules init
+- `*/models/__main__.py` — Models CLI entry point
+- `*/hooks/scripts/help_freshness_nudge.py` — Standalone hook script (not importable via pytest)
+- `*/attune/config.py` — Shadowed by attune/config/ package — unreachable import
+
+## How lanes run (parallel delegation)
+
+Modules with disjoint files are independent lanes. Emit briefs with `--briefs N` (or `--briefs-dir`) and dispatch them as PARALLEL delegated lanes: seats implement advisory on fresh branches, the lead re-runs every receipt centrally before the chair-armed merge. A lane's self-report is never the receipt.

--- a/scripts/modules_needing_work.py
+++ b/scripts/modules_needing_work.py
@@ -1,0 +1,328 @@
+#!/usr/bin/env python3
+"""Generate the standing modules-needing-work report from Codecov.
+
+Mechanizes the 2026-07-30 hand-built report
+(``docs/reports/modules-needing-work-2026-07-30.md``) so the backlog
+of coverage lanes stays CURRENT instead of drifting stale (issue
+#1569's tracked candidates were 16 points out of date when checked).
+
+Data source: Codecov's public API for the repo's main branch —
+per-file totals plus ``line_coverage`` pairs (``0``=hit, ``1``=miss,
+``2``=partial), which compress to exact missed-line ranges. This
+deliberately avoids both the stale local ``.coverage`` trap and a
+full worktree suite run (see the 2026-07-30 lessons batch).
+
+Usage::
+
+    python scripts/modules_needing_work.py                  # write report
+    python scripts/modules_needing_work.py --briefs 3       # + print top-3
+                                                            #   delegation briefs
+    python scripts/modules_needing_work.py --briefs-dir DIR # write briefs
+
+The report lands at ``docs/reports/modules-needing-work.md`` (one
+canonical file — regenerate and diff, don't accrete dated copies;
+the 2026-07-30 dated file stays as the historical first edition).
+
+Delegation briefs are self-contained lane prompts (miss ranges,
+constraints, receipts pre-declared) so independent modules can run
+as PARALLEL delegated lanes per the feature-lead model: seats
+implement advisory, the lead re-runs receipts centrally, the chair
+arms the merge.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under the Apache License, Version 2.0
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import urllib.request
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_REPO = "Smart-AI-Memory/attune-ai"
+DEFAULT_BAR = 85.0
+DEFAULT_OUT = Path("docs") / "reports" / "modules-needing-work.md"
+
+_API_TEMPLATE = "https://api.codecov.io/api/v2/github/{owner}/repos/{name}/report/?branch={branch}"
+
+#: Coverage-list prefixes that count as production code for this report.
+_PRODUCTION_PREFIXES = ("src/", "attune_redis/")
+
+#: Omit-list globs that are measurement plumbing, not production entries.
+_OMIT_META_MARKERS = ("tests", "__pycache__", "site-packages", "_example", "test_")
+
+
+@dataclass
+class ModuleGap:
+    """One module measuring below the bar."""
+
+    path: str
+    coverage: float
+    lines: int
+    misses: int
+    miss_ranges: str = ""
+
+    @property
+    def short_path(self) -> str:
+        return self.path.removeprefix("src/attune/")
+
+    @property
+    def cluster(self) -> str:
+        rel = self.short_path
+        return rel.split("/", 1)[0] if "/" in rel else "(top-level)"
+
+
+@dataclass
+class Report:
+    """Everything the renderer needs, decoupled from the fetch."""
+
+    total_coverage: float
+    total_files: int
+    gaps: list[ModuleGap] = field(default_factory=list)
+    omit_entries: list[str] = field(default_factory=list)
+    generated_at: str = ""
+
+
+def compress_ranges(lines: list[int]) -> str:
+    """Compress sorted line numbers to ``"a-b, c"`` form."""
+    out: list[str] = []
+    start = end = None
+    for line in lines:
+        if start is None:
+            start = end = line
+        elif line == end + 1:
+            end = line
+        else:
+            out.append(f"{start}" if start == end else f"{start}-{end}")
+            start = end = line
+    if start is not None:
+        out.append(f"{start}" if start == end else f"{start}-{end}")
+    return ", ".join(out)
+
+
+def extract_gaps(payload: dict, bar: float = DEFAULT_BAR) -> list[ModuleGap]:
+    """Production files below ``bar``, ascending by coverage."""
+    gaps: list[ModuleGap] = []
+    for entry in payload.get("files", []):
+        name = entry.get("name", "")
+        totals = entry.get("totals") or {}
+        coverage = totals.get("coverage")
+        if coverage is None or coverage >= bar:
+            continue
+        if not name.startswith(_PRODUCTION_PREFIXES):
+            continue
+        misses = [line for line, status in entry.get("line_coverage", []) if status == 1]
+        gaps.append(
+            ModuleGap(
+                path=name,
+                coverage=round(float(coverage), 2),
+                lines=int(totals.get("lines", 0)),
+                misses=int(totals.get("misses", 0)),
+                miss_ranges=compress_ranges(misses),
+            )
+        )
+    gaps.sort(key=lambda g: (g.coverage, -g.lines))
+    return gaps
+
+
+def extract_omit_entries(pyproject_text: str) -> list[str]:
+    """Production globs still in ``[tool.coverage.run] omit``."""
+    match = re.search(r"^omit = \[(.*?)^\]", pyproject_text, re.DOTALL | re.MULTILINE)
+    if match is None:
+        return []
+    entries: list[str] = []
+    for raw_line in match.group(1).splitlines():
+        line = raw_line.strip()
+        if not line.startswith('"'):
+            continue
+        glob = line.split('"')[1]
+        if any(marker in glob for marker in _OMIT_META_MARKERS):
+            continue
+        comment = raw_line.split("#", 1)[1].strip() if "#" in raw_line else ""
+        entries.append(f"`{glob}` — {comment}" if comment else f"`{glob}`")
+    return entries
+
+
+def cluster_summary(gaps: list[ModuleGap]) -> list[tuple[str, int, int]]:
+    """``(cluster, module_count, total_misses)`` sorted by miss volume."""
+    counts: dict[str, tuple[int, int]] = {}
+    for gap in gaps:
+        n, m = counts.get(gap.cluster, (0, 0))
+        counts[gap.cluster] = (n + 1, m + gap.misses)
+    return sorted(
+        ((name, n, m) for name, (n, m) in counts.items()),
+        key=lambda row: -row[2],
+    )
+
+
+def render_report(report: Report, bar: float = DEFAULT_BAR) -> str:
+    """The standing markdown report."""
+    lines = [
+        "# Modules needing work",
+        "",
+        f"**Generated:** {report.generated_at} by `scripts/modules_needing_work.py` "
+        "— regenerate in place, don't hand-edit (the dated 2026-07-30 report is "
+        "the historical first edition).",
+        "",
+        f"**Source:** Codecov main — project total {report.total_coverage:.2f}% "
+        f"across {report.total_files} files. Candidate list for coverage lanes "
+        "(test-quality program #1569).",
+        "",
+        f"## Tier 1 — measured below the {bar:.0f}% bar ({len(report.gaps)} modules)",
+        "",
+    ]
+    if report.gaps:
+        clusters = cluster_summary(report.gaps)
+        lines += [
+            "### Clusters by miss volume",
+            "",
+            "| Cluster | Modules | Missed lines |",
+            "|---|---|---|",
+        ]
+        lines += [f"| `{name}` | {n} | {m} |" for name, n, m in clusters]
+        lines += [
+            "",
+            "### Full list (ascending coverage)",
+            "",
+            "| Cover | Lines | Miss | Module |",
+            "|---|---|---|---|",
+        ]
+        lines += [
+            f"| {g.coverage:.2f}% | {g.lines} | {g.misses} | `{g.path}` |" for g in report.gaps
+        ]
+    else:
+        lines.append(f"Nothing below {bar:.0f}% — the floor is the ceiling today.")
+    lines += [
+        "",
+        "## Tier 2 — omitted from measurement (un-omit-audit candidates)",
+        "",
+        "Production entries still in the `pyproject.toml` omit list. Every stated "
+        "reason is a hypothesis until probed — 12 labels have been falsified so far.",
+        "",
+    ]
+    lines += [f"- {entry}" for entry in report.omit_entries] or ["- (none)"]
+    lines += [
+        "",
+        "## How lanes run (parallel delegation)",
+        "",
+        "Modules with disjoint files are independent lanes. Emit briefs with "
+        "`--briefs N` (or `--briefs-dir`) and dispatch them as PARALLEL delegated "
+        "lanes: seats implement advisory on fresh branches, the lead re-runs "
+        "every receipt centrally before the chair-armed merge. A lane's "
+        "self-report is never the receipt.",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def render_brief(gap: ModuleGap, repo: str = DEFAULT_REPO) -> str:
+    """A self-contained delegation brief for one coverage lane."""
+    slug = gap.short_path.replace("/", "-").removesuffix(".py")
+    return "\n".join(
+        [
+            f"# Lane brief: raise `{gap.path}` from {gap.coverage:.1f}% to >=85%",
+            "",
+            f"Repo: {repo} — branch off origin/main as `codex/coverage-{slug}`.",
+            "",
+            "## Target",
+            "",
+            f"- Module: `{gap.path}` ({gap.lines} lines, {gap.misses} missed)",
+            f"- Missed line ranges (Codecov main): {gap.miss_ranges or '(fetch fresh)'}",
+            "",
+            "## Constraints",
+            "",
+            "- TESTS-ONLY: no production code changes. If the miss regions reveal a",
+            "  production bug, STOP and report it — do not fix it in this lane.",
+            "- Keyless: no network, no live Redis, no API keys. Mock at module",
+            "  seams (`sys.modules` fakes for optional deps).",
+            "- Match the conventions of the nearest existing test directory.",
+            "",
+            "## Receipts (declared now, re-run centrally by the lead)",
+            "",
+            "- suite: run the module's test directory SERIALLY",
+            '  (`PYTEST_ADDOPTS="-p no:xdist -o addopts=" python -m pytest <dir> -q`)',
+            "  and return the exact tail.",
+            "- metric: re-measure ONLY this module",
+            '  (`cd /tmp && PYTHONPATH=<repo>/src PYTEST_ADDOPTS="-p no:xdist -o addopts="',
+            "  python -m coverage run --rcfile=/dev/null --source=<dotted.module>",
+            "  -m pytest <repo>/tests/... && python -m coverage report --rcfile=/dev/null`).",
+            "  NOTE: the /tmp run's pass/fail tail is NOT the suite receipt — a",
+            "  cwd-sensitive test may fail there; the repo-root run is the suite tail.",
+            "",
+            "## Done when",
+            "",
+            f"- `{gap.path}` measures >=85% from the recipe above.",
+            "- The full surrounding test directory passes from the repo root.",
+            "- One commit, pushed, PR opened tests-only with both receipts in the body.",
+        ]
+    )
+
+
+def fetch_codecov(repo: str = DEFAULT_REPO, branch: str = "main") -> dict:
+    """Fetch the Codecov report payload (public API, read-only)."""
+    owner, name = repo.split("/", 1)
+    url = _API_TEMPLATE.format(owner=owner, name=name, branch=branch)
+    with urllib.request.urlopen(url, timeout=30) as resp:  # nosec B310 — fixed https host
+        return json.load(resp)
+
+
+def build_report(payload: dict, pyproject_text: str, bar: float = DEFAULT_BAR) -> Report:
+    totals = payload.get("totals") or {}
+    return Report(
+        total_coverage=round(float(totals.get("coverage", 0.0)), 2),
+        total_files=int(totals.get("files", 0)),
+        gaps=extract_gaps(payload, bar),
+        omit_entries=extract_omit_entries(pyproject_text),
+        generated_at=datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC"),
+    )
+
+
+def _validated_out_path(out: Path) -> Path:
+    """Resolve ``out`` and require it inside the repo (path validation)."""
+    resolved = (REPO_ROOT / out).resolve() if not out.is_absolute() else out.resolve()
+    if not resolved.is_relative_to(REPO_ROOT):
+        raise ValueError(f"refusing to write outside the repo: {resolved}")
+    return resolved
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--repo", default=DEFAULT_REPO)
+    parser.add_argument("--branch", default="main")
+    parser.add_argument("--bar", type=float, default=DEFAULT_BAR)
+    parser.add_argument("--out", type=Path, default=DEFAULT_OUT)
+    parser.add_argument("--briefs", type=int, default=0, help="Print top-N lane briefs")
+    parser.add_argument("--briefs-dir", type=Path, default=None, help="Write briefs here instead")
+    args = parser.parse_args(argv)
+
+    payload = fetch_codecov(args.repo, args.branch)
+    pyproject_text = (REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    report = build_report(payload, pyproject_text, args.bar)
+
+    out_path = _validated_out_path(args.out)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(render_report(report, args.bar), encoding="utf-8")
+    print(f"wrote {out_path} ({len(report.gaps)} modules below {args.bar:.0f}%)")
+
+    ranked = sorted(report.gaps, key=lambda g: -g.misses)
+    if args.briefs_dir is not None:
+        briefs_dir = _validated_out_path(args.briefs_dir)
+        briefs_dir.mkdir(parents=True, exist_ok=True)
+        for gap in ranked[: args.briefs or len(ranked)]:
+            slug = gap.short_path.replace("/", "-").removesuffix(".py")
+            (briefs_dir / f"{slug}.md").write_text(render_brief(gap, args.repo) + "\n", "utf-8")
+        print(f"wrote {min(args.briefs or len(ranked), len(ranked))} briefs to {briefs_dir}")
+    elif args.briefs:
+        for gap in ranked[: args.briefs]:
+            print("\n" + "=" * 72 + "\n" + render_brief(gap, args.repo))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover — CLI entry
+    sys.exit(main())

--- a/tests/unit/scripts/test_modules_needing_work.py
+++ b/tests/unit/scripts/test_modules_needing_work.py
@@ -1,0 +1,154 @@
+"""Tests for scripts/modules_needing_work.py (pure logic, no network).
+
+The fetch is a thin urllib wrapper; everything else is pure and
+tested here against a fixture payload shaped like Codecov's
+``/report/`` response.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+_SCRIPT = Path(__file__).resolve().parents[3] / "scripts" / "modules_needing_work.py"
+_spec = importlib.util.spec_from_file_location("modules_needing_work", _SCRIPT)
+mnw = importlib.util.module_from_spec(_spec)
+sys.modules["modules_needing_work"] = mnw
+_spec.loader.exec_module(mnw)
+
+
+PAYLOAD = {
+    "totals": {"coverage": 93.82, "files": 4},
+    "files": [
+        {
+            "name": "src/attune/ops/collab_data.py",
+            "totals": {"coverage": 77.0, "lines": 139, "misses": 26},
+            "line_coverage": [[80, 1], [81, 1], [83, 1], [90, 0], [104, 1]],
+        },
+        {
+            "name": "src/attune/diagnosis/triage.py",
+            "totals": {"coverage": 68.3, "lines": 104, "misses": 30},
+            "line_coverage": [[55, 1], [59, 1], [60, 1], [61, 1]],
+        },
+        {
+            "name": "src/attune/covered.py",
+            "totals": {"coverage": 99.0, "lines": 10, "misses": 0},
+            "line_coverage": [],
+        },
+        {
+            "name": "tests/unit/not_production.py",
+            "totals": {"coverage": 10.0, "lines": 5, "misses": 4},
+            "line_coverage": [],
+        },
+        {
+            "name": "src/attune/no_data.py",
+            "totals": {"coverage": None, "lines": 0, "misses": 0},
+            "line_coverage": [],
+        },
+    ],
+}
+
+PYPROJECT = """
+[tool.coverage.run]
+omit = [
+    "*/tests/*",
+    "*/__pycache__/*",
+    "*/site-packages/*",
+    "*/*_example.py",
+    "*/models/auth_cli.py",  # Interactive auth setup
+    "*/workflows/progress_server.py",
+]
+branch = true
+"""
+
+
+class TestCompressRanges:
+    def test_mixed_runs_and_singletons(self) -> None:
+        assert mnw.compress_ranges([1, 2, 3, 7, 10, 11]) == "1-3, 7, 10-11"
+
+    def test_empty(self) -> None:
+        assert mnw.compress_ranges([]) == ""
+
+    def test_single(self) -> None:
+        assert mnw.compress_ranges([42]) == "42"
+
+
+class TestExtractGaps:
+    def test_filters_sorts_and_compresses(self) -> None:
+        gaps = mnw.extract_gaps(PAYLOAD, bar=85.0)
+        # Non-production and above-bar and no-data files excluded;
+        # ascending coverage order.
+        assert [g.path for g in gaps] == [
+            "src/attune/diagnosis/triage.py",
+            "src/attune/ops/collab_data.py",
+        ]
+        assert gaps[0].miss_ranges == "55, 59-61"
+        assert gaps[1].miss_ranges == "80-81, 83, 104"
+        assert gaps[1].cluster == "ops"
+
+    def test_bar_is_exclusive_of_equal(self) -> None:
+        gaps = mnw.extract_gaps(PAYLOAD, bar=68.3)
+        assert gaps == []
+
+
+class TestExtractOmitEntries:
+    def test_meta_globs_skipped_comments_carried(self) -> None:
+        entries = mnw.extract_omit_entries(PYPROJECT)
+        assert entries == [
+            "`*/models/auth_cli.py` — Interactive auth setup",
+            "`*/workflows/progress_server.py`",
+        ]
+
+    def test_missing_omit_block(self) -> None:
+        assert mnw.extract_omit_entries("[tool.other]\nx = 1\n") == []
+
+
+class TestClusterSummary:
+    def test_sorted_by_miss_volume(self) -> None:
+        gaps = mnw.extract_gaps(PAYLOAD, bar=85.0)
+        assert mnw.cluster_summary(gaps) == [
+            ("diagnosis", 1, 30),
+            ("ops", 1, 26),
+        ]
+
+
+class TestRendering:
+    def _report(self) -> object:
+        return mnw.build_report(PAYLOAD, PYPROJECT, bar=85.0)
+
+    def test_report_contains_tiers_and_tables(self) -> None:
+        text = mnw.render_report(self._report(), bar=85.0)
+        assert "# Modules needing work" in text
+        assert "project total 93.82%" in text
+        assert "## Tier 1 — measured below the 85% bar (2 modules)" in text
+        assert "| 68.30% | 104 | 30 | `src/attune/diagnosis/triage.py` |" in text
+        assert "`*/models/auth_cli.py` — Interactive auth setup" in text
+        assert "## How lanes run (parallel delegation)" in text
+
+    def test_report_empty_state(self) -> None:
+        report = mnw.build_report({"totals": {}, "files": []}, PYPROJECT, bar=85.0)
+        text = mnw.render_report(report, bar=85.0)
+        assert "Nothing below 85%" in text
+
+    def test_brief_is_self_contained(self) -> None:
+        gap = mnw.extract_gaps(PAYLOAD, bar=85.0)[0]
+        brief = mnw.render_brief(gap)
+        assert "raise `src/attune/diagnosis/triage.py` from 68.3% to >=85%" in brief
+        assert "codex/coverage-diagnosis-triage" in brief
+        assert "Missed line ranges (Codecov main): 55, 59-61" in brief
+        assert "TESTS-ONLY" in brief
+        assert "suite:" in brief and "metric:" in brief
+        assert "NOT the suite receipt" in brief
+
+
+class TestValidatedOutPath:
+    def test_relative_path_lands_in_repo(self) -> None:
+        resolved = mnw._validated_out_path(Path("docs/reports/x.md"))
+        assert resolved.is_relative_to(mnw.REPO_ROOT)
+
+    def test_escape_rejected(self) -> None:
+        with pytest.raises(ValueError, match="outside the repo"):
+            mnw._validated_out_path(Path("/etc/passwd"))


### PR DESCRIPTION
## What

Adoption of items 1 + 2 from today's session retro: the modules-needing-work report becomes a **standing generated artifact** with **parallel-delegation lane briefs** built in.

- `scripts/modules_needing_work.py` — stdlib-only generator. Fetches Codecov main's per-file `line_coverage` (public API, read-only, free), writes `docs/reports/modules-needing-work.md` in place: Tier 1 below-85% table + cluster miss-volume summary, Tier 2 production omit entries, and a "How lanes run" section. `--briefs N` / `--briefs-dir` emit **self-contained delegation briefs** per module — miss ranges, tests-only + keyless constraints, receipts pre-declared (suite serial + metric via the /tmp recipe, including the receipt-split caveat), done-when — so independent modules dispatch as parallel delegated lanes per the feature-lead model (seats advisory, lead re-runs receipts, chair arms). Output paths validated inside the repo.
- `tests/unit/scripts/test_modules_needing_work.py` — 13 tests over the pure logic against a fixture payload; the network fetch stays a thin urllib wrapper.
- `docs/reports/modules-needing-work.md` — first generated edition. The live data already shows today's five lanes landed: **64 → 53 modules below the bar, project 93.82% → 94.57%**.
- Companion (machine-local, not in this diff): weekly scheduled task `modules-needing-work-weekly` (Mondays 09:00 ET) regenerates the file and opens a labeled PR only on material change.

The dated `modules-needing-work-2026-07-30.md` stays untouched as the historical first edition.

## Receipts

- **suite** (serial): 13 passed in 0.05s.
- **live-fire**: the generator ran against real Codecov data and produced the committed report plus a valid brief for the current top candidate (`authoring/source_introspection.py`, 51 misses).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
