### PR TITLE
docs(tutorials): fix-test tutorial — fix a failing test, then automate it

### DIFF
--- a/.help/templates/fix-test/comparison.md
+++ b/.help/templates/fix-test/comparison.md
@@ -3,8 +3,8 @@ type: comparison
 name: fix-test-comparison
 feature: fix-test
 depth: comparison
-generated_at: 2026-06-22T11:30:53.046085+00:00
-source_hash: 2a68f682c715ddba2510a8395022ba9b502452e2fce1c7a1d13419ce2a2f0f1b
+generated_at: 2026-07-30T21:39:00.970482+00:00
+source_hash: 56383ae48a3d6c0dcdadb645912bf30697dbdd296c66e69e3c40100a6c12ab69
 status: generated
 ---
 

--- a/.help/templates/fix-test/concept.md
+++ b/.help/templates/fix-test/concept.md
@@ -3,8 +3,8 @@ type: concept
 name: fix-test-concept
 feature: fix-test
 depth: concept
-generated_at: 2026-06-22T11:30:53.046085+00:00
-source_hash: 2a68f682c715ddba2510a8395022ba9b502452e2fce1c7a1d13419ce2a2f0f1b
+generated_at: 2026-07-30T21:39:00.970482+00:00
+source_hash: 56383ae48a3d6c0dcdadb645912bf30697dbdd296c66e69e3c40100a6c12ab69
 status: generated
 ---
 

--- a/.help/templates/fix-test/error.md
+++ b/.help/templates/fix-test/error.md
@@ -3,8 +3,8 @@ type: error
 name: fix-test-error
 feature: fix-test
 depth: error
-generated_at: 2026-06-22T11:30:53.046085+00:00
-source_hash: 2a68f682c715ddba2510a8395022ba9b502452e2fce1c7a1d13419ce2a2f0f1b
+generated_at: 2026-07-30T21:39:00.970482+00:00
+source_hash: 56383ae48a3d6c0dcdadb645912bf30697dbdd296c66e69e3c40100a6c12ab69
 status: generated
 ---
 

--- a/.help/templates/fix-test/faq.md
+++ b/.help/templates/fix-test/faq.md
@@ -3,8 +3,8 @@ type: faq
 name: fix-test-faq
 feature: fix-test
 depth: faq
-generated_at: 2026-07-14T15:58:52.133407+00:00
-source_hash: 2a68f682c715ddba2510a8395022ba9b502452e2fce1c7a1d13419ce2a2f0f1b
+generated_at: 2026-07-30T21:39:00.970482+00:00
+source_hash: 56383ae48a3d6c0dcdadb645912bf30697dbdd296c66e69e3c40100a6c12ab69
 status: generated
 ---
 

--- a/.help/templates/fix-test/note.md
+++ b/.help/templates/fix-test/note.md
@@ -3,8 +3,8 @@ type: note
 name: fix-test-note
 feature: fix-test
 depth: note
-generated_at: 2026-06-22T11:30:53.046085+00:00
-source_hash: 2a68f682c715ddba2510a8395022ba9b502452e2fce1c7a1d13419ce2a2f0f1b
+generated_at: 2026-07-30T21:39:00.970482+00:00
+source_hash: 56383ae48a3d6c0dcdadb645912bf30697dbdd296c66e69e3c40100a6c12ab69
 status: generated
 ---
 

--- a/.help/templates/fix-test/quickstart.md
+++ b/.help/templates/fix-test/quickstart.md
@@ -3,25 +3,24 @@ type: quickstart
 name: fix-test-quickstart
 feature: fix-test
 depth: quickstart
-generated_at: 2026-06-22T11:30:53.046085+00:00
-source_hash: 2a68f682c715ddba2510a8395022ba9b502452e2fce1c7a1d13419ce2a2f0f1b
+generated_at: 2026-07-30T21:39:00.970482+00:00
+source_hash: 56383ae48a3d6c0dcdadb645912bf30697dbdd296c66e69e3c40100a6c12ab69
 status: generated
 ---
 
 # Auto-diagnose test gaps from file changes and track test outcomes
 
-## Fastest path: /fix-test in Claude Code
+## Quickstart
 
-For an interactive fix, run `/fix-test <test file or pattern>` in a
-Claude Code session — it scopes the target, classifies the root
-cause, applies a fix, and re-runs (up to 3 attempts) before
-reporting. The full walkthrough, including wiring a tests-on-edit
-hook so failures are caught and fixed the moment an edit creates
-them, is the tutorial at `docs/tutorials/fix-test.md`.
+**Fastest path — `/fix-test` in Claude Code.** For an interactive
+fix, run `/fix-test <test file or pattern>` in a Claude Code
+session — it scopes the target, classifies the root cause, applies
+a fix, and re-runs (up to 3 attempts) before reporting. The full
+walkthrough, including wiring a tests-on-edit hook so failures are
+caught and fixed the moment an edit creates them, is the tutorial
+at `docs/tutorials/fix-test.md`.
 
-## Quickstart (Python API)
-
-Generate a maintenance plan for the whole project.
+For the Python API, generate a maintenance plan for the whole project.
 `TestMaintenanceWorkflow.run` is an async coroutine, so drive it with
 `asyncio.run` (or `await` it inside an existing event loop):
 

--- a/.help/templates/fix-test/quickstart.md
+++ b/.help/templates/fix-test/quickstart.md
@@ -10,7 +10,16 @@ status: generated
 
 # Auto-diagnose test gaps from file changes and track test outcomes
 
-## Quickstart
+## Fastest path: /fix-test in Claude Code
+
+For an interactive fix, run `/fix-test <test file or pattern>` in a
+Claude Code session — it scopes the target, classifies the root
+cause, applies a fix, and re-runs (up to 3 attempts) before
+reporting. The full walkthrough, including wiring a tests-on-edit
+hook so failures are caught and fixed the moment an edit creates
+them, is the tutorial at `docs/tutorials/fix-test.md`.
+
+## Quickstart (Python API)
 
 Generate a maintenance plan for the whole project.
 `TestMaintenanceWorkflow.run` is an async coroutine, so drive it with

--- a/.help/templates/fix-test/reference.md
+++ b/.help/templates/fix-test/reference.md
@@ -3,8 +3,8 @@ type: reference
 name: fix-test-reference
 feature: fix-test
 depth: reference
-generated_at: 2026-06-22T11:30:53.046085+00:00
-source_hash: 2a68f682c715ddba2510a8395022ba9b502452e2fce1c7a1d13419ce2a2f0f1b
+generated_at: 2026-07-30T21:39:00.970482+00:00
+source_hash: 56383ae48a3d6c0dcdadb645912bf30697dbdd296c66e69e3c40100a6c12ab69
 status: generated
 ---
 

--- a/.help/templates/fix-test/task.md
+++ b/.help/templates/fix-test/task.md
@@ -3,8 +3,8 @@ type: task
 name: fix-test-task
 feature: fix-test
 depth: task
-generated_at: 2026-06-22T11:30:53.046085+00:00
-source_hash: 2a68f682c715ddba2510a8395022ba9b502452e2fce1c7a1d13419ce2a2f0f1b
+generated_at: 2026-07-30T21:39:00.970482+00:00
+source_hash: 56383ae48a3d6c0dcdadb645912bf30697dbdd296c66e69e3c40100a6c12ab69
 status: generated
 ---
 

--- a/.help/templates/fix-test/tip.md
+++ b/.help/templates/fix-test/tip.md
@@ -3,8 +3,8 @@ type: tip
 name: fix-test-tip
 feature: fix-test
 depth: tip
-generated_at: 2026-06-22T11:30:53.046085+00:00
-source_hash: 2a68f682c715ddba2510a8395022ba9b502452e2fce1c7a1d13419ce2a2f0f1b
+generated_at: 2026-07-30T21:39:00.970482+00:00
+source_hash: 56383ae48a3d6c0dcdadb645912bf30697dbdd296c66e69e3c40100a6c12ab69
 status: generated
 ---
 

--- a/.help/templates/fix-test/troubleshooting.md
+++ b/.help/templates/fix-test/troubleshooting.md
@@ -3,8 +3,8 @@ type: troubleshooting
 name: fix-test-troubleshooting
 feature: fix-test
 depth: troubleshooting
-generated_at: 2026-06-22T11:30:53.046085+00:00
-source_hash: 2a68f682c715ddba2510a8395022ba9b502452e2fce1c7a1d13419ce2a2f0f1b
+generated_at: 2026-07-30T21:39:00.970482+00:00
+source_hash: 56383ae48a3d6c0dcdadb645912bf30697dbdd296c66e69e3c40100a6c12ab69
 status: generated
 ---
 

--- a/.help/templates/fix-test/warning.md
+++ b/.help/templates/fix-test/warning.md
@@ -3,8 +3,8 @@ type: warning
 name: fix-test-warning
 feature: fix-test
 depth: warning
-generated_at: 2026-06-22T11:30:53.046085+00:00
-source_hash: 2a68f682c715ddba2510a8395022ba9b502452e2fce1c7a1d13419ce2a2f0f1b
+generated_at: 2026-07-30T21:39:00.970482+00:00
+source_hash: 56383ae48a3d6c0dcdadb645912bf30697dbdd296c66e69e3c40100a6c12ab69
 status: generated
 ---
 

--- a/content/features/fix-test.md
+++ b/content/features/fix-test.md
@@ -99,7 +99,15 @@ signatures and return types — import or call the one you mean.
 
 ## Quickstart
 
-Generate a maintenance plan for the whole project.
+**Fastest path — `/fix-test` in Claude Code.** For an interactive
+fix, run `/fix-test <test file or pattern>` in a Claude Code
+session — it scopes the target, classifies the root cause, applies
+a fix, and re-runs (up to 3 attempts) before reporting. The full
+walkthrough, including wiring a tests-on-edit hook so failures are
+caught and fixed the moment an edit creates them, is the tutorial
+at `docs/tutorials/fix-test.md`.
+
+For the Python API, generate a maintenance plan for the whole project.
 `TestMaintenanceWorkflow.run` is an async coroutine, so drive it with
 `asyncio.run` (or `await` it inside an existing event loop):
 

--- a/docs/architecture/fix-test.md
+++ b/docs/architecture/fix-test.md
@@ -118,4 +118,4 @@ signatures and return types — import or call the one you mean.
   `get_stale_tests` and `get_test_health_summary` surface the gaps the
   recorded telemetry exposes.
 
-<!-- attune-generated: source_hash=2a68f682c715ddba2510a8395022ba9b502452e2fce1c7a1d13419ce2a2f0f1b feature=fix-test kind=architecture generated_at=2026-06-22 -->
+<!-- attune-generated: source_hash=56383ae48a3d6c0dcdadb645912bf30697dbdd296c66e69e3c40100a6c12ab69 feature=fix-test kind=architecture generated_at=2026-07-30 -->

--- a/docs/how-to/fix-test.md
+++ b/docs/how-to/fix-test.md
@@ -2,7 +2,15 @@
 
 ## Quickstart
 
-Generate a maintenance plan for the whole project.
+**Fastest path — `/fix-test` in Claude Code.** For an interactive
+fix, run `/fix-test <test file or pattern>` in a Claude Code
+session — it scopes the target, classifies the root cause, applies
+a fix, and re-runs (up to 3 attempts) before reporting. The full
+walkthrough, including wiring a tests-on-edit hook so failures are
+caught and fixed the moment an edit creates them, is the tutorial
+at `docs/tutorials/fix-test.md`.
+
+For the Python API, generate a maintenance plan for the whole project.
 `TestMaintenanceWorkflow.run` is an async coroutine, so drive it with
 `asyncio.run` (or `await` it inside an existing event loop):
 
@@ -185,4 +193,4 @@ Fix-test's public API spans two workflow modules. The record types
 | `auto_executable` | `bool` | Whether `"auto"` mode may run it (default `True`). |
 | `metadata` | `dict` | Free-form extra context. |
 
-<!-- attune-generated: source_hash=2a68f682c715ddba2510a8395022ba9b502452e2fce1c7a1d13419ce2a2f0f1b feature=fix-test kind=how-to generated_at=2026-06-22 -->
+<!-- attune-generated: source_hash=56383ae48a3d6c0dcdadb645912bf30697dbdd296c66e69e3c40100a6c12ab69 feature=fix-test kind=how-to generated_at=2026-07-30 -->

--- a/docs/reference/fix-test.md
+++ b/docs/reference/fix-test.md
@@ -47,4 +47,4 @@ Fix-test's public API spans two workflow modules. The record types
 | `auto_executable` | `bool` | Whether `"auto"` mode may run it (default `True`). |
 | `metadata` | `dict` | Free-form extra context. |
 
-<!-- attune-generated: source_hash=2a68f682c715ddba2510a8395022ba9b502452e2fce1c7a1d13419ce2a2f0f1b feature=fix-test kind=reference generated_at=2026-06-22 -->
+<!-- attune-generated: source_hash=56383ae48a3d6c0dcdadb645912bf30697dbdd296c66e69e3c40100a6c12ab69 feature=fix-test kind=reference generated_at=2026-07-30 -->

--- a/docs/tutorials/fix-test.md
+++ b/docs/tutorials/fix-test.md
@@ -1,0 +1,187 @@
+---
+type: tutorial
+name: fix-test
+tags: [fix-test, testing, hooks, automation, debugging]
+source: plugin/skills/fix-test/SKILL.md
+---
+
+# Tutorial: Fix a Failing Test — Then Make It Automatic
+
+In this tutorial you'll fix a real failing test with attune-ai's
+`/fix-test` skill, then wire a Claude Code hook so every future edit
+runs its matching test immediately — failures get caught (and fixed)
+the moment they're created, not at the next full suite run.
+
+**You'll need:** Claude Code with the attune-ai plugin installed
+(`pip install attune-ai`), and a Python project with a pytest suite.
+
+**Time:** about 10 minutes.
+
+---
+
+## Part 1 — See the failure
+
+Every fix starts with a reproducible failure. Run the failing test
+directly so you know exactly what Claude will see:
+
+```bash
+uv run pytest tests/unit/test_pricing.py -v --tb=short
+```
+
+```text
+FAILED tests/unit/test_pricing.py::test_discount_applies -
+AssertionError: assert 90.0 == 85.0
+```
+
+If you don't have a failing test handy and want to follow along,
+break one on purpose — change an expected value in any assertion.
+
+## Part 2 — Fix it with /fix-test
+
+In Claude Code, run:
+
+```text
+/fix-test tests/unit/test_pricing.py
+```
+
+The skill scopes before it acts — expect two questions:
+
+1. **Target** — which test is failing (you just gave it), or whether
+   it should hunt for failures itself.
+2. **Context** — did this start failing after a recent change, or
+   has it been broken a while? (This routes the diagnosis: assertion
+   drift after a refactor is a different fix than a stale mock.)
+
+Then it loops: run the test, classify the root cause, apply a
+targeted fix, re-run — up to **3 attempts** before it stops and
+reports honestly. The root-cause classes it recognizes:
+
+| Error pattern | Likely root cause | Typical fix |
+| --- | --- | --- |
+| `ModuleNotFoundError` | Import path changed | Update the import |
+| `AttributeError` on a mock | Mock target wrong | Match the real import path |
+| `AssertionError` | Expected value drift | Update the assertion |
+| `TypeError: __init__` | Constructor changed | Update the call site |
+| `FileNotFoundError` | Fixture path wrong | Use `tmp_path` |
+
+You get a report at the end — tests fixed, attempts used, and
+anything still failing with notes. **A fix that changes the
+assertion deserves a skeptical read**: if the production behavior
+changed *unintentionally*, updating the test buries a bug. The
+report names the root cause precisely so you can make that call.
+
+## Part 3 — Make it automatic
+
+The manual loop works, but the best moment to fix a test is the
+moment an edit breaks it. Claude Code **hooks** make that happen:
+a `PostToolUse` hook runs after every file edit, and anything it
+writes to stderr with exit code 2 is fed straight back to Claude —
+which then sees the failure *in the same session that caused it*
+and fixes it immediately.
+
+### Step 1 — add the hook script
+
+Save this as `.claude/hooks/run_matching_test.py` in your project:
+
+```python
+#!/usr/bin/env python3
+"""PostToolUse hook: run the test file matching an edited source file.
+
+Reads the hook event JSON on stdin. If the edited file is production
+code, finds test files named after it (tests/**/test_<stem>*.py) and
+runs them. Exit 0 when they pass (silent); exit 2 with the pytest
+tail on stderr when they fail — Claude Code feeds exit-2 stderr back
+to Claude, which fixes the failure immediately.
+"""
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+event = json.load(sys.stdin)
+edited = event.get("tool_input", {}).get("file_path", "")
+path = Path(edited)
+
+# Only react to production .py edits — never to test edits (that
+# would loop) and never to docs/config.
+if path.suffix != ".py" or "test" in path.name or "tests" in path.parts:
+    sys.exit(0)
+
+project_root = Path.cwd()
+matches = sorted(project_root.glob(f"tests/**/test_{path.stem}*.py"))
+if not matches:
+    sys.exit(0)  # no matching test file — nothing to run
+
+proc = subprocess.run(
+    ["uv", "run", "pytest", *map(str, matches), "-x", "-q", "--tb=short"],
+    capture_output=True,
+    text=True,
+    timeout=120,
+)
+if proc.returncode == 0:
+    sys.exit(0)
+
+tail = "\n".join((proc.stdout + proc.stderr).splitlines()[-30:])
+print(
+    f"Tests for {path.name} FAILED after your edit:\n{tail}\n"
+    "Fix the failure before continuing (or run /fix-test).",
+    file=sys.stderr,
+)
+sys.exit(2)
+```
+
+### Step 2 — register it
+
+Add this to your project's `.claude/settings.json` (create the file
+if it doesn't exist; if you already have a `hooks` block, merge the
+`PostToolUse` entry into it):
+
+```json
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR/.claude/hooks/run_matching_test.py\""
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+### Step 3 — watch the loop close
+
+Ask Claude to change something in a file that has tests. The moment
+the edit lands, the hook runs the matching tests. If the edit broke
+one, Claude sees the failure output immediately and repairs it —
+usually before you'd have noticed anything was wrong. If the repair
+isn't obvious, `/fix-test` is one command away with the failure
+already on screen.
+
+Convention note: the hook maps `src/**/pricing.py` to
+`tests/**/test_pricing*.py`. If your suite names tests differently,
+adjust the `glob` pattern on the `matches` line — that one line is
+the whole mapping.
+
+## What you built
+
+- A diagnosis-first fix loop (`/fix-test`) that classifies root
+  causes instead of pattern-matching on error text, and knows when
+  to stop.
+- A tests-on-edit hook that turns every edit into an immediate
+  verification, with failures routed back to the session that
+  caused them.
+
+## Where to go next
+
+- `/smart-test` — find test *gaps* and generate tests for uncovered
+  code (the complement of fixing existing ones).
+- `/quick-test` — run tests affected by recent changes on demand.
+- The [fix-test help pages](../features/fix-test.md) cover the
+  Python-level `TestMaintenanceWorkflow` API for scripted
+  maintenance plans.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -203,6 +203,7 @@ nav:
   - Tutorials:
       - tutorials/index.md
       - Build a Workflow: tutorials/build-a-workflow.md
+      - Fix a Failing Test (and Automate It): tutorials/fix-test.md
       - Ops Dashboard: tutorials/ops-dashboard.md
       - Examples:
           - Code Review Assistant: tutorials/examples/simple-chatbot.md

--- a/plugin/help/generated/quickstarts/fix-test.md
+++ b/plugin/help/generated/quickstarts/fix-test.md
@@ -12,7 +12,15 @@ type: quickstart
 
 ## Quickstart
 
-Generate a maintenance plan for the whole project.
+**Fastest path — `/fix-test` in Claude Code.** For an interactive
+fix, run `/fix-test <test file or pattern>` in a Claude Code
+session — it scopes the target, classifies the root cause, applies
+a fix, and re-runs (up to 3 attempts) before reporting. The full
+walkthrough, including wiring a tests-on-edit hook so failures are
+caught and fixed the moment an edit creates them, is the tutorial
+at `docs/tutorials/fix-test.md`.
+
+For the Python API, generate a maintenance plan for the whole project.
 `TestMaintenanceWorkflow.run` is an async coroutine, so drive it with
 `asyncio.run` (or `await` it inside an existing event loop):
 

--- a/plugin/help/generated/source_manifest.json
+++ b/plugin/help/generated/source_manifest.json
@@ -2,6026 +2,6026 @@
   "com-agents": {
     "source": "content/features/agents.md",
     "hash": "a5b1678ecf012c7b2877a6c7ecae4a6c3f14c084c13fbcbb7eee79119dce6fa3",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "com-auth-strategies": {
     "source": "src/attune/models/auth_cli.py",
     "hash": "586101ee6a646d50a06299d3c9e96f60467c65376782c191c910af6cf52ef268",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "com-bug-predict": {
     "source": "content/features/bug-predict.md",
     "hash": "6a4f420eba38e2fb884b837dd9758acb60ba60cdaf9248ec4280120b0d382b16",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "com-cli": {
     "source": "content/features/cli.md",
     "hash": "a37b4dc4f0b3706a62184b02d2be1536ad75eef39a0f22a9699db5d03b8ee050",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "com-code-quality": {
     "source": "content/features/code-quality.md",
     "hash": "ce16ac87eb92e33a08d8c2f06e86ef22e436966f47f3a28c3f4eba19060b550a",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "com-configuration": {
     "source": "content/features/configuration.md",
     "hash": "8add90392883a46899ef8b57d135b625d92c5b61231d8a5301727f8b42f8e46f",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "com-cross-review": {
     "source": "content/features/cross-review.md",
     "hash": "dc5ae75883b05f97983377b51e275bab79921e992d842ebb2616726b8c8c2cdb",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "com-deep-review": {
     "source": "content/features/deep-review.md",
     "hash": "6a4fffc907302b4847d96097189bd8d329d3f1548d1ee46d9232f6ceecdfb450",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "com-doc-gen": {
     "source": "content/features/doc-gen.md",
     "hash": "26e02a71a523775f5bb9e371b2e563c3c858386436a73b727422f62f57de0282",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "com-elicitation-forms": {
     "source": "content/features/elicitation-forms.md",
     "hash": "4f326dd6f99f86af163cf44167b243d73ee5165ef8373bf4cea83039aec723d2",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "com-fix-test": {
     "source": "content/features/fix-test.md",
-    "hash": "da54b69787cc1af5c087b2d8674442afe9b8c6fc88dca37a65e99590bb84fee0",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "8b182bab8816d525d3325746f4cdeed013113a1bdb0a43d36963e121afa42812",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "com-help-system": {
     "source": "content/features/help-system.md",
     "hash": "24468c8fe4f1a0e350e620098d65a3bcc007000cd5aa4dbe20a6e6c83efa87b3",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "com-hooks": {
     "source": "content/features/hooks.md",
     "hash": "5c6b8a45457387c76f628561d3baa56e9af1709bc9bd21bba9830b2c2478c8dd",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "com-mcp-server": {
     "source": "content/features/mcp-server.md",
     "hash": "8e4b8c74eff980330480ae70856a1cf0393559cd22eb9ba0210b43249f9b5181",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "com-memory": {
     "source": "content/features/memory.md",
     "hash": "32b3121d9110dc9ac327bb9e838f060fbe9940a033366b0147ef34ef2efaa4dc",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "com-models": {
     "source": "content/features/models.md",
     "hash": "2117cbb0d8e863db6091870874e4ce80b48780c9ee8bb7330d8033c172ccb02b",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "com-ops-dashboard": {
     "source": "content/features/ops-dashboard.md",
     "hash": "fefc8e2b2b4a25055fcbdf96cbd8638d75278cbcacd256873b725df89544c1f6",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "com-orchestration": {
     "source": "content/features/orchestration.md",
     "hash": "4998437e04355011a7dee68dbce7e9e78bbe97f637e0b6a14c1ec972f541695c",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "com-plugin": {
     "source": "content/features/plugin.md",
     "hash": "8cc6e5702ffc8228ed63cfb74a25dd3e99e79e5335c4b1c8c134950f8b9a043d",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "com-rag-grounding": {
     "source": "content/features/rag-grounding.md",
     "hash": "3464dd78c83f06980912a7c49dc185b09830be1b1c163203f10e5aa1708fcf4e",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "com-refactor-plan": {
     "source": "content/features/refactor-plan.md",
     "hash": "8f8c684cd94fca7b2580ecaaf955ccb79924022796d576d477cdab9330df9704",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "com-release-notes": {
     "source": "content/features/release-notes.md",
     "hash": "da7101ffbec4d209fcb1cef754f01cef8a13458a6f961c3a23909edfec77e58c",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "com-release-prep": {
     "source": "content/features/release-prep.md",
     "hash": "cd77b5903fbeb7d7e0acef570bab9727b4c143181ea6be1f52b9a25bc11418bb",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "com-resilience": {
     "source": "content/features/resilience.md",
     "hash": "ae2a76f0f1ecbb9ca687e5a041acc2b4a25a5113ec57eaad550f48b8aadc4be2",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "com-security-audit": {
     "source": "content/features/security-audit.md",
     "hash": "9cce18573c827fab9a380efe8c65c2f8c5b4ada3f7e383dd71ec523a0875fb05",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "com-session-handoff": {
     "source": "content/features/session-handoff.md",
     "hash": "236c16ee2d2e48f0bd8ba075c69f50ead16a46ef185fede3d84b529c66fd41a0",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "com-smart-test": {
     "source": "content/features/smart-test.md",
     "hash": "58c691c8313ddf9699deb913e6b5c50fafc684563539ddf4816a4b94a9ea3e80",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "com-spec-engine": {
     "source": "content/features/spec-engine.md",
     "hash": "c8549016aa848eeeaecbde8329f5850562f56280ab66428cb7c20887b428d81a",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "com-telemetry": {
     "source": "content/features/telemetry.md",
     "hash": "59473ab809113116a3d58d2ead3a5f13e362d6992d8cee0a89364feded5cbd50",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "com-wizards": {
     "source": "content/features/wizards.md",
     "hash": "6fe7722a026d11276ebfbdf4ea046a05112be94b560f9abf3ffee410f8637d8f",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "com-workflow-vs-wizard": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "con-agents": {
     "source": "content/features/agents.md",
     "hash": "a5b1678ecf012c7b2877a6c7ecae4a6c3f14c084c13fbcbb7eee79119dce6fa3",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "con-audience-adaptation": {
     "source": "src/attune/help/transformers.py",
     "hash": "00861e98056d93ab47c8ca43e64c941c802a1876da7faaad2ed0f825d698938c",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "con-bug-predict": {
     "source": "content/features/bug-predict.md",
     "hash": "6a4f420eba38e2fb884b837dd9758acb60ba60cdaf9248ec4280120b0d382b16",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "con-cli": {
     "source": "content/features/cli.md",
     "hash": "a37b4dc4f0b3706a62184b02d2be1536ad75eef39a0f22a9699db5d03b8ee050",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "con-code-quality": {
     "source": "content/features/code-quality.md",
     "hash": "ce16ac87eb92e33a08d8c2f06e86ef22e436966f47f3a28c3f4eba19060b550a",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "con-configuration": {
     "source": "content/features/configuration.md",
     "hash": "8add90392883a46899ef8b57d135b625d92c5b61231d8a5301727f8b42f8e46f",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "con-cross-linking": {
     "source": "scripts/build_cross_links.py",
     "hash": "f271a7146802a35388670a2541ab016e3358a78bf5aa876f30f9af1d4d4344b0",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "con-cross-review": {
     "source": "content/features/cross-review.md",
     "hash": "dc5ae75883b05f97983377b51e275bab79921e992d842ebb2616726b8c8c2cdb",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "con-deep-review": {
     "source": "content/features/deep-review.md",
     "hash": "6a4fffc907302b4847d96097189bd8d329d3f1548d1ee46d9232f6ceecdfb450",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "con-doc-gen": {
     "source": "content/features/doc-gen.md",
     "hash": "26e02a71a523775f5bb9e371b2e563c3c858386436a73b727422f62f57de0282",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "con-elicitation-forms": {
     "source": "content/features/elicitation-forms.md",
     "hash": "4f326dd6f99f86af163cf44167b243d73ee5165ef8373bf4cea83039aec723d2",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "con-feedback-loop": {
     "source": "src/attune/help/engine.py",
     "hash": "cefbd9ea62f941969da6b381754835e6994bcbece1867d76998f7199ef39265a",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "con-fix-test": {
     "source": "content/features/fix-test.md",
-    "hash": "da54b69787cc1af5c087b2d8674442afe9b8c6fc88dca37a65e99590bb84fee0",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "8b182bab8816d525d3325746f4cdeed013113a1bdb0a43d36963e121afa42812",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "con-help-system": {
     "source": "content/features/help-system.md",
     "hash": "24468c8fe4f1a0e350e620098d65a3bcc007000cd5aa4dbe20a6e6c83efa87b3",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "con-hooks": {
     "source": "content/features/hooks.md",
     "hash": "5c6b8a45457387c76f628561d3baa56e9af1709bc9bd21bba9830b2c2478c8dd",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "con-mcp-server": {
     "source": "content/features/mcp-server.md",
     "hash": "8e4b8c74eff980330480ae70856a1cf0393559cd22eb9ba0210b43249f9b5181",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "con-memory": {
     "source": "content/features/memory.md",
     "hash": "32b3121d9110dc9ac327bb9e838f060fbe9940a033366b0147ef34ef2efaa4dc",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "con-models": {
     "source": "content/features/models.md",
     "hash": "2117cbb0d8e863db6091870874e4ce80b48780c9ee8bb7330d8033c172ccb02b",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "con-ops-dashboard": {
     "source": "content/features/ops-dashboard.md",
     "hash": "fefc8e2b2b4a25055fcbdf96cbd8638d75278cbcacd256873b725df89544c1f6",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "con-orchestration": {
     "source": "content/features/orchestration.md",
     "hash": "4998437e04355011a7dee68dbce7e9e78bbe97f637e0b6a14c1ec972f541695c",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "con-plugin": {
     "source": "content/features/plugin.md",
     "hash": "8cc6e5702ffc8228ed63cfb74a25dd3e99e79e5335c4b1c8c134950f8b9a043d",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "con-progressive-depth": {
     "source": "src/attune/help/engine.py",
     "hash": "cefbd9ea62f941969da6b381754835e6994bcbece1867d76998f7199ef39265a",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "con-rag-grounding": {
     "source": "content/features/rag-grounding.md",
     "hash": "3464dd78c83f06980912a7c49dc185b09830be1b1c163203f10e5aa1708fcf4e",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "con-refactor-plan": {
     "source": "content/features/refactor-plan.md",
     "hash": "8f8c684cd94fca7b2580ecaaf955ccb79924022796d576d477cdab9330df9704",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "con-release-notes": {
     "source": "content/features/release-notes.md",
     "hash": "da7101ffbec4d209fcb1cef754f01cef8a13458a6f961c3a23909edfec77e58c",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "con-release-prep": {
     "source": "content/features/release-prep.md",
     "hash": "cd77b5903fbeb7d7e0acef570bab9727b4c143181ea6be1f52b9a25bc11418bb",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "con-resilience": {
     "source": "content/features/resilience.md",
     "hash": "ae2a76f0f1ecbb9ca687e5a041acc2b4a25a5113ec57eaad550f48b8aadc4be2",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "con-security-audit": {
     "source": "content/features/security-audit.md",
     "hash": "9cce18573c827fab9a380efe8c65c2f8c5b4ada3f7e383dd71ec523a0875fb05",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "con-session-handoff": {
     "source": "content/features/session-handoff.md",
     "hash": "236c16ee2d2e48f0bd8ba075c69f50ead16a46ef185fede3d84b529c66fd41a0",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "con-smart-test": {
     "source": "content/features/smart-test.md",
     "hash": "58c691c8313ddf9699deb913e6b5c50fafc684563539ddf4816a4b94a9ea3e80",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "con-socratic-discovery": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "con-spec-engine": {
     "source": "content/features/spec-engine.md",
     "hash": "c8549016aa848eeeaecbde8329f5850562f56280ab66428cb7c20887b428d81a",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "con-sync-paradigm": {
     "source": "scripts/generate_all.py",
     "hash": "6a3e4428fe0b789f45a226f983116d18827b19b6a12162691c522fd4861862a3",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "con-telemetry": {
     "source": "content/features/telemetry.md",
     "hash": "59473ab809113116a3d58d2ead3a5f13e362d6992d8cee0a89364feded5cbd50",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "con-template-composition": {
     "source": "src/attune/help/engine.py",
     "hash": "cefbd9ea62f941969da6b381754835e6994bcbece1867d76998f7199ef39265a",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "con-tier-routing": {
     "source": "src/attune/workflows/base.py",
     "hash": "8651c3e2645e5ec764718119ed55284d1dc4853fa9903663925e2a0c42ff60de",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "con-tool-attune-hub": {
     "source": "plugin/skills/attune-hub/SKILL.md",
     "hash": "2a18d84bd5efb5738643d716c803440f602d40871b172238996c4aebcf498032",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "con-tool-bug-predict": {
     "source": "plugin/skills/bug-predict/SKILL.md",
     "hash": "992b9e6cd3452af0d31213985e5e5c607f078edd2310df76d786b95d7e6a83ce",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "con-tool-coach": {
     "source": "plugin/skills/coach/SKILL.md",
     "hash": "a1842d674325f3f1ea289e3bd7ed1dcfbb4b3301160181edab081d2b4352aeac",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "con-tool-code-quality": {
     "source": "plugin/skills/code-quality/SKILL.md",
     "hash": "769c4c885992fd1937adbdf5d97305894bd08c159c83930d7a9fb86cb4ae78b7",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "con-tool-doc-gen": {
     "source": "plugin/skills/doc-gen/SKILL.md",
     "hash": "da9a9c23727eaa9433b2c4d1dfe87d850ef560d56b855f2eb7bd0f279efc3c72",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "con-tool-fix-test": {
     "source": "plugin/skills/fix-test/SKILL.md",
     "hash": "665ff7c4978beddd72e87f3764b073e4f962b27a896bd66542d499a1a00429da",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "con-tool-memory-and-context": {
     "source": "plugin/skills/memory-and-context/SKILL.md",
     "hash": "d026a40d0c5315123672c7ed3770b643ba803a3b5d57cb994c236fcd6baa8305",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "con-tool-planning": {
     "source": "plugin/skills/planning/SKILL.md",
     "hash": "f56a42c83f514b300b4f89ea6669820ec158da952efa2894c56abb00c39eb58a",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "con-tool-rag-code-gen": {
     "source": "plugin/skills/rag-code-gen/SKILL.md",
     "hash": "0d84a32e2f89e8debd740b4343c7930b17efcca37fcb68737f342f8b6b5f6f77",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "con-tool-refactor-plan": {
     "source": "plugin/skills/refactor-plan/SKILL.md",
     "hash": "080a84b5df5dde88cd3c994ca2c2b68ec12e2cf241f2e81893f21aa9dac315f6",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "con-tool-release-prep": {
     "source": "plugin/skills/release-prep/SKILL.md",
     "hash": "8aab944ae2f53a24c94d39329bf000067a68f43b51de6657b517678bec90c67a",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "con-tool-security-audit": {
     "source": "plugin/skills/security-audit/SKILL.md",
     "hash": "f370003a809c342d35b37990da231fbb72545e75e5a37e1e1d39a27db5364761",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "con-tool-smart-test": {
     "source": "plugin/skills/smart-test/SKILL.md",
     "hash": "a5e874d1054dd123d78d9d8e9014c7c6888230f36685a203ea26176a3d649ffb",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "con-tool-spec": {
     "source": "plugin/skills/spec/SKILL.md",
     "hash": "4e1ce2c9da6fcad85ebcf7cb6b755f44c27d00608ad97b72b93a82a45e3c0186",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "con-tool-workflow-orchestration": {
     "source": "plugin/skills/workflow-orchestration/SKILL.md",
     "hash": "831c00dfb29ae4c72b35921fd3bab9e9f17affabf32b8164deb801557e031127",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "con-wizards": {
     "source": "content/features/wizards.md",
     "hash": "6fe7722a026d11276ebfbdf4ea046a05112be94b560f9abf3ffee410f8637d8f",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "con-workflow-chain-prediction": {
     "source": "src/attune/workflows/suggestions.py",
     "hash": "caa3f48a039def99a5bf58dc29129aba9548dfc74a42cc69dfb067aeb71f3200",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-adding-a-plugin-skill-has-three-enforcement-gates-not-one": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-adding-a-workspace-sibling-package-as-an-extra-can-silently": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-adding-dns-resolution-to-validate-webhook-url-breaks-tests-that": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-adding-logger-before-eager-imports-triggers-e402-in-init-py": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-after-a-pr-merges-while-youre-afk-pull-main-before-tagging": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-after-a-squash-merge-of-a-feature-branch-local-main-can-have": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-agents": {
     "source": "content/features/agents.md",
     "hash": "a5b1678ecf012c7b2877a6c7ecae4a6c3f14c084c13fbcbb7eee79119dce6fa3",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-agents-skills-must-stay-synced-with-plugin-skills": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-anchor-tag-buttons-need-text-white-no-underline": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-anthropics-built-in-prompt-caching-supersedes-custom-caching": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-any-unstaged-file-triggers-pre-commit-stash-conflicts-with-auto": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-apply-lessons-by-problem-not-by-keyword": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-attune-author-check-staleness-load-manifest-is-the-python-api": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-attune-help-re-exports-create-a-hidden-cross-package-dep-on": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-attune-helps-sidecar-schemas-dont-match-path-keyed-assumptions": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-attune-skill-names-must-not-collide-with-claude-code-built-in": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-attune-workflow-run-code-review-and-security-audit-require-a": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-b904-raise-x-from-e-is-not-auto-fixable-by-ruff": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-background-processes-from-previous-sessions-persist-across": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-bandit-b108-blocks-hardcoded-tmp-paths": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-bare-manifest-in-gitignore-silently-excludes-any-manifest": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-baseworkflow-now-provides-self-logger": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-baseworkflow-uses-class-attributes-not-constructor-params": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-bg-var-primary-bg-opacity-10-is-invisible-in-dark-mode": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-broad-gitignore-patterns-match-nested-directories": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-bug-predict": {
     "source": "content/features/bug-predict.md",
     "hash": "6a4f420eba38e2fb884b837dd9758acb60ba60cdaf9248ec4280120b0d382b16",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-bug-predict-dangerous-eval-flags-subprocess-exec": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-bugpredictionworkflow-not-bugpredictworkflow": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-changing-error-messages-breaks-tests-across-the-codebase": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-changing-the-citation-anchor-format-can-silently-regress-llm": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-changing-user-facing-output-strings-cascades-through-test": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-chicken-and-egg-for-optional-extras-in-dev": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-ci-timeout-tests-enforce-the-range-you-set": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-citation-forced-prompting-and-prompt-injection-resistance-are": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-claude-agent-sdk-is-now-a-core-dependency-of-attune-ai": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-claude-agent-sdk-systempromptpreset-as-of-0-1-63-is-claude-code": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-claude-code-plugin-is-platform-specific": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-claude-code-plugins-expect-plugin-json-inside-claude-plugin": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-claude-plugin-install-is-marketplace-only": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-cli": {
     "source": "content/features/cli.md",
     "hash": "a37b4dc4f0b3706a62184b02d2be1536ad75eef39a0f22a9699db5d03b8ee050",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-clusterfuzz-dockerfile-copies-to-src-repo-but-also-copies": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-clusterfuzzlite-no-deps-misses-transitive-imports": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-coach-is-the-user-facing-entry-point-for-the-help-system": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-code-quality": {
     "source": "content/features/code-quality.md",
     "hash": "ce16ac87eb92e33a08d8c2f06e86ef22e436966f47f3a28c3f4eba19060b550a",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-codecov-patch-0-usually-means-tests-skipped-not-failed": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-codeql-alerts-dismissible-in-bulk-via-gh-api": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-codeql-js-stored-xss-flags-jsx-even-though-react-auto-escapes": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-codeql-py-clear-text-logging-sensitive-data-traces-data-flow": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-combine-two-unreleased-changelog-drafts-into-one-version-when": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-commands-are-not-namespaced-in-plugins-skills-are": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-config-py-alongside-config-creates-a-mypy-duplicate-module": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-configuration": {
     "source": "content/features/configuration.md",
     "hash": "8add90392883a46899ef8b57d135b625d92c5b61231d8a5301727f8b42f8e46f",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-costreport-fields-are-named-not-positional": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-costreport-is-a-dataclass-not-a-dict": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-cross-review": {
     "source": "content/features/cross-review.md",
     "hash": "dc5ae75883b05f97983377b51e275bab79921e992d842ebb2616726b8c8c2cdb",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-custom-mcp-stdio-loop-fails-claude-code-handshake": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-dataclassorder-true-needs-compare-false-on-list-fields": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-datetime-utcnow-datetime-nowtimezone-utc-cascades-through-the": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-dead-code-modules-with-full-test-suites-look-alive": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-dead-tests-from-monorepo-extraction-accumulate-in-packages-with": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-deep-review": {
     "source": "content/features/deep-review.md",
     "hash": "6a4fffc907302b4847d96097189bd8d329d3f1548d1ee46d9232f6ceecdfb450",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-deep-review-false-positives-verify-before-acting": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-delete-deprecated-module-is-rarely-a-simple-delete-grep-src-and": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-dependency-lower-bounds-trigger-scorecard-vulnerability-alerts": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-detect-secrets-flags-fake-as-a-secret-in-test-fixtures": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-direct-pushes-to-main-are-blocked-by-the-presence-of-required": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-dispatch-tables-hold-direct-function-references-mocks-must": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-dist-can-contain-stale-artifacts-after-version-bumps": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-doc-gen": {
     "source": "content/features/doc-gen.md",
     "hash": "26e02a71a523775f5bb9e371b2e563c3c858386436a73b727422f62f57de0282",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-dont-append-z-to-timezone-aware-isoformat": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-dry-run-candidate-golden-queries-through-the-resolver-before": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-duck-typed-test-fakes-fail-isinstance-based-collectors-silently": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-duplicate-plugins-cause-conflicting-skill-triggers": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-elicitation-forms": {
     "source": "content/features/elicitation-forms.md",
     "hash": "4f326dd6f99f86af163cf44167b243d73ee5165ef8373bf4cea83039aec723d2",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-enforce-admins-false-defeats-code-review-scorecard-check": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-enforce-admins-required-reviews-blocks-solo-dev-merges": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-exclude-hard-queries-from-aggregate-p-1-metrics-in-benchmark": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-exploration-agents-fabricate-names-verify-against-source": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-f841-unused-fixture-lint-fires-when-a-test-is-refactored-to": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-fastembed-is-the-local-embeddings-path-that-passes-a-50mb": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-fix-test": {
     "source": "content/features/fix-test.md",
-    "hash": "da54b69787cc1af5c087b2d8674442afe9b8c6fc88dca37a65e99590bb84fee0",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "8b182bab8816d525d3325746f4cdeed013113a1bdb0a43d36963e121afa42812",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-forced-anthropic-tool-use-is-the-cleanest-path-to-guaranteed": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-forced-cite-per-claim-prompting-is-the-structural-lever-for-rag": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-formatter-strips-imports-that-are-unused-at-the-moment-you-save": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-full-coverage-runs-on-15k-test-suites-timeout-easily": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-generated-content-with-trailing-whitespace-causes-perpetual-pre": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-getattrmodule-name-none-at-call-site-is-the-clean-degradation": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-gh-api-x-patch-f-name-n-rejects-integers-as-strings": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-gh-pr-checks-json-field-names": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-gh-pr-merge-admin-is-blocked-by-in-progress-required-checks": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-gh-pr-merge-admin-prints-a-fast-forward-warning-even-when-the": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-gh-repo-create-source-path-push-is-a-one-shot-for-new-sibling": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-gh-workflow-run-file-yml-ref-tag-re-triggers-a-release-gated": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-ghost-command-references-survive-cli-renames": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-git-commit-q-can-exit-0-with-pre-commit-hook-feedback-that": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-git-pull-refuses-with-unstaged-changes-when-pull-rebase-true": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-git-rebase-root-exec-git-commit-amend-no-edit-s-re-signs-every": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-git-stash-pop-after-pre-commit-can-resurrect-stale-tool-state": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-github-actions-environment-deployment-approvals-can-be-self": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-github-copilot-autofix-pushes-commits-directly-to-pr-branches": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-github-protected-tags-cannot-be-force-updated": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-github-repos-serve-as-claude-code-marketplaces": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-gitignore-exclusions-break-ci-tests-that-read-those-files": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-glob-based-hash-computation-must-exclude-cache-dirs": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-golden-query-benchmarks-reveal-two-distinct-failure-classes": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-golden-query-test-fixtures-must-match-the-actual-corpus-layout": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-gpg-signing-fails-in-non-interactive-terminals-vscode-extension": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-hand-crafted-summary-prototype-is-the-fastest-way-to-measure-a": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-handoff-memory-option-b-proposals-are-often-wrong-re-analyze": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-hardcoded-root-paths-in-tests": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-hardcoded-strings-in-method-bodies-survive-class-attribute": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-hardcoded-user-id-defeats-ownership-checks": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-help-system": {
     "source": "content/features/help-system.md",
     "hash": "24468c8fe4f1a0e350e620098d65a3bcc007000cd5aa4dbe20a6e6c83efa87b3",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-hooks": {
     "source": "content/features/hooks.md",
     "hash": "5c6b8a45457387c76f628561d3baa56e9af1709bc9bd21bba9830b2c2478c8dd",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-hot-reload-subsystem-was-1-038-lines-of-dead-code": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-import-x-inside-a-try-block-except-x-someerror-in-the-except": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-importlib-import-module-is-an-arbitrary-code-execution-vector": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-industry-terminology-wont-appear-in-llm-polished-rag-summaries": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-integration-tests-gated-by-has-api-key-can-poison-the-whole-ci": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-is-private-is-a-superset-in-python-ipaddress": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-kwargs-collides-with-explicit-params-of-the-same-name": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-lazy-imports-inside-function-bodies-cant-be-patched-with": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-linkedin-paste-use-ascii-markers-not-unicode-arrows": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-list-wizards-is-a-function-not-a-class-method": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-list-workflows-deduplication-must-keep-base-names-visible": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-llm-api-responses-lack-trailing-newlines": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-local-telemetry-trackers-need-an-autouse-conftest-fixture": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-macos-var-private-var-symlink-breaks-path-assertions": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-mcp-attune-ai-doc-orchestrator-is-a-no-op-stub": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-mcp-call-tool-wrapper-pattern": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-mcp-handler-validate-paths-before-importing-workflows": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-mcp-json-python-resolves-to-pyenv-shim-not-project-venv": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-mcp-server": {
     "source": "content/features/mcp-server.md",
     "hash": "8e4b8c74eff980330480ae70856a1cf0393559cd22eb9ba0210b43249f9b5181",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-mcp-server-process-doesnt-inherit-env-variables": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-mcp-tool-count-tests-are-hardcoded": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-mcp-tool-renames-propagate-to-skill-docs": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-mcp-workspace-root-defaults-to-os-getcwd-tests-with-tmp-path": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-memory": {
     "source": "content/features/memory.md",
     "hash": "32b3121d9110dc9ac327bb9e838f060fbe9940a033366b0147ef34ef2efaa4dc",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-metadata-can-reach-a-retriever-with-zero-signal-if-the-sidecar": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-metapathfinder-find-module-load-module-is-dead-in-python-3-12": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-mixin-classes-inherit-self-workspace-root-at-runtime-not-at": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-mkdocs-build-crashing-with-attributeerror-nonetype-object-has": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-mkdocs-strict-treats-broken-links-as-fatal-errors": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-mock-a-lazy-import-x-with-types-moduletype-patch-dictsys-modules": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-models": {
     "source": "content/features/models.md",
     "hash": "2117cbb0d8e863db6091870874e4ce80b48780c9ee8bb7330d8033c172ccb02b",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-modeltier-has-two-copies-imports-must-match": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-module-level-optional-imports-enable-clean-test-patching": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-multiple-pinentry-program-lines-in-gpg-agent-conf-first-wins": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-mutual-competition-between-polished-rag-features-is-real-and": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-mypy-437-errors-was-stale-actual-count-was-2": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-naive-suffix-strip-stemming-fails-on-english-doubling-consonant": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-never-paste-pypi-tokens-into-chat-or-logs": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-new-dataclass-fields-need-both-the-class-and-the-parser-updated": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-new-mcp-handlers-must-match-the-validation-pattern-of-adjacent": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-new-security-features-need-dedicated-tests-before-release": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-next-js-shared-data-libs-prevent-page-duplication": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-non-baseworkflow-classes-in-workflow-registry-crash-the-cli": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-noqa-f401-re-exports-break-silently-on-satellite-file-deletion": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-openssf-scorecard-alerts-2-codereviewid-3-sastid-are-process": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-ops-dashboard": {
     "source": "content/features/ops-dashboard.md",
     "hash": "fefc8e2b2b4a25055fcbdf96cbd8638d75278cbcacd256873b725df89544c1f6",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-orchestration": {
     "source": "content/features/orchestration.md",
     "hash": "4998437e04355011a7dee68dbce7e9e78bbe97f637e0b6a14c1ec972f541695c",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-orphan-help-dirs-are-deprecated-3-depth-output-adding-them-to": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-orphan-top-level-docs-directories-stay-invisible-to-readers": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-packages-attune-in-attune-ai-are-pointer-stubs-not-source": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-past-due-deprecations-are-deletion-targets-not-implementation": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-patch-requires-the-target-name-to-exist-at-module-scope-at": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-patch-the-source-module-for-from-x-import-y-in-function-bodies": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-path-cwd-at-module-level-captures-import-time-cwd": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-path-globdir-matches-directories-not-files": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-path-rename-fails-on-windows-when-target-exists": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-pip-audit-fails-on-unpublished-versions": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-platform-conditional-security-test-assertions-should-accept-any": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-plugin": {
     "source": "content/features/plugin.md",
     "hash": "8cc6e5702ffc8228ed63cfb74a25dd3e99e79e5335c4b1c8c134950f8b9a043d",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-plugin-read-skill-references-break-outside-the-plugin": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-pr-test-workflows-may-not-auto-trigger-after-close-reopen-or": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-pre-commit-auto-fix-requires-re-stage-before-retry": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-pre-commit-black-unstaged-files-re-stage-after-failure": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-pre-commit-stash-conflict-when-black-ruff-fix-files-with": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-pre-commit-stash-conflict-with-auto-fix-hooks": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-pre-commit-stash-conflicts-when-any-tracked-unstaged-file": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-pre-committed-decision-matrices-survive-contact-with-data": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-pre-flight-pre-commits-pinned-black-ruff-on-new-files-before": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-prefer-github-actions-trusted-publishing-over-local-twine-uv": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-prompt-template-word-wrap-silently-breaks-single-line-substring": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-provenance-citation-records-usually-store-short-previews-not": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-pull-main-before-merging-develop-to-avoid-merge-commits": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-pureposixpath-match-doesnt-support-in-python-3-10": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-pureposixpath-strips-trailing-slashes": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-push-specific-tags-not-tags": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-pypi-env-policies-may-whitelist-branches-only-tag-triggered": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-pypi-environment-requires-manual-approval-in-github-actions": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-pypi-renders-readme-links-relative-to-its-own-domain": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-pypi-trusted-publisher-workflow-name-field-wants-the-filename": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-pytest-importorskip-triggers-ruff-e402": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-pytest-lives-in-the-dev-extra-not-developer": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-query-fixtures-are-self-diagnostic-for-rag-corpora-even-without": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-rag-grounding": {
     "source": "content/features/rag-grounding.md",
     "hash": "3464dd78c83f06980912a7c49dc185b09830be1b1c163203f10e5aa1708fcf4e",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-re-adding-an-import-after-the-formatter-strips-it-use-function": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-re-enabling-required-reviews-kills-queued-auto-merge": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-re-export-accessibility-tests-are-scattered-across-batch-files": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-read-source-before-writing-tests-for-tricky-logic": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-real-project-files-on-disk-override-test-mocks": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-rebuild-dist-after-readme-changes": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-reclassify-unexpectedly-hard-golden-queries-up-the-difficulty": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-redisshorttermmemory-mock-injection-path": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-refactor-plan": {
     "source": "content/features/refactor-plan.md",
     "hash": "8f8c684cd94fca7b2580ecaaf955ccb79924022796d576d477cdab9330df9704",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-registry-count-assertions-are-scattered-across-test-files": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-release-branches-carry-unmerged-commits-that-feature-branches": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-release-notes": {
     "source": "content/features/release-notes.md",
     "hash": "da7101ffbec4d209fcb1cef754f01cef8a13458a6f961c3a23909edfec77e58c",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-release-prep": {
     "source": "content/features/release-prep.md",
     "hash": "cd77b5903fbeb7d7e0acef570bab9727b4c143181ea6be1f52b9a25bc11418bb",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-release-published-workflow-dispatch-both-approved-for-pypi-env": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-removing-one-workspace-dep-can-cascade-to-remove-others": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-replacing-a-mixin-based-class-scatters-test-failures-across": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-repo-merge-policy-may-restrict-merge-strategies": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-repo-root-parents-count-varies-by-file-depth": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-required-status-check-names-must-match-githubs-exact-check-names": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-research-subagents-can-hallucinate-sdk-signatures-introspect": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-resilience": {
     "source": "content/features/resilience.md",
     "hash": "ae2a76f0f1ecbb9ca687e5a041acc2b4a25a5113ec57eaad550f48b8aadc4be2",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-resultmessage-result-is-often-none-capture-assistantmessage": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-rich-live-is-output-only-use-textual-for-any-interactive-row": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-ruff-auto-fix-strips-imports-before-usage-code-exists": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-ruff-parses-pytest-ini-as-python": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-run-simplify-catches-per-file-errors-internally": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-sbin-is-a-symlink-to-usr-sbin-on-modern-ubuntu": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-scorecards-pip-parser-ignores-hash-flags-entirely": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-sdk-adapter-swallows-subagent-findings-lesson-was-wrong-adapter": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-sdk-agent-model-config-uses-stale-model-names": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-sdk-native-security-audit-workflow-swallows-subagent-findings": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-sdk-native-workflows-validate-in-execute-not-input-schema": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-security-audit": {
     "source": "content/features/security-audit.md",
     "hash": "9cce18573c827fab9a380efe8c65c2f8c5b4ada3f7e383dd71ec523a0875fb05",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-selective-hook-skip-with-skip-hookname-is-not-the-same-as-no": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-semantic-cache-70-hit-rate-claim-was-unmeasured": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-session-handoff": {
     "source": "content/features/session-handoff.md",
     "hash": "236c16ee2d2e48f0bd8ba075c69f50ead16a46ef185fede3d84b529c66fd41a0",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-session-hooks-may-be-vestigial": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-shadow-directories-at-repo-root-break-imports": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-silent-pass-blocks-in-discovery-registry-code-hide-import": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-skill-descriptions-must-be-under-250-characters": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-skill-frontmatter-allowlist-march-2026": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-skill-frontmatter-has-a-strict-allowlist": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-smart-test": {
     "source": "content/features/smart-test.md",
     "hash": "58c691c8313ddf9699deb913e6b5c50fafc684563539ddf4816a4b94a9ea3e80",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-spec-engine": {
     "source": "content/features/spec-engine.md",
     "hash": "c8549016aa848eeeaecbde8329f5850562f56280ab66428cb7c20887b428d81a",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-squash-merge-deletes-the-remote-branch-subsequent-push-silently": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-ssrf-always-decode-urls-before-validating-hostnames": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-ssrf-in-webhook-handlers-is-easy-to-miss": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-ssrf-strip-ipv6-zone-ids-before-ip-validation": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-stacked-patch-decorators-inject-args-bottom-up": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-staleness-detection-in-attune-author-attune-ais-help-system-is": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-stop-hook-ordering-matters": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-stop-hooks-inject-stderr-not-stdout": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-stop-hooks-loop-without-a-sentinel": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-stop-hooks-missing-cd-prefix-inherit-session-cwd": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-structlog-default-output-pollutes-stdout-captured-cli-tests": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-structlog-kwargs-vs-stdlib-logger": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-tags-pushed-before-squash-merge-point-to-the-wrong-commit": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-telemetry": {
     "source": "content/features/telemetry.md",
     "hash": "59473ab809113116a3d58d2ead3a5f13e362d6992d8cee0a89364feded5cbd50",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-template-generators-overwrite-hand-written-files": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-test-mocks-must-match-imports": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-tests-for-optional-dep-code-need-pytest-importorskip-guards-in": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-text-white-on-gradient-primary-sections-gets-overridden": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-todo-counts-are-inflated-by-docstrings-and-prompt-strings": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-twine-cannot-prompt-for-tokens-in-claude-codes-non-interactive": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-two-codeql-setups-can-coexist-in-one-repo-and-deadlock-merges": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-two-parallel-help-template-generators-in-the-attune-ecosystem": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-uncommitted-claude-mcp-json-means-mcp-server-never-starts": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-untracked-scripts-break-ci-when-tests-import-them": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-unused-init-py-re-exports-become-invisible-runtime-deps": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-use-dataclass-post-init-to-coalesce-between-a-scalar-legacy": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-uv-lock-can-drift-from-pyproject-toml-on-shared-branches": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-uv-lock-may-briefly-fail-to-find-a-just-published-pypi-version": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-uv-lock-retains-editable-name-paths-after-tool-uv-sources-edits": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-uv-pip-install-e-does-not-regenerate-project-scripts-console": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-uv-pip-install-e-path-can-ship-stale-package-data-even-after": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-uv-pip-install-e-sibling-path-no-deps-is-the-clean-venv-local": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-uv-run-in-pre-commit-hooks-propagates-lockfile-errors-as-hook": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-uv-run-pip-audit-runs-the-pyenv-shim-not-the-venv": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-uv-sync-respects-existing-lockfile-pins-when-they-still-satisfy": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-uv-sync-wipes-packages-installed-via-pip-install": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-validate-file-path-needed-on-reads-too-not-just-writes": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-validate-infrastructure-against-user-value-before-extending": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-verify-mcp-tool-wiring-after-adding-new-tools": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-verify-new-dispatch-branches-with-a-known-fixture-not-just": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-verify-optional-dep-boundaries-with-a-metapathfinder-not-by": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-version-bumps-must-update-7-files-not-just-pyproject-toml": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-vs-code-extension-reads-mcp-json-at-project-root-not-claude-mcp": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-website-feature-lists-can-diverge-from-the-python-registry": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-windows-ci-encoding": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-windows-ci-runners-are-3x-slower-than-ubuntu-macos": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-windows-path-resolve-prepends-the-drive-letter-to-unix-paths": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-windows-time-time-can-return-0-0-duration-for-fast-operations": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-wizards": {
     "source": "content/features/wizards.md",
     "hash": "6fe7722a026d11276ebfbdf4ea046a05112be94b560f9abf3ffee410f8637d8f",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-wizards-call-workflows-internally-they-are-not-duplicates": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-workflowresult-constructor-mismatches-surface-only-at-runtime": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-yaml-run-block-scalars-break-on-blank-lines-inside-multi-line": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-yaml-run-values-with-colons-cause-parse-errors": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "err-zsh-has-status-as-a-read-only-builtin-variable": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-adding-a-plugin-skill-has-three-enforcement-gates-not-one": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-adding-a-workspace-sibling-package-as-an-extra-can-silently": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-adding-dns-resolution-to-validate-webhook-url-breaks-tests-that": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-adding-logger-before-eager-imports-triggers-e402-in-init-py": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-after-a-pr-merges-while-youre-afk-pull-main-before-tagging": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-after-a-squash-merge-of-a-feature-branch-local-main-can-have": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-agents": {
     "source": "content/features/agents.md",
     "hash": "a5b1678ecf012c7b2877a6c7ecae4a6c3f14c084c13fbcbb7eee79119dce6fa3",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-agents-skills-must-stay-synced-with-plugin-skills": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-anchor-tag-buttons-need-text-white-no-underline": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-anthropics-built-in-prompt-caching-supersedes-custom-caching": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-any-unstaged-file-triggers-pre-commit-stash-conflicts-with-auto": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-apply-lessons-by-problem-not-by-keyword": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-attune-author-check-staleness-load-manifest-is-the-python-api": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-attune-help-re-exports-create-a-hidden-cross-package-dep-on": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-attune-helps-sidecar-schemas-dont-match-path-keyed-assumptions": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-attune-skill-names-must-not-collide-with-claude-code-built-in": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-attune-workflow-run-code-review-and-security-audit-require-a": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-b904-raise-x-from-e-is-not-auto-fixable-by-ruff": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-background-processes-from-previous-sessions-persist-across": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-bandit-b108-blocks-hardcoded-tmp-paths": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-bare-manifest-in-gitignore-silently-excludes-any-manifest": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-baseworkflow-now-provides-self-logger": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-baseworkflow-uses-class-attributes-not-constructor-params": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-bg-var-primary-bg-opacity-10-is-invisible-in-dark-mode": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-broad-gitignore-patterns-match-nested-directories": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-bug-predict": {
     "source": "content/features/bug-predict.md",
     "hash": "6a4f420eba38e2fb884b837dd9758acb60ba60cdaf9248ec4280120b0d382b16",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-bug-predict-dangerous-eval-flags-subprocess-exec": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-bugpredictionworkflow-not-bugpredictworkflow": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-changing-error-messages-breaks-tests-across-the-codebase": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-changing-the-citation-anchor-format-can-silently-regress-llm": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-changing-user-facing-output-strings-cascades-through-test": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-chicken-and-egg-for-optional-extras-in-dev": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-ci-timeout-tests-enforce-the-range-you-set": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-citation-forced-prompting-and-prompt-injection-resistance-are": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-claude-agent-sdk-is-now-a-core-dependency-of-attune-ai": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-claude-agent-sdk-systempromptpreset-as-of-0-1-63-is-claude-code": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-claude-code-plugin-is-platform-specific": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-claude-code-plugins-expect-plugin-json-inside-claude-plugin": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-claude-plugin-install-is-marketplace-only": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-cli": {
     "source": "content/features/cli.md",
     "hash": "a37b4dc4f0b3706a62184b02d2be1536ad75eef39a0f22a9699db5d03b8ee050",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-clusterfuzz-dockerfile-copies-to-src-repo-but-also-copies": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-clusterfuzzlite-no-deps-misses-transitive-imports": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-coach-is-the-user-facing-entry-point-for-the-help-system": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-code-quality": {
     "source": "content/features/code-quality.md",
     "hash": "ce16ac87eb92e33a08d8c2f06e86ef22e436966f47f3a28c3f4eba19060b550a",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-codecov-patch-0-usually-means-tests-skipped-not-failed": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-codeql-alerts-dismissible-in-bulk-via-gh-api": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-codeql-js-stored-xss-flags-jsx-even-though-react-auto-escapes": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-codeql-py-clear-text-logging-sensitive-data-traces-data-flow": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-combine-two-unreleased-changelog-drafts-into-one-version-when": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-commands-are-not-namespaced-in-plugins-skills-are": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-config-py-alongside-config-creates-a-mypy-duplicate-module": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-configuration": {
     "source": "content/features/configuration.md",
     "hash": "8add90392883a46899ef8b57d135b625d92c5b61231d8a5301727f8b42f8e46f",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-costreport-fields-are-named-not-positional": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-costreport-is-a-dataclass-not-a-dict": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-cross-review": {
     "source": "content/features/cross-review.md",
     "hash": "dc5ae75883b05f97983377b51e275bab79921e992d842ebb2616726b8c8c2cdb",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-custom-mcp-stdio-loop-fails-claude-code-handshake": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-dataclassorder-true-needs-compare-false-on-list-fields": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-datetime-utcnow-datetime-nowtimezone-utc-cascades-through-the": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-dead-code-modules-with-full-test-suites-look-alive": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-dead-tests-from-monorepo-extraction-accumulate-in-packages-with": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-deep-review": {
     "source": "content/features/deep-review.md",
     "hash": "6a4fffc907302b4847d96097189bd8d329d3f1548d1ee46d9232f6ceecdfb450",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-deep-review-false-positives-verify-before-acting": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-delete-deprecated-module-is-rarely-a-simple-delete-grep-src-and": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-dependency-lower-bounds-trigger-scorecard-vulnerability-alerts": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-detect-secrets-flags-fake-as-a-secret-in-test-fixtures": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-direct-pushes-to-main-are-blocked-by-the-presence-of-required": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-dispatch-tables-hold-direct-function-references-mocks-must": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-dist-can-contain-stale-artifacts-after-version-bumps": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-doc-gen": {
     "source": "content/features/doc-gen.md",
     "hash": "26e02a71a523775f5bb9e371b2e563c3c858386436a73b727422f62f57de0282",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-dont-append-z-to-timezone-aware-isoformat": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-dry-run-candidate-golden-queries-through-the-resolver-before": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-duck-typed-test-fakes-fail-isinstance-based-collectors-silently": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-duplicate-plugins-cause-conflicting-skill-triggers": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-elicitation-forms": {
     "source": "content/features/elicitation-forms.md",
     "hash": "4f326dd6f99f86af163cf44167b243d73ee5165ef8373bf4cea83039aec723d2",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-enforce-admins-false-defeats-code-review-scorecard-check": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-enforce-admins-required-reviews-blocks-solo-dev-merges": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-exclude-hard-queries-from-aggregate-p-1-metrics-in-benchmark": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-exploration-agents-fabricate-names-verify-against-source": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-f841-unused-fixture-lint-fires-when-a-test-is-refactored-to": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-fastembed-is-the-local-embeddings-path-that-passes-a-50mb": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-fix-test": {
     "source": "content/features/fix-test.md",
-    "hash": "da54b69787cc1af5c087b2d8674442afe9b8c6fc88dca37a65e99590bb84fee0",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "8b182bab8816d525d3325746f4cdeed013113a1bdb0a43d36963e121afa42812",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-forced-anthropic-tool-use-is-the-cleanest-path-to-guaranteed": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-forced-cite-per-claim-prompting-is-the-structural-lever-for-rag": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-formatter-strips-imports-that-are-unused-at-the-moment-you-save": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-full-coverage-runs-on-15k-test-suites-timeout-easily": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-generated-content-with-trailing-whitespace-causes-perpetual-pre": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-getattrmodule-name-none-at-call-site-is-the-clean-degradation": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-gh-api-x-patch-f-name-n-rejects-integers-as-strings": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-gh-pr-checks-json-field-names": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-gh-pr-merge-admin-is-blocked-by-in-progress-required-checks": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-gh-pr-merge-admin-prints-a-fast-forward-warning-even-when-the": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-gh-repo-create-source-path-push-is-a-one-shot-for-new-sibling": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-gh-workflow-run-file-yml-ref-tag-re-triggers-a-release-gated": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-ghost-command-references-survive-cli-renames": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-git-commit-q-can-exit-0-with-pre-commit-hook-feedback-that": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-git-pull-refuses-with-unstaged-changes-when-pull-rebase-true": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-git-rebase-root-exec-git-commit-amend-no-edit-s-re-signs-every": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-git-stash-pop-after-pre-commit-can-resurrect-stale-tool-state": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-github-actions-environment-deployment-approvals-can-be-self": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-github-copilot-autofix-pushes-commits-directly-to-pr-branches": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-github-protected-tags-cannot-be-force-updated": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-github-repos-serve-as-claude-code-marketplaces": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-gitignore-exclusions-break-ci-tests-that-read-those-files": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-glob-based-hash-computation-must-exclude-cache-dirs": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-golden-query-benchmarks-reveal-two-distinct-failure-classes": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-golden-query-test-fixtures-must-match-the-actual-corpus-layout": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-gpg-signing-fails-in-non-interactive-terminals-vscode-extension": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-hand-crafted-summary-prototype-is-the-fastest-way-to-measure-a": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-handoff-memory-option-b-proposals-are-often-wrong-re-analyze": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-hardcoded-root-paths-in-tests": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-hardcoded-strings-in-method-bodies-survive-class-attribute": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-hardcoded-user-id-defeats-ownership-checks": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-help-system": {
     "source": "content/features/help-system.md",
     "hash": "24468c8fe4f1a0e350e620098d65a3bcc007000cd5aa4dbe20a6e6c83efa87b3",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-hooks": {
     "source": "content/features/hooks.md",
     "hash": "5c6b8a45457387c76f628561d3baa56e9af1709bc9bd21bba9830b2c2478c8dd",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-hot-reload-subsystem-was-1-038-lines-of-dead-code": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-import-x-inside-a-try-block-except-x-someerror-in-the-except": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-importlib-import-module-is-an-arbitrary-code-execution-vector": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-industry-terminology-wont-appear-in-llm-polished-rag-summaries": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-integration-tests-gated-by-has-api-key-can-poison-the-whole-ci": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-is-private-is-a-superset-in-python-ipaddress": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-kwargs-collides-with-explicit-params-of-the-same-name": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-lazy-imports-inside-function-bodies-cant-be-patched-with": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-linkedin-paste-use-ascii-markers-not-unicode-arrows": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-list-wizards-is-a-function-not-a-class-method": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-list-workflows-deduplication-must-keep-base-names-visible": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-llm-api-responses-lack-trailing-newlines": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-local-telemetry-trackers-need-an-autouse-conftest-fixture": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-macos-var-private-var-symlink-breaks-path-assertions": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-mcp-attune-ai-doc-orchestrator-is-a-no-op-stub": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-mcp-call-tool-wrapper-pattern": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-mcp-handler-validate-paths-before-importing-workflows": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-mcp-json-python-resolves-to-pyenv-shim-not-project-venv": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-mcp-server": {
     "source": "content/features/mcp-server.md",
     "hash": "8e4b8c74eff980330480ae70856a1cf0393559cd22eb9ba0210b43249f9b5181",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-mcp-server-process-doesnt-inherit-env-variables": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-mcp-tool-count-tests-are-hardcoded": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-mcp-tool-renames-propagate-to-skill-docs": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-mcp-workspace-root-defaults-to-os-getcwd-tests-with-tmp-path": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-memory": {
     "source": "content/features/memory.md",
     "hash": "32b3121d9110dc9ac327bb9e838f060fbe9940a033366b0147ef34ef2efaa4dc",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-metadata-can-reach-a-retriever-with-zero-signal-if-the-sidecar": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-metapathfinder-find-module-load-module-is-dead-in-python-3-12": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-mixin-classes-inherit-self-workspace-root-at-runtime-not-at": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-mkdocs-build-crashing-with-attributeerror-nonetype-object-has": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-mkdocs-strict-treats-broken-links-as-fatal-errors": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-mock-a-lazy-import-x-with-types-moduletype-patch-dictsys-modules": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-models": {
     "source": "content/features/models.md",
     "hash": "2117cbb0d8e863db6091870874e4ce80b48780c9ee8bb7330d8033c172ccb02b",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-modeltier-has-two-copies-imports-must-match": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-module-level-optional-imports-enable-clean-test-patching": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-multiple-pinentry-program-lines-in-gpg-agent-conf-first-wins": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-mutual-competition-between-polished-rag-features-is-real-and": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-mypy-437-errors-was-stale-actual-count-was-2": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-naive-suffix-strip-stemming-fails-on-english-doubling-consonant": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-never-paste-pypi-tokens-into-chat-or-logs": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-new-dataclass-fields-need-both-the-class-and-the-parser-updated": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-new-mcp-handlers-must-match-the-validation-pattern-of-adjacent": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-new-security-features-need-dedicated-tests-before-release": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-next-js-shared-data-libs-prevent-page-duplication": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-non-baseworkflow-classes-in-workflow-registry-crash-the-cli": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-noqa-f401-re-exports-break-silently-on-satellite-file-deletion": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-openssf-scorecard-alerts-2-codereviewid-3-sastid-are-process": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-ops-dashboard": {
     "source": "content/features/ops-dashboard.md",
     "hash": "fefc8e2b2b4a25055fcbdf96cbd8638d75278cbcacd256873b725df89544c1f6",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-orchestration": {
     "source": "content/features/orchestration.md",
     "hash": "4998437e04355011a7dee68dbce7e9e78bbe97f637e0b6a14c1ec972f541695c",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-orphan-help-dirs-are-deprecated-3-depth-output-adding-them-to": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-orphan-top-level-docs-directories-stay-invisible-to-readers": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-packages-attune-in-attune-ai-are-pointer-stubs-not-source": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-past-due-deprecations-are-deletion-targets-not-implementation": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-patch-requires-the-target-name-to-exist-at-module-scope-at": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-patch-the-source-module-for-from-x-import-y-in-function-bodies": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-path-cwd-at-module-level-captures-import-time-cwd": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-path-globdir-matches-directories-not-files": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-path-rename-fails-on-windows-when-target-exists": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-pip-audit-fails-on-unpublished-versions": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-platform-conditional-security-test-assertions-should-accept-any": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-plugin": {
     "source": "content/features/plugin.md",
     "hash": "8cc6e5702ffc8228ed63cfb74a25dd3e99e79e5335c4b1c8c134950f8b9a043d",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-plugin-read-skill-references-break-outside-the-plugin": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-pr-test-workflows-may-not-auto-trigger-after-close-reopen-or": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-pre-commit-auto-fix-requires-re-stage-before-retry": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-pre-commit-black-unstaged-files-re-stage-after-failure": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-pre-commit-stash-conflict-when-black-ruff-fix-files-with": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-pre-commit-stash-conflict-with-auto-fix-hooks": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-pre-commit-stash-conflicts-when-any-tracked-unstaged-file": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-pre-committed-decision-matrices-survive-contact-with-data": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-pre-flight-pre-commits-pinned-black-ruff-on-new-files-before": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-prefer-github-actions-trusted-publishing-over-local-twine-uv": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-prompt-template-word-wrap-silently-breaks-single-line-substring": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-provenance-citation-records-usually-store-short-previews-not": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-pull-main-before-merging-develop-to-avoid-merge-commits": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-pureposixpath-match-doesnt-support-in-python-3-10": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-pureposixpath-strips-trailing-slashes": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-push-specific-tags-not-tags": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-pypi-env-policies-may-whitelist-branches-only-tag-triggered": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-pypi-environment-requires-manual-approval-in-github-actions": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-pypi-renders-readme-links-relative-to-its-own-domain": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-pypi-trusted-publisher-workflow-name-field-wants-the-filename": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-pytest-importorskip-triggers-ruff-e402": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-pytest-lives-in-the-dev-extra-not-developer": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-query-fixtures-are-self-diagnostic-for-rag-corpora-even-without": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-rag-grounding": {
     "source": "content/features/rag-grounding.md",
     "hash": "3464dd78c83f06980912a7c49dc185b09830be1b1c163203f10e5aa1708fcf4e",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-re-adding-an-import-after-the-formatter-strips-it-use-function": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-re-enabling-required-reviews-kills-queued-auto-merge": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-re-export-accessibility-tests-are-scattered-across-batch-files": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-read-source-before-writing-tests-for-tricky-logic": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-real-project-files-on-disk-override-test-mocks": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-rebuild-dist-after-readme-changes": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-reclassify-unexpectedly-hard-golden-queries-up-the-difficulty": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-redisshorttermmemory-mock-injection-path": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-refactor-plan": {
     "source": "content/features/refactor-plan.md",
     "hash": "8f8c684cd94fca7b2580ecaaf955ccb79924022796d576d477cdab9330df9704",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-registry-count-assertions-are-scattered-across-test-files": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-release-branches-carry-unmerged-commits-that-feature-branches": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-release-notes": {
     "source": "content/features/release-notes.md",
     "hash": "da7101ffbec4d209fcb1cef754f01cef8a13458a6f961c3a23909edfec77e58c",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-release-prep": {
     "source": "content/features/release-prep.md",
     "hash": "cd77b5903fbeb7d7e0acef570bab9727b4c143181ea6be1f52b9a25bc11418bb",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-release-published-workflow-dispatch-both-approved-for-pypi-env": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-removing-one-workspace-dep-can-cascade-to-remove-others": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-replacing-a-mixin-based-class-scatters-test-failures-across": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-repo-merge-policy-may-restrict-merge-strategies": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-repo-root-parents-count-varies-by-file-depth": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-required-status-check-names-must-match-githubs-exact-check-names": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-research-subagents-can-hallucinate-sdk-signatures-introspect": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-resilience": {
     "source": "content/features/resilience.md",
     "hash": "ae2a76f0f1ecbb9ca687e5a041acc2b4a25a5113ec57eaad550f48b8aadc4be2",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-resultmessage-result-is-often-none-capture-assistantmessage": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-rich-live-is-output-only-use-textual-for-any-interactive-row": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-ruff-auto-fix-strips-imports-before-usage-code-exists": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-ruff-parses-pytest-ini-as-python": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-run-simplify-catches-per-file-errors-internally": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-sbin-is-a-symlink-to-usr-sbin-on-modern-ubuntu": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-scorecards-pip-parser-ignores-hash-flags-entirely": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-sdk-adapter-swallows-subagent-findings-lesson-was-wrong-adapter": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-sdk-agent-model-config-uses-stale-model-names": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-sdk-native-security-audit-workflow-swallows-subagent-findings": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-sdk-native-workflows-validate-in-execute-not-input-schema": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-security-audit": {
     "source": "content/features/security-audit.md",
     "hash": "9cce18573c827fab9a380efe8c65c2f8c5b4ada3f7e383dd71ec523a0875fb05",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-selective-hook-skip-with-skip-hookname-is-not-the-same-as-no": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-semantic-cache-70-hit-rate-claim-was-unmeasured": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-session-handoff": {
     "source": "content/features/session-handoff.md",
     "hash": "236c16ee2d2e48f0bd8ba075c69f50ead16a46ef185fede3d84b529c66fd41a0",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-session-hooks-may-be-vestigial": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-shadow-directories-at-repo-root-break-imports": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-silent-pass-blocks-in-discovery-registry-code-hide-import": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-skill-descriptions-must-be-under-250-characters": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-skill-frontmatter-allowlist-march-2026": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-skill-frontmatter-has-a-strict-allowlist": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-smart-test": {
     "source": "content/features/smart-test.md",
     "hash": "58c691c8313ddf9699deb913e6b5c50fafc684563539ddf4816a4b94a9ea3e80",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-spec-engine": {
     "source": "content/features/spec-engine.md",
     "hash": "c8549016aa848eeeaecbde8329f5850562f56280ab66428cb7c20887b428d81a",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-squash-merge-deletes-the-remote-branch-subsequent-push-silently": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-ssrf-always-decode-urls-before-validating-hostnames": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-ssrf-in-webhook-handlers-is-easy-to-miss": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-ssrf-strip-ipv6-zone-ids-before-ip-validation": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-stacked-patch-decorators-inject-args-bottom-up": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-staleness-detection-in-attune-author-attune-ais-help-system-is": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-stop-hook-ordering-matters": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-stop-hooks-inject-stderr-not-stdout": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-stop-hooks-loop-without-a-sentinel": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-stop-hooks-missing-cd-prefix-inherit-session-cwd": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-structlog-default-output-pollutes-stdout-captured-cli-tests": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-structlog-kwargs-vs-stdlib-logger": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-tags-pushed-before-squash-merge-point-to-the-wrong-commit": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-telemetry": {
     "source": "content/features/telemetry.md",
     "hash": "59473ab809113116a3d58d2ead3a5f13e362d6992d8cee0a89364feded5cbd50",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-template-generators-overwrite-hand-written-files": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-test-mocks-must-match-imports": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-tests-for-optional-dep-code-need-pytest-importorskip-guards-in": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-text-white-on-gradient-primary-sections-gets-overridden": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-todo-counts-are-inflated-by-docstrings-and-prompt-strings": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-twine-cannot-prompt-for-tokens-in-claude-codes-non-interactive": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-two-codeql-setups-can-coexist-in-one-repo-and-deadlock-merges": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-two-parallel-help-template-generators-in-the-attune-ecosystem": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-uncommitted-claude-mcp-json-means-mcp-server-never-starts": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-untracked-scripts-break-ci-when-tests-import-them": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-unused-init-py-re-exports-become-invisible-runtime-deps": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-use-dataclass-post-init-to-coalesce-between-a-scalar-legacy": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-uv-lock-can-drift-from-pyproject-toml-on-shared-branches": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-uv-lock-may-briefly-fail-to-find-a-just-published-pypi-version": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-uv-lock-retains-editable-name-paths-after-tool-uv-sources-edits": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-uv-pip-install-e-does-not-regenerate-project-scripts-console": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-uv-pip-install-e-path-can-ship-stale-package-data-even-after": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-uv-pip-install-e-sibling-path-no-deps-is-the-clean-venv-local": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-uv-run-in-pre-commit-hooks-propagates-lockfile-errors-as-hook": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-uv-run-pip-audit-runs-the-pyenv-shim-not-the-venv": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-uv-sync-respects-existing-lockfile-pins-when-they-still-satisfy": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-uv-sync-wipes-packages-installed-via-pip-install": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-validate-file-path-needed-on-reads-too-not-just-writes": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-validate-infrastructure-against-user-value-before-extending": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-verify-mcp-tool-wiring-after-adding-new-tools": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-verify-new-dispatch-branches-with-a-known-fixture-not-just": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-verify-optional-dep-boundaries-with-a-metapathfinder-not-by": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-version-bumps-must-update-7-files-not-just-pyproject-toml": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-vs-code-extension-reads-mcp-json-at-project-root-not-claude-mcp": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-website-feature-lists-can-diverge-from-the-python-registry": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-windows-ci-encoding": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-windows-ci-runners-are-3x-slower-than-ubuntu-macos": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-windows-path-resolve-prepends-the-drive-letter-to-unix-paths": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-windows-time-time-can-return-0-0-duration-for-fast-operations": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-wizards": {
     "source": "content/features/wizards.md",
     "hash": "6fe7722a026d11276ebfbdf4ea046a05112be94b560f9abf3ffee410f8637d8f",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-wizards-call-workflows-internally-they-are-not-duplicates": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-workflowresult-constructor-mismatches-surface-only-at-runtime": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-yaml-run-block-scalars-break-on-blank-lines-inside-multi-line": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-yaml-run-values-with-colons-cause-parse-errors": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "faq-zsh-has-status-as-a-read-only-builtin-variable": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "not-agents": {
     "source": "content/features/agents.md",
     "hash": "a5b1678ecf012c7b2877a6c7ecae4a6c3f14c084c13fbcbb7eee79119dce6fa3",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "not-bug-predict": {
     "source": "content/features/bug-predict.md",
     "hash": "6a4f420eba38e2fb884b837dd9758acb60ba60cdaf9248ec4280120b0d382b16",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "not-cli": {
     "source": "content/features/cli.md",
     "hash": "a37b4dc4f0b3706a62184b02d2be1536ad75eef39a0f22a9699db5d03b8ee050",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "not-code-quality": {
     "source": "content/features/code-quality.md",
     "hash": "ce16ac87eb92e33a08d8c2f06e86ef22e436966f47f3a28c3f4eba19060b550a",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "not-code-simplification": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "not-command-hubs": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "not-configuration": {
     "source": "content/features/configuration.md",
     "hash": "8add90392883a46899ef8b57d135b625d92c5b61231d8a5301727f8b42f8e46f",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "not-critical-rules": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "not-cross-review": {
     "source": "content/features/cross-review.md",
     "hash": "dc5ae75883b05f97983377b51e275bab79921e992d842ebb2616726b8c8c2cdb",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "not-decision-d1-template-schemas-live-in-the-repo": {
     "source": ".claude/plans/documentation-stack-spec.md",
     "hash": "8ac207215df6d59686f456b44e76ec33e6c5b8dd6acb5d7754100c158865bd88",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "not-decision-d2-search-index-first-unified-later": {
     "source": ".claude/plans/documentation-stack-spec.md",
     "hash": "8ac207215df6d59686f456b44e76ec33e6c5b8dd6acb5d7754100c158865bd88",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "not-decision-d3-faq-sourcing-four-channels": {
     "source": ".claude/plans/documentation-stack-spec.md",
     "hash": "8ac207215df6d59686f456b44e76ec33e6c5b8dd6acb5d7754100c158865bd88",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "not-decision-d4-code-is-the-source-of-truth": {
     "source": ".claude/plans/documentation-stack-spec.md",
     "hash": "8ac207215df6d59686f456b44e76ec33e6c5b8dd6acb5d7754100c158865bd88",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "not-decision-d5-intelligent-templates-the-engine": {
     "source": ".claude/plans/documentation-stack-spec.md",
     "hash": "8ac207215df6d59686f456b44e76ec33e6c5b8dd6acb5d7754100c158865bd88",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "not-decision-d6-proof-of-concept-lessons-learned-error-templates": {
     "source": ".claude/plans/documentation-stack-spec.md",
     "hash": "8ac207215df6d59686f456b44e76ec33e6c5b8dd6acb5d7754100c158865bd88",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "not-deep-review": {
     "source": "content/features/deep-review.md",
     "hash": "6a4fffc907302b4847d96097189bd8d329d3f1548d1ee46d9232f6ceecdfb450",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "not-doc-gen": {
     "source": "content/features/doc-gen.md",
     "hash": "26e02a71a523775f5bb9e371b2e563c3c858386436a73b727422f62f57de0282",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "not-elicitation-forms": {
     "source": "content/features/elicitation-forms.md",
     "hash": "4f326dd6f99f86af163cf44167b243d73ee5165ef8373bf4cea83039aec723d2",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "not-fix-test": {
     "source": "content/features/fix-test.md",
-    "hash": "da54b69787cc1af5c087b2d8674442afe9b8c6fc88dca37a65e99590bb84fee0",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "8b182bab8816d525d3325746f4cdeed013113a1bdb0a43d36963e121afa42812",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "not-help-system": {
     "source": "content/features/help-system.md",
     "hash": "24468c8fe4f1a0e350e620098d65a3bcc007000cd5aa4dbe20a6e6c83efa87b3",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "not-hooks": {
     "source": "content/features/hooks.md",
     "hash": "5c6b8a45457387c76f628561d3baa56e9af1709bc9bd21bba9830b2c2478c8dd",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "not-markdown-formatting": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "not-mcp-server": {
     "source": "content/features/mcp-server.md",
     "hash": "8e4b8c74eff980330480ae70856a1cf0393559cd22eb9ba0210b43249f9b5181",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "not-memory": {
     "source": "content/features/memory.md",
     "hash": "32b3121d9110dc9ac327bb9e838f060fbe9940a033366b0147ef34ef2efaa4dc",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "not-models": {
     "source": "content/features/models.md",
     "hash": "2117cbb0d8e863db6091870874e4ce80b48780c9ee8bb7330d8033c172ccb02b",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "not-ops-dashboard": {
     "source": "content/features/ops-dashboard.md",
     "hash": "fefc8e2b2b4a25055fcbdf96cbd8638d75278cbcacd256873b725df89544c1f6",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "not-orchestration": {
     "source": "content/features/orchestration.md",
     "hash": "4998437e04355011a7dee68dbce7e9e78bbe97f637e0b6a14c1ec972f541695c",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "not-plugin": {
     "source": "content/features/plugin.md",
     "hash": "8cc6e5702ffc8228ed63cfb74a25dd3e99e79e5335c4b1c8c134950f8b9a043d",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "not-project-structure": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "not-rag-grounding": {
     "source": "content/features/rag-grounding.md",
     "hash": "3464dd78c83f06980912a7c49dc185b09830be1b1c163203f10e5aa1708fcf4e",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "not-refactor-plan": {
     "source": "content/features/refactor-plan.md",
     "hash": "8f8c684cd94fca7b2580ecaaf955ccb79924022796d576d477cdab9330df9704",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "not-release-notes": {
     "source": "content/features/release-notes.md",
     "hash": "da7101ffbec4d209fcb1cef754f01cef8a13458a6f961c3a23909edfec77e58c",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "not-release-prep": {
     "source": "content/features/release-prep.md",
     "hash": "cd77b5903fbeb7d7e0acef570bab9727b4c143181ea6be1f52b9a25bc11418bb",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "not-resilience": {
     "source": "content/features/resilience.md",
     "hash": "ae2a76f0f1ecbb9ca687e5a041acc2b4a25a5113ec57eaad550f48b8aadc4be2",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "not-security-audit": {
     "source": "content/features/security-audit.md",
     "hash": "9cce18573c827fab9a380efe8c65c2f8c5b4ada3f7e383dd71ec523a0875fb05",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "not-session-handoff": {
     "source": "content/features/session-handoff.md",
     "hash": "236c16ee2d2e48f0bd8ba075c69f50ead16a46ef185fede3d84b529c66fd41a0",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "not-smart-test": {
     "source": "content/features/smart-test.md",
     "hash": "58c691c8313ddf9699deb913e6b5c50fafc684563539ddf4816a4b94a9ea3e80",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "not-socratic-interaction-rule": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "not-spec-engine": {
     "source": "content/features/spec-engine.md",
     "hash": "c8549016aa848eeeaecbde8329f5850562f56280ab66428cb7c20887b428d81a",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "not-telemetry": {
     "source": "content/features/telemetry.md",
     "hash": "59473ab809113116a3d58d2ead3a5f13e362d6992d8cee0a89364feded5cbd50",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "not-term-cli": {
     "source": "CLAUDE.md",
-    "hash": "811c9cf90d6a42eb767f78b7fc6874a5ab0c6ae914fc1533ec40cc800f40749c",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "f543008dc0e937626c0d5d2090f690c0c3c2b34a7a39482703ec02848450a553",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "not-term-crew": {
     "source": "CLAUDE.md",
-    "hash": "811c9cf90d6a42eb767f78b7fc6874a5ab0c6ae914fc1533ec40cc800f40749c",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "f543008dc0e937626c0d5d2090f690c0c3c2b34a7a39482703ec02848450a553",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "not-term-hub": {
     "source": "CLAUDE.md",
-    "hash": "811c9cf90d6a42eb767f78b7fc6874a5ab0c6ae914fc1533ec40cc800f40749c",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "f543008dc0e937626c0d5d2090f690c0c3c2b34a7a39482703ec02848450a553",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "not-term-llm": {
     "source": "CLAUDE.md",
-    "hash": "811c9cf90d6a42eb767f78b7fc6874a5ab0c6ae914fc1533ec40cc800f40749c",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "f543008dc0e937626c0d5d2090f690c0c3c2b34a7a39482703ec02848450a553",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "not-term-p2b": {
     "source": "CLAUDE.md",
-    "hash": "811c9cf90d6a42eb767f78b7fc6874a5ab0c6ae914fc1533ec40cc800f40749c",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "f543008dc0e937626c0d5d2090f690c0c3c2b34a7a39482703ec02848450a553",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "not-term-progressive": {
     "source": "CLAUDE.md",
-    "hash": "811c9cf90d6a42eb767f78b7fc6874a5ab0c6ae914fc1533ec40cc800f40749c",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "f543008dc0e937626c0d5d2090f690c0c3c2b34a7a39482703ec02848450a553",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "not-term-sdk": {
     "source": "CLAUDE.md",
-    "hash": "811c9cf90d6a42eb767f78b7fc6874a5ab0c6ae914fc1533ec40cc800f40749c",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "f543008dc0e937626c0d5d2090f690c0c3c2b34a7a39482703ec02848450a553",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "not-term-socratic": {
     "source": "CLAUDE.md",
-    "hash": "811c9cf90d6a42eb767f78b7fc6874a5ab0c6ae914fc1533ec40cc800f40749c",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "f543008dc0e937626c0d5d2090f690c0c3c2b34a7a39482703ec02848450a553",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "not-term-tier": {
     "source": "CLAUDE.md",
-    "hash": "811c9cf90d6a42eb767f78b7fc6874a5ab0c6ae914fc1533ec40cc800f40749c",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "f543008dc0e937626c0d5d2090f690c0c3c2b34a7a39482703ec02848450a553",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "not-term-wizard": {
     "source": "CLAUDE.md",
-    "hash": "811c9cf90d6a42eb767f78b7fc6874a5ab0c6ae914fc1533ec40cc800f40749c",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "f543008dc0e937626c0d5d2090f690c0c3c2b34a7a39482703ec02848450a553",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "not-wizards": {
     "source": "content/features/wizards.md",
     "hash": "6fe7722a026d11276ebfbdf4ea046a05112be94b560f9abf3ffee410f8637d8f",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "qui-agents": {
     "source": "content/features/agents.md",
     "hash": "a5b1678ecf012c7b2877a6c7ecae4a6c3f14c084c13fbcbb7eee79119dce6fa3",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "qui-browse-help": {
     "source": "src/attune/cli_commands/help_commands.py",
     "hash": "d284892c4f058b5a9d4861f08f7f2de09c8050d33766471014bb739215a83582",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "qui-bug-predict": {
     "source": "content/features/bug-predict.md",
     "hash": "6a4f420eba38e2fb884b837dd9758acb60ba60cdaf9248ec4280120b0d382b16",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "qui-check-costs": {
     "source": "src/attune/cli_minimal.py",
     "hash": "8e78816c6a743c24afd05568ba29a5d0eec548beea557ab098a48630b1f82ac8",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "qui-check-health": {
     "source": "src/attune/cli_minimal.py",
     "hash": "8e78816c6a743c24afd05568ba29a5d0eec548beea557ab098a48630b1f82ac8",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "qui-cli": {
     "source": "content/features/cli.md",
     "hash": "a37b4dc4f0b3706a62184b02d2be1536ad75eef39a0f22a9699db5d03b8ee050",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "qui-code-quality": {
     "source": "content/features/code-quality.md",
     "hash": "ce16ac87eb92e33a08d8c2f06e86ef22e436966f47f3a28c3f4eba19060b550a",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "qui-configuration": {
     "source": "content/features/configuration.md",
     "hash": "8add90392883a46899ef8b57d135b625d92c5b61231d8a5301727f8b42f8e46f",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "qui-cross-review": {
     "source": "content/features/cross-review.md",
     "hash": "dc5ae75883b05f97983377b51e275bab79921e992d842ebb2616726b8c8c2cdb",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "qui-deep-review": {
     "source": "content/features/deep-review.md",
     "hash": "6a4fffc907302b4847d96097189bd8d329d3f1548d1ee46d9232f6ceecdfb450",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "qui-doc-gen": {
     "source": "content/features/doc-gen.md",
     "hash": "26e02a71a523775f5bb9e371b2e563c3c858386436a73b727422f62f57de0282",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "qui-elicitation-forms": {
     "source": "content/features/elicitation-forms.md",
     "hash": "4f326dd6f99f86af163cf44167b243d73ee5165ef8373bf4cea83039aec723d2",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "qui-fix-test": {
     "source": "content/features/fix-test.md",
-    "hash": "da54b69787cc1af5c087b2d8674442afe9b8c6fc88dca37a65e99590bb84fee0",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "8b182bab8816d525d3325746f4cdeed013113a1bdb0a43d36963e121afa42812",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "qui-generate-tests": {
     "source": "src/attune/cli_minimal.py",
     "hash": "8e78816c6a743c24afd05568ba29a5d0eec548beea557ab098a48630b1f82ac8",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "qui-help-system": {
     "source": "content/features/help-system.md",
     "hash": "24468c8fe4f1a0e350e620098d65a3bcc007000cd5aa4dbe20a6e6c83efa87b3",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "qui-hooks": {
     "source": "content/features/hooks.md",
     "hash": "5c6b8a45457387c76f628561d3baa56e9af1709bc9bd21bba9830b2c2478c8dd",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "qui-install": {
     "source": "README.md",
     "hash": "fcc62f0951ab8912c5080913462e9831fd6256f0062027fb7f2db6b6ccf0b615",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "qui-install-plugin": {
     "source": "README.md",
     "hash": "fcc62f0951ab8912c5080913462e9831fd6256f0062027fb7f2db6b6ccf0b615",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "qui-mcp-server": {
     "source": "content/features/mcp-server.md",
     "hash": "8e4b8c74eff980330480ae70856a1cf0393559cd22eb9ba0210b43249f9b5181",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "qui-memory": {
     "source": "content/features/memory.md",
     "hash": "32b3121d9110dc9ac327bb9e838f060fbe9940a033366b0147ef34ef2efaa4dc",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "qui-models": {
     "source": "content/features/models.md",
     "hash": "2117cbb0d8e863db6091870874e4ce80b48780c9ee8bb7330d8033c172ccb02b",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "qui-ops-dashboard": {
     "source": "content/features/ops-dashboard.md",
     "hash": "fefc8e2b2b4a25055fcbdf96cbd8638d75278cbcacd256873b725df89544c1f6",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "qui-orchestration": {
     "source": "content/features/orchestration.md",
     "hash": "4998437e04355011a7dee68dbce7e9e78bbe97f637e0b6a14c1ec972f541695c",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "qui-plugin": {
     "source": "content/features/plugin.md",
     "hash": "8cc6e5702ffc8228ed63cfb74a25dd3e99e79e5335c4b1c8c134950f8b9a043d",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "qui-rag-grounding": {
     "source": "content/features/rag-grounding.md",
     "hash": "3464dd78c83f06980912a7c49dc185b09830be1b1c163203f10e5aa1708fcf4e",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "qui-refactor-plan": {
     "source": "content/features/refactor-plan.md",
     "hash": "8f8c684cd94fca7b2580ecaaf955ccb79924022796d576d477cdab9330df9704",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "qui-release-notes": {
     "source": "content/features/release-notes.md",
     "hash": "da7101ffbec4d209fcb1cef754f01cef8a13458a6f961c3a23909edfec77e58c",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "qui-release-prep": {
     "source": "content/features/release-prep.md",
     "hash": "cd77b5903fbeb7d7e0acef570bab9727b4c143181ea6be1f52b9a25bc11418bb",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "qui-resilience": {
     "source": "content/features/resilience.md",
     "hash": "ae2a76f0f1ecbb9ca687e5a041acc2b4a25a5113ec57eaad550f48b8aadc4be2",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "qui-run-code-review": {
     "source": "src/attune/cli_minimal.py",
     "hash": "8e78816c6a743c24afd05568ba29a5d0eec548beea557ab098a48630b1f82ac8",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "qui-run-security-audit": {
     "source": "src/attune/cli_minimal.py",
     "hash": "8e78816c6a743c24afd05568ba29a5d0eec548beea557ab098a48630b1f82ac8",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "qui-security-audit": {
     "source": "content/features/security-audit.md",
     "hash": "9cce18573c827fab9a380efe8c65c2f8c5b4ada3f7e383dd71ec523a0875fb05",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "qui-session-handoff": {
     "source": "content/features/session-handoff.md",
     "hash": "236c16ee2d2e48f0bd8ba075c69f50ead16a46ef185fede3d84b529c66fd41a0",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "qui-skill-attune-hub": {
     "source": "plugin/skills/attune-hub/SKILL.md",
     "hash": "2a18d84bd5efb5738643d716c803440f602d40871b172238996c4aebcf498032",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "qui-skill-bug-predict": {
     "source": "plugin/skills/bug-predict/SKILL.md",
     "hash": "992b9e6cd3452af0d31213985e5e5c607f078edd2310df76d786b95d7e6a83ce",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "qui-skill-coach": {
     "source": "plugin/skills/coach/SKILL.md",
     "hash": "a1842d674325f3f1ea289e3bd7ed1dcfbb4b3301160181edab081d2b4352aeac",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "qui-skill-code-quality": {
     "source": "plugin/skills/code-quality/SKILL.md",
     "hash": "769c4c885992fd1937adbdf5d97305894bd08c159c83930d7a9fb86cb4ae78b7",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "qui-skill-doc-gen": {
     "source": "plugin/skills/doc-gen/SKILL.md",
     "hash": "da9a9c23727eaa9433b2c4d1dfe87d850ef560d56b855f2eb7bd0f279efc3c72",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "qui-skill-fix-test": {
     "source": "plugin/skills/fix-test/SKILL.md",
     "hash": "665ff7c4978beddd72e87f3764b073e4f962b27a896bd66542d499a1a00429da",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "qui-skill-memory-and-context": {
     "source": "plugin/skills/memory-and-context/SKILL.md",
     "hash": "d026a40d0c5315123672c7ed3770b643ba803a3b5d57cb994c236fcd6baa8305",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "qui-skill-planning": {
     "source": "plugin/skills/planning/SKILL.md",
     "hash": "f56a42c83f514b300b4f89ea6669820ec158da952efa2894c56abb00c39eb58a",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "qui-skill-rag-code-gen": {
     "source": "plugin/skills/rag-code-gen/SKILL.md",
     "hash": "0d84a32e2f89e8debd740b4343c7930b17efcca37fcb68737f342f8b6b5f6f77",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "qui-skill-refactor-plan": {
     "source": "plugin/skills/refactor-plan/SKILL.md",
     "hash": "080a84b5df5dde88cd3c994ca2c2b68ec12e2cf241f2e81893f21aa9dac315f6",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "qui-skill-release-prep": {
     "source": "plugin/skills/release-prep/SKILL.md",
     "hash": "8aab944ae2f53a24c94d39329bf000067a68f43b51de6657b517678bec90c67a",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "qui-skill-security-audit": {
     "source": "plugin/skills/security-audit/SKILL.md",
     "hash": "f370003a809c342d35b37990da231fbb72545e75e5a37e1e1d39a27db5364761",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "qui-skill-smart-test": {
     "source": "plugin/skills/smart-test/SKILL.md",
     "hash": "a5e874d1054dd123d78d9d8e9014c7c6888230f36685a203ea26176a3d649ffb",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "qui-skill-spec": {
     "source": "plugin/skills/spec/SKILL.md",
     "hash": "4e1ce2c9da6fcad85ebcf7cb6b755f44c27d00608ad97b72b93a82a45e3c0186",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "qui-skill-workflow-orchestration": {
     "source": "plugin/skills/workflow-orchestration/SKILL.md",
     "hash": "831c00dfb29ae4c72b35921fd3bab9e9f17affabf32b8164deb801557e031127",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "qui-smart-test": {
     "source": "content/features/smart-test.md",
     "hash": "58c691c8313ddf9699deb913e6b5c50fafc684563539ddf4816a4b94a9ea3e80",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "qui-spec-engine": {
     "source": "content/features/spec-engine.md",
     "hash": "c8549016aa848eeeaecbde8329f5850562f56280ab66428cb7c20887b428d81a",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "qui-telemetry": {
     "source": "content/features/telemetry.md",
     "hash": "59473ab809113116a3d58d2ead3a5f13e362d6992d8cee0a89364feded5cbd50",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "qui-wizards": {
     "source": "content/features/wizards.md",
     "hash": "6fe7722a026d11276ebfbdf4ea046a05112be94b560f9abf3ffee410f8637d8f",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "ref-agents": {
     "source": "content/features/agents.md",
     "hash": "a5b1678ecf012c7b2877a6c7ecae4a6c3f14c084c13fbcbb7eee79119dce6fa3",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "ref-bug-predict": {
     "source": "content/features/bug-predict.md",
     "hash": "6a4f420eba38e2fb884b837dd9758acb60ba60cdaf9248ec4280120b0d382b16",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "ref-cli": {
     "source": "content/features/cli.md",
     "hash": "a37b4dc4f0b3706a62184b02d2be1536ad75eef39a0f22a9699db5d03b8ee050",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "ref-code-quality": {
     "source": "content/features/code-quality.md",
     "hash": "ce16ac87eb92e33a08d8c2f06e86ef22e436966f47f3a28c3f4eba19060b550a",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "ref-configuration": {
     "source": "content/features/configuration.md",
     "hash": "8add90392883a46899ef8b57d135b625d92c5b61231d8a5301727f8b42f8e46f",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "ref-cross-review": {
     "source": "content/features/cross-review.md",
     "hash": "dc5ae75883b05f97983377b51e275bab79921e992d842ebb2616726b8c8c2cdb",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "ref-deep-review": {
     "source": "content/features/deep-review.md",
     "hash": "6a4fffc907302b4847d96097189bd8d329d3f1548d1ee46d9232f6ceecdfb450",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "ref-doc-gen": {
     "source": "content/features/doc-gen.md",
     "hash": "26e02a71a523775f5bb9e371b2e563c3c858386436a73b727422f62f57de0282",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "ref-elicitation-forms": {
     "source": "content/features/elicitation-forms.md",
     "hash": "4f326dd6f99f86af163cf44167b243d73ee5165ef8373bf4cea83039aec723d2",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "ref-fix-test": {
     "source": "content/features/fix-test.md",
-    "hash": "da54b69787cc1af5c087b2d8674442afe9b8c6fc88dca37a65e99590bb84fee0",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "8b182bab8816d525d3325746f4cdeed013113a1bdb0a43d36963e121afa42812",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "ref-help-system": {
     "source": "content/features/help-system.md",
     "hash": "24468c8fe4f1a0e350e620098d65a3bcc007000cd5aa4dbe20a6e6c83efa87b3",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "ref-hooks": {
     "source": "content/features/hooks.md",
     "hash": "5c6b8a45457387c76f628561d3baa56e9af1709bc9bd21bba9830b2c2478c8dd",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "ref-mcp-server": {
     "source": "content/features/mcp-server.md",
     "hash": "8e4b8c74eff980330480ae70856a1cf0393559cd22eb9ba0210b43249f9b5181",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "ref-memory": {
     "source": "content/features/memory.md",
     "hash": "32b3121d9110dc9ac327bb9e838f060fbe9940a033366b0147ef34ef2efaa4dc",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "ref-models": {
     "source": "content/features/models.md",
     "hash": "2117cbb0d8e863db6091870874e4ce80b48780c9ee8bb7330d8033c172ccb02b",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "ref-ops-dashboard": {
     "source": "content/features/ops-dashboard.md",
     "hash": "fefc8e2b2b4a25055fcbdf96cbd8638d75278cbcacd256873b725df89544c1f6",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "ref-orchestration": {
     "source": "content/features/orchestration.md",
     "hash": "4998437e04355011a7dee68dbce7e9e78bbe97f637e0b6a14c1ec972f541695c",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "ref-plugin": {
     "source": "content/features/plugin.md",
     "hash": "8cc6e5702ffc8228ed63cfb74a25dd3e99e79e5335c4b1c8c134950f8b9a043d",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "ref-rag-grounding": {
     "source": "content/features/rag-grounding.md",
     "hash": "3464dd78c83f06980912a7c49dc185b09830be1b1c163203f10e5aa1708fcf4e",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "ref-refactor-plan": {
     "source": "content/features/refactor-plan.md",
     "hash": "8f8c684cd94fca7b2580ecaaf955ccb79924022796d576d477cdab9330df9704",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "ref-release-notes": {
     "source": "content/features/release-notes.md",
     "hash": "da7101ffbec4d209fcb1cef754f01cef8a13458a6f961c3a23909edfec77e58c",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "ref-release-prep": {
     "source": "content/features/release-prep.md",
     "hash": "cd77b5903fbeb7d7e0acef570bab9727b4c143181ea6be1f52b9a25bc11418bb",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "ref-resilience": {
     "source": "content/features/resilience.md",
     "hash": "ae2a76f0f1ecbb9ca687e5a041acc2b4a25a5113ec57eaad550f48b8aadc4be2",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "ref-security-audit": {
     "source": "content/features/security-audit.md",
     "hash": "9cce18573c827fab9a380efe8c65c2f8c5b4ada3f7e383dd71ec523a0875fb05",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "ref-session-handoff": {
     "source": "content/features/session-handoff.md",
     "hash": "236c16ee2d2e48f0bd8ba075c69f50ead16a46ef185fede3d84b529c66fd41a0",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "ref-skill-attune-hub": {
     "source": "plugin/skills/attune-hub/SKILL.md",
     "hash": "2a18d84bd5efb5738643d716c803440f602d40871b172238996c4aebcf498032",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "ref-skill-bug-predict": {
     "source": "plugin/skills/bug-predict/SKILL.md",
     "hash": "992b9e6cd3452af0d31213985e5e5c607f078edd2310df76d786b95d7e6a83ce",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "ref-skill-coach": {
     "source": "plugin/skills/coach/SKILL.md",
     "hash": "a1842d674325f3f1ea289e3bd7ed1dcfbb4b3301160181edab081d2b4352aeac",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "ref-skill-code-quality": {
     "source": "plugin/skills/code-quality/SKILL.md",
     "hash": "769c4c885992fd1937adbdf5d97305894bd08c159c83930d7a9fb86cb4ae78b7",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "ref-skill-doc-gen": {
     "source": "plugin/skills/doc-gen/SKILL.md",
     "hash": "da9a9c23727eaa9433b2c4d1dfe87d850ef560d56b855f2eb7bd0f279efc3c72",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "ref-skill-fix-test": {
     "source": "plugin/skills/fix-test/SKILL.md",
     "hash": "665ff7c4978beddd72e87f3764b073e4f962b27a896bd66542d499a1a00429da",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "ref-skill-memory-and-context": {
     "source": "plugin/skills/memory-and-context/SKILL.md",
     "hash": "d026a40d0c5315123672c7ed3770b643ba803a3b5d57cb994c236fcd6baa8305",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "ref-skill-planning": {
     "source": "plugin/skills/planning/SKILL.md",
     "hash": "f56a42c83f514b300b4f89ea6669820ec158da952efa2894c56abb00c39eb58a",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "ref-skill-rag-code-gen": {
     "source": "plugin/skills/rag-code-gen/SKILL.md",
     "hash": "0d84a32e2f89e8debd740b4343c7930b17efcca37fcb68737f342f8b6b5f6f77",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "ref-skill-refactor-plan": {
     "source": "plugin/skills/refactor-plan/SKILL.md",
     "hash": "080a84b5df5dde88cd3c994ca2c2b68ec12e2cf241f2e81893f21aa9dac315f6",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "ref-skill-release-prep": {
     "source": "plugin/skills/release-prep/SKILL.md",
     "hash": "8aab944ae2f53a24c94d39329bf000067a68f43b51de6657b517678bec90c67a",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "ref-skill-security-audit": {
     "source": "plugin/skills/security-audit/SKILL.md",
     "hash": "f370003a809c342d35b37990da231fbb72545e75e5a37e1e1d39a27db5364761",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "ref-skill-smart-test": {
     "source": "plugin/skills/smart-test/SKILL.md",
     "hash": "a5e874d1054dd123d78d9d8e9014c7c6888230f36685a203ea26176a3d649ffb",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "ref-skill-spec": {
     "source": "plugin/skills/spec/SKILL.md",
     "hash": "4e1ce2c9da6fcad85ebcf7cb6b755f44c27d00608ad97b72b93a82a45e3c0186",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "ref-skill-workflow-orchestration": {
     "source": "plugin/skills/workflow-orchestration/SKILL.md",
     "hash": "831c00dfb29ae4c72b35921fd3bab9e9f17affabf32b8164deb801557e031127",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "ref-smart-test": {
     "source": "content/features/smart-test.md",
     "hash": "58c691c8313ddf9699deb913e6b5c50fafc684563539ddf4816a4b94a9ea3e80",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "ref-spec-engine": {
     "source": "content/features/spec-engine.md",
     "hash": "c8549016aa848eeeaecbde8329f5850562f56280ab66428cb7c20887b428d81a",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "ref-telemetry": {
     "source": "content/features/telemetry.md",
     "hash": "59473ab809113116a3d58d2ead3a5f13e362d6992d8cee0a89364feded5cbd50",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "ref-tool-analyze-batch": {
     "source": "src/attune/mcp/tool_schemas.py",
     "hash": "686dca2b600048257e5e19f651ef375a58c92c2b97cd7f76e4a6551d97c22525",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "ref-tool-analyze-image": {
     "source": "src/attune/mcp/tool_schemas.py",
     "hash": "686dca2b600048257e5e19f651ef375a58c92c2b97cd7f76e4a6551d97c22525",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "ref-tool-attune-get-level": {
     "source": "src/attune/mcp/tool_schemas.py",
     "hash": "686dca2b600048257e5e19f651ef375a58c92c2b97cd7f76e4a6551d97c22525",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "ref-tool-attune-set-level": {
     "source": "src/attune/mcp/tool_schemas.py",
     "hash": "686dca2b600048257e5e19f651ef375a58c92c2b97cd7f76e4a6551d97c22525",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "ref-tool-auth-recommend": {
     "source": "src/attune/mcp/tool_schemas.py",
     "hash": "686dca2b600048257e5e19f651ef375a58c92c2b97cd7f76e4a6551d97c22525",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "ref-tool-auth-status": {
     "source": "src/attune/mcp/tool_schemas.py",
     "hash": "686dca2b600048257e5e19f651ef375a58c92c2b97cd7f76e4a6551d97c22525",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "ref-tool-bug-predict": {
     "source": "src/attune/mcp/tool_schemas.py",
     "hash": "686dca2b600048257e5e19f651ef375a58c92c2b97cd7f76e4a6551d97c22525",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "ref-tool-code-review": {
     "source": "src/attune/mcp/tool_schemas.py",
     "hash": "686dca2b600048257e5e19f651ef375a58c92c2b97cd7f76e4a6551d97c22525",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "ref-tool-context-get": {
     "source": "src/attune/mcp/tool_schemas.py",
     "hash": "686dca2b600048257e5e19f651ef375a58c92c2b97cd7f76e4a6551d97c22525",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "ref-tool-context-set": {
     "source": "src/attune/mcp/tool_schemas.py",
     "hash": "686dca2b600048257e5e19f651ef375a58c92c2b97cd7f76e4a6551d97c22525",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "ref-tool-deep-review": {
     "source": "src/attune/mcp/tool_schemas.py",
     "hash": "686dca2b600048257e5e19f651ef375a58c92c2b97cd7f76e4a6551d97c22525",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "ref-tool-dependency-check": {
     "source": "src/attune/mcp/tool_schemas.py",
     "hash": "686dca2b600048257e5e19f651ef375a58c92c2b97cd7f76e4a6551d97c22525",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "ref-tool-doc-audit": {
     "source": "src/attune/mcp/tool_schemas.py",
     "hash": "686dca2b600048257e5e19f651ef375a58c92c2b97cd7f76e4a6551d97c22525",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "ref-tool-doc-gen": {
     "source": "src/attune/mcp/tool_schemas.py",
     "hash": "686dca2b600048257e5e19f651ef375a58c92c2b97cd7f76e4a6551d97c22525",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "ref-tool-doc-orchestrator": {
     "source": "src/attune/mcp/tool_schemas.py",
     "hash": "686dca2b600048257e5e19f651ef375a58c92c2b97cd7f76e4a6551d97c22525",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "ref-tool-health-check": {
     "source": "src/attune/mcp/tool_schemas.py",
     "hash": "686dca2b600048257e5e19f651ef375a58c92c2b97cd7f76e4a6551d97c22525",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "ref-tool-memory-forget": {
     "source": "src/attune/mcp/tool_schemas.py",
     "hash": "686dca2b600048257e5e19f651ef375a58c92c2b97cd7f76e4a6551d97c22525",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "ref-tool-memory-retrieve": {
     "source": "src/attune/mcp/tool_schemas.py",
     "hash": "686dca2b600048257e5e19f651ef375a58c92c2b97cd7f76e4a6551d97c22525",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "ref-tool-memory-search": {
     "source": "src/attune/mcp/tool_schemas.py",
     "hash": "686dca2b600048257e5e19f651ef375a58c92c2b97cd7f76e4a6551d97c22525",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "ref-tool-memory-store": {
     "source": "src/attune/mcp/tool_schemas.py",
     "hash": "686dca2b600048257e5e19f651ef375a58c92c2b97cd7f76e4a6551d97c22525",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "ref-tool-performance-audit": {
     "source": "src/attune/mcp/tool_schemas.py",
     "hash": "686dca2b600048257e5e19f651ef375a58c92c2b97cd7f76e4a6551d97c22525",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "ref-tool-rag-knowledge-query": {
     "source": "src/attune/mcp/tool_schemas.py",
     "hash": "686dca2b600048257e5e19f651ef375a58c92c2b97cd7f76e4a6551d97c22525",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "ref-tool-refactor-plan": {
     "source": "src/attune/mcp/tool_schemas.py",
     "hash": "686dca2b600048257e5e19f651ef375a58c92c2b97cd7f76e4a6551d97c22525",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "ref-tool-release-prep": {
     "source": "src/attune/mcp/tool_schemas.py",
     "hash": "686dca2b600048257e5e19f651ef375a58c92c2b97cd7f76e4a6551d97c22525",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "ref-tool-research-synthesis": {
     "source": "src/attune/mcp/tool_schemas.py",
     "hash": "686dca2b600048257e5e19f651ef375a58c92c2b97cd7f76e4a6551d97c22525",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "ref-tool-secure-release": {
     "source": "src/attune/mcp/tool_schemas.py",
     "hash": "686dca2b600048257e5e19f651ef375a58c92c2b97cd7f76e4a6551d97c22525",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "ref-tool-security-audit": {
     "source": "src/attune/mcp/tool_schemas.py",
     "hash": "686dca2b600048257e5e19f651ef375a58c92c2b97cd7f76e4a6551d97c22525",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "ref-tool-simplify-code": {
     "source": "src/attune/mcp/tool_schemas.py",
     "hash": "686dca2b600048257e5e19f651ef375a58c92c2b97cd7f76e4a6551d97c22525",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "ref-tool-telemetry-stats": {
     "source": "src/attune/mcp/tool_schemas.py",
     "hash": "686dca2b600048257e5e19f651ef375a58c92c2b97cd7f76e4a6551d97c22525",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "ref-tool-test-audit": {
     "source": "src/attune/mcp/tool_schemas.py",
     "hash": "686dca2b600048257e5e19f651ef375a58c92c2b97cd7f76e4a6551d97c22525",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "ref-tool-test-gen-parallel": {
     "source": "src/attune/mcp/tool_schemas.py",
     "hash": "686dca2b600048257e5e19f651ef375a58c92c2b97cd7f76e4a6551d97c22525",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "ref-tool-test-generation": {
     "source": "src/attune/mcp/tool_schemas.py",
     "hash": "686dca2b600048257e5e19f651ef375a58c92c2b97cd7f76e4a6551d97c22525",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "ref-wizards": {
     "source": "content/features/wizards.md",
     "hash": "6fe7722a026d11276ebfbdf4ea046a05112be94b560f9abf3ffee410f8637d8f",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "tas-agents": {
     "source": "content/features/agents.md",
     "hash": "a5b1678ecf012c7b2877a6c7ecae4a6c3f14c084c13fbcbb7eee79119dce6fa3",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "tas-browse-help-docs": {
     "source": "src/attune/cli_commands/help_commands.py",
     "hash": "d284892c4f058b5a9d4861f08f7f2de09c8050d33766471014bb739215a83582",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "tas-bug-predict": {
     "source": "content/features/bug-predict.md",
     "hash": "6a4f420eba38e2fb884b837dd9758acb60ba60cdaf9248ec4280120b0d382b16",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "tas-check-auth-status": {
     "source": "src/attune/cli_minimal.py",
     "hash": "8e78816c6a743c24afd05568ba29a5d0eec548beea557ab098a48630b1f82ac8",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "tas-cli": {
     "source": "content/features/cli.md",
     "hash": "a37b4dc4f0b3706a62184b02d2be1536ad75eef39a0f22a9699db5d03b8ee050",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "tas-code-quality": {
     "source": "content/features/code-quality.md",
     "hash": "ce16ac87eb92e33a08d8c2f06e86ef22e436966f47f3a28c3f4eba19060b550a",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "tas-configuration": {
     "source": "content/features/configuration.md",
     "hash": "8add90392883a46899ef8b57d135b625d92c5b61231d8a5301727f8b42f8e46f",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "tas-cross-review": {
     "source": "content/features/cross-review.md",
     "hash": "dc5ae75883b05f97983377b51e275bab79921e992d842ebb2616726b8c8c2cdb",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "tas-deep-review": {
     "source": "content/features/deep-review.md",
     "hash": "6a4fffc907302b4847d96097189bd8d329d3f1548d1ee46d9232f6ceecdfb450",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "tas-doc-gen": {
     "source": "content/features/doc-gen.md",
     "hash": "26e02a71a523775f5bb9e371b2e563c3c858386436a73b727422f62f57de0282",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "tas-elicitation-forms": {
     "source": "content/features/elicitation-forms.md",
     "hash": "4f326dd6f99f86af163cf44167b243d73ee5165ef8373bf4cea83039aec723d2",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "tas-export-telemetry": {
     "source": "src/attune/cli_minimal.py",
     "hash": "8e78816c6a743c24afd05568ba29a5d0eec548beea557ab098a48630b1f82ac8",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "tas-fix-test": {
     "source": "content/features/fix-test.md",
-    "hash": "da54b69787cc1af5c087b2d8674442afe9b8c6fc88dca37a65e99590bb84fee0",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "8b182bab8816d525d3325746f4cdeed013113a1bdb0a43d36963e121afa42812",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "tas-help-system": {
     "source": "content/features/help-system.md",
     "hash": "24468c8fe4f1a0e350e620098d65a3bcc007000cd5aa4dbe20a6e6c83efa87b3",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "tas-hooks": {
     "source": "content/features/hooks.md",
     "hash": "5c6b8a45457387c76f628561d3baa56e9af1709bc9bd21bba9830b2c2478c8dd",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "tas-install-plugin": {
     "source": "README.md",
     "hash": "fcc62f0951ab8912c5080913462e9831fd6256f0062027fb7f2db6b6ccf0b615",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "tas-manage-lessons": {
     "source": "src/attune/cli_minimal.py",
     "hash": "8e78816c6a743c24afd05568ba29a5d0eec548beea557ab098a48630b1f82ac8",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "tas-mcp-server": {
     "source": "content/features/mcp-server.md",
     "hash": "8e4b8c74eff980330480ae70856a1cf0393559cd22eb9ba0210b43249f9b5181",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "tas-memory": {
     "source": "content/features/memory.md",
     "hash": "32b3121d9110dc9ac327bb9e838f060fbe9940a033366b0147ef34ef2efaa4dc",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "tas-models": {
     "source": "content/features/models.md",
     "hash": "2117cbb0d8e863db6091870874e4ce80b48780c9ee8bb7330d8033c172ccb02b",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "tas-ops-dashboard": {
     "source": "content/features/ops-dashboard.md",
     "hash": "fefc8e2b2b4a25055fcbdf96cbd8638d75278cbcacd256873b725df89544c1f6",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "tas-orchestration": {
     "source": "content/features/orchestration.md",
     "hash": "4998437e04355011a7dee68dbce7e9e78bbe97f637e0b6a14c1ec972f541695c",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "tas-plugin": {
     "source": "content/features/plugin.md",
     "hash": "8cc6e5702ffc8228ed63cfb74a25dd3e99e79e5335c4b1c8c134950f8b9a043d",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "tas-rag-grounding": {
     "source": "content/features/rag-grounding.md",
     "hash": "3464dd78c83f06980912a7c49dc185b09830be1b1c163203f10e5aa1708fcf4e",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "tas-refactor-plan": {
     "source": "content/features/refactor-plan.md",
     "hash": "8f8c684cd94fca7b2580ecaaf955ccb79924022796d576d477cdab9330df9704",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "tas-release-notes": {
     "source": "content/features/release-notes.md",
     "hash": "da7101ffbec4d209fcb1cef754f01cef8a13458a6f961c3a23909edfec77e58c",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "tas-release-prep": {
     "source": "content/features/release-prep.md",
     "hash": "cd77b5903fbeb7d7e0acef570bab9727b4c143181ea6be1f52b9a25bc11418bb",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "tas-resilience": {
     "source": "content/features/resilience.md",
     "hash": "ae2a76f0f1ecbb9ca687e5a041acc2b4a25a5113ec57eaad550f48b8aadc4be2",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "tas-run-doctor": {
     "source": "src/attune/cli_minimal.py",
     "hash": "8e78816c6a743c24afd05568ba29a5d0eec548beea557ab098a48630b1f82ac8",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "tas-run-workflow": {
     "source": "src/attune/cli_minimal.py",
     "hash": "8e78816c6a743c24afd05568ba29a5d0eec548beea557ab098a48630b1f82ac8",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "tas-security-audit": {
     "source": "content/features/security-audit.md",
     "hash": "9cce18573c827fab9a380efe8c65c2f8c5b4ada3f7e383dd71ec523a0875fb05",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "tas-session-handoff": {
     "source": "content/features/session-handoff.md",
     "hash": "236c16ee2d2e48f0bd8ba075c69f50ead16a46ef185fede3d84b529c66fd41a0",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "tas-smart-test": {
     "source": "content/features/smart-test.md",
     "hash": "58c691c8313ddf9699deb913e6b5c50fafc684563539ddf4816a4b94a9ea3e80",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "tas-spec-engine": {
     "source": "content/features/spec-engine.md",
     "hash": "c8549016aa848eeeaecbde8329f5850562f56280ab66428cb7c20887b428d81a",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "tas-telemetry": {
     "source": "content/features/telemetry.md",
     "hash": "59473ab809113116a3d58d2ead3a5f13e362d6992d8cee0a89364feded5cbd50",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "tas-use-attune-hub": {
     "source": "plugin/skills/attune-hub/SKILL.md",
     "hash": "2a18d84bd5efb5738643d716c803440f602d40871b172238996c4aebcf498032",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "tas-use-bug-predict": {
     "source": "plugin/skills/bug-predict/SKILL.md",
     "hash": "992b9e6cd3452af0d31213985e5e5c607f078edd2310df76d786b95d7e6a83ce",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "tas-use-coach": {
     "source": "plugin/skills/coach/SKILL.md",
     "hash": "a1842d674325f3f1ea289e3bd7ed1dcfbb4b3301160181edab081d2b4352aeac",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "tas-use-code-quality": {
     "source": "plugin/skills/code-quality/SKILL.md",
     "hash": "769c4c885992fd1937adbdf5d97305894bd08c159c83930d7a9fb86cb4ae78b7",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "tas-use-doc-gen": {
     "source": "plugin/skills/doc-gen/SKILL.md",
     "hash": "da9a9c23727eaa9433b2c4d1dfe87d850ef560d56b855f2eb7bd0f279efc3c72",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "tas-use-fix-test": {
     "source": "plugin/skills/fix-test/SKILL.md",
     "hash": "665ff7c4978beddd72e87f3764b073e4f962b27a896bd66542d499a1a00429da",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "tas-use-memory-and-context": {
     "source": "plugin/skills/memory-and-context/SKILL.md",
     "hash": "d026a40d0c5315123672c7ed3770b643ba803a3b5d57cb994c236fcd6baa8305",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "tas-use-planning": {
     "source": "plugin/skills/planning/SKILL.md",
     "hash": "f56a42c83f514b300b4f89ea6669820ec158da952efa2894c56abb00c39eb58a",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "tas-use-rag-code-gen": {
     "source": "plugin/skills/rag-code-gen/SKILL.md",
     "hash": "0d84a32e2f89e8debd740b4343c7930b17efcca37fcb68737f342f8b6b5f6f77",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "tas-use-refactor-plan": {
     "source": "plugin/skills/refactor-plan/SKILL.md",
     "hash": "080a84b5df5dde88cd3c994ca2c2b68ec12e2cf241f2e81893f21aa9dac315f6",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "tas-use-release-prep": {
     "source": "plugin/skills/release-prep/SKILL.md",
     "hash": "8aab944ae2f53a24c94d39329bf000067a68f43b51de6657b517678bec90c67a",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "tas-use-security-audit": {
     "source": "plugin/skills/security-audit/SKILL.md",
     "hash": "f370003a809c342d35b37990da231fbb72545e75e5a37e1e1d39a27db5364761",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "tas-use-smart-test": {
     "source": "plugin/skills/smart-test/SKILL.md",
     "hash": "a5e874d1054dd123d78d9d8e9014c7c6888230f36685a203ea26176a3d649ffb",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "tas-use-spec": {
     "source": "plugin/skills/spec/SKILL.md",
     "hash": "4e1ce2c9da6fcad85ebcf7cb6b755f44c27d00608ad97b72b93a82a45e3c0186",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "tas-use-workflow-orchestration": {
     "source": "plugin/skills/workflow-orchestration/SKILL.md",
     "hash": "831c00dfb29ae4c72b35921fd3bab9e9f17affabf32b8164deb801557e031127",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "tas-wizards": {
     "source": "content/features/wizards.md",
     "hash": "6fe7722a026d11276ebfbdf4ea046a05112be94b560f9abf3ffee410f8637d8f",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "tip-after-10-inspects": {
     "source": "src/attune/discovery.py",
     "hash": "7041db92a9dadeb05ccec51831e49c162a38d62dbd11c69a487e68e7beebf15d",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "tip-after-5-ships": {
     "source": "src/attune/discovery.py",
     "hash": "7041db92a9dadeb05ccec51831e49c162a38d62dbd11c69a487e68e7beebf15d",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "tip-after-bug-predict": {
     "source": "src/attune/workflows/suggestions.py",
     "hash": "caa3f48a039def99a5bf58dc29129aba9548dfc74a42cc69dfb067aeb71f3200",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "tip-after-code-review": {
     "source": "src/attune/workflows/suggestions.py",
     "hash": "caa3f48a039def99a5bf58dc29129aba9548dfc74a42cc69dfb067aeb71f3200",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "tip-after-dependency-check": {
     "source": "src/attune/workflows/suggestions.py",
     "hash": "caa3f48a039def99a5bf58dc29129aba9548dfc74a42cc69dfb067aeb71f3200",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "tip-after-first-health": {
     "source": "src/attune/discovery.py",
     "hash": "7041db92a9dadeb05ccec51831e49c162a38d62dbd11c69a487e68e7beebf15d",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "tip-after-first-inspect": {
     "source": "src/attune/discovery.py",
     "hash": "7041db92a9dadeb05ccec51831e49c162a38d62dbd11c69a487e68e7beebf15d",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "tip-after-perf-audit": {
     "source": "src/attune/workflows/suggestions.py",
     "hash": "caa3f48a039def99a5bf58dc29129aba9548dfc74a42cc69dfb067aeb71f3200",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "tip-after-refactor-plan": {
     "source": "src/attune/workflows/suggestions.py",
     "hash": "caa3f48a039def99a5bf58dc29129aba9548dfc74a42cc69dfb067aeb71f3200",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "tip-after-security-audit": {
     "source": "src/attune/workflows/suggestions.py",
     "hash": "caa3f48a039def99a5bf58dc29129aba9548dfc74a42cc69dfb067aeb71f3200",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "tip-after-simplify-code": {
     "source": "src/attune/workflows/suggestions.py",
     "hash": "caa3f48a039def99a5bf58dc29129aba9548dfc74a42cc69dfb067aeb71f3200",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "tip-after-test-gen": {
     "source": "src/attune/workflows/suggestions.py",
     "hash": "caa3f48a039def99a5bf58dc29129aba9548dfc74a42cc69dfb067aeb71f3200",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "tip-agents": {
     "source": "content/features/agents.md",
     "hash": "a5b1678ecf012c7b2877a6c7ecae4a6c3f14c084c13fbcbb7eee79119dce6fa3",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "tip-bug-predict": {
     "source": "content/features/bug-predict.md",
     "hash": "6a4f420eba38e2fb884b837dd9758acb60ba60cdaf9248ec4280120b0d382b16",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "tip-cli": {
     "source": "content/features/cli.md",
     "hash": "a37b4dc4f0b3706a62184b02d2be1536ad75eef39a0f22a9699db5d03b8ee050",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "tip-code-quality": {
     "source": "content/features/code-quality.md",
     "hash": "ce16ac87eb92e33a08d8c2f06e86ef22e436966f47f3a28c3f4eba19060b550a",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "tip-configuration": {
     "source": "content/features/configuration.md",
     "hash": "8add90392883a46899ef8b57d135b625d92c5b61231d8a5301727f8b42f8e46f",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "tip-cost-savings": {
     "source": "src/attune/discovery.py",
     "hash": "7041db92a9dadeb05ccec51831e49c162a38d62dbd11c69a487e68e7beebf15d",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "tip-cross-review": {
     "source": "content/features/cross-review.md",
     "hash": "dc5ae75883b05f97983377b51e275bab79921e992d842ebb2616726b8c8c2cdb",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "tip-deep-review": {
     "source": "content/features/deep-review.md",
     "hash": "6a4fffc907302b4847d96097189bd8d329d3f1548d1ee46d9232f6ceecdfb450",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "tip-doc-gen": {
     "source": "content/features/doc-gen.md",
     "hash": "26e02a71a523775f5bb9e371b2e563c3c858386436a73b727422f62f57de0282",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "tip-elicitation-forms": {
     "source": "content/features/elicitation-forms.md",
     "hash": "4f326dd6f99f86af163cf44167b243d73ee5165ef8373bf4cea83039aec723d2",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "tip-fix-test": {
     "source": "content/features/fix-test.md",
-    "hash": "da54b69787cc1af5c087b2d8674442afe9b8c6fc88dca37a65e99590bb84fee0",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "8b182bab8816d525d3325746f4cdeed013113a1bdb0a43d36963e121afa42812",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "tip-help-system": {
     "source": "content/features/help-system.md",
     "hash": "24468c8fe4f1a0e350e620098d65a3bcc007000cd5aa4dbe20a6e6c83efa87b3",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "tip-high-tech-debt": {
     "source": "src/attune/discovery.py",
     "hash": "7041db92a9dadeb05ccec51831e49c162a38d62dbd11c69a487e68e7beebf15d",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "tip-hooks": {
     "source": "content/features/hooks.md",
     "hash": "5c6b8a45457387c76f628561d3baa56e9af1709bc9bd21bba9830b2c2478c8dd",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "tip-mcp-server": {
     "source": "content/features/mcp-server.md",
     "hash": "8e4b8c74eff980330480ae70856a1cf0393559cd22eb9ba0210b43249f9b5181",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "tip-memory": {
     "source": "content/features/memory.md",
     "hash": "32b3121d9110dc9ac327bb9e838f060fbe9940a033366b0147ef34ef2efaa4dc",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "tip-models": {
     "source": "content/features/models.md",
     "hash": "2117cbb0d8e863db6091870874e4ce80b48780c9ee8bb7330d8033c172ccb02b",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "tip-no-patterns": {
     "source": "src/attune/discovery.py",
     "hash": "7041db92a9dadeb05ccec51831e49c162a38d62dbd11c69a487e68e7beebf15d",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "tip-ops-dashboard": {
     "source": "content/features/ops-dashboard.md",
     "hash": "fefc8e2b2b4a25055fcbdf96cbd8638d75278cbcacd256873b725df89544c1f6",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "tip-orchestration": {
     "source": "content/features/orchestration.md",
     "hash": "4998437e04355011a7dee68dbce7e9e78bbe97f637e0b6a14c1ec972f541695c",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "tip-plugin": {
     "source": "content/features/plugin.md",
     "hash": "8cc6e5702ffc8228ed63cfb74a25dd3e99e79e5335c4b1c8c134950f8b9a043d",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "tip-rag-grounding": {
     "source": "content/features/rag-grounding.md",
     "hash": "3464dd78c83f06980912a7c49dc185b09830be1b1c163203f10e5aa1708fcf4e",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "tip-refactor-plan": {
     "source": "content/features/refactor-plan.md",
     "hash": "8f8c684cd94fca7b2580ecaaf955ccb79924022796d576d477cdab9330df9704",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "tip-release-notes": {
     "source": "content/features/release-notes.md",
     "hash": "da7101ffbec4d209fcb1cef754f01cef8a13458a6f961c3a23909edfec77e58c",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "tip-release-prep": {
     "source": "content/features/release-prep.md",
     "hash": "cd77b5903fbeb7d7e0acef570bab9727b4c143181ea6be1f52b9a25bc11418bb",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "tip-resilience": {
     "source": "content/features/resilience.md",
     "hash": "ae2a76f0f1ecbb9ca687e5a041acc2b4a25a5113ec57eaad550f48b8aadc4be2",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "tip-security-audit": {
     "source": "content/features/security-audit.md",
     "hash": "9cce18573c827fab9a380efe8c65c2f8c5b4ada3f7e383dd71ec523a0875fb05",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "tip-session-handoff": {
     "source": "content/features/session-handoff.md",
     "hash": "236c16ee2d2e48f0bd8ba075c69f50ead16a46ef185fede3d84b529c66fd41a0",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "tip-smart-test": {
     "source": "content/features/smart-test.md",
     "hash": "58c691c8313ddf9699deb913e6b5c50fafc684563539ddf4816a4b94a9ea3e80",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "tip-spec-engine": {
     "source": "content/features/spec-engine.md",
     "hash": "c8549016aa848eeeaecbde8329f5850562f56280ab66428cb7c20887b428d81a",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "tip-telemetry": {
     "source": "content/features/telemetry.md",
     "hash": "59473ab809113116a3d58d2ead3a5f13e362d6992d8cee0a89364feded5cbd50",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "tip-weekly-review": {
     "source": "src/attune/discovery.py",
     "hash": "7041db92a9dadeb05ccec51831e49c162a38d62dbd11c69a487e68e7beebf15d",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "tip-wizards": {
     "source": "content/features/wizards.md",
     "hash": "6fe7722a026d11276ebfbdf4ea046a05112be94b560f9abf3ffee410f8637d8f",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "tro-agents": {
     "source": "content/features/agents.md",
     "hash": "a5b1678ecf012c7b2877a6c7ecae4a6c3f14c084c13fbcbb7eee79119dce6fa3",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "tro-bug-predict": {
     "source": "content/features/bug-predict.md",
     "hash": "6a4f420eba38e2fb884b837dd9758acb60ba60cdaf9248ec4280120b0d382b16",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "tro-cli": {
     "source": "content/features/cli.md",
     "hash": "a37b4dc4f0b3706a62184b02d2be1536ad75eef39a0f22a9699db5d03b8ee050",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "tro-code-quality": {
     "source": "content/features/code-quality.md",
     "hash": "ce16ac87eb92e33a08d8c2f06e86ef22e436966f47f3a28c3f4eba19060b550a",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "tro-configuration": {
     "source": "content/features/configuration.md",
     "hash": "8add90392883a46899ef8b57d135b625d92c5b61231d8a5301727f8b42f8e46f",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "tro-cross-review": {
     "source": "content/features/cross-review.md",
     "hash": "dc5ae75883b05f97983377b51e275bab79921e992d842ebb2616726b8c8c2cdb",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "tro-deep-review": {
     "source": "content/features/deep-review.md",
     "hash": "6a4fffc907302b4847d96097189bd8d329d3f1548d1ee46d9232f6ceecdfb450",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "tro-doc-gen": {
     "source": "content/features/doc-gen.md",
     "hash": "26e02a71a523775f5bb9e371b2e563c3c858386436a73b727422f62f57de0282",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "tro-elicitation-forms": {
     "source": "content/features/elicitation-forms.md",
     "hash": "4f326dd6f99f86af163cf44167b243d73ee5165ef8373bf4cea83039aec723d2",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "tro-fix-test": {
     "source": "content/features/fix-test.md",
-    "hash": "da54b69787cc1af5c087b2d8674442afe9b8c6fc88dca37a65e99590bb84fee0",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "8b182bab8816d525d3325746f4cdeed013113a1bdb0a43d36963e121afa42812",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "tro-help-system": {
     "source": "content/features/help-system.md",
     "hash": "24468c8fe4f1a0e350e620098d65a3bcc007000cd5aa4dbe20a6e6c83efa87b3",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "tro-hooks": {
     "source": "content/features/hooks.md",
     "hash": "5c6b8a45457387c76f628561d3baa56e9af1709bc9bd21bba9830b2c2478c8dd",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "tro-mcp-server": {
     "source": "content/features/mcp-server.md",
     "hash": "8e4b8c74eff980330480ae70856a1cf0393559cd22eb9ba0210b43249f9b5181",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "tro-memory": {
     "source": "content/features/memory.md",
     "hash": "32b3121d9110dc9ac327bb9e838f060fbe9940a033366b0147ef34ef2efaa4dc",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "tro-models": {
     "source": "content/features/models.md",
     "hash": "2117cbb0d8e863db6091870874e4ce80b48780c9ee8bb7330d8033c172ccb02b",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "tro-ops-dashboard": {
     "source": "content/features/ops-dashboard.md",
     "hash": "fefc8e2b2b4a25055fcbdf96cbd8638d75278cbcacd256873b725df89544c1f6",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "tro-orchestration": {
     "source": "content/features/orchestration.md",
     "hash": "4998437e04355011a7dee68dbce7e9e78bbe97f637e0b6a14c1ec972f541695c",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "tro-plugin": {
     "source": "content/features/plugin.md",
     "hash": "8cc6e5702ffc8228ed63cfb74a25dd3e99e79e5335c4b1c8c134950f8b9a043d",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "tro-rag-grounding": {
     "source": "content/features/rag-grounding.md",
     "hash": "3464dd78c83f06980912a7c49dc185b09830be1b1c163203f10e5aa1708fcf4e",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "tro-refactor-plan": {
     "source": "content/features/refactor-plan.md",
     "hash": "8f8c684cd94fca7b2580ecaaf955ccb79924022796d576d477cdab9330df9704",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "tro-release-notes": {
     "source": "content/features/release-notes.md",
     "hash": "da7101ffbec4d209fcb1cef754f01cef8a13458a6f961c3a23909edfec77e58c",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "tro-release-prep": {
     "source": "content/features/release-prep.md",
     "hash": "cd77b5903fbeb7d7e0acef570bab9727b4c143181ea6be1f52b9a25bc11418bb",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "tro-resilience": {
     "source": "content/features/resilience.md",
     "hash": "ae2a76f0f1ecbb9ca687e5a041acc2b4a25a5113ec57eaad550f48b8aadc4be2",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "tro-security-audit": {
     "source": "content/features/security-audit.md",
     "hash": "9cce18573c827fab9a380efe8c65c2f8c5b4ada3f7e383dd71ec523a0875fb05",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "tro-session-handoff": {
     "source": "content/features/session-handoff.md",
     "hash": "236c16ee2d2e48f0bd8ba075c69f50ead16a46ef185fede3d84b529c66fd41a0",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "tro-smart-test": {
     "source": "content/features/smart-test.md",
     "hash": "58c691c8313ddf9699deb913e6b5c50fafc684563539ddf4816a4b94a9ea3e80",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "tro-spec-engine": {
     "source": "content/features/spec-engine.md",
     "hash": "c8549016aa848eeeaecbde8329f5850562f56280ab66428cb7c20887b428d81a",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "tro-telemetry": {
     "source": "content/features/telemetry.md",
     "hash": "59473ab809113116a3d58d2ead3a5f13e362d6992d8cee0a89364feded5cbd50",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "tro-wizards": {
     "source": "content/features/wizards.md",
     "hash": "6fe7722a026d11276ebfbdf4ea046a05112be94b560f9abf3ffee410f8637d8f",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-adding-a-plugin-skill-has-three-enforcement-gates-not-one": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-adding-a-workspace-sibling-package-as-an-extra-can-silently": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-adding-logger-before-eager-imports-triggers-e402-in-init-py": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-after-a-pr-merges-while-youre-afk-pull-main-before-tagging": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-after-a-squash-merge-of-a-feature-branch-local-main-can-have": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-agents": {
     "source": "content/features/agents.md",
     "hash": "a5b1678ecf012c7b2877a6c7ecae4a6c3f14c084c13fbcbb7eee79119dce6fa3",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-agents-skills-must-stay-synced-with-plugin-skills": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-anchor-tag-buttons-need-text-white-no-underline": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-anthropics-built-in-prompt-caching-supersedes-custom-caching": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-any-unstaged-file-triggers-pre-commit-stash-conflicts-with-auto": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-attune-author-check-staleness-load-manifest-is-the-python-api": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-attune-helps-sidecar-schemas-dont-match-path-keyed-assumptions": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-attune-skill-names-must-not-collide-with-claude-code-built-in": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-b904-raise-x-from-e-is-not-auto-fixable-by-ruff": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-background-processes-from-previous-sessions-persist-across": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-bare-manifest-in-gitignore-silently-excludes-any-manifest": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-bg-var-primary-bg-opacity-10-is-invisible-in-dark-mode": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-bug-predict": {
     "source": "content/features/bug-predict.md",
     "hash": "6a4f420eba38e2fb884b837dd9758acb60ba60cdaf9248ec4280120b0d382b16",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-bug-predict-dangerous-eval-flags-subprocess-exec": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-bugpredictionworkflow-not-bugpredictworkflow": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-changing-error-messages-breaks-tests-across-the-codebase": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-changing-the-citation-anchor-format-can-silently-regress-llm": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-changing-user-facing-output-strings-cascades-through-test": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-chicken-and-egg-for-optional-extras-in-dev": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-citation-forced-prompting-and-prompt-injection-resistance-are": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-claude-code-plugin-is-platform-specific": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-claude-code-plugins-expect-plugin-json-inside-claude-plugin": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-cli": {
     "source": "content/features/cli.md",
     "hash": "a37b4dc4f0b3706a62184b02d2be1536ad75eef39a0f22a9699db5d03b8ee050",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-clusterfuzz-dockerfile-copies-to-src-repo-but-also-copies": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-clusterfuzzlite-no-deps-misses-transitive-imports": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-code-quality": {
     "source": "content/features/code-quality.md",
     "hash": "ce16ac87eb92e33a08d8c2f06e86ef22e436966f47f3a28c3f4eba19060b550a",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-codecov-patch-0-usually-means-tests-skipped-not-failed": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-codeql-alerts-dismissible-in-bulk-via-gh-api": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-combine-two-unreleased-changelog-drafts-into-one-version-when": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-commands-are-not-namespaced-in-plugins-skills-are": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-configuration": {
     "source": "content/features/configuration.md",
     "hash": "8add90392883a46899ef8b57d135b625d92c5b61231d8a5301727f8b42f8e46f",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-costreport-fields-are-named-not-positional": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-costreport-is-a-dataclass-not-a-dict": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-cross-review": {
     "source": "content/features/cross-review.md",
     "hash": "dc5ae75883b05f97983377b51e275bab79921e992d842ebb2616726b8c8c2cdb",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-dataclassorder-true-needs-compare-false-on-list-fields": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-dead-code-modules-with-full-test-suites-look-alive": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-dead-tests-from-monorepo-extraction-accumulate-in-packages-with": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-deep-review": {
     "source": "content/features/deep-review.md",
     "hash": "6a4fffc907302b4847d96097189bd8d329d3f1548d1ee46d9232f6ceecdfb450",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-deep-review-false-positives-verify-before-acting": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-detect-secrets-flags-fake-as-a-secret-in-test-fixtures": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-direct-pushes-to-main-are-blocked-by-the-presence-of-required": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-dispatch-tables-hold-direct-function-references-mocks-must": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-dist-can-contain-stale-artifacts-after-version-bumps": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-doc-gen": {
     "source": "content/features/doc-gen.md",
     "hash": "26e02a71a523775f5bb9e371b2e563c3c858386436a73b727422f62f57de0282",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-dont-append-z-to-timezone-aware-isoformat": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-dry-run-candidate-golden-queries-through-the-resolver-before": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-duck-typed-test-fakes-fail-isinstance-based-collectors-silently": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-duplicate-plugins-cause-conflicting-skill-triggers": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-elicitation-forms": {
     "source": "content/features/elicitation-forms.md",
     "hash": "4f326dd6f99f86af163cf44167b243d73ee5165ef8373bf4cea83039aec723d2",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-exclude-hard-queries-from-aggregate-p-1-metrics-in-benchmark": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-exploration-agents-fabricate-names-verify-against-source": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-f841-unused-fixture-lint-fires-when-a-test-is-refactored-to": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-fastembed-is-the-local-embeddings-path-that-passes-a-50mb": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-fix-test": {
     "source": "content/features/fix-test.md",
-    "hash": "da54b69787cc1af5c087b2d8674442afe9b8c6fc88dca37a65e99590bb84fee0",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "8b182bab8816d525d3325746f4cdeed013113a1bdb0a43d36963e121afa42812",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-forced-anthropic-tool-use-is-the-cleanest-path-to-guaranteed": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-formatter-strips-imports-that-are-unused-at-the-moment-you-save": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-generated-content-with-trailing-whitespace-causes-perpetual-pre": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-gh-api-x-patch-f-name-n-rejects-integers-as-strings": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-gh-pr-checks-json-field-names": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-gh-pr-merge-admin-is-blocked-by-in-progress-required-checks": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-gh-pr-merge-admin-prints-a-fast-forward-warning-even-when-the": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-gh-workflow-run-file-yml-ref-tag-re-triggers-a-release-gated": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-git-commit-q-can-exit-0-with-pre-commit-hook-feedback-that": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-git-pull-refuses-with-unstaged-changes-when-pull-rebase-true": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-git-rebase-root-exec-git-commit-amend-no-edit-s-re-signs-every": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-git-stash-pop-after-pre-commit-can-resurrect-stale-tool-state": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-github-actions-environment-deployment-approvals-can-be-self": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-github-copilot-autofix-pushes-commits-directly-to-pr-branches": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-github-protected-tags-cannot-be-force-updated": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-github-repos-serve-as-claude-code-marketplaces": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-gitignore-exclusions-break-ci-tests-that-read-those-files": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-glob-based-hash-computation-must-exclude-cache-dirs": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-golden-query-benchmarks-reveal-two-distinct-failure-classes": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-golden-query-test-fixtures-must-match-the-actual-corpus-layout": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-gpg-signing-fails-in-non-interactive-terminals-vscode-extension": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-hand-crafted-summary-prototype-is-the-fastest-way-to-measure-a": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-handoff-memory-option-b-proposals-are-often-wrong-re-analyze": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-hardcoded-root-paths-in-tests": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-hardcoded-strings-in-method-bodies-survive-class-attribute": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-hardcoded-user-id-defeats-ownership-checks": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-help-system": {
     "source": "content/features/help-system.md",
     "hash": "24468c8fe4f1a0e350e620098d65a3bcc007000cd5aa4dbe20a6e6c83efa87b3",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-hooks": {
     "source": "content/features/hooks.md",
     "hash": "5c6b8a45457387c76f628561d3baa56e9af1709bc9bd21bba9830b2c2478c8dd",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-hot-reload-subsystem-was-1-038-lines-of-dead-code": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-import-x-inside-a-try-block-except-x-someerror-in-the-except": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-importlib-import-module-is-an-arbitrary-code-execution-vector": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-industry-terminology-wont-appear-in-llm-polished-rag-summaries": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-is-private-is-a-superset-in-python-ipaddress": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-lazy-imports-inside-function-bodies-cant-be-patched-with": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-linkedin-paste-use-ascii-markers-not-unicode-arrows": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-list-workflows-deduplication-must-keep-base-names-visible": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-llm-api-responses-lack-trailing-newlines": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-mcp-attune-ai-doc-orchestrator-is-a-no-op-stub": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-mcp-call-tool-wrapper-pattern": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-mcp-handler-validate-paths-before-importing-workflows": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-mcp-json-python-resolves-to-pyenv-shim-not-project-venv": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-mcp-server": {
     "source": "content/features/mcp-server.md",
     "hash": "8e4b8c74eff980330480ae70856a1cf0393559cd22eb9ba0210b43249f9b5181",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-mcp-tool-renames-propagate-to-skill-docs": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-memory": {
     "source": "content/features/memory.md",
     "hash": "32b3121d9110dc9ac327bb9e838f060fbe9940a033366b0147ef34ef2efaa4dc",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-metadata-can-reach-a-retriever-with-zero-signal-if-the-sidecar": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-mkdocs-build-crashing-with-attributeerror-nonetype-object-has": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-models": {
     "source": "content/features/models.md",
     "hash": "2117cbb0d8e863db6091870874e4ce80b48780c9ee8bb7330d8033c172ccb02b",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-modeltier-has-two-copies-imports-must-match": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-module-level-optional-imports-enable-clean-test-patching": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-multiple-pinentry-program-lines-in-gpg-agent-conf-first-wins": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-mutual-competition-between-polished-rag-features-is-real-and": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-mypy-437-errors-was-stale-actual-count-was-2": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-naive-suffix-strip-stemming-fails-on-english-doubling-consonant": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-never-paste-pypi-tokens-into-chat-or-logs": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-new-dataclass-fields-need-both-the-class-and-the-parser-updated": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-new-mcp-handlers-must-match-the-validation-pattern-of-adjacent": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-new-security-features-need-dedicated-tests-before-release": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-non-baseworkflow-classes-in-workflow-registry-crash-the-cli": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-noqa-f401-re-exports-break-silently-on-satellite-file-deletion": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-openssf-scorecard-alerts-2-codereviewid-3-sastid-are-process": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-ops-dashboard": {
     "source": "content/features/ops-dashboard.md",
     "hash": "fefc8e2b2b4a25055fcbdf96cbd8638d75278cbcacd256873b725df89544c1f6",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-orchestration": {
     "source": "content/features/orchestration.md",
     "hash": "4998437e04355011a7dee68dbce7e9e78bbe97f637e0b6a14c1ec972f541695c",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-orphan-help-dirs-are-deprecated-3-depth-output-adding-them-to": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-orphan-top-level-docs-directories-stay-invisible-to-readers": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-packages-attune-in-attune-ai-are-pointer-stubs-not-source": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-past-due-deprecations-are-deletion-targets-not-implementation": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-patch-requires-the-target-name-to-exist-at-module-scope-at": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-path-globdir-matches-directories-not-files": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-path-rename-fails-on-windows-when-target-exists": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-platform-conditional-security-test-assertions-should-accept-any": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-plugin": {
     "source": "content/features/plugin.md",
     "hash": "8cc6e5702ffc8228ed63cfb74a25dd3e99e79e5335c4b1c8c134950f8b9a043d",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-plugin-read-skill-references-break-outside-the-plugin": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-pre-commit-auto-fix-requires-re-stage-before-retry": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-pre-commit-black-unstaged-files-re-stage-after-failure": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-pre-commit-stash-conflict-when-black-ruff-fix-files-with": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-pre-commit-stash-conflict-with-auto-fix-hooks": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-pre-commit-stash-conflicts-when-any-tracked-unstaged-file": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-pre-committed-decision-matrices-survive-contact-with-data": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-pre-flight-pre-commits-pinned-black-ruff-on-new-files-before": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-prefer-github-actions-trusted-publishing-over-local-twine-uv": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-provenance-citation-records-usually-store-short-previews-not": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-pull-main-before-merging-develop-to-avoid-merge-commits": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-pureposixpath-match-doesnt-support-in-python-3-10": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-pureposixpath-strips-trailing-slashes": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-push-specific-tags-not-tags": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-pypi-env-policies-may-whitelist-branches-only-tag-triggered": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-pypi-renders-readme-links-relative-to-its-own-domain": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-pypi-trusted-publisher-workflow-name-field-wants-the-filename": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-pytest-importorskip-triggers-ruff-e402": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-query-fixtures-are-self-diagnostic-for-rag-corpora-even-without": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-rag-grounding": {
     "source": "content/features/rag-grounding.md",
     "hash": "3464dd78c83f06980912a7c49dc185b09830be1b1c163203f10e5aa1708fcf4e",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-re-adding-an-import-after-the-formatter-strips-it-use-function": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-re-enabling-required-reviews-kills-queued-auto-merge": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-read-source-before-writing-tests-for-tricky-logic": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-rebuild-dist-after-readme-changes": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-reclassify-unexpectedly-hard-golden-queries-up-the-difficulty": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-redisshorttermmemory-mock-injection-path": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-refactor-plan": {
     "source": "content/features/refactor-plan.md",
     "hash": "8f8c684cd94fca7b2580ecaaf955ccb79924022796d576d477cdab9330df9704",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-registry-count-assertions-are-scattered-across-test-files": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-release-branches-carry-unmerged-commits-that-feature-branches": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-release-notes": {
     "source": "content/features/release-notes.md",
     "hash": "da7101ffbec4d209fcb1cef754f01cef8a13458a6f961c3a23909edfec77e58c",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-release-prep": {
     "source": "content/features/release-prep.md",
     "hash": "cd77b5903fbeb7d7e0acef570bab9727b4c143181ea6be1f52b9a25bc11418bb",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-release-published-workflow-dispatch-both-approved-for-pypi-env": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-removing-one-workspace-dep-can-cascade-to-remove-others": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-replacing-a-mixin-based-class-scatters-test-failures-across": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-repo-merge-policy-may-restrict-merge-strategies": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-repo-root-parents-count-varies-by-file-depth": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-required-status-check-names-must-match-githubs-exact-check-names": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-research-subagents-can-hallucinate-sdk-signatures-introspect": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-resilience": {
     "source": "content/features/resilience.md",
     "hash": "ae2a76f0f1ecbb9ca687e5a041acc2b4a25a5113ec57eaad550f48b8aadc4be2",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-resultmessage-result-is-often-none-capture-assistantmessage": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-rich-live-is-output-only-use-textual-for-any-interactive-row": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-ruff-auto-fix-strips-imports-before-usage-code-exists": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-run-simplify-catches-per-file-errors-internally": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-sbin-is-a-symlink-to-usr-sbin-on-modern-ubuntu": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-sdk-adapter-swallows-subagent-findings-lesson-was-wrong-adapter": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-sdk-agent-model-config-uses-stale-model-names": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-sdk-native-workflows-validate-in-execute-not-input-schema": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-security-audit": {
     "source": "content/features/security-audit.md",
     "hash": "9cce18573c827fab9a380efe8c65c2f8c5b4ada3f7e383dd71ec523a0875fb05",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-semantic-cache-70-hit-rate-claim-was-unmeasured": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-session-handoff": {
     "source": "content/features/session-handoff.md",
     "hash": "236c16ee2d2e48f0bd8ba075c69f50ead16a46ef185fede3d84b529c66fd41a0",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-session-hooks-may-be-vestigial": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-shadow-directories-at-repo-root-break-imports": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-silent-pass-blocks-in-discovery-registry-code-hide-import": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-skill-descriptions-must-be-under-250-characters": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-skill-frontmatter-has-a-strict-allowlist": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-smart-test": {
     "source": "content/features/smart-test.md",
     "hash": "58c691c8313ddf9699deb913e6b5c50fafc684563539ddf4816a4b94a9ea3e80",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-spec-engine": {
     "source": "content/features/spec-engine.md",
     "hash": "c8549016aa848eeeaecbde8329f5850562f56280ab66428cb7c20887b428d81a",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-squash-merge-deletes-the-remote-branch-subsequent-push-silently": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-ssrf-always-decode-urls-before-validating-hostnames": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-ssrf-strip-ipv6-zone-ids-before-ip-validation": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-stacked-patch-decorators-inject-args-bottom-up": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-staleness-detection-in-attune-author-attune-ais-help-system-is": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-stop-hooks-inject-stderr-not-stdout": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-stop-hooks-loop-without-a-sentinel": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-stop-hooks-missing-cd-prefix-inherit-session-cwd": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-structlog-default-output-pollutes-stdout-captured-cli-tests": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-structlog-kwargs-vs-stdlib-logger": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-tags-pushed-before-squash-merge-point-to-the-wrong-commit": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-telemetry": {
     "source": "content/features/telemetry.md",
     "hash": "59473ab809113116a3d58d2ead3a5f13e362d6992d8cee0a89364feded5cbd50",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-template-generators-overwrite-hand-written-files": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-test-mocks-must-match-imports": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-tests-for-optional-dep-code-need-pytest-importorskip-guards-in": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-text-white-on-gradient-primary-sections-gets-overridden": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-two-codeql-setups-can-coexist-in-one-repo-and-deadlock-merges": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-uncommitted-claude-mcp-json-means-mcp-server-never-starts": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-untracked-scripts-break-ci-when-tests-import-them": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-unused-init-py-re-exports-become-invisible-runtime-deps": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-use-dataclass-post-init-to-coalesce-between-a-scalar-legacy": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-uv-lock-can-drift-from-pyproject-toml-on-shared-branches": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-uv-lock-retains-editable-name-paths-after-tool-uv-sources-edits": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-uv-pip-install-e-path-can-ship-stale-package-data-even-after": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-uv-pip-install-e-sibling-path-no-deps-is-the-clean-venv-local": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-uv-run-in-pre-commit-hooks-propagates-lockfile-errors-as-hook": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-uv-sync-wipes-packages-installed-via-pip-install": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-validate-infrastructure-against-user-value-before-extending": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-verify-new-dispatch-branches-with-a-known-fixture-not-just": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-version-bumps-must-update-7-files-not-just-pyproject-toml": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-website-feature-lists-can-diverge-from-the-python-registry": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-windows-ci-encoding": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-windows-ci-runners-are-3x-slower-than-ubuntu-macos": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-windows-time-time-can-return-0-0-duration-for-fast-operations": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-wizards": {
     "source": "content/features/wizards.md",
     "hash": "6fe7722a026d11276ebfbdf4ea046a05112be94b560f9abf3ffee410f8637d8f",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-wizards-call-workflows-internally-they-are-not-duplicates": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-workflowresult-constructor-mismatches-surface-only-at-runtime": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-yaml-run-block-scalars-break-on-blank-lines-inside-multi-line": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-yaml-run-values-with-colons-cause-parse-errors": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   },
   "war-zsh-has-status-as-a-read-only-builtin-variable": {
     "source": ".claude/CLAUDE.md",
-    "hash": "419bb170341fda31f865346c0ce4f9f25b6c732582b9279f704708989da35742",
-    "generated_at": "2026-07-29T00:49:32.702020+00:00"
+    "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
+    "generated_at": "2026-07-30T21:39:09.594518+00:00"
   }
 }


### PR DESCRIPTION
## What

New user-facing tutorial: **fix a failing test with `/fix-test`, then make the loop automatic** — plus its `.help` integration and nav entry.

- `docs/tutorials/fix-test.md` — three parts: reproduce the failure, run the `/fix-test` skill (scoping questions, root-cause classes, 3-attempt loop, honest report — including the "assertion-update deserves a skeptical read" caution), then wire a Claude Code `PostToolUse` hook that runs the matching test after every `Edit|Write`. Failures return to Claude as exit-2 stderr, so the session that broke the test fixes it immediately.
- `mkdocs.yml` — nav entry under Tutorials.
- `.help/templates/fix-test/quickstart.md` — "fastest path" section pointing at `/fix-test` and the tutorial, ahead of the existing Python-API quickstart (feature is `status: manual`; hand-authoring is the sanctioned path).

## Receipts

**The embedded hook script is live-verified, not aspirational**: extracted verbatim from the page's code fence and executed against a scratch project —

| Path | Result |
|---|---|
| Edit with passing tests | exit 0, silent |
| Edit that breaks a test | exit 2, pytest tail on stderr + guidance |
| Edit to a test file (loop guard) | exit 0 |
| Edit with no matching test | exit 0 |

The example failure output in Part 1 (`assert 90.0 == 85.0`) is the actual output of that run. Code fences import stdlib only — doc-import gate clean.

Companion delivered in-session (not in this diff): a Screen Studio shooting script for the video version — 6 clips, ~4–5 min cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
