### PR TITLE
docs(specs): capture two candidates — lane-yield cap (unruled) + hooks-install

### DIFF
--- a/docs/specs/hooks-install/requirements.md
+++ b/docs/specs/hooks-install/requirements.md
@@ -1,0 +1,66 @@
+# Hooks Install — Requirements (CANDIDATE)
+
+**Status:** draft (2026-07-30) — spec CANDIDATE captured at
+Patrick's request; a `/spec` interview re-derives requirements from
+this brainstorm input. Do not implement from this document.
+**Slug:** `hooks-install`
+**Provenance:** 2026-07-30 fix-test tutorial session (PR #1798 +
+Screen Studio shooting script). The tutorial's automation chapter
+teaches users to hand-copy a ~40-line PostToolUse hook script plus
+a settings.json block; the session retro named the product gap:
+"the tutorial teaches a hook that attune doesn't actually ship."
+
+## Problem (motivating evidence)
+
+The tests-on-edit loop (run the matching test after every
+`Edit|Write`, route failures back to Claude as exit-2 stderr) is
+the highest-leverage automation attune currently documents — and
+its install path is two manual copy-pastes into the user's repo.
+The tutorial and its video create demand for exactly this pattern;
+every viewer who wants it must transcribe code from a doc. attune
+already ships a hooks runtime (`plugin/hooks/hooks.json`,
+`src/attune/hooks/scripts/`) but has no way to install a hook INTO
+a user's project.
+
+## Sketch (one line)
+
+`attune hooks install tests-on-edit` — copies the hook script into
+the project's `.claude/hooks/` and merges the `PostToolUse` entry
+into `.claude/settings.json`, idempotently; `attune hooks list` /
+`attune hooks uninstall <name>` complete the lifecycle.
+
+## Pre-listed /spec interview questions
+
+1. **Catalog scope** — is `tests-on-edit` the only launch hook, or
+   does a catalog shape the design from day one (format-on-save,
+   lessons-reminder, etc.)? Smallest-viable vs. registry.
+2. **settings.json merge strategy** — programmatically editing a
+   user's `.claude/settings.json` is the riskiest surface (comments
+   are lost, existing hooks blocks must merge, a bad write breaks
+   every session). Merge in place, emit a paste-ready diff, or
+   write a separate include if the harness supports one?
+3. **Script placement** — copy the script into the user's repo
+   (vendored, user-editable, drift-prone) vs. reference the
+   installed attune package path (upgrades propagate, but the hook
+   breaks if attune is uninstalled)?
+4. **Test-mapping convention** — the tutorial's glob
+   (`tests/**/test_<stem>*.py`) is one line by design; does install
+   prompt for the project's convention (Socratic scoping) or ship
+   the default with a documented edit point?
+5. **Uninstall/upgrade story** — what marks a managed hook as
+   attune-installed so uninstall removes only what install added,
+   and upgrade can re-write it?
+6. **Interaction with plugin hooks** — the attune plugin already
+   registers its own hooks via `plugin/hooks/hooks.json`; installed
+   project hooks must not collide or double-fire.
+7. **Security posture** — an installer that writes executable hook
+   code into repos needs the path-validation gate treatment and
+   security tests (Critical Rules); does it also need a dry-run
+   default?
+
+## Non-goals (candidate-stage)
+
+- Not a general hook framework or marketplace — attune-authored
+  hooks only.
+- No daemon/watcher; Claude Code's hook runtime is the only
+  execution surface.

--- a/docs/specs/test-quality-program/decisions.md
+++ b/docs/specs/test-quality-program/decisions.md
@@ -784,3 +784,38 @@ with a dated tombstone comment. Module now **100.00%** under the repo
 exclude rules. No client mocking was ever needed — Tier-2 rank 1 cost
 ~an hour, not the estimated mocking effort. Next Tier-2 pick:
 `monitoring/otel_backend.py`.
+
+## Candidate policy — lane yield weighting + a 90% routine cap (2026-07-30, UNRULED)
+
+**Status: chair decision candidate, captured at Patrick's request —
+not a ruling. Nothing changes until ruled.**
+
+Evidence from the 2026-07-30 modules-needing-work session (#1788,
+#1791–#1796): ~260 new tests across 14 modules produced ONE real
+production bug (the `attune.ops` Config-shadowing find — from the
+cheapest lane, the Tier 3 shims, not the big clusters). That is ~7%
+of modules vs the program's historical ~22% bug-find rate — and the
+delta is consistent with D14's freshness thesis
+(feature-lead-governance): settled, mock-heavy modules yield less
+per test than recently-churned code.
+
+**Candidate (two parts):**
+
+1. **Pick-order weighting** — `scripts/modules_needing_work.py`
+   ranks lane candidates by miss-volume alone; add bug-find
+   likelihood signals (recent churn via `git log --since`, module
+   age, seam density) so lanes chase yield, not just coverage
+   points.
+2. **A ~90% routine-lane cap** — stop routine lanes at ~90% instead
+   of 100%; the last ten points are mostly error-path theater on
+   settled code.
+
+**Counter-case (carried per COUNTER-CASE discipline):**
+coverage-as-floor is a RATCHET, and ratchets work because they are
+not negotiated per-module. A cap invites lane-by-lane drift and
+weakens the "modules at 100%" accounting that the bug log's
+find-rate denominator depends on. If adopted, the cap must be a
+deliberate ruled policy with a bright line (e.g. "routine lanes
+target 90%; 100% remains the bar for modules touched by a bug fix"),
+never an ad-hoc stopping point. Also: tonight's 7% is one session's
+n=14 — a chair may reasonably want one more session of data first.


### PR DESCRIPTION
Captured from tonight's retro at Patrick's request. Docs-only, both explicitly non-binding:

1. **test-quality-program/decisions.md** — UNRULED candidate: pick-order bug-find-likelihood weighting + a ~90% routine-lane cap, with tonight's yield evidence (1 bug / ~260 tests / 14 settled modules ≈ 7% vs the historical 22%) and the ratchet **counter-case carried** (a cap invites per-module drift; if adopted it needs a bright line, e.g. 100% stays the bar for bug-fix-touched modules). Chair rules; nothing changes until then.
2. **docs/specs/hooks-install/requirements.md** — spec CANDIDATE (docs-outbox pattern) for `attune hooks install tests-on-edit`, productizing the fix-test tutorial's copy-paste hook. 7 pre-listed /spec interview questions (settings.json merge strategy is the risk center); do-not-implement-from-draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)