### PR TITLE
fix(cli): normalize fix-receipt paths to POSIX (latent Windows scope bug)

### DIFF
--- a/src/attune/cli_commands/fix_commands.py
+++ b/src/attune/cli_commands/fix_commands.py
@@ -246,12 +246,11 @@ def _run_fix(args: Namespace, contract: FixContract, selected: str) -> int:
     # with like — a `./pricing.py` or absolute spelling must never
     # read as an out-of-scope violation (codex D11 lane finding).
     resolved_scope = Path(scope).resolve()
-    try:
-        scope_rel = resolved_scope.relative_to(repo_root)
-    except ValueError:
-        print(f"cannot run: --scope {scope!r} resolves outside the repo root {repo_root}")
-        return EXIT_CLI_ERROR
-    scope_paths = [scope_rel]
+    # `build_contract` already rejected any scope outside the repo via
+    # `_validate_file_path`, so `relative_to` cannot raise here — no
+    # second guard (it would be unreachable, and an unreachable guard
+    # is worse than none: it reads as protection that never fires).
+    scope_paths = [resolved_scope.relative_to(repo_root)]
     baseline = capture_baseline(repo_root, scope_paths)
 
     workflow_cls = get_workflow(selected)

--- a/src/attune/cli_commands/fix_receipt.py
+++ b/src/attune/cli_commands/fix_receipt.py
@@ -144,7 +144,10 @@ def capture_baseline(repo_root: Path, scope_paths: list[Path]) -> Baseline:
     lane finding).
     """
     dirty, git_ok = _git_dirty_paths(repo_root)
-    to_hash = {str(p) for p in scope_paths} | dirty
+    # POSIX form throughout: git porcelain emits forward slashes on
+    # every platform, so str(WindowsPath("a/b")) -> "a\\b" would never
+    # match and every nested scope path would read as a violation.
+    to_hash = {Path(p).as_posix() for p in scope_paths} | dirty
     hashes = {p: _hash_file(repo_root / p) for p in sorted(to_hash)}
     return Baseline(
         repo_root=repo_root, dirty_paths=dirty, scope_hashes=hashes, git_available=git_ok
@@ -251,7 +254,7 @@ def assemble_receipt(
 ) -> FixReceipt:
     """Compute the receipt from the baseline diff + probe evidence."""
     dirty_now, git_ok = _git_dirty_paths(baseline.repo_root)
-    scope_strs = {str(p) for p in scope_paths}
+    scope_strs = {Path(p).as_posix() for p in scope_paths}  # see capture_baseline
 
     attributed = _attributed_paths(baseline, git_ok, dirty_now)
     # A baseline-dirty file the run modified FURTHER is attributed

--- a/src/attune/ops/workflow_concern.py
+++ b/src/attune/ops/workflow_concern.py
@@ -6,7 +6,7 @@ and returns one of seven concern bucket labels:
 - ``review``  — code-review, deep-review, security-audit, bug-predict
 - ``test``    — test-gen, test-audit
 - ``docs``    — doc-gen, doc-audit, doc-orchestrator
-- ``refactor``— simplify-code, refactor-plan
+- ``refactor``— simplify-code, refactor-plan, fix
 - ``audit``   — discovery-sweep, perf-audit, dependency-check
 - ``meta``    — release-prep, secure-release, orchestrated-health-check, health-check
 - ``other``   — rag-code-gen, research-synthesis

--- a/tests/unit/cli_commands/test_fix_receipt.py
+++ b/tests/unit/cli_commands/test_fix_receipt.py
@@ -438,3 +438,59 @@ def test_scope_paths_accepts_bare_string_from_ops_runner(
 
     result = asyncio.run(FixWorkflow().execute(goal="g", scope_paths=str(target)))
     assert result.metadata["scope_paths"] == [str(target)]
+
+
+def test_nested_scope_path_is_not_a_false_violation(
+    fix_repo: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Regression: scope paths were compared as `str(Path(...))`, which
+    is backslash-separated on Windows, while git porcelain always emits
+    forward slashes — so any NESTED scope path read as an out-of-scope
+    violation and forced exit 1 on a correct fix. The original fixture
+    used a flat `pricing.py` (identical under both conventions), so the
+    Windows lanes passed while the bug was live.
+    """
+    pkg = fix_repo / "pkg"
+    pkg.mkdir()
+    (pkg / "pricing.py").write_text((fix_repo / "pricing.py").read_text())
+    subprocess.run(
+        ["git", "-c", "user.email=t@t", "-c", "user.name=t", "add", "."],
+        cwd=fix_repo,
+        check=True,
+    )
+    subprocess.run(
+        ["git", "-c", "user.email=t@t", "-c", "user.name=t", "commit", "-qm", "nested"],
+        cwd=fix_repo,
+        check=True,
+    )
+
+    class _StubFixesNested:
+        async def execute(self, **kwargs):
+            t = Path.cwd() / "pkg" / "pricing.py"
+            t.write_text(
+                t.read_text().replace("if units > BULK_THRESHOLD", "if units >= BULK_THRESHOLD")
+            )
+            return SimpleNamespace(success=True, metadata={})
+
+    _install_stub(monkeypatch, _StubFixesNested)
+    code = cmd_fix(
+        _args(
+            scope="pkg/pricing.py",
+            probe=[f"{PY} -c 'raise SystemExit(0)'".replace("'", '"')],
+        )
+    )
+    out = capsys.readouterr().out
+    assert "SCOPE VIOLATIONS" not in out, out
+    assert code == 0, out
+    # Attribution is recorded in POSIX form, matching git's output.
+    assert "pkg/pricing.py" in out
+
+
+def test_baseline_hash_keys_are_posix_form(fix_repo: Path) -> None:
+    """Baseline keys must match git porcelain's forward-slash form."""
+    pkg = fix_repo / "pkg"
+    pkg.mkdir()
+    (pkg / "mod.py").write_text("x = 1\n")
+    baseline = capture_baseline(fix_repo, [Path("pkg") / "mod.py"])
+    assert "pkg/mod.py" in baseline.scope_hashes
+    assert not any("\\" in k for k in baseline.scope_hashes)

--- a/tests/unit/cli_commands/test_fix_receipt.py
+++ b/tests/unit/cli_commands/test_fix_receipt.py
@@ -494,3 +494,103 @@ def test_baseline_hash_keys_are_posix_form(fix_repo: Path) -> None:
     baseline = capture_baseline(fix_repo, [Path("pkg") / "mod.py"])
     assert "pkg/mod.py" in baseline.scope_hashes
     assert not any("\\" in k for k in baseline.scope_hashes)
+
+
+# ---------------------------------------------------------------
+# Error paths (codecov gap review) — each is reachable and each
+# asserts BEHAVIOR, not merely that the line executed.
+# ---------------------------------------------------------------
+
+
+def test_whitespace_only_probe_is_rejected() -> None:
+    """`--probe "   "` shlex-splits to [] — must abstain, not crash."""
+    from attune.cli_commands.fix_commands import build_contract
+
+    contract, error = build_contract(_args(probe=["   "], run=False))
+    assert contract is None
+    assert error is not None and "empty" in error
+
+
+def test_cmd_fix_reports_contract_failure_through_the_command(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The contract-rejection branch inside cmd_fix (not build_contract)."""
+    assert cmd_fix(_args(probe=[], run=False)) == 3
+    out = capsys.readouterr().out
+    assert "cannot preview:" in out
+    assert "--probe" in out
+
+
+def test_git_binary_missing_degrades_not_raises(
+    fix_repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """No git on PATH -> git_available False, never an exception."""
+    import attune.cli_commands.fix_receipt as module
+
+    def _boom(*a, **k):
+        raise OSError("git not found")
+
+    monkeypatch.setattr(module.subprocess, "run", _boom)
+    baseline = capture_baseline(fix_repo, [Path("pricing.py")])
+    assert baseline.git_available is False
+    assert baseline.dirty_paths == set()
+
+
+def test_git_nonzero_exit_degrades(tmp_path: Path) -> None:
+    """`git status` failing (not a repo) degrades to hash-only."""
+    from attune.cli_commands.fix_receipt import _git_dirty_paths
+
+    paths, ok = _git_dirty_paths(tmp_path)
+    assert ok is False
+    assert paths == set()
+
+
+def test_probe_oserror_records_skipped_with_reason(
+    fix_repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A probe that dies mid-spawn is SKIPPED with the reason, not lost."""
+    import attune.cli_commands.fix_receipt as module
+    from attune.cli_commands.fix_commands import VerificationProbe
+
+    def _boom(*a, **k):
+        raise OSError("spawn failed")
+
+    monkeypatch.setattr(module.subprocess, "run", _boom)
+    outcomes = run_probes([VerificationProbe(argv=["anything"])], cwd=fix_repo)
+    assert outcomes[0].status == "SKIPPED"
+    assert "spawn failed" in outcomes[0].reason
+
+
+def test_scope_guard_denies_when_path_cannot_resolve(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Unresolvable path must DENY (fail closed), never allow."""
+    import attune.workflows.fix_workflow as module
+
+    guard = make_edit_scope_guard([tmp_path])
+
+    def _boom(self):
+        raise OSError("cannot resolve")
+
+    monkeypatch.setattr(module.Path, "resolve", _boom)
+    decision = asyncio.run(guard({"tool_input": {"file_path": "whatever.py"}}, None, None))
+    assert decision["hookSpecificOutput"]["permissionDecision"] == "deny"
+
+
+def test_porcelain_parser_handles_short_and_rename_lines(
+    fix_repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Parser contract against crafted porcelain: degenerate short
+    lines are skipped, renames yield BOTH paths, normal lines pass."""
+    import attune.cli_commands.fix_receipt as module
+    from attune.cli_commands.fix_receipt import _git_dirty_paths
+
+    crafted = " M src/real.py\n??\n\nR  old.py -> new.py\n"
+    monkeypatch.setattr(
+        module.subprocess,
+        "run",
+        lambda *a, **k: SimpleNamespace(returncode=0, stdout=crafted, stderr=""),
+    )
+    paths, ok = _git_dirty_paths(fix_repo)
+    assert ok is True
+    assert paths == {"src/real.py", "old.py", "new.py"}


### PR DESCRIPTION
Follow-up to #1811.

## The bug

`assemble_receipt` and `capture_baseline` compared scope paths as `str(Path(...))`. Git porcelain emits **forward slashes on every platform**; `str(WindowsPath("pkg/mod.py"))` is `pkg\\mod.py`. They never match — so on Windows any **nested** scope path was classified as an out-of-scope violation, printing SCOPE VIOLATIONS and exiting 1 on a perfectly correct fix.

## Why CI was green

The fixture used a flat `pricing.py` — no separator, identical under both conventions. All five Windows lanes passed on #1811 while the bug was live. Green lanes, latent bug.

## Receipts

- Both sites normalized with `.as_posix()`.
- New `test_nested_scope_path_is_not_a_false_violation` — **verified red-then-green** by temporarily forcing backslash separators to simulate Windows (fails: `SCOPE VIOLATIONS`; passes after the fix).
- New `test_baseline_hash_keys_are_posix_form` asserts keys match git's convention.
- 1956 tests green locally across cli_commands, ops, characterization, complexity ratchet.

Also fixes the `workflow_concern` module docstring, whose bucket listing still omitted `fix`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)