### PR TITLE
feat(fix): outcome-first-fix Phase 3 — receipt honesty, prompt-persistence evidence, docs, metrics

### DIFF
--- a/.help/features.yaml
+++ b/.help/features.yaml
@@ -222,6 +222,17 @@ features:
     tags: [tests, debugging, fixes]
     status: manual
 
+  # `fix` is the outcome-first CLI surface (`attune fix`), distinct
+  # from the `/fix-test` skill above — see content/features/fix.md for
+  # the relationship. Single-sourced from that master and rendered by
+  # scripts/project_features.py, so `status: manual` WITHOUT `files:`
+  # keeps maintenance from overwriting the projection with LLM output
+  # (same contract as mcp-server below, DD5).
+  fix:
+    description: Outcome-first fixes — state the goal and its probes, get a verified receipt
+    tags: [fixes, verification, cli]
+    status: manual
+
   # mcp-server is single-sourced (status: manual) from
   # content/features/mcp-server.md and rendered by
   # attune_author.projector (scripts/project_features.py), which owns

--- a/.help/templates/fix/comparison.md
+++ b/.help/templates/fix/comparison.md
@@ -1,0 +1,24 @@
+---
+type: comparison
+name: fix-comparison
+feature: fix
+depth: comparison
+generated_at: 2026-07-31T11:22:57.025655+00:00
+source_hash: 4069f8ae171ca3c4ccb53ebae95b598ce6d800fcd66ed605ccb4583f5d3f9290
+status: generated
+---
+
+# Outcome-first fixes — state the goal and its probes, get a verified receipt
+
+## Comparison
+
+| | `attune fix` | `/fix-test` skill | `attune workflow run` |
+|---|---|---|---|
+| Surface | CLI | Claude Code conversation | CLI |
+| You supply | goal + probes + scope | a failing test | workflow name + inputs |
+| Verification | probes run by the CLI, independently | the skill re-runs the test as it iterates | whatever the workflow reports |
+| Best for | a known outcome you want verified | a failure you want diagnosed | direct access to a specific workflow |
+
+`attune workflow run` is unchanged and remains the expert path.
+Outcome-first does not mean the internal machinery disappears — it
+means you should not *need* it.

--- a/.help/templates/fix/concept.md
+++ b/.help/templates/fix/concept.md
@@ -1,0 +1,82 @@
+---
+type: concept
+name: fix-concept
+feature: fix
+depth: concept
+generated_at: 2026-07-31T11:23:30.696651+00:00
+source_hash: 4069f8ae171ca3c4ccb53ebae95b598ce6d800fcd66ed605ccb4583f5d3f9290
+status: generated
+---
+
+# Outcome-first fixes — state the goal and its probes, get a verified receipt
+
+## Overview
+
+`attune fix` is the outcome-first entry point: you state **what should
+be true** and **how to check it**, and Attune reports what it actually
+did with evidence. You do not pick a workflow tier, write a prompt, or
+read an internal report format.
+
+Two artifacts carry the whole surface:
+
+- the **contract** — your goal, its done conditions, the scope the fix
+  may touch, and one or more verification **probes** (each an argv
+  list, never a shell string);
+- the **receipt** — what changed (attributed against a pre-run
+  baseline), which probes ran with their exact argv and exit codes,
+  what remains uncertain, and the safest next action.
+
+The rule that makes the receipt worth reading: **the workflow's own
+exit never decides success.** Probes are executed by the CLI after the
+fix agent finishes, in a real subprocess, and their results alone set
+the exit code.
+
+> **Scope — `attune fix` vs the `/fix-test` skill.** These are
+> different surfaces and neither replaces the other. **`attune fix`**
+> is a CLI command: you supply the goal and the probes, and it returns
+> a verified receipt. **`/fix-test`** is a skill on the Claude Code
+> conversational surface that auto-diagnoses failing tests and iterates
+> on them for you. Reach for `/fix-test` when you want the diagnosis
+> done for you in conversation; reach for `attune fix` when you already
+> know the outcome you want and need it verified and attributed.
+
+## Concepts
+
+### The contract is data, not a prompt
+
+`FixContract` holds the goal verbatim — no inference — plus done
+conditions, constraints, and probes. It is an **internal** boundary
+DTO: no JSON schema is emitted and no import stability is promised
+outside `attune.*`. It stays internal until at least two outcome
+intents demonstrate identical semantics.
+
+### Probes are argv, and they are the authority
+
+`VerificationProbe` holds an argv list and an expected exit code.
+Probe strings containing shell metacharacters (`;` `|` `&` `<` `>`
+`` ` `` `$`) are rejected outright rather than silently treated as
+literals — probes are never run through a shell. Every probe runs
+through `subprocess.run` **after** the fix, and the receipt records the
+argv, return code, and duration as provenance.
+
+A probe that cannot run records `SKIPPED` with a reason and appears
+under remaining uncertainty. It never silently counts as a pass.
+
+### Scope is enforced twice
+
+Prevention: the fix workflow installs a `PreToolUse` guard that denies
+`Edit`/`Write` outside the contract's scope paths at tool-call time.
+Detection: the receipt re-checks the post-run diff against the pre-run
+baseline and reports any out-of-scope path as a violation, forcing a
+non-zero exit.
+
+### Attribution is measured from a pre-run baseline
+
+Before execution, `attune fix` snapshots the dirty-path set and content
+hashes. Only paths that changed **relative to that snapshot** are
+attributed to the run. Files you already had in flight are listed
+separately as pre-existing and are never named in revert advice.
+
+If git is unavailable, scope cannot be verified at all — the receipt
+says so and the run does not report success, because passing probes
+would prove the goal but not the scope constraint.

--- a/.help/templates/fix/error.md
+++ b/.help/templates/fix/error.md
@@ -1,0 +1,36 @@
+---
+type: error
+name: fix-error
+feature: fix
+depth: error
+generated_at: 2026-07-31T11:22:57.025655+00:00
+source_hash: 4069f8ae171ca3c4ccb53ebae95b598ce6d800fcd66ed605ccb4583f5d3f9290
+status: generated
+---
+
+# Outcome-first fixes — state the goal and its probes, get a verified receipt
+
+## Failure modes
+
+**"no verification probes given — cannot verify a fix"** — a fix with
+no probe cannot be verified, so the command abstains (exit 3) instead
+of running something it could not check. Add `--probe`.
+
+**"no --workflow given — selection abstains rather than guess"** — a
+false confident route is worse than an abstention. Pass `--workflow
+fix`.
+
+**"probe contains shell metacharacters"** — probes are argv lists.
+Rewrite the probe without pipes or redirection; if you need shell
+semantics, put them in a script and probe the script.
+
+**"cannot run: --run requires --scope"** — an unscoped fix has no edit
+boundary to enforce, so `--run` refuses.
+
+**"SCOPE NOT VERIFIED — no git available"** — attribution fell back to
+content hashes of the declared scope files, so edits elsewhere are
+undetectable. The run will not report success; review the tree by hand.
+
+**Probe reported `SKIPPED`** — the command could not be executed (most
+often a missing binary). This is uncertainty, not a pass; the exit code
+is non-zero.

--- a/.help/templates/fix/faq.md
+++ b/.help/templates/fix/faq.md
@@ -1,0 +1,43 @@
+---
+type: faq
+name: fix-faq
+feature: fix
+depth: faq
+generated_at: 2026-07-31T11:22:57.025655+00:00
+source_hash: 4069f8ae171ca3c4ccb53ebae95b598ce6d800fcd66ed605ccb4583f5d3f9290
+status: generated
+---
+
+# Fix FAQ
+
+## Does a successful workflow run mean my fix worked?
+
+No. The workflow's exit is never trusted. Only the probes, run
+independently by the CLI after the fix, decide the outcome.
+
+## What happens if the agent edits a file outside my scope?
+
+The edit is denied at tool-call time by a `PreToolUse` guard,
+and if anything still slipped through it is reported as a scope
+violation with a non-zero exit and a targeted revert as the next
+action.
+
+## Will my own uncommitted work get blamed on the run?
+
+No. Paths dirty before the run are attributed as pre-existing
+and are never named in revert advice.
+
+## Is `attune fix` the same as the `/fix-test` skill?
+
+No. `/fix-test` diagnoses failing tests conversationally in
+Claude Code; `attune fix` takes an outcome you have already defined
+and returns a verified, attributed receipt from the CLI.
+
+## Is my request text stored anywhere?
+
+The `attune fix` command persists nothing — the contract lives
+for the length of the run.
+
+## Can I use it without a scope?
+
+Only for previews. `--run` requires `--scope`.

--- a/.help/templates/fix/note.md
+++ b/.help/templates/fix/note.md
@@ -1,0 +1,95 @@
+---
+type: note
+name: fix-note
+feature: fix
+depth: note
+generated_at: 2026-07-31T11:22:57.025655+00:00
+source_hash: 4069f8ae171ca3c4ccb53ebae95b598ce6d800fcd66ed605ccb4583f5d3f9290
+status: generated
+---
+
+# Outcome-first fixes — state the goal and its probes, get a verified receipt
+
+## Overview
+
+`attune fix` is the outcome-first entry point: you state **what should
+be true** and **how to check it**, and Attune reports what it actually
+did with evidence. You do not pick a workflow tier, write a prompt, or
+read an internal report format.
+
+Two artifacts carry the whole surface:
+
+- the **contract** — your goal, its done conditions, the scope the fix
+  may touch, and one or more verification **probes** (each an argv
+  list, never a shell string);
+- the **receipt** — what changed (attributed against a pre-run
+  baseline), which probes ran with their exact argv and exit codes,
+  what remains uncertain, and the safest next action.
+
+The rule that makes the receipt worth reading: **the workflow's own
+exit never decides success.** Probes are executed by the CLI after the
+fix agent finishes, in a real subprocess, and their results alone set
+the exit code.
+
+> **Scope — `attune fix` vs the `/fix-test` skill.** These are
+> different surfaces and neither replaces the other. **`attune fix`**
+> is a CLI command: you supply the goal and the probes, and it returns
+> a verified receipt. **`/fix-test`** is a skill on the Claude Code
+> conversational surface that auto-diagnoses failing tests and iterates
+> on them for you. Reach for `/fix-test` when you want the diagnosis
+> done for you in conversation; reach for `attune fix` when you already
+> know the outcome you want and need it verified and attributed.
+
+## Concepts
+
+### The contract is data, not a prompt
+
+`FixContract` holds the goal verbatim — no inference — plus done
+conditions, constraints, and probes. It is an **internal** boundary
+DTO: no JSON schema is emitted and no import stability is promised
+outside `attune.*`. It stays internal until at least two outcome
+intents demonstrate identical semantics.
+
+### Probes are argv, and they are the authority
+
+`VerificationProbe` holds an argv list and an expected exit code.
+Probe strings containing shell metacharacters (`;` `|` `&` `<` `>`
+`` ` `` `$`) are rejected outright rather than silently treated as
+literals — probes are never run through a shell. Every probe runs
+through `subprocess.run` **after** the fix, and the receipt records the
+argv, return code, and duration as provenance.
+
+A probe that cannot run records `SKIPPED` with a reason and appears
+under remaining uncertainty. It never silently counts as a pass.
+
+### Scope is enforced twice
+
+Prevention: the fix workflow installs a `PreToolUse` guard that denies
+`Edit`/`Write` outside the contract's scope paths at tool-call time.
+Detection: the receipt re-checks the post-run diff against the pre-run
+baseline and reports any out-of-scope path as a violation, forcing a
+non-zero exit.
+
+### Attribution is measured from a pre-run baseline
+
+Before execution, `attune fix` snapshots the dirty-path set and content
+hashes. Only paths that changed **relative to that snapshot** are
+attributed to the run. Files you already had in flight are listed
+separately as pre-existing and are never named in revert advice.
+
+If git is unavailable, scope cannot be verified at all — the receipt
+says so and the run does not report success, because passing probes
+would prove the goal but not the scope constraint.
+
+## Notes & tips
+
+- Preview first. The preview costs nothing and catches malformed probes
+  before a run.
+- Prefer plural probes that are distinct from the fix target — a target
+  probe plus a suite probe plus a scope constraint is the shape that
+  actually proves something.
+- The receipt distinguishes "changed nothing and the conditions already
+  held" from "fixed and verified". If you see the former, check that
+  your goal described a real gap.
+- Probe subprocesses run with bytecode and pytest-cache writes disabled
+  so their own artifacts are never mistaken for the fix's changes.

--- a/.help/templates/fix/quickstart.md
+++ b/.help/templates/fix/quickstart.md
@@ -1,0 +1,35 @@
+---
+type: quickstart
+name: fix-quickstart
+feature: fix
+depth: quickstart
+generated_at: 2026-07-31T11:22:57.025655+00:00
+source_hash: 4069f8ae171ca3c4ccb53ebae95b598ce6d800fcd66ed605ccb4583f5d3f9290
+status: generated
+---
+
+# Outcome-first fixes — state the goal and its probes, get a verified receipt
+
+## Quickstart
+
+Preview a fix without executing anything (the default — nothing runs,
+nothing is written):
+
+```bash
+attune fix "boundary order must price as bulk" --probe "python -m pytest tests/test_pricing.py -q"
+```
+
+Execute it, scoped to one file:
+
+```bash
+attune fix "boundary order must price as bulk" --workflow fix --scope src/pricing.py --probe "python -m pytest tests/test_pricing.py -q" --run
+```
+
+Read the exit code:
+
+| Exit | Meaning |
+|---|---|
+| 0 | every probe passed, scope held, and scope was verifiable |
+| 1 | the run completed but a done condition failed or could not be verified |
+| 2 | the workflow crashed (a partial receipt is still printed) |
+| 3 | CLI error or abstention — nothing ran |

--- a/.help/templates/fix/reference.md
+++ b/.help/templates/fix/reference.md
@@ -1,0 +1,46 @@
+---
+type: reference
+name: fix-reference
+feature: fix
+depth: reference
+generated_at: 2026-07-31T11:22:57.025655+00:00
+source_hash: 4069f8ae171ca3c4ccb53ebae95b598ce6d800fcd66ed605ccb4583f5d3f9290
+status: generated
+---
+
+# Outcome-first fixes — state the goal and its probes, get a verified receipt
+
+## Reference
+
+### CLI
+
+`attune fix "<request>" [--probe CMD]... [--workflow NAME] [--scope PATH] [--explain] [--run]`
+
+| Flag | Effect |
+|---|---|
+| `--probe CMD` | A verification command as an argv string. Repeatable. At least one is required. |
+| `--workflow NAME` | Which registered workflow performs the fix. Without it, selection **abstains** and lists candidates rather than guessing. `--run` accepts only `fix`. |
+| `--scope PATH` | Bound the edit surface. Required with `--run`. |
+| `--explain` | Preview only, suppressing the "pass --run" notice. |
+| `--run` | Execute the contract, then verify it independently. |
+
+### Python
+
+`attune.cli_commands.fix_commands` — `FixContract`,
+`VerificationProbe`, `build_contract(args)`, `cmd_fix(args)`.
+
+`attune.cli_commands.fix_receipt` — `capture_baseline(repo_root,
+scope_paths)`, `run_probes(probes, cwd)`, `assemble_receipt(contract,
+baseline, scope_paths, probe_outcomes)`, and the `ProbeOutcome` /
+`FixReceipt` dataclasses. `FixReceipt.exit_code()` returns 0 only when
+every probe passed, no scope violation was found, **and** scope was
+verifiable.
+
+`attune.workflows.fix_workflow` — `FixWorkflow` (registered as `fix`)
+and `make_edit_scope_guard(scope_paths)`.
+
+### Receipt sections
+
+`Changes made` · `Pre-existing changes` (when present) · `SCOPE
+VIOLATIONS` (when present) · `Probes (evaluated independently)` ·
+`Remaining uncertainty` (when present) · `Safest next action`.

--- a/.help/templates/fix/task.md
+++ b/.help/templates/fix/task.md
@@ -1,0 +1,49 @@
+---
+type: task
+name: fix-task
+feature: fix
+depth: task
+generated_at: 2026-07-31T11:22:57.025655+00:00
+source_hash: 4069f8ae171ca3c4ccb53ebae95b598ce6d800fcd66ed605ccb4583f5d3f9290
+status: generated
+---
+
+# Outcome-first fixes — state the goal and its probes, get a verified receipt
+
+## Tasks
+
+### Preview before you commit to a run
+
+Run without `--run`. The preview prints the goal, the derived done
+conditions, the constraints, and the validated probes, then states that
+nothing was executed. Use it to check that your probes say what you
+meant before spending a run.
+
+### Scope a fix to one file or directory
+
+Pass `--scope <path>`. The path is validated against the enclosing
+repository root, so any spelling — relative, absolute, or `./`-prefixed
+— resolves to the same place. A directory scope permits edits to its
+descendants. `--run` requires `--scope`: an unbounded fix is not
+runnable.
+
+### Verify with more than one probe
+
+Repeat `--probe`. Each probe becomes its own done condition, and the
+receipt reports each independently. Plural probes are the point — one
+probe that is also the fix target proves very little, whereas a target
+probe plus a full-suite probe plus a scope constraint tells you the fix
+worked *and* broke nothing.
+
+### Read a failed run
+
+When probes fail, the receipt names **every** failing probe with its
+exact command, so re-running verification is a copy-paste. If the run
+changed no files at all, the receipt says that plainly rather than
+advising you to inspect a diff that does not exist.
+
+### Recover from a scope violation
+
+The receipt lists the out-of-scope paths by name and the next action is
+a targeted revert. Pre-existing dirty paths are excluded from that
+advice by construction.

--- a/.help/templates/fix/tip.md
+++ b/.help/templates/fix/tip.md
@@ -1,0 +1,24 @@
+---
+type: tip
+name: fix-tip
+feature: fix
+depth: tip
+generated_at: 2026-07-31T11:22:57.025655+00:00
+source_hash: 4069f8ae171ca3c4ccb53ebae95b598ce6d800fcd66ed605ccb4583f5d3f9290
+status: generated
+---
+
+# Outcome-first fixes — state the goal and its probes, get a verified receipt
+
+## Notes & tips
+
+- Preview first. The preview costs nothing and catches malformed probes
+  before a run.
+- Prefer plural probes that are distinct from the fix target — a target
+  probe plus a suite probe plus a scope constraint is the shape that
+  actually proves something.
+- The receipt distinguishes "changed nothing and the conditions already
+  held" from "fixed and verified". If you see the former, check that
+  your goal described a real gap.
+- Probe subprocesses run with bytecode and pytest-cache writes disabled
+  so their own artifacts are never mistaken for the fix's changes.

--- a/.help/templates/fix/troubleshooting.md
+++ b/.help/templates/fix/troubleshooting.md
@@ -1,0 +1,36 @@
+---
+type: troubleshooting
+name: fix-troubleshooting
+feature: fix
+depth: troubleshooting
+generated_at: 2026-07-31T11:22:57.025655+00:00
+source_hash: 4069f8ae171ca3c4ccb53ebae95b598ce6d800fcd66ed605ccb4583f5d3f9290
+status: generated
+---
+
+# Outcome-first fixes — state the goal and its probes, get a verified receipt
+
+## Failure modes
+
+**"no verification probes given — cannot verify a fix"** — a fix with
+no probe cannot be verified, so the command abstains (exit 3) instead
+of running something it could not check. Add `--probe`.
+
+**"no --workflow given — selection abstains rather than guess"** — a
+false confident route is worse than an abstention. Pass `--workflow
+fix`.
+
+**"probe contains shell metacharacters"** — probes are argv lists.
+Rewrite the probe without pipes or redirection; if you need shell
+semantics, put them in a script and probe the script.
+
+**"cannot run: --run requires --scope"** — an unscoped fix has no edit
+boundary to enforce, so `--run` refuses.
+
+**"SCOPE NOT VERIFIED — no git available"** — attribution fell back to
+content hashes of the declared scope files, so edits elsewhere are
+undetectable. The run will not report success; review the tree by hand.
+
+**Probe reported `SKIPPED`** — the command could not be executed (most
+often a missing binary). This is uncertainty, not a pass; the exit code
+is non-zero.

--- a/.help/templates/fix/warning.md
+++ b/.help/templates/fix/warning.md
@@ -1,0 +1,36 @@
+---
+type: warning
+name: fix-warning
+feature: fix
+depth: warning
+generated_at: 2026-07-31T11:22:57.025655+00:00
+source_hash: 4069f8ae171ca3c4ccb53ebae95b598ce6d800fcd66ed605ccb4583f5d3f9290
+status: generated
+---
+
+# Outcome-first fixes — state the goal and its probes, get a verified receipt
+
+## Failure modes
+
+**"no verification probes given — cannot verify a fix"** — a fix with
+no probe cannot be verified, so the command abstains (exit 3) instead
+of running something it could not check. Add `--probe`.
+
+**"no --workflow given — selection abstains rather than guess"** — a
+false confident route is worse than an abstention. Pass `--workflow
+fix`.
+
+**"probe contains shell metacharacters"** — probes are argv lists.
+Rewrite the probe without pipes or redirection; if you need shell
+semantics, put them in a script and probe the script.
+
+**"cannot run: --run requires --scope"** — an unscoped fix has no edit
+boundary to enforce, so `--run` refuses.
+
+**"SCOPE NOT VERIFIED — no git available"** — attribution fell back to
+content hashes of the declared scope files, so edits elsewhere are
+undetectable. The run will not report success; review the tree by hand.
+
+**Probe reported `SKIPPED`** — the command could not be executed (most
+often a missing binary). This is uncertainty, not a pass; the exit code
+is non-zero.

--- a/content/features/fix.md
+++ b/content/features/fix.md
@@ -1,0 +1,277 @@
+---
+feature: fix
+summary: Outcome-first fixes — state the goal and its probes, get a verified receipt
+tags: [fixes, verification, cli]
+source_globs:
+  - src/attune/cli_commands/fix_commands.py
+  - src/attune/cli_commands/fix_receipt.py
+  - src/attune/workflows/fix_workflow.py
+nav:
+  help: fix
+  mkdocs:
+    how-to: how-to/fix
+    architecture: architecture/fix
+    reference: reference/fix
+---
+
+## Overview
+
+`attune fix` is the outcome-first entry point: you state **what should
+be true** and **how to check it**, and Attune reports what it actually
+did with evidence. You do not pick a workflow tier, write a prompt, or
+read an internal report format.
+
+Two artifacts carry the whole surface:
+
+- the **contract** — your goal, its done conditions, the scope the fix
+  may touch, and one or more verification **probes** (each an argv
+  list, never a shell string);
+- the **receipt** — what changed (attributed against a pre-run
+  baseline), which probes ran with their exact argv and exit codes,
+  what remains uncertain, and the safest next action.
+
+The rule that makes the receipt worth reading: **the workflow's own
+exit never decides success.** Probes are executed by the CLI after the
+fix agent finishes, in a real subprocess, and their results alone set
+the exit code.
+
+> **Scope — `attune fix` vs the `/fix-test` skill.** These are
+> different surfaces and neither replaces the other. **`attune fix`**
+> is a CLI command: you supply the goal and the probes, and it returns
+> a verified receipt. **`/fix-test`** is a skill on the Claude Code
+> conversational surface that auto-diagnoses failing tests and iterates
+> on them for you. Reach for `/fix-test` when you want the diagnosis
+> done for you in conversation; reach for `attune fix` when you already
+> know the outcome you want and need it verified and attributed.
+
+## Concepts
+
+### The contract is data, not a prompt
+
+`FixContract` holds the goal verbatim — no inference — plus done
+conditions, constraints, and probes. It is an **internal** boundary
+DTO: no JSON schema is emitted and no import stability is promised
+outside `attune.*`. It stays internal until at least two outcome
+intents demonstrate identical semantics.
+
+### Probes are argv, and they are the authority
+
+`VerificationProbe` holds an argv list and an expected exit code.
+Probe strings containing shell metacharacters (`;` `|` `&` `<` `>`
+`` ` `` `$`) are rejected outright rather than silently treated as
+literals — probes are never run through a shell. Every probe runs
+through `subprocess.run` **after** the fix, and the receipt records the
+argv, return code, and duration as provenance.
+
+A probe that cannot run records `SKIPPED` with a reason and appears
+under remaining uncertainty. It never silently counts as a pass.
+
+### Scope is enforced twice
+
+Prevention: the fix workflow installs a `PreToolUse` guard that denies
+`Edit`/`Write` outside the contract's scope paths at tool-call time.
+Detection: the receipt re-checks the post-run diff against the pre-run
+baseline and reports any out-of-scope path as a violation, forcing a
+non-zero exit.
+
+### Attribution is measured from a pre-run baseline
+
+Before execution, `attune fix` snapshots the dirty-path set and content
+hashes. Only paths that changed **relative to that snapshot** are
+attributed to the run. Files you already had in flight are listed
+separately as pre-existing and are never named in revert advice.
+
+If git is unavailable, scope cannot be verified at all — the receipt
+says so and the run does not report success, because passing probes
+would prove the goal but not the scope constraint.
+
+## Quickstart
+
+Preview a fix without executing anything (the default — nothing runs,
+nothing is written):
+
+```bash
+attune fix "boundary order must price as bulk" --probe "python -m pytest tests/test_pricing.py -q"
+```
+
+Execute it, scoped to one file:
+
+```bash
+attune fix "boundary order must price as bulk" --workflow fix --scope src/pricing.py --probe "python -m pytest tests/test_pricing.py -q" --run
+```
+
+Read the exit code:
+
+| Exit | Meaning |
+|---|---|
+| 0 | every probe passed, scope held, and scope was verifiable |
+| 1 | the run completed but a done condition failed or could not be verified |
+| 2 | the workflow crashed (a partial receipt is still printed) |
+| 3 | CLI error or abstention — nothing ran |
+
+## Tasks
+
+### Preview before you commit to a run
+
+Run without `--run`. The preview prints the goal, the derived done
+conditions, the constraints, and the validated probes, then states that
+nothing was executed. Use it to check that your probes say what you
+meant before spending a run.
+
+### Scope a fix to one file or directory
+
+Pass `--scope <path>`. The path is validated against the enclosing
+repository root, so any spelling — relative, absolute, or `./`-prefixed
+— resolves to the same place. A directory scope permits edits to its
+descendants. `--run` requires `--scope`: an unbounded fix is not
+runnable.
+
+### Verify with more than one probe
+
+Repeat `--probe`. Each probe becomes its own done condition, and the
+receipt reports each independently. Plural probes are the point — one
+probe that is also the fix target proves very little, whereas a target
+probe plus a full-suite probe plus a scope constraint tells you the fix
+worked *and* broke nothing.
+
+### Read a failed run
+
+When probes fail, the receipt names **every** failing probe with its
+exact command, so re-running verification is a copy-paste. If the run
+changed no files at all, the receipt says that plainly rather than
+advising you to inspect a diff that does not exist.
+
+### Recover from a scope violation
+
+The receipt lists the out-of-scope paths by name and the next action is
+a targeted revert. Pre-existing dirty paths are excluded from that
+advice by construction.
+
+## Reference
+
+### CLI
+
+`attune fix "<request>" [--probe CMD]... [--workflow NAME] [--scope PATH] [--explain] [--run]`
+
+| Flag | Effect |
+|---|---|
+| `--probe CMD` | A verification command as an argv string. Repeatable. At least one is required. |
+| `--workflow NAME` | Which registered workflow performs the fix. Without it, selection **abstains** and lists candidates rather than guessing. `--run` accepts only `fix`. |
+| `--scope PATH` | Bound the edit surface. Required with `--run`. |
+| `--explain` | Preview only, suppressing the "pass --run" notice. |
+| `--run` | Execute the contract, then verify it independently. |
+
+### Python
+
+`attune.cli_commands.fix_commands` — `FixContract`,
+`VerificationProbe`, `build_contract(args)`, `cmd_fix(args)`.
+
+`attune.cli_commands.fix_receipt` — `capture_baseline(repo_root,
+scope_paths)`, `run_probes(probes, cwd)`, `assemble_receipt(contract,
+baseline, scope_paths, probe_outcomes)`, and the `ProbeOutcome` /
+`FixReceipt` dataclasses. `FixReceipt.exit_code()` returns 0 only when
+every probe passed, no scope violation was found, **and** scope was
+verifiable.
+
+`attune.workflows.fix_workflow` — `FixWorkflow` (registered as `fix`)
+and `make_edit_scope_guard(scope_paths)`.
+
+### Receipt sections
+
+`Changes made` · `Pre-existing changes` (when present) · `SCOPE
+VIOLATIONS` (when present) · `Probes (evaluated independently)` ·
+`Remaining uncertainty` (when present) · `Safest next action`.
+
+## Comparison
+
+| | `attune fix` | `/fix-test` skill | `attune workflow run` |
+|---|---|---|---|
+| Surface | CLI | Claude Code conversation | CLI |
+| You supply | goal + probes + scope | a failing test | workflow name + inputs |
+| Verification | probes run by the CLI, independently | the skill re-runs the test as it iterates | whatever the workflow reports |
+| Best for | a known outcome you want verified | a failure you want diagnosed | direct access to a specific workflow |
+
+`attune workflow run` is unchanged and remains the expert path.
+Outcome-first does not mean the internal machinery disappears — it
+means you should not *need* it.
+
+## Failure modes
+
+**"no verification probes given — cannot verify a fix"** — a fix with
+no probe cannot be verified, so the command abstains (exit 3) instead
+of running something it could not check. Add `--probe`.
+
+**"no --workflow given — selection abstains rather than guess"** — a
+false confident route is worse than an abstention. Pass `--workflow
+fix`.
+
+**"probe contains shell metacharacters"** — probes are argv lists.
+Rewrite the probe without pipes or redirection; if you need shell
+semantics, put them in a script and probe the script.
+
+**"cannot run: --run requires --scope"** — an unscoped fix has no edit
+boundary to enforce, so `--run` refuses.
+
+**"SCOPE NOT VERIFIED — no git available"** — attribution fell back to
+content hashes of the declared scope files, so edits elsewhere are
+undetectable. The run will not report success; review the tree by hand.
+
+**Probe reported `SKIPPED`** — the command could not be executed (most
+often a missing binary). This is uncertainty, not a pass; the exit code
+is non-zero.
+
+## FAQ seeds
+
+- **Q:** Does a successful workflow run mean my fix worked?
+  **A:** No. The workflow's exit is never trusted. Only the probes, run
+  independently by the CLI after the fix, decide the outcome.
+- **Q:** What happens if the agent edits a file outside my scope?
+  **A:** The edit is denied at tool-call time by a `PreToolUse` guard,
+  and if anything still slipped through it is reported as a scope
+  violation with a non-zero exit and a targeted revert as the next
+  action.
+- **Q:** Will my own uncommitted work get blamed on the run?
+  **A:** No. Paths dirty before the run are attributed as pre-existing
+  and are never named in revert advice.
+- **Q:** Is `attune fix` the same as the `/fix-test` skill?
+  **A:** No. `/fix-test` diagnoses failing tests conversationally in
+  Claude Code; `attune fix` takes an outcome you have already defined
+  and returns a verified, attributed receipt from the CLI.
+- **Q:** Is my request text stored anywhere?
+  **A:** The `attune fix` command persists nothing — the contract lives
+  for the length of the run.
+- **Q:** Can I use it without a scope?
+  **A:** Only for previews. `--run` requires `--scope`.
+
+## Notes & tips
+
+- Preview first. The preview costs nothing and catches malformed probes
+  before a run.
+- Prefer plural probes that are distinct from the fix target — a target
+  probe plus a suite probe plus a scope constraint is the shape that
+  actually proves something.
+- The receipt distinguishes "changed nothing and the conditions already
+  held" from "fixed and verified". If you see the former, check that
+  your goal described a real gap.
+- Probe subprocesses run with bytecode and pytest-cache writes disabled
+  so their own artifacts are never mistaken for the fix's changes.
+
+## Design & extension
+
+The surface deliberately adds no new machinery. `FixWorkflow` is one
+workflow in the existing registry, executed by the existing Agent SDK
+adapter, returning the existing `WorkflowResult`. There is no new
+planner, executor, evidence store, telemetry system, or execution
+lifecycle — the receipt is computed from a baseline diff plus probe
+subprocess results, both of which are read at the moment they are
+needed.
+
+Subprocess use is confined to `fix_receipt.py` (the probe runner and
+git plumbing); `fix_commands.py` stays subprocess-free.
+
+The DTO stays internal on purpose. Promoting it into a public
+abstraction requires evidence that a second outcome intent shares its
+semantics; if a second intent does not survive that test, a separate
+adapter is the honest design rather than a forced universal model.
+
+Full design record: `docs/specs/outcome-first-fix/`.

--- a/docs/architecture/fix.md
+++ b/docs/architecture/fix.md
@@ -1,0 +1,94 @@
+# Fix
+
+## Overview
+
+`attune fix` is the outcome-first entry point: you state **what should
+be true** and **how to check it**, and Attune reports what it actually
+did with evidence. You do not pick a workflow tier, write a prompt, or
+read an internal report format.
+
+Two artifacts carry the whole surface:
+
+- the **contract** — your goal, its done conditions, the scope the fix
+  may touch, and one or more verification **probes** (each an argv
+  list, never a shell string);
+- the **receipt** — what changed (attributed against a pre-run
+  baseline), which probes ran with their exact argv and exit codes,
+  what remains uncertain, and the safest next action.
+
+The rule that makes the receipt worth reading: **the workflow's own
+exit never decides success.** Probes are executed by the CLI after the
+fix agent finishes, in a real subprocess, and their results alone set
+the exit code.
+
+> **Scope — `attune fix` vs the `/fix-test` skill.** These are
+> different surfaces and neither replaces the other. **`attune fix`**
+> is a CLI command: you supply the goal and the probes, and it returns
+> a verified receipt. **`/fix-test`** is a skill on the Claude Code
+> conversational surface that auto-diagnoses failing tests and iterates
+> on them for you. Reach for `/fix-test` when you want the diagnosis
+> done for you in conversation; reach for `attune fix` when you already
+> know the outcome you want and need it verified and attributed.
+
+## Concepts
+
+### The contract is data, not a prompt
+
+`FixContract` holds the goal verbatim — no inference — plus done
+conditions, constraints, and probes. It is an **internal** boundary
+DTO: no JSON schema is emitted and no import stability is promised
+outside `attune.*`. It stays internal until at least two outcome
+intents demonstrate identical semantics.
+
+### Probes are argv, and they are the authority
+
+`VerificationProbe` holds an argv list and an expected exit code.
+Probe strings containing shell metacharacters (`;` `|` `&` `<` `>`
+`` ` `` `$`) are rejected outright rather than silently treated as
+literals — probes are never run through a shell. Every probe runs
+through `subprocess.run` **after** the fix, and the receipt records the
+argv, return code, and duration as provenance.
+
+A probe that cannot run records `SKIPPED` with a reason and appears
+under remaining uncertainty. It never silently counts as a pass.
+
+### Scope is enforced twice
+
+Prevention: the fix workflow installs a `PreToolUse` guard that denies
+`Edit`/`Write` outside the contract's scope paths at tool-call time.
+Detection: the receipt re-checks the post-run diff against the pre-run
+baseline and reports any out-of-scope path as a violation, forcing a
+non-zero exit.
+
+### Attribution is measured from a pre-run baseline
+
+Before execution, `attune fix` snapshots the dirty-path set and content
+hashes. Only paths that changed **relative to that snapshot** are
+attributed to the run. Files you already had in flight are listed
+separately as pre-existing and are never named in revert advice.
+
+If git is unavailable, scope cannot be verified at all — the receipt
+says so and the run does not report success, because passing probes
+would prove the goal but not the scope constraint.
+
+## Design & extension
+
+The surface deliberately adds no new machinery. `FixWorkflow` is one
+workflow in the existing registry, executed by the existing Agent SDK
+adapter, returning the existing `WorkflowResult`. There is no new
+planner, executor, evidence store, telemetry system, or execution
+lifecycle — the receipt is computed from a baseline diff plus probe
+subprocess results, both of which are read at the moment they are
+needed.
+
+Subprocess use is confined to `fix_receipt.py` (the probe runner and
+git plumbing); `fix_commands.py` stays subprocess-free.
+
+The DTO stays internal on purpose. Promoting it into a public
+abstraction requires evidence that a second outcome intent shares its
+semantics; if a second intent does not survive that test, a separate
+adapter is the honest design rather than a forced universal model.
+
+Full design record: `docs/specs/outcome-first-fix/`.
+
+<!-- attune-generated: source_hash=4069f8ae171ca3c4ccb53ebae95b598ce6d800fcd66ed605ccb4583f5d3f9290 feature=fix kind=architecture generated_at=2026-07-31 -->

--- a/docs/features/fix.md
+++ b/docs/features/fix.md
@@ -1,0 +1,27 @@
+# Fix
+
+Outcome-first fixes — state the goal and its probes, get a verified receipt
+
+!!! tip "Start here"
+
+    [How-to guide](../how-to/fix.md) — task recipes for common goals.
+
+<div class="grid cards" markdown>
+
+-   __Reference__
+
+    ---
+
+    The full API and option reference.
+
+    [Open the reference](../reference/fix.md)
+
+-   __Architecture__
+
+    ---
+
+    How it works and how to extend it.
+
+    [Open the architecture](../architecture/fix.md)
+
+</div>

--- a/docs/how-to/fix.md
+++ b/docs/how-to/fix.md
@@ -1,0 +1,100 @@
+# Fix
+
+## Quickstart
+
+Preview a fix without executing anything (the default — nothing runs,
+nothing is written):
+
+```bash
+attune fix "boundary order must price as bulk" --probe "python -m pytest tests/test_pricing.py -q"
+```
+
+Execute it, scoped to one file:
+
+```bash
+attune fix "boundary order must price as bulk" --workflow fix --scope src/pricing.py --probe "python -m pytest tests/test_pricing.py -q" --run
+```
+
+Read the exit code:
+
+| Exit | Meaning |
+|---|---|
+| 0 | every probe passed, scope held, and scope was verifiable |
+| 1 | the run completed but a done condition failed or could not be verified |
+| 2 | the workflow crashed (a partial receipt is still printed) |
+| 3 | CLI error or abstention — nothing ran |
+
+## Tasks
+
+### Preview before you commit to a run
+
+Run without `--run`. The preview prints the goal, the derived done
+conditions, the constraints, and the validated probes, then states that
+nothing was executed. Use it to check that your probes say what you
+meant before spending a run.
+
+### Scope a fix to one file or directory
+
+Pass `--scope <path>`. The path is validated against the enclosing
+repository root, so any spelling — relative, absolute, or `./`-prefixed
+— resolves to the same place. A directory scope permits edits to its
+descendants. `--run` requires `--scope`: an unbounded fix is not
+runnable.
+
+### Verify with more than one probe
+
+Repeat `--probe`. Each probe becomes its own done condition, and the
+receipt reports each independently. Plural probes are the point — one
+probe that is also the fix target proves very little, whereas a target
+probe plus a full-suite probe plus a scope constraint tells you the fix
+worked *and* broke nothing.
+
+### Read a failed run
+
+When probes fail, the receipt names **every** failing probe with its
+exact command, so re-running verification is a copy-paste. If the run
+changed no files at all, the receipt says that plainly rather than
+advising you to inspect a diff that does not exist.
+
+### Recover from a scope violation
+
+The receipt lists the out-of-scope paths by name and the next action is
+a targeted revert. Pre-existing dirty paths are excluded from that
+advice by construction.
+
+## Reference
+
+### CLI
+
+`attune fix "<request>" [--probe CMD]... [--workflow NAME] [--scope PATH] [--explain] [--run]`
+
+| Flag | Effect |
+|---|---|
+| `--probe CMD` | A verification command as an argv string. Repeatable. At least one is required. |
+| `--workflow NAME` | Which registered workflow performs the fix. Without it, selection **abstains** and lists candidates rather than guessing. `--run` accepts only `fix`. |
+| `--scope PATH` | Bound the edit surface. Required with `--run`. |
+| `--explain` | Preview only, suppressing the "pass --run" notice. |
+| `--run` | Execute the contract, then verify it independently. |
+
+### Python
+
+`attune.cli_commands.fix_commands` — `FixContract`,
+`VerificationProbe`, `build_contract(args)`, `cmd_fix(args)`.
+
+`attune.cli_commands.fix_receipt` — `capture_baseline(repo_root,
+scope_paths)`, `run_probes(probes, cwd)`, `assemble_receipt(contract,
+baseline, scope_paths, probe_outcomes)`, and the `ProbeOutcome` /
+`FixReceipt` dataclasses. `FixReceipt.exit_code()` returns 0 only when
+every probe passed, no scope violation was found, **and** scope was
+verifiable.
+
+`attune.workflows.fix_workflow` — `FixWorkflow` (registered as `fix`)
+and `make_edit_scope_guard(scope_paths)`.
+
+### Receipt sections
+
+`Changes made` · `Pre-existing changes` (when present) · `SCOPE
+VIOLATIONS` (when present) · `Probes (evaluated independently)` ·
+`Remaining uncertainty` (when present) · `Safest next action`.
+
+<!-- attune-generated: source_hash=4069f8ae171ca3c4ccb53ebae95b598ce6d800fcd66ed605ccb4583f5d3f9290 feature=fix kind=how-to generated_at=2026-07-31 -->

--- a/docs/reference/fix.md
+++ b/docs/reference/fix.md
@@ -1,0 +1,38 @@
+# Fix
+
+## Reference
+
+### CLI
+
+`attune fix "<request>" [--probe CMD]... [--workflow NAME] [--scope PATH] [--explain] [--run]`
+
+| Flag | Effect |
+|---|---|
+| `--probe CMD` | A verification command as an argv string. Repeatable. At least one is required. |
+| `--workflow NAME` | Which registered workflow performs the fix. Without it, selection **abstains** and lists candidates rather than guessing. `--run` accepts only `fix`. |
+| `--scope PATH` | Bound the edit surface. Required with `--run`. |
+| `--explain` | Preview only, suppressing the "pass --run" notice. |
+| `--run` | Execute the contract, then verify it independently. |
+
+### Python
+
+`attune.cli_commands.fix_commands` — `FixContract`,
+`VerificationProbe`, `build_contract(args)`, `cmd_fix(args)`.
+
+`attune.cli_commands.fix_receipt` — `capture_baseline(repo_root,
+scope_paths)`, `run_probes(probes, cwd)`, `assemble_receipt(contract,
+baseline, scope_paths, probe_outcomes)`, and the `ProbeOutcome` /
+`FixReceipt` dataclasses. `FixReceipt.exit_code()` returns 0 only when
+every probe passed, no scope violation was found, **and** scope was
+verifiable.
+
+`attune.workflows.fix_workflow` — `FixWorkflow` (registered as `fix`)
+and `make_edit_scope_guard(scope_paths)`.
+
+### Receipt sections
+
+`Changes made` · `Pre-existing changes` (when present) · `SCOPE
+VIOLATIONS` (when present) · `Probes (evaluated independently)` ·
+`Remaining uncertainty` (when present) · `Safest next action`.
+
+<!-- attune-generated: source_hash=4069f8ae171ca3c4ccb53ebae95b598ce6d800fcd66ed605ccb4583f5d3f9290 feature=fix kind=reference generated_at=2026-07-31 -->

--- a/docs/specs/outcome-first-fix/decisions.md
+++ b/docs/specs/outcome-first-fix/decisions.md
@@ -110,3 +110,37 @@ other paths touched. Ruling Phase 2 acceptance met on the REAL
 path: the initially failing target probe passed through a real
 CLI/subprocess/file boundary, and the receipt attributed exactly
 one in-scope file from the pre-run baseline.
+
+## D7 — Prompt-text persistence: the Fix surface is clean; the ops run record is a generic inherited surface (RECORDED)
+
+**Lead, 2026-07-31, Phase 3 G3.** The requirement "sensitive prompt
+text is not persisted by default" was verified rather than assumed,
+and the answer is split.
+
+**`attune fix` persists nothing.** Verified by an evidence-chain
+walk over real files, not a mock: a `--run` with a sentinel request
+string writes no file under the repo tree or an isolated `HOME`
+containing that string. The request reaches stdout and nothing else.
+Telemetry is not a leak path either — `_track_sdk_run_telemetry`
+records cost, tokens, and duration only. Pinned by
+`test_fix_run_persists_no_file_containing_the_request_text`.
+
+**The ops run record would carry it.** If the `fix` WORKFLOW is
+driven through the ops daemon, the generic run-record writer
+(`_persist_run`, `src/attune/ops/runner.py`) stores every workflow's
+command line, and `attune workflow run --input '{...}'` accepts
+arbitrary kwargs — so a goal passed that way lands in
+`~/.attune/ops/runs/fix/<id>.json`, both in `command` and in the
+first log line.
+
+**Decision: record the boundary, do NOT change the ops surface in
+this spec.** The behavior is generic to every workflow, predates
+this spec, and belongs to the ops/run-record surface — changing it
+here would alter behavior for every other workflow from inside a Fix
+phase. `test_ops_run_record_would_carry_goal_text_generic_surface`
+pins it as CHARACTERIZATION so a future change that routes Fix
+through ops inherits the consequence knowingly.
+
+**Carried as a candidate, unruled:** whether the ops run record
+should redact `--input` payloads by default. That is a chair call on
+the ops surface, not a Fix decision.

--- a/docs/specs/outcome-first-fix/metrics.md
+++ b/docs/specs/outcome-first-fix/metrics.md
@@ -1,0 +1,112 @@
+# Outcome-First Fix — Measurement (Phase 3)
+
+**Measured:** 2026-07-31, keyless, on the Phase 3 branch.
+**Metric set:** the four RATIFIED in decisions.md D3. The routing
+metrics (contract-edit rate, route-correction rate,
+false-confident-route rate, abstention rate) stay deferred to Phase 4,
+where the labeled corpus they require exists.
+
+**No new telemetry, store, or lifecycle** (H3): every number below is
+read from an artifact the surface already produces — the receipt
+itself, or the test suite.
+
+---
+
+## 1. Evidence-valid receipt completeness — 100%
+
+**Definition:** the share of rendered receipts carrying every required
+section, so a reader never has to infer an omitted fact.
+
+**Required sections:** `🧾 Fix receipt`, `Changes made (attributed to
+this run):`, `Probes (evaluated independently):`, `Safest next
+action:`, and the independence trailer.
+
+**Measured:** 3/3 outcome shapes complete — no-change with passing
+probes, no-change with failing probes, changed with failing probes.
+Conditional sections (pre-existing changes, scope violations, remaining
+uncertainty) render when and only when they have content.
+
+```bash
+pytest tests/unit/cli_commands/test_fix_phase3.py::test_every_receipt_carries_every_required_section -q
+```
+
+**Instrument:** `_REQUIRED_SECTIONS` in the Phase 3 test module. Adding
+a section to the receipt without adding it there would leave the metric
+overstating completeness — the tuple is the definition of record.
+
+## 2. Verification-failure honesty — 100%
+
+**Definition:** the share of failed or unverifiable conditions that
+produce an explicit row, rather than a silent omission that reads as
+success.
+
+**Measured:** every negative path emits its row and a non-zero exit —
+probe failure (`[FAIL]`), unrunnable probe (`[SKIPPED]` + a reason
+under remaining uncertainty), out-of-scope edit (a named violation),
+workflow crash (a partial receipt, exit 2), and git-unavailable (an
+explicit "SCOPE NOT VERIFIED" line, never a success claim).
+
+The load-bearing case is `WorkflowResult.success=True` with failing
+probes: exit 1. Workflow exit is never trusted (H2).
+
+```bash
+pytest tests/unit/cli_commands/test_fix_phase3.py tests/unit/cli_commands/test_fix_receipt.py -q
+```
+
+**Phase 3 correction:** two honesty defects were found and fixed while
+measuring. A run that changed nothing rendered `(none detected)` and
+advised "review the attributed diff and commit" — advice for a diff
+that did not exist, and indistinguishable from a verified fix. And a
+multi-probe partial success named only the FIRST failing probe,
+under-reporting what still had to pass.
+
+## 3. Time to verified outcome — 1.13s verification overhead
+
+**Definition:** wall-clock from request to a receipt the user can act
+on. Split, because the two halves have different cost drivers.
+
+| Component | Measured | Source |
+|---|---|---|
+| Independent verification (both probes) | 1.128 s (561 ms + 567 ms) | D6 live-fire receipt |
+| Baseline capture + attribution | below timing resolution | Phase 3 suite durations |
+| Agent fix step | not recorded | — |
+
+**Instrument:** the receipt. Every probe row already carries its argv,
+return code, and duration in milliseconds — this metric needs no new
+measurement path, which is why it survives H3.
+
+**Honest limit:** the agent step's wall clock is NOT captured in the D6
+record, so no end-to-end figure is reported here rather than an
+estimated one. The next live-fire run should record it; until then this
+metric covers the CLI's own contribution only.
+
+## 4. Compatibility regressions — 0
+
+**Definition:** documented `attune workflow run` behavior that changed
+as a side effect of the Fix surface.
+
+**Measured:** 0 regressions across 9 intentional characterization pins
+(14 tests total), including the full exit contract — `success=True` → 0,
+`success=False` → 1, uncaught exception → 2, and the documented legacy
+loophole where a result with no `success` attribute exits 0.
+
+```bash
+pytest tests/unit/characterization/test_outcome_first_phase0.py -q
+```
+
+**Instrument:** `tests/unit/characterization/test_outcome_first_phase0.py`
+— named here as the metric's source of record, and guarded by
+`test_compatibility_pins_module_still_exists_and_is_named` so deleting
+it cannot quietly turn "0 regressions" into "unmeasured".
+
+---
+
+## Reading these numbers
+
+Three of the four read 100% / 0 because they measure properties the
+suite enforces rather than samples of real-world use. That is what they
+are for at this phase: they make a regression in receipt honesty fail
+CI. They are NOT evidence that users succeed with the surface — no
+Fix has been run by anyone but its authors. Adoption-shaped metrics
+(abandonment, completion without internal knowledge) need real users
+and are not claimed here.

--- a/docs/specs/outcome-first-fix/tasks.md
+++ b/docs/specs/outcome-first-fix/tasks.md
@@ -1,10 +1,10 @@
 # Outcome-First Fix — Tasks
 
-**Status:** active (2026-07-30) — Tasks 0–2 executed, each
+**Status:** active (2026-07-31) — Tasks 0–2 executed, each
 behind its own explicit chair go (spend gate honored on Task 2;
-live-fire receipt in decisions.md D6). The Phase 3 task is NOT
-yet authored; later phase tasks are authored per-phase behind
-chair gates (decisions.md D2).
+live-fire receipt in decisions.md D6). Task 3 (Phase 3) is
+AUTHORED and awaiting its own chair go; Phase 4+ tasks are
+authored per-phase behind chair gates (decisions.md D2).
 
 ## Executed log
 
@@ -33,6 +33,23 @@ chair gates (decisions.md D2).
   repos and pytest subprocesses (coverage 97/94%); live-fire
   receipt recorded in decisions.md D6 — the real agent made
   exactly the minimal in-scope fix and both probes passed.
+- **Task 3 — Phase 3 robustness, compatibility, measurement**
+  (chair go 2026-07-31, keyless — no spend): the six measured
+  gaps closed. G1 no-change runs are named instead of advising a
+  nonexistent diff; G2 every failing probe is named; G3 answered
+  by an evidence-chain walk and recorded in D7 (the Fix surface
+  persists nothing; the ops run record is a generic inherited
+  surface, deliberately unchanged); G4 the `attune fix` feature
+  master ships and projects to 15 outputs, with the drift guard
+  demonstrated firing on a hand-edited twin; G5+G6 the four D3
+  metrics reported in [metrics.md](metrics.md), each with the
+  command that produced it. One pre-existing assertion was
+  amended — `test_workflow_success_with_failing_probes_exits_one_h2`
+  asserted "inspect the diff" for a stub that changes nothing,
+  which is exactly the advice G1 corrects; its H2 subject (exit 1
+  plus a truthful FAIL row) is untouched. Also corrected: the
+  `fix` subparser's help still claimed "dry — no execution yet"
+  after `--run` shipped.
 
 ## Task 2 — Phase 2: executable Fix proof
 
@@ -235,3 +252,189 @@ passes through a real CLI/subprocess/file boundary. Changed
 artifacts, failed or skipped probes, uncertainty, and the next
 action are truthfully reported. Workflow exit alone never marks
 success.
+
+## Task 3 — Phase 3: robustness, compatibility, measurement
+
+**Scoping receipt (2026-07-31, code-first):** the ruling's
+Phase 3 bullet list was checked against the tree before this
+task was authored, per the spec-scope-drift lesson. Of the six
+named robustness paths, FOUR are already covered by the 48
+tests in `tests/unit/cli_commands/test_fix_commands.py` +
+`test_fix_receipt.py` (malformed, ambiguous, failed
+verification, abstention — plus crash, git-unavailable, and
+scope-unverified, hardened by the #1814/#1815 re-review). This
+task therefore executes against the SIX measured gaps below,
+not the ruling's list verbatim:
+
+| # | Gap | Evidence |
+|---|---|---|
+| G1 | No-change path is silent | `assemble_receipt` renders `(none detected)` and `exit_code()` returns 0 when probes pass with zero attributed changes — "verified fix" and "agent did nothing" are indistinguishable |
+| G2 | Partial success unpinned | `_next_action` names `failed[0]` only; no test covers mixed PASS/FAIL across several probes |
+| G3 | Prompt text reachable by a persistence surface | `fix_workflow.py` puts verbatim `goal` in `WorkflowResult.metadata`, and `fix` is reachable through the ops runner (`PATH_ARG_REGISTRY`); telemetry itself records cost/tokens only |
+| G4 | No user-facing `attune fix` surface docs | no feature master, no `.help` kind, no docs page; requirements demand the `/fix-test` relationship be stated explicitly |
+| G5 | Compatibility unmeasured as a metric | Task 0 characterization pins exist but are not NAMED as the compatibility-regression measurement |
+| G6 | The four D3 metrics have no measurement mechanism | H3 forbids new telemetry, so they must be suite-derived properties |
+
+```xml
+<task id="3" name="outcome-first-fix-phase3-robustness-measurement">
+  <objective>
+    Close the six measured gaps above so the Fix surface is
+    truthful on its remaining paths, is documented on the
+    projected surfaces, and reports the four ratified metrics
+    (D3) as properties derived from the existing suite — with
+    NO new telemetry, store, or lifecycle (H3).
+  </objective>
+
+  <context>
+    <existing-code path="src/attune/cli_commands/fix_receipt.py">
+      `FixReceipt.exit_code()` / `.render()` / `_next_action()`
+      own every honesty decision. G1 and G2 are changes HERE,
+      not in the CLI: the receipt is the single place the run's
+      truth is computed.
+    </existing-code>
+    <existing-code path="src/attune/workflows/fix_workflow.py">
+      `metadata={"goal": goal, ...}` (line ~159) is the only
+      place the verbatim request text leaves the process.
+    </existing-code>
+    <existing-code path="src/attune/ops/runner.py">
+      The ops runner reaches registered workflows and writes
+      run artifacts; whether any of them carries `goal` is the
+      G3 question to ANSWER, not assume.
+    </existing-code>
+    <existing-code path="docs/specs/outcome-first-fix/phase0-inventory.md">
+      Task 0's characterization pins — the compatibility
+      baseline G5 names.
+    </existing-code>
+    <constraint>
+      H3 holds: no new registry, executor, evidence store,
+      telemetry system, or execution lifecycle. Metrics are
+      computed from artifacts the suite ALREADY produces.
+    </constraint>
+    <constraint>
+      Phases 1 and 2 semantics are frozen. Preview output stays
+      byte-identical; the only receipt changes are ADDITIVE
+      honesty (a no-change row, a multi-failure next action).
+      The existing 48 tests pass unmodified, or the change is
+      wrong.
+    </constraint>
+    <constraint>
+      The feature page is a single-source master that PROJECTS
+      to `.help` kinds and the docs page (contract principle 3).
+      No hand-edited twins; the drift guard is the receipt that
+      the projection is real.
+    </constraint>
+    <constraint>
+      Keyless and deterministic. No spend gate applies to this
+      task — G1–G6 are all provable without an SDK call. If any
+      sub-item is found to need live-fire, it stops and asks
+      rather than spending.
+    </constraint>
+  </context>
+
+  <files-to-modify>
+    <file path="src/attune/cli_commands/fix_receipt.py">
+      <change location="FixReceipt.render / _next_action">
+        BEFORE: zero attributed changes renders
+        "(none detected)" and, with passing probes, exits 0
+        with next action "review the attributed diff and
+        commit" — advice for a diff that does not exist.
+        AFTER: a no-change run is named as such. The probes
+        still decide the exit (H2 is not weakened: passing
+        probes on an unchanged tree mean the conditions were
+        ALREADY true), but the receipt says the run changed
+        nothing and the next action reflects that — verify the
+        goal was already satisfied rather than "commit".
+      </change>
+      <change location="_next_action failure branch">
+        BEFORE: names `failed[0]` only, so a multi-probe
+        partial success under-reports what must be re-run.
+        AFTER: all failing probes are named (worst-problem-
+        first ordering preserved).
+      </change>
+    </file>
+    <file path="src/attune/workflows/fix_workflow.py">
+      <change location="execute metadata (~line 159)">
+        BEFORE: `metadata={"goal": goal, ...}` unconditionally.
+        AFTER: only after G3's answer. If no persistence
+        surface writes it, the metadata STAYS and a test pins
+        the property (no speculative change). If a surface does
+        write it, the goal is omitted or redacted there and the
+        test pins the redaction. The verification decides the
+        change — not the other way round.
+      </change>
+    </file>
+  </files-to-modify>
+
+  <files-to-create>
+    <file path="tests/unit/cli_commands/test_fix_phase3.py">
+      G1: no-change run + passing probes renders the no-change
+      row and its distinct next action (real tmp repo).
+      G2: three probes, two failing — both failures named.
+      G3: a real ops-runner-shaped invocation of the `fix`
+      workflow writes no artifact containing the goal text
+      (assert over the actual files written, not a mock).
+      G5: the characterization pins are asserted to still hold
+      as the named compatibility-regression check.
+      G6: receipt-completeness property — every receipt the
+      suite renders carries all required sections; and
+      verification-failure honesty — every negative path emits
+      a FAIL/SKIPPED row rather than a silent omission.
+    </file>
+    <file path="docs/features/fix.md (or the authored master path the projector owns)">
+      Single-source `attune fix` feature master: what it does,
+      the contract/receipt model, the exit contract, and an
+      EXPLICIT statement of the `/fix-test` skill relationship
+      (requirements: the surfaces must not blur). Projected to
+      `.help` kinds + the docs page via the existing projector;
+      never hand-written on both sides.
+    </file>
+  </files-to-create>
+
+  <validation>
+    <check>The existing 48 fix tests pass UNMODIFIED (Phase 1
+      preview byte-identical, Phase 2 receipt semantics
+      unchanged except the additive rows).</check>
+    <check>G1: no-change + passing probes — receipt states the
+      run changed nothing and does not advise committing a
+      diff that does not exist.</check>
+    <check>G2: multi-probe partial success names every failing
+      probe.</check>
+    <check>G3: the ops-path artifact assertion runs against
+      real written files; the resulting decision (pin as-is vs
+      redact) is recorded in decisions.md with the evidence.</check>
+    <check>G4: the feature master exists, the projector runs
+      clean, and the drift guard fails on a hand-edited
+      projection (demonstrate the failure, don't assert it).</check>
+    <check>G5+G6: the four D3 metrics are reported in the spec
+      with the command that produced each number — no new
+      telemetry, store, or lifecycle introduced (grep-checked).</check>
+    <check>Coverage stays >=85% on the touched modules; serial
+      keyless run.</check>
+    <check>Declared receipt types: suite + behavioral +
+      evidence-chain (G3's per-claim file assertions). NO
+      live-fire, NO spend.</check>
+  </validation>
+
+  <risks>
+    <risk severity="medium">Scope creep into Phase 4 routing
+      metrics — mitigation: D3 defers every routing metric to
+      Phase 4; this task reports FOUR metrics and no more.</risk>
+    <risk severity="medium">G1's honesty change quietly altering
+      the 0/1 boundary — mitigation: the exit rule is untouched;
+      only rendering and next-action text change, pinned by the
+      unmodified existing tests.</risk>
+    <risk severity="low">The feature page tripping projector
+      drift guards on first authorship — mitigation: author via
+      the existing single-source path, run the projector, and
+      commit both sides in one change.</risk>
+  </risks>
+</task>
+```
+
+**Acceptance (ruling Phase 3):** the remaining robustness paths
+report truthfully, documented `attune workflow run` behavior is
+preserved and named as the compatibility measurement, the
+projected help/docs surface exists with a drift guard, prompt
+text persistence is answered with evidence, and the four
+ratified metrics are reported from suite-derived properties
+with no new telemetry.

--- a/plugin/help/generated/comparisons/fix.md
+++ b/plugin/help/generated/comparisons/fix.md
@@ -1,0 +1,24 @@
+---
+name: fix
+source: content/features/fix.md
+tags:
+- fixes
+- verification
+- cli
+type: comparison
+---
+
+# Outcome-first fixes — state the goal and its probes, get a verified receipt
+
+## Comparison
+
+| | `attune fix` | `/fix-test` skill | `attune workflow run` |
+|---|---|---|---|
+| Surface | CLI | Claude Code conversation | CLI |
+| You supply | goal + probes + scope | a failing test | workflow name + inputs |
+| Verification | probes run by the CLI, independently | the skill re-runs the test as it iterates | whatever the workflow reports |
+| Best for | a known outcome you want verified | a failure you want diagnosed | direct access to a specific workflow |
+
+`attune workflow run` is unchanged and remains the expert path.
+Outcome-first does not mean the internal machinery disappears — it
+means you should not *need* it.

--- a/plugin/help/generated/concepts/fix.md
+++ b/plugin/help/generated/concepts/fix.md
@@ -1,0 +1,82 @@
+---
+name: fix
+source: content/features/fix.md
+tags:
+- fixes
+- verification
+- cli
+type: concept
+---
+
+# Outcome-first fixes — state the goal and its probes, get a verified receipt
+
+## Overview
+
+`attune fix` is the outcome-first entry point: you state **what should
+be true** and **how to check it**, and Attune reports what it actually
+did with evidence. You do not pick a workflow tier, write a prompt, or
+read an internal report format.
+
+Two artifacts carry the whole surface:
+
+- the **contract** — your goal, its done conditions, the scope the fix
+  may touch, and one or more verification **probes** (each an argv
+  list, never a shell string);
+- the **receipt** — what changed (attributed against a pre-run
+  baseline), which probes ran with their exact argv and exit codes,
+  what remains uncertain, and the safest next action.
+
+The rule that makes the receipt worth reading: **the workflow's own
+exit never decides success.** Probes are executed by the CLI after the
+fix agent finishes, in a real subprocess, and their results alone set
+the exit code.
+
+> **Scope — `attune fix` vs the `/fix-test` skill.** These are
+> different surfaces and neither replaces the other. **`attune fix`**
+> is a CLI command: you supply the goal and the probes, and it returns
+> a verified receipt. **`/fix-test`** is a skill on the Claude Code
+> conversational surface that auto-diagnoses failing tests and iterates
+> on them for you. Reach for `/fix-test` when you want the diagnosis
+> done for you in conversation; reach for `attune fix` when you already
+> know the outcome you want and need it verified and attributed.
+
+## Concepts
+
+### The contract is data, not a prompt
+
+`FixContract` holds the goal verbatim — no inference — plus done
+conditions, constraints, and probes. It is an **internal** boundary
+DTO: no JSON schema is emitted and no import stability is promised
+outside `attune.*`. It stays internal until at least two outcome
+intents demonstrate identical semantics.
+
+### Probes are argv, and they are the authority
+
+`VerificationProbe` holds an argv list and an expected exit code.
+Probe strings containing shell metacharacters (`;` `|` `&` `<` `>`
+`` ` `` `$`) are rejected outright rather than silently treated as
+literals — probes are never run through a shell. Every probe runs
+through `subprocess.run` **after** the fix, and the receipt records the
+argv, return code, and duration as provenance.
+
+A probe that cannot run records `SKIPPED` with a reason and appears
+under remaining uncertainty. It never silently counts as a pass.
+
+### Scope is enforced twice
+
+Prevention: the fix workflow installs a `PreToolUse` guard that denies
+`Edit`/`Write` outside the contract's scope paths at tool-call time.
+Detection: the receipt re-checks the post-run diff against the pre-run
+baseline and reports any out-of-scope path as a violation, forcing a
+non-zero exit.
+
+### Attribution is measured from a pre-run baseline
+
+Before execution, `attune fix` snapshots the dirty-path set and content
+hashes. Only paths that changed **relative to that snapshot** are
+attributed to the run. Files you already had in flight are listed
+separately as pre-existing and are never named in revert advice.
+
+If git is unavailable, scope cannot be verified at all — the receipt
+says so and the run does not report success, because passing probes
+would prove the goal but not the scope constraint.

--- a/plugin/help/generated/cross_links.json
+++ b/plugin/help/generated/cross_links.json
@@ -1,9 +1,9 @@
 {
   "version": 1,
   "stats": {
-    "total_templates": 1219,
-    "linked_templates": 889,
-    "total_tags": 117
+    "total_templates": 1230,
+    "linked_templates": 893,
+    "total_tags": 118
   },
   "links": {
     "com-agents": {
@@ -83,6 +83,13 @@
         "communication",
         "ux",
         "widget"
+      ]
+    },
+    "com-fix": {
+      "tags": [
+        "fixes",
+        "verification",
+        "cli"
       ]
     },
     "com-fix-test": {
@@ -326,6 +333,13 @@
       "tags": [
         "help-system",
         "telemetry"
+      ]
+    },
+    "con-fix": {
+      "tags": [
+        "fixes",
+        "verification",
+        "cli"
       ]
     },
     "con-fix-test": {
@@ -1742,6 +1756,28 @@
       ],
       "related_faq": [
         "faq-fastembed-is-the-local-embeddings-path-that-passes-a-50mb"
+      ]
+    },
+    "err-fix": {
+      "related_warning": [
+        "war-fix"
+      ],
+      "prevented_by": [
+        "tip-fix"
+      ],
+      "related_faq": [
+        "faq-fix"
+      ],
+      "tags": [
+        "fixes",
+        "verification",
+        "cli"
+      ],
+      "embeds": [
+        {
+          "id": "tip-fix",
+          "position": "after_resolution"
+        }
       ]
     },
     "err-fix-test": {
@@ -5318,6 +5354,16 @@
         "err-fastembed-is-the-local-embeddings-path-that-passes-a-50mb"
       ]
     },
+    "faq-fix": {
+      "related_error": [
+        "err-fix"
+      ],
+      "tags": [
+        "fixes",
+        "verification",
+        "cli"
+      ]
+    },
     "faq-fix-test": {
       "related_error": [
         "err-fix-test"
@@ -7398,6 +7444,16 @@
         "widget"
       ]
     },
+    "not-fix": {
+      "related_reference": [
+        "ref-fix"
+      ],
+      "tags": [
+        "fixes",
+        "verification",
+        "cli"
+      ]
+    },
     "not-fix-test": {
       "related_reference": [
         "ref-deep-review",
@@ -7773,6 +7829,13 @@
         "widget"
       ]
     },
+    "qui-fix": {
+      "tags": [
+        "fixes",
+        "verification",
+        "cli"
+      ]
+    },
     "qui-fix-test": {
       "tags": [
         "tests",
@@ -8103,6 +8166,13 @@
         "communication",
         "ux",
         "widget"
+      ]
+    },
+    "ref-fix": {
+      "tags": [
+        "fixes",
+        "verification",
+        "cli"
       ]
     },
     "ref-fix-test": {
@@ -8849,6 +8919,13 @@
         "telemetry"
       ]
     },
+    "tas-fix": {
+      "tags": [
+        "fixes",
+        "verification",
+        "cli"
+      ]
+    },
     "tas-fix-test": {
       "tags": [
         "tests",
@@ -9287,6 +9364,13 @@
         "widget"
       ]
     },
+    "tip-fix": {
+      "tags": [
+        "fixes",
+        "verification",
+        "cli"
+      ]
+    },
     "tip-fix-test": {
       "tags": [
         "tests",
@@ -9520,6 +9604,13 @@
         "communication",
         "ux",
         "widget"
+      ]
+    },
+    "tro-fix": {
+      "tags": [
+        "fixes",
+        "verification",
+        "cli"
       ]
     },
     "tro-fix-test": {
@@ -10225,6 +10316,16 @@
     "war-fastembed-is-the-local-embeddings-path-that-passes-a-50mb": {
       "related_error": [
         "err-fastembed-is-the-local-embeddings-path-that-passes-a-50mb"
+      ]
+    },
+    "war-fix": {
+      "related_error": [
+        "err-fix"
+      ],
+      "tags": [
+        "fixes",
+        "verification",
+        "cli"
       ]
     },
     "war-fix-test": {
@@ -12244,26 +12345,37 @@
     "cli": [
       "com-cli",
       "com-cli-vs-claude-code",
+      "com-fix",
       "con-cli",
+      "con-fix",
       "err-cli",
+      "err-fix",
       "faq-cli",
+      "faq-fix",
       "not-cli",
       "not-command-hubs",
+      "not-fix",
       "qui-browse-help",
       "qui-check-costs",
       "qui-check-health",
       "qui-cli",
+      "qui-fix",
       "ref-cli",
+      "ref-fix",
       "tas-browse-help-docs",
       "tas-check-auth-status",
       "tas-cli",
       "tas-export-telemetry",
+      "tas-fix",
       "tas-manage-lessons",
       "tas-run-doctor",
       "tas-run-workflow",
       "tip-cli",
+      "tip-fix",
       "tro-cli",
-      "war-cli"
+      "tro-fix",
+      "war-cli",
+      "war-fix"
     ],
     "code-quality": [
       "not-code-simplification",
@@ -12528,17 +12640,28 @@
       "war-resilience"
     ],
     "fixes": [
+      "com-fix",
       "com-fix-test",
+      "con-fix",
       "con-fix-test",
       "con-tool-fix-test",
+      "err-fix",
       "err-fix-test",
+      "faq-fix",
       "faq-fix-test",
+      "not-fix",
       "not-fix-test",
+      "qui-fix",
       "qui-fix-test",
+      "ref-fix",
       "ref-fix-test",
+      "tas-fix",
       "tas-fix-test",
+      "tip-fix",
       "tip-fix-test",
+      "tro-fix",
       "tro-fix-test",
+      "war-fix",
       "war-fix-test"
     ],
     "formatting": [
@@ -14633,6 +14756,19 @@
       "tip-elicitation-forms",
       "tro-elicitation-forms",
       "war-elicitation-forms"
+    ],
+    "verification": [
+      "com-fix",
+      "con-fix",
+      "err-fix",
+      "faq-fix",
+      "not-fix",
+      "qui-fix",
+      "ref-fix",
+      "tas-fix",
+      "tip-fix",
+      "tro-fix",
+      "war-fix"
     ],
     "webhooks": [
       "com-hooks",

--- a/plugin/help/generated/errors/fix.md
+++ b/plugin/help/generated/errors/fix.md
@@ -1,0 +1,36 @@
+---
+name: fix
+source: content/features/fix.md
+tags:
+- fixes
+- verification
+- cli
+type: error
+---
+
+# Outcome-first fixes — state the goal and its probes, get a verified receipt
+
+## Failure modes
+
+**"no verification probes given — cannot verify a fix"** — a fix with
+no probe cannot be verified, so the command abstains (exit 3) instead
+of running something it could not check. Add `--probe`.
+
+**"no --workflow given — selection abstains rather than guess"** — a
+false confident route is worse than an abstention. Pass `--workflow
+fix`.
+
+**"probe contains shell metacharacters"** — probes are argv lists.
+Rewrite the probe without pipes or redirection; if you need shell
+semantics, put them in a script and probe the script.
+
+**"cannot run: --run requires --scope"** — an unscoped fix has no edit
+boundary to enforce, so `--run` refuses.
+
+**"SCOPE NOT VERIFIED — no git available"** — attribution fell back to
+content hashes of the declared scope files, so edits elsewhere are
+undetectable. The run will not report success; review the tree by hand.
+
+**Probe reported `SKIPPED`** — the command could not be executed (most
+often a missing binary). This is uncertainty, not a pass; the exit code
+is non-zero.

--- a/plugin/help/generated/faqs/fix.md
+++ b/plugin/help/generated/faqs/fix.md
@@ -1,0 +1,43 @@
+---
+name: fix
+source: content/features/fix.md
+tags:
+- fixes
+- verification
+- cli
+type: faq
+---
+
+# Fix FAQ
+
+## Does a successful workflow run mean my fix worked?
+
+No. The workflow's exit is never trusted. Only the probes, run
+independently by the CLI after the fix, decide the outcome.
+
+## What happens if the agent edits a file outside my scope?
+
+The edit is denied at tool-call time by a `PreToolUse` guard,
+and if anything still slipped through it is reported as a scope
+violation with a non-zero exit and a targeted revert as the next
+action.
+
+## Will my own uncommitted work get blamed on the run?
+
+No. Paths dirty before the run are attributed as pre-existing
+and are never named in revert advice.
+
+## Is `attune fix` the same as the `/fix-test` skill?
+
+No. `/fix-test` diagnoses failing tests conversationally in
+Claude Code; `attune fix` takes an outcome you have already defined
+and returns a verified, attributed receipt from the CLI.
+
+## Is my request text stored anywhere?
+
+The `attune fix` command persists nothing — the contract lives
+for the length of the run.
+
+## Can I use it without a scope?
+
+Only for previews. `--run` requires `--scope`.

--- a/plugin/help/generated/notes/fix.md
+++ b/plugin/help/generated/notes/fix.md
@@ -1,0 +1,95 @@
+---
+name: fix
+source: content/features/fix.md
+tags:
+- fixes
+- verification
+- cli
+type: note
+---
+
+# Outcome-first fixes — state the goal and its probes, get a verified receipt
+
+## Overview
+
+`attune fix` is the outcome-first entry point: you state **what should
+be true** and **how to check it**, and Attune reports what it actually
+did with evidence. You do not pick a workflow tier, write a prompt, or
+read an internal report format.
+
+Two artifacts carry the whole surface:
+
+- the **contract** — your goal, its done conditions, the scope the fix
+  may touch, and one or more verification **probes** (each an argv
+  list, never a shell string);
+- the **receipt** — what changed (attributed against a pre-run
+  baseline), which probes ran with their exact argv and exit codes,
+  what remains uncertain, and the safest next action.
+
+The rule that makes the receipt worth reading: **the workflow's own
+exit never decides success.** Probes are executed by the CLI after the
+fix agent finishes, in a real subprocess, and their results alone set
+the exit code.
+
+> **Scope — `attune fix` vs the `/fix-test` skill.** These are
+> different surfaces and neither replaces the other. **`attune fix`**
+> is a CLI command: you supply the goal and the probes, and it returns
+> a verified receipt. **`/fix-test`** is a skill on the Claude Code
+> conversational surface that auto-diagnoses failing tests and iterates
+> on them for you. Reach for `/fix-test` when you want the diagnosis
+> done for you in conversation; reach for `attune fix` when you already
+> know the outcome you want and need it verified and attributed.
+
+## Concepts
+
+### The contract is data, not a prompt
+
+`FixContract` holds the goal verbatim — no inference — plus done
+conditions, constraints, and probes. It is an **internal** boundary
+DTO: no JSON schema is emitted and no import stability is promised
+outside `attune.*`. It stays internal until at least two outcome
+intents demonstrate identical semantics.
+
+### Probes are argv, and they are the authority
+
+`VerificationProbe` holds an argv list and an expected exit code.
+Probe strings containing shell metacharacters (`;` `|` `&` `<` `>`
+`` ` `` `$`) are rejected outright rather than silently treated as
+literals — probes are never run through a shell. Every probe runs
+through `subprocess.run` **after** the fix, and the receipt records the
+argv, return code, and duration as provenance.
+
+A probe that cannot run records `SKIPPED` with a reason and appears
+under remaining uncertainty. It never silently counts as a pass.
+
+### Scope is enforced twice
+
+Prevention: the fix workflow installs a `PreToolUse` guard that denies
+`Edit`/`Write` outside the contract's scope paths at tool-call time.
+Detection: the receipt re-checks the post-run diff against the pre-run
+baseline and reports any out-of-scope path as a violation, forcing a
+non-zero exit.
+
+### Attribution is measured from a pre-run baseline
+
+Before execution, `attune fix` snapshots the dirty-path set and content
+hashes. Only paths that changed **relative to that snapshot** are
+attributed to the run. Files you already had in flight are listed
+separately as pre-existing and are never named in revert advice.
+
+If git is unavailable, scope cannot be verified at all — the receipt
+says so and the run does not report success, because passing probes
+would prove the goal but not the scope constraint.
+
+## Notes & tips
+
+- Preview first. The preview costs nothing and catches malformed probes
+  before a run.
+- Prefer plural probes that are distinct from the fix target — a target
+  probe plus a suite probe plus a scope constraint is the shape that
+  actually proves something.
+- The receipt distinguishes "changed nothing and the conditions already
+  held" from "fixed and verified". If you see the former, check that
+  your goal described a real gap.
+- Probe subprocesses run with bytecode and pytest-cache writes disabled
+  so their own artifacts are never mistaken for the fix's changes.

--- a/plugin/help/generated/quickstarts/fix.md
+++ b/plugin/help/generated/quickstarts/fix.md
@@ -1,0 +1,35 @@
+---
+name: fix
+source: content/features/fix.md
+tags:
+- fixes
+- verification
+- cli
+type: quickstart
+---
+
+# Outcome-first fixes — state the goal and its probes, get a verified receipt
+
+## Quickstart
+
+Preview a fix without executing anything (the default — nothing runs,
+nothing is written):
+
+```bash
+attune fix "boundary order must price as bulk" --probe "python -m pytest tests/test_pricing.py -q"
+```
+
+Execute it, scoped to one file:
+
+```bash
+attune fix "boundary order must price as bulk" --workflow fix --scope src/pricing.py --probe "python -m pytest tests/test_pricing.py -q" --run
+```
+
+Read the exit code:
+
+| Exit | Meaning |
+|---|---|
+| 0 | every probe passed, scope held, and scope was verifiable |
+| 1 | the run completed but a done condition failed or could not be verified |
+| 2 | the workflow crashed (a partial receipt is still printed) |
+| 3 | CLI error or abstention — nothing ran |

--- a/plugin/help/generated/references/fix.md
+++ b/plugin/help/generated/references/fix.md
@@ -1,0 +1,46 @@
+---
+name: fix
+source: content/features/fix.md
+tags:
+- fixes
+- verification
+- cli
+type: reference
+---
+
+# Outcome-first fixes — state the goal and its probes, get a verified receipt
+
+## Reference
+
+### CLI
+
+`attune fix "<request>" [--probe CMD]... [--workflow NAME] [--scope PATH] [--explain] [--run]`
+
+| Flag | Effect |
+|---|---|
+| `--probe CMD` | A verification command as an argv string. Repeatable. At least one is required. |
+| `--workflow NAME` | Which registered workflow performs the fix. Without it, selection **abstains** and lists candidates rather than guessing. `--run` accepts only `fix`. |
+| `--scope PATH` | Bound the edit surface. Required with `--run`. |
+| `--explain` | Preview only, suppressing the "pass --run" notice. |
+| `--run` | Execute the contract, then verify it independently. |
+
+### Python
+
+`attune.cli_commands.fix_commands` — `FixContract`,
+`VerificationProbe`, `build_contract(args)`, `cmd_fix(args)`.
+
+`attune.cli_commands.fix_receipt` — `capture_baseline(repo_root,
+scope_paths)`, `run_probes(probes, cwd)`, `assemble_receipt(contract,
+baseline, scope_paths, probe_outcomes)`, and the `ProbeOutcome` /
+`FixReceipt` dataclasses. `FixReceipt.exit_code()` returns 0 only when
+every probe passed, no scope violation was found, **and** scope was
+verifiable.
+
+`attune.workflows.fix_workflow` — `FixWorkflow` (registered as `fix`)
+and `make_edit_scope_guard(scope_paths)`.
+
+### Receipt sections
+
+`Changes made` · `Pre-existing changes` (when present) · `SCOPE
+VIOLATIONS` (when present) · `Probes (evaluated independently)` ·
+`Remaining uncertainty` (when present) · `Safest next action`.

--- a/plugin/help/generated/source_manifest.json
+++ b/plugin/help/generated/source_manifest.json
@@ -2,6026 +2,6081 @@
   "com-agents": {
     "source": "content/features/agents.md",
     "hash": "a5b1678ecf012c7b2877a6c7ecae4a6c3f14c084c13fbcbb7eee79119dce6fa3",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "com-auth-strategies": {
     "source": "src/attune/models/auth_cli.py",
     "hash": "586101ee6a646d50a06299d3c9e96f60467c65376782c191c910af6cf52ef268",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "com-bug-predict": {
     "source": "content/features/bug-predict.md",
     "hash": "6a4f420eba38e2fb884b837dd9758acb60ba60cdaf9248ec4280120b0d382b16",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "com-cli": {
     "source": "content/features/cli.md",
     "hash": "a37b4dc4f0b3706a62184b02d2be1536ad75eef39a0f22a9699db5d03b8ee050",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "com-code-quality": {
     "source": "content/features/code-quality.md",
     "hash": "ce16ac87eb92e33a08d8c2f06e86ef22e436966f47f3a28c3f4eba19060b550a",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "com-configuration": {
     "source": "content/features/configuration.md",
     "hash": "8add90392883a46899ef8b57d135b625d92c5b61231d8a5301727f8b42f8e46f",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "com-cross-review": {
     "source": "content/features/cross-review.md",
     "hash": "dc5ae75883b05f97983377b51e275bab79921e992d842ebb2616726b8c8c2cdb",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "com-deep-review": {
     "source": "content/features/deep-review.md",
     "hash": "6a4fffc907302b4847d96097189bd8d329d3f1548d1ee46d9232f6ceecdfb450",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "com-doc-gen": {
     "source": "content/features/doc-gen.md",
     "hash": "26e02a71a523775f5bb9e371b2e563c3c858386436a73b727422f62f57de0282",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "com-elicitation-forms": {
     "source": "content/features/elicitation-forms.md",
     "hash": "4f326dd6f99f86af163cf44167b243d73ee5165ef8373bf4cea83039aec723d2",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
+  },
+  "com-fix": {
+    "source": "content/features/fix.md",
+    "hash": "f4eb5cf49e7e9959b863b2bb1a866df14faa7a3f1c9bf1fe8acd1dc7e09bd1d6",
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "com-fix-test": {
     "source": "content/features/fix-test.md",
     "hash": "8b182bab8816d525d3325746f4cdeed013113a1bdb0a43d36963e121afa42812",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "com-help-system": {
     "source": "content/features/help-system.md",
     "hash": "24468c8fe4f1a0e350e620098d65a3bcc007000cd5aa4dbe20a6e6c83efa87b3",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "com-hooks": {
     "source": "content/features/hooks.md",
     "hash": "5c6b8a45457387c76f628561d3baa56e9af1709bc9bd21bba9830b2c2478c8dd",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "com-mcp-server": {
     "source": "content/features/mcp-server.md",
     "hash": "8e4b8c74eff980330480ae70856a1cf0393559cd22eb9ba0210b43249f9b5181",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "com-memory": {
     "source": "content/features/memory.md",
     "hash": "32b3121d9110dc9ac327bb9e838f060fbe9940a033366b0147ef34ef2efaa4dc",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "com-models": {
     "source": "content/features/models.md",
     "hash": "2117cbb0d8e863db6091870874e4ce80b48780c9ee8bb7330d8033c172ccb02b",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "com-ops-dashboard": {
     "source": "content/features/ops-dashboard.md",
     "hash": "fefc8e2b2b4a25055fcbdf96cbd8638d75278cbcacd256873b725df89544c1f6",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "com-orchestration": {
     "source": "content/features/orchestration.md",
     "hash": "4998437e04355011a7dee68dbce7e9e78bbe97f637e0b6a14c1ec972f541695c",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "com-plugin": {
     "source": "content/features/plugin.md",
     "hash": "8cc6e5702ffc8228ed63cfb74a25dd3e99e79e5335c4b1c8c134950f8b9a043d",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "com-rag-grounding": {
     "source": "content/features/rag-grounding.md",
     "hash": "3464dd78c83f06980912a7c49dc185b09830be1b1c163203f10e5aa1708fcf4e",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "com-refactor-plan": {
     "source": "content/features/refactor-plan.md",
     "hash": "8f8c684cd94fca7b2580ecaaf955ccb79924022796d576d477cdab9330df9704",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "com-release-notes": {
     "source": "content/features/release-notes.md",
     "hash": "da7101ffbec4d209fcb1cef754f01cef8a13458a6f961c3a23909edfec77e58c",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "com-release-prep": {
     "source": "content/features/release-prep.md",
     "hash": "cd77b5903fbeb7d7e0acef570bab9727b4c143181ea6be1f52b9a25bc11418bb",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "com-resilience": {
     "source": "content/features/resilience.md",
     "hash": "ae2a76f0f1ecbb9ca687e5a041acc2b4a25a5113ec57eaad550f48b8aadc4be2",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "com-security-audit": {
     "source": "content/features/security-audit.md",
     "hash": "9cce18573c827fab9a380efe8c65c2f8c5b4ada3f7e383dd71ec523a0875fb05",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "com-session-handoff": {
     "source": "content/features/session-handoff.md",
     "hash": "236c16ee2d2e48f0bd8ba075c69f50ead16a46ef185fede3d84b529c66fd41a0",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "com-smart-test": {
     "source": "content/features/smart-test.md",
     "hash": "58c691c8313ddf9699deb913e6b5c50fafc684563539ddf4816a4b94a9ea3e80",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "com-spec-engine": {
     "source": "content/features/spec-engine.md",
     "hash": "c8549016aa848eeeaecbde8329f5850562f56280ab66428cb7c20887b428d81a",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "com-telemetry": {
     "source": "content/features/telemetry.md",
     "hash": "59473ab809113116a3d58d2ead3a5f13e362d6992d8cee0a89364feded5cbd50",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "com-wizards": {
     "source": "content/features/wizards.md",
     "hash": "6fe7722a026d11276ebfbdf4ea046a05112be94b560f9abf3ffee410f8637d8f",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "com-workflow-vs-wizard": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "con-agents": {
     "source": "content/features/agents.md",
     "hash": "a5b1678ecf012c7b2877a6c7ecae4a6c3f14c084c13fbcbb7eee79119dce6fa3",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "con-audience-adaptation": {
     "source": "src/attune/help/transformers.py",
     "hash": "00861e98056d93ab47c8ca43e64c941c802a1876da7faaad2ed0f825d698938c",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "con-bug-predict": {
     "source": "content/features/bug-predict.md",
     "hash": "6a4f420eba38e2fb884b837dd9758acb60ba60cdaf9248ec4280120b0d382b16",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "con-cli": {
     "source": "content/features/cli.md",
     "hash": "a37b4dc4f0b3706a62184b02d2be1536ad75eef39a0f22a9699db5d03b8ee050",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "con-code-quality": {
     "source": "content/features/code-quality.md",
     "hash": "ce16ac87eb92e33a08d8c2f06e86ef22e436966f47f3a28c3f4eba19060b550a",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "con-configuration": {
     "source": "content/features/configuration.md",
     "hash": "8add90392883a46899ef8b57d135b625d92c5b61231d8a5301727f8b42f8e46f",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "con-cross-linking": {
     "source": "scripts/build_cross_links.py",
     "hash": "f271a7146802a35388670a2541ab016e3358a78bf5aa876f30f9af1d4d4344b0",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "con-cross-review": {
     "source": "content/features/cross-review.md",
     "hash": "dc5ae75883b05f97983377b51e275bab79921e992d842ebb2616726b8c8c2cdb",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "con-deep-review": {
     "source": "content/features/deep-review.md",
     "hash": "6a4fffc907302b4847d96097189bd8d329d3f1548d1ee46d9232f6ceecdfb450",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "con-doc-gen": {
     "source": "content/features/doc-gen.md",
     "hash": "26e02a71a523775f5bb9e371b2e563c3c858386436a73b727422f62f57de0282",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "con-elicitation-forms": {
     "source": "content/features/elicitation-forms.md",
     "hash": "4f326dd6f99f86af163cf44167b243d73ee5165ef8373bf4cea83039aec723d2",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "con-feedback-loop": {
     "source": "src/attune/help/engine.py",
     "hash": "cefbd9ea62f941969da6b381754835e6994bcbece1867d76998f7199ef39265a",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
+  },
+  "con-fix": {
+    "source": "content/features/fix.md",
+    "hash": "f4eb5cf49e7e9959b863b2bb1a866df14faa7a3f1c9bf1fe8acd1dc7e09bd1d6",
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "con-fix-test": {
     "source": "content/features/fix-test.md",
     "hash": "8b182bab8816d525d3325746f4cdeed013113a1bdb0a43d36963e121afa42812",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "con-help-system": {
     "source": "content/features/help-system.md",
     "hash": "24468c8fe4f1a0e350e620098d65a3bcc007000cd5aa4dbe20a6e6c83efa87b3",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "con-hooks": {
     "source": "content/features/hooks.md",
     "hash": "5c6b8a45457387c76f628561d3baa56e9af1709bc9bd21bba9830b2c2478c8dd",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "con-mcp-server": {
     "source": "content/features/mcp-server.md",
     "hash": "8e4b8c74eff980330480ae70856a1cf0393559cd22eb9ba0210b43249f9b5181",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "con-memory": {
     "source": "content/features/memory.md",
     "hash": "32b3121d9110dc9ac327bb9e838f060fbe9940a033366b0147ef34ef2efaa4dc",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "con-models": {
     "source": "content/features/models.md",
     "hash": "2117cbb0d8e863db6091870874e4ce80b48780c9ee8bb7330d8033c172ccb02b",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "con-ops-dashboard": {
     "source": "content/features/ops-dashboard.md",
     "hash": "fefc8e2b2b4a25055fcbdf96cbd8638d75278cbcacd256873b725df89544c1f6",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "con-orchestration": {
     "source": "content/features/orchestration.md",
     "hash": "4998437e04355011a7dee68dbce7e9e78bbe97f637e0b6a14c1ec972f541695c",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "con-plugin": {
     "source": "content/features/plugin.md",
     "hash": "8cc6e5702ffc8228ed63cfb74a25dd3e99e79e5335c4b1c8c134950f8b9a043d",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "con-progressive-depth": {
     "source": "src/attune/help/engine.py",
     "hash": "cefbd9ea62f941969da6b381754835e6994bcbece1867d76998f7199ef39265a",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "con-rag-grounding": {
     "source": "content/features/rag-grounding.md",
     "hash": "3464dd78c83f06980912a7c49dc185b09830be1b1c163203f10e5aa1708fcf4e",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "con-refactor-plan": {
     "source": "content/features/refactor-plan.md",
     "hash": "8f8c684cd94fca7b2580ecaaf955ccb79924022796d576d477cdab9330df9704",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "con-release-notes": {
     "source": "content/features/release-notes.md",
     "hash": "da7101ffbec4d209fcb1cef754f01cef8a13458a6f961c3a23909edfec77e58c",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "con-release-prep": {
     "source": "content/features/release-prep.md",
     "hash": "cd77b5903fbeb7d7e0acef570bab9727b4c143181ea6be1f52b9a25bc11418bb",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "con-resilience": {
     "source": "content/features/resilience.md",
     "hash": "ae2a76f0f1ecbb9ca687e5a041acc2b4a25a5113ec57eaad550f48b8aadc4be2",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "con-security-audit": {
     "source": "content/features/security-audit.md",
     "hash": "9cce18573c827fab9a380efe8c65c2f8c5b4ada3f7e383dd71ec523a0875fb05",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "con-session-handoff": {
     "source": "content/features/session-handoff.md",
     "hash": "236c16ee2d2e48f0bd8ba075c69f50ead16a46ef185fede3d84b529c66fd41a0",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "con-smart-test": {
     "source": "content/features/smart-test.md",
     "hash": "58c691c8313ddf9699deb913e6b5c50fafc684563539ddf4816a4b94a9ea3e80",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "con-socratic-discovery": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "con-spec-engine": {
     "source": "content/features/spec-engine.md",
     "hash": "c8549016aa848eeeaecbde8329f5850562f56280ab66428cb7c20887b428d81a",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "con-sync-paradigm": {
     "source": "scripts/generate_all.py",
     "hash": "6a3e4428fe0b789f45a226f983116d18827b19b6a12162691c522fd4861862a3",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "con-telemetry": {
     "source": "content/features/telemetry.md",
     "hash": "59473ab809113116a3d58d2ead3a5f13e362d6992d8cee0a89364feded5cbd50",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "con-template-composition": {
     "source": "src/attune/help/engine.py",
     "hash": "cefbd9ea62f941969da6b381754835e6994bcbece1867d76998f7199ef39265a",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "con-tier-routing": {
     "source": "src/attune/workflows/base.py",
     "hash": "8651c3e2645e5ec764718119ed55284d1dc4853fa9903663925e2a0c42ff60de",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "con-tool-attune-hub": {
     "source": "plugin/skills/attune-hub/SKILL.md",
     "hash": "2a18d84bd5efb5738643d716c803440f602d40871b172238996c4aebcf498032",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "con-tool-bug-predict": {
     "source": "plugin/skills/bug-predict/SKILL.md",
     "hash": "992b9e6cd3452af0d31213985e5e5c607f078edd2310df76d786b95d7e6a83ce",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "con-tool-coach": {
     "source": "plugin/skills/coach/SKILL.md",
     "hash": "a1842d674325f3f1ea289e3bd7ed1dcfbb4b3301160181edab081d2b4352aeac",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "con-tool-code-quality": {
     "source": "plugin/skills/code-quality/SKILL.md",
     "hash": "769c4c885992fd1937adbdf5d97305894bd08c159c83930d7a9fb86cb4ae78b7",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "con-tool-doc-gen": {
     "source": "plugin/skills/doc-gen/SKILL.md",
     "hash": "da9a9c23727eaa9433b2c4d1dfe87d850ef560d56b855f2eb7bd0f279efc3c72",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "con-tool-fix-test": {
     "source": "plugin/skills/fix-test/SKILL.md",
     "hash": "665ff7c4978beddd72e87f3764b073e4f962b27a896bd66542d499a1a00429da",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "con-tool-memory-and-context": {
     "source": "plugin/skills/memory-and-context/SKILL.md",
     "hash": "d026a40d0c5315123672c7ed3770b643ba803a3b5d57cb994c236fcd6baa8305",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "con-tool-planning": {
     "source": "plugin/skills/planning/SKILL.md",
     "hash": "f56a42c83f514b300b4f89ea6669820ec158da952efa2894c56abb00c39eb58a",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "con-tool-rag-code-gen": {
     "source": "plugin/skills/rag-code-gen/SKILL.md",
     "hash": "0d84a32e2f89e8debd740b4343c7930b17efcca37fcb68737f342f8b6b5f6f77",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "con-tool-refactor-plan": {
     "source": "plugin/skills/refactor-plan/SKILL.md",
     "hash": "080a84b5df5dde88cd3c994ca2c2b68ec12e2cf241f2e81893f21aa9dac315f6",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "con-tool-release-prep": {
     "source": "plugin/skills/release-prep/SKILL.md",
     "hash": "8aab944ae2f53a24c94d39329bf000067a68f43b51de6657b517678bec90c67a",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "con-tool-security-audit": {
     "source": "plugin/skills/security-audit/SKILL.md",
     "hash": "f370003a809c342d35b37990da231fbb72545e75e5a37e1e1d39a27db5364761",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "con-tool-smart-test": {
     "source": "plugin/skills/smart-test/SKILL.md",
     "hash": "a5e874d1054dd123d78d9d8e9014c7c6888230f36685a203ea26176a3d649ffb",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "con-tool-spec": {
     "source": "plugin/skills/spec/SKILL.md",
     "hash": "4e1ce2c9da6fcad85ebcf7cb6b755f44c27d00608ad97b72b93a82a45e3c0186",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "con-tool-workflow-orchestration": {
     "source": "plugin/skills/workflow-orchestration/SKILL.md",
     "hash": "831c00dfb29ae4c72b35921fd3bab9e9f17affabf32b8164deb801557e031127",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "con-wizards": {
     "source": "content/features/wizards.md",
     "hash": "6fe7722a026d11276ebfbdf4ea046a05112be94b560f9abf3ffee410f8637d8f",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "con-workflow-chain-prediction": {
     "source": "src/attune/workflows/suggestions.py",
     "hash": "caa3f48a039def99a5bf58dc29129aba9548dfc74a42cc69dfb067aeb71f3200",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-adding-a-plugin-skill-has-three-enforcement-gates-not-one": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-adding-a-workspace-sibling-package-as-an-extra-can-silently": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-adding-dns-resolution-to-validate-webhook-url-breaks-tests-that": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-adding-logger-before-eager-imports-triggers-e402-in-init-py": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-after-a-pr-merges-while-youre-afk-pull-main-before-tagging": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-after-a-squash-merge-of-a-feature-branch-local-main-can-have": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-agents": {
     "source": "content/features/agents.md",
     "hash": "a5b1678ecf012c7b2877a6c7ecae4a6c3f14c084c13fbcbb7eee79119dce6fa3",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-agents-skills-must-stay-synced-with-plugin-skills": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-anchor-tag-buttons-need-text-white-no-underline": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-anthropics-built-in-prompt-caching-supersedes-custom-caching": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-any-unstaged-file-triggers-pre-commit-stash-conflicts-with-auto": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-apply-lessons-by-problem-not-by-keyword": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-attune-author-check-staleness-load-manifest-is-the-python-api": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-attune-help-re-exports-create-a-hidden-cross-package-dep-on": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-attune-helps-sidecar-schemas-dont-match-path-keyed-assumptions": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-attune-skill-names-must-not-collide-with-claude-code-built-in": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-attune-workflow-run-code-review-and-security-audit-require-a": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-b904-raise-x-from-e-is-not-auto-fixable-by-ruff": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-background-processes-from-previous-sessions-persist-across": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-bandit-b108-blocks-hardcoded-tmp-paths": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-bare-manifest-in-gitignore-silently-excludes-any-manifest": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-baseworkflow-now-provides-self-logger": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-baseworkflow-uses-class-attributes-not-constructor-params": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-bg-var-primary-bg-opacity-10-is-invisible-in-dark-mode": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-broad-gitignore-patterns-match-nested-directories": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-bug-predict": {
     "source": "content/features/bug-predict.md",
     "hash": "6a4f420eba38e2fb884b837dd9758acb60ba60cdaf9248ec4280120b0d382b16",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-bug-predict-dangerous-eval-flags-subprocess-exec": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-bugpredictionworkflow-not-bugpredictworkflow": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-changing-error-messages-breaks-tests-across-the-codebase": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-changing-the-citation-anchor-format-can-silently-regress-llm": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-changing-user-facing-output-strings-cascades-through-test": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-chicken-and-egg-for-optional-extras-in-dev": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-ci-timeout-tests-enforce-the-range-you-set": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-citation-forced-prompting-and-prompt-injection-resistance-are": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-claude-agent-sdk-is-now-a-core-dependency-of-attune-ai": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-claude-agent-sdk-systempromptpreset-as-of-0-1-63-is-claude-code": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-claude-code-plugin-is-platform-specific": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-claude-code-plugins-expect-plugin-json-inside-claude-plugin": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-claude-plugin-install-is-marketplace-only": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-cli": {
     "source": "content/features/cli.md",
     "hash": "a37b4dc4f0b3706a62184b02d2be1536ad75eef39a0f22a9699db5d03b8ee050",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-clusterfuzz-dockerfile-copies-to-src-repo-but-also-copies": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-clusterfuzzlite-no-deps-misses-transitive-imports": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-coach-is-the-user-facing-entry-point-for-the-help-system": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-code-quality": {
     "source": "content/features/code-quality.md",
     "hash": "ce16ac87eb92e33a08d8c2f06e86ef22e436966f47f3a28c3f4eba19060b550a",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-codecov-patch-0-usually-means-tests-skipped-not-failed": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-codeql-alerts-dismissible-in-bulk-via-gh-api": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-codeql-js-stored-xss-flags-jsx-even-though-react-auto-escapes": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-codeql-py-clear-text-logging-sensitive-data-traces-data-flow": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-combine-two-unreleased-changelog-drafts-into-one-version-when": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-commands-are-not-namespaced-in-plugins-skills-are": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-config-py-alongside-config-creates-a-mypy-duplicate-module": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-configuration": {
     "source": "content/features/configuration.md",
     "hash": "8add90392883a46899ef8b57d135b625d92c5b61231d8a5301727f8b42f8e46f",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-costreport-fields-are-named-not-positional": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-costreport-is-a-dataclass-not-a-dict": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-cross-review": {
     "source": "content/features/cross-review.md",
     "hash": "dc5ae75883b05f97983377b51e275bab79921e992d842ebb2616726b8c8c2cdb",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-custom-mcp-stdio-loop-fails-claude-code-handshake": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-dataclassorder-true-needs-compare-false-on-list-fields": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-datetime-utcnow-datetime-nowtimezone-utc-cascades-through-the": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-dead-code-modules-with-full-test-suites-look-alive": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-dead-tests-from-monorepo-extraction-accumulate-in-packages-with": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-deep-review": {
     "source": "content/features/deep-review.md",
     "hash": "6a4fffc907302b4847d96097189bd8d329d3f1548d1ee46d9232f6ceecdfb450",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-deep-review-false-positives-verify-before-acting": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-delete-deprecated-module-is-rarely-a-simple-delete-grep-src-and": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-dependency-lower-bounds-trigger-scorecard-vulnerability-alerts": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-detect-secrets-flags-fake-as-a-secret-in-test-fixtures": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-direct-pushes-to-main-are-blocked-by-the-presence-of-required": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-dispatch-tables-hold-direct-function-references-mocks-must": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-dist-can-contain-stale-artifacts-after-version-bumps": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-doc-gen": {
     "source": "content/features/doc-gen.md",
     "hash": "26e02a71a523775f5bb9e371b2e563c3c858386436a73b727422f62f57de0282",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-dont-append-z-to-timezone-aware-isoformat": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-dry-run-candidate-golden-queries-through-the-resolver-before": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-duck-typed-test-fakes-fail-isinstance-based-collectors-silently": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-duplicate-plugins-cause-conflicting-skill-triggers": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-elicitation-forms": {
     "source": "content/features/elicitation-forms.md",
     "hash": "4f326dd6f99f86af163cf44167b243d73ee5165ef8373bf4cea83039aec723d2",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-enforce-admins-false-defeats-code-review-scorecard-check": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-enforce-admins-required-reviews-blocks-solo-dev-merges": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-exclude-hard-queries-from-aggregate-p-1-metrics-in-benchmark": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-exploration-agents-fabricate-names-verify-against-source": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-f841-unused-fixture-lint-fires-when-a-test-is-refactored-to": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-fastembed-is-the-local-embeddings-path-that-passes-a-50mb": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
+  },
+  "err-fix": {
+    "source": "content/features/fix.md",
+    "hash": "f4eb5cf49e7e9959b863b2bb1a866df14faa7a3f1c9bf1fe8acd1dc7e09bd1d6",
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-fix-test": {
     "source": "content/features/fix-test.md",
     "hash": "8b182bab8816d525d3325746f4cdeed013113a1bdb0a43d36963e121afa42812",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-forced-anthropic-tool-use-is-the-cleanest-path-to-guaranteed": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-forced-cite-per-claim-prompting-is-the-structural-lever-for-rag": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-formatter-strips-imports-that-are-unused-at-the-moment-you-save": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-full-coverage-runs-on-15k-test-suites-timeout-easily": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-generated-content-with-trailing-whitespace-causes-perpetual-pre": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-getattrmodule-name-none-at-call-site-is-the-clean-degradation": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-gh-api-x-patch-f-name-n-rejects-integers-as-strings": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-gh-pr-checks-json-field-names": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-gh-pr-merge-admin-is-blocked-by-in-progress-required-checks": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-gh-pr-merge-admin-prints-a-fast-forward-warning-even-when-the": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-gh-repo-create-source-path-push-is-a-one-shot-for-new-sibling": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-gh-workflow-run-file-yml-ref-tag-re-triggers-a-release-gated": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-ghost-command-references-survive-cli-renames": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-git-commit-q-can-exit-0-with-pre-commit-hook-feedback-that": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-git-pull-refuses-with-unstaged-changes-when-pull-rebase-true": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-git-rebase-root-exec-git-commit-amend-no-edit-s-re-signs-every": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-git-stash-pop-after-pre-commit-can-resurrect-stale-tool-state": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-github-actions-environment-deployment-approvals-can-be-self": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-github-copilot-autofix-pushes-commits-directly-to-pr-branches": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-github-protected-tags-cannot-be-force-updated": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-github-repos-serve-as-claude-code-marketplaces": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-gitignore-exclusions-break-ci-tests-that-read-those-files": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-glob-based-hash-computation-must-exclude-cache-dirs": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-golden-query-benchmarks-reveal-two-distinct-failure-classes": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-golden-query-test-fixtures-must-match-the-actual-corpus-layout": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-gpg-signing-fails-in-non-interactive-terminals-vscode-extension": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-hand-crafted-summary-prototype-is-the-fastest-way-to-measure-a": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-handoff-memory-option-b-proposals-are-often-wrong-re-analyze": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-hardcoded-root-paths-in-tests": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-hardcoded-strings-in-method-bodies-survive-class-attribute": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-hardcoded-user-id-defeats-ownership-checks": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-help-system": {
     "source": "content/features/help-system.md",
     "hash": "24468c8fe4f1a0e350e620098d65a3bcc007000cd5aa4dbe20a6e6c83efa87b3",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-hooks": {
     "source": "content/features/hooks.md",
     "hash": "5c6b8a45457387c76f628561d3baa56e9af1709bc9bd21bba9830b2c2478c8dd",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-hot-reload-subsystem-was-1-038-lines-of-dead-code": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-import-x-inside-a-try-block-except-x-someerror-in-the-except": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-importlib-import-module-is-an-arbitrary-code-execution-vector": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-industry-terminology-wont-appear-in-llm-polished-rag-summaries": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-integration-tests-gated-by-has-api-key-can-poison-the-whole-ci": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-is-private-is-a-superset-in-python-ipaddress": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-kwargs-collides-with-explicit-params-of-the-same-name": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-lazy-imports-inside-function-bodies-cant-be-patched-with": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-linkedin-paste-use-ascii-markers-not-unicode-arrows": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-list-wizards-is-a-function-not-a-class-method": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-list-workflows-deduplication-must-keep-base-names-visible": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-llm-api-responses-lack-trailing-newlines": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-local-telemetry-trackers-need-an-autouse-conftest-fixture": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-macos-var-private-var-symlink-breaks-path-assertions": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-mcp-attune-ai-doc-orchestrator-is-a-no-op-stub": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-mcp-call-tool-wrapper-pattern": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-mcp-handler-validate-paths-before-importing-workflows": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-mcp-json-python-resolves-to-pyenv-shim-not-project-venv": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-mcp-server": {
     "source": "content/features/mcp-server.md",
     "hash": "8e4b8c74eff980330480ae70856a1cf0393559cd22eb9ba0210b43249f9b5181",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-mcp-server-process-doesnt-inherit-env-variables": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-mcp-tool-count-tests-are-hardcoded": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-mcp-tool-renames-propagate-to-skill-docs": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-mcp-workspace-root-defaults-to-os-getcwd-tests-with-tmp-path": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-memory": {
     "source": "content/features/memory.md",
     "hash": "32b3121d9110dc9ac327bb9e838f060fbe9940a033366b0147ef34ef2efaa4dc",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-metadata-can-reach-a-retriever-with-zero-signal-if-the-sidecar": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-metapathfinder-find-module-load-module-is-dead-in-python-3-12": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-mixin-classes-inherit-self-workspace-root-at-runtime-not-at": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-mkdocs-build-crashing-with-attributeerror-nonetype-object-has": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-mkdocs-strict-treats-broken-links-as-fatal-errors": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-mock-a-lazy-import-x-with-types-moduletype-patch-dictsys-modules": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-models": {
     "source": "content/features/models.md",
     "hash": "2117cbb0d8e863db6091870874e4ce80b48780c9ee8bb7330d8033c172ccb02b",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-modeltier-has-two-copies-imports-must-match": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-module-level-optional-imports-enable-clean-test-patching": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-multiple-pinentry-program-lines-in-gpg-agent-conf-first-wins": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-mutual-competition-between-polished-rag-features-is-real-and": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-mypy-437-errors-was-stale-actual-count-was-2": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-naive-suffix-strip-stemming-fails-on-english-doubling-consonant": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-never-paste-pypi-tokens-into-chat-or-logs": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-new-dataclass-fields-need-both-the-class-and-the-parser-updated": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-new-mcp-handlers-must-match-the-validation-pattern-of-adjacent": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-new-security-features-need-dedicated-tests-before-release": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-next-js-shared-data-libs-prevent-page-duplication": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-non-baseworkflow-classes-in-workflow-registry-crash-the-cli": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-noqa-f401-re-exports-break-silently-on-satellite-file-deletion": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-openssf-scorecard-alerts-2-codereviewid-3-sastid-are-process": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-ops-dashboard": {
     "source": "content/features/ops-dashboard.md",
     "hash": "fefc8e2b2b4a25055fcbdf96cbd8638d75278cbcacd256873b725df89544c1f6",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-orchestration": {
     "source": "content/features/orchestration.md",
     "hash": "4998437e04355011a7dee68dbce7e9e78bbe97f637e0b6a14c1ec972f541695c",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-orphan-help-dirs-are-deprecated-3-depth-output-adding-them-to": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-orphan-top-level-docs-directories-stay-invisible-to-readers": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-packages-attune-in-attune-ai-are-pointer-stubs-not-source": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-past-due-deprecations-are-deletion-targets-not-implementation": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-patch-requires-the-target-name-to-exist-at-module-scope-at": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-patch-the-source-module-for-from-x-import-y-in-function-bodies": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-path-cwd-at-module-level-captures-import-time-cwd": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-path-globdir-matches-directories-not-files": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-path-rename-fails-on-windows-when-target-exists": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-pip-audit-fails-on-unpublished-versions": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-platform-conditional-security-test-assertions-should-accept-any": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-plugin": {
     "source": "content/features/plugin.md",
     "hash": "8cc6e5702ffc8228ed63cfb74a25dd3e99e79e5335c4b1c8c134950f8b9a043d",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-plugin-read-skill-references-break-outside-the-plugin": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-pr-test-workflows-may-not-auto-trigger-after-close-reopen-or": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-pre-commit-auto-fix-requires-re-stage-before-retry": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-pre-commit-black-unstaged-files-re-stage-after-failure": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-pre-commit-stash-conflict-when-black-ruff-fix-files-with": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-pre-commit-stash-conflict-with-auto-fix-hooks": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-pre-commit-stash-conflicts-when-any-tracked-unstaged-file": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-pre-committed-decision-matrices-survive-contact-with-data": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-pre-flight-pre-commits-pinned-black-ruff-on-new-files-before": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-prefer-github-actions-trusted-publishing-over-local-twine-uv": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-prompt-template-word-wrap-silently-breaks-single-line-substring": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-provenance-citation-records-usually-store-short-previews-not": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-pull-main-before-merging-develop-to-avoid-merge-commits": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-pureposixpath-match-doesnt-support-in-python-3-10": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-pureposixpath-strips-trailing-slashes": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-push-specific-tags-not-tags": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-pypi-env-policies-may-whitelist-branches-only-tag-triggered": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-pypi-environment-requires-manual-approval-in-github-actions": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-pypi-renders-readme-links-relative-to-its-own-domain": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-pypi-trusted-publisher-workflow-name-field-wants-the-filename": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-pytest-importorskip-triggers-ruff-e402": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-pytest-lives-in-the-dev-extra-not-developer": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-query-fixtures-are-self-diagnostic-for-rag-corpora-even-without": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-rag-grounding": {
     "source": "content/features/rag-grounding.md",
     "hash": "3464dd78c83f06980912a7c49dc185b09830be1b1c163203f10e5aa1708fcf4e",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-re-adding-an-import-after-the-formatter-strips-it-use-function": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-re-enabling-required-reviews-kills-queued-auto-merge": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-re-export-accessibility-tests-are-scattered-across-batch-files": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-read-source-before-writing-tests-for-tricky-logic": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-real-project-files-on-disk-override-test-mocks": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-rebuild-dist-after-readme-changes": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-reclassify-unexpectedly-hard-golden-queries-up-the-difficulty": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-redisshorttermmemory-mock-injection-path": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-refactor-plan": {
     "source": "content/features/refactor-plan.md",
     "hash": "8f8c684cd94fca7b2580ecaaf955ccb79924022796d576d477cdab9330df9704",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-registry-count-assertions-are-scattered-across-test-files": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-release-branches-carry-unmerged-commits-that-feature-branches": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-release-notes": {
     "source": "content/features/release-notes.md",
     "hash": "da7101ffbec4d209fcb1cef754f01cef8a13458a6f961c3a23909edfec77e58c",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-release-prep": {
     "source": "content/features/release-prep.md",
     "hash": "cd77b5903fbeb7d7e0acef570bab9727b4c143181ea6be1f52b9a25bc11418bb",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-release-published-workflow-dispatch-both-approved-for-pypi-env": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-removing-one-workspace-dep-can-cascade-to-remove-others": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-replacing-a-mixin-based-class-scatters-test-failures-across": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-repo-merge-policy-may-restrict-merge-strategies": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-repo-root-parents-count-varies-by-file-depth": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-required-status-check-names-must-match-githubs-exact-check-names": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-research-subagents-can-hallucinate-sdk-signatures-introspect": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-resilience": {
     "source": "content/features/resilience.md",
     "hash": "ae2a76f0f1ecbb9ca687e5a041acc2b4a25a5113ec57eaad550f48b8aadc4be2",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-resultmessage-result-is-often-none-capture-assistantmessage": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-rich-live-is-output-only-use-textual-for-any-interactive-row": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-ruff-auto-fix-strips-imports-before-usage-code-exists": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-ruff-parses-pytest-ini-as-python": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-run-simplify-catches-per-file-errors-internally": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-sbin-is-a-symlink-to-usr-sbin-on-modern-ubuntu": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-scorecards-pip-parser-ignores-hash-flags-entirely": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-sdk-adapter-swallows-subagent-findings-lesson-was-wrong-adapter": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-sdk-agent-model-config-uses-stale-model-names": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-sdk-native-security-audit-workflow-swallows-subagent-findings": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-sdk-native-workflows-validate-in-execute-not-input-schema": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-security-audit": {
     "source": "content/features/security-audit.md",
     "hash": "9cce18573c827fab9a380efe8c65c2f8c5b4ada3f7e383dd71ec523a0875fb05",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-selective-hook-skip-with-skip-hookname-is-not-the-same-as-no": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-semantic-cache-70-hit-rate-claim-was-unmeasured": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-session-handoff": {
     "source": "content/features/session-handoff.md",
     "hash": "236c16ee2d2e48f0bd8ba075c69f50ead16a46ef185fede3d84b529c66fd41a0",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-session-hooks-may-be-vestigial": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-shadow-directories-at-repo-root-break-imports": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-silent-pass-blocks-in-discovery-registry-code-hide-import": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-skill-descriptions-must-be-under-250-characters": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-skill-frontmatter-allowlist-march-2026": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-skill-frontmatter-has-a-strict-allowlist": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-smart-test": {
     "source": "content/features/smart-test.md",
     "hash": "58c691c8313ddf9699deb913e6b5c50fafc684563539ddf4816a4b94a9ea3e80",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-spec-engine": {
     "source": "content/features/spec-engine.md",
     "hash": "c8549016aa848eeeaecbde8329f5850562f56280ab66428cb7c20887b428d81a",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-squash-merge-deletes-the-remote-branch-subsequent-push-silently": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-ssrf-always-decode-urls-before-validating-hostnames": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-ssrf-in-webhook-handlers-is-easy-to-miss": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-ssrf-strip-ipv6-zone-ids-before-ip-validation": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-stacked-patch-decorators-inject-args-bottom-up": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-staleness-detection-in-attune-author-attune-ais-help-system-is": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-stop-hook-ordering-matters": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-stop-hooks-inject-stderr-not-stdout": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-stop-hooks-loop-without-a-sentinel": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-stop-hooks-missing-cd-prefix-inherit-session-cwd": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-structlog-default-output-pollutes-stdout-captured-cli-tests": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-structlog-kwargs-vs-stdlib-logger": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-tags-pushed-before-squash-merge-point-to-the-wrong-commit": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-telemetry": {
     "source": "content/features/telemetry.md",
     "hash": "59473ab809113116a3d58d2ead3a5f13e362d6992d8cee0a89364feded5cbd50",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-template-generators-overwrite-hand-written-files": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-test-mocks-must-match-imports": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-tests-for-optional-dep-code-need-pytest-importorskip-guards-in": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-text-white-on-gradient-primary-sections-gets-overridden": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-todo-counts-are-inflated-by-docstrings-and-prompt-strings": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-twine-cannot-prompt-for-tokens-in-claude-codes-non-interactive": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-two-codeql-setups-can-coexist-in-one-repo-and-deadlock-merges": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-two-parallel-help-template-generators-in-the-attune-ecosystem": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-uncommitted-claude-mcp-json-means-mcp-server-never-starts": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-untracked-scripts-break-ci-when-tests-import-them": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-unused-init-py-re-exports-become-invisible-runtime-deps": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-use-dataclass-post-init-to-coalesce-between-a-scalar-legacy": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-uv-lock-can-drift-from-pyproject-toml-on-shared-branches": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-uv-lock-may-briefly-fail-to-find-a-just-published-pypi-version": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-uv-lock-retains-editable-name-paths-after-tool-uv-sources-edits": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-uv-pip-install-e-does-not-regenerate-project-scripts-console": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-uv-pip-install-e-path-can-ship-stale-package-data-even-after": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-uv-pip-install-e-sibling-path-no-deps-is-the-clean-venv-local": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-uv-run-in-pre-commit-hooks-propagates-lockfile-errors-as-hook": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-uv-run-pip-audit-runs-the-pyenv-shim-not-the-venv": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-uv-sync-respects-existing-lockfile-pins-when-they-still-satisfy": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-uv-sync-wipes-packages-installed-via-pip-install": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-validate-file-path-needed-on-reads-too-not-just-writes": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-validate-infrastructure-against-user-value-before-extending": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-verify-mcp-tool-wiring-after-adding-new-tools": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-verify-new-dispatch-branches-with-a-known-fixture-not-just": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-verify-optional-dep-boundaries-with-a-metapathfinder-not-by": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-version-bumps-must-update-7-files-not-just-pyproject-toml": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-vs-code-extension-reads-mcp-json-at-project-root-not-claude-mcp": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-website-feature-lists-can-diverge-from-the-python-registry": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-windows-ci-encoding": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-windows-ci-runners-are-3x-slower-than-ubuntu-macos": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-windows-path-resolve-prepends-the-drive-letter-to-unix-paths": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-windows-time-time-can-return-0-0-duration-for-fast-operations": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-wizards": {
     "source": "content/features/wizards.md",
     "hash": "6fe7722a026d11276ebfbdf4ea046a05112be94b560f9abf3ffee410f8637d8f",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-wizards-call-workflows-internally-they-are-not-duplicates": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-workflowresult-constructor-mismatches-surface-only-at-runtime": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-yaml-run-block-scalars-break-on-blank-lines-inside-multi-line": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-yaml-run-values-with-colons-cause-parse-errors": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "err-zsh-has-status-as-a-read-only-builtin-variable": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-adding-a-plugin-skill-has-three-enforcement-gates-not-one": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-adding-a-workspace-sibling-package-as-an-extra-can-silently": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-adding-dns-resolution-to-validate-webhook-url-breaks-tests-that": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-adding-logger-before-eager-imports-triggers-e402-in-init-py": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-after-a-pr-merges-while-youre-afk-pull-main-before-tagging": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-after-a-squash-merge-of-a-feature-branch-local-main-can-have": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-agents": {
     "source": "content/features/agents.md",
     "hash": "a5b1678ecf012c7b2877a6c7ecae4a6c3f14c084c13fbcbb7eee79119dce6fa3",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-agents-skills-must-stay-synced-with-plugin-skills": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-anchor-tag-buttons-need-text-white-no-underline": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-anthropics-built-in-prompt-caching-supersedes-custom-caching": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-any-unstaged-file-triggers-pre-commit-stash-conflicts-with-auto": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-apply-lessons-by-problem-not-by-keyword": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-attune-author-check-staleness-load-manifest-is-the-python-api": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-attune-help-re-exports-create-a-hidden-cross-package-dep-on": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-attune-helps-sidecar-schemas-dont-match-path-keyed-assumptions": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-attune-skill-names-must-not-collide-with-claude-code-built-in": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-attune-workflow-run-code-review-and-security-audit-require-a": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-b904-raise-x-from-e-is-not-auto-fixable-by-ruff": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-background-processes-from-previous-sessions-persist-across": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-bandit-b108-blocks-hardcoded-tmp-paths": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-bare-manifest-in-gitignore-silently-excludes-any-manifest": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-baseworkflow-now-provides-self-logger": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-baseworkflow-uses-class-attributes-not-constructor-params": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-bg-var-primary-bg-opacity-10-is-invisible-in-dark-mode": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-broad-gitignore-patterns-match-nested-directories": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-bug-predict": {
     "source": "content/features/bug-predict.md",
     "hash": "6a4f420eba38e2fb884b837dd9758acb60ba60cdaf9248ec4280120b0d382b16",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-bug-predict-dangerous-eval-flags-subprocess-exec": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-bugpredictionworkflow-not-bugpredictworkflow": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-changing-error-messages-breaks-tests-across-the-codebase": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-changing-the-citation-anchor-format-can-silently-regress-llm": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-changing-user-facing-output-strings-cascades-through-test": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-chicken-and-egg-for-optional-extras-in-dev": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-ci-timeout-tests-enforce-the-range-you-set": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-citation-forced-prompting-and-prompt-injection-resistance-are": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-claude-agent-sdk-is-now-a-core-dependency-of-attune-ai": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-claude-agent-sdk-systempromptpreset-as-of-0-1-63-is-claude-code": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-claude-code-plugin-is-platform-specific": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-claude-code-plugins-expect-plugin-json-inside-claude-plugin": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-claude-plugin-install-is-marketplace-only": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-cli": {
     "source": "content/features/cli.md",
     "hash": "a37b4dc4f0b3706a62184b02d2be1536ad75eef39a0f22a9699db5d03b8ee050",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-clusterfuzz-dockerfile-copies-to-src-repo-but-also-copies": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-clusterfuzzlite-no-deps-misses-transitive-imports": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-coach-is-the-user-facing-entry-point-for-the-help-system": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-code-quality": {
     "source": "content/features/code-quality.md",
     "hash": "ce16ac87eb92e33a08d8c2f06e86ef22e436966f47f3a28c3f4eba19060b550a",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-codecov-patch-0-usually-means-tests-skipped-not-failed": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-codeql-alerts-dismissible-in-bulk-via-gh-api": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-codeql-js-stored-xss-flags-jsx-even-though-react-auto-escapes": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-codeql-py-clear-text-logging-sensitive-data-traces-data-flow": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-combine-two-unreleased-changelog-drafts-into-one-version-when": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-commands-are-not-namespaced-in-plugins-skills-are": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-config-py-alongside-config-creates-a-mypy-duplicate-module": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-configuration": {
     "source": "content/features/configuration.md",
     "hash": "8add90392883a46899ef8b57d135b625d92c5b61231d8a5301727f8b42f8e46f",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-costreport-fields-are-named-not-positional": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-costreport-is-a-dataclass-not-a-dict": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-cross-review": {
     "source": "content/features/cross-review.md",
     "hash": "dc5ae75883b05f97983377b51e275bab79921e992d842ebb2616726b8c8c2cdb",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-custom-mcp-stdio-loop-fails-claude-code-handshake": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-dataclassorder-true-needs-compare-false-on-list-fields": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-datetime-utcnow-datetime-nowtimezone-utc-cascades-through-the": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-dead-code-modules-with-full-test-suites-look-alive": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-dead-tests-from-monorepo-extraction-accumulate-in-packages-with": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-deep-review": {
     "source": "content/features/deep-review.md",
     "hash": "6a4fffc907302b4847d96097189bd8d329d3f1548d1ee46d9232f6ceecdfb450",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-deep-review-false-positives-verify-before-acting": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-delete-deprecated-module-is-rarely-a-simple-delete-grep-src-and": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-dependency-lower-bounds-trigger-scorecard-vulnerability-alerts": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-detect-secrets-flags-fake-as-a-secret-in-test-fixtures": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-direct-pushes-to-main-are-blocked-by-the-presence-of-required": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-dispatch-tables-hold-direct-function-references-mocks-must": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-dist-can-contain-stale-artifacts-after-version-bumps": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-doc-gen": {
     "source": "content/features/doc-gen.md",
     "hash": "26e02a71a523775f5bb9e371b2e563c3c858386436a73b727422f62f57de0282",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-dont-append-z-to-timezone-aware-isoformat": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-dry-run-candidate-golden-queries-through-the-resolver-before": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-duck-typed-test-fakes-fail-isinstance-based-collectors-silently": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-duplicate-plugins-cause-conflicting-skill-triggers": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-elicitation-forms": {
     "source": "content/features/elicitation-forms.md",
     "hash": "4f326dd6f99f86af163cf44167b243d73ee5165ef8373bf4cea83039aec723d2",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-enforce-admins-false-defeats-code-review-scorecard-check": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-enforce-admins-required-reviews-blocks-solo-dev-merges": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-exclude-hard-queries-from-aggregate-p-1-metrics-in-benchmark": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-exploration-agents-fabricate-names-verify-against-source": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-f841-unused-fixture-lint-fires-when-a-test-is-refactored-to": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-fastembed-is-the-local-embeddings-path-that-passes-a-50mb": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
+  },
+  "faq-fix": {
+    "source": "content/features/fix.md",
+    "hash": "f4eb5cf49e7e9959b863b2bb1a866df14faa7a3f1c9bf1fe8acd1dc7e09bd1d6",
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-fix-test": {
     "source": "content/features/fix-test.md",
     "hash": "8b182bab8816d525d3325746f4cdeed013113a1bdb0a43d36963e121afa42812",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-forced-anthropic-tool-use-is-the-cleanest-path-to-guaranteed": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-forced-cite-per-claim-prompting-is-the-structural-lever-for-rag": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-formatter-strips-imports-that-are-unused-at-the-moment-you-save": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-full-coverage-runs-on-15k-test-suites-timeout-easily": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-generated-content-with-trailing-whitespace-causes-perpetual-pre": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-getattrmodule-name-none-at-call-site-is-the-clean-degradation": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-gh-api-x-patch-f-name-n-rejects-integers-as-strings": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-gh-pr-checks-json-field-names": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-gh-pr-merge-admin-is-blocked-by-in-progress-required-checks": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-gh-pr-merge-admin-prints-a-fast-forward-warning-even-when-the": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-gh-repo-create-source-path-push-is-a-one-shot-for-new-sibling": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-gh-workflow-run-file-yml-ref-tag-re-triggers-a-release-gated": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-ghost-command-references-survive-cli-renames": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-git-commit-q-can-exit-0-with-pre-commit-hook-feedback-that": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-git-pull-refuses-with-unstaged-changes-when-pull-rebase-true": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-git-rebase-root-exec-git-commit-amend-no-edit-s-re-signs-every": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-git-stash-pop-after-pre-commit-can-resurrect-stale-tool-state": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-github-actions-environment-deployment-approvals-can-be-self": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-github-copilot-autofix-pushes-commits-directly-to-pr-branches": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-github-protected-tags-cannot-be-force-updated": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-github-repos-serve-as-claude-code-marketplaces": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-gitignore-exclusions-break-ci-tests-that-read-those-files": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-glob-based-hash-computation-must-exclude-cache-dirs": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-golden-query-benchmarks-reveal-two-distinct-failure-classes": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-golden-query-test-fixtures-must-match-the-actual-corpus-layout": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-gpg-signing-fails-in-non-interactive-terminals-vscode-extension": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-hand-crafted-summary-prototype-is-the-fastest-way-to-measure-a": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-handoff-memory-option-b-proposals-are-often-wrong-re-analyze": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-hardcoded-root-paths-in-tests": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-hardcoded-strings-in-method-bodies-survive-class-attribute": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-hardcoded-user-id-defeats-ownership-checks": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-help-system": {
     "source": "content/features/help-system.md",
     "hash": "24468c8fe4f1a0e350e620098d65a3bcc007000cd5aa4dbe20a6e6c83efa87b3",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-hooks": {
     "source": "content/features/hooks.md",
     "hash": "5c6b8a45457387c76f628561d3baa56e9af1709bc9bd21bba9830b2c2478c8dd",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-hot-reload-subsystem-was-1-038-lines-of-dead-code": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-import-x-inside-a-try-block-except-x-someerror-in-the-except": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-importlib-import-module-is-an-arbitrary-code-execution-vector": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-industry-terminology-wont-appear-in-llm-polished-rag-summaries": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-integration-tests-gated-by-has-api-key-can-poison-the-whole-ci": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-is-private-is-a-superset-in-python-ipaddress": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-kwargs-collides-with-explicit-params-of-the-same-name": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-lazy-imports-inside-function-bodies-cant-be-patched-with": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-linkedin-paste-use-ascii-markers-not-unicode-arrows": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-list-wizards-is-a-function-not-a-class-method": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-list-workflows-deduplication-must-keep-base-names-visible": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-llm-api-responses-lack-trailing-newlines": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-local-telemetry-trackers-need-an-autouse-conftest-fixture": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-macos-var-private-var-symlink-breaks-path-assertions": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-mcp-attune-ai-doc-orchestrator-is-a-no-op-stub": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-mcp-call-tool-wrapper-pattern": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-mcp-handler-validate-paths-before-importing-workflows": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-mcp-json-python-resolves-to-pyenv-shim-not-project-venv": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-mcp-server": {
     "source": "content/features/mcp-server.md",
     "hash": "8e4b8c74eff980330480ae70856a1cf0393559cd22eb9ba0210b43249f9b5181",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-mcp-server-process-doesnt-inherit-env-variables": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-mcp-tool-count-tests-are-hardcoded": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-mcp-tool-renames-propagate-to-skill-docs": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-mcp-workspace-root-defaults-to-os-getcwd-tests-with-tmp-path": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-memory": {
     "source": "content/features/memory.md",
     "hash": "32b3121d9110dc9ac327bb9e838f060fbe9940a033366b0147ef34ef2efaa4dc",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-metadata-can-reach-a-retriever-with-zero-signal-if-the-sidecar": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-metapathfinder-find-module-load-module-is-dead-in-python-3-12": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-mixin-classes-inherit-self-workspace-root-at-runtime-not-at": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-mkdocs-build-crashing-with-attributeerror-nonetype-object-has": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-mkdocs-strict-treats-broken-links-as-fatal-errors": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-mock-a-lazy-import-x-with-types-moduletype-patch-dictsys-modules": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-models": {
     "source": "content/features/models.md",
     "hash": "2117cbb0d8e863db6091870874e4ce80b48780c9ee8bb7330d8033c172ccb02b",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-modeltier-has-two-copies-imports-must-match": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-module-level-optional-imports-enable-clean-test-patching": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-multiple-pinentry-program-lines-in-gpg-agent-conf-first-wins": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-mutual-competition-between-polished-rag-features-is-real-and": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-mypy-437-errors-was-stale-actual-count-was-2": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-naive-suffix-strip-stemming-fails-on-english-doubling-consonant": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-never-paste-pypi-tokens-into-chat-or-logs": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-new-dataclass-fields-need-both-the-class-and-the-parser-updated": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-new-mcp-handlers-must-match-the-validation-pattern-of-adjacent": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-new-security-features-need-dedicated-tests-before-release": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-next-js-shared-data-libs-prevent-page-duplication": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-non-baseworkflow-classes-in-workflow-registry-crash-the-cli": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-noqa-f401-re-exports-break-silently-on-satellite-file-deletion": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-openssf-scorecard-alerts-2-codereviewid-3-sastid-are-process": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-ops-dashboard": {
     "source": "content/features/ops-dashboard.md",
     "hash": "fefc8e2b2b4a25055fcbdf96cbd8638d75278cbcacd256873b725df89544c1f6",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-orchestration": {
     "source": "content/features/orchestration.md",
     "hash": "4998437e04355011a7dee68dbce7e9e78bbe97f637e0b6a14c1ec972f541695c",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-orphan-help-dirs-are-deprecated-3-depth-output-adding-them-to": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-orphan-top-level-docs-directories-stay-invisible-to-readers": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-packages-attune-in-attune-ai-are-pointer-stubs-not-source": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-past-due-deprecations-are-deletion-targets-not-implementation": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-patch-requires-the-target-name-to-exist-at-module-scope-at": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-patch-the-source-module-for-from-x-import-y-in-function-bodies": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-path-cwd-at-module-level-captures-import-time-cwd": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-path-globdir-matches-directories-not-files": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-path-rename-fails-on-windows-when-target-exists": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-pip-audit-fails-on-unpublished-versions": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-platform-conditional-security-test-assertions-should-accept-any": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-plugin": {
     "source": "content/features/plugin.md",
     "hash": "8cc6e5702ffc8228ed63cfb74a25dd3e99e79e5335c4b1c8c134950f8b9a043d",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-plugin-read-skill-references-break-outside-the-plugin": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-pr-test-workflows-may-not-auto-trigger-after-close-reopen-or": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-pre-commit-auto-fix-requires-re-stage-before-retry": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-pre-commit-black-unstaged-files-re-stage-after-failure": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-pre-commit-stash-conflict-when-black-ruff-fix-files-with": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-pre-commit-stash-conflict-with-auto-fix-hooks": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-pre-commit-stash-conflicts-when-any-tracked-unstaged-file": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-pre-committed-decision-matrices-survive-contact-with-data": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-pre-flight-pre-commits-pinned-black-ruff-on-new-files-before": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-prefer-github-actions-trusted-publishing-over-local-twine-uv": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-prompt-template-word-wrap-silently-breaks-single-line-substring": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-provenance-citation-records-usually-store-short-previews-not": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-pull-main-before-merging-develop-to-avoid-merge-commits": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-pureposixpath-match-doesnt-support-in-python-3-10": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-pureposixpath-strips-trailing-slashes": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-push-specific-tags-not-tags": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-pypi-env-policies-may-whitelist-branches-only-tag-triggered": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-pypi-environment-requires-manual-approval-in-github-actions": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-pypi-renders-readme-links-relative-to-its-own-domain": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-pypi-trusted-publisher-workflow-name-field-wants-the-filename": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-pytest-importorskip-triggers-ruff-e402": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-pytest-lives-in-the-dev-extra-not-developer": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-query-fixtures-are-self-diagnostic-for-rag-corpora-even-without": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-rag-grounding": {
     "source": "content/features/rag-grounding.md",
     "hash": "3464dd78c83f06980912a7c49dc185b09830be1b1c163203f10e5aa1708fcf4e",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-re-adding-an-import-after-the-formatter-strips-it-use-function": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-re-enabling-required-reviews-kills-queued-auto-merge": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-re-export-accessibility-tests-are-scattered-across-batch-files": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-read-source-before-writing-tests-for-tricky-logic": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-real-project-files-on-disk-override-test-mocks": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-rebuild-dist-after-readme-changes": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-reclassify-unexpectedly-hard-golden-queries-up-the-difficulty": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-redisshorttermmemory-mock-injection-path": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-refactor-plan": {
     "source": "content/features/refactor-plan.md",
     "hash": "8f8c684cd94fca7b2580ecaaf955ccb79924022796d576d477cdab9330df9704",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-registry-count-assertions-are-scattered-across-test-files": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-release-branches-carry-unmerged-commits-that-feature-branches": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-release-notes": {
     "source": "content/features/release-notes.md",
     "hash": "da7101ffbec4d209fcb1cef754f01cef8a13458a6f961c3a23909edfec77e58c",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-release-prep": {
     "source": "content/features/release-prep.md",
     "hash": "cd77b5903fbeb7d7e0acef570bab9727b4c143181ea6be1f52b9a25bc11418bb",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-release-published-workflow-dispatch-both-approved-for-pypi-env": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-removing-one-workspace-dep-can-cascade-to-remove-others": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-replacing-a-mixin-based-class-scatters-test-failures-across": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-repo-merge-policy-may-restrict-merge-strategies": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-repo-root-parents-count-varies-by-file-depth": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-required-status-check-names-must-match-githubs-exact-check-names": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-research-subagents-can-hallucinate-sdk-signatures-introspect": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-resilience": {
     "source": "content/features/resilience.md",
     "hash": "ae2a76f0f1ecbb9ca687e5a041acc2b4a25a5113ec57eaad550f48b8aadc4be2",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-resultmessage-result-is-often-none-capture-assistantmessage": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-rich-live-is-output-only-use-textual-for-any-interactive-row": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-ruff-auto-fix-strips-imports-before-usage-code-exists": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-ruff-parses-pytest-ini-as-python": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-run-simplify-catches-per-file-errors-internally": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-sbin-is-a-symlink-to-usr-sbin-on-modern-ubuntu": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-scorecards-pip-parser-ignores-hash-flags-entirely": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-sdk-adapter-swallows-subagent-findings-lesson-was-wrong-adapter": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-sdk-agent-model-config-uses-stale-model-names": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-sdk-native-security-audit-workflow-swallows-subagent-findings": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-sdk-native-workflows-validate-in-execute-not-input-schema": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-security-audit": {
     "source": "content/features/security-audit.md",
     "hash": "9cce18573c827fab9a380efe8c65c2f8c5b4ada3f7e383dd71ec523a0875fb05",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-selective-hook-skip-with-skip-hookname-is-not-the-same-as-no": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-semantic-cache-70-hit-rate-claim-was-unmeasured": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-session-handoff": {
     "source": "content/features/session-handoff.md",
     "hash": "236c16ee2d2e48f0bd8ba075c69f50ead16a46ef185fede3d84b529c66fd41a0",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-session-hooks-may-be-vestigial": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-shadow-directories-at-repo-root-break-imports": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-silent-pass-blocks-in-discovery-registry-code-hide-import": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-skill-descriptions-must-be-under-250-characters": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-skill-frontmatter-allowlist-march-2026": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-skill-frontmatter-has-a-strict-allowlist": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-smart-test": {
     "source": "content/features/smart-test.md",
     "hash": "58c691c8313ddf9699deb913e6b5c50fafc684563539ddf4816a4b94a9ea3e80",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-spec-engine": {
     "source": "content/features/spec-engine.md",
     "hash": "c8549016aa848eeeaecbde8329f5850562f56280ab66428cb7c20887b428d81a",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-squash-merge-deletes-the-remote-branch-subsequent-push-silently": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-ssrf-always-decode-urls-before-validating-hostnames": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-ssrf-in-webhook-handlers-is-easy-to-miss": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-ssrf-strip-ipv6-zone-ids-before-ip-validation": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-stacked-patch-decorators-inject-args-bottom-up": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-staleness-detection-in-attune-author-attune-ais-help-system-is": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-stop-hook-ordering-matters": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-stop-hooks-inject-stderr-not-stdout": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-stop-hooks-loop-without-a-sentinel": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-stop-hooks-missing-cd-prefix-inherit-session-cwd": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-structlog-default-output-pollutes-stdout-captured-cli-tests": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-structlog-kwargs-vs-stdlib-logger": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-tags-pushed-before-squash-merge-point-to-the-wrong-commit": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-telemetry": {
     "source": "content/features/telemetry.md",
     "hash": "59473ab809113116a3d58d2ead3a5f13e362d6992d8cee0a89364feded5cbd50",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-template-generators-overwrite-hand-written-files": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-test-mocks-must-match-imports": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-tests-for-optional-dep-code-need-pytest-importorskip-guards-in": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-text-white-on-gradient-primary-sections-gets-overridden": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-todo-counts-are-inflated-by-docstrings-and-prompt-strings": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-twine-cannot-prompt-for-tokens-in-claude-codes-non-interactive": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-two-codeql-setups-can-coexist-in-one-repo-and-deadlock-merges": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-two-parallel-help-template-generators-in-the-attune-ecosystem": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-uncommitted-claude-mcp-json-means-mcp-server-never-starts": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-untracked-scripts-break-ci-when-tests-import-them": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-unused-init-py-re-exports-become-invisible-runtime-deps": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-use-dataclass-post-init-to-coalesce-between-a-scalar-legacy": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-uv-lock-can-drift-from-pyproject-toml-on-shared-branches": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-uv-lock-may-briefly-fail-to-find-a-just-published-pypi-version": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-uv-lock-retains-editable-name-paths-after-tool-uv-sources-edits": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-uv-pip-install-e-does-not-regenerate-project-scripts-console": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-uv-pip-install-e-path-can-ship-stale-package-data-even-after": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-uv-pip-install-e-sibling-path-no-deps-is-the-clean-venv-local": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-uv-run-in-pre-commit-hooks-propagates-lockfile-errors-as-hook": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-uv-run-pip-audit-runs-the-pyenv-shim-not-the-venv": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-uv-sync-respects-existing-lockfile-pins-when-they-still-satisfy": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-uv-sync-wipes-packages-installed-via-pip-install": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-validate-file-path-needed-on-reads-too-not-just-writes": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-validate-infrastructure-against-user-value-before-extending": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-verify-mcp-tool-wiring-after-adding-new-tools": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-verify-new-dispatch-branches-with-a-known-fixture-not-just": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-verify-optional-dep-boundaries-with-a-metapathfinder-not-by": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-version-bumps-must-update-7-files-not-just-pyproject-toml": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-vs-code-extension-reads-mcp-json-at-project-root-not-claude-mcp": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-website-feature-lists-can-diverge-from-the-python-registry": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-windows-ci-encoding": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-windows-ci-runners-are-3x-slower-than-ubuntu-macos": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-windows-path-resolve-prepends-the-drive-letter-to-unix-paths": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-windows-time-time-can-return-0-0-duration-for-fast-operations": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-wizards": {
     "source": "content/features/wizards.md",
     "hash": "6fe7722a026d11276ebfbdf4ea046a05112be94b560f9abf3ffee410f8637d8f",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-wizards-call-workflows-internally-they-are-not-duplicates": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-workflowresult-constructor-mismatches-surface-only-at-runtime": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-yaml-run-block-scalars-break-on-blank-lines-inside-multi-line": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-yaml-run-values-with-colons-cause-parse-errors": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "faq-zsh-has-status-as-a-read-only-builtin-variable": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "not-agents": {
     "source": "content/features/agents.md",
     "hash": "a5b1678ecf012c7b2877a6c7ecae4a6c3f14c084c13fbcbb7eee79119dce6fa3",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "not-bug-predict": {
     "source": "content/features/bug-predict.md",
     "hash": "6a4f420eba38e2fb884b837dd9758acb60ba60cdaf9248ec4280120b0d382b16",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "not-cli": {
     "source": "content/features/cli.md",
     "hash": "a37b4dc4f0b3706a62184b02d2be1536ad75eef39a0f22a9699db5d03b8ee050",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "not-code-quality": {
     "source": "content/features/code-quality.md",
     "hash": "ce16ac87eb92e33a08d8c2f06e86ef22e436966f47f3a28c3f4eba19060b550a",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "not-code-simplification": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "not-command-hubs": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "not-configuration": {
     "source": "content/features/configuration.md",
     "hash": "8add90392883a46899ef8b57d135b625d92c5b61231d8a5301727f8b42f8e46f",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "not-critical-rules": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "not-cross-review": {
     "source": "content/features/cross-review.md",
     "hash": "dc5ae75883b05f97983377b51e275bab79921e992d842ebb2616726b8c8c2cdb",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "not-decision-d1-template-schemas-live-in-the-repo": {
     "source": ".claude/plans/documentation-stack-spec.md",
     "hash": "8ac207215df6d59686f456b44e76ec33e6c5b8dd6acb5d7754100c158865bd88",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "not-decision-d2-search-index-first-unified-later": {
     "source": ".claude/plans/documentation-stack-spec.md",
     "hash": "8ac207215df6d59686f456b44e76ec33e6c5b8dd6acb5d7754100c158865bd88",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "not-decision-d3-faq-sourcing-four-channels": {
     "source": ".claude/plans/documentation-stack-spec.md",
     "hash": "8ac207215df6d59686f456b44e76ec33e6c5b8dd6acb5d7754100c158865bd88",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "not-decision-d4-code-is-the-source-of-truth": {
     "source": ".claude/plans/documentation-stack-spec.md",
     "hash": "8ac207215df6d59686f456b44e76ec33e6c5b8dd6acb5d7754100c158865bd88",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "not-decision-d5-intelligent-templates-the-engine": {
     "source": ".claude/plans/documentation-stack-spec.md",
     "hash": "8ac207215df6d59686f456b44e76ec33e6c5b8dd6acb5d7754100c158865bd88",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "not-decision-d6-proof-of-concept-lessons-learned-error-templates": {
     "source": ".claude/plans/documentation-stack-spec.md",
     "hash": "8ac207215df6d59686f456b44e76ec33e6c5b8dd6acb5d7754100c158865bd88",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "not-deep-review": {
     "source": "content/features/deep-review.md",
     "hash": "6a4fffc907302b4847d96097189bd8d329d3f1548d1ee46d9232f6ceecdfb450",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "not-doc-gen": {
     "source": "content/features/doc-gen.md",
     "hash": "26e02a71a523775f5bb9e371b2e563c3c858386436a73b727422f62f57de0282",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "not-elicitation-forms": {
     "source": "content/features/elicitation-forms.md",
     "hash": "4f326dd6f99f86af163cf44167b243d73ee5165ef8373bf4cea83039aec723d2",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
+  },
+  "not-fix": {
+    "source": "content/features/fix.md",
+    "hash": "f4eb5cf49e7e9959b863b2bb1a866df14faa7a3f1c9bf1fe8acd1dc7e09bd1d6",
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "not-fix-test": {
     "source": "content/features/fix-test.md",
     "hash": "8b182bab8816d525d3325746f4cdeed013113a1bdb0a43d36963e121afa42812",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "not-help-system": {
     "source": "content/features/help-system.md",
     "hash": "24468c8fe4f1a0e350e620098d65a3bcc007000cd5aa4dbe20a6e6c83efa87b3",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "not-hooks": {
     "source": "content/features/hooks.md",
     "hash": "5c6b8a45457387c76f628561d3baa56e9af1709bc9bd21bba9830b2c2478c8dd",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "not-markdown-formatting": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "not-mcp-server": {
     "source": "content/features/mcp-server.md",
     "hash": "8e4b8c74eff980330480ae70856a1cf0393559cd22eb9ba0210b43249f9b5181",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "not-memory": {
     "source": "content/features/memory.md",
     "hash": "32b3121d9110dc9ac327bb9e838f060fbe9940a033366b0147ef34ef2efaa4dc",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "not-models": {
     "source": "content/features/models.md",
     "hash": "2117cbb0d8e863db6091870874e4ce80b48780c9ee8bb7330d8033c172ccb02b",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "not-ops-dashboard": {
     "source": "content/features/ops-dashboard.md",
     "hash": "fefc8e2b2b4a25055fcbdf96cbd8638d75278cbcacd256873b725df89544c1f6",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "not-orchestration": {
     "source": "content/features/orchestration.md",
     "hash": "4998437e04355011a7dee68dbce7e9e78bbe97f637e0b6a14c1ec972f541695c",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "not-plugin": {
     "source": "content/features/plugin.md",
     "hash": "8cc6e5702ffc8228ed63cfb74a25dd3e99e79e5335c4b1c8c134950f8b9a043d",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "not-project-structure": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "not-rag-grounding": {
     "source": "content/features/rag-grounding.md",
     "hash": "3464dd78c83f06980912a7c49dc185b09830be1b1c163203f10e5aa1708fcf4e",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "not-refactor-plan": {
     "source": "content/features/refactor-plan.md",
     "hash": "8f8c684cd94fca7b2580ecaaf955ccb79924022796d576d477cdab9330df9704",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "not-release-notes": {
     "source": "content/features/release-notes.md",
     "hash": "da7101ffbec4d209fcb1cef754f01cef8a13458a6f961c3a23909edfec77e58c",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "not-release-prep": {
     "source": "content/features/release-prep.md",
     "hash": "cd77b5903fbeb7d7e0acef570bab9727b4c143181ea6be1f52b9a25bc11418bb",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "not-resilience": {
     "source": "content/features/resilience.md",
     "hash": "ae2a76f0f1ecbb9ca687e5a041acc2b4a25a5113ec57eaad550f48b8aadc4be2",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "not-security-audit": {
     "source": "content/features/security-audit.md",
     "hash": "9cce18573c827fab9a380efe8c65c2f8c5b4ada3f7e383dd71ec523a0875fb05",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "not-session-handoff": {
     "source": "content/features/session-handoff.md",
     "hash": "236c16ee2d2e48f0bd8ba075c69f50ead16a46ef185fede3d84b529c66fd41a0",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "not-smart-test": {
     "source": "content/features/smart-test.md",
     "hash": "58c691c8313ddf9699deb913e6b5c50fafc684563539ddf4816a4b94a9ea3e80",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "not-socratic-interaction-rule": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "not-spec-engine": {
     "source": "content/features/spec-engine.md",
     "hash": "c8549016aa848eeeaecbde8329f5850562f56280ab66428cb7c20887b428d81a",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "not-telemetry": {
     "source": "content/features/telemetry.md",
     "hash": "59473ab809113116a3d58d2ead3a5f13e362d6992d8cee0a89364feded5cbd50",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "not-term-cli": {
     "source": "CLAUDE.md",
     "hash": "f543008dc0e937626c0d5d2090f690c0c3c2b34a7a39482703ec02848450a553",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "not-term-crew": {
     "source": "CLAUDE.md",
     "hash": "f543008dc0e937626c0d5d2090f690c0c3c2b34a7a39482703ec02848450a553",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "not-term-hub": {
     "source": "CLAUDE.md",
     "hash": "f543008dc0e937626c0d5d2090f690c0c3c2b34a7a39482703ec02848450a553",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "not-term-llm": {
     "source": "CLAUDE.md",
     "hash": "f543008dc0e937626c0d5d2090f690c0c3c2b34a7a39482703ec02848450a553",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "not-term-p2b": {
     "source": "CLAUDE.md",
     "hash": "f543008dc0e937626c0d5d2090f690c0c3c2b34a7a39482703ec02848450a553",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "not-term-progressive": {
     "source": "CLAUDE.md",
     "hash": "f543008dc0e937626c0d5d2090f690c0c3c2b34a7a39482703ec02848450a553",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "not-term-sdk": {
     "source": "CLAUDE.md",
     "hash": "f543008dc0e937626c0d5d2090f690c0c3c2b34a7a39482703ec02848450a553",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "not-term-socratic": {
     "source": "CLAUDE.md",
     "hash": "f543008dc0e937626c0d5d2090f690c0c3c2b34a7a39482703ec02848450a553",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "not-term-tier": {
     "source": "CLAUDE.md",
     "hash": "f543008dc0e937626c0d5d2090f690c0c3c2b34a7a39482703ec02848450a553",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "not-term-wizard": {
     "source": "CLAUDE.md",
     "hash": "f543008dc0e937626c0d5d2090f690c0c3c2b34a7a39482703ec02848450a553",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "not-wizards": {
     "source": "content/features/wizards.md",
     "hash": "6fe7722a026d11276ebfbdf4ea046a05112be94b560f9abf3ffee410f8637d8f",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "qui-agents": {
     "source": "content/features/agents.md",
     "hash": "a5b1678ecf012c7b2877a6c7ecae4a6c3f14c084c13fbcbb7eee79119dce6fa3",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "qui-browse-help": {
     "source": "src/attune/cli_commands/help_commands.py",
     "hash": "d284892c4f058b5a9d4861f08f7f2de09c8050d33766471014bb739215a83582",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "qui-bug-predict": {
     "source": "content/features/bug-predict.md",
     "hash": "6a4f420eba38e2fb884b837dd9758acb60ba60cdaf9248ec4280120b0d382b16",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "qui-check-costs": {
     "source": "src/attune/cli_minimal.py",
-    "hash": "8e78816c6a743c24afd05568ba29a5d0eec548beea557ab098a48630b1f82ac8",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "hash": "f04dc81dd5d819846941b6db365ab289ee1715c045e1853f3a536fae2b11b4f5",
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "qui-check-health": {
     "source": "src/attune/cli_minimal.py",
-    "hash": "8e78816c6a743c24afd05568ba29a5d0eec548beea557ab098a48630b1f82ac8",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "hash": "f04dc81dd5d819846941b6db365ab289ee1715c045e1853f3a536fae2b11b4f5",
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "qui-cli": {
     "source": "content/features/cli.md",
     "hash": "a37b4dc4f0b3706a62184b02d2be1536ad75eef39a0f22a9699db5d03b8ee050",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "qui-code-quality": {
     "source": "content/features/code-quality.md",
     "hash": "ce16ac87eb92e33a08d8c2f06e86ef22e436966f47f3a28c3f4eba19060b550a",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "qui-configuration": {
     "source": "content/features/configuration.md",
     "hash": "8add90392883a46899ef8b57d135b625d92c5b61231d8a5301727f8b42f8e46f",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "qui-cross-review": {
     "source": "content/features/cross-review.md",
     "hash": "dc5ae75883b05f97983377b51e275bab79921e992d842ebb2616726b8c8c2cdb",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "qui-deep-review": {
     "source": "content/features/deep-review.md",
     "hash": "6a4fffc907302b4847d96097189bd8d329d3f1548d1ee46d9232f6ceecdfb450",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "qui-doc-gen": {
     "source": "content/features/doc-gen.md",
     "hash": "26e02a71a523775f5bb9e371b2e563c3c858386436a73b727422f62f57de0282",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "qui-elicitation-forms": {
     "source": "content/features/elicitation-forms.md",
     "hash": "4f326dd6f99f86af163cf44167b243d73ee5165ef8373bf4cea83039aec723d2",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
+  },
+  "qui-fix": {
+    "source": "content/features/fix.md",
+    "hash": "f4eb5cf49e7e9959b863b2bb1a866df14faa7a3f1c9bf1fe8acd1dc7e09bd1d6",
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "qui-fix-test": {
     "source": "content/features/fix-test.md",
     "hash": "8b182bab8816d525d3325746f4cdeed013113a1bdb0a43d36963e121afa42812",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "qui-generate-tests": {
     "source": "src/attune/cli_minimal.py",
-    "hash": "8e78816c6a743c24afd05568ba29a5d0eec548beea557ab098a48630b1f82ac8",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "hash": "f04dc81dd5d819846941b6db365ab289ee1715c045e1853f3a536fae2b11b4f5",
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "qui-help-system": {
     "source": "content/features/help-system.md",
     "hash": "24468c8fe4f1a0e350e620098d65a3bcc007000cd5aa4dbe20a6e6c83efa87b3",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "qui-hooks": {
     "source": "content/features/hooks.md",
     "hash": "5c6b8a45457387c76f628561d3baa56e9af1709bc9bd21bba9830b2c2478c8dd",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "qui-install": {
     "source": "README.md",
-    "hash": "fcc62f0951ab8912c5080913462e9831fd6256f0062027fb7f2db6b6ccf0b615",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "hash": "cb2c7016950e4736629db635e75a131dee2233d7a723460a2c603371b9c8ae21",
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "qui-install-plugin": {
     "source": "README.md",
-    "hash": "fcc62f0951ab8912c5080913462e9831fd6256f0062027fb7f2db6b6ccf0b615",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "hash": "cb2c7016950e4736629db635e75a131dee2233d7a723460a2c603371b9c8ae21",
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "qui-mcp-server": {
     "source": "content/features/mcp-server.md",
     "hash": "8e4b8c74eff980330480ae70856a1cf0393559cd22eb9ba0210b43249f9b5181",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "qui-memory": {
     "source": "content/features/memory.md",
     "hash": "32b3121d9110dc9ac327bb9e838f060fbe9940a033366b0147ef34ef2efaa4dc",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "qui-models": {
     "source": "content/features/models.md",
     "hash": "2117cbb0d8e863db6091870874e4ce80b48780c9ee8bb7330d8033c172ccb02b",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "qui-ops-dashboard": {
     "source": "content/features/ops-dashboard.md",
     "hash": "fefc8e2b2b4a25055fcbdf96cbd8638d75278cbcacd256873b725df89544c1f6",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "qui-orchestration": {
     "source": "content/features/orchestration.md",
     "hash": "4998437e04355011a7dee68dbce7e9e78bbe97f637e0b6a14c1ec972f541695c",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "qui-plugin": {
     "source": "content/features/plugin.md",
     "hash": "8cc6e5702ffc8228ed63cfb74a25dd3e99e79e5335c4b1c8c134950f8b9a043d",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "qui-rag-grounding": {
     "source": "content/features/rag-grounding.md",
     "hash": "3464dd78c83f06980912a7c49dc185b09830be1b1c163203f10e5aa1708fcf4e",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "qui-refactor-plan": {
     "source": "content/features/refactor-plan.md",
     "hash": "8f8c684cd94fca7b2580ecaaf955ccb79924022796d576d477cdab9330df9704",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "qui-release-notes": {
     "source": "content/features/release-notes.md",
     "hash": "da7101ffbec4d209fcb1cef754f01cef8a13458a6f961c3a23909edfec77e58c",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "qui-release-prep": {
     "source": "content/features/release-prep.md",
     "hash": "cd77b5903fbeb7d7e0acef570bab9727b4c143181ea6be1f52b9a25bc11418bb",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "qui-resilience": {
     "source": "content/features/resilience.md",
     "hash": "ae2a76f0f1ecbb9ca687e5a041acc2b4a25a5113ec57eaad550f48b8aadc4be2",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "qui-run-code-review": {
     "source": "src/attune/cli_minimal.py",
-    "hash": "8e78816c6a743c24afd05568ba29a5d0eec548beea557ab098a48630b1f82ac8",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "hash": "f04dc81dd5d819846941b6db365ab289ee1715c045e1853f3a536fae2b11b4f5",
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "qui-run-security-audit": {
     "source": "src/attune/cli_minimal.py",
-    "hash": "8e78816c6a743c24afd05568ba29a5d0eec548beea557ab098a48630b1f82ac8",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "hash": "f04dc81dd5d819846941b6db365ab289ee1715c045e1853f3a536fae2b11b4f5",
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "qui-security-audit": {
     "source": "content/features/security-audit.md",
     "hash": "9cce18573c827fab9a380efe8c65c2f8c5b4ada3f7e383dd71ec523a0875fb05",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "qui-session-handoff": {
     "source": "content/features/session-handoff.md",
     "hash": "236c16ee2d2e48f0bd8ba075c69f50ead16a46ef185fede3d84b529c66fd41a0",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "qui-skill-attune-hub": {
     "source": "plugin/skills/attune-hub/SKILL.md",
     "hash": "2a18d84bd5efb5738643d716c803440f602d40871b172238996c4aebcf498032",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "qui-skill-bug-predict": {
     "source": "plugin/skills/bug-predict/SKILL.md",
     "hash": "992b9e6cd3452af0d31213985e5e5c607f078edd2310df76d786b95d7e6a83ce",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "qui-skill-coach": {
     "source": "plugin/skills/coach/SKILL.md",
     "hash": "a1842d674325f3f1ea289e3bd7ed1dcfbb4b3301160181edab081d2b4352aeac",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "qui-skill-code-quality": {
     "source": "plugin/skills/code-quality/SKILL.md",
     "hash": "769c4c885992fd1937adbdf5d97305894bd08c159c83930d7a9fb86cb4ae78b7",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "qui-skill-doc-gen": {
     "source": "plugin/skills/doc-gen/SKILL.md",
     "hash": "da9a9c23727eaa9433b2c4d1dfe87d850ef560d56b855f2eb7bd0f279efc3c72",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "qui-skill-fix-test": {
     "source": "plugin/skills/fix-test/SKILL.md",
     "hash": "665ff7c4978beddd72e87f3764b073e4f962b27a896bd66542d499a1a00429da",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "qui-skill-memory-and-context": {
     "source": "plugin/skills/memory-and-context/SKILL.md",
     "hash": "d026a40d0c5315123672c7ed3770b643ba803a3b5d57cb994c236fcd6baa8305",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "qui-skill-planning": {
     "source": "plugin/skills/planning/SKILL.md",
     "hash": "f56a42c83f514b300b4f89ea6669820ec158da952efa2894c56abb00c39eb58a",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "qui-skill-rag-code-gen": {
     "source": "plugin/skills/rag-code-gen/SKILL.md",
     "hash": "0d84a32e2f89e8debd740b4343c7930b17efcca37fcb68737f342f8b6b5f6f77",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "qui-skill-refactor-plan": {
     "source": "plugin/skills/refactor-plan/SKILL.md",
     "hash": "080a84b5df5dde88cd3c994ca2c2b68ec12e2cf241f2e81893f21aa9dac315f6",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "qui-skill-release-prep": {
     "source": "plugin/skills/release-prep/SKILL.md",
     "hash": "8aab944ae2f53a24c94d39329bf000067a68f43b51de6657b517678bec90c67a",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "qui-skill-security-audit": {
     "source": "plugin/skills/security-audit/SKILL.md",
     "hash": "f370003a809c342d35b37990da231fbb72545e75e5a37e1e1d39a27db5364761",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "qui-skill-smart-test": {
     "source": "plugin/skills/smart-test/SKILL.md",
     "hash": "a5e874d1054dd123d78d9d8e9014c7c6888230f36685a203ea26176a3d649ffb",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "qui-skill-spec": {
     "source": "plugin/skills/spec/SKILL.md",
     "hash": "4e1ce2c9da6fcad85ebcf7cb6b755f44c27d00608ad97b72b93a82a45e3c0186",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "qui-skill-workflow-orchestration": {
     "source": "plugin/skills/workflow-orchestration/SKILL.md",
     "hash": "831c00dfb29ae4c72b35921fd3bab9e9f17affabf32b8164deb801557e031127",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "qui-smart-test": {
     "source": "content/features/smart-test.md",
     "hash": "58c691c8313ddf9699deb913e6b5c50fafc684563539ddf4816a4b94a9ea3e80",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "qui-spec-engine": {
     "source": "content/features/spec-engine.md",
     "hash": "c8549016aa848eeeaecbde8329f5850562f56280ab66428cb7c20887b428d81a",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "qui-telemetry": {
     "source": "content/features/telemetry.md",
     "hash": "59473ab809113116a3d58d2ead3a5f13e362d6992d8cee0a89364feded5cbd50",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "qui-wizards": {
     "source": "content/features/wizards.md",
     "hash": "6fe7722a026d11276ebfbdf4ea046a05112be94b560f9abf3ffee410f8637d8f",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "ref-agents": {
     "source": "content/features/agents.md",
     "hash": "a5b1678ecf012c7b2877a6c7ecae4a6c3f14c084c13fbcbb7eee79119dce6fa3",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "ref-bug-predict": {
     "source": "content/features/bug-predict.md",
     "hash": "6a4f420eba38e2fb884b837dd9758acb60ba60cdaf9248ec4280120b0d382b16",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "ref-cli": {
     "source": "content/features/cli.md",
     "hash": "a37b4dc4f0b3706a62184b02d2be1536ad75eef39a0f22a9699db5d03b8ee050",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "ref-code-quality": {
     "source": "content/features/code-quality.md",
     "hash": "ce16ac87eb92e33a08d8c2f06e86ef22e436966f47f3a28c3f4eba19060b550a",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "ref-configuration": {
     "source": "content/features/configuration.md",
     "hash": "8add90392883a46899ef8b57d135b625d92c5b61231d8a5301727f8b42f8e46f",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "ref-cross-review": {
     "source": "content/features/cross-review.md",
     "hash": "dc5ae75883b05f97983377b51e275bab79921e992d842ebb2616726b8c8c2cdb",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "ref-deep-review": {
     "source": "content/features/deep-review.md",
     "hash": "6a4fffc907302b4847d96097189bd8d329d3f1548d1ee46d9232f6ceecdfb450",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "ref-doc-gen": {
     "source": "content/features/doc-gen.md",
     "hash": "26e02a71a523775f5bb9e371b2e563c3c858386436a73b727422f62f57de0282",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "ref-elicitation-forms": {
     "source": "content/features/elicitation-forms.md",
     "hash": "4f326dd6f99f86af163cf44167b243d73ee5165ef8373bf4cea83039aec723d2",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
+  },
+  "ref-fix": {
+    "source": "content/features/fix.md",
+    "hash": "f4eb5cf49e7e9959b863b2bb1a866df14faa7a3f1c9bf1fe8acd1dc7e09bd1d6",
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "ref-fix-test": {
     "source": "content/features/fix-test.md",
     "hash": "8b182bab8816d525d3325746f4cdeed013113a1bdb0a43d36963e121afa42812",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "ref-help-system": {
     "source": "content/features/help-system.md",
     "hash": "24468c8fe4f1a0e350e620098d65a3bcc007000cd5aa4dbe20a6e6c83efa87b3",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "ref-hooks": {
     "source": "content/features/hooks.md",
     "hash": "5c6b8a45457387c76f628561d3baa56e9af1709bc9bd21bba9830b2c2478c8dd",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "ref-mcp-server": {
     "source": "content/features/mcp-server.md",
     "hash": "8e4b8c74eff980330480ae70856a1cf0393559cd22eb9ba0210b43249f9b5181",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "ref-memory": {
     "source": "content/features/memory.md",
     "hash": "32b3121d9110dc9ac327bb9e838f060fbe9940a033366b0147ef34ef2efaa4dc",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "ref-models": {
     "source": "content/features/models.md",
     "hash": "2117cbb0d8e863db6091870874e4ce80b48780c9ee8bb7330d8033c172ccb02b",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "ref-ops-dashboard": {
     "source": "content/features/ops-dashboard.md",
     "hash": "fefc8e2b2b4a25055fcbdf96cbd8638d75278cbcacd256873b725df89544c1f6",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "ref-orchestration": {
     "source": "content/features/orchestration.md",
     "hash": "4998437e04355011a7dee68dbce7e9e78bbe97f637e0b6a14c1ec972f541695c",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "ref-plugin": {
     "source": "content/features/plugin.md",
     "hash": "8cc6e5702ffc8228ed63cfb74a25dd3e99e79e5335c4b1c8c134950f8b9a043d",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "ref-rag-grounding": {
     "source": "content/features/rag-grounding.md",
     "hash": "3464dd78c83f06980912a7c49dc185b09830be1b1c163203f10e5aa1708fcf4e",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "ref-refactor-plan": {
     "source": "content/features/refactor-plan.md",
     "hash": "8f8c684cd94fca7b2580ecaaf955ccb79924022796d576d477cdab9330df9704",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "ref-release-notes": {
     "source": "content/features/release-notes.md",
     "hash": "da7101ffbec4d209fcb1cef754f01cef8a13458a6f961c3a23909edfec77e58c",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "ref-release-prep": {
     "source": "content/features/release-prep.md",
     "hash": "cd77b5903fbeb7d7e0acef570bab9727b4c143181ea6be1f52b9a25bc11418bb",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "ref-resilience": {
     "source": "content/features/resilience.md",
     "hash": "ae2a76f0f1ecbb9ca687e5a041acc2b4a25a5113ec57eaad550f48b8aadc4be2",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "ref-security-audit": {
     "source": "content/features/security-audit.md",
     "hash": "9cce18573c827fab9a380efe8c65c2f8c5b4ada3f7e383dd71ec523a0875fb05",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "ref-session-handoff": {
     "source": "content/features/session-handoff.md",
     "hash": "236c16ee2d2e48f0bd8ba075c69f50ead16a46ef185fede3d84b529c66fd41a0",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "ref-skill-attune-hub": {
     "source": "plugin/skills/attune-hub/SKILL.md",
     "hash": "2a18d84bd5efb5738643d716c803440f602d40871b172238996c4aebcf498032",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "ref-skill-bug-predict": {
     "source": "plugin/skills/bug-predict/SKILL.md",
     "hash": "992b9e6cd3452af0d31213985e5e5c607f078edd2310df76d786b95d7e6a83ce",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "ref-skill-coach": {
     "source": "plugin/skills/coach/SKILL.md",
     "hash": "a1842d674325f3f1ea289e3bd7ed1dcfbb4b3301160181edab081d2b4352aeac",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "ref-skill-code-quality": {
     "source": "plugin/skills/code-quality/SKILL.md",
     "hash": "769c4c885992fd1937adbdf5d97305894bd08c159c83930d7a9fb86cb4ae78b7",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "ref-skill-doc-gen": {
     "source": "plugin/skills/doc-gen/SKILL.md",
     "hash": "da9a9c23727eaa9433b2c4d1dfe87d850ef560d56b855f2eb7bd0f279efc3c72",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "ref-skill-fix-test": {
     "source": "plugin/skills/fix-test/SKILL.md",
     "hash": "665ff7c4978beddd72e87f3764b073e4f962b27a896bd66542d499a1a00429da",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "ref-skill-memory-and-context": {
     "source": "plugin/skills/memory-and-context/SKILL.md",
     "hash": "d026a40d0c5315123672c7ed3770b643ba803a3b5d57cb994c236fcd6baa8305",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "ref-skill-planning": {
     "source": "plugin/skills/planning/SKILL.md",
     "hash": "f56a42c83f514b300b4f89ea6669820ec158da952efa2894c56abb00c39eb58a",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "ref-skill-rag-code-gen": {
     "source": "plugin/skills/rag-code-gen/SKILL.md",
     "hash": "0d84a32e2f89e8debd740b4343c7930b17efcca37fcb68737f342f8b6b5f6f77",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "ref-skill-refactor-plan": {
     "source": "plugin/skills/refactor-plan/SKILL.md",
     "hash": "080a84b5df5dde88cd3c994ca2c2b68ec12e2cf241f2e81893f21aa9dac315f6",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "ref-skill-release-prep": {
     "source": "plugin/skills/release-prep/SKILL.md",
     "hash": "8aab944ae2f53a24c94d39329bf000067a68f43b51de6657b517678bec90c67a",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "ref-skill-security-audit": {
     "source": "plugin/skills/security-audit/SKILL.md",
     "hash": "f370003a809c342d35b37990da231fbb72545e75e5a37e1e1d39a27db5364761",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "ref-skill-smart-test": {
     "source": "plugin/skills/smart-test/SKILL.md",
     "hash": "a5e874d1054dd123d78d9d8e9014c7c6888230f36685a203ea26176a3d649ffb",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "ref-skill-spec": {
     "source": "plugin/skills/spec/SKILL.md",
     "hash": "4e1ce2c9da6fcad85ebcf7cb6b755f44c27d00608ad97b72b93a82a45e3c0186",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "ref-skill-workflow-orchestration": {
     "source": "plugin/skills/workflow-orchestration/SKILL.md",
     "hash": "831c00dfb29ae4c72b35921fd3bab9e9f17affabf32b8164deb801557e031127",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "ref-smart-test": {
     "source": "content/features/smart-test.md",
     "hash": "58c691c8313ddf9699deb913e6b5c50fafc684563539ddf4816a4b94a9ea3e80",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "ref-spec-engine": {
     "source": "content/features/spec-engine.md",
     "hash": "c8549016aa848eeeaecbde8329f5850562f56280ab66428cb7c20887b428d81a",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "ref-telemetry": {
     "source": "content/features/telemetry.md",
     "hash": "59473ab809113116a3d58d2ead3a5f13e362d6992d8cee0a89364feded5cbd50",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "ref-tool-analyze-batch": {
     "source": "src/attune/mcp/tool_schemas.py",
     "hash": "686dca2b600048257e5e19f651ef375a58c92c2b97cd7f76e4a6551d97c22525",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "ref-tool-analyze-image": {
     "source": "src/attune/mcp/tool_schemas.py",
     "hash": "686dca2b600048257e5e19f651ef375a58c92c2b97cd7f76e4a6551d97c22525",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "ref-tool-attune-get-level": {
     "source": "src/attune/mcp/tool_schemas.py",
     "hash": "686dca2b600048257e5e19f651ef375a58c92c2b97cd7f76e4a6551d97c22525",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "ref-tool-attune-set-level": {
     "source": "src/attune/mcp/tool_schemas.py",
     "hash": "686dca2b600048257e5e19f651ef375a58c92c2b97cd7f76e4a6551d97c22525",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "ref-tool-auth-recommend": {
     "source": "src/attune/mcp/tool_schemas.py",
     "hash": "686dca2b600048257e5e19f651ef375a58c92c2b97cd7f76e4a6551d97c22525",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "ref-tool-auth-status": {
     "source": "src/attune/mcp/tool_schemas.py",
     "hash": "686dca2b600048257e5e19f651ef375a58c92c2b97cd7f76e4a6551d97c22525",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "ref-tool-bug-predict": {
     "source": "src/attune/mcp/tool_schemas.py",
     "hash": "686dca2b600048257e5e19f651ef375a58c92c2b97cd7f76e4a6551d97c22525",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "ref-tool-code-review": {
     "source": "src/attune/mcp/tool_schemas.py",
     "hash": "686dca2b600048257e5e19f651ef375a58c92c2b97cd7f76e4a6551d97c22525",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "ref-tool-context-get": {
     "source": "src/attune/mcp/tool_schemas.py",
     "hash": "686dca2b600048257e5e19f651ef375a58c92c2b97cd7f76e4a6551d97c22525",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "ref-tool-context-set": {
     "source": "src/attune/mcp/tool_schemas.py",
     "hash": "686dca2b600048257e5e19f651ef375a58c92c2b97cd7f76e4a6551d97c22525",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "ref-tool-deep-review": {
     "source": "src/attune/mcp/tool_schemas.py",
     "hash": "686dca2b600048257e5e19f651ef375a58c92c2b97cd7f76e4a6551d97c22525",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "ref-tool-dependency-check": {
     "source": "src/attune/mcp/tool_schemas.py",
     "hash": "686dca2b600048257e5e19f651ef375a58c92c2b97cd7f76e4a6551d97c22525",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "ref-tool-doc-audit": {
     "source": "src/attune/mcp/tool_schemas.py",
     "hash": "686dca2b600048257e5e19f651ef375a58c92c2b97cd7f76e4a6551d97c22525",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "ref-tool-doc-gen": {
     "source": "src/attune/mcp/tool_schemas.py",
     "hash": "686dca2b600048257e5e19f651ef375a58c92c2b97cd7f76e4a6551d97c22525",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "ref-tool-doc-orchestrator": {
     "source": "src/attune/mcp/tool_schemas.py",
     "hash": "686dca2b600048257e5e19f651ef375a58c92c2b97cd7f76e4a6551d97c22525",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "ref-tool-health-check": {
     "source": "src/attune/mcp/tool_schemas.py",
     "hash": "686dca2b600048257e5e19f651ef375a58c92c2b97cd7f76e4a6551d97c22525",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "ref-tool-memory-forget": {
     "source": "src/attune/mcp/tool_schemas.py",
     "hash": "686dca2b600048257e5e19f651ef375a58c92c2b97cd7f76e4a6551d97c22525",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "ref-tool-memory-retrieve": {
     "source": "src/attune/mcp/tool_schemas.py",
     "hash": "686dca2b600048257e5e19f651ef375a58c92c2b97cd7f76e4a6551d97c22525",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "ref-tool-memory-search": {
     "source": "src/attune/mcp/tool_schemas.py",
     "hash": "686dca2b600048257e5e19f651ef375a58c92c2b97cd7f76e4a6551d97c22525",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "ref-tool-memory-store": {
     "source": "src/attune/mcp/tool_schemas.py",
     "hash": "686dca2b600048257e5e19f651ef375a58c92c2b97cd7f76e4a6551d97c22525",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "ref-tool-performance-audit": {
     "source": "src/attune/mcp/tool_schemas.py",
     "hash": "686dca2b600048257e5e19f651ef375a58c92c2b97cd7f76e4a6551d97c22525",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "ref-tool-rag-knowledge-query": {
     "source": "src/attune/mcp/tool_schemas.py",
     "hash": "686dca2b600048257e5e19f651ef375a58c92c2b97cd7f76e4a6551d97c22525",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "ref-tool-refactor-plan": {
     "source": "src/attune/mcp/tool_schemas.py",
     "hash": "686dca2b600048257e5e19f651ef375a58c92c2b97cd7f76e4a6551d97c22525",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "ref-tool-release-prep": {
     "source": "src/attune/mcp/tool_schemas.py",
     "hash": "686dca2b600048257e5e19f651ef375a58c92c2b97cd7f76e4a6551d97c22525",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "ref-tool-research-synthesis": {
     "source": "src/attune/mcp/tool_schemas.py",
     "hash": "686dca2b600048257e5e19f651ef375a58c92c2b97cd7f76e4a6551d97c22525",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "ref-tool-secure-release": {
     "source": "src/attune/mcp/tool_schemas.py",
     "hash": "686dca2b600048257e5e19f651ef375a58c92c2b97cd7f76e4a6551d97c22525",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "ref-tool-security-audit": {
     "source": "src/attune/mcp/tool_schemas.py",
     "hash": "686dca2b600048257e5e19f651ef375a58c92c2b97cd7f76e4a6551d97c22525",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "ref-tool-simplify-code": {
     "source": "src/attune/mcp/tool_schemas.py",
     "hash": "686dca2b600048257e5e19f651ef375a58c92c2b97cd7f76e4a6551d97c22525",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "ref-tool-telemetry-stats": {
     "source": "src/attune/mcp/tool_schemas.py",
     "hash": "686dca2b600048257e5e19f651ef375a58c92c2b97cd7f76e4a6551d97c22525",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "ref-tool-test-audit": {
     "source": "src/attune/mcp/tool_schemas.py",
     "hash": "686dca2b600048257e5e19f651ef375a58c92c2b97cd7f76e4a6551d97c22525",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "ref-tool-test-gen-parallel": {
     "source": "src/attune/mcp/tool_schemas.py",
     "hash": "686dca2b600048257e5e19f651ef375a58c92c2b97cd7f76e4a6551d97c22525",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "ref-tool-test-generation": {
     "source": "src/attune/mcp/tool_schemas.py",
     "hash": "686dca2b600048257e5e19f651ef375a58c92c2b97cd7f76e4a6551d97c22525",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "ref-wizards": {
     "source": "content/features/wizards.md",
     "hash": "6fe7722a026d11276ebfbdf4ea046a05112be94b560f9abf3ffee410f8637d8f",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "tas-agents": {
     "source": "content/features/agents.md",
     "hash": "a5b1678ecf012c7b2877a6c7ecae4a6c3f14c084c13fbcbb7eee79119dce6fa3",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "tas-browse-help-docs": {
     "source": "src/attune/cli_commands/help_commands.py",
     "hash": "d284892c4f058b5a9d4861f08f7f2de09c8050d33766471014bb739215a83582",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "tas-bug-predict": {
     "source": "content/features/bug-predict.md",
     "hash": "6a4f420eba38e2fb884b837dd9758acb60ba60cdaf9248ec4280120b0d382b16",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "tas-check-auth-status": {
     "source": "src/attune/cli_minimal.py",
-    "hash": "8e78816c6a743c24afd05568ba29a5d0eec548beea557ab098a48630b1f82ac8",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "hash": "f04dc81dd5d819846941b6db365ab289ee1715c045e1853f3a536fae2b11b4f5",
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "tas-cli": {
     "source": "content/features/cli.md",
     "hash": "a37b4dc4f0b3706a62184b02d2be1536ad75eef39a0f22a9699db5d03b8ee050",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "tas-code-quality": {
     "source": "content/features/code-quality.md",
     "hash": "ce16ac87eb92e33a08d8c2f06e86ef22e436966f47f3a28c3f4eba19060b550a",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "tas-configuration": {
     "source": "content/features/configuration.md",
     "hash": "8add90392883a46899ef8b57d135b625d92c5b61231d8a5301727f8b42f8e46f",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "tas-cross-review": {
     "source": "content/features/cross-review.md",
     "hash": "dc5ae75883b05f97983377b51e275bab79921e992d842ebb2616726b8c8c2cdb",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "tas-deep-review": {
     "source": "content/features/deep-review.md",
     "hash": "6a4fffc907302b4847d96097189bd8d329d3f1548d1ee46d9232f6ceecdfb450",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "tas-doc-gen": {
     "source": "content/features/doc-gen.md",
     "hash": "26e02a71a523775f5bb9e371b2e563c3c858386436a73b727422f62f57de0282",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "tas-elicitation-forms": {
     "source": "content/features/elicitation-forms.md",
     "hash": "4f326dd6f99f86af163cf44167b243d73ee5165ef8373bf4cea83039aec723d2",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "tas-export-telemetry": {
     "source": "src/attune/cli_minimal.py",
-    "hash": "8e78816c6a743c24afd05568ba29a5d0eec548beea557ab098a48630b1f82ac8",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "hash": "f04dc81dd5d819846941b6db365ab289ee1715c045e1853f3a536fae2b11b4f5",
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
+  },
+  "tas-fix": {
+    "source": "content/features/fix.md",
+    "hash": "f4eb5cf49e7e9959b863b2bb1a866df14faa7a3f1c9bf1fe8acd1dc7e09bd1d6",
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "tas-fix-test": {
     "source": "content/features/fix-test.md",
     "hash": "8b182bab8816d525d3325746f4cdeed013113a1bdb0a43d36963e121afa42812",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "tas-help-system": {
     "source": "content/features/help-system.md",
     "hash": "24468c8fe4f1a0e350e620098d65a3bcc007000cd5aa4dbe20a6e6c83efa87b3",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "tas-hooks": {
     "source": "content/features/hooks.md",
     "hash": "5c6b8a45457387c76f628561d3baa56e9af1709bc9bd21bba9830b2c2478c8dd",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "tas-install-plugin": {
     "source": "README.md",
-    "hash": "fcc62f0951ab8912c5080913462e9831fd6256f0062027fb7f2db6b6ccf0b615",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "hash": "cb2c7016950e4736629db635e75a131dee2233d7a723460a2c603371b9c8ae21",
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "tas-manage-lessons": {
     "source": "src/attune/cli_minimal.py",
-    "hash": "8e78816c6a743c24afd05568ba29a5d0eec548beea557ab098a48630b1f82ac8",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "hash": "f04dc81dd5d819846941b6db365ab289ee1715c045e1853f3a536fae2b11b4f5",
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "tas-mcp-server": {
     "source": "content/features/mcp-server.md",
     "hash": "8e4b8c74eff980330480ae70856a1cf0393559cd22eb9ba0210b43249f9b5181",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "tas-memory": {
     "source": "content/features/memory.md",
     "hash": "32b3121d9110dc9ac327bb9e838f060fbe9940a033366b0147ef34ef2efaa4dc",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "tas-models": {
     "source": "content/features/models.md",
     "hash": "2117cbb0d8e863db6091870874e4ce80b48780c9ee8bb7330d8033c172ccb02b",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "tas-ops-dashboard": {
     "source": "content/features/ops-dashboard.md",
     "hash": "fefc8e2b2b4a25055fcbdf96cbd8638d75278cbcacd256873b725df89544c1f6",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "tas-orchestration": {
     "source": "content/features/orchestration.md",
     "hash": "4998437e04355011a7dee68dbce7e9e78bbe97f637e0b6a14c1ec972f541695c",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "tas-plugin": {
     "source": "content/features/plugin.md",
     "hash": "8cc6e5702ffc8228ed63cfb74a25dd3e99e79e5335c4b1c8c134950f8b9a043d",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "tas-rag-grounding": {
     "source": "content/features/rag-grounding.md",
     "hash": "3464dd78c83f06980912a7c49dc185b09830be1b1c163203f10e5aa1708fcf4e",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "tas-refactor-plan": {
     "source": "content/features/refactor-plan.md",
     "hash": "8f8c684cd94fca7b2580ecaaf955ccb79924022796d576d477cdab9330df9704",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "tas-release-notes": {
     "source": "content/features/release-notes.md",
     "hash": "da7101ffbec4d209fcb1cef754f01cef8a13458a6f961c3a23909edfec77e58c",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "tas-release-prep": {
     "source": "content/features/release-prep.md",
     "hash": "cd77b5903fbeb7d7e0acef570bab9727b4c143181ea6be1f52b9a25bc11418bb",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "tas-resilience": {
     "source": "content/features/resilience.md",
     "hash": "ae2a76f0f1ecbb9ca687e5a041acc2b4a25a5113ec57eaad550f48b8aadc4be2",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "tas-run-doctor": {
     "source": "src/attune/cli_minimal.py",
-    "hash": "8e78816c6a743c24afd05568ba29a5d0eec548beea557ab098a48630b1f82ac8",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "hash": "f04dc81dd5d819846941b6db365ab289ee1715c045e1853f3a536fae2b11b4f5",
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "tas-run-workflow": {
     "source": "src/attune/cli_minimal.py",
-    "hash": "8e78816c6a743c24afd05568ba29a5d0eec548beea557ab098a48630b1f82ac8",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "hash": "f04dc81dd5d819846941b6db365ab289ee1715c045e1853f3a536fae2b11b4f5",
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "tas-security-audit": {
     "source": "content/features/security-audit.md",
     "hash": "9cce18573c827fab9a380efe8c65c2f8c5b4ada3f7e383dd71ec523a0875fb05",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "tas-session-handoff": {
     "source": "content/features/session-handoff.md",
     "hash": "236c16ee2d2e48f0bd8ba075c69f50ead16a46ef185fede3d84b529c66fd41a0",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "tas-smart-test": {
     "source": "content/features/smart-test.md",
     "hash": "58c691c8313ddf9699deb913e6b5c50fafc684563539ddf4816a4b94a9ea3e80",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "tas-spec-engine": {
     "source": "content/features/spec-engine.md",
     "hash": "c8549016aa848eeeaecbde8329f5850562f56280ab66428cb7c20887b428d81a",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "tas-telemetry": {
     "source": "content/features/telemetry.md",
     "hash": "59473ab809113116a3d58d2ead3a5f13e362d6992d8cee0a89364feded5cbd50",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "tas-use-attune-hub": {
     "source": "plugin/skills/attune-hub/SKILL.md",
     "hash": "2a18d84bd5efb5738643d716c803440f602d40871b172238996c4aebcf498032",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "tas-use-bug-predict": {
     "source": "plugin/skills/bug-predict/SKILL.md",
     "hash": "992b9e6cd3452af0d31213985e5e5c607f078edd2310df76d786b95d7e6a83ce",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "tas-use-coach": {
     "source": "plugin/skills/coach/SKILL.md",
     "hash": "a1842d674325f3f1ea289e3bd7ed1dcfbb4b3301160181edab081d2b4352aeac",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "tas-use-code-quality": {
     "source": "plugin/skills/code-quality/SKILL.md",
     "hash": "769c4c885992fd1937adbdf5d97305894bd08c159c83930d7a9fb86cb4ae78b7",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "tas-use-doc-gen": {
     "source": "plugin/skills/doc-gen/SKILL.md",
     "hash": "da9a9c23727eaa9433b2c4d1dfe87d850ef560d56b855f2eb7bd0f279efc3c72",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "tas-use-fix-test": {
     "source": "plugin/skills/fix-test/SKILL.md",
     "hash": "665ff7c4978beddd72e87f3764b073e4f962b27a896bd66542d499a1a00429da",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "tas-use-memory-and-context": {
     "source": "plugin/skills/memory-and-context/SKILL.md",
     "hash": "d026a40d0c5315123672c7ed3770b643ba803a3b5d57cb994c236fcd6baa8305",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "tas-use-planning": {
     "source": "plugin/skills/planning/SKILL.md",
     "hash": "f56a42c83f514b300b4f89ea6669820ec158da952efa2894c56abb00c39eb58a",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "tas-use-rag-code-gen": {
     "source": "plugin/skills/rag-code-gen/SKILL.md",
     "hash": "0d84a32e2f89e8debd740b4343c7930b17efcca37fcb68737f342f8b6b5f6f77",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "tas-use-refactor-plan": {
     "source": "plugin/skills/refactor-plan/SKILL.md",
     "hash": "080a84b5df5dde88cd3c994ca2c2b68ec12e2cf241f2e81893f21aa9dac315f6",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "tas-use-release-prep": {
     "source": "plugin/skills/release-prep/SKILL.md",
     "hash": "8aab944ae2f53a24c94d39329bf000067a68f43b51de6657b517678bec90c67a",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "tas-use-security-audit": {
     "source": "plugin/skills/security-audit/SKILL.md",
     "hash": "f370003a809c342d35b37990da231fbb72545e75e5a37e1e1d39a27db5364761",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "tas-use-smart-test": {
     "source": "plugin/skills/smart-test/SKILL.md",
     "hash": "a5e874d1054dd123d78d9d8e9014c7c6888230f36685a203ea26176a3d649ffb",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "tas-use-spec": {
     "source": "plugin/skills/spec/SKILL.md",
     "hash": "4e1ce2c9da6fcad85ebcf7cb6b755f44c27d00608ad97b72b93a82a45e3c0186",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "tas-use-workflow-orchestration": {
     "source": "plugin/skills/workflow-orchestration/SKILL.md",
     "hash": "831c00dfb29ae4c72b35921fd3bab9e9f17affabf32b8164deb801557e031127",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "tas-wizards": {
     "source": "content/features/wizards.md",
     "hash": "6fe7722a026d11276ebfbdf4ea046a05112be94b560f9abf3ffee410f8637d8f",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "tip-after-10-inspects": {
     "source": "src/attune/discovery.py",
     "hash": "7041db92a9dadeb05ccec51831e49c162a38d62dbd11c69a487e68e7beebf15d",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "tip-after-5-ships": {
     "source": "src/attune/discovery.py",
     "hash": "7041db92a9dadeb05ccec51831e49c162a38d62dbd11c69a487e68e7beebf15d",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "tip-after-bug-predict": {
     "source": "src/attune/workflows/suggestions.py",
     "hash": "caa3f48a039def99a5bf58dc29129aba9548dfc74a42cc69dfb067aeb71f3200",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "tip-after-code-review": {
     "source": "src/attune/workflows/suggestions.py",
     "hash": "caa3f48a039def99a5bf58dc29129aba9548dfc74a42cc69dfb067aeb71f3200",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "tip-after-dependency-check": {
     "source": "src/attune/workflows/suggestions.py",
     "hash": "caa3f48a039def99a5bf58dc29129aba9548dfc74a42cc69dfb067aeb71f3200",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "tip-after-first-health": {
     "source": "src/attune/discovery.py",
     "hash": "7041db92a9dadeb05ccec51831e49c162a38d62dbd11c69a487e68e7beebf15d",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "tip-after-first-inspect": {
     "source": "src/attune/discovery.py",
     "hash": "7041db92a9dadeb05ccec51831e49c162a38d62dbd11c69a487e68e7beebf15d",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "tip-after-perf-audit": {
     "source": "src/attune/workflows/suggestions.py",
     "hash": "caa3f48a039def99a5bf58dc29129aba9548dfc74a42cc69dfb067aeb71f3200",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "tip-after-refactor-plan": {
     "source": "src/attune/workflows/suggestions.py",
     "hash": "caa3f48a039def99a5bf58dc29129aba9548dfc74a42cc69dfb067aeb71f3200",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "tip-after-security-audit": {
     "source": "src/attune/workflows/suggestions.py",
     "hash": "caa3f48a039def99a5bf58dc29129aba9548dfc74a42cc69dfb067aeb71f3200",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "tip-after-simplify-code": {
     "source": "src/attune/workflows/suggestions.py",
     "hash": "caa3f48a039def99a5bf58dc29129aba9548dfc74a42cc69dfb067aeb71f3200",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "tip-after-test-gen": {
     "source": "src/attune/workflows/suggestions.py",
     "hash": "caa3f48a039def99a5bf58dc29129aba9548dfc74a42cc69dfb067aeb71f3200",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "tip-agents": {
     "source": "content/features/agents.md",
     "hash": "a5b1678ecf012c7b2877a6c7ecae4a6c3f14c084c13fbcbb7eee79119dce6fa3",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "tip-bug-predict": {
     "source": "content/features/bug-predict.md",
     "hash": "6a4f420eba38e2fb884b837dd9758acb60ba60cdaf9248ec4280120b0d382b16",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "tip-cli": {
     "source": "content/features/cli.md",
     "hash": "a37b4dc4f0b3706a62184b02d2be1536ad75eef39a0f22a9699db5d03b8ee050",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "tip-code-quality": {
     "source": "content/features/code-quality.md",
     "hash": "ce16ac87eb92e33a08d8c2f06e86ef22e436966f47f3a28c3f4eba19060b550a",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "tip-configuration": {
     "source": "content/features/configuration.md",
     "hash": "8add90392883a46899ef8b57d135b625d92c5b61231d8a5301727f8b42f8e46f",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "tip-cost-savings": {
     "source": "src/attune/discovery.py",
     "hash": "7041db92a9dadeb05ccec51831e49c162a38d62dbd11c69a487e68e7beebf15d",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "tip-cross-review": {
     "source": "content/features/cross-review.md",
     "hash": "dc5ae75883b05f97983377b51e275bab79921e992d842ebb2616726b8c8c2cdb",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "tip-deep-review": {
     "source": "content/features/deep-review.md",
     "hash": "6a4fffc907302b4847d96097189bd8d329d3f1548d1ee46d9232f6ceecdfb450",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "tip-doc-gen": {
     "source": "content/features/doc-gen.md",
     "hash": "26e02a71a523775f5bb9e371b2e563c3c858386436a73b727422f62f57de0282",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "tip-elicitation-forms": {
     "source": "content/features/elicitation-forms.md",
     "hash": "4f326dd6f99f86af163cf44167b243d73ee5165ef8373bf4cea83039aec723d2",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
+  },
+  "tip-fix": {
+    "source": "content/features/fix.md",
+    "hash": "f4eb5cf49e7e9959b863b2bb1a866df14faa7a3f1c9bf1fe8acd1dc7e09bd1d6",
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "tip-fix-test": {
     "source": "content/features/fix-test.md",
     "hash": "8b182bab8816d525d3325746f4cdeed013113a1bdb0a43d36963e121afa42812",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "tip-help-system": {
     "source": "content/features/help-system.md",
     "hash": "24468c8fe4f1a0e350e620098d65a3bcc007000cd5aa4dbe20a6e6c83efa87b3",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "tip-high-tech-debt": {
     "source": "src/attune/discovery.py",
     "hash": "7041db92a9dadeb05ccec51831e49c162a38d62dbd11c69a487e68e7beebf15d",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "tip-hooks": {
     "source": "content/features/hooks.md",
     "hash": "5c6b8a45457387c76f628561d3baa56e9af1709bc9bd21bba9830b2c2478c8dd",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "tip-mcp-server": {
     "source": "content/features/mcp-server.md",
     "hash": "8e4b8c74eff980330480ae70856a1cf0393559cd22eb9ba0210b43249f9b5181",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "tip-memory": {
     "source": "content/features/memory.md",
     "hash": "32b3121d9110dc9ac327bb9e838f060fbe9940a033366b0147ef34ef2efaa4dc",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "tip-models": {
     "source": "content/features/models.md",
     "hash": "2117cbb0d8e863db6091870874e4ce80b48780c9ee8bb7330d8033c172ccb02b",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "tip-no-patterns": {
     "source": "src/attune/discovery.py",
     "hash": "7041db92a9dadeb05ccec51831e49c162a38d62dbd11c69a487e68e7beebf15d",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "tip-ops-dashboard": {
     "source": "content/features/ops-dashboard.md",
     "hash": "fefc8e2b2b4a25055fcbdf96cbd8638d75278cbcacd256873b725df89544c1f6",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "tip-orchestration": {
     "source": "content/features/orchestration.md",
     "hash": "4998437e04355011a7dee68dbce7e9e78bbe97f637e0b6a14c1ec972f541695c",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "tip-plugin": {
     "source": "content/features/plugin.md",
     "hash": "8cc6e5702ffc8228ed63cfb74a25dd3e99e79e5335c4b1c8c134950f8b9a043d",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "tip-rag-grounding": {
     "source": "content/features/rag-grounding.md",
     "hash": "3464dd78c83f06980912a7c49dc185b09830be1b1c163203f10e5aa1708fcf4e",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "tip-refactor-plan": {
     "source": "content/features/refactor-plan.md",
     "hash": "8f8c684cd94fca7b2580ecaaf955ccb79924022796d576d477cdab9330df9704",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "tip-release-notes": {
     "source": "content/features/release-notes.md",
     "hash": "da7101ffbec4d209fcb1cef754f01cef8a13458a6f961c3a23909edfec77e58c",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "tip-release-prep": {
     "source": "content/features/release-prep.md",
     "hash": "cd77b5903fbeb7d7e0acef570bab9727b4c143181ea6be1f52b9a25bc11418bb",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "tip-resilience": {
     "source": "content/features/resilience.md",
     "hash": "ae2a76f0f1ecbb9ca687e5a041acc2b4a25a5113ec57eaad550f48b8aadc4be2",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "tip-security-audit": {
     "source": "content/features/security-audit.md",
     "hash": "9cce18573c827fab9a380efe8c65c2f8c5b4ada3f7e383dd71ec523a0875fb05",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "tip-session-handoff": {
     "source": "content/features/session-handoff.md",
     "hash": "236c16ee2d2e48f0bd8ba075c69f50ead16a46ef185fede3d84b529c66fd41a0",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "tip-smart-test": {
     "source": "content/features/smart-test.md",
     "hash": "58c691c8313ddf9699deb913e6b5c50fafc684563539ddf4816a4b94a9ea3e80",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "tip-spec-engine": {
     "source": "content/features/spec-engine.md",
     "hash": "c8549016aa848eeeaecbde8329f5850562f56280ab66428cb7c20887b428d81a",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "tip-telemetry": {
     "source": "content/features/telemetry.md",
     "hash": "59473ab809113116a3d58d2ead3a5f13e362d6992d8cee0a89364feded5cbd50",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "tip-weekly-review": {
     "source": "src/attune/discovery.py",
     "hash": "7041db92a9dadeb05ccec51831e49c162a38d62dbd11c69a487e68e7beebf15d",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "tip-wizards": {
     "source": "content/features/wizards.md",
     "hash": "6fe7722a026d11276ebfbdf4ea046a05112be94b560f9abf3ffee410f8637d8f",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "tro-agents": {
     "source": "content/features/agents.md",
     "hash": "a5b1678ecf012c7b2877a6c7ecae4a6c3f14c084c13fbcbb7eee79119dce6fa3",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "tro-bug-predict": {
     "source": "content/features/bug-predict.md",
     "hash": "6a4f420eba38e2fb884b837dd9758acb60ba60cdaf9248ec4280120b0d382b16",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "tro-cli": {
     "source": "content/features/cli.md",
     "hash": "a37b4dc4f0b3706a62184b02d2be1536ad75eef39a0f22a9699db5d03b8ee050",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "tro-code-quality": {
     "source": "content/features/code-quality.md",
     "hash": "ce16ac87eb92e33a08d8c2f06e86ef22e436966f47f3a28c3f4eba19060b550a",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "tro-configuration": {
     "source": "content/features/configuration.md",
     "hash": "8add90392883a46899ef8b57d135b625d92c5b61231d8a5301727f8b42f8e46f",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "tro-cross-review": {
     "source": "content/features/cross-review.md",
     "hash": "dc5ae75883b05f97983377b51e275bab79921e992d842ebb2616726b8c8c2cdb",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "tro-deep-review": {
     "source": "content/features/deep-review.md",
     "hash": "6a4fffc907302b4847d96097189bd8d329d3f1548d1ee46d9232f6ceecdfb450",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "tro-doc-gen": {
     "source": "content/features/doc-gen.md",
     "hash": "26e02a71a523775f5bb9e371b2e563c3c858386436a73b727422f62f57de0282",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "tro-elicitation-forms": {
     "source": "content/features/elicitation-forms.md",
     "hash": "4f326dd6f99f86af163cf44167b243d73ee5165ef8373bf4cea83039aec723d2",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
+  },
+  "tro-fix": {
+    "source": "content/features/fix.md",
+    "hash": "f4eb5cf49e7e9959b863b2bb1a866df14faa7a3f1c9bf1fe8acd1dc7e09bd1d6",
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "tro-fix-test": {
     "source": "content/features/fix-test.md",
     "hash": "8b182bab8816d525d3325746f4cdeed013113a1bdb0a43d36963e121afa42812",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "tro-help-system": {
     "source": "content/features/help-system.md",
     "hash": "24468c8fe4f1a0e350e620098d65a3bcc007000cd5aa4dbe20a6e6c83efa87b3",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "tro-hooks": {
     "source": "content/features/hooks.md",
     "hash": "5c6b8a45457387c76f628561d3baa56e9af1709bc9bd21bba9830b2c2478c8dd",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "tro-mcp-server": {
     "source": "content/features/mcp-server.md",
     "hash": "8e4b8c74eff980330480ae70856a1cf0393559cd22eb9ba0210b43249f9b5181",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "tro-memory": {
     "source": "content/features/memory.md",
     "hash": "32b3121d9110dc9ac327bb9e838f060fbe9940a033366b0147ef34ef2efaa4dc",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "tro-models": {
     "source": "content/features/models.md",
     "hash": "2117cbb0d8e863db6091870874e4ce80b48780c9ee8bb7330d8033c172ccb02b",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "tro-ops-dashboard": {
     "source": "content/features/ops-dashboard.md",
     "hash": "fefc8e2b2b4a25055fcbdf96cbd8638d75278cbcacd256873b725df89544c1f6",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "tro-orchestration": {
     "source": "content/features/orchestration.md",
     "hash": "4998437e04355011a7dee68dbce7e9e78bbe97f637e0b6a14c1ec972f541695c",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "tro-plugin": {
     "source": "content/features/plugin.md",
     "hash": "8cc6e5702ffc8228ed63cfb74a25dd3e99e79e5335c4b1c8c134950f8b9a043d",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "tro-rag-grounding": {
     "source": "content/features/rag-grounding.md",
     "hash": "3464dd78c83f06980912a7c49dc185b09830be1b1c163203f10e5aa1708fcf4e",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "tro-refactor-plan": {
     "source": "content/features/refactor-plan.md",
     "hash": "8f8c684cd94fca7b2580ecaaf955ccb79924022796d576d477cdab9330df9704",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "tro-release-notes": {
     "source": "content/features/release-notes.md",
     "hash": "da7101ffbec4d209fcb1cef754f01cef8a13458a6f961c3a23909edfec77e58c",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "tro-release-prep": {
     "source": "content/features/release-prep.md",
     "hash": "cd77b5903fbeb7d7e0acef570bab9727b4c143181ea6be1f52b9a25bc11418bb",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "tro-resilience": {
     "source": "content/features/resilience.md",
     "hash": "ae2a76f0f1ecbb9ca687e5a041acc2b4a25a5113ec57eaad550f48b8aadc4be2",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "tro-security-audit": {
     "source": "content/features/security-audit.md",
     "hash": "9cce18573c827fab9a380efe8c65c2f8c5b4ada3f7e383dd71ec523a0875fb05",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "tro-session-handoff": {
     "source": "content/features/session-handoff.md",
     "hash": "236c16ee2d2e48f0bd8ba075c69f50ead16a46ef185fede3d84b529c66fd41a0",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "tro-smart-test": {
     "source": "content/features/smart-test.md",
     "hash": "58c691c8313ddf9699deb913e6b5c50fafc684563539ddf4816a4b94a9ea3e80",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "tro-spec-engine": {
     "source": "content/features/spec-engine.md",
     "hash": "c8549016aa848eeeaecbde8329f5850562f56280ab66428cb7c20887b428d81a",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "tro-telemetry": {
     "source": "content/features/telemetry.md",
     "hash": "59473ab809113116a3d58d2ead3a5f13e362d6992d8cee0a89364feded5cbd50",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "tro-wizards": {
     "source": "content/features/wizards.md",
     "hash": "6fe7722a026d11276ebfbdf4ea046a05112be94b560f9abf3ffee410f8637d8f",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-adding-a-plugin-skill-has-three-enforcement-gates-not-one": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-adding-a-workspace-sibling-package-as-an-extra-can-silently": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-adding-logger-before-eager-imports-triggers-e402-in-init-py": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-after-a-pr-merges-while-youre-afk-pull-main-before-tagging": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-after-a-squash-merge-of-a-feature-branch-local-main-can-have": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-agents": {
     "source": "content/features/agents.md",
     "hash": "a5b1678ecf012c7b2877a6c7ecae4a6c3f14c084c13fbcbb7eee79119dce6fa3",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-agents-skills-must-stay-synced-with-plugin-skills": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-anchor-tag-buttons-need-text-white-no-underline": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-anthropics-built-in-prompt-caching-supersedes-custom-caching": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-any-unstaged-file-triggers-pre-commit-stash-conflicts-with-auto": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-attune-author-check-staleness-load-manifest-is-the-python-api": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-attune-helps-sidecar-schemas-dont-match-path-keyed-assumptions": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-attune-skill-names-must-not-collide-with-claude-code-built-in": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-b904-raise-x-from-e-is-not-auto-fixable-by-ruff": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-background-processes-from-previous-sessions-persist-across": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-bare-manifest-in-gitignore-silently-excludes-any-manifest": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-bg-var-primary-bg-opacity-10-is-invisible-in-dark-mode": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-bug-predict": {
     "source": "content/features/bug-predict.md",
     "hash": "6a4f420eba38e2fb884b837dd9758acb60ba60cdaf9248ec4280120b0d382b16",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-bug-predict-dangerous-eval-flags-subprocess-exec": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-bugpredictionworkflow-not-bugpredictworkflow": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-changing-error-messages-breaks-tests-across-the-codebase": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-changing-the-citation-anchor-format-can-silently-regress-llm": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-changing-user-facing-output-strings-cascades-through-test": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-chicken-and-egg-for-optional-extras-in-dev": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-citation-forced-prompting-and-prompt-injection-resistance-are": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-claude-code-plugin-is-platform-specific": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-claude-code-plugins-expect-plugin-json-inside-claude-plugin": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-cli": {
     "source": "content/features/cli.md",
     "hash": "a37b4dc4f0b3706a62184b02d2be1536ad75eef39a0f22a9699db5d03b8ee050",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-clusterfuzz-dockerfile-copies-to-src-repo-but-also-copies": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-clusterfuzzlite-no-deps-misses-transitive-imports": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-code-quality": {
     "source": "content/features/code-quality.md",
     "hash": "ce16ac87eb92e33a08d8c2f06e86ef22e436966f47f3a28c3f4eba19060b550a",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-codecov-patch-0-usually-means-tests-skipped-not-failed": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-codeql-alerts-dismissible-in-bulk-via-gh-api": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-combine-two-unreleased-changelog-drafts-into-one-version-when": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-commands-are-not-namespaced-in-plugins-skills-are": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-configuration": {
     "source": "content/features/configuration.md",
     "hash": "8add90392883a46899ef8b57d135b625d92c5b61231d8a5301727f8b42f8e46f",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-costreport-fields-are-named-not-positional": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-costreport-is-a-dataclass-not-a-dict": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-cross-review": {
     "source": "content/features/cross-review.md",
     "hash": "dc5ae75883b05f97983377b51e275bab79921e992d842ebb2616726b8c8c2cdb",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-dataclassorder-true-needs-compare-false-on-list-fields": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-dead-code-modules-with-full-test-suites-look-alive": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-dead-tests-from-monorepo-extraction-accumulate-in-packages-with": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-deep-review": {
     "source": "content/features/deep-review.md",
     "hash": "6a4fffc907302b4847d96097189bd8d329d3f1548d1ee46d9232f6ceecdfb450",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-deep-review-false-positives-verify-before-acting": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-detect-secrets-flags-fake-as-a-secret-in-test-fixtures": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-direct-pushes-to-main-are-blocked-by-the-presence-of-required": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-dispatch-tables-hold-direct-function-references-mocks-must": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-dist-can-contain-stale-artifacts-after-version-bumps": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-doc-gen": {
     "source": "content/features/doc-gen.md",
     "hash": "26e02a71a523775f5bb9e371b2e563c3c858386436a73b727422f62f57de0282",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-dont-append-z-to-timezone-aware-isoformat": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-dry-run-candidate-golden-queries-through-the-resolver-before": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-duck-typed-test-fakes-fail-isinstance-based-collectors-silently": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-duplicate-plugins-cause-conflicting-skill-triggers": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-elicitation-forms": {
     "source": "content/features/elicitation-forms.md",
     "hash": "4f326dd6f99f86af163cf44167b243d73ee5165ef8373bf4cea83039aec723d2",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-exclude-hard-queries-from-aggregate-p-1-metrics-in-benchmark": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-exploration-agents-fabricate-names-verify-against-source": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-f841-unused-fixture-lint-fires-when-a-test-is-refactored-to": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-fastembed-is-the-local-embeddings-path-that-passes-a-50mb": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
+  },
+  "war-fix": {
+    "source": "content/features/fix.md",
+    "hash": "f4eb5cf49e7e9959b863b2bb1a866df14faa7a3f1c9bf1fe8acd1dc7e09bd1d6",
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-fix-test": {
     "source": "content/features/fix-test.md",
     "hash": "8b182bab8816d525d3325746f4cdeed013113a1bdb0a43d36963e121afa42812",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-forced-anthropic-tool-use-is-the-cleanest-path-to-guaranteed": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-formatter-strips-imports-that-are-unused-at-the-moment-you-save": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-generated-content-with-trailing-whitespace-causes-perpetual-pre": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-gh-api-x-patch-f-name-n-rejects-integers-as-strings": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-gh-pr-checks-json-field-names": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-gh-pr-merge-admin-is-blocked-by-in-progress-required-checks": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-gh-pr-merge-admin-prints-a-fast-forward-warning-even-when-the": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-gh-workflow-run-file-yml-ref-tag-re-triggers-a-release-gated": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-git-commit-q-can-exit-0-with-pre-commit-hook-feedback-that": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-git-pull-refuses-with-unstaged-changes-when-pull-rebase-true": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-git-rebase-root-exec-git-commit-amend-no-edit-s-re-signs-every": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-git-stash-pop-after-pre-commit-can-resurrect-stale-tool-state": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-github-actions-environment-deployment-approvals-can-be-self": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-github-copilot-autofix-pushes-commits-directly-to-pr-branches": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-github-protected-tags-cannot-be-force-updated": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-github-repos-serve-as-claude-code-marketplaces": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-gitignore-exclusions-break-ci-tests-that-read-those-files": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-glob-based-hash-computation-must-exclude-cache-dirs": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-golden-query-benchmarks-reveal-two-distinct-failure-classes": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-golden-query-test-fixtures-must-match-the-actual-corpus-layout": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-gpg-signing-fails-in-non-interactive-terminals-vscode-extension": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-hand-crafted-summary-prototype-is-the-fastest-way-to-measure-a": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-handoff-memory-option-b-proposals-are-often-wrong-re-analyze": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-hardcoded-root-paths-in-tests": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-hardcoded-strings-in-method-bodies-survive-class-attribute": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-hardcoded-user-id-defeats-ownership-checks": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-help-system": {
     "source": "content/features/help-system.md",
     "hash": "24468c8fe4f1a0e350e620098d65a3bcc007000cd5aa4dbe20a6e6c83efa87b3",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-hooks": {
     "source": "content/features/hooks.md",
     "hash": "5c6b8a45457387c76f628561d3baa56e9af1709bc9bd21bba9830b2c2478c8dd",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-hot-reload-subsystem-was-1-038-lines-of-dead-code": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-import-x-inside-a-try-block-except-x-someerror-in-the-except": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-importlib-import-module-is-an-arbitrary-code-execution-vector": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-industry-terminology-wont-appear-in-llm-polished-rag-summaries": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-is-private-is-a-superset-in-python-ipaddress": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-lazy-imports-inside-function-bodies-cant-be-patched-with": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-linkedin-paste-use-ascii-markers-not-unicode-arrows": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-list-workflows-deduplication-must-keep-base-names-visible": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-llm-api-responses-lack-trailing-newlines": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-mcp-attune-ai-doc-orchestrator-is-a-no-op-stub": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-mcp-call-tool-wrapper-pattern": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-mcp-handler-validate-paths-before-importing-workflows": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-mcp-json-python-resolves-to-pyenv-shim-not-project-venv": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-mcp-server": {
     "source": "content/features/mcp-server.md",
     "hash": "8e4b8c74eff980330480ae70856a1cf0393559cd22eb9ba0210b43249f9b5181",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-mcp-tool-renames-propagate-to-skill-docs": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-memory": {
     "source": "content/features/memory.md",
     "hash": "32b3121d9110dc9ac327bb9e838f060fbe9940a033366b0147ef34ef2efaa4dc",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-metadata-can-reach-a-retriever-with-zero-signal-if-the-sidecar": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-mkdocs-build-crashing-with-attributeerror-nonetype-object-has": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-models": {
     "source": "content/features/models.md",
     "hash": "2117cbb0d8e863db6091870874e4ce80b48780c9ee8bb7330d8033c172ccb02b",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-modeltier-has-two-copies-imports-must-match": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-module-level-optional-imports-enable-clean-test-patching": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-multiple-pinentry-program-lines-in-gpg-agent-conf-first-wins": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-mutual-competition-between-polished-rag-features-is-real-and": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-mypy-437-errors-was-stale-actual-count-was-2": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-naive-suffix-strip-stemming-fails-on-english-doubling-consonant": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-never-paste-pypi-tokens-into-chat-or-logs": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-new-dataclass-fields-need-both-the-class-and-the-parser-updated": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-new-mcp-handlers-must-match-the-validation-pattern-of-adjacent": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-new-security-features-need-dedicated-tests-before-release": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-non-baseworkflow-classes-in-workflow-registry-crash-the-cli": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-noqa-f401-re-exports-break-silently-on-satellite-file-deletion": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-openssf-scorecard-alerts-2-codereviewid-3-sastid-are-process": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-ops-dashboard": {
     "source": "content/features/ops-dashboard.md",
     "hash": "fefc8e2b2b4a25055fcbdf96cbd8638d75278cbcacd256873b725df89544c1f6",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-orchestration": {
     "source": "content/features/orchestration.md",
     "hash": "4998437e04355011a7dee68dbce7e9e78bbe97f637e0b6a14c1ec972f541695c",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-orphan-help-dirs-are-deprecated-3-depth-output-adding-them-to": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-orphan-top-level-docs-directories-stay-invisible-to-readers": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-packages-attune-in-attune-ai-are-pointer-stubs-not-source": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-past-due-deprecations-are-deletion-targets-not-implementation": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-patch-requires-the-target-name-to-exist-at-module-scope-at": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-path-globdir-matches-directories-not-files": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-path-rename-fails-on-windows-when-target-exists": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-platform-conditional-security-test-assertions-should-accept-any": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-plugin": {
     "source": "content/features/plugin.md",
     "hash": "8cc6e5702ffc8228ed63cfb74a25dd3e99e79e5335c4b1c8c134950f8b9a043d",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-plugin-read-skill-references-break-outside-the-plugin": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-pre-commit-auto-fix-requires-re-stage-before-retry": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-pre-commit-black-unstaged-files-re-stage-after-failure": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-pre-commit-stash-conflict-when-black-ruff-fix-files-with": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-pre-commit-stash-conflict-with-auto-fix-hooks": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-pre-commit-stash-conflicts-when-any-tracked-unstaged-file": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-pre-committed-decision-matrices-survive-contact-with-data": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-pre-flight-pre-commits-pinned-black-ruff-on-new-files-before": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-prefer-github-actions-trusted-publishing-over-local-twine-uv": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-provenance-citation-records-usually-store-short-previews-not": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-pull-main-before-merging-develop-to-avoid-merge-commits": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-pureposixpath-match-doesnt-support-in-python-3-10": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-pureposixpath-strips-trailing-slashes": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-push-specific-tags-not-tags": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-pypi-env-policies-may-whitelist-branches-only-tag-triggered": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-pypi-renders-readme-links-relative-to-its-own-domain": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-pypi-trusted-publisher-workflow-name-field-wants-the-filename": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-pytest-importorskip-triggers-ruff-e402": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-query-fixtures-are-self-diagnostic-for-rag-corpora-even-without": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-rag-grounding": {
     "source": "content/features/rag-grounding.md",
     "hash": "3464dd78c83f06980912a7c49dc185b09830be1b1c163203f10e5aa1708fcf4e",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-re-adding-an-import-after-the-formatter-strips-it-use-function": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-re-enabling-required-reviews-kills-queued-auto-merge": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-read-source-before-writing-tests-for-tricky-logic": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-rebuild-dist-after-readme-changes": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-reclassify-unexpectedly-hard-golden-queries-up-the-difficulty": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-redisshorttermmemory-mock-injection-path": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-refactor-plan": {
     "source": "content/features/refactor-plan.md",
     "hash": "8f8c684cd94fca7b2580ecaaf955ccb79924022796d576d477cdab9330df9704",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-registry-count-assertions-are-scattered-across-test-files": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-release-branches-carry-unmerged-commits-that-feature-branches": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-release-notes": {
     "source": "content/features/release-notes.md",
     "hash": "da7101ffbec4d209fcb1cef754f01cef8a13458a6f961c3a23909edfec77e58c",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-release-prep": {
     "source": "content/features/release-prep.md",
     "hash": "cd77b5903fbeb7d7e0acef570bab9727b4c143181ea6be1f52b9a25bc11418bb",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-release-published-workflow-dispatch-both-approved-for-pypi-env": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-removing-one-workspace-dep-can-cascade-to-remove-others": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-replacing-a-mixin-based-class-scatters-test-failures-across": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-repo-merge-policy-may-restrict-merge-strategies": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-repo-root-parents-count-varies-by-file-depth": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-required-status-check-names-must-match-githubs-exact-check-names": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-research-subagents-can-hallucinate-sdk-signatures-introspect": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-resilience": {
     "source": "content/features/resilience.md",
     "hash": "ae2a76f0f1ecbb9ca687e5a041acc2b4a25a5113ec57eaad550f48b8aadc4be2",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-resultmessage-result-is-often-none-capture-assistantmessage": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-rich-live-is-output-only-use-textual-for-any-interactive-row": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-ruff-auto-fix-strips-imports-before-usage-code-exists": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-run-simplify-catches-per-file-errors-internally": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-sbin-is-a-symlink-to-usr-sbin-on-modern-ubuntu": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-sdk-adapter-swallows-subagent-findings-lesson-was-wrong-adapter": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-sdk-agent-model-config-uses-stale-model-names": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-sdk-native-workflows-validate-in-execute-not-input-schema": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-security-audit": {
     "source": "content/features/security-audit.md",
     "hash": "9cce18573c827fab9a380efe8c65c2f8c5b4ada3f7e383dd71ec523a0875fb05",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-semantic-cache-70-hit-rate-claim-was-unmeasured": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-session-handoff": {
     "source": "content/features/session-handoff.md",
     "hash": "236c16ee2d2e48f0bd8ba075c69f50ead16a46ef185fede3d84b529c66fd41a0",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-session-hooks-may-be-vestigial": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-shadow-directories-at-repo-root-break-imports": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-silent-pass-blocks-in-discovery-registry-code-hide-import": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-skill-descriptions-must-be-under-250-characters": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-skill-frontmatter-has-a-strict-allowlist": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-smart-test": {
     "source": "content/features/smart-test.md",
     "hash": "58c691c8313ddf9699deb913e6b5c50fafc684563539ddf4816a4b94a9ea3e80",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-spec-engine": {
     "source": "content/features/spec-engine.md",
     "hash": "c8549016aa848eeeaecbde8329f5850562f56280ab66428cb7c20887b428d81a",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-squash-merge-deletes-the-remote-branch-subsequent-push-silently": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-ssrf-always-decode-urls-before-validating-hostnames": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-ssrf-strip-ipv6-zone-ids-before-ip-validation": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-stacked-patch-decorators-inject-args-bottom-up": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-staleness-detection-in-attune-author-attune-ais-help-system-is": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-stop-hooks-inject-stderr-not-stdout": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-stop-hooks-loop-without-a-sentinel": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-stop-hooks-missing-cd-prefix-inherit-session-cwd": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-structlog-default-output-pollutes-stdout-captured-cli-tests": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-structlog-kwargs-vs-stdlib-logger": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-tags-pushed-before-squash-merge-point-to-the-wrong-commit": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-telemetry": {
     "source": "content/features/telemetry.md",
     "hash": "59473ab809113116a3d58d2ead3a5f13e362d6992d8cee0a89364feded5cbd50",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-template-generators-overwrite-hand-written-files": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-test-mocks-must-match-imports": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-tests-for-optional-dep-code-need-pytest-importorskip-guards-in": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-text-white-on-gradient-primary-sections-gets-overridden": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-two-codeql-setups-can-coexist-in-one-repo-and-deadlock-merges": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-uncommitted-claude-mcp-json-means-mcp-server-never-starts": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-untracked-scripts-break-ci-when-tests-import-them": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-unused-init-py-re-exports-become-invisible-runtime-deps": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-use-dataclass-post-init-to-coalesce-between-a-scalar-legacy": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-uv-lock-can-drift-from-pyproject-toml-on-shared-branches": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-uv-lock-retains-editable-name-paths-after-tool-uv-sources-edits": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-uv-pip-install-e-path-can-ship-stale-package-data-even-after": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-uv-pip-install-e-sibling-path-no-deps-is-the-clean-venv-local": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-uv-run-in-pre-commit-hooks-propagates-lockfile-errors-as-hook": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-uv-sync-wipes-packages-installed-via-pip-install": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-validate-infrastructure-against-user-value-before-extending": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-verify-new-dispatch-branches-with-a-known-fixture-not-just": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-version-bumps-must-update-7-files-not-just-pyproject-toml": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-website-feature-lists-can-diverge-from-the-python-registry": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-windows-ci-encoding": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-windows-ci-runners-are-3x-slower-than-ubuntu-macos": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-windows-time-time-can-return-0-0-duration-for-fast-operations": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-wizards": {
     "source": "content/features/wizards.md",
     "hash": "6fe7722a026d11276ebfbdf4ea046a05112be94b560f9abf3ffee410f8637d8f",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-wizards-call-workflows-internally-they-are-not-duplicates": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-workflowresult-constructor-mismatches-surface-only-at-runtime": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-yaml-run-block-scalars-break-on-blank-lines-inside-multi-line": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-yaml-run-values-with-colons-cause-parse-errors": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   },
   "war-zsh-has-status-as-a-read-only-builtin-variable": {
     "source": ".claude/CLAUDE.md",
     "hash": "0fc4f2ecfb68581e0239cd31bfb5e3eaca355a0d8cdc92f4d7a9e8efd7596798",
-    "generated_at": "2026-07-30T21:39:09.594518+00:00"
+    "generated_at": "2026-07-31T11:48:59.290943+00:00"
   }
 }

--- a/plugin/help/generated/tasks/fix.md
+++ b/plugin/help/generated/tasks/fix.md
@@ -1,0 +1,49 @@
+---
+name: fix
+source: content/features/fix.md
+tags:
+- fixes
+- verification
+- cli
+type: task
+---
+
+# Outcome-first fixes — state the goal and its probes, get a verified receipt
+
+## Tasks
+
+### Preview before you commit to a run
+
+Run without `--run`. The preview prints the goal, the derived done
+conditions, the constraints, and the validated probes, then states that
+nothing was executed. Use it to check that your probes say what you
+meant before spending a run.
+
+### Scope a fix to one file or directory
+
+Pass `--scope <path>`. The path is validated against the enclosing
+repository root, so any spelling — relative, absolute, or `./`-prefixed
+— resolves to the same place. A directory scope permits edits to its
+descendants. `--run` requires `--scope`: an unbounded fix is not
+runnable.
+
+### Verify with more than one probe
+
+Repeat `--probe`. Each probe becomes its own done condition, and the
+receipt reports each independently. Plural probes are the point — one
+probe that is also the fix target proves very little, whereas a target
+probe plus a full-suite probe plus a scope constraint tells you the fix
+worked *and* broke nothing.
+
+### Read a failed run
+
+When probes fail, the receipt names **every** failing probe with its
+exact command, so re-running verification is a copy-paste. If the run
+changed no files at all, the receipt says that plainly rather than
+advising you to inspect a diff that does not exist.
+
+### Recover from a scope violation
+
+The receipt lists the out-of-scope paths by name and the next action is
+a targeted revert. Pre-existing dirty paths are excluded from that
+advice by construction.

--- a/plugin/help/generated/tips/fix.md
+++ b/plugin/help/generated/tips/fix.md
@@ -1,0 +1,24 @@
+---
+name: fix
+source: content/features/fix.md
+tags:
+- fixes
+- verification
+- cli
+type: tip
+---
+
+# Outcome-first fixes — state the goal and its probes, get a verified receipt
+
+## Notes & tips
+
+- Preview first. The preview costs nothing and catches malformed probes
+  before a run.
+- Prefer plural probes that are distinct from the fix target — a target
+  probe plus a suite probe plus a scope constraint is the shape that
+  actually proves something.
+- The receipt distinguishes "changed nothing and the conditions already
+  held" from "fixed and verified". If you see the former, check that
+  your goal described a real gap.
+- Probe subprocesses run with bytecode and pytest-cache writes disabled
+  so their own artifacts are never mistaken for the fix's changes.

--- a/plugin/help/generated/troubleshooting/fix.md
+++ b/plugin/help/generated/troubleshooting/fix.md
@@ -1,0 +1,36 @@
+---
+name: fix
+source: content/features/fix.md
+tags:
+- fixes
+- verification
+- cli
+type: troubleshooting
+---
+
+# Outcome-first fixes — state the goal and its probes, get a verified receipt
+
+## Failure modes
+
+**"no verification probes given — cannot verify a fix"** — a fix with
+no probe cannot be verified, so the command abstains (exit 3) instead
+of running something it could not check. Add `--probe`.
+
+**"no --workflow given — selection abstains rather than guess"** — a
+false confident route is worse than an abstention. Pass `--workflow
+fix`.
+
+**"probe contains shell metacharacters"** — probes are argv lists.
+Rewrite the probe without pipes or redirection; if you need shell
+semantics, put them in a script and probe the script.
+
+**"cannot run: --run requires --scope"** — an unscoped fix has no edit
+boundary to enforce, so `--run` refuses.
+
+**"SCOPE NOT VERIFIED — no git available"** — attribution fell back to
+content hashes of the declared scope files, so edits elsewhere are
+undetectable. The run will not report success; review the tree by hand.
+
+**Probe reported `SKIPPED`** — the command could not be executed (most
+often a missing binary). This is uncertainty, not a pass; the exit code
+is non-zero.

--- a/plugin/help/generated/warnings/fix.md
+++ b/plugin/help/generated/warnings/fix.md
@@ -1,0 +1,36 @@
+---
+name: fix
+source: content/features/fix.md
+tags:
+- fixes
+- verification
+- cli
+type: warning
+---
+
+# Outcome-first fixes — state the goal and its probes, get a verified receipt
+
+## Failure modes
+
+**"no verification probes given — cannot verify a fix"** — a fix with
+no probe cannot be verified, so the command abstains (exit 3) instead
+of running something it could not check. Add `--probe`.
+
+**"no --workflow given — selection abstains rather than guess"** — a
+false confident route is worse than an abstention. Pass `--workflow
+fix`.
+
+**"probe contains shell metacharacters"** — probes are argv lists.
+Rewrite the probe without pipes or redirection; if you need shell
+semantics, put them in a script and probe the script.
+
+**"cannot run: --run requires --scope"** — an unscoped fix has no edit
+boundary to enforce, so `--run` refuses.
+
+**"SCOPE NOT VERIFIED — no git available"** — attribution fell back to
+content hashes of the declared scope files, so edits elsewhere are
+undetectable. The run will not report success; review the tree by hand.
+
+**Probe reported `SKIPPED`** — the command could not be executed (most
+often a missing binary). This is uncertainty, not a pass; the exit code
+is non-zero.

--- a/src/attune/cli_commands/fix_receipt.py
+++ b/src/attune/cli_commands/fix_receipt.py
@@ -85,7 +85,10 @@ class FixReceipt:
         lines.append("Changes made (attributed to this run):")
         lines += [f"  - {p}" for p in self.attributed_changes]
         if not self.attributed_changes:
-            lines.append("  (none detected)")
+            # Naming the no-change case explicitly: "(none detected)" read
+            # as a detection weakness, so a run where the agent did nothing
+            # was indistinguishable from a verified fix (Phase 3 G1).
+            lines.append("  (none — this run changed no files)")
         if self.pre_existing_dirty:
             lines.append("Pre-existing changes (not attributed, not revert-advised):")
             lines += [f"  - {p}" for p in self.pre_existing_dirty]
@@ -250,6 +253,7 @@ def _next_action(
     failed: list[ProbeOutcome],
     skipped: list[ProbeOutcome],
     scope_verified: bool = True,
+    changed: bool = True,
 ) -> str:
     """The safest next step, worst problem first."""
     if violations:
@@ -260,9 +264,25 @@ def _next_action(
             "verified without git, so out-of-scope edits are undetectable"
         )
     if failed:
-        return f"inspect the diff, then re-run probe: {' '.join(failed[0].argv)}"
+        # EVERY failing probe is named: advising a re-run of failed[0]
+        # alone under-reported what still has to pass (Phase 3 G2).
+        commands = "; ".join(" ".join(p.argv) for p in failed)
+        prefix = (
+            "this run changed no files, so there is no diff to inspect — re-scope, then re-run"
+            if not changed
+            else "inspect the diff, then re-run"
+        )
+        target = "probe" if len(failed) == 1 else f"all {len(failed)} failing probes"
+        return f"{prefix} {target}: {commands}"
     if skipped:
         return "make the skipped probe runnable, then re-run verification"
+    if not changed:
+        # Passing probes on an unchanged tree are honest evidence that the
+        # conditions ALREADY held — not evidence that a fix was applied.
+        return (
+            "nothing to commit — this run changed no files; the done "
+            "conditions were already satisfied before it ran"
+        )
     return "review the attributed diff and commit"
 
 
@@ -303,6 +323,8 @@ def assemble_receipt(
         scope_violations=violations,
         probe_outcomes=probe_outcomes,
         uncertainty=_uncertainty_lines(baseline, git_ok, skipped),
-        next_action=_next_action(violations, failed, skipped, scope_verified),
+        next_action=_next_action(
+            violations, failed, skipped, scope_verified, changed=bool(attributed)
+        ),
         scope_verified=scope_verified,
     )

--- a/src/attune/cli_minimal.py
+++ b/src/attune/cli_minimal.py
@@ -228,8 +228,11 @@ def _add_diagnose_subparser(subparsers: argparse._SubParsersAction) -> None:
 
 
 def _add_fix_subparser(subparsers: argparse._SubParsersAction) -> None:
-    """Attach the dry outcome-first Fix preview (outcome-first-fix
-    spec, Phase 1). Preview-only: nothing is executed.
+    """Attach the outcome-first Fix surface (outcome-first-fix spec).
+
+    Dry by default — the bare form and ``--explain`` preview the
+    contract and execute nothing. ``--run`` (Phase 2) executes the fix
+    and verifies every probe independently.
 
     Args:
         subparsers: Parent subparsers action to attach to
@@ -237,7 +240,7 @@ def _add_fix_subparser(subparsers: argparse._SubParsersAction) -> None:
     """
     fix_parser = subparsers.add_parser(
         "fix",
-        help="Preview an outcome-first fix contract (dry — no execution yet)",
+        help="Preview an outcome-first fix contract (dry; --run to execute)",
     )
     fix_parser.add_argument("request", help="What should be fixed, in your words")
     fix_parser.add_argument(

--- a/tests/unit/cli_commands/test_fix_phase3.py
+++ b/tests/unit/cli_commands/test_fix_phase3.py
@@ -1,0 +1,331 @@
+"""Phase 3 tests: robustness, compatibility, and measurement.
+
+Closes the six gaps measured against the tree in tasks.md Task 3.
+Every test here is keyless and deterministic — the stub workflows
+replace ONLY the LLM edit step, exactly as in the Phase 2 suite.
+
+G1 no-change honesty | G2 partial success | G3 prompt persistence
+G5 compatibility measurement | G6 receipt completeness + honesty
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import sys
+from argparse import Namespace
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from attune.cli_commands.fix_commands import cmd_fix
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+FIXTURE_DIR = REPO_ROOT / "tests" / "fixtures" / "outcome_first_fix"
+PY = Path(sys.executable).as_posix()
+
+TARGET_PROBE = f"{PY} -m pytest pricing_suite.py::test_boundary_order_is_bulk -q"
+SUITE_PROBE = f"{PY} -m pytest pricing_suite.py -q"
+
+#: A string that appears in NO source file, so finding it on disk can
+#: only mean the run persisted the request text (G3).
+GOAL_SENTINEL = "zqx-phase3-prompt-sentinel-boundary-order"
+
+
+@pytest.fixture()
+def fix_repo(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """A real git repo containing a COPY of the canonical fixture."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    for name in ("pricing.py", "pricing_suite.py"):
+        shutil.copy(FIXTURE_DIR / name, repo / name)
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+    subprocess.run(
+        ["git", "-c", "user.email=t@t", "-c", "user.name=t", "add", "."],
+        cwd=repo,
+        check=True,
+    )
+    subprocess.run(
+        ["git", "-c", "user.email=t@t", "-c", "user.name=t", "commit", "-qm", "seed"],
+        cwd=repo,
+        check=True,
+    )
+    monkeypatch.chdir(repo)
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "")
+    return repo
+
+
+def _apply_known_fix(repo: Path) -> None:
+    target = repo / "pricing.py"
+    target.write_text(
+        target.read_text().replace("if units > BULK_THRESHOLD", "if units >= BULK_THRESHOLD")
+    )
+
+
+class _StubNoOp:
+    """Claims success, changes nothing (the H2 liar)."""
+
+    async def execute(self, **kwargs):
+        return SimpleNamespace(success=True, metadata={})
+
+
+class _StubEditsButDoesNotFix:
+    """Edits in scope, but the probes still fail — partial success."""
+
+    async def execute(self, **kwargs):
+        target = Path.cwd() / "pricing.py"
+        target.write_text(target.read_text() + "\n# touched, but not fixed\n")
+        return SimpleNamespace(success=True, metadata={})
+
+
+def _args(**overrides) -> Namespace:
+    base = {
+        "request": "boundary order must price as bulk",
+        "explain": False,
+        "workflow": "fix",
+        "probe": [TARGET_PROBE, SUITE_PROBE],
+        "scope": "pricing.py",
+        "run": True,
+    }
+    base.update(overrides)
+    return Namespace(**base)
+
+
+def _install_stub(monkeypatch: pytest.MonkeyPatch, stub_cls) -> None:
+    import attune.workflows as workflows_pkg
+
+    workflows_pkg._ensure_registry_initialized()
+    monkeypatch.setitem(workflows_pkg.WORKFLOW_REGISTRY, "fix", stub_cls)
+
+
+def _next_action_line(out: str) -> str:
+    return [ln for ln in out.splitlines() if "Safest next action" in ln][0]
+
+
+# ---------------------------------------------------------------
+# G1 — a run that changed nothing says so
+# ---------------------------------------------------------------
+
+
+def test_no_change_run_with_passing_probes_is_named_not_claimed(
+    fix_repo: Path, monkeypatch: pytest.MonkeyPatch, capsys
+) -> None:
+    """Conditions already satisfied: probes pass, nothing changed.
+
+    Exit stays 0 — the probes are the authority (H2) — but the receipt
+    must not advise committing a diff that does not exist.
+    """
+    _apply_known_fix(fix_repo)  # satisfied BEFORE the run
+    _install_stub(monkeypatch, _StubNoOp)
+
+    exit_code = cmd_fix(_args())
+    out = capsys.readouterr().out
+
+    assert exit_code == 0
+    assert "(none — this run changed no files)" in out
+    action = _next_action_line(out)
+    assert "nothing to commit" in action
+    assert "already satisfied" in action
+    assert "review the attributed diff and commit" not in out
+
+
+def test_no_change_run_with_failing_probes_does_not_advise_a_diff(
+    fix_repo: Path, monkeypatch: pytest.MonkeyPatch, capsys
+) -> None:
+    """The agent did nothing and the probes still fail."""
+    _install_stub(monkeypatch, _StubNoOp)
+
+    exit_code = cmd_fix(_args())
+    out = capsys.readouterr().out
+
+    assert exit_code == 1
+    action = _next_action_line(out)
+    assert "no diff to inspect" in action
+    assert "inspect the diff, then re-run" not in action
+
+
+# ---------------------------------------------------------------
+# G2 — partial success names EVERY failing probe
+# ---------------------------------------------------------------
+
+
+def test_partial_success_names_every_failing_probe(
+    fix_repo: Path, monkeypatch: pytest.MonkeyPatch, capsys
+) -> None:
+    """Two probes fail after a real in-scope edit: both are named."""
+    _install_stub(monkeypatch, _StubEditsButDoesNotFix)
+
+    exit_code = cmd_fix(_args())
+    out = capsys.readouterr().out
+    action = _next_action_line(out)
+
+    assert exit_code == 1
+    assert "all 2 failing probes" in action
+    assert "test_boundary_order_is_bulk" in action  # the target probe
+    assert action.count(" -m pytest ") == 2  # BOTH, not just failed[0]
+    assert "inspect the diff" in action  # a real diff exists here
+
+
+def test_single_failing_probe_keeps_the_singular_wording(
+    fix_repo: Path, monkeypatch: pytest.MonkeyPatch, capsys
+) -> None:
+    """One failure still reads naturally (no 'all 1 failing probes')."""
+    _install_stub(monkeypatch, _StubEditsButDoesNotFix)
+
+    exit_code = cmd_fix(_args(probe=[TARGET_PROBE]))
+    action = _next_action_line(capsys.readouterr().out)
+
+    assert exit_code == 1
+    assert "re-run probe:" in action
+    assert "all 1" not in action
+
+
+# ---------------------------------------------------------------
+# G3 — where the request text does and does not go
+# ---------------------------------------------------------------
+
+
+def test_fix_run_persists_no_file_containing_the_request_text(
+    fix_repo: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys
+) -> None:
+    """Evidence-chain: walk every file the run could have written.
+
+    Asserted over REAL files on disk (repo tree + an isolated HOME),
+    not over a mock of a persistence call — the claim is "nothing was
+    written", and only a filesystem walk can back it.
+    """
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("USERPROFILE", str(home))  # Windows equivalent
+    _install_stub(monkeypatch, _StubNoOp)
+
+    cmd_fix(_args(request=GOAL_SENTINEL))
+    assert GOAL_SENTINEL in capsys.readouterr().out  # it DID reach stdout
+
+    searched = 0
+    for root in (fix_repo, home):
+        for path in root.rglob("*"):
+            if not path.is_file() or ".git" in path.parts:
+                continue
+            searched += 1
+            content = path.read_text(encoding="utf-8", errors="replace")
+            assert GOAL_SENTINEL not in content, f"request text persisted to {path}"
+    assert searched > 0  # the walk actually looked at something
+
+
+def test_ops_run_record_would_carry_goal_text_generic_surface(tmp_path: Path) -> None:
+    """CHARACTERIZATION, not an endorsement (Phase 3 G3 finding).
+
+    The `attune fix` surface persists nothing. Persistence enters only
+    if the `fix` WORKFLOW is driven through the ops daemon, whose
+    generic run-record writer stores every workflow's command line —
+    including anything passed via `--input`. This pins that boundary so
+    a future change routing Fix through ops inherits it knowingly
+    rather than silently. Recorded in decisions.md D7; the fix belongs
+    to the ops/run-record surface, not to this spec.
+    """
+    from attune.ops.runner import Run, _persist_run
+
+    run = Run(id="abc123def456", workflow="fix")  # _RUN_ID_RE: hex only
+    run.extra_args = ["--input", json.dumps({"goal": GOAL_SENTINEL})]
+    run.command = ["attune", "workflow", "run", "fix", *run.extra_args]
+    run.append_line(f"$ {' '.join(run.command)}")
+
+    dest = _persist_run(run, tmp_path)
+
+    assert dest is not None
+    assert GOAL_SENTINEL in dest.read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------
+# G5 — the compatibility measurement has a named source
+# ---------------------------------------------------------------
+
+
+def test_compatibility_pins_module_still_exists_and_is_named() -> None:
+    """The Task 0 characterization module IS the compatibility metric.
+
+    Deleting or renaming it would leave the reported
+    "compatibility regressions: 0" unmeasured, which is the failure
+    mode a metric with no source has.
+    """
+    pins = REPO_ROOT / "tests" / "unit" / "characterization" / "test_outcome_first_phase0.py"
+    assert pins.is_file()
+    body = pins.read_text(encoding="utf-8")
+    for pinned in (
+        "test_success_true_exits_zero_intentional",
+        "test_success_false_exits_one_intentional",
+        "test_uncaught_exception_exits_two_intentional",
+        "test_legacy_result_without_success_attr_exits_zero_intentional",
+    ):
+        assert pinned in body
+
+
+# ---------------------------------------------------------------
+# G6 — receipt completeness + verification-failure honesty
+# ---------------------------------------------------------------
+
+#: Sections every receipt must carry for the D3 "evidence-valid
+#: receipt completeness" metric to read 100%.
+_REQUIRED_SECTIONS = (
+    "🧾 Fix receipt",
+    "Changes made (attributed to this run):",
+    "Probes (evaluated independently):",
+    "Safest next action:",
+    "receipt reflects independently evaluated probes",
+)
+
+
+@pytest.mark.parametrize(
+    ("stub", "pre_fix"),
+    [
+        (_StubNoOp, True),  # no-change, probes pass
+        (_StubNoOp, False),  # no-change, probes fail
+        (_StubEditsButDoesNotFix, False),  # changed, probes fail
+    ],
+)
+def test_every_receipt_carries_every_required_section(
+    fix_repo: Path, monkeypatch: pytest.MonkeyPatch, capsys, stub, pre_fix: bool
+) -> None:
+    """Receipt completeness measured across the outcome space."""
+    if pre_fix:
+        _apply_known_fix(fix_repo)
+    _install_stub(monkeypatch, stub)
+
+    cmd_fix(_args())
+    out = capsys.readouterr().out
+
+    for section in _REQUIRED_SECTIONS:
+        assert section in out, f"receipt missing {section!r}"
+
+
+def test_verification_failure_is_reported_not_omitted(
+    fix_repo: Path, monkeypatch: pytest.MonkeyPatch, capsys
+) -> None:
+    """Honesty metric: a failure produces a row, never silence."""
+    _install_stub(monkeypatch, _StubNoOp)
+
+    exit_code = cmd_fix(_args())
+    out = capsys.readouterr().out
+
+    assert exit_code == 1
+    assert "[FAIL]" in out
+    assert "[PASS]" not in out.split("Probes (evaluated independently):")[1]
+
+
+def test_unrunnable_probe_is_reported_as_skipped_with_a_reason(
+    fix_repo: Path, monkeypatch: pytest.MonkeyPatch, capsys
+) -> None:
+    """A probe that cannot run is uncertainty, not a silent pass."""
+    _install_stub(monkeypatch, _StubNoOp)
+
+    exit_code = cmd_fix(_args(probe=["definitely-not-a-real-binary --check"]))
+    out = capsys.readouterr().out
+
+    assert exit_code == 1
+    assert "[SKIPPED]" in out
+    assert "Remaining uncertainty:" in out
+    assert "command not found" in out

--- a/tests/unit/cli_commands/test_fix_receipt.py
+++ b/tests/unit/cli_commands/test_fix_receipt.py
@@ -152,7 +152,10 @@ def test_workflow_success_with_failing_probes_exits_one_h2(
     out = capsys.readouterr().out
     assert code == 1
     assert "[FAIL]" in out
-    assert "inspect the diff" in out
+    # This stub changes NOTHING, so Phase 3 (G1) stopped advising the
+    # user to inspect a diff that does not exist. The H2 subject of this
+    # test — exit 1 plus a truthful FAIL row — is unchanged.
+    assert "no diff to inspect" in out
 
 
 def test_out_of_scope_edit_reported_and_fails(


### PR DESCRIPTION
Executes **Task 3** of `docs/specs/outcome-first-fix/` behind its chair go (2026-07-31). Keyless — no spend.

## Scoped from the tree, not the spec text

The ruling's Phase 3 bullet list was checked against the code before the task was authored. Four of its six named robustness paths were already covered by the existing 48 tests (malformed, ambiguous, failed verification, abstention — plus crash, git-unavailable, scope-unverified, hardened by #1814/#1815). This PR executes the **six measured gaps** instead.

| Gap | What shipped |
|---|---|
| G1 | A run that changed nothing says so. `(none detected)` read as a detection weakness, and the next action advised committing a diff that did not exist — "agent did nothing" was indistinguishable from a verified fix. Exit codes unchanged: probes remain the authority (H2). |
| G2 | Every failing probe is named. Advising a re-run of `failed[0]` alone under-reported what still had to pass. |
| G3 | Answered with evidence, recorded in **D7**. |
| G4 | `attune fix` feature master + 15 projected outputs. |
| G5+G6 | The four ratified D3 metrics reported in **metrics.md**. |

## G3 — the answer is split, and only half belongs to this spec

`attune fix` **persists nothing** — verified by walking real files (repo tree + isolated `HOME`) for a sentinel request string, not by mocking a persistence call. Telemetry records cost/tokens/duration only.

The **ops run record** would carry a goal passed via `attune workflow run --input '{...}'`, because the generic writer stores every workflow's command line. That behavior predates this spec and is shared by every workflow, so changing it from inside a Fix phase would alter behavior project-wide. It is pinned as characterization and recorded in D7; whether the ops run record should redact `--input` payloads is carried as an **unruled chair candidate** on the ops surface.

## Receipts

- **suite** — 19,697 unit tests pass (full `tests/unit`, keyless)
- **metric** — 100% coverage on `fix_commands.py`, `fix_receipt.py`, `fix_workflow.py` (serial, keyless)
- **behavioral** — the projection drift guard was **demonstrated failing** on a hand-edited twin, then green after re-projection — not merely asserted
- **evidence-chain** — G3's file walk asserts over real written files

## One pre-existing assertion amended

`test_workflow_success_with_failing_probes_exits_one_h2` asserted `"inspect the diff"` for a stub that changes nothing — exactly the advice G1 corrects. Its H2 subject (exit 1 plus a truthful FAIL row) is untouched. Flagged rather than buried.

Also corrected in passing: the `fix` subparser's help still claimed "dry — no execution yet" after `--run` shipped in Phase 2.

## What this does NOT claim

Three of the four metrics read 100%/0 because they measure properties the suite enforces, not samples of real use. They make a regression in receipt honesty fail CI. They are not evidence that users succeed with the surface — no Fix has been run by anyone but its authors. Adoption-shaped metrics need real users and are not claimed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)