### PR TITLE
fix(ops): guard the run-start endpoint against free-text passthrough (outcome-first-fix D7)

### DIFF
--- a/docs/specs/outcome-first-fix/decisions.md
+++ b/docs/specs/outcome-first-fix/decisions.md
@@ -125,22 +125,50 @@ Telemetry is not a leak path either — `_track_sdk_run_telemetry`
 records cost, tokens, and duration only. Pinned by
 `test_fix_run_persists_no_file_containing_the_request_text`.
 
-**The ops run record would carry it.** If the `fix` WORKFLOW is
-driven through the ops daemon, the generic run-record writer
-(`_persist_run`, `src/attune/ops/runner.py`) stores every workflow's
-command line, and `attune workflow run --input '{...}'` accepts
-arbitrary kwargs — so a goal passed that way lands in
-`~/.attune/ops/runs/fix/<id>.json`, both in `command` and in the
-first log line.
+**The ops run record would carry it — but nothing can reach that
+path today (CORRECTED 2026-07-31, same day).** The first wording of
+this decision said a goal "passed that way lands in the record,"
+which implies a reachable exposure. It is not reachable, and the
+correction matters enough to state plainly:
+
+- `_persist_run` has exactly one caller, and `persistence_dir` is
+  wired ONLY in the ops dashboard server — CLI- and MCP-launched
+  runs never write an ops run record at all. So neither
+  `attune fix --run` nor `attune workflow run fix --input '{...}'`
+  from a terminal persists anything.
+- The dashboard's start endpoint (`POST /workflows/{name}/run`,
+  `src/attune/ops/routes/runner.py`) reads exactly `path` and
+  `trigger` from the body and passes only those to
+  `RunnerService.start`. There is no `--input` or `extra_args`
+  passthrough; the single `extra_args` caller in the tree is the
+  self-heal `diagnose` route passing a run id.
+- A dashboard-launched `fix` would therefore fail on "goal argument
+  is required" before any record content exists.
+
+What remains true: the writer stores whatever argv it is given, so
+the exposure would arrive the day the endpoint grows a free-text
+passthrough.
 
 **Decision: record the boundary, do NOT change the ops surface in
 this spec.** The behavior is generic to every workflow, predates
 this spec, and belongs to the ops/run-record surface — changing it
 here would alter behavior for every other workflow from inside a Fix
 phase. `test_ops_run_record_would_carry_goal_text_generic_surface`
-pins it as CHARACTERIZATION so a future change that routes Fix
-through ops inherits the consequence knowingly.
+pins the writer's behavior as CHARACTERIZATION.
 
-**Carried as a candidate, unruled:** whether the ops run record
-should redact `--input` payloads by default. That is a chair call on
-the ops surface, not a Fix decision.
+**Chair ruling on the carried candidate (Patrick, 2026-07-31):
+guard the endpoint, do not redact the writer.** Redaction was
+declined — it would change a shared surface for a path no caller can
+reach, and would mask argv fields that are genuinely useful when
+debugging a failed run. Instead the RISK BOUNDARY is guarded where
+it actually lives:
+`tests/unit/ops/test_run_start_no_freetext_passthrough.py` asserts
+the start endpoint forwards no caller-supplied arguments, that no
+prose reaches the subprocess argv or the run record, and that the
+body parser still honors exactly two keys. Demonstrated firing: with
+an `extra_args` passthrough temporarily wired into the route, the
+guard fails on the argv assertion; restored, it passes.
+
+The redaction question is CLOSED unless the endpoint gains a
+free-text passthrough — at which point the guard fails and forces
+the decision then, with the exposure real rather than theoretical.

--- a/tests/unit/ops/test_run_start_no_freetext_passthrough.py
+++ b/tests/unit/ops/test_run_start_no_freetext_passthrough.py
@@ -1,0 +1,106 @@
+"""Guard: the ops run-start endpoint accepts no free-text passthrough.
+
+outcome-first-fix D7. The ops run-record writer persists every run's
+command line, so any endpoint that let a caller inject arbitrary
+subprocess arguments would put user prose (a Fix goal, a prompt) on
+disk under ``~/.attune/ops/runs/``. Today it cannot: the endpoint reads
+exactly ``path`` and ``trigger`` from the body and passes only those to
+``RunnerService.start``.
+
+That is the property worth guarding — NOT the writer's behavior. The
+writer storing what it is given is correct; the exposure would arrive
+the day this endpoint grows an ``--input`` / ``extra_args`` passthrough.
+This test fails on that day.
+"""
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+pytest.importorskip("fastapi")
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from attune.ops.config import build_config  # noqa: E402
+from attune.ops.runner import RunnerService  # noqa: E402
+from attune.ops.server import create_app  # noqa: E402
+
+#: Free text that must never reach a subprocess argv or a run record.
+PROSE = "zqx-d7-sentinel-make-the-boundary-order-bulk"
+
+
+def _echo_cmd(workflow: str) -> tuple[str, ...]:
+    script = f"import sys; print('start {workflow}'); sys.exit(0)"
+    return (sys.executable, "-c", script)
+
+
+def _app(tmp_path, monkeypatch):
+    monkeypatch.setenv("ATTUNE_HOME", str(tmp_path / "attune-home"))
+    config = build_config(
+        project_root=tmp_path,
+        allow_run=True,
+        trusted_hosts=("testserver", "test"),
+    )
+    runner = RunnerService(command_builder=_echo_cmd)
+    return create_app(config, runner=runner), runner
+
+
+def test_free_text_body_fields_never_reach_the_subprocess(tmp_path, monkeypatch):
+    """Extra body keys are ignored, not forwarded as arguments."""
+    app, runner = _app(tmp_path, monkeypatch)
+
+    with TestClient(app) as client:
+        resp = client.post(
+            "/workflows/code-review/run",
+            json={
+                "trigger": "manual",
+                # Every shape a caller might try to smuggle prose through:
+                "input": f'{{"goal": "{PROSE}"}}',
+                "extra_args": ["--input", f'{{"goal": "{PROSE}"}}'],
+                "goal": PROSE,
+                "args": [PROSE],
+            },
+        )
+
+    assert resp.status_code == 201, resp.text
+    run = runner.get(resp.json()["run_id"])
+    assert run is not None
+    assert run.extra_args is None, "endpoint forwarded caller-supplied arguments"
+    assert PROSE not in " ".join(run.command or []), "prose reached the subprocess argv"
+
+
+def test_free_text_body_fields_never_reach_the_persisted_record(tmp_path, monkeypatch):
+    """The record is the thing on disk — assert over its real content."""
+    app, runner = _app(tmp_path, monkeypatch)
+
+    with TestClient(app) as client:
+        resp = client.post(
+            "/workflows/code-review/run",
+            json={"trigger": "manual", "goal": PROSE, "input": PROSE},
+        )
+        run_id = resp.json()["run_id"]
+
+    run = runner.get(run_id)
+    assert run is not None
+    record = run.to_record()
+    assert PROSE not in str(record), "prose reached the run record"
+
+
+def test_only_path_and_trigger_are_read_from_the_body(tmp_path, monkeypatch):
+    """Pin the parser's surface: widening it is what creates the risk.
+
+    A body field that IS honored must be added here deliberately, with
+    the D7 consequence considered — that is the point of the guard.
+    """
+    from attune.ops.routes import runner as runner_routes
+
+    source = runner_routes._read_run_body.__doc__ or ""
+    assert "path" in source and "trigger" in source
+
+    import inspect
+
+    body = inspect.getsource(runner_routes._read_run_body)
+    honored = {line for line in body.splitlines() if "raw.get(" in line}
+    assert len(honored) == 2, f"run body now reads more than path+trigger: {honored}"


### PR DESCRIPTION
Acts on the chair ruling for the candidate carried out of #1818, and **corrects D7's own wording** in the same change.

## The correction

D7 as merged said a Fix goal "passed that way lands in the record", which implies a reachable exposure. **It is not reachable:**

- `_persist_run` has one caller, and `persistence_dir` is wired **only** in the ops dashboard server — CLI- and MCP-launched runs write no ops run record at all. Neither `attune fix --run` nor `attune workflow run fix --input '{...}'` from a terminal persists anything.
- The dashboard's start endpoint reads exactly `path` and `trigger` from the body and passes only those to `RunnerService.start`. No `--input` or `extra_args` passthrough exists; the sole `extra_args` caller in the tree is the self-heal `diagnose` route passing a run id.
- A dashboard-launched `fix` would fail on "goal argument is required" before any record content exists.

The underlying facts in D7 were right; the reachability claim was not.

## The ruling

**Guard the endpoint, don't redact the writer.** Redaction was declined — it changes a shared surface for a path no caller can reach, and masks argv fields that matter when debugging a failed run. The risk boundary is guarded where it actually lives.

`tests/unit/ops/test_run_start_no_freetext_passthrough.py` asserts three things:

1. extra body keys (`input`, `extra_args`, `goal`, `args`) are ignored — nothing reaches the subprocess argv;
2. no prose reaches the persisted record, asserted over `to_record()`;
3. the body parser still honors exactly two keys, so widening it is deliberate rather than accidental.

## Receipt — demonstrated, not asserted

With an `extra_args` passthrough temporarily wired into the route, the guard **fails** on the argv assertion:

```
assert ['--input', '{"goal": "zqx-d7-sentinel-..."}'] ... .extra_args
FAILED test_free_text_body_fields_never_reach_the_subprocess
```

Route restored, all three pass. 1,951 tests green across `tests/unit/ops` + `tests/unit/cli_commands`.

The redaction question is closed unless the endpoint gains a passthrough — at which point this guard fails and forces the decision then, with the exposure real rather than theoretical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)