### PR TITLE
docs(usage-signals): AFTER-snapshot 2026-07-31 (serves 11.0.0 + 11.1.0)

### DIFF
--- a/docs/specs/usage-signals/snapshots/2026-07-31.json
+++ b/docs/specs/usage-signals/snapshots/2026-07-31.json
@@ -1,0 +1,55 @@
+{
+  "attempts": [
+    {
+      "at": "2026-07-31T12:15:24.006278+00:00",
+      "captured": 0,
+      "outcome": "rate-limited"
+    },
+    {
+      "at": "2026-07-31T13:21:43.381834+00:00",
+      "captured": 3,
+      "outcome": "rate-limited"
+    }
+  ],
+  "date": "2026-07-31",
+  "github": {},
+  "manifest": {
+    "captured": [
+      "attune-ai",
+      "attune-rag",
+      "attune-help"
+    ],
+    "complete": false,
+    "expected": [
+      "attune-ai",
+      "attune-rag",
+      "attune-help",
+      "attune-author",
+      "attune-verify"
+    ],
+    "missing": [
+      "attune-author",
+      "attune-verify"
+    ],
+    "observed_at": "2026-07-31T13:21:43.382224+00:00",
+    "source": "pypistats.org/api/recent"
+  },
+  "pypi_recent": {
+    "attune-ai": {
+      "last_day": 83,
+      "last_month": 4552,
+      "last_week": 484
+    },
+    "attune-help": {
+      "last_day": 3272,
+      "last_month": 9249,
+      "last_week": 8310
+    },
+    "attune-rag": {
+      "last_day": 4152,
+      "last_month": 48994,
+      "last_week": 16570
+    }
+  },
+  "taken_at": "2026-07-31T13:21:43.382224+00:00"
+}


### PR DESCRIPTION
Reach AFTER-snapshot captured by the `reach-snapshot-after-windows` scheduled task.

## Which windows this serves

Capture timestamp **2026-07-31T13:21:43Z (09:21 ET)** falls inside **both** open AFTER-measurement windows (usage-signals US-5):

| Release | Window (ET) | Served |
|---|---|---|
| 11.0.0 | Wed 07-29 19:05 → Fri 07-31 19:05 | yes |
| 11.1.0 | Fri 07-31 08:00 → Sun 08-02 08:00 | yes |

## Receipt — partial, 3/5

The `captured` count is the receipt, not the exit code (the script soft-fails exit 0 on rate-limit).

| Attempt | Time (UTC) | Captured | Outcome |
|---|---|---|---|
| 1 | 12:15:24 | 0/5 | rate-limited |
| 2 | 13:21:43 | **3/5** | rate-limited (partial) |

- **Captured:** `attune-ai`, `attune-rag`, `attune-help`
- **Missing:** `attune-author`, `attune-verify`
- Manifest carries `complete: false` and the incomplete-receipt warning.

`attune-ai` — the package the release AFTER-leg is actually about — **is** captured: `last_day` 83, `last_week` 484, `last_month` 4552.

## Why this is committed despite being incomplete

The 07-30 snapshot captured **0/5 across two attempts**, so the 11.0.0 leg had no data at all. Its window closes today at 19:05 ET and both of today's budgeted attempts are spent — this is the only data that will exist inside it. Committing preserves the primary signal; the two missing packages are stated rather than papered over.

**Chair decision owed:** whether the missing `attune-author` / `attune-verify` legs are waived for 11.0.0 (its window closes 19:05 ET today, unrecoverable) or re-attempted for 11.1.0, whose window stays open until Sun 08-02 08:00 ET.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
