### PR TITLE
feat(spec): new-spec intake form — outcome/done-when/area/slug, derived candidates

### DIFF
--- a/.agents/skills/spec/SKILL.md
+++ b/.agents/skills/spec/SKILL.md
@@ -45,6 +45,35 @@ options:
 If the user provides arguments (e.g., "resume" or a file
 path), skip the picker and route directly.
 
+### New-spec intake (one form, not N questions)
+
+When the route is "Start a new spec", gather the framing as ONE
+form per the Socratic rule — never as sequential question turns:
+
+```bash
+python -m attune.elicitation.spec_intake
+```
+
+The JSON payload carries a validated form definition
+(`attune.elicitation.spec_intake.build_spec_intake_form`) —
+outcome, done-when acceptance, primary code area (options derived
+from the tree's packages), and an optional slug — plus
+`taken_slugs` for collision awareness. Render it widget-first with
+the `AskUserQuestion` fallback (batching opts in via
+`metadata.source` containing "form"). If the user's invocation
+already stated what to build, carry it into the outcome field
+instead of asking again.
+
+Compose the answers into the session-contract block that seeds
+Stage 1:
+
+```bash
+echo '<answers JSON>' | python -m attune.elicitation.spec_intake --compose
+```
+
+A slug collision renders as a WARNING, not an error — offer to
+amend the existing spec before forking a new one.
+
 ## How It Works
 
 Five stages, one flow:

--- a/plugin/skills/spec/SKILL.md
+++ b/plugin/skills/spec/SKILL.md
@@ -47,6 +47,35 @@ options:
 If the user provides arguments (e.g., "resume" or a file
 path), skip the picker and route directly.
 
+### New-spec intake (one form, not N questions)
+
+When the route is "Start a new spec", gather the framing as ONE
+form per the Socratic rule — never as sequential question turns:
+
+```bash
+python -m attune.elicitation.spec_intake
+```
+
+The JSON payload carries a validated form definition
+(`attune.elicitation.spec_intake.build_spec_intake_form`) —
+outcome, done-when acceptance, primary code area (options derived
+from the tree's packages), and an optional slug — plus
+`taken_slugs` for collision awareness. Render it widget-first with
+the `AskUserQuestion` fallback (batching opts in via
+`metadata.source` containing "form"). If the user's invocation
+already stated what to build, carry it into the outcome field
+instead of asking again.
+
+Compose the answers into the session-contract block that seeds
+Stage 1:
+
+```bash
+echo '<answers JSON>' | python -m attune.elicitation.spec_intake --compose
+```
+
+A slug collision renders as a WARNING, not an error — offer to
+amend the existing spec before forking a new one.
+
 ## How It Works
 
 Five stages, one flow:

--- a/src/attune/elicitation/spec_intake.py
+++ b/src/attune/elicitation/spec_intake.py
@@ -1,0 +1,184 @@
+"""Spec intake — derived candidates and the new-spec intake form.
+
+The `/spec` analog of :mod:`attune.elicitation.fix_intake` (same
+pattern, chair-requested 2026-07-31): one form batches the
+dimensions a NEW spec needs — what should exist, the acceptance
+criteria, the primary code area, and an optional slug — instead of
+N sequential question turns. Candidates are DERIVED from the tree
+(package directories, existing spec slugs); nothing is
+hand-maintained.
+
+The composed output is a session-contract block (outcome /
+done-when / scope), which is what a spec's Stage 1 brainstorm
+actually consumes.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under Apache 2.0
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+from attune.elicitation.bridge import form_from_dict
+from attune.meta_workflows.models import FormSchema
+
+#: Free-text sentinel offered alongside derived options.
+OTHER = "other (name an area)"
+
+_SKIP_DIRS = frozenset({"__pycache__", ".pytest_cache", ".git"})
+
+
+def existing_spec_slugs(repo_root: Path) -> list[str]:
+    """Slugs already taken under ``docs/specs/`` (collision check)."""
+    specs_dir = repo_root / "docs" / "specs"
+    if not specs_dir.is_dir():
+        return []
+    return sorted(d.name for d in specs_dir.iterdir() if d.is_dir() and d.name not in _SKIP_DIRS)
+
+
+def area_candidates(repo_root: Path, limit: int = 6) -> list[str]:
+    """Likely primary code areas: packages under ``src/attune/``.
+
+    Mechanical derivation — a directory with an ``__init__.py`` is a
+    package. Capped at ``limit``; the form always appends a free-text
+    escape, so the cap bounds noise, not reach.
+    """
+    pkg_root = repo_root / "src" / "attune"
+    if not pkg_root.is_dir():
+        return []
+    areas = [
+        f"src/attune/{d.name}"
+        for d in sorted(pkg_root.iterdir())
+        if d.is_dir() and (d / "__init__.py").is_file() and d.name not in _SKIP_DIRS
+    ]
+    return areas[:limit]
+
+
+def build_spec_intake_form(areas: list[str]) -> FormSchema:
+    """The one new-spec intake form (D21: widget-first, batched)."""
+    fields: list[dict[str, Any]] = [
+        {
+            "id": "outcome",
+            "text": "What should exist when this spec is done?",
+            "type": "textarea",
+            "required": True,
+            "help_text": "One or two sentences — becomes the spec's outcome statement.",
+        },
+        {
+            "id": "done_when",
+            "text": "Done when? (acceptance criteria)",
+            "type": "textarea",
+            "required": True,
+            "help_text": "Cheap to write, expensive to skip — e.g. 'PR merged green, regression test landed'.",
+        },
+    ]
+    if areas:
+        fields.append(
+            {
+                "id": "area",
+                "text": "Primary code area?",
+                "type": "single_select",
+                "options": [*areas, OTHER],
+                "help_text": "Where most of the change lands — bounds the design conversation.",
+            }
+        )
+    else:
+        fields.append(
+            {
+                "id": "area",
+                "text": "Primary code area? (path or name)",
+                "type": "text_input",
+                "required": True,
+            }
+        )
+    fields.append(
+        {
+            "id": "slug",
+            "text": "Spec slug (optional — leave blank to derive one)",
+            "type": "text_input",
+            "required": False,
+            "help_text": "kebab-case directory name under docs/specs/.",
+        }
+    )
+    return form_from_dict(
+        {
+            "title": "New spec intake",
+            "description": "Frame the spec before brainstorming: outcome, acceptance, area.",
+            "fields": fields,
+        }
+    )
+
+
+def compose_spec_contract(answers: dict[str, Any], taken_slugs: list[str]) -> str:
+    """Render answers as the session-contract block Stage 1 consumes.
+
+    A slug collision is surfaced as a WARNING line rather than an
+    error — the existing spec may be exactly where the work belongs
+    (amend, don't fork), and that call is the user's.
+    """
+    outcome = str(answers.get("outcome", "")).strip()
+    done_when = str(answers.get("done_when", "")).strip()
+    area = str(answers.get("area", "")).strip()
+    slug = str(answers.get("slug", "")).strip()
+    lines = [
+        "## Session contract",
+        "",
+        f"- **Outcome:** {outcome}",
+        f"- **Done when:** {done_when}",
+    ]
+    if area and area != OTHER:
+        lines.append(f"- **Scope:** {area}")
+    if slug:
+        lines.append(f"- **Spec:** docs/specs/{slug}/")
+        if slug in taken_slugs:
+            lines.append(
+                f"- **WARNING:** docs/specs/{slug}/ already exists — "
+                "amend that spec or pick a new slug."
+            )
+    return "\n".join(lines) + "\n"
+
+
+def _main(argv: list[str]) -> int:
+    """CLI seam for the /spec skill (mirrors fix_intake's contract).
+
+    Default: print ``{"form": ..., "areas": [...], "taken_slugs":
+    [...]}`` for the current repo. With ``--compose``, read answers
+    JSON on stdin and print the composed session-contract block.
+    """
+    repo_root = Path.cwd()
+    if "--compose" in argv:
+        answers = json.load(sys.stdin)
+        print(compose_spec_contract(answers, existing_spec_slugs(repo_root)))
+        return 0
+    areas = area_candidates(repo_root)
+    form = build_spec_intake_form(areas)
+    payload = {
+        "form": {
+            "title": form.title,
+            "description": form.description,
+            "fields": [
+                {
+                    "id": q.id,
+                    "text": q.text,
+                    "type": q.type.value,
+                    "options": list(q.options),
+                    "default": q.default,
+                    "help_text": q.help_text,
+                    "required": q.required,
+                }
+                for q in form.questions
+            ],
+        },
+        "areas": areas,
+        "taken_slugs": existing_spec_slugs(repo_root),
+    }
+    print(json.dumps(payload, indent=2))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover — thin seam, tested via functions
+    raise SystemExit(_main(sys.argv[1:]))

--- a/tests/unit/elicitation/test_spec_intake.py
+++ b/tests/unit/elicitation/test_spec_intake.py
@@ -1,0 +1,91 @@
+"""Spec intake: derived candidates, form validity, contract
+composition — real tmp trees, no mocks (mirrors test_fix_intake)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from attune.elicitation.spec_intake import (
+    OTHER,
+    area_candidates,
+    build_spec_intake_form,
+    compose_spec_contract,
+    existing_spec_slugs,
+)
+
+
+def _repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    for pkg in ("workflows", "elicitation"):
+        d = repo / "src" / "attune" / pkg
+        d.mkdir(parents=True)
+        (d / "__init__.py").write_text("")
+    (repo / "src" / "attune" / "__pycache__").mkdir()
+    for slug in ("outcome-first-fix", "local-first-reports"):
+        (repo / "docs" / "specs" / slug).mkdir(parents=True)
+    return repo
+
+
+def test_area_candidates_are_packages_only(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    (repo / "src" / "attune" / "not_a_pkg").mkdir()
+    areas = area_candidates(repo)
+    assert areas == ["src/attune/elicitation", "src/attune/workflows"]
+
+
+def test_existing_spec_slugs_listed(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    assert existing_spec_slugs(repo) == ["local-first-reports", "outcome-first-fix"]
+    assert existing_spec_slugs(tmp_path / "empty") == []
+
+
+def test_form_builds_with_areas_and_offers_other(tmp_path: Path) -> None:
+    form = build_spec_intake_form(["src/attune/workflows"])
+    ids = [q.id for q in form.questions]
+    assert ids == ["outcome", "done_when", "area", "slug"]
+    area_q = form.questions[2]
+    assert area_q.type.value == "single_select"
+    assert area_q.options[-1] == OTHER
+    assert form.questions[3].required is False
+
+
+def test_form_degrades_to_free_text_without_areas() -> None:
+    form = build_spec_intake_form([])
+    area_q = form.questions[2]
+    assert area_q.type.value == "text_input"
+    assert area_q.required
+
+
+def test_compose_contract_full() -> None:
+    block = compose_spec_contract(
+        {
+            "outcome": "a spec intake form ships",
+            "done_when": "PR merged green",
+            "area": "src/attune/elicitation",
+            "slug": "spec-intake",
+        },
+        taken_slugs=["outcome-first-fix"],
+    )
+    assert "- **Outcome:** a spec intake form ships" in block
+    assert "- **Done when:** PR merged green" in block
+    assert "- **Scope:** src/attune/elicitation" in block
+    assert "- **Spec:** docs/specs/spec-intake/" in block
+    assert "WARNING" not in block
+
+
+def test_compose_contract_slug_collision_warns() -> None:
+    block = compose_spec_contract(
+        {"outcome": "x", "done_when": "y", "slug": "outcome-first-fix"},
+        taken_slugs=["outcome-first-fix"],
+    )
+    assert "WARNING" in block
+    assert "amend that spec or pick a new slug" in block
+
+
+def test_compose_contract_omits_other_area_and_blank_slug() -> None:
+    block = compose_spec_contract(
+        {"outcome": "x", "done_when": "y", "area": OTHER, "slug": ""},
+        taken_slugs=[],
+    )
+    assert "Scope" not in block
+    assert "docs/specs/" not in block


### PR DESCRIPTION
The `/spec` analog of the Fix intake (#1824), chair-requested.

- `attune/elicitation/spec_intake.py` — area options derived from the tree's packages, `docs/specs` slugs for collision awareness, validated `FormSchema` (widget-first, AskUserQuestion fallback), and a composer that renders answers as the **session-contract block** (outcome / done-when / scope) that Stage 1 consumes. Slug collisions WARN and steer toward amending the existing spec rather than forking.
- `/spec` skill: the 'Start a new spec' route gathers framing as ONE form per the Socratic rule; `.agents` mirror synced.
- 7 tests on real tmp trees; count guards unaffected (no new skill dir).

Receipts: elicitation+plugins+claim-drift+website guards — 506 pass locally; live smoke on this repo derived real areas and rendered the collision warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)