### PR TITLE
docs(spec): workflow-intake-forms design + tasks — shared form theme, gated ladder

### DIFF
--- a/docs/specs/workflow-intake-forms/design.md
+++ b/docs/specs/workflow-intake-forms/design.md
@@ -1,0 +1,160 @@
+# Workflow Intake Forms — Design
+
+**Status:** draft (2026-07-31) — authored on the approved
+requirements; implementation authority still arrives per-phase via
+chair gates.
+
+## Layer map
+
+```text
+contracts        InputSchema on each workflow (validation.py) —
+                 what a workflow takes; already validated at run
+templates        FormTemplate: field slots + provider names —
+                 how to ASK for those inputs
+providers        named derivations (git-changed paths, test-shaped
+                 files, package areas, taken slugs) — the options
+generation       intake_form(workflow) -> FormSchema
+surfaces         widget (claude.ai) · AskUserQuestion fallback ·
+                 ops dashboard — all owned by elicitation-form-surface
+theme            ONE tracked CSS source, projected into every
+                 surface — the shared look (this spec's addition)
+```
+
+Everything above `generation` exists today; this spec adds the
+template/provider layer and the theme, and completes the contracts
+layer's coverage (requirements Phase 1).
+
+## Contracts layer (Phase 1)
+
+`InputSchema` (`attune/workflows/validation.py`: required keys +
+key types, opt-in via `LLMWorkflowMixin.input_schema`) is the
+single source. Design rules:
+
+- Workflows declare WHAT they take, never how to ask —
+  presentation metadata (labels, help text, provider hints) lives
+  on the template layer, so the contracts stay UI-free and the
+  ops runner / `workflow run` validation reuse them unchanged.
+- The execution scope for the sweep is grep-derived at task time
+  (`input_schema` absence across the live registry), not a list
+  frozen in this document — the code is the contract.
+- `PATH_ARG_REGISTRY` consumers migrate onto `input_schema`
+  lookups where the change is mechanical; the registry is deleted
+  only when its last consumer is gone.
+
+## Template + provider layer (Phase 2, rule-of-three gated)
+
+```python
+@dataclass
+class FormTemplate:
+    workflow: str                 # registry name
+    fields: list[FieldSlot]       # ordered
+
+@dataclass
+class FieldSlot:
+    key: str                      # matches an InputSchema key
+    text: str                     # question text
+    provider: str | None = None   # candidate provider name
+    control: str | None = None    # override; else derived from type
+    help_text: str | None = None
+    required: bool | None = None  # else derived from InputSchema
+```
+
+- Providers are plain callables in a module-level dict:
+  `PROVIDERS: dict[str, Callable[[ProviderContext], list[str]]]`.
+  `ProviderContext` carries `repo_root`, the invocation text, and
+  the already-answered fields. No entry points, no plugins — a
+  dict (H3-no-parallel-framework).
+- Control derivation: `str` → `text_input`/`textarea` (by
+  `max_length`), enum-like → `single_select`, `list[str]` +
+  provider → `multi_select`, `int`/`float` → `number`, `bool` →
+  `boolean`. A slot's `control` overrides.
+- A field whose value is already present in the invocation text
+  or context is PREFILLED, rendered as inferred (the existing
+  `inferred_from` path) — never re-asked blind.
+- Proof obligation: the fix and spec intakes re-expressed as
+  templates render byte-identical `FormSchema`s to the shipped
+  hand modules, pinned by test, before any third consumer ships.
+
+## Generation flow
+
+```text
+intake_form(workflow_name, invocation_text) ->
+  1. registry lookup -> workflow_cls.input_schema  (fail: no form,
+     fall back to free-text ask — never block)
+  2. template lookup (in-tree dict; missing -> derive a minimal
+     template from the schema alone)
+  3. run providers (bounded; see latency)
+  4. build FormSchema via form_from_dict  (validation unchanged)
+  5. surface via select_form_surface      (unchanged)
+```
+
+## The shared look — form theme (chair requirement)
+
+**Problem.** Every widget currently inlines its own ~2.4 KB style
+block (measured 2026-07-31: 2,462 B of 6,542 B total), authored
+inside `form_to_widget_html`. Styling drifts per generator, and a
+family of intake forms should read as ONE surface.
+
+**Design: single source, projected — never fetched.**
+
+- `attune/elicitation/theme.py` exports `FORM_THEME_CSS`: design
+  tokens as CSS custom properties plus the component classes
+  (`.ae-field`, `.ae-label`, `.ae-input`, `.ae-submit`, …).
+  Tokens default to the HOST's variables with literal fallbacks —
+  `var(--surface-1, #f7f6f3)`, `var(--text-primary, #2c2c2a)` —
+  so one stylesheet renders native on claude.ai widgets
+  (light/dark follows the host automatically), in the ops
+  dashboard, and standalone.
+- **Widgets: inline injection is the design, not a compromise.**
+  The widget sandbox's CSP forbids external stylesheet fetches,
+  so "shared" cannot mean shared-by-URL there. It means
+  shared-by-SOURCE: `form_to_widget_html` injects `FORM_THEME_CSS`
+  once per widget, keeping the per-instance scoping wrapper
+  (`#attune-elicit-form-<id>`) for isolation.
+- **Ops dashboard: same constant, served once.** The dashboard
+  serves the identical string as a static `/static/form-theme.css`
+  (one cacheable fetch); a drift test asserts the served file is
+  byte-equal to the constant — one source, two projections.
+
+**Latency analysis (the chair's constraint).**
+
+- Zero added round trips anywhere: widgets were already inline;
+  the dashboard file is cached after first load.
+- Byte budget: `FORM_THEME_CSS` ≤ 4 KB raw, enforced by a
+  residency-style drift test (`test_form_theme_budget`) so the
+  theme cannot quietly grow into a framework. At ≤4 KB the
+  render-time cost is sub-millisecond against the ~100–145 ms
+  derivation baseline — styling is not on the latency path, and
+  the budget test keeps it that way.
+- No external fonts, no icon fonts, no images: system font stack
+  and host tokens only. (An @import or webfont would be the first
+  real latency regression this section exists to forbid.)
+
+## Latency mechanics (Phase 3, measurement-gated)
+
+- Instrument `intake_form` end-to-end (derive/build/render marks)
+  behind the existing telemetry surface — no new store.
+- Cache: candidates keyed on
+  `(repo_root, HEAD, sha256(sorted dirty set))` — the key IS the
+  state, so invalidation is structural. In-process dict first;
+  the existing memory backend second.
+- The Redis Function (chair's stored procedure): `FCALL
+  intake_form_digest` assembling cached candidate fragments
+  server-side for surfaces already holding a connection (MCP, ops
+  dashboard) — read-side only, hydrated from the tracked tree
+  (principle 12), and Redis-absent falls back to inline
+  derivation (principle 15). Ships only with a measured
+  before/after showing a budget miss it closes.
+
+## Receipts design
+
+- Phase 1: registry coverage sweep test + a malformed-input CLI
+  run showing named-field errors (behavioral).
+- Phase 2: byte-identical re-expression pins for fix/spec intakes
+  (behavioral); provider unit tests on real tmp trees (suite).
+- Theme: budget drift test, widget/dashboard byte-equality drift
+  test, and a rendered-form screenshot on both surfaces in the
+  PR (evidence of the user-visible behavior, per the
+  verification-receipts contract).
+- Phase 3: the latency numbers re-measured from the instrument,
+  never quoted from this document (metric).

--- a/docs/specs/workflow-intake-forms/tasks.md
+++ b/docs/specs/workflow-intake-forms/tasks.md
@@ -1,0 +1,84 @@
+# Workflow Intake Forms — Tasks
+
+**Status:** active (2026-07-31) — Task 1 authored, awaiting its
+chair go. Tasks 2–4 are gated placeholders: each is authored only
+after the prior phase's acceptance passes (spec rule; no batch
+authorization exists).
+
+## Task 1 — Phase 1: declare the input contracts (AUTHORED, not started)
+
+```xml
+<task id="1" name="input-schema-sweep">
+  <objective>
+    Every registered workflow declares an InputSchema; workflow
+    run rejects malformed input with named-field errors; the
+    PATH_ARG_REGISTRY consumers that can cheaply read
+    input_schema do so.
+  </objective>
+  <context>
+    <existing-code path="src/attune/workflows/validation.py">
+      InputSchema (required keys + key types) and
+      validate_against_input_schema already exist; coverage is
+      the gap, not machinery.
+    </existing-code>
+    <constraint>
+      Execution scope is GREP-DERIVED at start time: the set of
+      registry workflows whose class lacks input_schema — never
+      this document's guess. Record the measured set in the PR.
+    </constraint>
+    <constraint>
+      Contracts stay UI-free: no labels, help text, or provider
+      hints on workflows — that is the template layer's job
+      (design.md).
+    </constraint>
+  </context>
+  <files-to-modify>
+    <file path="src/attune/workflows/*.py">
+      Add input_schema declarations matching each workflow's
+      actual execute() consumption (read the code, not the docs).
+    </file>
+  </files-to-modify>
+  <files-to-create>
+    <file path="tests/unit/workflows/test_input_schema_coverage.py">
+      Registry sweep: every discovered workflow declares
+      input_schema (shrink-only allowlist for any ruled
+      exception); plus one behavioral case per key type showing
+      the named-field rejection message.
+    </file>
+  </files-to-create>
+  <validation>
+    <check>Coverage sweep passes with an empty (or ruled)
+      allowlist.</check>
+    <check>`attune workflow run fix --input '{}'` (and one more
+      workflow) fail with named missing keys, exit per the pinned
+      0/1/2/3 contract — characterization pins untouched.</check>
+    <check>No behavior change for valid inputs: full suite green,
+      serial keyless.</check>
+  </validation>
+  <risks>
+    <risk severity="medium">A declared schema stricter than a
+      workflow's real tolerance breaks a working caller —
+      mitigation: derive keys from execute() reads, and land the
+      sweep test's behavioral cases per workflow touched.</risk>
+  </risks>
+</task>
+```
+
+## Task 2 — Phase 2: FormTemplate + providers (GATED)
+
+Authored only when the rule-of-three fires (a third intake is
+requested). Must include the byte-identical re-expression pins
+for the fix and spec intakes (design.md proof obligation).
+
+## Task 3 — Phase 2/theme: shared form theme (GATED)
+
+`attune/elicitation/theme.py` (`FORM_THEME_CSS`, host-token
+fallbacks), widget injection swap, dashboard static projection,
+budget + byte-equality drift tests, rendered screenshots on both
+surfaces. May be authored alongside Task 2 or independently —
+chair's call; it has no dependency on the template layer.
+
+## Task 4 — Phase 3: latency instrumentation + cache (GATED)
+
+Instrument first; cache and the Redis-Function escalation only on
+a measured budget miss (design.md latency mechanics).


### PR DESCRIPTION
Completes the spec's document set on the approved requirements.

**[design.md](https://github.com/Smart-AI-Memory/attune-ai/blob/claude/intake-spec-design/docs/specs/workflow-intake-forms/design.md)** — the layer map (contracts → templates → providers → generation → surfaces → theme) and the chair-required **shared form look**: one tracked CSS source (`attune/elicitation/theme.py`) with host-token fallbacks, projected **inline** into widgets (the widget CSP forbids external fetches — shared-by-source, not by URL) and served once, cached, on the ops dashboard. Latency-safe by construction: zero added round trips, ≤4 KB budget enforced by a drift test, sub-millisecond against the measured ~100–145 ms derivation baseline; external fonts/imports explicitly forbidden. Plus the Phase 3 latency mechanics (keyed cache → measurement-gated Redis `FCALL`, read-side only, degrades gracefully).

**[tasks.md](https://github.com/Smart-AI-Memory/attune-ai/blob/claude/intake-spec-design/docs/specs/workflow-intake-forms/tasks.md)** — Task 1 (input_schema sweep, grep-derived scope) AUTHORED and awaiting its chair go; Tasks 2–4 are gated placeholders per the per-phase authorization rule. The theme task (Task 3) has no dependency on the template layer and can be authorized independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)