### PR TITLE
feat(workflows): input_schema on all 21 registered workflows + named-field CLI errors (intake Task 1)

### DIFF
--- a/src/attune/agents/release/release_prep_team.py
+++ b/src/attune/agents/release/release_prep_team.py
@@ -41,6 +41,7 @@ from attune.workflows.output import (
     TableSection,
     WorkflowReport,
 )
+from attune.workflows.validation import InputSchema
 
 # Re-export agent classes and helpers
 from .release_agents import (  # noqa: F401
@@ -411,6 +412,10 @@ class ReleasePrepTeamWorkflow(BaseWorkflow):
         super().__init__()
         self.quality_gates = quality_gates
         self._kwargs = kwargs
+
+    input_schema = InputSchema(
+        optional_fields={"path": str, "context": dict},
+    )
 
     async def execute(
         self,

--- a/src/attune/agents/release/release_prep_team.py
+++ b/src/attune/agents/release/release_prep_team.py
@@ -438,6 +438,9 @@ class ReleasePrepTeamWorkflow(BaseWorkflow):
             (``metadata["approved"]``), so a BLOCKED release still exits 0.
 
         """
+        self.validate_input(
+            {k: v for k, v in {"path": path, "context": context}.items() if v is not None}
+        )
         # Map 'target' to 'path' for VSCode/CLI compatibility
         if "target" in kwargs and path == ".":
             path = kwargs["target"]

--- a/src/attune/cli_commands/_exit_codes.py
+++ b/src/attune/cli_commands/_exit_codes.py
@@ -31,6 +31,8 @@ import traceback
 from collections.abc import Callable
 from typing import Any
 
+from attune.workflows.validation import WorkflowValidationError
+
 logger = logging.getLogger(__name__)
 
 # Exit-code contract — see module docstring / decisions.md.
@@ -170,6 +172,15 @@ def run_workflow_with_exit_code(
             result = asyncio.run(workflow.execute(**input_data))
         else:
             result = workflow.execute(**input_data)
+    except WorkflowValidationError as exc:
+        # Malformed INPUT is a CLI-level error, not a workflow crash:
+        # name every failing field cleanly, no traceback (Task 1 of
+        # docs/specs/workflow-intake-forms/ — schemas now validate).
+        logger.info("Workflow %r rejected its input: %s", name, exc)
+        print(f"❌ Invalid input for workflow '{name}':")
+        for err in getattr(exc, "errors", None) or [str(exc)]:
+            print(f"  - {err}")
+        return EXIT_CLI_ERROR
     except Exception as exc:  # noqa: BLE001
         # INTENTIONAL: any uncaught error from the workflow is the
         # exit-2 "unplanned failure" branch. Traceback to stderr so

--- a/src/attune/workflows/bug_predict.py
+++ b/src/attune/workflows/bug_predict.py
@@ -48,6 +48,7 @@ from .bug_predict_patterns import (
 )
 from .data_classes import WorkflowResult
 from .step_config import WorkflowStepConfig
+from .validation import InputSchema
 
 logger = logging.getLogger(__name__)
 
@@ -142,6 +143,10 @@ class BugPredictionWorkflow(BaseWorkflow):
         super().__init__(**kwargs)
         self._system_prompt_suffix = system_prompt_suffix
 
+    input_schema = InputSchema(
+        optional_fields={"path": str, "depth": str, "max_budget_usd": (int, float)},
+    )
+
     async def execute(self, **kwargs: Any) -> WorkflowResult:
         """Execute the Agent SDK bug prediction.
 
@@ -154,6 +159,7 @@ class BugPredictionWorkflow(BaseWorkflow):
         Returns:
             WorkflowResult with findings, suggestions, and metadata.
         """
+        self.validate_input(kwargs)
         path_arg: str = kwargs.get("path", "")
         depth: str = kwargs.get("depth", "standard")
 

--- a/src/attune/workflows/code_review.py
+++ b/src/attune/workflows/code_review.py
@@ -47,6 +47,7 @@ from .base import BaseWorkflow, ModelTier
 from .data_classes import WorkflowResult
 from .output_schemas import WORKFLOW_OUTPUT_SCHEMA
 from .step_config import WorkflowStepConfig
+from .validation import InputSchema
 
 logger = logging.getLogger(__name__)
 
@@ -204,6 +205,10 @@ class CodeReviewWorkflow(BaseWorkflow):
         """
         super().__init__(**kwargs)
 
+    input_schema = InputSchema(
+        optional_fields={"path": str, "depth": str},
+    )
+
     async def execute(self, **kwargs: Any) -> WorkflowResult:
         """Execute the Agent SDK code review.
 
@@ -216,6 +221,7 @@ class CodeReviewWorkflow(BaseWorkflow):
         Returns:
             WorkflowResult with findings, suggestions, and metadata.
         """
+        self.validate_input(kwargs)
         path_arg: str = kwargs.get("path", "")
         depth: str = kwargs.get("depth", "standard")
 

--- a/src/attune/workflows/deep_review.py
+++ b/src/attune/workflows/deep_review.py
@@ -44,6 +44,7 @@ from .agent_sdk_adapter import (
 )
 from .base import BaseWorkflow, ModelTier
 from .data_classes import WorkflowResult
+from .validation import InputSchema
 
 logger = logging.getLogger(__name__)
 
@@ -178,6 +179,10 @@ class DeepReviewAgentSDKWorkflow(BaseWorkflow):
     stages = ["deep-review"]
     tier_map = {"deep-review": ModelTier.CAPABLE}
 
+    input_schema = InputSchema(
+        optional_fields={"path": str, "depth": str, "focus": list},
+    )
+
     async def execute(self, **kwargs: Any) -> WorkflowResult:
         """Execute the multi-pass deep review.
 
@@ -193,6 +198,7 @@ class DeepReviewAgentSDKWorkflow(BaseWorkflow):
         Returns:
             WorkflowResult with findings, suggestions, and metadata.
         """
+        self.validate_input(kwargs)
         path_arg: str = kwargs.get("path", "")
         depth: str = kwargs.get("depth", "standard")
         focus: list[str] | None = kwargs.get("focus")

--- a/src/attune/workflows/dependency_check.py
+++ b/src/attune/workflows/dependency_check.py
@@ -47,6 +47,7 @@ from .dependency_check_report import (  # noqa: F401
     main,
 )
 from .step_config import WorkflowStepConfig
+from .validation import InputSchema
 
 logger = logging.getLogger(__name__)
 
@@ -135,6 +136,10 @@ class DependencyCheckWorkflow(BaseWorkflow):
         super().__init__(**kwargs)
         self._system_prompt_suffix = system_prompt_suffix
 
+    input_schema = InputSchema(
+        optional_fields={"path": str, "depth": str, "max_budget_usd": (int, float)},
+    )
+
     async def execute(self, **kwargs: Any) -> WorkflowResult:
         """Execute the Agent SDK dependency check.
 
@@ -147,6 +152,7 @@ class DependencyCheckWorkflow(BaseWorkflow):
         Returns:
             WorkflowResult with findings, suggestions, and metadata.
         """
+        self.validate_input(kwargs)
         path_arg: str = kwargs.get("path", "")
         depth: str = kwargs.get("depth", "standard")
 

--- a/src/attune/workflows/discovery_sweep/workflow.py
+++ b/src/attune/workflows/discovery_sweep/workflow.py
@@ -534,6 +534,7 @@ class DiscoverySweepWorkflow(BaseWorkflow):
                 (the ops daemon passes its ``run_id``; CLI leaves
                 it None).
         """
+        self.validate_input(kwargs)
         path: str = kwargs.get("path", "")
         budget_usd: float = float(kwargs.get("budget_usd", DEFAULT_BUDGET_USD))
         sources: list[FindingSource] | None = kwargs.get("sources")

--- a/src/attune/workflows/discovery_sweep/workflow.py
+++ b/src/attune/workflows/discovery_sweep/workflow.py
@@ -31,6 +31,7 @@ from attune.models import ModelTier
 from attune.workflows.base import BaseWorkflow
 from attune.workflows.data_classes import CostReport, WorkflowResult, WorkflowStage
 
+from ..validation import InputSchema
 from . import ds_stdout, verification
 
 logger = logging.getLogger(__name__)
@@ -486,6 +487,18 @@ class DiscoverySweepWorkflow(BaseWorkflow):
     def __init__(self, **kwargs: Any) -> None:
         """Pass through to BaseWorkflow."""
         super().__init__(**kwargs)
+
+    input_schema = InputSchema(
+        optional_fields={
+            "path": str,
+            "depth": str,
+            "budget_usd": (int, float),
+            "no_llm": bool,
+            "output_format": str,
+            "source": str,
+            "sources": list,
+        },
+    )
 
     async def execute(self, **kwargs: Any) -> WorkflowResult:
         """Run the sweep.

--- a/src/attune/workflows/doc_audit/workflow.py
+++ b/src/attune/workflows/doc_audit/workflow.py
@@ -34,6 +34,7 @@ from ..agent_sdk_adapter import (
 )
 from ..base import BaseWorkflow, ModelTier
 from ..data_classes import WorkflowResult
+from ..validation import InputSchema
 from .checks import CheckResult, run_all_checks  # noqa: F401  # re-export
 
 logger = logging.getLogger(__name__)
@@ -113,6 +114,10 @@ class DocAuditWorkflow(BaseWorkflow):
         super().__init__(**kwargs)
         self._system_prompt_suffix = system_prompt_suffix
 
+    input_schema = InputSchema(
+        optional_fields={"path": str, "depth": str, "max_budget_usd": (int, float)},
+    )
+
     async def execute(self, **kwargs: Any) -> WorkflowResult:
         """Execute the Agent SDK documentation audit.
 
@@ -126,6 +131,7 @@ class DocAuditWorkflow(BaseWorkflow):
             WorkflowResult with findings, suggestions, and metadata.
 
         """
+        self.validate_input(kwargs)
         path_arg: str = kwargs.get("path", "")
         depth: str = kwargs.get("depth", "standard")
 

--- a/src/attune/workflows/document_gen/workflow.py
+++ b/src/attune/workflows/document_gen/workflow.py
@@ -35,6 +35,7 @@ from ..base import BaseWorkflow, ModelTier
 from ..context import WorkflowContext
 from ..data_classes import WorkflowResult
 from ..services import ParsingService, PromptService
+from ..validation import InputSchema
 from .config import DOC_GEN_STEPS, TOKEN_COSTS  # noqa: F401  # re-export
 
 logger = logging.getLogger(__name__)
@@ -121,6 +122,10 @@ class DocumentGenerationWorkflow(BaseWorkflow):
             parsing=ParsingService(xml_config=xml_config),
         )
 
+    input_schema = InputSchema(
+        optional_fields={"path": str, "depth": str},
+    )
+
     async def execute(self, **kwargs: Any) -> WorkflowResult:
         """Execute the Agent SDK documentation generation.
 
@@ -133,6 +138,7 @@ class DocumentGenerationWorkflow(BaseWorkflow):
         Returns:
             WorkflowResult with documentation, suggestions, and metadata.
         """
+        self.validate_input(kwargs)
         path_arg: str = kwargs.get("path", "")
         depth: str = kwargs.get("depth", "standard")
 

--- a/src/attune/workflows/documentation_orchestrator.py
+++ b/src/attune/workflows/documentation_orchestrator.py
@@ -432,6 +432,7 @@ class DocumentationOrchestrator(
             OrchestratorResult with full details
 
         """
+        self.validate_input({"context": context} if context is not None else {})
         started_at = datetime.now()
         result = OrchestratorResult(success=False, phase="scout")
         errors: list[str] = []

--- a/src/attune/workflows/documentation_orchestrator.py
+++ b/src/attune/workflows/documentation_orchestrator.py
@@ -31,6 +31,7 @@ from .compat import ModelTier
 from .doc_orch_filters import DocOrchFilterMixin
 from .doc_orch_report import DocOrchReportMixin
 from .doc_orch_scout import DocOrchScoutMixin
+from .validation import InputSchema
 
 logger = logging.getLogger(__name__)
 
@@ -407,6 +408,10 @@ class DocumentationOrchestrator(
         result.total_cost = self._total_cost
         result.summary = self._generate_summary(result, summary_items)
         return result
+
+    input_schema = InputSchema(
+        optional_fields={"context": dict},
+    )
 
     async def execute(
         self,

--- a/src/attune/workflows/fix_workflow.py
+++ b/src/attune/workflows/fix_workflow.py
@@ -33,6 +33,7 @@ from .agent_sdk_adapter import (
 )
 from .base import BaseWorkflow, ModelTier
 from .data_classes import WorkflowResult
+from .validation import InputSchema
 
 logger = logging.getLogger(__name__)
 
@@ -114,6 +115,11 @@ class FixWorkflow(BaseWorkflow):
     description = "Apply a minimal in-place fix within the contract's scope"
     stages = ["agent-fix"]
     tier_map = {"agent-fix": ModelTier.CAPABLE}
+
+    input_schema = InputSchema(
+        required_fields={"goal": str, "scope_paths": list},
+        optional_fields={"done_conditions": list},
+    )
 
     async def execute(self, **kwargs: Any) -> WorkflowResult:
         """Run the scoped fix agent.

--- a/src/attune/workflows/orchestrated_health_check.py
+++ b/src/attune/workflows/orchestrated_health_check.py
@@ -61,6 +61,7 @@ from .health_check_tracking import (
     save_health_json,
     save_tracking_history,
 )
+from .validation import InputSchema
 
 # Re-export public API for backward compatibility
 __all__ = [
@@ -175,6 +176,10 @@ class OrchestratedHealthCheckWorkflow(BaseWorkflow):
             mode,
             project_root,
         )
+
+    input_schema = InputSchema(
+        optional_fields={"path": str, "project_root": str, "context": dict},
+    )
 
     async def execute(
         self,

--- a/src/attune/workflows/orchestrated_health_check.py
+++ b/src/attune/workflows/orchestrated_health_check.py
@@ -209,6 +209,13 @@ class OrchestratedHealthCheckWorkflow(BaseWorkflow):
             ValueError: If path is invalid
 
         """
+        self.validate_input(
+            {
+                k: v
+                for k, v in {"path": path, "project_root": project_root, "context": context}.items()
+                if v is not None
+            }
+        )
         # Migrate the deprecated `project_root=` kwarg → `path=`.
         if project_root is not None and path is None:
             warnings.warn(

--- a/src/attune/workflows/perf_audit.py
+++ b/src/attune/workflows/perf_audit.py
@@ -38,6 +38,7 @@ from .agent_sdk_adapter import (
 )
 from .base import BaseWorkflow, ModelTier
 from .data_classes import WorkflowResult
+from .validation import InputSchema
 
 logger = logging.getLogger(__name__)
 
@@ -132,6 +133,10 @@ class PerformanceAuditWorkflow(BaseWorkflow):
         super().__init__(**kwargs)
         self._system_prompt_suffix = system_prompt_suffix
 
+    input_schema = InputSchema(
+        optional_fields={"path": str, "depth": str, "max_budget_usd": (int, float)},
+    )
+
     async def execute(self, **kwargs: Any) -> WorkflowResult:
         """Execute the Agent SDK performance audit.
 
@@ -144,6 +149,7 @@ class PerformanceAuditWorkflow(BaseWorkflow):
         Returns:
             WorkflowResult with findings, suggestions, and metadata.
         """
+        self.validate_input(kwargs)
         path_arg: str = kwargs.get("path", "")
         depth: str = kwargs.get("depth", "standard")
 

--- a/src/attune/workflows/rag_code_gen.py
+++ b/src/attune/workflows/rag_code_gen.py
@@ -42,6 +42,7 @@ from .agent_sdk_adapter import (
 )
 from .base import BaseWorkflow, ModelTier
 from .data_classes import WorkflowResult
+from .validation import InputSchema
 
 # Hoisted to module scope so an ImportError surfaces at module
 # load — not after the agent has spent real API budget. Guarded
@@ -382,6 +383,10 @@ class RagCodeGenWorkflow(BaseWorkflow):
             },
             agent_run_result=run_result,
         )
+
+    input_schema = InputSchema(
+        optional_fields={"path": str, "depth": str, "k": int, "feedback": str, "cwd": str},
+    )
 
     async def execute(self, **kwargs: Any) -> WorkflowResult:
         params, err = self._parse_execute_kwargs(kwargs)

--- a/src/attune/workflows/refactor_plan.py
+++ b/src/attune/workflows/refactor_plan.py
@@ -41,6 +41,7 @@ from .refactor_plan_report import (
     main,  # noqa: F401 - re-exported
 )
 from .step_config import WorkflowStepConfig
+from .validation import InputSchema
 
 logger = logging.getLogger(__name__)
 
@@ -136,6 +137,10 @@ class RefactorPlanWorkflow(BaseWorkflow):
         kwargs.setdefault("enable_post_simplification", True)
         super().__init__(**kwargs)
 
+    input_schema = InputSchema(
+        optional_fields={"path": str, "depth": str},
+    )
+
     async def execute(self, **kwargs: Any) -> WorkflowResult:
         """Execute the Agent SDK refactoring plan.
 
@@ -148,6 +153,7 @@ class RefactorPlanWorkflow(BaseWorkflow):
         Returns:
             WorkflowResult with findings, suggestions, and metadata.
         """
+        self.validate_input(kwargs)
         path_arg: str = kwargs.get("path", "")
         depth: str = kwargs.get("depth", "standard")
 

--- a/src/attune/workflows/release_prep.py
+++ b/src/attune/workflows/release_prep.py
@@ -33,6 +33,7 @@ from .agent_sdk_adapter import (
 )
 from .base import BaseWorkflow, ModelTier
 from .data_classes import WorkflowResult
+from .validation import InputSchema
 
 __all__ = [
     "ReleasePreparationWorkflow",
@@ -115,6 +116,10 @@ class ReleasePreparationWorkflow(BaseWorkflow):
     stages = ["agent-prep"]
     tier_map = {"agent-prep": ModelTier.CAPABLE}
 
+    input_schema = InputSchema(
+        optional_fields={"path": str, "depth": str},
+    )
+
     async def execute(self, **kwargs: Any) -> WorkflowResult:
         """Execute the Agent SDK release preparation.
 
@@ -127,6 +132,7 @@ class ReleasePreparationWorkflow(BaseWorkflow):
         Returns:
             WorkflowResult with findings, suggestions, and metadata.
         """
+        self.validate_input(kwargs)
         path_arg: str = kwargs.get("path", "")
         depth: str = kwargs.get("depth", "standard")
 

--- a/src/attune/workflows/research_synthesis.py
+++ b/src/attune/workflows/research_synthesis.py
@@ -40,6 +40,7 @@ from .agent_sdk_adapter import (
 from .base import BaseWorkflow, ModelTier
 from .data_classes import WorkflowResult
 from .step_config import WorkflowStepConfig
+from .validation import InputSchema
 
 # Step configurations preserved for backward compatibility
 SUMMARIZE_STEP = WorkflowStepConfig(
@@ -133,6 +134,10 @@ class ResearchSynthesisWorkflow(BaseWorkflow):
     stages = ["agent-synthesis"]
     tier_map = {"agent-synthesis": ModelTier.CAPABLE}
 
+    input_schema = InputSchema(
+        optional_fields={"path": str, "depth": str},
+    )
+
     async def execute(self, **kwargs: Any) -> WorkflowResult:
         """Execute the Agent SDK research synthesis.
 
@@ -145,6 +150,7 @@ class ResearchSynthesisWorkflow(BaseWorkflow):
         Returns:
             WorkflowResult with findings, suggestions, and metadata.
         """
+        self.validate_input(kwargs)
         path_arg: str = kwargs.get("path", "")
         depth: str = kwargs.get("depth", "standard")
 

--- a/src/attune/workflows/secure_release.py
+++ b/src/attune/workflows/secure_release.py
@@ -172,6 +172,18 @@ class SecureReleasePipeline(BaseWorkflow):
             SecureReleaseResult with combined analysis
 
         """
+        self.validate_input(
+            {
+                k: v
+                for k, v in {
+                    "path": path,
+                    "diff": diff,
+                    "files_changed": files_changed,
+                    "since": since,
+                }.items()
+                if v is not None
+            }
+        )
         try:
             from .security_adapters import (
                 _check_crew_available,

--- a/src/attune/workflows/secure_release.py
+++ b/src/attune/workflows/secure_release.py
@@ -21,6 +21,7 @@ from typing import Any
 
 from .base import BaseWorkflow, WorkflowResult
 from .compat import ModelTier
+from .validation import InputSchema
 
 logger = logging.getLogger(__name__)
 
@@ -145,6 +146,10 @@ class SecureReleasePipeline(BaseWorkflow):
         self.parallel_crew = parallel_crew
         self.crew_config = crew_config or {}
         self.kwargs = kwargs
+
+    input_schema = InputSchema(
+        optional_fields={"path": str, "diff": str, "files_changed": list, "since": str},
+    )
 
     async def execute(
         self,

--- a/src/attune/workflows/security_audit.py
+++ b/src/attune/workflows/security_audit.py
@@ -44,6 +44,7 @@ from .agent_sdk_adapter import (
 from .base import BaseWorkflow, ModelTier
 from .data_classes import WorkflowResult
 from .output_schemas import WORKFLOW_OUTPUT_SCHEMA
+from .validation import InputSchema
 
 logger = logging.getLogger(__name__)
 
@@ -127,6 +128,10 @@ class SecurityAuditWorkflow(BaseWorkflow):
         super().__init__(**kwargs)
         self._system_prompt_suffix = system_prompt_suffix
 
+    input_schema = InputSchema(
+        optional_fields={"path": str, "depth": str, "max_budget_usd": (int, float)},
+    )
+
     async def execute(self, **kwargs: Any) -> WorkflowResult:
         """Execute the Agent SDK security audit.
 
@@ -139,6 +144,7 @@ class SecurityAuditWorkflow(BaseWorkflow):
         Returns:
             WorkflowResult with findings, suggestions, and metadata.
         """
+        self.validate_input(kwargs)
         path_arg: str = kwargs.get("path", "")
         depth: str = kwargs.get("depth", "standard")
 

--- a/src/attune/workflows/simplify_code.py
+++ b/src/attune/workflows/simplify_code.py
@@ -39,6 +39,7 @@ from .agent_sdk_adapter import (
 )
 from .base import BaseWorkflow, ModelTier
 from .data_classes import WorkflowResult
+from .validation import InputSchema
 
 logger = logging.getLogger(__name__)
 
@@ -128,6 +129,10 @@ class SimplifyCodeWorkflow(BaseWorkflow):
     stages = ["agent-simplify"]
     tier_map = {"agent-simplify": ModelTier.CAPABLE}
 
+    input_schema = InputSchema(
+        optional_fields={"path": str, "depth": str},
+    )
+
     async def execute(self, **kwargs: Any) -> WorkflowResult:
         """Execute the Agent SDK code simplification.
 
@@ -140,6 +145,7 @@ class SimplifyCodeWorkflow(BaseWorkflow):
         Returns:
             WorkflowResult with findings, suggestions, and metadata.
         """
+        self.validate_input(kwargs)
         path_arg: str = kwargs.get("path", "")
         depth: str = kwargs.get("depth", "standard")
 

--- a/src/attune/workflows/test_audit/workflow.py
+++ b/src/attune/workflows/test_audit/workflow.py
@@ -35,6 +35,7 @@ from ..agent_sdk_adapter import (
 )
 from ..base import BaseWorkflow, ModelTier
 from ..data_classes import WorkflowResult
+from ..validation import InputSchema
 
 # Backward-compatibility re-exports — subpackage modules still exist.
 from .coverage_parser import ModuleCoverage, parse_coverage_json  # noqa: F401
@@ -122,6 +123,15 @@ class TestAuditWorkflow(BaseWorkflow):
         super().__init__(**kwargs)
         self._system_prompt_suffix = system_prompt_suffix
 
+    input_schema = InputSchema(
+        optional_fields={
+            "path": str,
+            "depth": str,
+            "max_budget_usd": (int, float),
+            "src_path": str,
+        },
+    )
+
     async def execute(self, **kwargs: Any) -> WorkflowResult:
         """Execute the Agent SDK test audit.
 
@@ -136,6 +146,7 @@ class TestAuditWorkflow(BaseWorkflow):
         Returns:
             WorkflowResult with findings, suggestions, and metadata.
         """
+        self.validate_input(kwargs)
         import warnings as _warnings  # local to keep formatter from stripping
 
         path_arg: str = kwargs.get("path", "") or kwargs.get("src_path", "")

--- a/src/attune/workflows/test_gen/workflow.py
+++ b/src/attune/workflows/test_gen/workflow.py
@@ -36,6 +36,7 @@ from ..agent_sdk_adapter import (
 )
 from ..base import BaseWorkflow, ModelTier
 from ..data_classes import WorkflowResult
+from ..validation import InputSchema
 from .config import DEFAULT_SKIP_PATTERNS  # noqa: F401 — re-exported
 
 logger = logging.getLogger(__name__)
@@ -114,6 +115,10 @@ class TestGenerationWorkflow(BaseWorkflow):
         """
         super().__init__(**kwargs)
 
+    input_schema = InputSchema(
+        optional_fields={"path": str, "depth": str},
+    )
+
     async def execute(self, **kwargs: Any) -> WorkflowResult:
         """Execute the Agent SDK test generation.
 
@@ -128,6 +133,7 @@ class TestGenerationWorkflow(BaseWorkflow):
             WorkflowResult with generated tests, coverage info,
             and metadata.
         """
+        self.validate_input(kwargs)
         path_arg: str = kwargs.get("path", "")
         depth: str = kwargs.get("depth", "standard")
 

--- a/tests/unit/workflows/test_input_schema_coverage.py
+++ b/tests/unit/workflows/test_input_schema_coverage.py
@@ -1,0 +1,103 @@
+"""Input-schema coverage sweep (workflow-intake-forms Task 1).
+
+Every registered workflow declares an InputSchema, and malformed
+input fails with NAMED fields — at the mixin seam and through the
+real CLI exit contract.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import attune.workflows as workflows_pkg
+from attune.workflows.validation import InputSchema, WorkflowValidationError
+
+#: Shrink-only: workflows ruled exempt from declaring a schema.
+#: Empty at seeding (2026-07-31) — additions need a chair ruling.
+ALLOWLIST: frozenset[str] = frozenset()
+
+
+def _registry() -> dict[str, type]:
+    workflows_pkg._ensure_registry_initialized()
+    return dict(workflows_pkg.WORKFLOW_REGISTRY)
+
+
+def test_every_registered_workflow_declares_input_schema() -> None:
+    missing = sorted(
+        name
+        for name, cls in _registry().items()
+        if name not in ALLOWLIST and getattr(cls, "input_schema", None) is None
+    )
+    assert missing == [], (
+        f"workflows without input_schema: {missing} — declare one "
+        "(attune.workflows.validation.InputSchema) or obtain a chair "
+        "ruling for the allowlist"
+    )
+
+
+def test_declared_schemas_are_wellformed() -> None:
+    for name, cls in _registry().items():
+        schema = getattr(cls, "input_schema", None)
+        if schema is None:
+            continue
+        assert isinstance(schema, InputSchema), f"{name}: input_schema is not an InputSchema"
+        overlap = set(schema.required_fields) & set(schema.optional_fields)
+        assert not overlap, f"{name}: fields both required and optional: {overlap}"
+
+
+def test_missing_required_field_is_named_at_the_seam() -> None:
+    """fix declares hard-required fields; missing ones are NAMED.
+
+    The standard family deliberately keeps `path` optional-typed:
+    those workflows already return a graceful in-result error for a
+    missing path (pinned by their execute tests), and the schema
+    layer must not regress that contract — its added value there is
+    TYPE validation.
+    """
+    from attune.workflows.fix_workflow import FixWorkflow
+
+    schema = FixWorkflow.input_schema
+    from attune.workflows.validation import validate_against_input_schema
+
+    errors = validate_against_input_schema({}, schema)
+    assert "Missing required field: 'goal'" in errors
+    assert "Missing required field: 'scope_paths'" in errors
+
+
+def test_wrong_type_is_named_at_the_seam() -> None:
+    from attune.workflows.security_audit import SecurityAuditWorkflow
+
+    wf = SecurityAuditWorkflow()
+    with pytest.raises(WorkflowValidationError) as exc_info:
+        wf.validate_input({"path": 42})
+    assert any("expected str" in e for e in exc_info.value.errors)
+
+
+def test_numeric_optionals_accept_int_and_float() -> None:
+    from attune.workflows.security_audit import SecurityAuditWorkflow
+
+    wf = SecurityAuditWorkflow()
+    wf.validate_input({"path": "src", "max_budget_usd": 5})
+    wf.validate_input({"path": "src", "max_budget_usd": 5.0})
+
+
+def test_cli_run_rejects_malformed_input_exit_3_no_traceback(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The real exit contract: validation error -> named fields,
+    EXIT_CLI_ERROR, and no traceback on stderr."""
+    from attune.cli_commands._exit_codes import EXIT_CLI_ERROR, run_workflow_with_exit_code
+    from attune.workflows.security_audit import SecurityAuditWorkflow
+
+    code = run_workflow_with_exit_code(
+        SecurityAuditWorkflow,
+        {"path": 42},
+        name="security-audit",
+        json_mode=False,
+        print_result=lambda result: None,
+    )
+    captured = capsys.readouterr()
+    assert code == EXIT_CLI_ERROR
+    assert "Invalid input for workflow 'security-audit'" in captured.out
+    assert "expected str" in captured.out
+    assert "Traceback" not in captured.err


### PR DESCRIPTION
workflow-intake-forms **Task 1** (chair go in-session). [Spec](https://github.com/Smart-AI-Memory/attune-ai/blob/main/docs/specs/workflow-intake-forms/requirements.md) · [Task](https://github.com/Smart-AI-Memory/attune-ai/blob/main/docs/specs/workflow-intake-forms/tasks.md)

**Scope correction recorded:** measured coverage was **0/21** classes (requirements said 2/23 — the mixin's class-level `None` default makes `hasattr` checks read as 'declared'). Now 21/21 declare, derived from each `execute()`'s actual kwargs reads.

- Standard family (14): `path`/`depth`/budget **optional-typed** + `validate_input` wired. `path` optional BY DESIGN — these workflows already return a graceful in-result error for missing path (pinned; test-audit accepts `src_path`); the schema's added value is type validation. `deep-review focus` corrected `str`→`list` (pins caught the docstring-derived guess — the code is the contract).
- fix / rag-code-gen: declaration-only (own stricter validators pinned).
- 4 orchestrators: all-optional declarations matching named signatures.
- CLI: `WorkflowValidationError` → clean named-field message, **exit 3**, no traceback (input error ≠ crash); existing 0/1/2 pins untouched.
- New sweep test: coverage (empty shrink-only allowlist), well-formedness, seam + real-CLI behavioral cases.

Receipts: 3,224 (workflows/cli/characterization) + 2,212 (agents/ops/mcp/elicitation) pass, serial keyless.

Windows-relevant (path handling): hold merge for the full matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)