### PR TITLE
feat(elicitation): fix-intake fallback candidates + folder drill-down seam

### DIFF
--- a/.agents/skills/fix/SKILL.md
+++ b/.agents/skills/fix/SKILL.md
@@ -32,7 +32,10 @@ python -m attune.elicitation.fix_intake
 
 The JSON payload contains a validated form definition
 (`attune.elicitation.fix_intake.build_fix_intake_form`) plus the
-derived `scopes` and `probes` lists. If the user's invocation
+derived `scopes` and `probes` lists. Changed paths lead; on a clean
+tree the candidates fall back to recently-touched directories from
+git history, so pickers render in either state — empty lists mean
+the repo has no usable history at all. If the user's invocation
 already stated the goal, carry it into the request field as the
 default rather than asking again.
 
@@ -44,6 +47,19 @@ rule: widget surface when available, `AskUserQuestion` fallback
 the batch). Never ask these as sequential single questions. When a
 field came back with no derived options it is free text — accept a
 path or command, do not invent options.
+
+When the user picks the "other (type a path)" scope option, offer a
+folder drill-down instead of bare free text:
+
+```bash
+python -m attune.elicitation.fix_intake --list-dirs .
+```
+
+Render the returned `dirs` as pills plus a "use this folder" pill
+for the current `path`; on a pick, re-run `--list-dirs` with the
+picked directory and repeat until "use this folder" (or a typed
+path) settles the scope. The payload validates paths against the
+repo root — an `error` key means degrade to free text.
 
 ## Step 3 — Compose and preview
 

--- a/plugin/skills/fix/SKILL.md
+++ b/plugin/skills/fix/SKILL.md
@@ -34,7 +34,10 @@ python -m attune.elicitation.fix_intake
 
 The JSON payload contains a validated form definition
 (`attune.elicitation.fix_intake.build_fix_intake_form`) plus the
-derived `scopes` and `probes` lists. If the user's invocation
+derived `scopes` and `probes` lists. Changed paths lead; on a clean
+tree the candidates fall back to recently-touched directories from
+git history, so pickers render in either state — empty lists mean
+the repo has no usable history at all. If the user's invocation
 already stated the goal, carry it into the request field as the
 default rather than asking again.
 
@@ -46,6 +49,19 @@ rule: widget surface when available, `AskUserQuestion` fallback
 the batch). Never ask these as sequential single questions. When a
 field came back with no derived options it is free text — accept a
 path or command, do not invent options.
+
+When the user picks the "other (type a path)" scope option, offer a
+folder drill-down instead of bare free text:
+
+```bash
+python -m attune.elicitation.fix_intake --list-dirs .
+```
+
+Render the returned `dirs` as pills plus a "use this folder" pill
+for the current `path`; on a pick, re-run `--list-dirs` with the
+picked directory and repeat until "use this folder" (or a typed
+path) settles the scope. The payload validates paths against the
+repo root — an `error` key means degrade to free text.
 
 ## Step 3 — Compose and preview
 

--- a/src/attune/cli_commands/fix_commands.py
+++ b/src/attune/cli_commands/fix_commands.py
@@ -49,6 +49,26 @@ class VerificationProbe:
         label = self.description or " ".join(self.argv)
         return f"{label} (expect exit {self.expected_exit})"
 
+    def missing_paths(self, root: Path) -> list[str]:
+        """Path-shaped argv tokens that do not exist under ``root``.
+
+        Advisory only — a probe may legitimately name a file the fix
+        run will create (TDD), so a missing path warns in the preview
+        and never rejects the contract. A token is path-shaped when it
+        is not a flag and contains ``/`` or ends with ``.py``; pytest
+        node ids (``path::test``) are checked by their path half.
+        """
+        missing: list[str] = []
+        for token in self.argv[1:]:
+            if token.startswith("-"):
+                continue
+            if "/" not in token and not token.endswith(".py"):
+                continue
+            candidate = token.split("::", 1)[0]
+            if not (root / candidate).exists():
+                missing.append(candidate)
+        return missing
+
 
 @dataclass
 class FixContract:
@@ -193,8 +213,11 @@ def cmd_fix(args: Namespace) -> int:
     for constraint in contract.constraints:
         print(f"  - {constraint}")
     print("\nProbes (validated, not run):")
+    probe_root = _repo_root()
     for probe in contract.probes:
         print(f"  - {probe.render()}")
+        for missing in probe.missing_paths(probe_root):
+            print(f"      warning: path does not exist yet: {missing}")
 
     if selected is None:
         print(f"\n{detail}")

--- a/src/attune/elicitation/fix_intake.py
+++ b/src/attune/elicitation/fix_intake.py
@@ -3,8 +3,9 @@
 Task 4 of docs/specs/outcome-first-fix/: input ergonomics for the
 interactive (plugin/skill) surface. Candidates are DERIVED from the
 working tree — git-changed paths for scope, matching test files for
-probes — never from a hand-maintained registry. The CLI contract
-(`attune fix`) is composed, not changed.
+probes, and on a clean tree the recently-touched directories from
+git history — never from a hand-maintained registry. The CLI
+contract (`attune fix`) is composed, not changed.
 
 The module degrades to free-text fields when git is unavailable or
 nothing is derivable: the form never blocks intake.
@@ -70,12 +71,58 @@ def _git_changed_files(repo_root: Path) -> list[str]:
     return files
 
 
+def _git_recent_file_counts(repo_root: Path, commits: int = 40) -> dict[str, int]:
+    """Touch counts per still-existing file over recent commits.
+
+    Missing git, no history, or a timeout all degrade to {}.
+    """
+    try:
+        proc = subprocess.run(  # nosec B603 B607 — fixed argv, no shell
+            ["git", "-C", str(repo_root), "log", "--name-only", f"-{commits}", "--pretty=format:"],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return {}
+    if proc.returncode != 0:
+        return {}
+    counts: dict[str, int] = {}
+    for line in proc.stdout.splitlines():
+        path = line.strip()
+        if not path or _SKIP_PARTS.intersection(path.split("/")):
+            continue
+        if (repo_root / path).is_file():
+            counts[path] = counts.get(path, 0) + 1
+    return counts
+
+
+def _fallback_scope_candidates(repo_root: Path, limit: int) -> list[str]:
+    """Recently-touched directories from git history, most-touched first.
+
+    The clean-tree fallback: with nothing changed, the places work
+    recently landed are the likeliest fix targets — still mechanical,
+    still registry-free.
+    """
+    scores: dict[str, int] = {}
+    for path, count in _git_recent_file_counts(repo_root).items():
+        parent = Path(path).parent.as_posix()
+        if parent == "." or not (repo_root / parent).is_dir():
+            continue
+        scores[parent] = scores.get(parent, 0) + count
+    ranked = sorted(scores, key=lambda d: (-scores[d], d))
+    return ranked[:limit]
+
+
 def scope_candidates(repo_root: Path, limit: int = 6) -> list[str]:
     """Likely ``--scope`` values: changed files first, then their parents.
 
     A fix usually targets where the problem already is — the changed
     set — so changed source files lead, followed by their containing
-    directories for wider scopes. Deduplicated, capped at ``limit``.
+    directories for wider scopes. On a clean tree, falls back to
+    recently-touched directories from git history, so the form keeps
+    its picker whenever history exists. Deduplicated, capped at
+    ``limit``.
     """
     changed = _git_changed_files(repo_root)
     ordered: dict[str, None] = {}
@@ -85,6 +132,8 @@ def scope_candidates(repo_root: Path, limit: int = 6) -> list[str]:
         parent = Path(path).parent.as_posix()
         if parent != ".":
             ordered.setdefault(parent, None)
+    if not ordered:
+        return _fallback_scope_candidates(repo_root, limit)
     return list(ordered)[:limit]
 
 
@@ -95,11 +144,12 @@ def _is_test_shaped(name: str) -> bool:
 def probe_candidates(repo_root: Path, scopes: list[str], limit: int = 4) -> list[str]:
     """Suggested ``--probe`` commands: test files related to the scopes.
 
-    Two derivations, both mechanical and ranked: test-shaped files
+    Three derivations, all mechanical and ranked: test-shaped files
     INSIDE a scope directory first (the suite that guards the code
-    being fixed), then test-shaped files under ``tests/`` whose name
-    contains a scope file's stem. Returned as runnable
-    ``pytest <path>`` commands.
+    being fixed), then the mirror test directory for a scope dir
+    (``src/pkg/x`` → ``tests/unit/x`` or ``tests/x``), then
+    test-shaped files under ``tests/`` whose name contains a scope
+    file's stem. Returned as runnable ``pytest <path>`` commands.
     """
     found: dict[str, None] = {}
     tests_root = repo_root / "tests"
@@ -109,6 +159,13 @@ def probe_candidates(repo_root: Path, scopes: list[str], limit: int = 4) -> list
             for pattern in _TEST_PATTERNS:
                 for match in sorted(target.rglob(pattern)):
                     found.setdefault(match.relative_to(repo_root).as_posix(), None)
+    for scope in scopes:
+        name = Path(scope).name
+        target = repo_root / scope
+        if target.is_dir() and name and not name.startswith("test"):
+            for mapped in (f"tests/unit/{name}", f"tests/{name}"):
+                if (repo_root / mapped).is_dir():
+                    found.setdefault(f"{mapped}/", None)
     for scope in scopes:
         target = repo_root / scope
         stem = Path(scope).stem
@@ -216,16 +273,47 @@ def compose_fix_command(answers: dict[str, Any]) -> str:
     return " ".join(parts)
 
 
+def list_subdirectories(repo_root: Path, raw: str) -> dict[str, Any]:
+    """Immediate subdirectories of a repo-relative path, for drill-down.
+
+    Powers the "Other path" folder picker: the skill renders each
+    level's directories as pills and drills by re-calling with the
+    picked one. The path is validated to stay inside ``repo_root``;
+    escapes and non-directories return an ``error`` payload instead
+    of raising, so the picker degrades to free text.
+    """
+    base = (repo_root / raw).resolve()
+    try:
+        rel = base.relative_to(repo_root.resolve())
+    except ValueError:
+        return {"error": "path escapes the repository", "path": raw, "dirs": []}
+    if not base.is_dir():
+        return {"error": "not a directory", "path": raw, "dirs": []}
+    dirs = sorted(
+        child.name
+        for child in base.iterdir()
+        if child.is_dir() and child.name not in _SKIP_PARTS and not child.name.startswith(".")
+    )
+    return {"path": rel.as_posix(), "dirs": dirs}
+
+
 def _main(argv: list[str]) -> int:
     """CLI seam for the /fix skill.
 
     Default: print ``{"form": <form dict>, "scopes": [...],
     "probes": [...]}`` for the current repo. With ``--compose``,
-    read answers JSON on stdin and print the composed command.
+    read answers JSON on stdin and print the composed command. With
+    ``--list-dirs <path>``, print the drill-down payload for the
+    "Other path" folder picker.
     """
     if "--compose" in argv:
         answers = json.load(sys.stdin)
         print(compose_fix_command(answers))
+        return 0
+    if "--list-dirs" in argv:
+        idx = argv.index("--list-dirs")
+        raw = argv[idx + 1] if len(argv) > idx + 1 else "."
+        print(json.dumps(list_subdirectories(Path.cwd(), raw)))
         return 0
     repo_root = Path.cwd()
     scopes = scope_candidates(repo_root)

--- a/tests/unit/cli_commands/test_fix_commands.py
+++ b/tests/unit/cli_commands/test_fix_commands.py
@@ -166,6 +166,37 @@ def test_representative_preview_is_truthful(capsys: pytest.CaptureFixture[str]) 
         assert forbidden not in out.lower()
 
 
+def test_missing_paths_flags_nonexistent_path_shaped_tokens(tmp_path: Path) -> None:
+    (tmp_path / "real.py").write_text("X = 1\n")
+    probe = VerificationProbe(
+        argv=["pytest", "real.py", "gone/test_x.py", "gone/test_x.py::test_y", "-q", "bareword"]
+    )
+    assert probe.missing_paths(tmp_path) == ["gone/test_x.py", "gone/test_x.py"]
+    assert VerificationProbe(argv=["pytest", "real.py"]).missing_paths(tmp_path) == []
+
+
+def test_preview_warns_on_missing_probe_path_but_still_previews(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A probe naming a nonexistent test path warns (advisory — the
+    fix run may create it) and the contract still previews exit 0."""
+    workflow = _first_registered_workflow()
+    assert (
+        cmd_fix(_args(workflow=workflow, probe=["pytest tests/unit/does_not_exist_suite.py"])) == 0
+    )
+    out = capsys.readouterr().out
+    assert "warning: path does not exist yet: tests/unit/does_not_exist_suite.py" in out
+    assert _TRAILER in out
+
+
+def test_preview_stays_silent_when_probe_paths_exist(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    workflow = _first_registered_workflow()
+    assert cmd_fix(_args(workflow=workflow)) == 0
+    assert "warning: path does not exist yet" not in capsys.readouterr().out
+
+
 def test_real_cli_entry_representative_exits_zero(
     capsys: pytest.CaptureFixture[str],
 ) -> None:

--- a/tests/unit/elicitation/test_fix_intake.py
+++ b/tests/unit/elicitation/test_fix_intake.py
@@ -11,6 +11,7 @@ from attune.elicitation.fix_intake import (
     OTHER,
     build_fix_intake_form,
     compose_fix_command,
+    list_subdirectories,
     probe_candidates,
     scope_candidates,
 )
@@ -21,6 +22,27 @@ def _git_repo(tmp_path: Path) -> Path:
     repo.mkdir()
     subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
     return repo
+
+
+def _commit_all(repo: Path, message: str = "x") -> None:
+    subprocess.run(["git", "add", "-A"], cwd=repo, check=True)
+    subprocess.run(
+        [
+            "git",
+            "-c",
+            "user.name=t",
+            "-c",
+            "user.email=t@t",
+            "-c",
+            "commit.gpgsign=false",
+            "commit",
+            "-q",
+            "-m",
+            message,
+        ],
+        cwd=repo,
+        check=True,
+    )
 
 
 def test_scope_candidates_changed_files_first(tmp_path: Path) -> None:
@@ -42,6 +64,65 @@ def test_scope_candidates_skip_cache_and_degrade_without_git(tmp_path: Path) -> 
     plain = tmp_path / "plain"
     plain.mkdir()
     assert scope_candidates(plain) == []
+
+
+def test_scope_candidates_fall_back_to_recent_history_on_clean_tree(tmp_path: Path) -> None:
+    repo = _git_repo(tmp_path)
+    pkg = repo / "src" / "pkg"
+    pkg.mkdir(parents=True)
+    (pkg / "mod.py").write_text("X = 1\n")
+    docs = repo / "docs"
+    docs.mkdir()
+    (docs / "note.md").write_text("note\n")
+    _commit_all(repo, "first")
+    (pkg / "mod.py").write_text("X = 2\n")
+    _commit_all(repo, "second")
+    scopes = scope_candidates(repo)
+    assert scopes, "clean tree with history must still derive candidates"
+    assert scopes[0] == "src/pkg", "most-touched directory ranks first"
+    assert "docs" in scopes
+
+
+def test_fallback_skips_deleted_paths_and_degrades_without_commits(tmp_path: Path) -> None:
+    repo = _git_repo(tmp_path)
+    (repo / "gone.py").write_text("X = 1\n")
+    _commit_all(repo)
+    (repo / "gone.py").unlink()
+    _commit_all(repo, "remove")
+    assert scope_candidates(repo) == []
+    sub = tmp_path / "sub"
+    sub.mkdir()
+    empty = _git_repo(sub)
+    assert scope_candidates(empty) == []
+
+
+def test_probe_candidates_map_scope_dir_to_mirror_test_dir(tmp_path: Path) -> None:
+    repo = _git_repo(tmp_path)
+    pkg = repo / "src" / "pkg" / "billing"
+    pkg.mkdir(parents=True)
+    (pkg / "mod.py").write_text("X = 1\n")
+    mirror = repo / "tests" / "unit" / "billing"
+    mirror.mkdir(parents=True)
+    (mirror / "test_mod.py").write_text("def test_x(): pass\n")
+    probes = probe_candidates(repo, ["src/pkg/billing"])
+    assert "pytest tests/unit/billing/" in probes
+
+
+def test_list_subdirectories_lists_validates_and_filters(tmp_path: Path) -> None:
+    repo = _git_repo(tmp_path)
+    (repo / "src").mkdir()
+    (repo / "docs").mkdir()
+    (repo / ".hidden").mkdir()
+    (repo / "__pycache__").mkdir()
+    (repo / "file.txt").write_text("x\n")
+    top = list_subdirectories(repo, ".")
+    assert top["dirs"] == ["docs", "src"]
+    assert "error" not in top
+    escape = list_subdirectories(repo, "../outside")
+    assert escape["error"] == "path escapes the repository"
+    assert escape["dirs"] == []
+    not_dir = list_subdirectories(repo, "file.txt")
+    assert not_dir["error"] == "not a directory"
 
 
 def test_probe_candidates_from_scope_dir_and_tests_tree(tmp_path: Path) -> None:


### PR DESCRIPTION
From tonight's /fix dogfood (Patrick's picks: fallback candidates + drill-down picker; caching declined by measurement):

- **Clean-tree fallback**: `scope_candidates` falls back to recently-touched directories from git history (frequency-ranked, mechanical, registry-free) — the intake form now renders clickable pickers even on a clean tree. Changed-path priority unchanged, pinned by tests.
- **Probe mirror mapping**: scope dir `src/pkg/x` suggests `pytest tests/unit/x/` / `pytest tests/x/` alongside in-scope test files.
- **`--list-dirs` drill-down seam**: repo-root-validated subdirectory listing (escapes refused → error payload) powering the "Other path" folder picker documented in the fix SKILL.md; `.agents` mirror re-projected.
- **Preview warns on probe paths that don't exist yet** (folded in after a live catch: a picked probe named a nonexistent test file and the preview validated it silently). Advisory only — TDD probes may name files the run will create, so it warns, never rejects.
- **Caching declined with receipt**: derive = 0.46 s total, 0.39 s of it interpreter+import startup; logic ~70 ms — nothing for a cache to save.

Receipts: 12/12 `test_fix_intake.py` (fallback ranking, deleted-path skip, no-history degrade, mirror mapping, list-dirs validation incl. traversal refusal); 352 passed `tests/unit/cli_commands/` (3 new: missing-path detection, preview warning, silent-when-real); 715-test sweep over elicitation + cli_commands + skill-mirror drift guard on the first commit.

Windows-relevant (pathlib/subprocess): holding the auto-merge label until Windows lanes pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)