### PR TITLE
fix(elicitation): probe candidates exclude production src/ files with test-shaped names

### DIFF
--- a/src/attune/elicitation/fix_intake.py
+++ b/src/attune/elicitation/fix_intake.py
@@ -141,12 +141,26 @@ def _is_test_shaped(name: str) -> bool:
     return name.startswith("test_") or name.endswith(("_test.py", "_suite.py"))
 
 
+def _is_production_path(rel: str) -> bool:
+    """True for paths under a top-level ``src/`` with no ``tests`` part.
+
+    Production packages legitimately contain modules with test-shaped
+    NAMES (``test_gen_parallel.py`` is a workflow, not a suite), so a
+    name match under ``src/`` is not probe material unless it sits in
+    an embedded ``tests`` directory.
+    """
+    parts = rel.split("/")
+    return parts[0] == "src" and "tests" not in parts
+
+
 def probe_candidates(repo_root: Path, scopes: list[str], limit: int = 4) -> list[str]:
     """Suggested ``--probe`` commands: test files related to the scopes.
 
     Three derivations, all mechanical and ranked: test-shaped files
     INSIDE a scope directory first (the suite that guards the code
-    being fixed), then the mirror test directory for a scope dir
+    being fixed — production paths under ``src/`` are excluded, since
+    a workflow module named ``test_*.py`` is not a suite), then the
+    mirror test directory for a scope dir
     (``src/pkg/x`` → ``tests/unit/x`` or ``tests/x``), then
     test-shaped files under ``tests/`` whose name contains a scope
     file's stem. Returned as runnable ``pytest <path>`` commands.
@@ -158,7 +172,9 @@ def probe_candidates(repo_root: Path, scopes: list[str], limit: int = 4) -> list
         if target.is_dir():
             for pattern in _TEST_PATTERNS:
                 for match in sorted(target.rglob(pattern)):
-                    found.setdefault(match.relative_to(repo_root).as_posix(), None)
+                    rel = match.relative_to(repo_root).as_posix()
+                    if not _is_production_path(rel):
+                        found.setdefault(rel, None)
     for scope in scopes:
         name = Path(scope).name
         target = repo_root / scope

--- a/tests/unit/elicitation/test_fix_intake.py
+++ b/tests/unit/elicitation/test_fix_intake.py
@@ -96,6 +96,19 @@ def test_fallback_skips_deleted_paths_and_degrades_without_commits(tmp_path: Pat
     assert scope_candidates(empty) == []
 
 
+def test_probe_candidates_exclude_production_src_files_with_test_names(tmp_path: Path) -> None:
+    repo = _git_repo(tmp_path)
+    pkg = repo / "src" / "pkg"
+    pkg.mkdir(parents=True)
+    (pkg / "test_gen_parallel.py").write_text("X = 1\n")
+    embedded = pkg / "tests"
+    embedded.mkdir()
+    (embedded / "test_real.py").write_text("def test_x(): pass\n")
+    probes = probe_candidates(repo, ["src/pkg"])
+    assert "pytest src/pkg/tests/test_real.py" in probes
+    assert all("test_gen_parallel" not in p for p in probes)
+
+
 def test_probe_candidates_map_scope_dir_to_mirror_test_dir(tmp_path: Path) -> None:
     repo = _git_repo(tmp_path)
     pkg = repo / "src" / "pkg" / "billing"


### PR DESCRIPTION
Third /fix dogfood round caught the fallback offering `pytest` against four production modules (`test_gen_parallel.py` is a workflow, not a suite). The in-scope test glob now skips `src/`-rooted matches unless they sit in an embedded `tests/` directory — scratch-dir suites and `src/pkg/tests/` keep working.

Clean-tree receipt after the fix: probes derive as `pytest tests/unit/workflows/`, `pytest tests/unit/cli_commands/`, … (mirror mapping) with zero `src/` files. 13/13 `test_fix_intake.py` incl. the new exclusion pin.

Windows lanes awaited before the auto-merge label, per standing rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)