### PR TITLE
feat(elicitation): intake-forms Task 3 (shared theme) + Phase 2a (FormTemplate + providers)

### DIFF
--- a/docs/specs/workflow-intake-forms/decisions.md
+++ b/docs/specs/workflow-intake-forms/decisions.md
@@ -20,3 +20,35 @@ ratchet remains the test itself plus the hard bans (no fonts, no
 icon fonts, no images, no @import), and widgets continue shipping
 per-form family subsets (~2.5–3 KB class). `test_form_theme_budget`
 enforces 6,144 B; design.md amended in the same commit.
+
+## D2 — Phase 2a ruled and executed same night: the merge fallback, six refinements, gate override (chair, 2026-07-31 ~22:15 ET)
+
+Roundtable `q-intake-forms-phase2-design-001` (transcript
+machine-local; msgs 2–5 promoted). Convergence 3/3: shape
+right-sized; cache-free v1; thin two-consumer staging; the
+re-expression gate right in spirit. Split 2–1 on template-less
+fallback (codex+antigravity: free-text until authored slots;
+claude: demand-gated derivation with telemetry).
+
+**Chair rulings:** (1) THE MERGE — free-text fallback in v1 plus
+claude's demand-telemetry marker on every template-less ask;
+derivation is a debug tool only. (2) All six refinements PROMOTED:
+structural-equality gate with stubbed providers; same-PR deletion
+of hand FORM-BUILDING; cache-free v1; list-without-provider
+rejected at build time; prefill exact-match only; drill-down
+re-entrancy design text before migration. (3) IMPLEMENT NOW —
+the chair's third timing override of the evening, over the lead's
+post-demo recommendation. Gate-override on record: the
+rule-of-three had not fired (two consumers); the chair overrode
+his own sequencing gate deliberately, and codex's warning stands
+in the spec as the third consumer's test: fix and spec "may be
+structurally similar enough to produce a misleadingly elegant
+API."
+
+**Executed same session:** `intake_template.py` + fix/spec
+re-expression + provider registration + 12-test gate suite
+(structural-equality goldens copied verbatim from the deleted
+hand construction), 347 elicitation tests green, existing 20
+behavioral pins untouched. The drill-down question dissolved on
+inspection: `--list-dirs` is a skill-side loop between renders,
+not an in-form dependency — recorded in design.md.

--- a/docs/specs/workflow-intake-forms/decisions.md
+++ b/docs/specs/workflow-intake-forms/decisions.md
@@ -1,0 +1,22 @@
+# Workflow Intake Forms — Decisions
+
+**Status:** active (decision log; grows as the spec advances)
+
+## D1 — Theme byte budget amended 4 KB → 6 KB (chair, 2026-07-31 ~21:20 ET, Task 3 execution)
+
+Task 3's execution measurement: `FORM_THEME_CSS` — the full family
+sheet WITH the design-mandated `var()` fallback literals — is
+5,574 B raw, 5,192 B minified; the scope-prefix repetition is
+~920 B, so even CSS-nesting restructuring lands ~4.3 K. The 4 KB
+figure was authored before the fallbacks existed and measured a
+per-widget subset, not the full concatenation.
+
+Chair ruled (over the presented fork, lead recommendation
+followed): amend the budget to 6 KB rather than cut real rules to
+honor a stale number. Rationale preserved from the original
+design: the latency claim (sub-millisecond against the ~100–145 ms
+derivation baseline) holds identically at 6 KB, the anti-framework
+ratchet remains the test itself plus the hard bans (no fonts, no
+icon fonts, no images, no @import), and widgets continue shipping
+per-form family subsets (~2.5–3 KB class). `test_form_theme_budget`
+enforces 6,144 B; design.md amended in the same commit.

--- a/docs/specs/workflow-intake-forms/design.md
+++ b/docs/specs/workflow-intake-forms/design.md
@@ -130,12 +130,17 @@ family of intake forms should read as ONE surface.
 
 - Zero added round trips anywhere: widgets were already inline;
   the dashboard file is cached after first load.
-- Byte budget: `FORM_THEME_CSS` ≤ 4 KB raw, enforced by a
-  residency-style drift test (`test_form_theme_budget`) so the
-  theme cannot quietly grow into a framework. At ≤4 KB the
-  render-time cost is sub-millisecond against the ~100–145 ms
-  derivation baseline — styling is not on the latency path, and
-  the budget test keeps it that way.
+- Byte budget: `FORM_THEME_CSS` ≤ 6 KB raw (AMENDED from 4 KB,
+  chair ruling 2026-07-31, execution-time measurement: the full
+  family sheet with the mandated `var()` fallback literals is
+  5,574 B — the 4 KB figure predated the fallbacks; see the spec's
+  decisions.md), enforced by a residency-style drift test
+  (`test_form_theme_budget`) so the theme cannot quietly grow into
+  a framework. At ≤6 KB the render-time cost is still
+  sub-millisecond against the ~100–145 ms derivation baseline —
+  styling is not on the latency path, and the budget test keeps it
+  that way. Widgets ship per-form family SUBSETS of the sheet, so
+  per-widget payloads stay in the ~2.5–3 KB class regardless.
 - No external fonts, no icon fonts, no images: system font stack
   and host tokens only. (An @import or webfont would be the first
   real latency regression this section exists to forbid.)

--- a/docs/specs/workflow-intake-forms/design.md
+++ b/docs/specs/workflow-intake-forms/design.md
@@ -81,9 +81,27 @@ class FieldSlot:
 - A field whose value is already present in the invocation text
   or context is PREFILLED, rendered as inferred (the existing
   `inferred_from` path) — never re-asked blind.
-- Proof obligation: the fix and spec intakes re-expressed as
-  templates render byte-identical `FormSchema`s to the shipped
-  hand modules, pinned by test, before any third consumer ships.
+- Proof obligation (AMENDED by roundtable D2, 2026-07-31): the fix
+  and spec intakes re-expressed as templates render STRUCTURALLY
+  EQUAL `FormSchema`s to the shipped hand shapes — equality on the
+  built object with providers stubbed to fixtures (fix reads live
+  git state, so byte-comparing against a real tree is flaky by
+  construction; claude seat, codex concurring). The gate ends in
+  same-PR deletion of the hand FORM-BUILDING (no hand-edited
+  twins); derivation functions become the registered providers and
+  CLI seams stay.
+- Binding is OPTIONAL (`workflow: str | None`): a bound template
+  is cross-checked against the registry `input_schema`
+  (tighten-only, list-needs-provider); an unbound template is a
+  standalone skill intake — /spec's is one, and fix's slot keys
+  are CLI-composition keys rather than schema keys, so both ship
+  unbound (execution note, 2026-07-31).
+- The `--list-dirs` folder drill-down is a SKILL-side loop over
+  the CLI seam BETWEEN renders, not an in-form dependency — so
+  single-pass provider execution suffices in v1, and the
+  drill-down survives migration untouched (answers the
+  antigravity/claude follow-up; `ProviderContext.answered` is the
+  seam if in-form dependency ever becomes real).
 
 ## Generation flow
 
@@ -91,8 +109,10 @@ class FieldSlot:
 intake_form(workflow_name, invocation_text) ->
   1. registry lookup -> workflow_cls.input_schema  (fail: no form,
      fall back to free-text ask — never block)
-  2. template lookup (in-tree dict; missing -> derive a minimal
-     template from the schema alone)
+  2. template lookup (in-tree dict; missing -> NO generated form:
+     free-text fallback + a demand-telemetry marker — the chair's
+     D2 merge ruling of the table's 2-1 split; schema-only
+     derivation is a debug tool, never a production surface)
   3. run providers (bounded; see latency)
   4. build FormSchema via form_from_dict  (validation unchanged)
   5. surface via select_form_surface      (unchanged)

--- a/docs/specs/workflow-intake-forms/tasks.md
+++ b/docs/specs/workflow-intake-forms/tasks.md
@@ -73,13 +73,15 @@ Authored only when the rule-of-three fires (a third intake is
 requested). Must include the byte-identical re-expression pins
 for the fix and spec intakes (design.md proof obligation).
 
-## Task 3 — Phase 2/theme: shared form theme (GATED)
+## Task 3 — Phase 2/theme: shared form theme (EXECUTED 2026-07-31, PR #1843)
 
 `attune/elicitation/theme.py` (`FORM_THEME_CSS`, host-token
-fallbacks), widget injection swap, dashboard static projection,
-budget + byte-equality drift tests, rendered screenshots on both
-surfaces. May be authored alongside Task 2 or independently —
-chair's call; it has no dependency on the template layer.
+fallbacks), widget swap shared-by-source (family subsets kept),
+dashboard static projection byte-equality-tested, budget test at
+the chair-amended 6 KB (decisions.md D1), standalone rendered
+receipt delivered in-session (fallbacks painting). Executed
+independently of Task 2 on the chair's `/spec execute` go — it has
+no dependency on the template layer.
 
 ## Task 4 — Phase 3: latency instrumentation + cache (GATED)
 

--- a/docs/specs/workflow-intake-forms/tasks.md
+++ b/docs/specs/workflow-intake-forms/tasks.md
@@ -67,11 +67,24 @@ authorization exists).
 </task>
 ```
 
-## Task 2 — Phase 2: FormTemplate + providers (GATED)
+## Task 2 — Phase 2a: FormTemplate + providers (EXECUTED 2026-07-31, chair gate-override)
 
-Authored only when the rule-of-three fires (a third intake is
-requested). Must include the byte-identical re-expression pins
-for the fix and spec intakes (design.md proof obligation).
+The rule-of-three had NOT fired (two consumers); the chair
+overrode his own gate, convened the table
+(`q-intake-forms-phase2-design-001`, 3 seats, ruling in
+decisions.md D2), and ordered same-night implementation. Shipped
+as the thin two-consumer extraction all three seats converged on:
+`attune/elicitation/intake_template.py` (FieldSlot / FormTemplate /
+ProviderContext / plain PROVIDERS dict / ruled build-time
+rejections), fix + spec intakes re-expressed as templates with
+their derivations registered as providers, hand FORM-BUILDING
+deleted in the same PR (CLI seams and public APIs unchanged — the
+20 existing behavioral tests pass untouched), structural-equality
+gate pinning the shipped hand shapes (goldens verbatim, providers
+stubbed), template-less → free-text + demand-telemetry marker
+(the chair's merge ruling), cache-free v1. Deferred to the third
+consumer: auto-derivation (debug tool only), caching, provider
+enrichment.
 
 ## Task 3 — Phase 2/theme: shared form theme (EXECUTED 2026-07-31, PR #1843)
 

--- a/src/attune/elicitation/fix_intake.py
+++ b/src/attune/elicitation/fix_intake.py
@@ -23,7 +23,14 @@ import sys
 from pathlib import Path
 from typing import Any
 
-from attune.elicitation.bridge import form_from_dict
+from attune.elicitation.intake_template import (
+    PROVIDERS,
+    TEMPLATES,
+    FieldSlot,
+    FormTemplate,
+    ProviderContext,
+    build_form,
+)
 from attune.meta_workflows.models import FormSchema
 
 #: Free-text sentinel offered alongside derived options.
@@ -192,78 +199,79 @@ def probe_candidates(repo_root: Path, scopes: list[str], limit: int = 4) -> list
     return [f"pytest {path}" for path in list(found)[:limit]]
 
 
+def _provider_fix_scopes(ctx: ProviderContext) -> list[str]:
+    """Registered provider: scope candidates for the fix intake."""
+    return scope_candidates(ctx.repo_root)
+
+
+def _provider_fix_probes(ctx: ProviderContext) -> list[str]:
+    """Registered provider: probe candidates for the fix intake."""
+    return probe_candidates(ctx.repo_root, scope_candidates(ctx.repo_root))
+
+
+PROVIDERS["fix_scopes"] = _provider_fix_scopes
+PROVIDERS["fix_probes"] = _provider_fix_probes
+
+#: The fix intake, declaratively (Phase 2a). Slot keys are CLI
+#: composition keys (request/scope/probes/mode), not the fix
+#: workflow's input_schema keys, so the template is standalone
+#: (unbound) by design — recorded in the Phase 2 execution notes.
+FIX_TEMPLATE = FormTemplate(
+    title="Fix intake",
+    description="Compose an outcome-first fix: goal, scope, verification.",
+    fields=[
+        FieldSlot(
+            key="request",
+            text="What should be fixed, in your words?",
+            control="textarea",
+            required=True,
+            help_text="Passed verbatim as the fix goal — no inference.",
+        ),
+        FieldSlot(
+            key="scope",
+            text="Where must the diff stay confined (--scope)?",
+            provider="fix_scopes",
+            other=OTHER,
+            fallback_text="Where must the diff stay confined (--scope)? (path)",
+            help_text="Changed paths first — a fix usually lands where the change is.",
+        ),
+        FieldSlot(
+            key="probes",
+            text="How do we verify the fix (--probe)?",
+            provider="fix_probes",
+            control="multi_select",
+            fallback_text="How do we verify the fix? (one command, e.g. pytest tests/x.py)",
+            help_text="Each probe is verified independently in the receipt.",
+        ),
+        FieldSlot(
+            key="mode",
+            text="Run it, or preview only?",
+            options=["preview only", "preview then run"],
+            default="preview only",
+            help_text="Preview renders the contract and executes nothing.",
+        ),
+    ],
+)
+
+TEMPLATES["fix"] = FIX_TEMPLATE
+
+
 def build_fix_intake_form(
     scopes: list[str],
     probes: list[str],
 ) -> FormSchema:
     """The one intake form: request + scope + probes + mode (D21).
 
-    Scope and probe fields render as pickers when candidates exist and
-    as free text otherwise — the form is always buildable.
+    Phase 2a: built from :data:`FIX_TEMPLATE` with the pre-derived
+    candidates as overrides — the hand-written construction this
+    function used to contain is deleted (same-PR rule, spec D2).
+    The structural-equality gate pins the output against the
+    shipped hand shape.
     """
-    fields: list[dict[str, Any]] = [
-        {
-            "id": "request",
-            "text": "What should be fixed, in your words?",
-            "type": "textarea",
-            "required": True,
-            "help_text": "Passed verbatim as the fix goal — no inference.",
-        }
-    ]
-    if scopes:
-        fields.append(
-            {
-                "id": "scope",
-                "text": "Where must the diff stay confined (--scope)?",
-                "type": "single_select",
-                "options": [*scopes, OTHER],
-                "help_text": "Changed paths first — a fix usually lands where the change is.",
-            }
-        )
-    else:
-        fields.append(
-            {
-                "id": "scope",
-                "text": "Where must the diff stay confined (--scope)? (path)",
-                "type": "text_input",
-                "required": True,
-            }
-        )
-    if probes:
-        fields.append(
-            {
-                "id": "probes",
-                "text": "How do we verify the fix (--probe)?",
-                "type": "multi_select",
-                "options": probes,
-                "help_text": "Each probe is verified independently in the receipt.",
-            }
-        )
-    else:
-        fields.append(
-            {
-                "id": "probes",
-                "text": "How do we verify the fix? (one command, e.g. pytest tests/x.py)",
-                "type": "text_input",
-                "required": True,
-            }
-        )
-    fields.append(
-        {
-            "id": "mode",
-            "text": "Run it, or preview only?",
-            "type": "single_select",
-            "options": ["preview only", "preview then run"],
-            "default": "preview only",
-            "help_text": "Preview renders the contract and executes nothing.",
-        }
-    )
-    return form_from_dict(
-        {
-            "title": "Fix intake",
-            "description": "Compose an outcome-first fix: goal, scope, verification.",
-            "fields": fields,
-        }
+    return build_form(
+        FIX_TEMPLATE,
+        ProviderContext(repo_root=Path.cwd()),
+        candidates_override={"scope": scopes, "probes": probes},
     )
 
 

--- a/src/attune/elicitation/intake_template.py
+++ b/src/attune/elicitation/intake_template.py
@@ -1,0 +1,243 @@
+"""Intake templates — generated forms from declarative slots (Phase 2).
+
+workflow-intake-forms Phase 2a, chair-ruled 2026-07-31 (spec
+decisions.md D2, roundtable `q-intake-forms-phase2-design-001`):
+one declarative :class:`FormTemplate` per intake replaces the
+hand-written form-building modules. The template layer OWNS form
+construction; candidate derivation stays in plain provider
+callables; rendering and validation stay in the substrate
+(`form_from_dict`, `select_form_surface`) unchanged.
+
+Ruled boundaries (do not drift):
+
+- **Tighten-only:** a slot may require a schema-optional field;
+  a schema-REQUIRED field rendered optional rejects at build time.
+- **`list` without a provider rejects at build time** — nothing
+  guesses candidates.
+- **Prefill is exact-match only** (a value already present in
+  ``ProviderContext.answered`` under the slot's key) — never
+  heuristic, never an LLM.
+- **Template-less workflows get NO generated form** in v1:
+  :func:`intake_form` returns ``None`` (caller falls back to a
+  free-text ask) and emits the demand-telemetry marker — the
+  chair-ruled merge of the table's 2-1 split.
+- **Cache-free v1**: providers run inline every time; caching
+  arrives only with a Phase 3 measured budget miss.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under Apache 2.0
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import structlog
+
+from attune.elicitation.bridge import form_from_dict
+from attune.meta_workflows.models import FormSchema
+
+logger = structlog.get_logger(__name__)
+
+#: Candidate providers by name: plain callables, no entry points,
+#: no plugins (H3-no-parallel-framework).
+PROVIDERS: dict[str, Callable[[ProviderContext], list[str]]] = {}
+
+
+@dataclass
+class ProviderContext:
+    """What a candidate provider may read — nothing else.
+
+    ``answered`` carries already-collected fields (exact-match
+    prefill and future inter-field candidates); ``invocation_text``
+    is the user's raw ask.
+    """
+
+    repo_root: Path
+    invocation_text: str = ""
+    answered: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class FieldSlot:
+    """One form field, declaratively.
+
+    ``provider`` names a :data:`PROVIDERS` entry whose candidates
+    become the options; with no candidates the slot degrades to a
+    required free-text input (``fallback_text`` or ``text``, help
+    dropped) — the always-buildable rule the hand modules pinned.
+    ``options`` is for static choice lists; ``other`` appends a
+    free-text sentinel after provider candidates.
+    """
+
+    key: str
+    text: str
+    control: str | None = None
+    provider: str | None = None
+    options: list[str] | None = None
+    other: str | None = None
+    fallback_text: str | None = None
+    help_text: str | None = None
+    required: bool | None = None
+    default: str | None = None
+
+
+@dataclass
+class FormTemplate:
+    """A whole intake form, declaratively.
+
+    ``workflow`` binds to a registry name for schema cross-checks;
+    ``None`` is a standalone (skill) intake — the spec intake is
+    one, so the binding is optional by design (recorded in the
+    Phase 2 execution notes).
+    """
+
+    title: str
+    description: str
+    fields: list[FieldSlot]
+    workflow: str | None = None
+
+
+class TemplateError(ValueError):
+    """A template violated a ruled build-time boundary."""
+
+
+def validate_template(template: FormTemplate) -> None:
+    """Build-time boundary checks (ruled; reject, never repair).
+
+    Raises:
+        TemplateError: tighten-only violated, a ``list``-typed
+            schema field has no provider, an ``other`` sentinel or
+            ``fallback_text`` appears without a provider, or a
+            named provider is unregistered.
+    """
+    for slot in template.fields:
+        if slot.provider is not None and slot.provider not in PROVIDERS:
+            raise TemplateError(f"slot {slot.key!r}: unknown provider {slot.provider!r}")
+        if slot.provider is None and (slot.other or slot.fallback_text):
+            raise TemplateError(f"slot {slot.key!r}: 'other'/'fallback_text' require a provider")
+    if template.workflow is None:
+        return
+    from attune.workflows import get_workflow
+
+    workflow_cls = get_workflow(template.workflow)
+    schema = getattr(workflow_cls, "input_schema", None)
+    if schema is None:
+        raise TemplateError(f"workflow {template.workflow!r} declares no input_schema")
+    slot_by_key = {slot.key: slot for slot in template.fields}
+    for key in schema.required_fields:
+        slot = slot_by_key.get(key)
+        if slot is not None and slot.required is False:
+            raise TemplateError(
+                f"slot {key!r}: schema-required field rendered optional (tighten-only)"
+            )
+    for key, py_type in {**schema.required_fields, **schema.optional_fields}.items():
+        slot = slot_by_key.get(key)
+        if slot is not None and py_type is list and slot.provider is None:
+            raise TemplateError(
+                f"slot {key!r}: list-typed field has no provider — rejected, not guessed"
+            )
+
+
+def _slot_field(
+    slot: FieldSlot,
+    ctx: ProviderContext,
+    overrides: dict[str, list[str]] | None = None,
+) -> dict[str, Any]:
+    """Render one slot to a ``form_from_dict`` field dict.
+
+    ``overrides`` supplies pre-derived candidates per slot key —
+    the seam the hand-module delegations and the equality gate's
+    stubbed-provider tests use (providers are NOT called for an
+    overridden slot).
+    """
+    prefilled = ctx.answered.get(slot.key)
+    base: dict[str, Any] = {"id": slot.key, "text": slot.text}
+    if slot.help_text is not None:
+        base["help_text"] = slot.help_text
+    if slot.required is not None:
+        base["required"] = slot.required
+    if slot.default is not None:
+        base["default"] = slot.default
+    if prefilled is not None:
+        base["default"] = str(prefilled)
+
+    if slot.provider is not None:
+        if overrides is not None and slot.key in overrides:
+            candidates = overrides[slot.key]
+        else:
+            candidates = PROVIDERS[slot.provider](ctx)
+        if candidates:
+            base["type"] = slot.control or "single_select"
+            base["options"] = [*candidates, slot.other] if slot.other else list(candidates)
+            return base
+        fallback = {
+            "id": slot.key,
+            "text": slot.fallback_text or slot.text,
+            "type": "text_input",
+            "required": True,
+        }
+        if slot.default is not None or prefilled is not None:
+            fallback["default"] = base.get("default")
+        return fallback
+
+    if slot.options is not None:
+        base["type"] = slot.control or "single_select"
+        base["options"] = list(slot.options)
+        return base
+
+    base["type"] = slot.control or "text_input"
+    return base
+
+
+def build_form(
+    template: FormTemplate,
+    ctx: ProviderContext,
+    candidates_override: dict[str, list[str]] | None = None,
+) -> FormSchema:
+    """Build the validated :class:`FormSchema` for a template."""
+    validate_template(template)
+    return form_from_dict(
+        {
+            "title": template.title,
+            "description": template.description,
+            "fields": [_slot_field(slot, ctx, candidates_override) for slot in template.fields],
+        }
+    )
+
+
+#: In-tree templates by intake name (registry workflow names and
+#: standalone skill-intake names share this namespace).
+TEMPLATES: dict[str, FormTemplate] = {}
+
+
+def intake_form(
+    name: str,
+    invocation_text: str = "",
+    repo_root: Path | None = None,
+    answered: dict[str, Any] | None = None,
+) -> FormSchema | None:
+    """Generate the intake form for ``name``, or ``None`` (ruled).
+
+    ``None`` means no template exists: the caller falls back to a
+    free-text ask — never an auto-derived form (chair merge ruling)
+    — and the demand marker below is the telemetry that makes slot
+    authoring demand-driven.
+    """
+    template = TEMPLATES.get(name)
+    if template is None:
+        logger.info(
+            "intake_form.template_missing",
+            intake=name,
+            invocation_present=bool(invocation_text),
+        )
+        return None
+    ctx = ProviderContext(
+        repo_root=repo_root or Path.cwd(),
+        invocation_text=invocation_text,
+        answered=answered or {},
+    )
+    return build_form(template, ctx)

--- a/src/attune/elicitation/spec_intake.py
+++ b/src/attune/elicitation/spec_intake.py
@@ -23,7 +23,14 @@ import sys
 from pathlib import Path
 from typing import Any
 
-from attune.elicitation.bridge import form_from_dict
+from attune.elicitation.intake_template import (
+    PROVIDERS,
+    TEMPLATES,
+    FieldSlot,
+    FormTemplate,
+    ProviderContext,
+    build_form,
+)
 from attune.meta_workflows.models import FormSchema
 
 #: Free-text sentinel offered alongside derived options.
@@ -58,58 +65,68 @@ def area_candidates(repo_root: Path, limit: int = 6) -> list[str]:
     return areas[:limit]
 
 
+def _provider_spec_areas(ctx: ProviderContext) -> list[str]:
+    """Registered provider: package-dir area candidates."""
+    return area_candidates(ctx.repo_root)
+
+
+PROVIDERS["spec_areas"] = _provider_spec_areas
+
+#: The new-spec intake, declaratively (Phase 2a). A standalone
+#: (unbound) template: /spec is a skill intake, not a registry
+#: workflow — the optional binding exists for exactly this case.
+SPEC_TEMPLATE = FormTemplate(
+    title="New spec intake",
+    description="Frame the spec before brainstorming: outcome, acceptance, area.",
+    fields=[
+        FieldSlot(
+            key="outcome",
+            text="What should exist when this spec is done?",
+            control="textarea",
+            required=True,
+            help_text="One or two sentences — becomes the spec's outcome statement.",
+        ),
+        FieldSlot(
+            key="done_when",
+            text="Done when? (acceptance criteria)",
+            control="textarea",
+            required=True,
+            help_text=(
+                "Cheap to write, expensive to skip — e.g. "
+                "'PR merged green, regression test landed'."
+            ),
+        ),
+        FieldSlot(
+            key="area",
+            text="Primary code area?",
+            provider="spec_areas",
+            other=OTHER,
+            fallback_text="Primary code area? (path or name)",
+            help_text="Where most of the change lands — bounds the design conversation.",
+        ),
+        FieldSlot(
+            key="slug",
+            text="Spec slug (optional — leave blank to derive one)",
+            required=False,
+            help_text="kebab-case directory name under docs/specs/.",
+        ),
+    ],
+)
+
+TEMPLATES["spec-intake"] = SPEC_TEMPLATE
+
+
 def build_spec_intake_form(areas: list[str]) -> FormSchema:
-    """The one new-spec intake form (D21: widget-first, batched)."""
-    fields: list[dict[str, Any]] = [
-        {
-            "id": "outcome",
-            "text": "What should exist when this spec is done?",
-            "type": "textarea",
-            "required": True,
-            "help_text": "One or two sentences — becomes the spec's outcome statement.",
-        },
-        {
-            "id": "done_when",
-            "text": "Done when? (acceptance criteria)",
-            "type": "textarea",
-            "required": True,
-            "help_text": "Cheap to write, expensive to skip — e.g. 'PR merged green, regression test landed'.",
-        },
-    ]
-    if areas:
-        fields.append(
-            {
-                "id": "area",
-                "text": "Primary code area?",
-                "type": "single_select",
-                "options": [*areas, OTHER],
-                "help_text": "Where most of the change lands — bounds the design conversation.",
-            }
-        )
-    else:
-        fields.append(
-            {
-                "id": "area",
-                "text": "Primary code area? (path or name)",
-                "type": "text_input",
-                "required": True,
-            }
-        )
-    fields.append(
-        {
-            "id": "slug",
-            "text": "Spec slug (optional — leave blank to derive one)",
-            "type": "text_input",
-            "required": False,
-            "help_text": "kebab-case directory name under docs/specs/.",
-        }
-    )
-    return form_from_dict(
-        {
-            "title": "New spec intake",
-            "description": "Frame the spec before brainstorming: outcome, acceptance, area.",
-            "fields": fields,
-        }
+    """The one new-spec intake form (D21: widget-first, batched).
+
+    Phase 2a: built from :data:`SPEC_TEMPLATE` with the pre-derived
+    areas as overrides — hand construction deleted (same-PR rule,
+    spec D2); the structural-equality gate pins the shipped shape.
+    """
+    return build_form(
+        SPEC_TEMPLATE,
+        ProviderContext(repo_root=Path.cwd()),
+        candidates_override={"area": areas},
     )
 
 

--- a/src/attune/elicitation/theme.py
+++ b/src/attune/elicitation/theme.py
@@ -1,0 +1,147 @@
+"""Shared form theme — the ONE tracked CSS source for intake forms.
+
+workflow-intake-forms Task 3 (design.md "The shared look"): every
+form surface renders from this module's CSS, projected — never
+hand-copied:
+
+- **Widgets** (claude.ai): ``form_to_widget_html`` injects the
+  needed family blocks inline (the widget sandbox's CSP forbids
+  external stylesheet fetches, so shared means shared-by-SOURCE).
+- **Ops dashboard**: the full ``FORM_THEME_CSS`` string is served
+  as ``/static/form-theme.css`` from a projected file that a drift
+  test keeps byte-equal to the constant.
+
+Every ``var()`` reference carries a literal fallback, so one
+stylesheet renders native on claude.ai (host tokens win,
+light/dark follows the host) and standalone (fallbacks win).
+
+Budget: ``FORM_THEME_CSS`` is capped at 6 KB raw by
+``test_form_theme_budget`` (amended from 4 KB by chair ruling
+2026-07-31 — the original figure predated the mandated fallback
+literals; measured full sheet = 5,574 B) — no fonts, no icon
+fonts, no images, no @import; growth past the cap is a design
+decision, not a drift.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under Apache 2.0
+"""
+
+from __future__ import annotations
+
+#: Base rules every form emits (scoped under ``#attune-elicit-form``;
+#: the widget renderer rewrites the id per instance).
+CSS_BASE = """#attune-elicit-form { display:block; width:100%; padding:1rem 0;
+  color:var(--text-primary,#2c2c2a); line-height:1.5; }
+#attune-elicit-form .sr-only { position:absolute; width:1px; height:1px;
+  overflow:hidden; clip:rect(0 0 0 0); }
+#attune-elicit-form h3 { font-size:18px; font-weight:500; margin:0 0 .25rem; }
+#attune-elicit-form .ae-msg { margin:0 0 .5rem; color:var(--text-secondary,#5f5e59); }
+#attune-elicit-form .ae-desc { margin:0 0 1rem; color:var(--text-muted,#8a887f);
+  font-size:15px; }
+#attune-elicit-form .ae-field { margin:0 0 1rem; }
+#attune-elicit-form .ae-label { display:block; font-weight:500;
+  margin:0 0 .35rem; }
+#attune-elicit-form .ae-req { color:var(--text-accent,#a1571c); margin-left:2px; }
+#attune-elicit-form .ae-confirm { font-size:14px; color:var(--text-secondary,#5f5e59);
+  border-left:3px solid var(--border-accent,#d8b89a); border-radius:0;
+  padding:.35rem .6rem; margin:0 0 1rem; }
+#attune-elicit-form .ae-inferred { font-size:13px; color:var(--text-muted,#8a887f);
+  margin:0 0 .35rem; }
+#attune-elicit-form .ae-inferred-b { display:inline-block; font-size:11px;
+  font-weight:500; text-transform:uppercase; letter-spacing:.04em;
+  color:var(--text-accent,#a1571c); background:var(--bg-accent,#f3ece4);
+  border:1px solid var(--border-accent,#d8b89a); border-radius:var(--radius,8px);
+  padding:0 .35rem; margin-right:.4rem; }
+#attune-elicit-form .ae-help { font-size:13px; color:var(--text-muted,#8a887f);
+  margin:0 0 .35rem; }
+#attune-elicit-form .ae-submit { margin-top:.5rem; padding:.55rem 1.1rem;
+  font-size:15px; font-weight:500; cursor:pointer; color:var(--text-primary,#2c2c2a);
+  background:var(--bg-accent,#f3ece4); border:1px solid var(--border-accent,#d8b89a);
+  border-radius:var(--radius,8px); }
+#attune-elicit-form .ae-submit:disabled { opacity:.6; cursor:default; }
+#attune-elicit-form .ae-error { margin-top:.5rem; font-size:14px;
+  color:var(--text-accent,#a1571c); }
+"""
+
+#: INPUT — text_input, textarea, number, date, boolean, non-list single_select.
+CSS_INPUT = """#attune-elicit-form .ae-input { width:100%; box-sizing:border-box;
+  padding:.5rem .6rem; font-size:15px; color:var(--text-primary,#2c2c2a);
+  background:var(--surface-1,#f7f6f3); border:1px solid var(--border,#e3e1dc);
+  border-radius:var(--radius,8px); }
+#attune-elicit-form .ae-textarea { resize:vertical; min-height:3.5rem; }
+"""
+
+#: CHECKS — non-list multi_select (checkbox rows).
+CSS_CHECKS = """#attune-elicit-form .ae-checks { display:flex; flex-direction:column;
+  gap:.35rem; }
+#attune-elicit-form .ae-check { display:flex; align-items:center; gap:.5rem;
+  font-weight:400; }
+"""
+
+#: LIST — any select rendered with ``list_style``.
+CSS_LIST = """#attune-elicit-form .ae-list { margin:0; padding-left:1.6rem;
+  display:flex; flex-direction:column; gap:.3rem; }
+#attune-elicit-form .ae-list-item label { display:inline-flex;
+  align-items:baseline; gap:.45rem; cursor:pointer; font-weight:400; }
+"""
+
+#: CARDS — decision / pushback option cards + the rationale callout (also
+#: reused by the progress blocked-picker).
+CSS_CARDS = """#attune-elicit-form .ae-cards { display:flex; flex-direction:column; gap:.5rem; }
+#attune-elicit-form .ae-card { position:relative; display:flex;
+  flex-direction:column; gap:.15rem; padding:.6rem 1.9rem .6rem .75rem;
+  border:1px solid var(--border,#e3e1dc); border-radius:var(--radius,8px);
+  cursor:pointer; }
+#attune-elicit-form .ae-card:hover { border-color:var(--text-muted,#8a887f); }
+#attune-elicit-form .ae-card-rec { border-color:var(--border-accent,#d8b89a); }
+#attune-elicit-form .ae-card input { position:absolute; top:.7rem; right:.6rem; }
+#attune-elicit-form .ae-card-title { font-weight:500; }
+#attune-elicit-form .ae-card-note { font-size:13px; color:var(--text-muted,#8a887f); }
+#attune-elicit-form .ae-rec-badge { font-size:11px; font-weight:600;
+  text-transform:uppercase; letter-spacing:.03em; color:var(--text-accent,#a1571c); }
+#attune-elicit-form .ae-yours-tag { font-size:11px; font-weight:600;
+  text-transform:uppercase; letter-spacing:.03em; color:var(--text-muted,#8a887f); }
+#attune-elicit-form .ae-rationale { margin:.6rem 0 0; padding:.4rem 0 .4rem .75rem;
+  font-size:13px; color:var(--text-secondary,#5f5e59);
+  border-left:2px solid var(--border-accent,#d8b89a); }
+#attune-elicit-form .ae-rationale-h { display:block; font-weight:600;
+  font-size:11px; text-transform:uppercase; letter-spacing:.03em;
+  color:var(--text-accent,#a1571c); margin-bottom:.15rem; }
+"""
+
+#: PROGRESS — the done/in_flight/blocked status rows (pulls CARDS too).
+CSS_PROGRESS = """#attune-elicit-form .ae-progress { display:flex; flex-direction:column; gap:.5rem; }
+#attune-elicit-form .ae-prog-rows { display:flex; flex-direction:column; gap:.25rem; }
+#attune-elicit-form .ae-prog-row { display:flex; align-items:baseline; gap:.5rem;
+  font-size:14px; color:var(--text-secondary,#5f5e59); }
+#attune-elicit-form .ae-prog-icon { flex:none; font-weight:700; width:1.1em;
+  text-align:center; }
+#attune-elicit-form .ae-prog-done .ae-prog-icon { color:var(--text-success,#3fb950); }
+#attune-elicit-form .ae-prog-in_flight .ae-prog-icon { color:var(--text-accent,#a1571c); }
+#attune-elicit-form .ae-prog-blocked { color:var(--text-accent,#a1571c); }
+#attune-elicit-form .ae-prog-detail { font-size:13px; color:var(--text-muted,#8a887f); }
+#attune-elicit-form .ae-prog-label { color:var(--text-primary,#2c2c2a); }
+#attune-elicit-form .ae-prog-done .ae-prog-label { text-decoration:line-through;
+  color:var(--text-muted,#8a887f); }
+#attune-elicit-form .ae-prog-blocked-h { font-size:11px; font-weight:600;
+  text-transform:uppercase; letter-spacing:.03em; color:var(--text-accent,#a1571c); }
+#attune-elicit-form .ae-prog-tag { flex:none; font-size:10px; font-weight:600;
+  text-transform:uppercase; letter-spacing:.04em; color:var(--text-muted,#8a887f);
+  border:1px solid var(--border,#e3e1dc); border-radius:3px; padding:0 .3em; }
+#attune-elicit-form .ae-card .ae-prog-tag { align-self:flex-start; }
+#attune-elicit-form .ae-card .ae-prog-icon { margin-right:.15rem; }
+"""
+
+#: Named family blocks in cascade-emission order (BASE is always first).
+CSS_FAMILIES: list[tuple[str, str]] = [
+    ("INPUT", CSS_INPUT),
+    ("CHECKS", CSS_CHECKS),
+    ("LIST", CSS_LIST),
+    ("CARDS", CSS_CARDS),
+    ("PROGRESS", CSS_PROGRESS),
+]
+
+#: The full theme: base + every family, in cascade order. This exact
+#: string is what the ops dashboard serves at ``/static/form-theme.css``
+#: (byte-equal by drift test) and what the 4 KB budget test measures.
+FORM_THEME_CSS = CSS_BASE + "".join(css for _name, css in CSS_FAMILIES)

--- a/src/attune/elicitation/widget.py
+++ b/src/attune/elicitation/widget.py
@@ -26,6 +26,8 @@ from collections.abc import Callable
 from html import escape
 
 from attune.elicitation.bridge import is_fully_inferred
+from attune.elicitation.theme import CSS_BASE as _CSS_BASE
+from attune.elicitation.theme import CSS_FAMILIES as _CSS_FAMILIES
 from attune.meta_workflows.models import FormQuestion, FormSchema, QuestionType
 
 #: Sentinel key the submit payload carries so the agent can recognise a
@@ -390,119 +392,13 @@ def _field_html(q: FormQuestion) -> str:
     )
 
 
-#: The form CSS, split by control family. Every form emits ``_CSS_BASE``;
-#: each field pulls in only the family its control renders with, so a form
-#: never ships styles for controls it lacks (a number+date form omits the
-#: cards/progress rules — ~60% of the block). See :func:`_needed_css`.
-_CSS_BASE = """#attune-elicit-form { display:block; width:100%; padding:1rem 0;
-  color:var(--text-primary); line-height:1.5; }
-#attune-elicit-form .sr-only { position:absolute; width:1px; height:1px;
-  overflow:hidden; clip:rect(0 0 0 0); }
-#attune-elicit-form h3 { font-size:18px; font-weight:500; margin:0 0 .25rem; }
-#attune-elicit-form .ae-msg { margin:0 0 .5rem; color:var(--text-secondary); }
-#attune-elicit-form .ae-desc { margin:0 0 1rem; color:var(--text-muted);
-  font-size:15px; }
-#attune-elicit-form .ae-field { margin:0 0 1rem; }
-#attune-elicit-form .ae-label { display:block; font-weight:500;
-  margin:0 0 .35rem; }
-#attune-elicit-form .ae-req { color:var(--text-accent); margin-left:2px; }
-#attune-elicit-form .ae-confirm { font-size:14px; color:var(--text-secondary);
-  border-left:3px solid var(--border-accent); border-radius:0;
-  padding:.35rem .6rem; margin:0 0 1rem; }
-#attune-elicit-form .ae-inferred { font-size:13px; color:var(--text-muted);
-  margin:0 0 .35rem; }
-#attune-elicit-form .ae-inferred-b { display:inline-block; font-size:11px;
-  font-weight:500; text-transform:uppercase; letter-spacing:.04em;
-  color:var(--text-accent); background:var(--bg-accent);
-  border:1px solid var(--border-accent); border-radius:var(--radius);
-  padding:0 .35rem; margin-right:.4rem; }
-#attune-elicit-form .ae-help { font-size:13px; color:var(--text-muted);
-  margin:0 0 .35rem; }
-#attune-elicit-form .ae-submit { margin-top:.5rem; padding:.55rem 1.1rem;
-  font-size:15px; font-weight:500; cursor:pointer; color:var(--text-primary);
-  background:var(--bg-accent); border:1px solid var(--border-accent);
-  border-radius:var(--radius); }
-#attune-elicit-form .ae-submit:disabled { opacity:.6; cursor:default; }
-#attune-elicit-form .ae-error { margin-top:.5rem; font-size:14px;
-  color:var(--text-accent); }
-"""
-
-#: INPUT — text_input, textarea, number, date, boolean, non-list single_select.
-_CSS_INPUT = """#attune-elicit-form .ae-input { width:100%; box-sizing:border-box;
-  padding:.5rem .6rem; font-size:15px; color:var(--text-primary);
-  background:var(--surface-1); border:1px solid var(--border);
-  border-radius:var(--radius); }
-#attune-elicit-form .ae-textarea { resize:vertical; min-height:3.5rem; }
-"""
-
-#: CHECKS — non-list multi_select (checkbox rows).
-_CSS_CHECKS = """#attune-elicit-form .ae-checks { display:flex; flex-direction:column;
-  gap:.35rem; }
-#attune-elicit-form .ae-check { display:flex; align-items:center; gap:.5rem;
-  font-weight:400; }
-"""
-
-#: LIST — any select rendered with ``list_style``.
-_CSS_LIST = """#attune-elicit-form .ae-list { margin:0; padding-left:1.6rem;
-  display:flex; flex-direction:column; gap:.3rem; }
-#attune-elicit-form .ae-list-item label { display:inline-flex;
-  align-items:baseline; gap:.45rem; cursor:pointer; font-weight:400; }
-"""
-
-#: CARDS — decision / pushback option cards + the rationale callout (also
-#: reused by the progress blocked-picker).
-_CSS_CARDS = """#attune-elicit-form .ae-cards { display:flex; flex-direction:column; gap:.5rem; }
-#attune-elicit-form .ae-card { position:relative; display:flex;
-  flex-direction:column; gap:.15rem; padding:.6rem 1.9rem .6rem .75rem;
-  border:1px solid var(--border); border-radius:var(--radius); cursor:pointer; }
-#attune-elicit-form .ae-card:hover { border-color:var(--text-muted); }
-#attune-elicit-form .ae-card-rec { border-color:var(--border-accent); }
-#attune-elicit-form .ae-card input { position:absolute; top:.7rem; right:.6rem; }
-#attune-elicit-form .ae-card-title { font-weight:500; }
-#attune-elicit-form .ae-card-note { font-size:13px; color:var(--text-muted); }
-#attune-elicit-form .ae-rec-badge { font-size:11px; font-weight:600;
-  text-transform:uppercase; letter-spacing:.03em; color:var(--text-accent); }
-#attune-elicit-form .ae-yours-tag { font-size:11px; font-weight:600;
-  text-transform:uppercase; letter-spacing:.03em; color:var(--text-muted); }
-#attune-elicit-form .ae-rationale { margin:.6rem 0 0; padding:.4rem 0 .4rem .75rem;
-  font-size:13px; color:var(--text-secondary);
-  border-left:2px solid var(--border-accent); }
-#attune-elicit-form .ae-rationale-h { display:block; font-weight:600;
-  font-size:11px; text-transform:uppercase; letter-spacing:.03em;
-  color:var(--text-accent); margin-bottom:.15rem; }
-"""
-
-#: PROGRESS — the done/in_flight/blocked status rows (pulls CARDS too).
-_CSS_PROGRESS = """#attune-elicit-form .ae-progress { display:flex; flex-direction:column; gap:.5rem; }
-#attune-elicit-form .ae-prog-rows { display:flex; flex-direction:column; gap:.25rem; }
-#attune-elicit-form .ae-prog-row { display:flex; align-items:baseline; gap:.5rem;
-  font-size:14px; color:var(--text-secondary); }
-#attune-elicit-form .ae-prog-icon { flex:none; font-weight:700; width:1.1em;
-  text-align:center; }
-#attune-elicit-form .ae-prog-done .ae-prog-icon { color:var(--text-success,#3fb950); }
-#attune-elicit-form .ae-prog-in_flight .ae-prog-icon { color:var(--text-accent); }
-#attune-elicit-form .ae-prog-blocked { color:var(--text-accent); }
-#attune-elicit-form .ae-prog-detail { font-size:13px; color:var(--text-muted); }
-#attune-elicit-form .ae-prog-label { color:var(--text-primary); }
-#attune-elicit-form .ae-prog-done .ae-prog-label { text-decoration:line-through;
-  color:var(--text-muted); }
-#attune-elicit-form .ae-prog-blocked-h { font-size:11px; font-weight:600;
-  text-transform:uppercase; letter-spacing:.03em; color:var(--text-accent); }
-#attune-elicit-form .ae-prog-tag { flex:none; font-size:10px; font-weight:600;
-  text-transform:uppercase; letter-spacing:.04em; color:var(--text-muted);
-  border:1px solid var(--border); border-radius:3px; padding:0 .3em; }
-#attune-elicit-form .ae-card .ae-prog-tag { align-self:flex-start; }
-#attune-elicit-form .ae-card .ae-prog-icon { margin-right:.15rem; }
-"""
-
-#: Named family blocks in cascade-emission order (BASE is always first).
-_CSS_FAMILIES: list[tuple[str, str]] = [
-    ("INPUT", _CSS_INPUT),
-    ("CHECKS", _CSS_CHECKS),
-    ("LIST", _CSS_LIST),
-    ("CARDS", _CSS_CARDS),
-    ("PROGRESS", _CSS_PROGRESS),
-]
+#: The form CSS lives in :mod:`attune.elicitation.theme` — the ONE
+#: tracked source (workflow-intake-forms Task 3), projected here as
+#: inline injection and to the ops dashboard as /static/form-theme.css.
+#: ``_CSS_BASE``/``_CSS_FAMILIES`` are imported aliases; the per-form
+#: family selection below is unchanged: every form emits BASE, each
+#: field pulls in only the family its control renders with, so a form
+#: never ships styles for controls it lacks. See :func:`_needed_css`.
 
 
 def _families_for(question: FormQuestion) -> set[str]:

--- a/src/attune/ops/static/form-theme.css
+++ b/src/attune/ops/static/form-theme.css
@@ -1,0 +1,84 @@
+#attune-elicit-form { display:block; width:100%; padding:1rem 0;
+  color:var(--text-primary,#2c2c2a); line-height:1.5; }
+#attune-elicit-form .sr-only { position:absolute; width:1px; height:1px;
+  overflow:hidden; clip:rect(0 0 0 0); }
+#attune-elicit-form h3 { font-size:18px; font-weight:500; margin:0 0 .25rem; }
+#attune-elicit-form .ae-msg { margin:0 0 .5rem; color:var(--text-secondary,#5f5e59); }
+#attune-elicit-form .ae-desc { margin:0 0 1rem; color:var(--text-muted,#8a887f);
+  font-size:15px; }
+#attune-elicit-form .ae-field { margin:0 0 1rem; }
+#attune-elicit-form .ae-label { display:block; font-weight:500;
+  margin:0 0 .35rem; }
+#attune-elicit-form .ae-req { color:var(--text-accent,#a1571c); margin-left:2px; }
+#attune-elicit-form .ae-confirm { font-size:14px; color:var(--text-secondary,#5f5e59);
+  border-left:3px solid var(--border-accent,#d8b89a); border-radius:0;
+  padding:.35rem .6rem; margin:0 0 1rem; }
+#attune-elicit-form .ae-inferred { font-size:13px; color:var(--text-muted,#8a887f);
+  margin:0 0 .35rem; }
+#attune-elicit-form .ae-inferred-b { display:inline-block; font-size:11px;
+  font-weight:500; text-transform:uppercase; letter-spacing:.04em;
+  color:var(--text-accent,#a1571c); background:var(--bg-accent,#f3ece4);
+  border:1px solid var(--border-accent,#d8b89a); border-radius:var(--radius,8px);
+  padding:0 .35rem; margin-right:.4rem; }
+#attune-elicit-form .ae-help { font-size:13px; color:var(--text-muted,#8a887f);
+  margin:0 0 .35rem; }
+#attune-elicit-form .ae-submit { margin-top:.5rem; padding:.55rem 1.1rem;
+  font-size:15px; font-weight:500; cursor:pointer; color:var(--text-primary,#2c2c2a);
+  background:var(--bg-accent,#f3ece4); border:1px solid var(--border-accent,#d8b89a);
+  border-radius:var(--radius,8px); }
+#attune-elicit-form .ae-submit:disabled { opacity:.6; cursor:default; }
+#attune-elicit-form .ae-error { margin-top:.5rem; font-size:14px;
+  color:var(--text-accent,#a1571c); }
+#attune-elicit-form .ae-input { width:100%; box-sizing:border-box;
+  padding:.5rem .6rem; font-size:15px; color:var(--text-primary,#2c2c2a);
+  background:var(--surface-1,#f7f6f3); border:1px solid var(--border,#e3e1dc);
+  border-radius:var(--radius,8px); }
+#attune-elicit-form .ae-textarea { resize:vertical; min-height:3.5rem; }
+#attune-elicit-form .ae-checks { display:flex; flex-direction:column;
+  gap:.35rem; }
+#attune-elicit-form .ae-check { display:flex; align-items:center; gap:.5rem;
+  font-weight:400; }
+#attune-elicit-form .ae-list { margin:0; padding-left:1.6rem;
+  display:flex; flex-direction:column; gap:.3rem; }
+#attune-elicit-form .ae-list-item label { display:inline-flex;
+  align-items:baseline; gap:.45rem; cursor:pointer; font-weight:400; }
+#attune-elicit-form .ae-cards { display:flex; flex-direction:column; gap:.5rem; }
+#attune-elicit-form .ae-card { position:relative; display:flex;
+  flex-direction:column; gap:.15rem; padding:.6rem 1.9rem .6rem .75rem;
+  border:1px solid var(--border,#e3e1dc); border-radius:var(--radius,8px);
+  cursor:pointer; }
+#attune-elicit-form .ae-card:hover { border-color:var(--text-muted,#8a887f); }
+#attune-elicit-form .ae-card-rec { border-color:var(--border-accent,#d8b89a); }
+#attune-elicit-form .ae-card input { position:absolute; top:.7rem; right:.6rem; }
+#attune-elicit-form .ae-card-title { font-weight:500; }
+#attune-elicit-form .ae-card-note { font-size:13px; color:var(--text-muted,#8a887f); }
+#attune-elicit-form .ae-rec-badge { font-size:11px; font-weight:600;
+  text-transform:uppercase; letter-spacing:.03em; color:var(--text-accent,#a1571c); }
+#attune-elicit-form .ae-yours-tag { font-size:11px; font-weight:600;
+  text-transform:uppercase; letter-spacing:.03em; color:var(--text-muted,#8a887f); }
+#attune-elicit-form .ae-rationale { margin:.6rem 0 0; padding:.4rem 0 .4rem .75rem;
+  font-size:13px; color:var(--text-secondary,#5f5e59);
+  border-left:2px solid var(--border-accent,#d8b89a); }
+#attune-elicit-form .ae-rationale-h { display:block; font-weight:600;
+  font-size:11px; text-transform:uppercase; letter-spacing:.03em;
+  color:var(--text-accent,#a1571c); margin-bottom:.15rem; }
+#attune-elicit-form .ae-progress { display:flex; flex-direction:column; gap:.5rem; }
+#attune-elicit-form .ae-prog-rows { display:flex; flex-direction:column; gap:.25rem; }
+#attune-elicit-form .ae-prog-row { display:flex; align-items:baseline; gap:.5rem;
+  font-size:14px; color:var(--text-secondary,#5f5e59); }
+#attune-elicit-form .ae-prog-icon { flex:none; font-weight:700; width:1.1em;
+  text-align:center; }
+#attune-elicit-form .ae-prog-done .ae-prog-icon { color:var(--text-success,#3fb950); }
+#attune-elicit-form .ae-prog-in_flight .ae-prog-icon { color:var(--text-accent,#a1571c); }
+#attune-elicit-form .ae-prog-blocked { color:var(--text-accent,#a1571c); }
+#attune-elicit-form .ae-prog-detail { font-size:13px; color:var(--text-muted,#8a887f); }
+#attune-elicit-form .ae-prog-label { color:var(--text-primary,#2c2c2a); }
+#attune-elicit-form .ae-prog-done .ae-prog-label { text-decoration:line-through;
+  color:var(--text-muted,#8a887f); }
+#attune-elicit-form .ae-prog-blocked-h { font-size:11px; font-weight:600;
+  text-transform:uppercase; letter-spacing:.03em; color:var(--text-accent,#a1571c); }
+#attune-elicit-form .ae-prog-tag { flex:none; font-size:10px; font-weight:600;
+  text-transform:uppercase; letter-spacing:.04em; color:var(--text-muted,#8a887f);
+  border:1px solid var(--border,#e3e1dc); border-radius:3px; padding:0 .3em; }
+#attune-elicit-form .ae-card .ae-prog-tag { align-self:flex-start; }
+#attune-elicit-form .ae-card .ae-prog-icon { margin-right:.15rem; }

--- a/tests/unit/elicitation/test_form_theme.py
+++ b/tests/unit/elicitation/test_form_theme.py
@@ -1,0 +1,64 @@
+"""Shared form theme (workflow-intake-forms Task 3): budget,
+projection byte-equality, fallback coverage, shared-by-source."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from attune.elicitation import theme
+from attune.elicitation import widget as widget_mod
+
+#: Chair-ruled cap (spec decisions.md D1: amended 4 KB -> 6 KB with
+#: the 5,574 B full-sheet measurement on record).
+_BUDGET_BYTES = 6144
+
+#: ``var(--name)`` with NO fallback value — the pattern the theme
+#: must never contain (host-token fallbacks are the design).
+_NO_FALLBACK_RE = re.compile(r"var\(--[a-zA-Z0-9-]+\)")
+
+
+def _ops_static_theme() -> Path:
+    import attune.ops as ops_pkg
+
+    return Path(ops_pkg.__file__).parent / "static" / "form-theme.css"
+
+
+def test_form_theme_budget() -> None:
+    size = len(theme.FORM_THEME_CSS.encode("utf-8"))
+    assert size <= _BUDGET_BYTES, (
+        f"FORM_THEME_CSS is {size} B (> {_BUDGET_BYTES}); growing the "
+        "theme past the cap is a design decision — see "
+        "docs/specs/workflow-intake-forms/decisions.md D1"
+    )
+
+
+def test_forbidden_latency_constructs_absent() -> None:
+    low = theme.FORM_THEME_CSS.lower()
+    for banned in ("@import", "@font-face", "url("):
+        assert banned not in low, f"{banned!r} is the latency regression the design forbids"
+
+
+def test_ops_static_projection_is_byte_equal() -> None:
+    served = _ops_static_theme()
+    assert served.is_file(), "ops static projection missing — re-project from theme.py"
+    assert served.read_text() == theme.FORM_THEME_CSS, (
+        "static/form-theme.css drifted from FORM_THEME_CSS — edit "
+        "theme.py (the master) and re-write the projection, never the file"
+    )
+
+
+def test_every_var_reference_carries_a_fallback() -> None:
+    bare = _NO_FALLBACK_RE.findall(theme.FORM_THEME_CSS)
+    assert not bare, f"var() references without fallbacks: {sorted(set(bare))}"
+
+
+def test_widget_css_is_theme_source_by_identity() -> None:
+    """Shared-by-SOURCE: the widget's CSS objects ARE the theme's."""
+    assert widget_mod._CSS_BASE is theme.CSS_BASE
+    assert widget_mod._CSS_FAMILIES is theme.CSS_FAMILIES
+
+
+def test_full_sheet_is_base_plus_all_families_in_order() -> None:
+    expected = theme.CSS_BASE + "".join(css for _n, css in theme.CSS_FAMILIES)
+    assert theme.FORM_THEME_CSS == expected

--- a/tests/unit/elicitation/test_intake_template.py
+++ b/tests/unit/elicitation/test_intake_template.py
@@ -1,0 +1,273 @@
+"""Intake template layer (workflow-intake-forms Phase 2a): the
+structural-equality migration gate, ruled build-time boundaries,
+and the template-less demand fallback."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+from attune.elicitation import fix_intake, spec_intake
+from attune.elicitation.bridge import form_from_dict
+from attune.elicitation.intake_template import (
+    PROVIDERS,
+    TEMPLATES,
+    FieldSlot,
+    FormTemplate,
+    ProviderContext,
+    TemplateError,
+    build_form,
+    intake_form,
+    validate_template,
+)
+
+_CTX = ProviderContext(repo_root=Path("/nonexistent"))
+
+
+# ---------------------------------------------------------------
+# The migration gate: template output == the SHIPPED hand shapes
+# (goldens below are copied verbatim from the deleted hand
+# construction; structural equality, providers stubbed — D2).
+# ---------------------------------------------------------------
+
+
+def _hand_fix_form(scopes: list[str], probes: list[str]):
+    fields = [
+        {
+            "id": "request",
+            "text": "What should be fixed, in your words?",
+            "type": "textarea",
+            "required": True,
+            "help_text": "Passed verbatim as the fix goal — no inference.",
+        }
+    ]
+    if scopes:
+        fields.append(
+            {
+                "id": "scope",
+                "text": "Where must the diff stay confined (--scope)?",
+                "type": "single_select",
+                "options": [*scopes, fix_intake.OTHER],
+                "help_text": "Changed paths first — a fix usually lands where the change is.",
+            }
+        )
+    else:
+        fields.append(
+            {
+                "id": "scope",
+                "text": "Where must the diff stay confined (--scope)? (path)",
+                "type": "text_input",
+                "required": True,
+            }
+        )
+    if probes:
+        fields.append(
+            {
+                "id": "probes",
+                "text": "How do we verify the fix (--probe)?",
+                "type": "multi_select",
+                "options": probes,
+                "help_text": "Each probe is verified independently in the receipt.",
+            }
+        )
+    else:
+        fields.append(
+            {
+                "id": "probes",
+                "text": "How do we verify the fix? (one command, e.g. pytest tests/x.py)",
+                "type": "text_input",
+                "required": True,
+            }
+        )
+    fields.append(
+        {
+            "id": "mode",
+            "text": "Run it, or preview only?",
+            "type": "single_select",
+            "options": ["preview only", "preview then run"],
+            "default": "preview only",
+            "help_text": "Preview renders the contract and executes nothing.",
+        }
+    )
+    return form_from_dict(
+        {
+            "title": "Fix intake",
+            "description": "Compose an outcome-first fix: goal, scope, verification.",
+            "fields": fields,
+        }
+    )
+
+
+@pytest.mark.parametrize(
+    ("scopes", "probes"),
+    [
+        (["src/pkg/mod.py", "src/pkg"], ["pytest tests/test_mod.py"]),
+        ([], []),
+        (["src/pkg"], []),
+    ],
+)
+def test_fix_template_matches_shipped_hand_shape(scopes, probes) -> None:
+    assert fix_intake.build_fix_intake_form(scopes, probes) == _hand_fix_form(scopes, probes)
+
+
+def _hand_spec_form(areas: list[str]):
+    fields = [
+        {
+            "id": "outcome",
+            "text": "What should exist when this spec is done?",
+            "type": "textarea",
+            "required": True,
+            "help_text": "One or two sentences — becomes the spec's outcome statement.",
+        },
+        {
+            "id": "done_when",
+            "text": "Done when? (acceptance criteria)",
+            "type": "textarea",
+            "required": True,
+            "help_text": (
+                "Cheap to write, expensive to skip — e.g. "
+                "'PR merged green, regression test landed'."
+            ),
+        },
+    ]
+    if areas:
+        fields.append(
+            {
+                "id": "area",
+                "text": "Primary code area?",
+                "type": "single_select",
+                "options": [*areas, spec_intake.OTHER],
+                "help_text": "Where most of the change lands — bounds the design conversation.",
+            }
+        )
+    else:
+        fields.append(
+            {
+                "id": "area",
+                "text": "Primary code area? (path or name)",
+                "type": "text_input",
+                "required": True,
+            }
+        )
+    fields.append(
+        {
+            "id": "slug",
+            "text": "Spec slug (optional — leave blank to derive one)",
+            "type": "text_input",
+            "required": False,
+            "help_text": "kebab-case directory name under docs/specs/.",
+        }
+    )
+    return form_from_dict(
+        {
+            "title": "New spec intake",
+            "description": "Frame the spec before brainstorming: outcome, acceptance, area.",
+            "fields": fields,
+        }
+    )
+
+
+@pytest.mark.parametrize("areas", [["src/attune/agents", "src/attune/ops"], []])
+def test_spec_template_matches_shipped_hand_shape(areas) -> None:
+    assert spec_intake.build_spec_intake_form(areas) == _hand_spec_form(areas)
+
+
+# ---------------------------------------------------------------
+# Ruled build-time boundaries
+# ---------------------------------------------------------------
+
+
+def test_unknown_provider_rejected() -> None:
+    t = FormTemplate("T", "d", [FieldSlot(key="x", text="x?", provider="nope")])
+    with pytest.raises(TemplateError, match="unknown provider"):
+        validate_template(t)
+
+
+def test_other_or_fallback_without_provider_rejected() -> None:
+    t = FormTemplate("T", "d", [FieldSlot(key="x", text="x?", other="other")])
+    with pytest.raises(TemplateError, match="require a provider"):
+        validate_template(t)
+
+
+@dataclass
+class _FakeSchema:
+    required_fields: dict
+    optional_fields: dict
+
+
+class _FakeWorkflow:
+    input_schema = _FakeSchema(
+        required_fields={"goal": str},
+        optional_fields={"paths": list},
+    )
+
+
+def test_bound_template_tighten_only_and_list_rules(monkeypatch) -> None:
+    import attune.workflows as workflows_pkg
+
+    monkeypatch.setattr(workflows_pkg, "get_workflow", lambda name: _FakeWorkflow)
+    loosened = FormTemplate(
+        "T", "d", [FieldSlot(key="goal", text="g?", required=False)], workflow="fake"
+    )
+    with pytest.raises(TemplateError, match="tighten-only"):
+        validate_template(loosened)
+    unprovided_list = FormTemplate("T", "d", [FieldSlot(key="paths", text="p?")], workflow="fake")
+    with pytest.raises(TemplateError, match="no provider"):
+        validate_template(unprovided_list)
+    tightened = FormTemplate(
+        "T",
+        "d",
+        [FieldSlot(key="goal", text="g?", required=True)],
+        workflow="fake",
+    )
+    validate_template(tightened)
+
+
+# ---------------------------------------------------------------
+# Overrides, prefill, and the template-less demand fallback
+# ---------------------------------------------------------------
+
+
+def test_override_bypasses_provider_and_provider_runs_otherwise() -> None:
+    calls: list[str] = []
+
+    def _prov(ctx: ProviderContext) -> list[str]:
+        calls.append("ran")
+        return ["a", "b"]
+
+    PROVIDERS["_test_prov"] = _prov
+    try:
+        t = FormTemplate("T", "d", [FieldSlot(key="x", text="x?", provider="_test_prov")])
+        overridden = build_form(t, _CTX, candidates_override={"x": ["z"]})
+        assert overridden.questions[0].options == ["z"]
+        assert calls == []
+        live = build_form(t, _CTX)
+        assert live.questions[0].options == ["a", "b"]
+        assert calls == ["ran"]
+    finally:
+        del PROVIDERS["_test_prov"]
+
+
+def test_prefill_is_exact_key_match_only() -> None:
+    t = FormTemplate("T", "d", [FieldSlot(key="goal", text="g?")])
+    ctx = ProviderContext(repo_root=Path("/nonexistent"), answered={"goal": "fix the boundary"})
+    form = build_form(t, ctx)
+    assert form.questions[0].default == "fix the boundary"
+    unrelated = ProviderContext(repo_root=Path("/nonexistent"), answered={"goal_hint": "not this"})
+    assert build_form(t, unrelated).questions[0].default is None
+
+
+def test_template_less_intake_returns_none_and_marks_demand() -> None:
+    assert "no-such-intake" not in TEMPLATES
+    assert intake_form("no-such-intake", invocation_text="do a thing") is None
+
+
+def test_registered_intakes_resolve_via_intake_form(tmp_path: Path) -> None:
+    form = intake_form("fix", repo_root=tmp_path)
+    assert form is not None
+    assert [q.id for q in form.questions] == ["request", "scope", "probes", "mode"]
+    spec_form = intake_form("spec-intake", repo_root=tmp_path)
+    assert spec_form is not None
+    assert [q.id for q in spec_form.questions][0] == "outcome"


### PR DESCRIPTION
Two chair-gated tasks of workflow-intake-forms, executed tonight on the chair's /spec go and the Phase 2 roundtable ruling (spec decisions.md D1 + D2):

**Task 3 — shared form theme** (`theme.py` as the ONE tracked CSS source; fallbacks on all var() refs; widget imports the same objects keeping family subsets; ops serves the byte-equal `/static/form-theme.css`; budget chair-amended 4→6 KB with the 5,574 B measurement in D1).

**Phase 2a — FormTemplate + provider layer** (roundtable `q-intake-forms-phase2-design-001`, 3 seats, chair rulings in D2): declarative FieldSlot/FormTemplate with ruled build-time rejections (tighten-only, list-needs-provider, prefill exact-match only); fix + spec intakes re-expressed as templates, derivations registered as plain providers; hand form-building deleted same-PR with CLI seams and public APIs unchanged; template-less → free-text + demand-telemetry marker (the chair's merge of the 2-1 split); cache-free v1.

Receipts: 347 passed `tests/unit/elicitation/` — 6 theme tests + 12 template tests (structural-equality goldens copied verbatim from the deleted hand construction; both candidate branches parametrized) with the pre-existing 20 intake behavioral pins untouched; live `/fix` derive field-identical through the template path.

Note for the record: Phase 2a landed on this branch rather than its own (lead oversight, disclosed) — kept as one PR since both tasks are the same spec and surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)