### PR TITLE
fix(elicitation): intake_form lazily loads builtin templates on cold import

### DIFF
--- a/src/attune/elicitation/intake_template.py
+++ b/src/attune/elicitation/intake_template.py
@@ -214,6 +214,20 @@ def build_form(
 TEMPLATES: dict[str, FormTemplate] = {}
 
 
+def _ensure_builtin_templates() -> None:
+    """Import the modules that register the built-in templates.
+
+    Registration is an import-time side effect of the intake
+    modules; a cold caller importing only THIS module would
+    otherwise see an empty registry and log a FALSE demand marker
+    for "fix" (caught live 2026-08-01, first cold sweep after
+    #1843). Lazy import here breaks the would-be cycle
+    (fix_intake imports this module for delegation).
+    """
+    import attune.elicitation.fix_intake  # noqa: F401
+    import attune.elicitation.spec_intake  # noqa: F401
+
+
 def intake_form(
     name: str,
     invocation_text: str = "",
@@ -227,6 +241,7 @@ def intake_form(
     — and the demand marker below is the telemetry that makes slot
     authoring demand-driven.
     """
+    _ensure_builtin_templates()
     template = TEMPLATES.get(name)
     if template is None:
         logger.info(

--- a/tests/unit/elicitation/test_intake_template.py
+++ b/tests/unit/elicitation/test_intake_template.py
@@ -264,6 +264,31 @@ def test_template_less_intake_returns_none_and_marks_demand() -> None:
     assert intake_form("no-such-intake", invocation_text="do a thing") is None
 
 
+def test_cold_import_resolves_builtin_templates(tmp_path: Path) -> None:
+    """Regression (2026-08-01): a process importing ONLY
+    intake_template must still resolve 'fix' — registration is an
+    import side effect of the intake modules, lazily ensured."""
+    import subprocess
+    import sys
+
+    code = (
+        "from attune.elicitation.intake_template import intake_form\n"
+        "from pathlib import Path\n"
+        "form = intake_form('fix', repo_root=Path('.'))\n"
+        "assert form is not None, 'cold import lost builtin templates'\n"
+        "print('cold-ok')\n"
+    )
+    proc = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+        cwd=tmp_path,
+        timeout=60,
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert "cold-ok" in proc.stdout
+
+
 def test_registered_intakes_resolve_via_intake_form(tmp_path: Path) -> None:
     form = intake_form("fix", repo_root=tmp_path)
     assert form is not None


### PR DESCRIPTION
Caught live this morning: `templates registered: []` on a cold sweep — registration was an import side effect of fix_intake/spec_intake, so importing only `intake_template` returned None for 'fix' and logged a false demand marker. `_ensure_builtin_templates()` lazily imports both (no cycle: they import this module, not vice versa at module level). Subprocess cold-import regression test pins it. 348 elicitation tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)