### PR TITLE
docs(lessons): EOD batch 7 — import-side-effect registries emit false signal on cold miss

### DIFF
--- a/.claude/lessons.md
+++ b/.claude/lessons.md
@@ -20575,3 +20575,26 @@ def ", start_idx + 1)` for module-
   finding), not how the system behaves — verify against the tree
   before writing machinery, and record the dissolved concern as
   design text so the next cold reader doesn't re-raise it.
+
+- **A registry populated by IMPORT SIDE EFFECT is invisible to any
+  caller who imports only the registry module — and when the miss
+  path emits telemetry, the bug ships FALSE SIGNAL, not just a
+  miss**: 2026-08-01, first cold sweep after #1843. `TEMPLATES`
+  lived in `intake_template.py` but was populated when
+  `fix_intake`/`spec_intake` were imported; a process importing
+  only the registry module got `intake_form("fix") -> None` AND a
+  false `template_missing` demand marker — the very telemetry
+  meant to rank real demand would have logged phantom asks for a
+  template that exists. All prior tests passed because the test
+  FILE imported the registering modules (the registration was an
+  accident of test-module imports, invisible to the suite). Fix
+  (#1845): `_ensure_builtin_templates()` lazily imports the
+  registering modules at the read seam; regression test runs a
+  SUBPROCESS importing only the registry module. Rules: (1) a
+  side-effect-populated registry needs an ensure-loaded call at
+  its READ seam, or explicit registration — never "someone will
+  have imported it"; (2) test cold paths in a subprocess, since
+  in-process tests inherit the test module's own imports; (3)
+  audit what the MISS path emits — a miss that produces data
+  (telemetry, defaults, empty-but-valid results) turns a loading
+  bug into corrupted signal.

--- a/tests/unit/workflows/discovery_sweep/test_event_sink.py
+++ b/tests/unit/workflows/discovery_sweep/test_event_sink.py
@@ -215,9 +215,16 @@ class TestSinkFaultTolerance:
         t0 = asyncio.get_event_loop().time()
         await wf.execute(path="src/", sources=[src], event_sink=slow_sink, sweep_id="r")
         elapsed = asyncio.get_event_loop().time() - t0
+        sink_event.set()  # release parked sink tasks promptly
 
-        # Sweep must finish promptly even though sinks are still waiting.
-        assert elapsed < 1.0, f"sweep took {elapsed:.3f}s, expected <1s"
+        # Sweep must finish while sinks are still waiting. The bound
+        # distinguishes REGIMES, not speed: inline-awaited delivery
+        # would take ~10s (the sink's wait), fire-and-forget takes
+        # well under a second on a quiet machine — but a loaded CI
+        # runner was measured at 1.578s (windows-latest under xdist,
+        # 2026-08-01), so a 1.0s bound flaked without any blocking.
+        # 5.0s keeps ≥2x margin against both regimes.
+        assert elapsed < 5.0, f"sweep took {elapsed:.3f}s, expected well under the sink's 10s wait"
 
         # Release the still-pending sink tasks so the test loop exits
         # cleanly without a "Task was destroyed but it is pending"


### PR DESCRIPTION
One from the morning sweep: a side-effect-populated registry needs an ensure-loaded call at its read seam, cold paths need subprocess tests, and a miss path that emits telemetry converts a loading bug into corrupted signal (#1845's cold-import fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)