### PR TITLE
test(roundtable): triage_appendix 81.8%→100% — coverage lane

### DIFF
--- a/tests/unit/roundtable/test_triage_appendix.py
+++ b/tests/unit/roundtable/test_triage_appendix.py
@@ -7,6 +7,8 @@ run real. No network, no Redis, no LLM.
 
 from __future__ import annotations
 
+import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -252,3 +254,199 @@ class TestEvidenceTiers:
         monkeypatch.setattr(ta, "_ci_gate_verdicts", lambda root: [])
         candidates, _dark, _extra = ta.pull_briefing(tmp_path)
         assert candidates and all(c.evidence_kind == "receipt" for c in candidates)
+
+
+class TestDefaultStatePath:
+    """The unpathed state API resolves under ATTUNE_HOME."""
+
+    def test_default_path_round_trips_under_attune_home(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("ATTUNE_HOME", str(tmp_path))
+        ta.record_digest("t-default", 2)
+        assert (tmp_path / "ops" / "triage_appendix.json").is_file()
+        assert ta.record_rulings("t-default", 1) is True
+        assert ta.is_demoted() is False
+
+
+class TestStateTolerance:
+    """Corrupt or foreign state degrades to empty — never raises."""
+
+    def test_malformed_json_degrades_to_empty(self, state, caplog):
+        state.write_text("{not json", encoding="utf-8")
+        with caplog.at_level("WARNING", logger="attune.roundtable.triage_appendix"):
+            assert ta._load_state(state) == {"digests": []}
+        assert "unreadable state" in caplog.text
+
+    def test_non_dict_json_degrades_to_empty(self, state):
+        state.write_text('["a", "b"]', encoding="utf-8")
+        assert ta._load_state(state) == {"digests": []}
+
+    def test_record_rulings_non_list_digests_returns_false(self, state):
+        state.write_text('{"digests": "nope"}', encoding="utf-8")
+        assert ta.record_rulings("t1", 2, path=state) is False
+
+
+class TestPullBriefingUnreadableSource:
+    """A raising source reader becomes UNREADABLE evidence, not a crash."""
+
+    def test_raising_source_reported_and_others_still_read(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("ATTUNE_HOME", str(tmp_path / "home"))
+        real_import = ta.importlib.import_module
+
+        def fake_import(name):
+            if name.endswith(".bulletin"):
+                raise RuntimeError("reader exploded")
+            return real_import(name)
+
+        monkeypatch.setattr(ta.importlib, "import_module", fake_import)
+        monkeypatch.setattr(ta, "_ci_gate_verdicts", lambda root: [])
+        candidates, _dark, extra = ta.pull_briefing(tmp_path)
+        assert any(
+            line.startswith("source bulletin: UNREADABLE") and "reader exploded" in line
+            for line in extra
+        )
+        # The routine survived and still appended the standing evidence lines.
+        assert any("local spend" in line for line in extra)
+
+
+class TestRunGh:
+    """_run_gh: fixed argv, degrades to coded reasons, never raises."""
+
+    def test_missing_binary_returns_127(self, tmp_path):
+        code, reason = ta._run_gh(["attune-no-such-binary-xyz"], tmp_path)
+        assert code == 127
+        assert reason == "gh not found"
+
+    def test_timeout_returns_124(self, tmp_path, monkeypatch):
+        def raise_timeout(*args, **kwargs):
+            raise subprocess.TimeoutExpired(cmd="gh", timeout=30)
+
+        monkeypatch.setattr(subprocess, "run", raise_timeout)
+        code, reason = ta._run_gh(["gh", "api", "x"], tmp_path)
+        assert code == 124
+        assert reason == "gh timed out"
+
+    def test_success_returns_stdout(self, tmp_path):
+        code, out = ta._run_gh([sys.executable, "-c", "print('ok')"], tmp_path)
+        assert code == 0
+        assert out == "ok"
+
+    def test_failure_returns_stderr(self, tmp_path):
+        code, out = ta._run_gh(
+            [sys.executable, "-c", "import sys; sys.stderr.write('bad'); sys.exit(3)"],
+            tmp_path,
+        )
+        assert code == 3
+        assert out == "bad"
+
+
+class TestCiGateVerdictsApiFailure:
+    def test_api_error_renders_timestamped_unavailable(self, tmp_path):
+        def runner(argv, cwd):
+            if "repo" in argv:
+                return 0, "o/r"
+            return 1, "api down"
+
+        (line,) = ta._ci_gate_verdicts(tmp_path, runner=runner)
+        assert "unavailable" in line
+        assert "api down" in line
+        assert "checked" in line
+
+
+class TestGateLedgerEvidence:
+    """Real ledger round trip under a tmp ATTUNE_HOME — no mocks."""
+
+    def _receipt(self, state: str, gate_id: str = "G-test", decisions_ref=None):
+        from attune.gates.lifecycle.protocol import GateReceipt
+
+        return GateReceipt(
+            gate_id=gate_id,
+            phase="execution",
+            target="spec-x",
+            state=state,
+            decisions_ref=decisions_ref,
+        )
+
+    def test_unresolved_chair_required_named(self, tmp_path, monkeypatch):
+        from attune.gates.lifecycle import ledger
+
+        monkeypatch.setenv("ATTUNE_HOME", str(tmp_path))
+        ledger.append(self._receipt("CHAIR_REQUIRED"))
+        (line,) = ta._gate_ledger_evidence()
+        assert "1 unresolved CHAIR_REQUIRED receipt(s)" in line
+        assert "G-test:spec-x" in line
+
+    def test_present_ledger_without_unresolved(self, tmp_path, monkeypatch):
+        from attune.gates.lifecycle import ledger
+
+        monkeypatch.setenv("ATTUNE_HOME", str(tmp_path))
+        ledger.append(self._receipt("PASS"))
+        (line,) = ta._gate_ledger_evidence()
+        assert line == "gate verdict ledger: present, no unresolved CHAIR_REQUIRED receipts"
+
+    def test_no_ledger_file_renders_dark(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("ATTUNE_HOME", str(tmp_path))
+        (line,) = ta._gate_ledger_evidence()
+        assert line.startswith("gate verdict ledger: dark")
+
+    def test_raising_ledger_renders_unreadable(self, tmp_path, monkeypatch):
+        from attune.gates.lifecycle import ledger
+
+        def boom():
+            raise OSError("disk gone")
+
+        monkeypatch.setattr(ledger, "ledger_path", boom)
+        (line,) = ta._gate_ledger_evidence()
+        assert "UNREADABLE" in line
+        assert "disk gone" in line
+
+
+class TestUsageFreshness:
+    def test_missing_usage_renders_dark(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("ATTUNE_HOME", str(tmp_path))
+        assert ta._usage_freshness_evidence() == "local spend: dark (no usage.jsonl)"
+
+    def test_fresh_usage_reports_age(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("ATTUNE_HOME", str(tmp_path))
+        usage = tmp_path / "telemetry" / "usage.jsonl"
+        usage.parent.mkdir(parents=True)
+        usage.write_text("{}\n", encoding="utf-8")
+        line = ta._usage_freshness_evidence()
+        assert line == "local spend: usage.jsonl last write 0h ago"
+
+
+class TestRunSubCapAndSynthesisFailure:
+    def _items(self):
+        return [ta.TriageItem("drifted-spec", "evidence", "disposition?")]
+
+    def test_sub_cap_halts_before_fourth_seat(self, state, tmp_path, monkeypatch):
+        monkeypatch.setattr(ta, "pull_briefing", lambda root: (self._items(), [], []))
+        recipes = tuple((seat, ("cmd", seat)) for seat in ("a", "b", "c", "d"))
+        board = StubBoard()
+        used = ta.run_triage_appendix(board, "t", tmp_path, _ok_seat, recipes, state_path=state)
+        kinds = [m["kind"] for m in board.messages]
+        assert kinds == ["question", "position", "position", "position", "halt", "synthesis"]
+        halt = board.messages[4]
+        assert halt["body"] == "appendix invocation sub-cap before seat 'd'"
+        assert used == ta.APPENDIX_MAX_INVOCATIONS
+
+    def test_synthesis_failure_posts_halt(self, state, tmp_path, monkeypatch, capsys):
+        monkeypatch.setattr(ta, "pull_briefing", lambda root: (self._items(), [], []))
+
+        def seat_ok_synthesis_fails(recipe, brief):
+            if brief.startswith("You are the moderator"):
+                return 1, "synthesis exploded"
+            return 0, "ITEM 1: recommendation."
+
+        board = StubBoard()
+        used = ta.run_triage_appendix(
+            board, "t", tmp_path, seat_ok_synthesis_fails, RECIPES, state_path=state
+        )
+        kinds = [m["kind"] for m in board.messages]
+        assert kinds == ["question", "position", "halt"]
+        assert "appendix synthesis failed (exit 1)" in board.messages[2]["body"]
+        assert "synthesis exploded" in board.messages[2]["body"]
+        assert used == 2
+        assert "synthesis: FAILED (exit 1)" in capsys.readouterr().out
+        # The failed-synthesis run still records its digest (T4 input).
+        digests = ta._load_state(state)["digests"]
+        assert digests[-1]["items"] == 1


### PR DESCRIPTION
Tests-only coverage lane (brief 4). Lane receipts re-run centrally: suite 315 passed serial; module 192 stmts, 0 missed, 100%. Real gate-ledger round trips under tmp ATTUNE_HOME (not mocks); corrupt-state degradation, UNREADABLE evidence rendering, gh-binary 127/timeout-124 mapping, invocation sub-cap halt, synthesis-failure halt all pinned. No production bugs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)