### PR TITLE
test(learning): storage 80.7%→100% — coverage lane

### DIFF
--- a/tests/learning/test_storage.py
+++ b/tests/learning/test_storage.py
@@ -399,3 +399,201 @@ class TestLearnedSkillsStorage:
             assert "## Learned Patterns" in context
             assert "TypeError" in context
             assert "Error Resolution" in context
+
+
+def _make_pattern(
+    trigger: str = "TypeError",
+    resolution: str = "Add null check",
+    category: PatternCategory = PatternCategory.ERROR_RESOLUTION,
+    confidence: float = 0.8,
+) -> ExtractedPattern:
+    """Build a minimal ExtractedPattern for storage tests."""
+    return ExtractedPattern(
+        category=category,
+        trigger=trigger,
+        context="ctx",
+        resolution=resolution,
+        confidence=confidence,
+        source_session="test-session",
+    )
+
+
+def _make_skill(
+    skill_id: str = "skill-001",
+    name: str = "Skill",
+    created_at: datetime | None = None,
+) -> LearnedSkill:
+    """Build a minimal LearnedSkill for storage tests."""
+    kwargs = {}
+    if created_at is not None:
+        kwargs["created_at"] = created_at
+    return LearnedSkill(
+        skill_id=skill_id,
+        name=name,
+        description="desc",
+        category=PatternCategory.CODE_PATTERN,
+        patterns=[],
+        confidence=0.7,
+        **kwargs,
+    )
+
+
+class TestPatternEdgeCases:
+    """Edge-case behavior for pattern operations."""
+
+    def test_save_duplicate_pattern_updates_in_place(self, tmp_path):
+        """Re-saving a pattern with the same ID replaces it, not appends."""
+        storage = LearnedSkillsStorage(storage_dir=tmp_path)
+
+        first = _make_pattern(confidence=0.5)
+        second = _make_pattern(confidence=0.9)  # same trigger/resolution => same ID
+        assert first.pattern_id == second.pattern_id
+
+        storage.save_pattern("user1", first)
+        storage.save_pattern("user1", second)
+
+        patterns = storage.get_all_patterns("user1")
+        assert len(patterns) == 1
+        assert patterns[0].confidence == 0.9
+
+    def test_delete_pattern_missing_returns_false(self, tmp_path):
+        """Deleting a nonexistent pattern returns False and keeps the rest."""
+        storage = LearnedSkillsStorage(storage_dir=tmp_path)
+        storage.save_pattern("user1", _make_pattern())
+
+        assert storage.delete_pattern("user1", "no-such-id") is False
+        assert len(storage.get_all_patterns("user1")) == 1
+
+    def test_corrupt_patterns_file_returns_empty(self, tmp_path):
+        """A corrupt patterns.json is tolerated and reads as no patterns."""
+        storage = LearnedSkillsStorage(storage_dir=tmp_path)
+        storage.save_pattern("user1", _make_pattern())
+
+        patterns_file = tmp_path / "user1" / "patterns.json"
+        patterns_file.write_text("{not valid json", encoding="utf-8")
+
+        assert storage.get_all_patterns("user1") == []
+
+
+class TestSkillEdgeCases:
+    """Edge-case behavior for skill operations."""
+
+    def test_save_duplicate_skill_updates_in_place(self, tmp_path):
+        """Re-saving a skill with the same ID replaces it, not appends."""
+        storage = LearnedSkillsStorage(storage_dir=tmp_path)
+
+        storage.save_skill("user1", _make_skill(name="Old Name"))
+        storage.save_skill("user1", _make_skill(name="New Name"))
+
+        skills = storage.get_all_skills("user1")
+        assert len(skills) == 1
+        assert skills[0].name == "New Name"
+
+    def test_max_skills_limit_keeps_newest(self, tmp_path):
+        """Saving beyond max_skills_per_user drops the oldest skills."""
+        storage = LearnedSkillsStorage(storage_dir=tmp_path, max_skills_per_user=2)
+
+        storage.save_skill("user1", _make_skill("s-old", created_at=datetime(2026, 1, 1)))
+        storage.save_skill("user1", _make_skill("s-mid", created_at=datetime(2026, 2, 1)))
+        storage.save_skill("user1", _make_skill("s-new", created_at=datetime(2026, 3, 1)))
+
+        skills = storage.get_all_skills("user1")
+        assert len(skills) == 2
+        assert {s.skill_id for s in skills} == {"s-mid", "s-new"}
+
+    def test_get_skill_missing_returns_none(self, tmp_path):
+        """Looking up an unknown skill ID returns None."""
+        storage = LearnedSkillsStorage(storage_dir=tmp_path)
+        storage.save_skill("user1", _make_skill("s-exists"))
+
+        assert storage.get_skill("user1", "s-missing") is None
+
+    def test_delete_skill_existing_returns_true(self, tmp_path):
+        """Deleting an existing skill removes it and returns True."""
+        storage = LearnedSkillsStorage(storage_dir=tmp_path)
+        storage.save_skill("user1", _make_skill("s-1"))
+
+        assert storage.delete_skill("user1", "s-1") is True
+        assert storage.get_all_skills("user1") == []
+
+    def test_delete_skill_missing_returns_false(self, tmp_path):
+        """Deleting a nonexistent skill returns False, leaving others intact."""
+        storage = LearnedSkillsStorage(storage_dir=tmp_path)
+        storage.save_skill("user1", _make_skill("s-1"))
+
+        assert storage.delete_skill("user1", "s-missing") is False
+        assert len(storage.get_all_skills("user1")) == 1
+
+    def test_corrupt_skills_file_returns_empty(self, tmp_path):
+        """A corrupt skills.json is tolerated and reads as no skills."""
+        storage = LearnedSkillsStorage(storage_dir=tmp_path)
+        storage.save_skill("user1", _make_skill("s-1"))
+
+        skills_file = tmp_path / "user1" / "skills.json"
+        skills_file.write_text("[truncated", encoding="utf-8")
+
+        assert storage.get_all_skills("user1") == []
+
+
+class TestClearUserDataEdgeCases:
+    """Edge-case behavior for clear_user_data."""
+
+    def test_clear_skips_corrupt_file_and_keeps_dir(self, tmp_path):
+        """A corrupt JSON file is skipped (not deleted) and the dir survives."""
+        storage = LearnedSkillsStorage(storage_dir=tmp_path)
+        storage.save_pattern("user1", _make_pattern())
+
+        user_dir = tmp_path / "user1"
+        corrupt = user_dir / "extra.json"
+        corrupt.write_text("{broken", encoding="utf-8")
+
+        count = storage.clear_user_data("user1")
+
+        assert count == 1  # only the valid pattern was counted
+        assert not (user_dir / "patterns.json").exists()
+        assert corrupt.exists()  # skipped, not deleted
+        assert user_dir.exists()  # rmdir failed on non-empty dir, tolerated
+
+    def test_clear_missing_user_returns_zero(self, tmp_path):
+        """Clearing a user with no data returns 0."""
+        storage = LearnedSkillsStorage(storage_dir=tmp_path)
+
+        assert storage.clear_user_data("ghost") == 0
+
+
+class TestFormatPatternsEdgeCases:
+    """Edge-case behavior for format_patterns_for_context."""
+
+    def test_category_filter_limits_output(self, tmp_path):
+        """Only patterns in the requested categories are formatted."""
+        storage = LearnedSkillsStorage(storage_dir=tmp_path)
+        storage.save_pattern("user1", _make_pattern(trigger="TypeError"))
+        storage.save_pattern(
+            "user1",
+            _make_pattern(
+                trigger="prefers tables",
+                resolution="use markdown tables",
+                category=PatternCategory.PREFERENCE,
+            ),
+        )
+
+        context = storage.format_patterns_for_context(
+            "user1",
+            categories=[PatternCategory.PREFERENCE],
+        )
+
+        assert "prefers tables" in context
+        assert "TypeError" not in context
+
+    def test_no_matching_patterns_returns_empty_string(self, tmp_path):
+        """No patterns (or none after filtering) yields an empty string."""
+        storage = LearnedSkillsStorage(storage_dir=tmp_path)
+
+        assert storage.format_patterns_for_context("nobody") == ""
+
+        storage.save_pattern("user1", _make_pattern())
+        filtered = storage.format_patterns_for_context(
+            "user1",
+            categories=[PatternCategory.WORKAROUND],
+        )
+        assert filtered == ""


### PR DESCRIPTION
Tests-only coverage lane (brief 6). Central re-run: suite 59 passed serial; module 192 stmts, 0 missed, 100%. All storage roots under tmp_path (no real ~/.attune contact). Corrupt-JSON tolerance on both load paths, max-skills trim, clear_user_data corrupt-file skip + rmdir tolerance pinned. One design observation recorded (corrupt file makes user dir unremovable — tolerated behavior, now pinned by test). No production bugs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)