### PR TITLE
test(authoring): ground_truth public_api 75.2%→100% — coverage lane (Sonnet)

### DIFF
--- a/tests/unit/authoring/ground_truth/test_public_api.py
+++ b/tests/unit/authoring/ground_truth/test_public_api.py
@@ -144,3 +144,145 @@ def test_module_label_includes_parent_dir(tmp_path: Path) -> None:
     result = extract_public_api([src])
 
     assert "# feature_pkg.core" in result
+
+
+def test_signature_features_posonly_vararg_kwonly_kwarg(tmp_path: Path) -> None:
+    # Exercises the positional-only marker, *args, the keyword-only loop
+    # (with and without a default), and **kwargs formatting in one pass.
+    src = _write(
+        tmp_path,
+        "module.py",
+        """
+        def f_kitchen_sink(a, b, /, c, *args, d, e=2, **kwargs) -> None:
+            pass
+        """,
+    )
+
+    result = extract_public_api([src])
+
+    assert "def f_kitchen_sink(a, b, /, c, *args, d, e = 2, **kwargs) -> None" in result
+
+
+def test_ast_unparse_failure_falls_back_to_ellipsis(tmp_path: Path, monkeypatch) -> None:
+    # Defensive fallback: if ast.unparse ever raises on a well-formed node
+    # (annotation, default, or return type), each call site substitutes
+    # "..." rather than propagating. Also exercises the bare "*" marker
+    # for keyword-only args with no vararg.
+    src = _write(
+        tmp_path,
+        "module.py",
+        """
+        def f(x: int = 1, *, y: str = "a") -> bool:
+            return True
+        """,
+    )
+
+    monkeypatch.setattr(
+        "attune.authoring.ground_truth.public_api.ast.unparse",
+        lambda node: (_ for _ in ()).throw(ValueError("boom")),
+    )
+
+    result = extract_public_api([src])
+
+    assert "def f(x: ... = ..., *, y: ... = ...) -> ..." in result
+
+
+def test_non_dunder_all_assignment_is_skipped(tmp_path: Path) -> None:
+    src = _write(
+        tmp_path,
+        "module.py",
+        """
+        SOME_CONST = 5
+
+        def public_thing():
+            pass
+        """,
+    )
+
+    result = extract_public_api([src])
+
+    assert "def public_thing()" in result
+    assert "__all__" not in result
+    assert "SOME_CONST" not in result
+
+
+def test_private_class_is_skipped(tmp_path: Path) -> None:
+    src = _write(
+        tmp_path,
+        "module.py",
+        """
+        class _Hidden:
+            def method(self):
+                pass
+
+        def marker():
+            pass
+        """,
+    )
+
+    result = extract_public_api([src])
+
+    assert "marker" in result
+    assert "_Hidden" not in result
+
+
+def test_unreadable_file_is_skipped(tmp_path: Path) -> None:
+    missing = tmp_path / "missing.py"  # never written -> read_text() raises OSError
+    good = _write(
+        tmp_path,
+        "good.py",
+        """
+        def working() -> None:
+            pass
+        """,
+    )
+
+    result = extract_public_api([missing, good])
+
+    assert "working" in result
+
+
+def test_module_label_drops_src_parent_segment(tmp_path: Path) -> None:
+    sub = tmp_path / "src"
+    sub.mkdir()
+    src = sub / "core.py"
+    src.write_text("def thing(): pass\n", encoding="utf-8")
+
+    result = extract_public_api([src])
+
+    assert "# core" in result
+    assert "# src.core" not in result
+
+
+def test_class_with_no_public_methods_has_no_body(tmp_path: Path) -> None:
+    src = _write(
+        tmp_path,
+        "module.py",
+        """
+        class Empty:
+            pass
+        """,
+    )
+
+    result = extract_public_api([src])
+
+    assert "class Empty" in result
+    assert "class Empty:\n" not in result
+
+
+def test_file_with_no_public_symbols_is_skipped(tmp_path: Path) -> None:
+    empty = _write(tmp_path, "constants.py", "TIMEOUT = 30\n")
+    good = _write(
+        tmp_path,
+        "module.py",
+        """
+        def public_thing():
+            pass
+        """,
+    )
+
+    result = extract_public_api([empty, good])
+
+    assert "public_thing" in result
+    assert "constants" not in result
+    assert "TIMEOUT" not in result


### PR DESCRIPTION
Tests-only coverage lane (brief 10, wave 3). Central re-run by the lead: suite 16 passed serial; module 121 stmts, 0 missed, 100%. Behavioral black-box tests via extract_public_api's text output; ast.unparse defensive handlers exercised via monkeypatch (no natural trigger exists — correct defensive code, not a bug). Three suite-interaction-covered lines now covered standalone. No production bugs; no unreachable regions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)