### PR TITLE
test(authoring): fact_check cli_refs 74.4%→97% — coverage lane (Sonnet)

### DIFF
--- a/tests/unit/authoring/fact_check/test_cli_refs.py
+++ b/tests/unit/authoring/fact_check/test_cli_refs.py
@@ -122,3 +122,74 @@ def test_missing_cli_short_circuits(tmp_path: Path) -> None:
     # (we'd be guessing). The version-coupling messaging is still
     # documented for the call sites that do find flags.
     assert findings == []
+
+
+def test_duplicate_flag_reference_is_deduplicated(tmp_path: Path) -> None:
+    """The same ``(chain, flag)`` pair referenced twice yields ONE
+    finding, not two — exercises the ``seen`` dedup guard."""
+    help_text = "Options:\n  --port INT\n"
+    body = "See `attune ops --bogus` and again `attune ops --bogus` here.\n"
+    with (
+        patch.object(cli_refs.shutil, "which", return_value="/fake/attune"),
+        patch.object(cli_refs.subprocess, "run", return_value=_fake_run(help_text)) as mock_run,
+        patch.object(cli_refs, "_installed_version", return_value="6.8.0"),
+    ):
+        findings = cli_refs.check(_write(tmp_path, body), tmp_path)
+    assert len(findings) == 1
+    # Only one --help probe: the chain is cached, and the dedup guard
+    # skips reprocessing the identical (chain, flag) pair.
+    assert mock_run.call_count == 1
+
+
+def test_resolve_cli_name_malformed_pyproject_returns_default(tmp_path: Path) -> None:
+    """A ``pyproject.toml`` that exists but fails to parse falls back
+    to the ``"attune"`` default rather than raising."""
+    (tmp_path / "pyproject.toml").write_text("not valid = = toml [[[", encoding="utf-8")
+    assert cli_refs._resolve_cli_name(tmp_path) == "attune"
+
+
+def test_installed_version_falls_back_to_cli_flag_on_package_not_found() -> None:
+    """``importlib.metadata.version`` raising ``PackageNotFoundError``
+    falls through to probing ``<cli> --version``."""
+    from importlib.metadata import PackageNotFoundError
+
+    with (
+        patch("importlib.metadata.version", side_effect=PackageNotFoundError()),
+        patch.object(cli_refs.subprocess, "run", return_value=_fake_run("attune-ai 1.2.3\n")),
+    ):
+        result = cli_refs._installed_version("attune")
+    assert result == "attune-ai 1.2.3"
+
+
+def test_installed_version_generic_metadata_error_and_subprocess_failure() -> None:
+    """A non-``PackageNotFoundError`` metadata error is swallowed
+    (INTENTIONAL broad catch) and, when the CLI probe also fails to
+    spawn, the result degrades to ``"unknown"``."""
+    with (
+        patch("importlib.metadata.version", side_effect=RuntimeError("deformed dist-info")),
+        patch.object(cli_refs.subprocess, "run", side_effect=OSError("no such file")),
+    ):
+        result = cli_refs._installed_version("attune")
+    assert result == "unknown"
+
+
+def test_help_text_missing_cli_returns_none_directly() -> None:
+    """``_help_text`` itself short-circuits when the CLI isn't on
+    PATH (exercised directly, since ``check()`` already short-
+    circuits before ever calling it in that scenario)."""
+    with patch.object(cli_refs.shutil, "which", return_value=None):
+        assert cli_refs._help_text("ghost-cli", []) is None
+
+
+def test_help_text_subprocess_error_returns_none() -> None:
+    """A spawn failure or timeout while probing ``--help`` returns
+    ``None`` rather than raising."""
+    with (
+        patch.object(cli_refs.shutil, "which", return_value="/fake/attune"),
+        patch.object(
+            cli_refs.subprocess,
+            "run",
+            side_effect=subprocess.TimeoutExpired(cmd="attune", timeout=5),
+        ),
+    ):
+        assert cli_refs._help_text("attune", []) is None


### PR DESCRIPTION
Tests-only coverage lane (brief 18, wave 5). Central re-run: suite 12 passed serial; module 90 stmts, 3 missed, 97% — all 18 brief-scoped miss lines covered; the 3 residual lines are reachable but out-of-scope and 97% clears the floor with margin (target-honesty clause applied, not chased). TOML-malformed fallback, PackageNotFoundError → CLI --version fallback, subprocess failure → 'unknown', help-text short-circuits all pinned behaviorally. No production bugs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)