### PR TITLE
test(authoring): fact_check numeric_refs 71.2%→97% — coverage lane (Sonnet) + PRODUCTION BUG

### DIFF
--- a/tests/unit/authoring/fact_check/test_numeric_refs.py
+++ b/tests/unit/authoring/fact_check/test_numeric_refs.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from attune.authoring.fact_check import numeric_refs
 from attune.authoring.fact_check.report import CHECK_NUMERIC_REFS
 
@@ -69,3 +71,121 @@ def test_no_help_dir_warns_rather_than_errors(tmp_path: Path) -> None:
     findings = numeric_refs.check(_write(tmp_path, body), tmp_path)
     # No deterministic verifier (or one that returned None) → warning, not error
     assert all(f.severity != "error" for f in findings)
+
+
+def test_missing_templates_dir_warns(tmp_path: Path) -> None:
+    """``.help/`` exists but ``.help/templates/`` does not — ``_count_templates``
+    returns ``None`` and the claim surfaces as a warning, not an error."""
+    (tmp_path / ".help").mkdir()
+    body = "There are 7 templates available.\n"
+    findings = numeric_refs.check(_write(tmp_path, body), tmp_path)
+    assert any(f.severity == "warning" and "7 templates" in f.message for f in findings)
+    assert not any(f.severity == "error" for f in findings)
+
+
+def test_missing_features_yaml_warns(tmp_path: Path) -> None:
+    """``.help/`` exists but ``features.yaml`` does not — ``_count_features``
+    returns ``None`` and the claim surfaces as a warning, not an error."""
+    (tmp_path / ".help").mkdir()
+    body = "Ships with 9 features today.\n"
+    findings = numeric_refs.check(_write(tmp_path, body), tmp_path)
+    assert any(f.severity == "warning" and "9 features" in f.message for f in findings)
+    assert not any(f.severity == "error" for f in findings)
+
+
+def test_features_yaml_invalid_utf8_warns(tmp_path: Path) -> None:
+    """A ``features.yaml`` that isn't valid UTF-8 raises ``UnicodeDecodeError``
+    (a ``ValueError`` subclass) from ``read_text`` — caught and treated as
+    unresolvable rather than propagating."""
+    help_dir = tmp_path / ".help"
+    help_dir.mkdir()
+    (help_dir / "features.yaml").write_bytes(b"\xff\xfe\x00bogus")
+    body = "Tracking 4 features currently.\n"
+    findings = numeric_refs.check(_write(tmp_path, body), tmp_path)
+    assert any(f.severity == "warning" and "4 features" in f.message for f in findings)
+    assert not any(f.severity == "error" for f in findings)
+
+
+def test_features_yaml_top_level_list_warns(tmp_path: Path) -> None:
+    """A ``features.yaml`` whose top level parses to a list (not a mapping)
+    is not a valid features document — ``_count_features`` returns ``None``."""
+    help_dir = tmp_path / ".help"
+    help_dir.mkdir()
+    (help_dir / "features.yaml").write_text("- one\n- two\n", encoding="utf-8")
+    body = "There are 2 features.\n"
+    findings = numeric_refs.check(_write(tmp_path, body), tmp_path)
+    assert any(f.severity == "warning" and "2 features" in f.message for f in findings)
+    assert not any(f.severity == "error" for f in findings)
+
+
+def test_features_yaml_features_key_is_list(tmp_path: Path) -> None:
+    """When ``features:`` maps to a list, the count is the list length."""
+    help_dir = tmp_path / ".help"
+    help_dir.mkdir()
+    (help_dir / "features.yaml").write_text(
+        "features:\n  - alpha\n  - beta\n  - gamma\n", encoding="utf-8"
+    )
+    body = "There are 3 features documented.\n"
+    findings = numeric_refs.check(_write(tmp_path, body), tmp_path)
+    assert not any(f.severity == "error" and "3 features" in f.message for f in findings)
+
+    mismatch_body = "There are 9 features documented.\n"
+    mismatch_findings = numeric_refs.check(_write(tmp_path, mismatch_body), tmp_path)
+    assert any(
+        f.severity == "error" and "actual count is 3" in f.message for f in mismatch_findings
+    )
+
+
+def test_features_yaml_features_key_is_scalar_warns(tmp_path: Path) -> None:
+    """When ``features:`` maps to neither a dict nor a list (a bare scalar),
+    ``_count_features`` cannot derive a count and returns ``None``."""
+    help_dir = tmp_path / ".help"
+    help_dir.mkdir()
+    (help_dir / "features.yaml").write_text("features: 5\n", encoding="utf-8")
+    body = "There are 5 features documented.\n"
+    findings = numeric_refs.check(_write(tmp_path, body), tmp_path)
+    assert any(f.severity == "warning" and "5 features" in f.message for f in findings)
+    assert not any(f.severity == "error" for f in findings)
+
+
+def test_count_kinds_resolves_when_kinds_importable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When ``attune.authoring.source_introspection.KINDS`` is importable
+    and sized, ``_count_kinds`` reports its length and mismatches surface
+    as errors (not warnings)."""
+    from attune.authoring import source_introspection
+
+    monkeypatch.setattr(source_introspection, "KINDS", ["a", "b", "c"], raising=False)
+    body = "Cap is 3 kinds.\n"
+    findings = numeric_refs.check(_write(tmp_path, body), tmp_path)
+    assert not any(f.severity == "error" and "3 kinds" in f.message for f in findings)
+
+    mismatch_body = "Cap is 9 kinds.\n"
+    mismatch_findings = numeric_refs.check(_write(tmp_path, mismatch_body), tmp_path)
+    assert any(
+        f.severity == "error" and "actual count is 3" in f.message for f in mismatch_findings
+    )
+
+
+def test_count_kinds_typeerror_warns(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """When ``KINDS`` is importable but not sized (``len()`` raises
+    ``TypeError``), ``_count_kinds`` falls back to ``None`` and the claim
+    surfaces as a warning rather than raising."""
+    from attune.authoring import source_introspection
+
+    monkeypatch.setattr(source_introspection, "KINDS", object(), raising=False)
+    body = "Cap is 11 kinds.\n"
+    findings = numeric_refs.check(_write(tmp_path, body), tmp_path)
+    assert any(f.severity == "warning" and "11 kinds" in f.message for f in findings)
+    assert not any(f.severity == "error" for f in findings)
+
+
+def test_duplicate_claim_deduped_across_lines(tmp_path: Path) -> None:
+    """The same ``(noun, count)`` claim repeated in the document is only
+    reported once — the ``seen`` set skips subsequent occurrences."""
+    _scaffold_help_tree(tmp_path, template_count=3, feature_count=2)
+    body = "There are 498 templates.\nAgain, 498 templates total.\n"
+    findings = numeric_refs.check(_write(tmp_path, body), tmp_path)
+    matches = [f for f in findings if "498" in f.message]
+    assert len(matches) == 1


### PR DESCRIPTION
Tests-only coverage lane (brief 21, wave 6). Central re-run: suite 13 passed serial; module 73 stmts, 2 missed, 97% (residual = a ValueError guard provably unreachable through the public API — Unicode Nd digits always int()-parse; reported, not chased).

**PRODUCTION BUG (reported, not fixed — lane contract):** `_count_kinds` imports `KINDS` from `attune.authoring.source_introspection` — the symbol does not exist anywhere in the tree (`# type: ignore[attr-defined]` was masking it). The import ALWAYS raises, so the function permanently falls to `except Exception: return None` and every "N kinds" prose claim is silently unverifiable — a fact-checker with a dead check. Bug-log entry follows in the fleet close-out docs PR; small fix pickable post-demo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)