### PR TITLE
fix(ci): clear both Windows-lane tree blockers stalling the merge train

### DIFF
--- a/src/attune/roundtable/triage_appendix.py
+++ b/src/attune/roundtable/triage_appendix.py
@@ -281,10 +281,13 @@ def _usage_freshness_evidence() -> str:
     usage = attune_dir / "telemetry" / "usage.jsonl"
     if not usage.is_file():
         return "local spend: dark (no usage.jsonl)"
-    age_h = (
+    age_s = (
         datetime.datetime.now(datetime.timezone.utc)
         - datetime.datetime.fromtimestamp(usage.stat().st_mtime, tz=datetime.timezone.utc)
-    ).total_seconds() / 3600
+    ).total_seconds()
+    # Filesystem mtime granularity can land ahead of the clock (seen on
+    # Windows), producing a nonsense negative age that renders as "-0h".
+    age_h = max(0.0, age_s) / 3600
     return f"local spend: usage.jsonl last write {age_h:.0f}h ago"
 
 

--- a/tests/unit/help/test_staleness.py
+++ b/tests/unit/help/test_staleness.py
@@ -299,19 +299,23 @@ class TestReadStoredHash:
         help_dir.mkdir()
         assert _read_stored_hash("auth", help_dir) is None
 
-    def test_unreadable_concept_file_returns_none(self, tmp_path: Path) -> None:
+    def test_unreadable_concept_file_returns_none(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """An OSError while reading concept.md degrades to None."""
         help_dir = tmp_path / ".help"
         concept_dir = help_dir / "templates" / "auth"
         concept_dir.mkdir(parents=True)
         concept = concept_dir / "concept.md"
         concept.write_text("---\nsource_hash: abc123\n---\nbody\n", encoding="utf-8")
-        concept.chmod(0o000)
-        try:
-            assert _read_stored_hash("auth", help_dir) is None
-        finally:
-            # Restore permissions so tmp_path cleanup works
-            concept.chmod(0o644)
+
+        # chmod(0o000) can't make a file unreadable on Windows; force the
+        # OSError branch portably instead.
+        def _deny_read(self: Path, *args: object, **kwargs: object) -> str:
+            raise OSError("permission denied")
+
+        monkeypatch.setattr(Path, "read_text", _deny_read)
+        assert _read_stored_hash("auth", help_dir) is None
 
 
 class TestCheckStalenessUnknownFeature:

--- a/tests/unit/roundtable/test_triage_appendix.py
+++ b/tests/unit/roundtable/test_triage_appendix.py
@@ -7,8 +7,10 @@ run real. No network, no Redis, no LLM.
 
 from __future__ import annotations
 
+import os
 import subprocess
 import sys
+import time
 from pathlib import Path
 
 import pytest
@@ -410,6 +412,17 @@ class TestUsageFreshness:
         usage = tmp_path / "telemetry" / "usage.jsonl"
         usage.parent.mkdir(parents=True)
         usage.write_text("{}\n", encoding="utf-8")
+        line = ta._usage_freshness_evidence()
+        assert line == "local spend: usage.jsonl last write 0h ago"
+
+    def test_mtime_ahead_of_clock_clamps_to_zero(self, tmp_path, monkeypatch):
+        """A file mtime slightly ahead of the clock must not render '-0h'."""
+        monkeypatch.setenv("ATTUNE_HOME", str(tmp_path))
+        usage = tmp_path / "telemetry" / "usage.jsonl"
+        usage.parent.mkdir(parents=True)
+        usage.write_text("{}\n", encoding="utf-8")
+        future = time.time() + 30
+        os.utime(usage, (future, future))
         line = ta._usage_freshness_evidence()
         assert line == "local spend: usage.jsonl last write 0h ago"
 


### PR DESCRIPTION
Two tests merged from last night's coverage lanes fail the Windows matrix for **every** PR (docs-only PRs #1890/#1875/#1861 included), stalling the auto-merge train on demo day.

## Blockers cleared

1. **triage_appendix `-0h` flake** (from #1851): `usage.jsonl` age can go fractionally negative when the filesystem mtime lands ahead of the clock (seen on windows-latest), rendering `last write -0h ago`. Fix: clamp age to ≥ 0 in `_usage_freshness_evidence`; regression test sets a future mtime via `os.utime` and asserts `0h ago`.
2. **help/staleness chmod test** (from #1886): `chmod(0o000)` cannot make a file unreadable on Windows, so the OSError branch never fires and the test fails deterministically (`'abc123' is not None`). Fix: force the OSError portably via monkeypatched `Path.read_text`.

## Receipts

- `pytest tests/unit/roundtable/test_triage_appendix.py tests/unit/help/test_staleness.py -p no:xdist` — 71 passed serially.
- Pinned black/ruff pre-flighted clean.

After this merges, the blocked PRs need fresh CI runs against the fixed base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)