### PR TITLE
test(agents): release coverage_agent 82.5%→100% — coverage lane (Sonnet)

### DIFF
--- a/tests/unit/agents/release/test_specialized_agents.py
+++ b/tests/unit/agents/release/test_specialized_agents.py
@@ -128,6 +128,82 @@ class TestTestCoverageAgent:
         assert findings["estimated"] is True
         assert findings["coverage_percent"] >= 80.0  # heuristic for >200 tests
 
+    def test_execute_tier_heuristic_over_500_tests(self):
+        """Heuristic yields 85.0 when test_count > 500."""
+        from attune.agents.release.release_models import Tier
+
+        agent = self._make_agent()
+        big_collect = "\n".join(f"test_foo::test_{i}" for i in range(600))
+
+        def fake_run(cmd, cwd="."):
+            if "--co" in cmd:
+                return (0, big_collect, "")
+            return (0, "no coverage info here", "")
+
+        with patch("attune.agents.release.coverage_agent._run_command", side_effect=fake_run):
+            success, findings = agent._execute_tier(".", Tier.CHEAP)
+
+        assert success is True
+        assert findings["estimated"] is True
+        assert findings["coverage_percent"] == pytest.approx(85.0)
+
+    def test_execute_tier_heuristic_over_100_tests(self):
+        """Heuristic yields 75.0 when 100 < test_count <= 200."""
+        from attune.agents.release.release_models import Tier
+
+        agent = self._make_agent()
+        collect_output = "\n".join(f"test_foo::test_{i}" for i in range(150))
+
+        def fake_run(cmd, cwd="."):
+            if "--co" in cmd:
+                return (0, collect_output, "")
+            return (0, "no coverage info here", "")
+
+        with patch("attune.agents.release.coverage_agent._run_command", side_effect=fake_run):
+            success, findings = agent._execute_tier(".", Tier.CHEAP)
+
+        assert success is True
+        assert findings["estimated"] is True
+        assert findings["coverage_percent"] == pytest.approx(75.0)
+
+    def test_execute_tier_heuristic_over_50_tests(self):
+        """Heuristic yields 60.0 when 50 < test_count <= 100."""
+        from attune.agents.release.release_models import Tier
+
+        agent = self._make_agent()
+        collect_output = "\n".join(f"test_foo::test_{i}" for i in range(75))
+
+        def fake_run(cmd, cwd="."):
+            if "--co" in cmd:
+                return (0, collect_output, "")
+            return (0, "no coverage info here", "")
+
+        with patch("attune.agents.release.coverage_agent._run_command", side_effect=fake_run):
+            success, findings = agent._execute_tier(".", Tier.CHEAP)
+
+        assert success is True
+        assert findings["estimated"] is True
+        assert findings["coverage_percent"] == pytest.approx(60.0)
+
+    def test_execute_tier_heuristic_over_10_tests(self):
+        """Heuristic yields 40.0 when 10 < test_count <= 50."""
+        from attune.agents.release.release_models import Tier
+
+        agent = self._make_agent()
+        collect_output = "\n".join(f"test_foo::test_{i}" for i in range(25))
+
+        def fake_run(cmd, cwd="."):
+            if "--co" in cmd:
+                return (0, collect_output, "")
+            return (0, "no coverage info here", "")
+
+        with patch("attune.agents.release.coverage_agent._run_command", side_effect=fake_run):
+            success, findings = agent._execute_tier(".", Tier.CHEAP)
+
+        assert success is True
+        assert findings["estimated"] is True
+        assert findings["coverage_percent"] == pytest.approx(40.0)
+
     def test_execute_tier_always_returns_true_on_estimated(self):
         """_execute_tier always returns True (quality gate handles threshold)."""
         from attune.agents.release.release_models import Tier


### PR DESCRIPTION
## Summary

Coverage lane: `src/attune/agents/release/coverage_agent.py` 82.5% → 100%.

Added four tests covering the previously-uncovered heuristic branches in
`TestCoverageAgent._execute_tier` (lines 94, 98, 100, 102) — the
`coverage_percent` estimate used when real coverage measurement is
unparseable, keyed off `test_count`:

- `test_count > 500` → 85.0
- `100 < test_count <= 200` → 75.0
- `50 < test_count <= 100` → 60.0
- `10 < test_count <= 50` → 40.0

Tests-only change; no production code modified.

## Receipts

### suite (serial run of tests/unit/agents/release/)

```
$ PYTHONPATH=<worktree>/src /Users/patrickroebuck/attune-ai/.venv/bin/python -m pytest tests/unit/agents/release/ -p no:xdist -o addopts= -q
........................................................................ [ 53%]
..............................................................          [100%]
134 passed in 0.47s
```

### metric (module-only coverage)

```
$ cd /tmp && rm -f .coverage && PYTHONPATH=<worktree>/src PYTEST_ADDOPTS="-p no:xdist -o addopts=" /Users/patrickroebuck/attune-ai/.venv/bin/python -m coverage run --rcfile=/dev/null --source=attune.agents.release.coverage_agent -m pytest <worktree>/tests/unit/agents/release/test_specialized_agents.py -q && /Users/patrickroebuck/attune-ai/.venv/bin/python -m coverage report --rcfile=/dev/null
..........................................                               [100%]
42 passed in 0.29s
Name                                                                     Stmts   Miss  Cover
-------------------------------------------------------------------------------------------
.../src/attune/agents/release/coverage_agent.py                            57      0   100%
-------------------------------------------------------------------------------------------
TOTAL                                                                       57      0   100%
```

## Test plan

- [x] New tests added for uncovered heuristic branches
- [x] Full release-agents test directory run serially, all green
- [x] Module coverage re-measured in isolation: 100%
- [x] black + ruff pre-flighted clean before staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)
