### PR TITLE
fix(ops): survive non-blocking stdout in run-meta emission — succeeded runs no longer exit 1

### DIFF
--- a/src/attune/cli_commands/workflow_commands.py
+++ b/src/attune/cli_commands/workflow_commands.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import json
 import logging
 import re
+import sys
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -465,12 +466,19 @@ def _emit_run_meta_for_daemon(result: object) -> None:
     # Emit version line first so the parser knows what grammar it's
     # reading. Cheap; downstream consumer ignores it after the version
     # check.
-    run_meta_stdout.emit_version_line()
-    if kind:
-        run_meta_stdout.emit_field_line("sdk_error_kind", str(kind))
-    if stderr_text:
-        encoded = run_meta_stdout.encode_stderr(str(stderr_text))
-        if encoded:
-            run_meta_stdout.emit_field_line("sdk_stderr_b64", encoded)
-    if report_encoded:
-        run_meta_stdout.emit_field_line("report_b64", report_encoded)
+    #
+    # Emission is daemon-side plumbing on top of an already-produced
+    # result — a pipe failure here (EPIPE, non-blocking EAGAIN edge)
+    # must not turn a succeeded run into exit 1.
+    try:
+        run_meta_stdout.emit_version_line()
+        if kind:
+            run_meta_stdout.emit_field_line("sdk_error_kind", str(kind))
+        if stderr_text:
+            encoded = run_meta_stdout.encode_stderr(str(stderr_text))
+            if encoded:
+                run_meta_stdout.emit_field_line("sdk_stderr_b64", encoded)
+        if report_encoded:
+            run_meta_stdout.emit_field_line("report_b64", report_encoded)
+    except OSError as exc:
+        print(f"warning: run-meta emission failed ({exc!r})", file=sys.stderr)

--- a/src/attune/ops/run_meta_stdout.py
+++ b/src/attune/ops/run_meta_stdout.py
@@ -49,13 +49,20 @@ Licensed under the Apache License, Version 2.0
 from __future__ import annotations
 
 import base64
+import io
 import os
 import re
+import select
 import sys
 from typing import Any
 
 EMIT_ENV = "ATTUNE_RUN_META_EMIT"
 VERSION = 1
+
+#: Max seconds to wait per select() round for a non-blocking stdout to
+#: drain. The loop re-selects until the write completes, so this bounds
+#: one wait, not the total.
+_WRITE_WAIT_S = 1.0
 
 # Allowed key names. Restricting to a known set keeps the grammar tight;
 # extending this requires updating both ``emit_field_line`` and
@@ -81,9 +88,40 @@ def is_emission_enabled() -> bool:
 
 def _write(line: str) -> None:
     """Write a single line to stdout and flush so a subprocess parent
-    reads it in real time."""
-    sys.stdout.write(line + "\n")
-    sys.stdout.flush()
+    reads it in real time.
+
+    The daemon runs the CLI with its stdout on a pipe that can be in
+    non-blocking mode, and ``report_b64`` lines routinely exceed the
+    64 KiB pipe buffer — a plain ``sys.stdout.write`` then raises
+    ``BlockingIOError`` mid-line and crashes an otherwise-succeeded
+    run. Write at the fd level with a ``select()``-wait retry so
+    partial writes complete instead.
+    """
+    try:
+        fd = sys.stdout.fileno()
+    except (ValueError, OSError, io.UnsupportedOperation):
+        # Captured/test stdout without a real fd: plain write is safe
+        # there (no non-blocking pipe involved).
+        sys.stdout.write(line + "\n")
+        sys.stdout.flush()
+        return
+
+    # Drain any buffered text output first so line ordering holds.
+    while True:
+        try:
+            sys.stdout.flush()
+            break
+        except BlockingIOError:
+            select.select([], [fd], [], _WRITE_WAIT_S)
+
+    data = (line + "\n").encode("utf-8")
+    view = memoryview(data)
+    offset = 0
+    while offset < len(data):
+        try:
+            offset += os.write(fd, view[offset:])
+        except BlockingIOError:
+            select.select([], [fd], [], _WRITE_WAIT_S)
 
 
 def emit_version_line() -> None:

--- a/src/attune/ops/run_meta_stdout.py
+++ b/src/attune/ops/run_meta_stdout.py
@@ -54,15 +54,22 @@ import os
 import re
 import select
 import sys
+import time
 from typing import Any
 
 EMIT_ENV = "ATTUNE_RUN_META_EMIT"
 VERSION = 1
 
 #: Max seconds to wait per select() round for a non-blocking stdout to
-#: drain. The loop re-selects until the write completes, so this bounds
-#: one wait, not the total.
+#: drain. The loop re-selects until the write completes or the
+#: deadline below expires.
 _WRITE_WAIT_S = 1.0
+
+#: Total elapsed ceiling for one _write() call. A reader that dies
+#: without closing its pipe end would otherwise stall the retry loop
+#: forever. Generous by design: the daemon drains continuously, so a
+#: healthy pipe never gets near this.
+_WRITE_DEADLINE_S = 30.0
 
 # Allowed key names. Restricting to a known set keeps the grammar tight;
 # extending this requires updating both ``emit_field_line`` and
@@ -96,6 +103,12 @@ def _write(line: str) -> None:
     ``BlockingIOError`` mid-line and crashes an otherwise-succeeded
     run. Write at the fd level with a ``select()``-wait retry so
     partial writes complete instead.
+
+    The retry is bounded by ``_WRITE_DEADLINE_S``: a reader that dies
+    without closing its end would otherwise park this loop forever —
+    trading the original crash for a silent hang. On deadline the
+    raised ``TimeoutError`` (an ``OSError``) reaches the caller's
+    emission guard, which warns and moves on.
     """
     try:
         fd = sys.stdout.fileno()
@@ -106,13 +119,22 @@ def _write(line: str) -> None:
         sys.stdout.flush()
         return
 
+    deadline = time.monotonic() + _WRITE_DEADLINE_S
+
+    def _wait_writable() -> None:
+        if time.monotonic() >= deadline:
+            raise TimeoutError(
+                f"run-meta write stalled >{_WRITE_DEADLINE_S:.0f}s on a non-draining pipe"
+            )
+        select.select([], [fd], [], _WRITE_WAIT_S)
+
     # Drain any buffered text output first so line ordering holds.
     while True:
         try:
             sys.stdout.flush()
             break
         except BlockingIOError:
-            select.select([], [fd], [], _WRITE_WAIT_S)
+            _wait_writable()
 
     data = (line + "\n").encode("utf-8")
     view = memoryview(data)
@@ -121,7 +143,7 @@ def _write(line: str) -> None:
         try:
             offset += os.write(fd, view[offset:])
         except BlockingIOError:
-            select.select([], [fd], [], _WRITE_WAIT_S)
+            _wait_writable()
 
 
 def emit_version_line() -> None:

--- a/src/attune/ops/runner.py
+++ b/src/attune/ops/runner.py
@@ -44,6 +44,13 @@ _BULLETIN_HEARTBEAT_INTERVAL_SEC = 30.0
 # the cap is a defense against runaway loops filling the disk.
 _PERSIST_LOG_BUDGET_BYTES = 200_000
 
+# Per-line ceiling for the child's stdout stream. asyncio's default
+# StreamReader limit is 64 KiB and readline() RAISES past it — a
+# run-meta ``report_b64`` line (base64 of a full WorkflowReport) can
+# exceed that, which would stamp a succeeded run failed. 8 MiB is far
+# above any real report while still bounding a runaway line.
+_STDOUT_LINE_LIMIT = 8 * 1024 * 1024
+
 # Workflow name shape — matches PATH_ARG_REGISTRY keys. Used to validate
 # the directory segment in the persistence path so a malformed workflow
 # name can't escape ``<runs_dir>``.
@@ -834,6 +841,12 @@ class RunnerService:
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.STDOUT,
                 env=proc_env,
+                # asyncio's default StreamReader limit is 64 KiB and
+                # readline() RAISES on a longer line — run-meta
+                # report_b64 lines routinely approach/exceed that, and
+                # the except below would stamp a succeeded run failed.
+                # Match the emitter's worst case with generous headroom.
+                limit=_STDOUT_LINE_LIMIT,
             )
         except FileNotFoundError as exc:
             run.append_line(f"[runner error] command not found: {exc}")

--- a/tests/unit/cli/test_workflow_commands_run_meta.py
+++ b/tests/unit/cli/test_workflow_commands_run_meta.py
@@ -157,3 +157,25 @@ class TestHappyPath:
                     decoded_stderr = run_meta_stdout.decode_stderr(parsed["value"])
         assert decoded_kind == "schema_rejected"
         assert decoded_stderr == stderr
+
+
+class TestEmissionFailureIsNonFatal:
+    """Regression: a pipe error during meta emission (EPIPE, non-blocking
+    EAGAIN edge) must not turn a succeeded run into exit 1 — the report
+    already exists; emission is daemon-side plumbing."""
+
+    def test_oserror_during_emission_is_swallowed(self, monkeypatch, capsys):
+        monkeypatch.setenv("ATTUNE_RUN_META_EMIT", "1")
+
+        from attune.ops import run_meta_stdout
+
+        def boom() -> None:
+            raise BlockingIOError(35, "write could not complete without blocking")
+
+        monkeypatch.setattr(run_meta_stdout, "emit_version_line", boom)
+        result = _FakeResult(metadata={"sdk_error_kind": "auth"})
+
+        _emit_run_meta_for_daemon(result)  # must not raise
+
+        err = capsys.readouterr().err
+        assert "run-meta emission failed" in err

--- a/tests/unit/ops/test_run_meta_stdout.py
+++ b/tests/unit/ops/test_run_meta_stdout.py
@@ -195,3 +195,46 @@ class TestStderrCodec:
         # Should contain replacement characters, not raise.
         assert isinstance(result, str)
         assert len(result) > 0
+
+
+class TestNonBlockingPipeWrite:
+    """Regression: ``report_b64`` lines routinely exceed the 64 KiB pipe
+    buffer, and the daemon's pipe can be in non-blocking mode — a plain
+    ``sys.stdout.write`` raised ``BlockingIOError`` mid-line and turned
+    an otherwise-succeeded run into exit 1 (dashboard run 87d8438e3e8c,
+    2026-08-02)."""
+
+    def test_large_line_on_nonblocking_pipe_completes(self, monkeypatch):
+        import os
+        import sys
+        import threading
+
+        read_fd, write_fd = os.pipe()
+        os.set_blocking(write_fd, False)
+        received: list[bytes] = []
+
+        def drain() -> None:
+            while True:
+                try:
+                    chunk = os.read(read_fd, 65536)
+                except OSError:
+                    break
+                if not chunk:
+                    break
+                received.append(chunk)
+
+        reader = threading.Thread(target=drain)
+        reader.start()
+        writer = os.fdopen(write_fd, "w", encoding="utf-8")
+        monkeypatch.setattr(sys, "stdout", writer)
+        big_value = "A" * 300_000  # ~5x the default pipe buffer
+        try:
+            run_meta_stdout.emit_field_line("report_b64", big_value)
+        finally:
+            monkeypatch.undo()
+        writer.close()
+        reader.join(timeout=10)
+        os.close(read_fd)
+        assert not reader.is_alive()
+        payload = b"".join(received).decode("utf-8")
+        assert payload == f"ATTUNE_RUN_META report_b64={big_value}\n"

--- a/tests/unit/ops/test_run_meta_stdout.py
+++ b/tests/unit/ops/test_run_meta_stdout.py
@@ -209,6 +209,11 @@ class TestNonBlockingPipeWrite:
         import sys
         import threading
 
+        if sys.platform == "win32":
+            import pytest
+
+            pytest.skip("non-blocking pipes + select() are POSIX semantics")
+
         read_fd, write_fd = os.pipe()
         os.set_blocking(write_fd, False)
         received: list[bytes] = []

--- a/tests/unit/ops/test_run_meta_stdout.py
+++ b/tests/unit/ops/test_run_meta_stdout.py
@@ -243,3 +243,97 @@ class TestNonBlockingPipeWrite:
         assert not reader.is_alive()
         payload = b"".join(received).decode("utf-8")
         assert payload == f"ATTUNE_RUN_META report_b64={big_value}\n"
+
+
+class TestFlushRetryAndDeadline:
+    """The review of #1904's own fix demanded these: the flush-retry
+    BlockingIOError branch was untested (the first regression test
+    writes to an empty pipe, so flush succeeds first try), and the
+    retry loop needed an elapsed ceiling so a dead-but-unclosed
+    reader hangs nothing."""
+
+    @staticmethod
+    def _full_nonblocking_pipe():
+        import os
+
+        read_fd, write_fd = os.pipe()
+        os.set_blocking(write_fd, False)
+        try:
+            while True:
+                os.write(write_fd, b"X" * 65536)
+        except BlockingIOError:
+            pass
+        return read_fd, write_fd
+
+    def test_flush_retry_branch_completes_when_reader_drains(self, monkeypatch):
+        import os
+        import sys
+        import threading
+        import time as _time
+
+        if sys.platform == "win32":
+            import pytest
+
+            pytest.skip("non-blocking pipes + select() are POSIX semantics")
+
+        read_fd, write_fd = self._full_nonblocking_pipe()
+        writer = os.fdopen(write_fd, "w", encoding="utf-8")
+        # Park text in the wrapper's buffer so _write's flush hits the
+        # full pipe and takes the BlockingIOError retry branch.
+        writer.write("BUFFERED|")
+        received: list[bytes] = []
+
+        def drain_later() -> None:
+            _time.sleep(0.3)
+            while True:
+                try:
+                    chunk = os.read(read_fd, 65536)
+                except OSError:
+                    break
+                if not chunk:
+                    break
+                received.append(chunk)
+
+        reader = threading.Thread(target=drain_later)
+        reader.start()
+        monkeypatch.setattr(sys, "stdout", writer)
+        try:
+            run_meta_stdout.emit_field_line("sdk_error_kind", "auth")
+        finally:
+            monkeypatch.undo()
+        writer.close()
+        reader.join(timeout=10)
+        os.close(read_fd)
+        assert not reader.is_alive()
+        payload = b"".join(received).decode("utf-8")
+        assert payload.endswith("BUFFERED|ATTUNE_RUN_META sdk_error_kind=auth\n")
+
+    def test_dead_reader_hits_deadline_not_hang(self, monkeypatch):
+        import os
+        import sys
+
+        if sys.platform == "win32":
+            import pytest
+
+            pytest.skip("non-blocking pipes + select() are POSIX semantics")
+
+        read_fd, write_fd = self._full_nonblocking_pipe()
+        writer = os.fdopen(write_fd, "w", encoding="utf-8")
+        monkeypatch.setattr(sys, "stdout", writer)
+        monkeypatch.setattr(run_meta_stdout, "_WRITE_DEADLINE_S", 0.3)
+        monkeypatch.setattr(run_meta_stdout, "_WRITE_WAIT_S", 0.05)
+        import pytest
+
+        try:
+            with pytest.raises(TimeoutError, match="run-meta write stalled"):
+                run_meta_stdout.emit_field_line("sdk_error_kind", "auth")
+        finally:
+            monkeypatch.undo()
+            os.close(read_fd)
+            os.close(write_fd)
+            # fdopen wrapper's fd is closed above; detach to avoid a
+            # double-close in its destructor.
+            try:
+                writer.detach()
+            except (ValueError, OSError):
+                pass

--- a/tests/unit/ops/test_runner.py
+++ b/tests/unit/ops/test_runner.py
@@ -561,3 +561,34 @@ async def test_executor_task_is_pinned_while_running_and_popped_on_completion(
             "executor task entry was not popped on completion — "
             "done_callback wiring is broken (dict will grow unbounded)"
         )
+
+
+def _long_line_cmd(workflow: str) -> tuple[str, ...]:
+    """One >64 KiB single line then exit 0 — exceeds asyncio's default
+    StreamReader limit, which readline() answers with ValueError."""
+    script = (
+        f"import sys; print('start {workflow}'); "
+        "print('L' * 200_000); "
+        "print('end-long'); sys.exit(0)"
+    )
+    return (sys.executable, "-c", script)
+
+
+@pytest.mark.asyncio
+async def test_line_over_64k_does_not_fail_run(tmp_path, monkeypatch):
+    """Regression (bug-predict 2026-08-02, run b67fca241221): the read
+    side of the run-meta channel — asyncio's default 64 KiB limit makes
+    readline() raise on a long report_b64 line and the runner's except
+    stamped a SUCCEEDED run failed. The subprocess limit is raised to
+    _STDOUT_LINE_LIMIT."""
+    app, runner = _make_app(tmp_path, monkeypatch, allow_run=True, command_builder=_long_line_cmd)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post("/workflows/code-review/run")
+        assert resp.status_code == 201
+        run = await _wait_terminal(runner, resp.json()["run_id"])
+        assert run.status == "completed"
+        assert run.exit_code == 0
+        assert not any("[runner error]" in ln for ln in run.lines)
+        assert any(len(ln) >= 200_000 for ln in run.lines)
+        assert any("end-long" in ln for ln in run.lines)


### PR DESCRIPTION
**P0 from today's dry-run** (dashboard run `87d8438e3e8c`): the code-review workflow succeeded with a full report, but the run was stamped **failed (exit 1)** — `BlockingIOError: [Errno 35]` in `run_meta_stdout._write` while emitting the >64 KiB `report_b64` line to the daemon's non-blocking pipe. The Jul 15 'failed' chip is the same bug.

## Fix (two layers)

1. **`run_meta_stdout._write`** — fd-level write loop with a `select()`-wait retry on `BlockingIOError`, so partial writes complete; falls back to plain write for fd-less streams (test capture).
2. **`_emit_run_meta_for_daemon`** — emission is daemon plumbing on top of an already-produced result; wrap in `try/except OSError` → stderr warning, never exit 1.

## Receipts

- Regression test drives a 300 KiB line through a genuinely non-blocking `os.pipe()` with a concurrent reader — delivered intact, clean EOF.
- Caller-side test: `BlockingIOError` during emission is swallowed with a warning, run result untouched.
- 367 neighboring `cli_commands`/`ops` tests pass serially.
- Post-merge live receipt: re-run code-review from the dashboard Workflows page → green chip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)