### PR TITLE
docs(specs): draft broad-except-ratchet + exit-code-honesty-guard for chair review

### DIFF
--- a/docs/specs/broad-except-ratchet/requirements.md
+++ b/docs/specs/broad-except-ratchet/requirements.md
@@ -1,0 +1,65 @@
+# Broad-Except Ratchet — Requirements
+
+**Status:** drafted (2026-08-02) — AWAITING CHAIR REVIEW. No
+implementation authority until the chair approves; this draft
+exists so the review has a concrete object.
+**Slug:** `broad-except-ratchet`
+**Provenance:** chair directive 2026-08-02 ("spec 3 and 4 for chair
+review") from the post-dry-run feedback exchange. Evidence base:
+bug-predict run `925f08cc1d32` and code-review run `603bd3c065c3`
+(2026-08-02) — both flagged the swallow-pattern cluster; bug-predict
+counted ~581 `except Exception` sites with the corresponding lint
+globally disabled.
+
+## Problem
+
+Broad `except Exception` handlers are the soil silent failures grow
+in. Both halves of the run-meta pipe bug (fixed in #1904) were
+masked at the consumer by a blanket except that stamped a succeeded
+run failed; the memory subsystem shows the same silent-degradation
+pattern. The Critical Rules already forbid *bare* `except:`, but
+`except Exception` with a swallow is functionally equivalent and
+unpoliced at ~581 sites.
+
+## Proposed mechanism (for review, not ratified)
+
+A shrink-only per-file baseline ratchet, modeled on
+`tests/unit/ci/test_no_new_sys_modules_patch.py`:
+
+- R1. A guard test scans `src/` for `except Exception` (and
+  `except BaseException`) occurrences per file and compares against
+  a frozen baseline dict. A NEW or RAISED count anywhere fails CI.
+- R2. The baseline is seeded from the current tree at approval time
+  and only ever ratchets DOWN — converting a file removes or lowers
+  its entry.
+- R3. Legitimate sites (evidence collectors, must-not-crash hook
+  paths — e.g. `pull_briefing`'s "appendix must not kill the
+  routine") stay in the baseline indefinitely; the ratchet freezes
+  debt, it does not force conversion.
+- R4. A site that logs AND re-raises, or logs and returns an
+  explicit degraded sentinel per a documented contract, is still
+  counted (keeping the scan mechanical); the baseline is the escape
+  hatch, not pattern-matching cleverness.
+
+## Open questions for the chair
+
+- Q1. Count `# noqa: BLE001`-annotated sites too, or treat the
+  annotation as the documented-contract marker and exclude them?
+  (Excluding makes the ratchet weaker but aligns with the existing
+  lint vocabulary.)
+- Q2. Scope: `src/attune` only, or also `attune_redis/` and
+  `backend/`?
+- Q3. Is a fires-on-violation test (per the principles-impact
+  candidate) required at approval, or part of implementation?
+
+## Acceptance criteria (when approved)
+
+- Guard test exists, seeded, green on the seeding commit.
+- Adding one new `except Exception` to any src file fails the guard
+  in CI (fires-on-violation receipt recorded in decisions.md).
+- Baseline documented as shrink-only in the test's docstring.
+
+## Out of scope
+
+- Converting any existing site (separate, opportunistic work).
+- Style enforcement beyond the two broad-exception forms.

--- a/docs/specs/broad-except-ratchet/requirements.md
+++ b/docs/specs/broad-except-ratchet/requirements.md
@@ -1,6 +1,6 @@
 # Broad-Except Ratchet — Requirements
 
-**Status:** drafted (2026-08-02) — AWAITING CHAIR REVIEW. No
+**Status:** draft (2026-08-02) — AWAITING CHAIR REVIEW. No
 implementation authority until the chair approves; this draft
 exists so the review has a concrete object.
 **Slug:** `broad-except-ratchet`

--- a/docs/specs/exit-code-honesty-guard/requirements.md
+++ b/docs/specs/exit-code-honesty-guard/requirements.md
@@ -1,6 +1,6 @@
 # Exit-Code Honesty Guard — Requirements
 
-**Status:** drafted (2026-08-02) — AWAITING CHAIR REVIEW. No
+**Status:** draft (2026-08-02) — AWAITING CHAIR REVIEW. No
 implementation authority until the chair approves; this draft
 exists so the review has a concrete object.
 **Slug:** `exit-code-honesty-guard`

--- a/docs/specs/exit-code-honesty-guard/requirements.md
+++ b/docs/specs/exit-code-honesty-guard/requirements.md
@@ -1,0 +1,57 @@
+# Exit-Code Honesty Guard — Requirements
+
+**Status:** drafted (2026-08-02) — AWAITING CHAIR REVIEW. No
+implementation authority until the chair approves; this draft
+exists so the review has a concrete object.
+**Slug:** `exit-code-honesty-guard`
+**Provenance:** chair directive 2026-08-02 ("spec 3 and 4 for chair
+review"). Evidence base: dashboard run `87d8438e3e8c` (2026-08-02)
+— a SUCCEEDED code-review run exited 1 because post-success
+run-meta emission crashed on a non-blocking pipe (fixed #1904); the
+Jul 15 run `63c533fb6e46` failed the same way.
+
+## Problem
+
+The CLI's exit code is the contract consumed by the ops dashboard
+chips, CI, and scripts. The class of bug: work that runs AFTER the
+workflow result is determined (telemetry emission, report encoding,
+daemon plumbing) can raise and overwrite the honest exit code.
+#1904 fixed the one known instance; nothing prevents the class from
+returning when the next post-success step is added.
+
+## Proposed mechanism (for review, not ratified)
+
+- R1. A drift-guard test pins the invariant on
+  `run_workflow_with_exit_code` (`_exit_codes.py`): with a
+  successful `WorkflowResult`, an exception raised by the
+  `print_result` / `on_result` / emission path must NOT change the
+  exit code from the result-derived value. (Today this holds only
+  because `_emit_run_meta_for_daemon` catches OSError internally —
+  the guard should hold even if that local guard is refactored
+  away.)
+- R2. The invariant is enforced at the `run_workflow_with_exit_code`
+  layer (catch-log-continue around post-result callbacks), not by
+  trusting each callback to guard itself. Uncaught exceptions
+  BEFORE the result exists keep the existing exit-2 contract.
+- R3. The guard test injects a raising callback for each post-result
+  hook point and asserts exit 0 with a stderr warning.
+
+## Open questions for the chair
+
+- Q1. Should a post-success plumbing failure be visible anywhere
+  beyond stderr (e.g. a run-record annotation), so silent-warn
+  doesn't hide chronic breakage?
+- Q2. Does the same invariant belong on the MCP handler path
+  (`_workflow_response`), which has its own error-shape history?
+
+## Acceptance criteria (when approved)
+
+- R2's catch-log-continue lands in `_exit_codes.py` with the R3
+  drift-guard test red-before/green-after recorded in decisions.md.
+- The #1904 regression suite continues to pass unchanged.
+
+## Out of scope
+
+- The runner/daemon side (covered by #1904's read-side fix).
+- Exit-code taxonomy changes (0/1/2/3 contract stays as specified
+  in the workflow-failure-exit-propagation spec).


### PR DESCRIPTION
Executes the chair's 2026-08-02 ruling from the post-dry-run feedback exchange: **adopt** the seam round-trip test class (→ EOD lessons batch) and the post-release self-review cadence (→ release-execute skill Phase D step 16, personal-global, applied directly); **spec for chair review** the two gate proposals:

- `docs/specs/broad-except-ratchet/` — shrink-only per-file baseline on `except Exception` (~581 sites, lint globally disabled). 3 open questions for the chair.
- `docs/specs/exit-code-honesty-guard/` — drift-guard pinning "post-success plumbing never owns the exit code" at the `run_workflow_with_exit_code` layer. 2 open questions.

Both drafts are status **AWAITING CHAIR REVIEW** and grant no implementation authority. Evidence traces to today's dashboard runs (603bd3c0, 925f08cc, 87d8438e).

🤖 Generated with [Claude Code](https://claude.com/claude-code)