### PR TITLE
release: 11.2.0 — outcome-first fix surface, guided intakes, run-record hardening

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "Spec-driven development for Claude Code — take an idea through requirements, design, tasks, and gated execution with an approval loop. Plus 27 auto-triggering skills: security audits, code review, test generation, release prep.",
-    "version": "11.1.0"
+    "version": "11.2.0"
   },
   "plugins": [
     {
       "name": "attune-ai",
       "description": "Spec-driven development is the core workflow: /spec carries an idea through brainstorm, requirements, design, and task execution with quality gates and your approval at each stage. Backed by 27 auto-triggering skills — security audits, code reviews, test generation, bug prediction, and release preparation. For help content tools, also install attune-help and attune-author from this marketplace.",
       "source": "./plugin",
-      "version": "11.1.0",
+      "version": "11.2.0",
       "author": {
         "name": "Smart AI Memory",
         "email": "patrick.roebuck@smartaimemory.com"

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,4 +1,4 @@
-# Attune AI Framework v11.1.0
+# Attune AI Framework v11.2.0
 
 AI-powered developer workflows with cost optimization and multi-agent orchestration.
 
@@ -552,7 +552,7 @@ attune_redis/          # Redis plugin — BUNDLED, ships in the attune-ai
 
 ---
 
-**Version:** 11.1.0 | **License:** Apache 2.0 | **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)
+**Version:** 11.2.0 | **License:** Apache 2.0 | **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)
 
 ## Lessons — core
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,79 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [11.2.0] — 2026-08-02
+
+The outcome-first release: `attune fix` ships — state the outcome
+you want and how to verify it, and get a receipt, not a promise.
+Around it: guided intakes in Claude Code, declared input schemas for
+every workflow, and a run-record pipeline hardened by its own
+review workflows.
+
+### Added
+
+- **`attune fix` — outcome-first fixing with verified receipts**
+  (#1805–#1819). `attune fix "<goal>" --scope <path> --probe <cmd>`
+  previews the contract (done conditions, constraints, probes —
+  nothing executes); adding `--run` executes it and returns a
+  receipt: changes attributed against a pre-run snapshot, probes
+  re-run independently of the workflow ("workflow exit was not
+  trusted"), exit 0 only when probes pass. A D7 endpoint guard
+  keeps free-text out of the ops run-start surface.
+- **Guided intakes in Claude Code** — `/fix` (#1824) and `/spec`
+  (#1826) compose their contracts through a form: goal pre-filled,
+  scope picker from paths you've touched, probes from matching test
+  files, with the composed command shown before anything runs.
+- **Every workflow declares its inputs** (#1831, #1832) — all 21
+  workflows carry an `input_schema`; unknown or malformed CLI
+  inputs now fail with named-field errors instead of silent drops.
+- **Shared form machinery** — `FormTemplate` + providers with a
+  shared theme (#1843) re-express the fix/spec intakes; 17 workflow
+  templates registered (#1847).
+- **Local-first reports, phase 1** (#1823) — roundtable transcripts
+  live under `~/.attune/reports/`; the repo keeps curated stubs.
+
+### Fixed
+
+- **Succeeded dashboard runs no longer exit 1** (#1904) — the
+  run-meta stdout channel survives non-blocking pipes on the write
+  side (fd-level retry with a bounded deadline), the runner accepts
+  report lines past asyncio's 64 KiB default on the read side, and
+  post-success emission failures warn instead of overwriting the
+  workflow's honest exit code. Found by dogfooding: the dashboard's
+  own code-review and bug-predict runs surfaced both halves.
+- **Windows test-lane blockers** (#1898) — file-age rendering
+  clamped (mtime can land ahead of the clock, printing "-0h ago")
+  and an unreadable-file test rewritten portably (chmod cannot
+  block reads on Windows).
+- **Production bugs from the coverage fleet** — dead `KINDS` check
+  in numeric refs, type-ignore-masked defects in the short-term
+  memory facade (sanitizer arg position, cross-session misbind,
+  dead `_client` property), doc-orchestrator scout and monitoring
+  metrics defects — logged in `docs/COVERAGE_BUG_LOG.md`, with
+  crashing behaviors pinned by tests pending their rulings.
+- **Test-suite reliability** — otel `find_spec` tests mock
+  selectively instead of globally (#1903, was sniping unrelated CI
+  lanes), `patch.dict("sys.modules")` conversions, and an
+  aiohttp-less hooks matrix guard.
+- **Bulletin file backend: concurrent Windows writers no longer lose
+  entries** — the CRT's `O_APPEND` is seek-to-end + write (not
+  atomic), so two processes could overwrite each other's records; up
+  to 15% loss was tolerated and a CI run still rolled 19%. Appends on
+  Windows now serialize on a cross-process `msvcrt.locking`
+  sentinel-byte mutex (stdlib, no new dependency), degrading to the
+  old unlocked append on lock timeout since the bulletin is advisory.
+  The concurrency test now asserts exact zero loss on every platform.
+
+### Internal
+
+- **Coverage fleet** — 30+ modules raised to ~100% line coverage by
+  delegated Sonnet lanes with centrally re-run receipts
+  (#1848–#1901); hybrid model routing ratified (mechanical lanes on
+  Sonnet, judgment on the lead).
+- **Release ritual grows a self-review step** — post-release
+  code-review + bug-predict runs from the ops dashboard, findings
+  triaged with verify-the-claim notes (chair-adopted 2026-08-02).
+
 ### Removed
 
 - **attune-gui parked** — the `attune-gui` marketplace plugin is
@@ -17,17 +90,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `attune ops`. Usage signal at the ruling: zero jobs in 7 days.
   The repo stays archived (not deleted) as the GUI seed if the
   living-docs product direction ever needs one.
-
-### Fixed
-
-- **Bulletin file backend: concurrent Windows writers no longer lose
-  entries** — the CRT's `O_APPEND` is seek-to-end + write (not
-  atomic), so two processes could overwrite each other's records; up
-  to 15% loss was tolerated and a CI run still rolled 19%. Appends on
-  Windows now serialize on a cross-process `msvcrt.locking`
-  sentinel-byte mutex (stdlib, no new dependency), degrading to the
-  old unlocked append on lock timeout since the bulletin is advisory.
-  The concurrency test now asserts exact zero loss on every platform.
 
 ## [11.1.0] — 2026-07-30
 

--- a/docs/reference/API_REFERENCE.md
+++ b/docs/reference/API_REFERENCE.md
@@ -1,6 +1,6 @@
 # Attune AI API Reference
 
-**Version:** 11.1.0
+**Version:** 11.2.0
 **License:** Apache License 2.0
 **Copyright:** 2025-2026 Smart AI Memory, LLC
 
@@ -1152,5 +1152,5 @@ msg = format_error(
 
 ---
 
-**Version:** 11.1.0 | **License:** Apache 2.0
+**Version:** 11.2.0 | **License:** Apache 2.0
 **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)

--- a/plugin/.claude-plugin/marketplace.json
+++ b/plugin/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "Spec-driven development for Claude Code — /spec plans, reviews, and executes with quality gates; plus security audits, code reviews, test generation, and release prep from /attune.",
-    "version": "11.1.0"
+    "version": "11.2.0"
   },
   "plugins": [
     {
       "name": "attune-ai",
       "description": "Spec-driven development for Claude Code — /spec plans, reviews, and executes with quality gates; plus security audits, code reviews, test generation, and release prep from /attune.",
       "source": "./",
-      "version": "11.1.0",
+      "version": "11.2.0",
       "author": {
         "name": "Smart AI Memory",
         "email": "patrick.roebuck@smartaimemory.com"

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "attune-ai",
-  "version": "11.1.0",
+  "version": "11.2.0",
   "description": "Spec-driven development for Claude Code — /spec plans, reviews, and executes with quality gates; plus security audits, code reviews, test generation, and release prep from /attune.",
   "author": {
     "name": "Smart AI Memory",

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -4,7 +4,7 @@ Spec-driven development for Claude Code — turn requirements
 into reliable software. <!-- cap:skill_count -->27 auto-triggering skills<!-- /cap -->, zero
 commands: say what you need and Claude picks the right skill.
 
-**Version:** 11.1.0 | **License:** Apache 2.0
+**Version:** 11.2.0 | **License:** Apache 2.0
 
 ## Install
 

--- a/plugin/core/__init__.py
+++ b/plugin/core/__init__.py
@@ -5,4 +5,4 @@ This module provides the core workflow functionality when the full
 attune-ai package is not installed via pip.
 """
 
-__version__ = "11.1.0"
+__version__ = "11.2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "attune-ai"
-version = "11.1.0"
+version = "11.2.0"
 description = "AI-powered developer workflows for Claude with cost optimization, multi-agent orchestration, and workflow automation."
 readme = {file = "README.md", content-type = "text/markdown"}
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -299,7 +299,7 @@ wheels = [
 
 [[package]]
 name = "attune-ai"
-version = "11.1.0"
+version = "11.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "agent-memory-client" },

--- a/website/app/page.tsx
+++ b/website/app/page.tsx
@@ -58,7 +58,7 @@ export default function Home() {
             <div className="grid lg:grid-cols-2 gap-16 items-center">
               <div className="z-10">
                 <div className="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-[var(--surface-container-high)] text-[var(--primary)] text-xs font-bold tracking-widest mb-6 uppercase">
-                  <span>v11.1.0</span>
+                  <span>v11.2.0</span>
                   <span className="w-1 h-1 rounded-full bg-[var(--primary)]"></span>
                   <span className="opacity-80">Spec-driven development platform</span>
                 </div>

--- a/website/lib/features.ts
+++ b/website/lib/features.ts
@@ -32,7 +32,7 @@ export const PRODUCTS: Product[] = [
     id: "attune-ai",
     name: "Attune AI",
     pypiName: "attune-ai",
-    version: "11.1.0",
+    version: "11.2.0",
     tagline: "Generate, maintain, and serve help from your code",
     installCommand: "pip install attune-ai",
     marketplaceInstall:
@@ -101,7 +101,7 @@ export const PRODUCTS: Product[] = [
     id: "claude-code-plugin",
     name: "Claude Code Plugin",
     pypiName: "attune-ai",
-    version: "11.1.0",
+    version: "11.2.0",
     tagline: "Progressive help right in your terminal",
     installCommand:
       "claude plugin marketplace add Smart-AI-Memory/attune-ai",


### PR DESCRIPTION
Release prep for **11.2.0** (minor — genuine feature release: the `attune fix` outcome-first surface #1805–#1819, guided `/fix` + `/spec` intakes, 21/21 workflow input schemas, run-record pipeline hardening #1898/#1903/#1904).

- `scripts/bump_version.py 11.2.0` — all 9 sites, count-validated
- `[Unreleased]` → `[11.2.0] — 2026-08-02` with the full section (Added / Fixed / Internal / Removed); fresh empty `[Unreleased]` kept
- `uv.lock`: 1-line version-only diff
- Docs regen: no-op (0 stale features)

Release-check state: PyPI 11.2.0 free, tag absent, tree clean, US-4 before-snapshot warning attached verbatim per the skill (24h floor passed; morning 5/5 capture satisfies 11.1.0's AFTER leg, not this BEFORE leg).

🤖 Generated with [Claude Code](https://claude.com/claude-code)