### PR TITLE
fix(release): add plugin/README.md version claim as bump_version.py's 10th site

### DIFF
--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -15,10 +15,13 @@ surface). Writes, in one validated pass:
    footer (``**Version:** X``)
 7. ``docs/reference/API_REFERENCE.md`` — header and footer
    (``**Version:** X``)
-8. ``website/lib/features.ts`` — the two attune-ai product entries
+8. ``plugin/README.md`` — version claim (``**Version:** X``; the
+   claim-drift gate ``tests/unit/gates/test_claim_drift.py`` fails
+   CI when this lags pyproject)
+9. ``website/lib/features.ts`` — the two attune-ai product entries
    (``pypiName: "attune-ai"`` + ``version: "X"``; other products'
    versions are independent and never touched)
-9. ``website/app/page.tsx`` — homepage badge (``<span>vX</span>``)
+10. ``website/app/page.tsx`` — homepage badge (``<span>vX</span>``)
 
 Every replacement is count-checked against the expected number of
 occurrences BEFORE any file is written; a mismatch aborts with no
@@ -101,6 +104,13 @@ def _sites(root: Path) -> list[Site]:
             "**Version:** {v}",
             2,
             min_count=True,
+        ),
+        # Version claim checked by the claim-drift gate — a stale
+        # value here fails CI on the release PR (hit on 11.2.0).
+        Site(
+            root / "plugin" / "README.md",
+            "**Version:** {v}",
+            1,
         ),
         # Website sites — enforced by tests/unit/
         # test_website_version_accuracy.py in the required CI lanes.

--- a/tests/unit/scripts/test_bump_version.py
+++ b/tests/unit/scripts/test_bump_version.py
@@ -1,7 +1,7 @@
 """Tests for scripts/bump_version.py (drift-guards-to-generators R4).
 
 Covers:
-- happy path: all 9 files rewritten (14 occurrences), old version
+- happy path: all 10 files rewritten (15 occurrences), old version
   returned;
 - dry-run: validation runs, nothing written;
 - semver / same-version rejection;
@@ -66,6 +66,10 @@ def fixture_root(tmp_path: Path) -> Path:
     core = tmp_path / "plugin" / "core"
     core.mkdir()
     (core / "__init__.py").write_text(f'__version__ = "{OLD}"\n', encoding="utf-8")
+    (tmp_path / "plugin" / "README.md").write_text(
+        f"# x\n\n**Version:** {OLD} | **License:** Apache 2.0\n",
+        encoding="utf-8",
+    )
     claude_dir = tmp_path / ".claude"
     claude_dir.mkdir()
     (claude_dir / "CLAUDE.md").write_text(
@@ -120,6 +124,7 @@ def _all_texts(root: Path) -> str:
             root / "plugin" / ".claude-plugin" / "marketplace.json",
             root / ".claude-plugin" / "marketplace.json",
             root / "plugin" / "core" / "__init__.py",
+            root / "plugin" / "README.md",
             root / ".claude" / "CLAUDE.md",
             root / "docs" / "reference" / "API_REFERENCE.md",
             root / "website" / "lib" / "features.ts",
@@ -135,9 +140,9 @@ class TestBump:
         combined = _all_texts(fixture_root)
         assert OLD not in combined
         # 1 pyproject + 1 plugin.json + 2+2 marketplace + 1 __init__
-        # + 2 CLAUDE.md + 2 API_REFERENCE + 2 features.ts
-        # + 1 page.tsx = 14 occurrences
-        assert combined.count(NEW) == 14
+        # + 1 plugin README + 2 CLAUDE.md + 2 API_REFERENCE
+        # + 2 features.ts + 1 page.tsx = 15 occurrences
+        assert combined.count(NEW) == 15
         # The sibling product's independent version is untouched.
         features = fixture_root / "website" / "lib" / "features.ts"
         assert 'version: "0.1.0"' in features.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

During 11.2.0 release prep, the claim-drift gate (`test_claim_matches_live_value[plugin/README.md::plugin version]`) caught a stale version claim after the 9-site bump — `scripts/bump_version.py` didn't cover `plugin/README.md`'s `**Version:** X | **License:** Apache 2.0` line, costing a CI cycle on #1906 (hand-fixed in 167a59145).

- Add `plugin/README.md` version claim as the 10th site in `bump_version.py` (count-validated, following the existing per-site pattern), with the docstring site list renumbered
- Extend `tests/unit/scripts/test_bump_version.py`: fixture carries the new site, occurrence count 14 → 15; the real-repo dry-run smoke now validates the site against the actual tree
- Updated the release-execute skill text (personal skill, untracked) from the stale "7 files / 9 sites" to the full 10-file list

## Verification

- `pytest tests/unit/scripts/test_bump_version.py` — 7/7 pass
- Scratch bump `11.2.0 → 99.99.99`: `git diff --stat` showed all 10 files moving together, including `plugin/README.md` (reverted afterward)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
