### PR TITLE
docs+marketplace: post-11.2.0 install-surface refresh (README rotating slot + sibling pins)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -37,7 +37,7 @@
       "name": "attune-help",
       "source": "./plugins/attune-help",
       "description": "Lightweight runtime reader for .help/ templates. Progressive depth (concept -> task -> reference). No AI keys required. Install alone to consume help content, or pair with attune-author to build it.",
-      "version": "0.11.1",
+      "version": "0.13.0",
       "author": {
         "name": "Smart AI Memory",
         "email": "patrick.roebuck@smartaimemory.com"
@@ -52,7 +52,7 @@
       "name": "attune-author",
       "source": "./plugins/attune-author",
       "description": "AI-powered authoring companion for attune-help. Generates, maintains, and validates .help/ templates through a 3-stage pipeline with staleness detection. Pairs with attune-help to build and ship context-sensitive help content.",
-      "version": "0.22.0",
+      "version": "0.25.0",
       "author": {
         "name": "Smart AI Memory",
         "email": "patrick.roebuck@smartaimemory.com"

--- a/README.md
+++ b/README.md
@@ -84,28 +84,44 @@ routing, and [Installation Options](#installation-options) for extras.
      a permanent section below (see "Dynamic forms" for the pattern).
      Don't stack a second "New in" section here. -->
 
-## New in 11.0.0 — attune-author invocation paths retired
+## New in 11.2.0 — Goal-Driven Development: receipts, not promises
 
-Major version, one breaking change: the **`[author]` install extra is
-removed**, along with the ops dashboard's help-regeneration surface
-(`/api/help/regen*` and the Admin-page regen UI). `/help/admin` is now
-report-only and points at `/coach maintain`, which is where
-documentation regeneration lives.
+The last two releases (11.1.0 + 11.2.0) build out one idea: **state
+the goal and how to verify it before anything runs, and get back a
+receipt — not a promise.** If you know acceptance-test-driven
+development, this is that discipline rebuilt for agent workflows:
+acceptance probes are declared up front, and the agent's own word is
+never the evidence.
 
-**Are you affected?** Only if you install with
-`pip install 'attune-ai[author]'` — that extra no longer resolves, so
-drop it from your requirements. Plain `pip install attune-ai` is
-unchanged, and no runtime API was removed. The extra existed to pull in
-`attune-author`, which was archived after its capability was absorbed
-here; keeping an extra that points at an archived package would have been
-the dishonest option.
+```bash
+attune fix "imports resolve after the rename" \
+  --scope src/attune/cli_minimal.py \
+  --probe "pytest tests/unit/test_cli_minimal.py"
+```
 
-Also in this release: handoff packets now carry memory linkage and
-report a real memory outcome instead of silence; the Health tab shows
-which surface rendered each Python-routed form; `session_memory_*` tools
-answer with per-verb summaries rather than a generic line; and the
-release model tier resolves at call time, so a changed override is
-observed without a restart.
+- **`attune fix` — outcome-first fixing.** The command above previews
+  a contract (done conditions, constraints, probes) and executes
+  nothing. Add `--run` and it executes, then returns a receipt:
+  changes attributed against a pre-run snapshot, probes re-run
+  independently of the workflow, exit 0 only when the probes pass.
+  The workflow saying "done" is not trusted — the probe result is.
+- **Guided intakes in Claude Code.** `/fix` and `/spec` compose
+  their contracts through a form: goal pre-filled, a scope picker
+  built from paths you've touched, probe suggestions from matching
+  test files — with the composed command shown before anything runs.
+- **Every workflow declares its inputs.** All 21 workflows carry an
+  `input_schema`; unknown or malformed inputs fail with named-field
+  errors instead of being silently dropped.
+- **Local-first reports.** Roundtable transcripts write to
+  `~/.attune/reports/`; the repo keeps curated stubs.
+
+From 11.1.0, the layer that keeps receipts honest: a failed or
+absent security auditor now **fails** the Security gate (absence is
+not a pass), spec-closure claims draw a rotating skeptic seat that
+must countersign executor-produced receipt artifacts, risk-class
+diffs authored by the lead model are reviewed by a *different*
+model before promotion, and editing/polish passes moved to a
+dedicated editing model at roughly half the previous cost.
 
 ## The memory suite — out of the box, measured
 
@@ -559,9 +575,10 @@ for the surfaces you use:
 | Everything most users need, incl. Redis memory | `pip install attune-ai` |
 | Claude API mode + optional LangChain/LangGraph interop adapters | `pip install 'attune-ai[developer]'` |
 | The ops dashboard (`attune ops`) | `pip install 'attune-ai[ops]'` |
-| Help authoring (generate / maintain `.help/` templates) | `pip install 'attune-ai[author]'` |
 
-(`[redis]` remains as an empty backward-compat alias.) Extras
+(`[redis]` remains as an empty backward-compat alias. The `[author]`
+extra was **removed in 11.0.0** — drop it from requirements;
+documentation regeneration lives in `/coach maintain`.) Extras
 combine — for example
 `pip install 'attune-ai[developer,ops]'`. Keep the quotes:
 zsh and bash treat square brackets as glob characters.

--- a/plugins/attune-author/.claude-plugin/plugin.json
+++ b/plugins/attune-author/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "attune-author",
-  "version": "0.21.0",
+  "version": "0.25.0",
   "description": "Documentation authoring for Claude Code — generate, maintain, and validate help content with the attune-author library",
   "author": {
     "name": "Smart AI Memory",

--- a/plugins/attune-author/core/__init__.py
+++ b/plugins/attune-author/core/__init__.py
@@ -1,3 +1,3 @@
 """Plugin version constant — keep in sync with plugin.json."""
 
-__version__ = "0.21.0"
+__version__ = "0.25.0"

--- a/plugins/attune-help/.claude-plugin/plugin.json
+++ b/plugins/attune-help/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "attune-help",
-  "version": "0.11.1",
+  "version": "0.13.0",
   "description": "Read and explore .help/ documentation with progressive depth. Lightweight runtime companion to attune-author — no AI keys required.",
   "author": {
     "name": "Smart AI Memory",

--- a/plugins/attune-help/core/__init__.py
+++ b/plugins/attune-help/core/__init__.py
@@ -4,4 +4,4 @@ Mirrors the pinned attune-help PyPI version advertised in this
 plugin's plugin.json and the marketplace.json entry.
 """
 
-__version__ = "0.11.1"
+__version__ = "0.13.0"


### PR DESCRIPTION
Completes the post-11.2.0 install-surface refresh:

- **README rotating slot** advances from 11.0.0 to 11.2.0 — "Goal-Driven
  Development: receipts, not promises" covering the outcome-first `attune fix`
  contract, `/fix`+`/spec` guided intakes, universal `input_schema`, and
  local-first reports, with the 11.1.0 receipt-honesty layer (fail-closed
  security gate, rotating skeptic, different-model lead review, editing-model
  split) summarized.
- **Doc-fiction fix:** Installation Options still advertised the `[author]`
  extra that 11.0.0 removed — row dropped, migration note added.
- **Marketplace sibling pins** refreshed to current PyPI releases:
  attune-help 0.11.1 → 0.13.0, attune-author 0.21.0/0.22.0 → 0.25.0 (all four
  sites: two plugin.json, two core/__init__.py, plus both root marketplace
  entries), fixing the pin-vs-content mismatch left by #1166.

Receipts: `test_claim_drift.py` + `test_brand_drift.py` +
`test_plugin_config_validation.py` (incl. `test_all_versions_match`) — 53
passed locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
