### PR TITLE
docs(plugin): fix update command — bare plugin name fails, use namespaced id

### DIFF
--- a/plugin/README.md
+++ b/plugin/README.md
@@ -16,7 +16,7 @@ claude plugin install attune-ai@attune-ai
 Update an existing install:
 
 ```bash
-claude plugin update attune-ai
+claude plugin update attune-ai@attune-ai
 ```
 
 ## Usage


### PR DESCRIPTION
The plugin README's "Update an existing install" block uses the bare-name form, which errors `Plugin "attune-ai" not found` — the installed id is namespaced (`attune-ai@attune-ai`), as the Install block above it already shows. Caught reviewing the shipped README after 11.2.0; verified against the recurring lesson (fails at every release when forgotten) and today's live update, which required the namespaced form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)