### PR TITLE
release: 11.2.1 — docs/metadata patch, README refresh to PyPI

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "Spec-driven development for Claude Code — take an idea through requirements, design, tasks, and gated execution with an approval loop. Plus 27 auto-triggering skills: security audits, code review, test generation, release prep.",
-    "version": "11.2.0"
+    "version": "11.2.1"
   },
   "plugins": [
     {
       "name": "attune-ai",
       "description": "Spec-driven development is the core workflow: /spec carries an idea through brainstorm, requirements, design, and task execution with quality gates and your approval at each stage. Backed by 27 auto-triggering skills — security audits, code reviews, test generation, bug prediction, and release preparation. For help content tools, also install attune-help and attune-author from this marketplace.",
       "source": "./plugin",
-      "version": "11.2.0",
+      "version": "11.2.1",
       "author": {
         "name": "Smart AI Memory",
         "email": "patrick.roebuck@smartaimemory.com"

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,4 +1,4 @@
-# Attune AI Framework v11.2.0
+# Attune AI Framework v11.2.1
 
 AI-powered developer workflows with cost optimization and multi-agent orchestration.
 
@@ -552,7 +552,7 @@ attune_redis/          # Redis plugin — BUNDLED, ships in the attune-ai
 
 ---
 
-**Version:** 11.2.0 | **License:** Apache 2.0 | **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)
+**Version:** 11.2.1 | **License:** Apache 2.0 | **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)
 
 ## Lessons — core
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [11.2.1] — 2026-08-02
+
+Docs/metadata patch — no code changes. Ships the refreshed README
+(the 11.2.0 "Goal-Driven Development: receipts, not promises"
+framing) to PyPI's project page, which still rendered the pre-11.2.0
+description.
+
+### Changed
+
+- **README refresh** (#1907): leads with Fix Receipts and the
+  Goal-Driven Development framing; "New in 11.2.0" section replaces
+  the 11.0.0 one.
+
+### Fixed
+
+- **`scripts/bump_version.py` covers `plugin/README.md`** (#1908):
+  the version claim the claim-drift gate checks is now the script's
+  10th site, so it can no longer go stale on a release PR (as it
+  did on #1906).
+
 ## [11.2.0] — 2026-08-02
 
 The outcome-first release: `attune fix` ships — state the outcome

--- a/docs/reference/API_REFERENCE.md
+++ b/docs/reference/API_REFERENCE.md
@@ -1,6 +1,6 @@
 # Attune AI API Reference
 
-**Version:** 11.2.0
+**Version:** 11.2.1
 **License:** Apache License 2.0
 **Copyright:** 2025-2026 Smart AI Memory, LLC
 
@@ -1152,5 +1152,5 @@ msg = format_error(
 
 ---
 
-**Version:** 11.2.0 | **License:** Apache 2.0
+**Version:** 11.2.1 | **License:** Apache 2.0
 **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)

--- a/plugin/.claude-plugin/marketplace.json
+++ b/plugin/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "Spec-driven development for Claude Code — /spec plans, reviews, and executes with quality gates; plus security audits, code reviews, test generation, and release prep from /attune.",
-    "version": "11.2.0"
+    "version": "11.2.1"
   },
   "plugins": [
     {
       "name": "attune-ai",
       "description": "Spec-driven development for Claude Code — /spec plans, reviews, and executes with quality gates; plus security audits, code reviews, test generation, and release prep from /attune.",
       "source": "./",
-      "version": "11.2.0",
+      "version": "11.2.1",
       "author": {
         "name": "Smart AI Memory",
         "email": "patrick.roebuck@smartaimemory.com"

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "attune-ai",
-  "version": "11.2.0",
+  "version": "11.2.1",
   "description": "Spec-driven development for Claude Code — /spec plans, reviews, and executes with quality gates; plus security audits, code reviews, test generation, and release prep from /attune.",
   "author": {
     "name": "Smart AI Memory",

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -4,7 +4,7 @@ Spec-driven development for Claude Code — turn requirements
 into reliable software. <!-- cap:skill_count -->27 auto-triggering skills<!-- /cap -->, zero
 commands: say what you need and Claude picks the right skill.
 
-**Version:** 11.2.0 | **License:** Apache 2.0
+**Version:** 11.2.1 | **License:** Apache 2.0
 
 > **Fix Receipts — new in 11.2.0.** Say `fix this and prove it`.
 > Attune previews the contract first — done conditions, scope,

--- a/plugin/core/__init__.py
+++ b/plugin/core/__init__.py
@@ -5,4 +5,4 @@ This module provides the core workflow functionality when the full
 attune-ai package is not installed via pip.
 """
 
-__version__ = "11.2.0"
+__version__ = "11.2.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "attune-ai"
-version = "11.2.0"
+version = "11.2.1"
 description = "AI-powered developer workflows for Claude with cost optimization, multi-agent orchestration, and workflow automation."
 readme = {file = "README.md", content-type = "text/markdown"}
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -299,7 +299,7 @@ wheels = [
 
 [[package]]
 name = "attune-ai"
-version = "11.2.0"
+version = "11.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "agent-memory-client" },

--- a/website/app/page.tsx
+++ b/website/app/page.tsx
@@ -58,7 +58,7 @@ export default function Home() {
             <div className="grid lg:grid-cols-2 gap-16 items-center">
               <div className="z-10">
                 <div className="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-[var(--surface-container-high)] text-[var(--primary)] text-xs font-bold tracking-widest mb-6 uppercase">
-                  <span>v11.2.0</span>
+                  <span>v11.2.1</span>
                   <span className="w-1 h-1 rounded-full bg-[var(--primary)]"></span>
                   <span className="opacity-80">Spec-driven development platform</span>
                 </div>

--- a/website/lib/features.ts
+++ b/website/lib/features.ts
@@ -32,7 +32,7 @@ export const PRODUCTS: Product[] = [
     id: "attune-ai",
     name: "Attune AI",
     pypiName: "attune-ai",
-    version: "11.2.0",
+    version: "11.2.1",
     tagline: "Generate, maintain, and serve help from your code",
     installCommand: "pip install attune-ai",
     marketplaceInstall:
@@ -101,7 +101,7 @@ export const PRODUCTS: Product[] = [
     id: "claude-code-plugin",
     name: "Claude Code Plugin",
     pypiName: "attune-ai",
-    version: "11.2.0",
+    version: "11.2.1",
     tagline: "Progressive help right in your terminal",
     installCommand:
       "claude plugin marketplace add Smart-AI-Memory/attune-ai",


### PR DESCRIPTION
## Summary

Docs/metadata patch — no code changes (lockstep policy: docs-only changes still get a patch release so PyPI ≡ repo ≡ manifests).

- Ships the refreshed README (#1907 — Goal-Driven Development / Fix Receipts framing) to PyPI's project page, which still renders the pre-11.2.0 description
- Carries the bump_version.py 10th-site fix (#1908); this is the first release bumped with the 10-site script — plugin/README.md's version claim moved automatically
- Version 11.2.0 → 11.2.1 across all 10 sites + changelog + uv.lock (self-version only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
