### PR TITLE
fix(website): refresh stale capability counts + surface fix receipts

### DIFF
--- a/website/app/docs/page.tsx
+++ b/website/app/docs/page.tsx
@@ -165,7 +165,7 @@ export default function DocsPage() {
                   <p className="text-sm text-[var(--text-secondary)] mb-5 flex-1">
                     The whole platform: spec engine, AI workflows, project
                     memory, retrieval grounding, and verification.
-                    20 workflows, 26 skills, 49 MCP tools.
+                    23 workflows, 27 skills, 60 MCP tools.
                   </p>
                   <div className="bg-[#213145] text-white/90 rounded-xl font-mono text-xs p-3">
                     <span className="text-white/50">$ </span>pip install attune-ai
@@ -452,7 +452,7 @@ export default function DocsPage() {
               </h2>
               <p className="text-center text-[var(--text-secondary)] mb-12 max-w-2xl mx-auto">
                 Install from the marketplace. Progressive help, project
-                bootstrapping, and 26 skills right in your terminal.
+                bootstrapping, and 27 skills right in your terminal.
               </p>
 
               <div className="bg-[var(--background)] border-2 border-[var(--border)] rounded-lg p-8 mb-8">
@@ -518,9 +518,9 @@ export default function DocsPage() {
                 Workflows &amp; Skills
               </h2>
               <p className="text-center text-[var(--text-secondary)] mb-12 max-w-2xl mx-auto">
-                The build half of the loop: 20 workflows,
-                26 auto-triggering Claude Code skills,
-                and an MCP server with 49 registered tools — review, tests,
+                The build half of the loop: 23 workflows,
+                27 auto-triggering Claude Code skills,
+                and an MCP server with 60 registered tools — review, tests,
                 bug prediction, refactor, and release prep.
               </p>
 

--- a/website/app/faq/page.tsx
+++ b/website/app/faq/page.tsx
@@ -30,11 +30,11 @@ const faqData: FAQCategory[] = [
       },
       {
         question: 'What is Attune AI built on?',
-        answer: 'Memory is the pillar: project memory carries cross-session findings and a retrievable lessons corpus, surfaced at the moment a prompt needs them. Around it ship four supporting capabilities, each real and shipped: dynamic forms (structured human/AI turns), AI workflows (20 workflows for review, tests, bug prediction, and refactors), retrieval grounding (citations back to your source via attune-rag), and verification (fact-checking generated content before it reaches main).',
+        answer: 'Memory is the pillar: project memory carries cross-session findings and a retrievable lessons corpus, surfaced at the moment a prompt needs them. Around it ship four supporting capabilities, each real and shipped: dynamic forms (structured human/AI turns), AI workflows (23 workflows for review, tests, bug prediction, refactors, and outcome-first fixes with verified receipts), retrieval grounding (citations back to your source via attune-rag), and verification (fact-checking generated content before it reaches main).',
       },
       {
         question: 'What can Attune AI do, in numbers?',
-        answer: 'Attune AI ships 20 workflows, 49 MCP tools, 26 auto-triggering skills, 5 wizards, and 15 template kinds. The spec engine runs via /spec, progressive help via /coach, and cross-session recall via /recall.',
+        answer: 'Attune AI ships 23 workflows, 60 MCP tools, 27 auto-triggering skills, 5 wizards, and 11 template kinds. The spec engine runs via /spec, progressive help via /coach, cross-session recall via /recall, and outcome-first fixes with verified receipts via attune fix.',
       },
       {
         question: "What's the difference between attune-ai and attune-gui?",

--- a/website/app/page.tsx
+++ b/website/app/page.tsx
@@ -451,7 +451,7 @@ export default function Home() {
               </div>
               <h3 className="text-xl font-bold mb-3">attune-ai</h3>
               <p className="text-[var(--text-secondary)] leading-relaxed text-sm">
-                Full framework. Workflows, staleness detection, MCP server, and 26 auto-triggering skills for Claude Code.
+                Full framework. Workflows, staleness detection, MCP server, and 27 auto-triggering skills for Claude Code.
               </p>
             </div>
 

--- a/website/lib/features.ts
+++ b/website/lib/features.ts
@@ -311,7 +311,7 @@ export const RELIABILITY_LOOP: LoopStage[] = [
     n: "03",
     name: "Build",
     description:
-      "21 workflows: review, tests, bug prediction, refactor.",
+      "23 workflows: review, tests, bug prediction, refactor.",
   },
   {
     n: "04",
@@ -407,7 +407,7 @@ export const PILLARS: Pillar[] = [
     tag: "AI workflows",
     title: "Specialist teams, not one prompt",
     description:
-      "20 workflows run teams of 2–6 Claude subagents to " +
+      "23 workflows run teams of 2–6 Claude subagents to " +
       "review code, surface vulnerabilities, generate tests, and plan " +
       "refactors — with cost-tiered model routing.",
     points: [


### PR DESCRIPTION
## Summary

Marketing copy on smartaimemory.com lagged the live registries. Refreshed via the /fix contract (scope `website/`, three probes):

- Capability counts corrected everywhere they appear: **23 workflows** (was 20/21), **60 MCP tools** (was 49), **27 auto-triggering skills** (was 26), **11 template kinds** (was 15) — verified against `WORKFLOW_REGISTRY`, the cap-annotated plugin README, `plugin/skills/`, and the .help docs
- FAQ now names **outcome-first fixes with verified receipts** (`attune fix`) — the 11.1/11.2 headline was absent from the site

## Receipt

- Probe 1: `pytest tests/unit/gates/test_claim_drift.py tests/unit/gates/test_brand_drift.py` — 24 passed
- Probe 2: `npm --prefix website test` (vitest) — 28 passed
- Probe 3: `pytest tests/unit/test_website_version_accuracy.py` — 15 passed
- Scope: diff confined to `website/`; rendered copy verified in the live dev server (FAQ answers show the new numbers)

Website-only change — no changelog entry per policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
