### PR TITLE
fix(skills): make the enhanced widget form the default /fix intake surface

### DIFF
--- a/.agents/skills/fix/SKILL.md
+++ b/.agents/skills/fix/SKILL.md
@@ -41,12 +41,23 @@ default rather than asking again.
 
 ## Step 2 — Render the form (communication grammar)
 
-Render ONE form — request, scope, probes, mode — per the Socratic
-rule: widget surface when available, `AskUserQuestion` fallback
-(batch the questions; `metadata.source` containing "form" opts into
-the batch). Never ask these as sequential single questions. When a
-field came back with no derived options it is free text — accept a
-path or command, do not invent options.
+Render ONE form — request, scope, probes, mode. The enhanced
+widget is the DEFAULT surface: build the `FormSchema` from the
+Step 1 payload, route it through `select_form_surface`, and when
+it returns "widget" render `form_to_widget_html(form)` on the
+widget surface — answers post back as an
+`__elicitation_response__` payload; parse them with
+`collect_form_response`. Carry an already-stated goal into the
+request field as its default.
+
+Fall back to `AskUserQuestion` ONLY when no widget surface exists
+(batch the questions; `metadata.source` containing "form" opts
+into the batch). Never ask these as sequential single questions —
+and never hand-write the ask turn without consulting
+`select_form_surface` first: steering that names the fallback
+concretely gets the fallback executed. When a field came back with
+no derived options it is free text — accept a path or command, do
+not invent options.
 
 When the user picks the "other (type a path)" scope option, offer a
 folder drill-down instead of bare free text:

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -454,6 +454,10 @@ that tool, so the communication grammar almost never fired.) Construct
 a `FormSchema` via `attune.elicitation.form_from_dict` and let
 `select_form_surface` pick the surface. The widget is the default;
 `AskUserQuestion` is one of its fallbacks, not the starting point.
+When the session is widget-capable, render `form_to_widget_html(form)`
+on the widget surface — hand-writing an `AskUserQuestion` turn without
+consulting `select_form_surface` IS the D21 failure mode (re-hit live
+2026-08-02 on the /fix intake; caught by Patrick).
 
 ### Two grammars, two directions — not a ranking
 

--- a/plugin/skills/fix/SKILL.md
+++ b/plugin/skills/fix/SKILL.md
@@ -43,12 +43,23 @@ default rather than asking again.
 
 ## Step 2 — Render the form (communication grammar)
 
-Render ONE form — request, scope, probes, mode — per the Socratic
-rule: widget surface when available, `AskUserQuestion` fallback
-(batch the questions; `metadata.source` containing "form" opts into
-the batch). Never ask these as sequential single questions. When a
-field came back with no derived options it is free text — accept a
-path or command, do not invent options.
+Render ONE form — request, scope, probes, mode. The enhanced
+widget is the DEFAULT surface: build the `FormSchema` from the
+Step 1 payload, route it through `select_form_surface`, and when
+it returns "widget" render `form_to_widget_html(form)` on the
+widget surface — answers post back as an
+`__elicitation_response__` payload; parse them with
+`collect_form_response`. Carry an already-stated goal into the
+request field as its default.
+
+Fall back to `AskUserQuestion` ONLY when no widget surface exists
+(batch the questions; `metadata.source` containing "form" opts
+into the batch). Never ask these as sequential single questions —
+and never hand-write the ask turn without consulting
+`select_form_surface` first: steering that names the fallback
+concretely gets the fallback executed. When a field came back with
+no derived options it is free text — accept a path or command, do
+not invent options.
 
 When the user picks the "other (type a path)" scope option, offer a
 folder drill-down instead of bare free text:


### PR DESCRIPTION
## Summary

Executes the /fix contract Patrick composed through the (now-corrected) widget intake + pushback flow: make the enhanced widget form the DEFAULT /fix intake surface, instead of prose / batched AskUserQuestion.

- **plugin/skills/fix/SKILL.md Step 2 rewritten**: the default path is named concretely — build the FormSchema, route through `select_form_surface`, render `form_to_widget_html` on the widget surface, parse the `__elicitation_response__` post-back with `collect_form_response`. `AskUserQuestion` is demoted to the explicit no-widget-surface fallback, with the drift warning spelled out: steering that names the fallback concretely gets the fallback executed.
- **Resident Socratic rule (.claude/CLAUDE.md)**: one-sentence guard added to D21 naming the concrete widget render path and the failure mode (re-hit live 2026-08-02).
- **.agents/skills/fix/SKILL.md**: re-projected via `sync_agents_skills.py --write` (44 ok).

## Receipt

- Probe 1: `pytest tests/unit/plugins/test_sync_agents_skills.py` + Probe 2: `pytest tests/unit/plugins/test_plugin_reference_validation.py` — 63 passed, 3 skipped
- Insurance: config-validation + rules-residency-budget + lessons-core-mirror — 36 passed
- Scope held: exactly the three planned files (shim needed no edit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
