### PR TITLE
docs(blog): multi-LLM release article — canonical source + style pass

### DIFF
--- a/docs/blog/social/linkedin_memory_suite.md
+++ b/docs/blog/social/linkedin_memory_suite.md
@@ -4,8 +4,11 @@ description: "LinkedIn Article — Attune AI Memory Suite (measured): we put har
 
 # LinkedIn Article — Attune AI Memory Suite (measured)
 
-*Format: LinkedIn Article (long-form, supports headers). ~450 words.
-ASCII markers only — LinkedIn mangles Unicode arrows on paste.*
+*Format: LinkedIn Article (long-form, supports headers). ~550 words.
+ASCII markers only — LinkedIn mangles Unicode arrows on paste.
+Revised 2026-08-02: style pass (honest-mistake paragraph, re-run
+note) + metrics converted to a proper list so LinkedIn stops
+running them together; published article updated in place same day.*
 
 ---
 
@@ -17,15 +20,15 @@ against our own live memory store, on our own codebase.
 
 Here's what persistent memory actually bought us:
 
--> 302,949 tokens of durable memory — 751 findings, lessons, and rules
-   distilled from our own sessions
--> A session recalls only the relevant slice: lessons injected at the
-   trap moment are capped at 3,000 tokens = **67x fewer tokens** than
-   loading the full corpus into context
--> Recall is one warm Redis call: **0.6 ms**, versus 4.4 ms to read the
-   files from disk — roughly **7x faster**
--> Retrieval quality: **P@3 96%** (100% on the high-severity subset) on
-   a frozen trap-moment benchmark
+- 302,949 tokens of durable memory — 751 findings, lessons, and rules
+  distilled from our own sessions
+- A session recalls only the relevant slice: lessons injected at the
+  trap moment are capped at 3,000 tokens = **67x fewer tokens** than
+  loading the full corpus into context
+- Recall is one warm Redis call: **0.6 ms**, versus 4.4 ms to read the
+  files from disk — roughly **7x faster**
+- Retrieval quality: **P@3 96%** (100% on the high-severity subset) on
+  a frozen trap-moment benchmark
 
 And both wins widen as the corpus grows — the budget cap stays constant,
 the recall call stays flat.
@@ -48,6 +51,17 @@ The loop:
 - Lessons at the trap moment — the right lesson shows up exactly when a
   prompt hits a known trap
 
+**The honest part: we shipped it broken once.**
+
+One release went out with recall broken — capture worked, recall
+returned nothing — and every unit test was green, because the tests
+mocked the exact layer that failed. What caught it was a dogfood probe
+of the shipped package: clean environment, fresh home directory,
+install what a user installs, run what a user runs. The fix became the
+next release's headline, and that probe is now part of the release
+ceremony. "The tests pass" and "it remembers" are different claims. We
+only trust the second one measured — which is why this article exists.
+
 As of the latest release it ships with a plain `pip install attune-ai` —
 no infrastructure required. Without Redis it degrades to files with
 clear guidance instead of failing silently.
@@ -61,7 +75,10 @@ memory suite is that idea, shipped and now measured.
 
 Everything above is reproducible — the numbers come straight out of
 `benchmarks/memory_savings.py`, run against the live store. No
-hand-picked figures.
+hand-picked figures. We re-ran the benchmark the day after publishing:
+the claims didn't just hold, they read slightly better, because the
+corpus had already grown. That's the shape you want — wins that widen
+on their own.
 
 What would your AI do differently if it remembered last month?
 

--- a/docs/blog/social/linkedin_multi_llm_release.md
+++ b/docs/blog/social/linkedin_multi_llm_release.md
@@ -1,0 +1,208 @@
+---
+description: "LinkedIn Article — the 10.6.x multi-LLM release: shared memory across Claude Code/Codex/Antigravity, handoffs that verify instead of trust, cross-provider review, and roundtable-picked features. Canonical source reconstructed 2026-08-02."
+---
+
+# LinkedIn Article — Multi-LLM release (agents talk to each other)
+
+*Format: LinkedIn Article. Title: "Your AI coding agents don't talk
+to each other. This release makes them." Published 2026-07-28
+(pulse slug -olxte). This file became the canonical source on
+2026-08-02: the published copy was reconstructed here (the original
+had no tracked source), given real paragraphs and code blocks (the
+July paste carried hard-wrapped line-per-paragraph spacing and
+literal fence markers LinkedIn never rendered), and extended with
+the team-structure and worked-example paragraphs. The published
+article was updated in place from this source the same day.*
+
+---
+
+**Your AI coding agents don't talk to each other. This release makes them.**
+
+I run three AI coding agents on the same repository: Claude Code,
+OpenAI's Codex, and Google's Antigravity. Each one is good at
+different things. And until this week, each one was an island.
+
+Start a task in Claude Code, hit a session limit or want a
+different model's strengths, open Codex — and everything the first
+session knew is gone. The goal, the decisions, the half-finished
+state, the "don't touch that file, it's load-bearing" — all of it
+evaporates at the provider boundary. You paste fragments and hope.
+
+attune-ai 10.6.0 is about deleting that boundary. One plugin, three
+agents, and the interesting part isn't any single feature — it's
+that the features had to be *provable* across vendors before we'd
+call them shipped.
+
+A word on how this team is structured, because it shapes everything
+below: the three agents are not interchangeable peers. Codex and
+Antigravity hold advisory seats — their findings route through
+review before anything lands — and I've chosen Claude for the lead
+programmer role, a choice written into the repo's collaboration
+contract. Running multi-model isn't hedging; it's an evaluated
+division of labor, and the evaluation is a year of receipts.
+
+### Shared memory, any agent
+
+The core of the release is a set of five session_memory_* MCP
+tools: capture, recall, recent, forget, status. Claude Code gets
+them automatically — its lifecycle hooks stash session findings as
+you work. Codex and Antigravity get the *same surface* through
+their MCP configuration: no sidecar, no second memory system, no
+"lite" version. A finding captured in one agent is recallable in
+the next, with PII scrubbed on the way in.
+
+That PII gate has a story. Our mocked unit tests — over a thousand
+of them — said the sanitizer was on. A live canary said otherwise:
+the constructor's defaults silently disabled both scrubbers.
+Nothing mocked would ever have caught it, because the mocks
+faithfully reproduced our wrong assumption. One live round-trip
+caught it in minutes. It's now enabled, and the fix ships in this
+release.
+
+**Receipt** — live round-trip against the real memory backend,
+2026-07-22. A canary carrying a real-looking address went in;
+recall returned the stored representation:
+
+```text
+T2-LIVE-CANARY-e5f1: contact [EMAIL] re parser deadlock
+```
+
+Redacted at rest, not just in the response. Forget deleted 1,
+re-recall found nothing — the canary cleaned up after itself.
+(Transport spec, receipt 3.)
+
+### Handoffs that verify instead of trust
+
+handoff_create writes a handoff packet for the current branch —
+but the git-derived facts (branch, changed files, HEAD) come from
+git at call time, never from what the model *says* it did. Claims
+without receipts are recorded as exactly that: not run.
+
+handoff_resume, on the receiving agent, re-checks the packet
+against the actual tree and reports drift — head moved, files
+diverged, branch missing — before any work continues. The
+receiving agent gets context clearly separated from claims. Our
+collaboration contract has said "a handoff is context, not
+authority" for months; now it's mechanical.
+
+**Receipt** — live Antigravity session, 2026-07-28, plugin 10.6.1.
+The packet was created in Claude Code on branch
+claude/handoff-t4-docs; handoff_resume then ran in a *different
+vendor's* agent, which re-checked it against the real tree and
+reported what had moved. It returned two warnings. The first,
+"head_moved", read: packet 3fed725b7 vs current afd3040f2. The
+second, "files_diverged", was more specific still — the packet
+recorded no changed files, while the tree it was resuming into had
+one: tests/unit/telemetry/test_memory_events.py.
+
+The world had shifted under that packet, and the receiving agent
+said so before touching anything. Note what it did *not* do: the
+packet's own verification row still reads not run, and it stays
+quarantined in the asserted block — the sending agent's prose,
+kept strictly apart from the git-rechecked facts in verified.
+Context, not authority, mechanically enforced.
+
+### Second opinions from a different vendor
+
+/cross-review sends your actual diff — not a summary of it — to
+one seat from a different provider for an adversarial pass.
+Different model, different blind spots. Findings come back
+anchored (file:line, severity), the run is recorded, and the whole
+thing is *advisory by spec*: it cannot gate a merge, fail a
+command, or block CI. If the reviewer's CLI is missing, you get an
+honest ABSENT — never a fabricated review.
+
+Whether it ever becomes more than advisory is not a roadmap
+decision. Every run appends a row to a public dogfood ledger —
+date, seat, findings, and whether a human judged them real or
+noise. That ledger is the only evidence that can upgrade it.
+
+### The features picked themselves
+
+Here's my favorite part. We didn't choose this release's headline
+features in a planning meeting. We asked the round table — the
+multi-LLM deliberation loop that shipped in a previous release.
+Three seats (Claude, Codex, Antigravity's Gemini) answered
+independently: given everything attune has, what's the obvious
+next win?
+
+Two of three converged, unprompted, on the same feature with
+nearly identical designs: the cross-provider handoff. The third
+proposed a verification pattern I ruled out — it needed seats to
+run shell, which our contract forbids. But all three flagged the
+same risk, still without seeing each other's answers: any of these
+features rots into ceremony unless the receipts stay real and the
+output stays advisory. That shaped the review discipline more than
+the feature picks did.
+
+Working across vendors also taught me a small, humbling lesson
+about specifications themselves. A format contract described in
+prose — clear prose, I thought — failed repeatedly for one seat,
+even through a repair round that quoted the exact failures back to
+it. What fixed it was putting a worked example in the brief. Two
+models read the same paragraph and produced different shapes; the
+example converged them where the prose could not. If a contract
+matters, ship an example with it.
+
+I chaired, ratified, and the specs were authored and built the
+same evening — with the deliberation thread, every seat's
+position, and my rulings promoted to a tracked report in the repo.
+The tooling deliberated its own roadmap. I just held the gavel.
+
+**Receipt** — the whole deliberation is public: every seat's
+position, the moderator synthesis, my rulings, and the two
+questions I left unruled.
+[q-multi-llm-obvious-win-001](https://github.com/Smart-AI-Memory/attune-ai/blob/main/docs/reports/roundtable/q-multi-llm-obvious-win-001.md),
+merged to main 2026-07-22.
+
+### Receipts or it didn't happen
+
+One discipline runs through all of this: no feature is "done"
+because its tests pass. Mocked tests prove your assumptions agree
+with themselves — the PII bug taught us that. So every boundary
+claim in this release carries a dated receipt from the real
+system, and the ledger keeps honest UNPROBED rows for anything we
+haven't proven yet.
+
+We even discovered a receipts lesson about our own distribution:
+an agent like Codex installs the plugin from its marketplace
+pinned to our main branch — so until a feature merges and
+publishes, no live probe from that agent can pass, no matter how
+finished the code looks. The honest ledger row for that day reads
+"probed — blocked pre-release." Today, post-release, it reads:
+
+**Receipt** — live Codex session, 2026-07-27, plugin 10.6.0. Four
+legs, all green: capture returned ok:true
+(id a1c7b6e0-2668-42c5-b14a-02e8770cbf36); recall returned the
+stored representation
+
+```text
+R4-LIVE-CANARY-20260727: codex post-lift probe, contact [EMAIL] re transport receipt
+```
+
+— the same redaction gate, enforced from a different vendor's
+agent; forget reported requested:1 deleted:1; the final re-recall
+found neither the token nor the id. (Transport spec, receipt 4.)
+
+### The design principle
+
+Claude Code gets automatic lifecycle hooks. Every other agent gets
+the same memory and the same contract through adapters — never a
+parallel subsystem, never a degraded copy. Cross-provider parity
+by adapters is the growth surface: when the next agent CLI ships,
+it gets a seat at the table and a key to the memory, not a fork.
+
+```bash
+pip install attune-ai
+```
+
+10.6.1 is on PyPI now — 10.6.0 plus a same-day patch. The round
+table is open.
+
+One question before you go: **what boundary kills your context?**
+Mine was the provider boundary — that's the one this release
+attacks. Yours might be somewhere else entirely: the gap between
+sessions, between you and the teammate picking up your branch,
+between staging and prod. I read the replies, and they feed the
+same loop the round table does — the last set of answers is part
+of why these features got built and not others.


### PR DESCRIPTION
The Jul 28 LinkedIn article ("Your AI coding agents don't talk to each other. This release makes them.") had no tracked source. This adds `docs/blog/social/linkedin_multi_llm_release.md` as the canonical source — reconstructed from the published copy with formatting inventory verified against the live editor DOM — plus two style-pass additions in Patrick's voice:

1. **Team structure** — Codex/Antigravity as advisory seats, Claude chosen for the lead programmer role per the collaboration contract ("an evaluated division of labor").
2. **Worked-example lesson** — the 2026-07-19 format-contract failure: prose specs diverged across vendors until a worked example converged them.

The rebuild also fixed two warts from the original July paste: hard-wrapped line-per-paragraph spacing and literal ``` fences LinkedIn never rendered (now real code blocks). The published article was updated in place from this source on 2026-08-02 — same URL, verified live.

Follows #1920/#1921 (discipline + memory-suite article style passes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)