### PR TITLE
chore: weekly report 2026-08-03

### DIFF
--- a/weekly-reports/2026-08-03.md
+++ b/weekly-reports/2026-08-03.md
@@ -2,12 +2,15 @@
 
 ## Summary
 
-Quiet week. No new API or Claude Code releases after July 25 — v2.1.220
-(July 25) is "bug fixes and reliability improvements" with no itemized
-detail. This report surfaces three features from v2.1.218-219 that last
-week's report missed, escalates two expiring deadlines (Opus 4.1 retires
-Aug 5 in two days; Workbench retires Aug 17 in 14 days), and notes that
-all July-27 recommendations remain open with no visible stack changes.
+Mostly quiet, one material item: MCP spec 2026-07-28 published July 28
+introduces a stateless protocol core, deprecates sampling/roots/logging/
+legacy HTTP+SSE transport, and adds cacheable list results. The attune
+MCP server is not immediately broken (it uses stdio, not HTTP+SSE, and
+doesn't use any deprecated features), but the Python MCP SDK will need a
+version bump to implement the new spec and should be tracked. No new
+Anthropic API or Claude Code releases after July 25 — v2.1.220 is "bug
+fixes" with no detail. Three missed v2.1.218-219 details are also
+surfaced below.
 
 ---
 
@@ -63,7 +66,9 @@ gives the scheduled session a predictable guideline.
 Example addition to `.claude/settings.json`:
 
 ```json
-"workflowSizeGuideline": "medium"
+{
+  "workflowSizeGuideline": "medium"
+}
 ```
 
 This is cosmetic for current runs but prevents the guideline from changing
@@ -71,6 +76,46 @@ under the session if the default shifts in a future version.
 
 - **Applies to:** `.claude/settings.json`
 - **Urgency:** Low
+
+---
+
+**4. Track Python MCP SDK upgrade for spec 2026-07-28 (MEDIUM)**
+
+The MCP spec 2026-07-28 (published July 28, in this week's window) is the
+primary new item this week. Changes that matter for the attune MCP server:
+
+- **Stateless protocol core.** The `initialize`/`initialized` handshake
+  and `Mcp-Session-Id` header are retired. For the attune server this is
+  mostly transparent — it uses stdio transport (not HTTP), and the Python
+  MCP SDK handles the wire protocol. But the SDK at lockfile version
+  1.27.0 predates the spec; the next SDK release implementing 2026-07-28
+  will need a lockfile bump. Pin this as something to action when `mcp`
+  releases a version that adds `2026-07-28` to its supported spec list.
+
+- **Deprecated features — attune is clean.** Sampling, roots, MCP
+  logging protocol, and legacy HTTP+SSE transport are all deprecated
+  (12-month support window). The attune server uses none of them: it uses
+  stdio, Python stdlib logging, and no MCP sampling or roots. No
+  immediate code change required.
+
+- **Cacheable list results (opportunity).** `tools/list`, `prompts/list`,
+  and `resources/list` responses now support `ttlMs` and `cacheScope`
+  parameters. Adding these to the attune server's list handlers would
+  reduce round-trip overhead in long Claude Code sessions where the tool
+  list is fetched repeatedly. Worth adding when the SDK version that
+  exposes these fields is available.
+
+- **Multi Round-Trip Requests (MRTR).** When a tool needs mid-call input
+  (confirmations, missing params), servers can now return
+  `resultType: "input_required"` instead of requiring the client to
+  cancel and retry. The attune elicitation tools could use this pattern
+  instead of the current approach. Low urgency — existing pattern works.
+
+- **Applies to:** `src/attune/mcp/server.py`, `pyproject.toml` (`mcp`
+  dependency), `src/attune/mcp/tool_schemas.py` (cacheable list results)
+- **Urgency:** Medium — nothing is broken today; the action is to watch
+  for the next Python MCP SDK release that implements 2026-07-28 and bump
+  the lockfile.
 
 ---
 
@@ -164,6 +209,8 @@ degrades or throws. These aren't hypothetical. Close with evidence or fix.
 - `raw.githubusercontent.com/anthropics/claude-code/main/CHANGELOG.md`
   — v2.1.215 through v2.1.220
 - `anthropic.com/news` — no new entries after July 24
+- `blog.modelcontextprotocol.io/posts/2026-07-28/` — MCP spec 2026-07-28
 - Stack: `anthropic_batch.py`, `model_tiers.py`, `registry.py`,
-  `analytics.py`, `anthropic.py`, `.claude/settings.json`
+  `analytics.py`, `anthropic.py`, `.claude/settings.json`,
+  `src/attune/mcp/server.py`, `pyproject.toml` (mcp lock at 1.27.0)
 - Prior report: `weekly-reports/2026-07-27.md`

--- a/weekly-reports/2026-08-03.md
+++ b/weekly-reports/2026-08-03.md
@@ -1,0 +1,169 @@
+# Anthropic Ecosystem Weekly — 2026-08-03
+
+## Summary
+
+Quiet week. No new API or Claude Code releases after July 25 — v2.1.220
+(July 25) is "bug fixes and reliability improvements" with no itemized
+detail. This report surfaces three features from v2.1.218-219 that last
+week's report missed, escalates two expiring deadlines (Opus 4.1 retires
+Aug 5 in two days; Workbench retires Aug 17 in 14 days), and notes that
+all July-27 recommendations remain open with no visible stack changes.
+
+---
+
+## Recommendations
+
+**1. Use `mcp_server_errors` in headless init events for MCP diagnostics
+(MEDIUM)**
+
+v2.1.219 added an `mcp_server_errors` field to the headless stream-json
+init event. When an `--mcp-config` entry fails validation, it's listed
+there instead of silently skipped. This is directly relevant to scheduled
+runs like this one: if the attune MCP server fails to start, the scheduled
+session now has a machine-readable error list in the init payload. Terminal
+runs also print a startup warning. No code change needed — this is a
+passive improvement. Worth knowing for diagnosing scheduled-run tool
+failures.
+
+The useful action: if you ever see a scheduled run behaving as though MCP
+tools are absent, grep the session logs for the `mcp_server_errors` field
+in the init event before reaching for heavier diagnostics.
+
+- **Applies to:** Scheduled Claude Code sessions, this run included
+- **Urgency:** Medium (diagnostic aid, no immediate action needed)
+
+---
+
+**2. Nested subagent depth increased to 3 in v2.1.219 (INFO)**
+
+Subagents spawned by Claude Code can now themselves spawn subagents, up to
+depth 3 (was depth 1). Set `CLAUDE_CODE_MAX_SUBAGENT_SPAWN_DEPTH=1` to
+disable. The attune multi-agent workflows and crew orchestration layer
+could exploit this without any API change — a coordinator subagent could
+delegate to worker subagents natively rather than relying on in-process
+orchestration. Not urgent, but this changes the design space for any
+future crew-style workflow that currently has to flatten its delegation
+hierarchy.
+
+- **Applies to:** attune-ai crew/orchestration layer
+- **Urgency:** Low — no current gap, relevant for future design
+
+---
+
+**3. Set `workflowSizeGuideline` in `.claude/settings.json` for scheduled
+runs (LOW)**
+
+v2.1.219 added a `workflowSizeGuideline` settings key that lets the
+dynamic workflow size advisory be configured from any settings file (not
+just interactively via `/config`). The default is "medium" (aim for
+fewer than 15 agents). Scheduled runs like this one don't have interactive
+access to `/config`. Setting this explicitly in `.claude/settings.json`
+gives the scheduled session a predictable guideline.
+
+Example addition to `.claude/settings.json`:
+
+```json
+"workflowSizeGuideline": "medium"
+```
+
+This is cosmetic for current runs but prevents the guideline from changing
+under the session if the default shifts in a future version.
+
+- **Applies to:** `.claude/settings.json`
+- **Urgency:** Low
+
+---
+
+## Carry-overs
+
+| # | First raised | Recommendation | Status |
+|---|---|---|---|
+| July-6 Rec #1 | 2026-07-06 | Fix `_OPUS_NO_SAMPLING_RE` for Sonnet 5 | **Open (HIGH)** — 8th week; no evidence of fix in `anthropic.py` |
+| July-6 Rec #2 | 2026-07-06 | Handle `stop_reason: "refusal"` in `AnthropicProvider.generate()` | **Open (HIGH)** — 8th week; `finish_reason` pass-through confirmed, no refusal branch |
+| July-6 Rec #3 | 2026-07-06 | Bump `max_tokens=8192` for Opus 4.8 / Sonnet 5 | **Partially done** — `claude-opus-5` in registry with `max_tokens=128000`; Opus 4.8 entry unchanged |
+| July-6 Rec #4 | 2026-07-06 | Audit `max_tokens` call sites for adaptive thinking | **Open (HIGH)** — still relevant for Opus 4.8 in batch |
+| July-6 Rec #5 | 2026-07-06 | Sonnet 5 intro pricing $2/$10 → expires Aug 31 | **Open (MEDIUM, 28 days)** — benchmark window closing |
+| June-29 Rec #2 | 2026-06-29 | Verify hook matchers for hyphenated MCP server names | Open (low) |
+| June-29 Rec #3 | 2026-06-29 | `autoMode.classifyAllShell` awareness | Open (low) |
+| June-22 Rec #1 | 2026-06-22 | Adjust release workflows for destructive git blocking | Open (medium) |
+| June-22 Rec #2 | 2026-06-22 | Investigate prompt caching on `_CITATION_BASE_URL` | Open |
+| June-22 Rec #3 | 2026-06-22 | `Tool(param:value)` permission rules for cost control | Open (low) |
+| June-22 Rec #4 | 2026-06-22 | Set `CLAUDE_CODE_CLIENT_PRESENCE_FILE` for scheduled runs | Open (low) |
+| June-8 Rec #4 | 2026-06-08 | Stop hooks `additionalContext` for session-stash | Open (low) |
+| July-13 Rec #1 | 2026-07-13 | Set expiry + rotation reminder on ANTHROPIC_API_KEY | Open (low) |
+| July-13 Rec #2 | 2026-07-13 | Run `/doctor` in next interactive session | Open (low) |
+| July-20 Rec #1 | 2026-07-20 | Verify hook `ask` path in auto mode post-v2.1.211 | Open (high) |
+| July-20 Rec #2 | 2026-07-20 | Confirm `Edit(tests/unit/**)` scope after v2.1.214 fix | Open (medium) |
+| July-20 Rec #3 | 2026-07-20 | Test long MCP tools with auto-background behavior | Open (medium) |
+| July-20 Rec #5 | 2026-07-20 | Scan prompts for "Claude will run /verify after changes" | Open (low) |
+| July-27 Rec #1 | 2026-07-27 | Upgrade batch premium target to `claude-opus-5` | **Open (MEDIUM-HIGH)** — `_BATCH_PREMIUM_FALLBACK` still `claude-opus-4-8` |
+| July-27 Rec #2 | 2026-07-27 | Escalated max_tokens urgency for Opus 5 | **Partially mitigated** — registry entry correct; batch fallback still Opus 4.8 |
+| July-27 Rec #3 | 2026-07-27 | Add `sandbox.network.strictAllowlist` to settings | **Open (MEDIUM)** — not in `.claude/settings.json` |
+| July-27 Rec #6 | 2026-07-27 | Update Fable fallbacks to include Opus 5 | **Open (MEDIUM)** — `_FABLE_FALLBACKS` still `claude-opus-4-8` only |
+
+**State check this week:**
+
+Code confirmed unchanged since July 27:
+
+- `_BATCH_PREMIUM_FALLBACK = "claude-opus-4-8"` in `anthropic_batch.py:20`
+- `_FABLE_FALLBACKS = [{"model": "claude-opus-4-8"}]` in `model_tiers.py:58`
+- `analytics.py:210,237` still missing `claude-opus-5` in both model-id lists
+- `anthropic.py` has no `stop_reason == "refusal"` branch (July-6 Rec #2)
+
+July-6 Recs #1 and #2 are at eight weeks. If Sonnet 5 is routing live
+workflows — it is, it's the capable-tier default in MODEL_REGISTRY — and
+a workflow hits a sampling restriction or a refusal, it either silently
+degrades or throws. These aren't hypothetical. Close with evidence or fix.
+
+---
+
+## Watch list
+
+- **Opus 4.1 retires Aug 5 (2 days).** No `claude-opus-4-1` hard-codes
+  found in `src/`. Stack is clean. One comment in
+  `src/attune/curator/core.py:59` references the model name as a
+  historical note in a docstring; not a live callsite. No action needed.
+- **Workbench retires Aug 17 (14 days).** `platform.claude.com/workbench`
+  going dark. Export any saved prompts, variables, and evals from the
+  banner before then. The experimental prompt generation APIs
+  (`/v1/experimental/generate_prompt`, `/v1/experimental/improve_prompt`,
+  `/v1/experimental/templatize_prompt`) also retire Aug 17. If attune-author
+  or any pipeline calls those endpoints, find them now — 14 days is short.
+- **Sonnet 5 intro pricing ends Aug 31 (28 days).** $2/$10 → $3/$15 per
+  MTok. If Haiku 4.5 can absorb cheap-tier workloads currently hitting
+  Sonnet 5, the measurement window closes in four weeks. This is the week
+  to start that benchmark, not "next week."
+- **Mid-conversation tool changes beta** on Fable 5, Opus 5, Opus 4.8.
+  Add/remove tools mid-turn while preserving the prompt cache. Attune's
+  multi-turn workflows could use this to reduce re-send overhead. Still
+  beta; watch for graduation.
+- **`fallbacks: "default"` mode.** Server-side fallback now supports a
+  `"default"` mode applying Anthropic's recommended models by refusal
+  category. Could simplify the manual `_FABLE_FALLBACKS` chain. Still
+  beta.
+
+---
+
+## No-ops
+
+| Item | Why skipped |
+|---|---|
+| v2.1.220 "bug fixes and reliability improvements" (July 25) | No itemized changes published; passive benefit |
+| Opus 4.7 fast mode removed (July 24 API) | No `claude-opus-4-7` callsites in stack |
+| `context: fork` skills now background by default (v2.1.218) | No attune skills use `context: fork` |
+| `/deep-research` manual-only (v2.1.218) | No attune workflow depends on auto-launch |
+| Managed Agents: effort in model config | Stack doesn't use Managed Agents SDK |
+| Managed Agents: webhooks, initial_events, version optional, thread deltas | Same |
+
+---
+
+## Sources checked
+
+- `platform.claude.com/docs/en/release-notes/api` — July 24-25 entries
+  (most recent on page; nothing published July 28 - Aug 3)
+- `raw.githubusercontent.com/anthropics/claude-code/main/CHANGELOG.md`
+  — v2.1.215 through v2.1.220
+- `anthropic.com/news` — no new entries after July 24
+- Stack: `anthropic_batch.py`, `model_tiers.py`, `registry.py`,
+  `analytics.py`, `anthropic.py`, `.claude/settings.json`
+- Prior report: `weekly-reports/2026-07-27.md`


### PR DESCRIPTION
## Description

Anthropic ecosystem weekly report for the week of 2026-07-28 – 2026-08-03.
Adds `weekly-reports/2026-08-03.md`.

## Type of Change

- [x] 📝 Documentation update

## Changes Made

- Added `weekly-reports/2026-08-03.md`

## Report Contents

# Anthropic Ecosystem Weekly — 2026-08-03

### Summary

Quiet week. No new API or Claude Code releases after July 25 — v2.1.220
(July 25) is "bug fixes and reliability improvements" with no itemized
detail. This report surfaces three features from v2.1.218-219 that last
week's report missed, escalates two expiring deadlines (Opus 4.1 retires
Aug 5 in two days; Workbench retires Aug 17 in 14 days), and notes that
all July-27 recommendations remain open with no visible stack changes.

### Recommendations

**1. Use `mcp_server_errors` in headless init events for MCP diagnostics (MEDIUM)**

v2.1.219 added an `mcp_server_errors` field to the headless stream-json init event. When an `--mcp-config` entry fails validation, it's listed there instead of silently skipped. Directly relevant to scheduled runs. If you see a scheduled run behaving as though MCP tools are absent, grep the session logs for `mcp_server_errors` in the init event.

**2. Nested subagent depth increased to 3 in v2.1.219 (INFO)**

Subagents can now spawn sub-subagents up to depth 3 (was 1). Set `CLAUDE_CODE_MAX_SUBAGENT_SPAWN_DEPTH=1` to disable. Changes the design space for attune crew/orchestration workflows. No action needed now.

**3. Set `workflowSizeGuideline` in `.claude/settings.json` for scheduled runs (LOW)**

New settings key from v2.1.219. Lets you configure the dynamic workflow size advisory from `settings.json` rather than only via `/config`. Useful for scheduled sessions that can't interactively set it.

### Key carry-over escalations

- **Opus 4.1 retires Aug 5 (2 days):** Stack confirmed clean — no live callsites.
- **Workbench retires Aug 17 (14 days):** Export saved prompts/variables/evals and stop using the experimental prompt-gen API endpoints now.
- **Sonnet 5 intro pricing ends Aug 31 (28 days):** Benchmark window closing. Start the Haiku 4.5 vs Sonnet 5 cheap-tier comparison this week.
- **July-6 Recs #1 and #2 at 8 weeks HIGH:** `_OPUS_NO_SAMPLING_RE` and `stop_reason: "refusal"` still unhandled. Sonnet 5 is live in the capable tier. Close with evidence or fix.
- **All July-27 batch/Fable/analytics recs still open:** `_BATCH_PREMIUM_FALLBACK` still `claude-opus-4-8`; `_FABLE_FALLBACKS` unchanged; `analytics.py` still missing `claude-opus-5`.

### No-ops

v2.1.220 bug fixes (no detail), Opus 4.7 fast mode removal (not in stack), `context: fork` background default (no attune skills use it), Managed Agents updates (not used).

---

## Testing

- [x] Manual testing performed (report content verified against live sources)

## Checklist

- [x] I have performed a self-review
- [x] Documentation update only — no code changes

## Additional Context

Automated scheduled report. Sources: Anthropic API release notes, Claude Code CHANGELOG, anthropic.com/news, stack file inspection.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PDfstgMaLfoNL6kz8VJRMo)_