### PR TITLE
docs(usage-signals): US-5 AFTER snapshot 2026-08-03 — 4/5 for 11.2.0+11.2.1

### DIFF
--- a/docs/specs/usage-signals/snapshots/2026-08-03.json
+++ b/docs/specs/usage-signals/snapshots/2026-08-03.json
@@ -1,0 +1,65 @@
+{
+  "attempts": [
+    {
+      "at": "2026-08-03T15:08:12.577613+00:00",
+      "captured": 3,
+      "outcome": "rate-limited"
+    },
+    {
+      "at": "2026-08-03T16:13:30.630827+00:00",
+      "captured": 3,
+      "outcome": "rate-limited"
+    },
+    {
+      "at": "2026-08-03T17:48:50.110031+00:00",
+      "captured": 4,
+      "outcome": "rate-limited"
+    }
+  ],
+  "date": "2026-08-03",
+  "github": {},
+  "manifest": {
+    "captured": [
+      "attune-ai",
+      "attune-rag",
+      "attune-help",
+      "attune-author"
+    ],
+    "complete": false,
+    "expected": [
+      "attune-ai",
+      "attune-rag",
+      "attune-help",
+      "attune-author",
+      "attune-verify"
+    ],
+    "missing": [
+      "attune-verify"
+    ],
+    "observed_at": "2026-08-03T17:48:50.110327+00:00",
+    "source": "pypistats.org/api/recent"
+  },
+  "pypi_recent": {
+    "attune-ai": {
+      "last_day": 265,
+      "last_month": 3973,
+      "last_week": 752
+    },
+    "attune-author": {
+      "last_day": 1,
+      "last_month": 919,
+      "last_week": 14
+    },
+    "attune-help": {
+      "last_day": 1441,
+      "last_month": 17236,
+      "last_week": 16331
+    },
+    "attune-rag": {
+      "last_day": 1853,
+      "last_month": 57667,
+      "last_week": 23429
+    }
+  },
+  "taken_at": "2026-08-03T17:48:50.110327+00:00"
+}


### PR DESCRIPTION
## US-5 AFTER reach snapshot — 2026-08-03 (PARTIAL, 4/5)

Closes the US-5 **AFTER** leg for both same-day tags (one AFTER leg serves both, per the starter's OWED section):

- **11.2.0** — tag `v11.2.0` @ `84d576697f2c`
- **11.2.1** — tag `v11.2.1` @ `be64690cb019`

Window: opened Mon 2026-08-03 ~11:00 ET, closes Tue 2026-08-04 ~11:00 ET (24–72h post-tag).

### Result: 4/5 — INCOMPLETE

Verified by the day-file **manifest**, not by exit code (`reach_snapshot.py` exits 0 on rate-limit).

| Package | Captured | last_day | last_week | last_month |
|---|---|---|---|---|
| attune-ai | yes | 265 | 752 | 3,973 |
| attune-rag | yes | 1,853 | 23,429 | 57,667 |
| attune-help | yes | 1,441 | 16,331 | 17,236 |
| attune-author | yes | 1 | 14 | 919 |
| **attune-verify** | **NO — rate-limited** | — | — | — |

`manifest.complete: false`, `manifest.missing: ["attune-verify"]`.

### Attempt log (today's 3-attempt budget, exhausted)

| # | Time (ET) | Cooldown before | Captured | Outcome |
|---|---|---|---|---|
| 1 | 11:08 | — | 3/5 | rate-limited on attune-author |
| 2 | 12:13 | 62 min | 3/5 | rate-limited on attune-author |
| 3 | 13:48 | 95 min | 4/5 | rate-limited on attune-verify |

The day-file seed converged as designed (3/5 → 3/5 → 4/5), reusing already-captured packages across attempts. attune-author — historically the choke point — needed a cooldown longer than the script's own recommended 60 min: a 62-minute wait was still refused, and it only cleared after 95 minutes.

### Chair call required

**Whether a 4/5 partial satisfies US-5 is a CHAIR decision — not assumed here.** This PR records the evidence as captured; it does not claim the AFTER leg is satisfied.

**Tuesday 2026-08-04 morning, before ~11:00 ET, is the last in-window shot** for attune-verify. A rerun then would reuse the four captured packages and need only the one remaining fetch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
