### PR TITLE
docs(usage-signals): US-5 AFTER snapshot completion 2026-08-04 — 5/5

### DIFF
--- a/docs/specs/usage-signals/snapshots/2026-08-04.json
+++ b/docs/specs/usage-signals/snapshots/2026-08-04.json
@@ -1,0 +1,64 @@
+{
+  "attempts": [
+    {
+      "at": "2026-08-04T12:40:29.507006+00:00",
+      "captured": 5,
+      "outcome": "complete"
+    }
+  ],
+  "date": "2026-08-04",
+  "github": {
+    "clones_14d": 70999,
+    "forks": 0,
+    "stars": 10,
+    "views_14d": 740
+  },
+  "manifest": {
+    "captured": [
+      "attune-ai",
+      "attune-rag",
+      "attune-help",
+      "attune-author",
+      "attune-verify"
+    ],
+    "complete": true,
+    "expected": [
+      "attune-ai",
+      "attune-rag",
+      "attune-help",
+      "attune-author",
+      "attune-verify"
+    ],
+    "missing": [],
+    "observed_at": "2026-08-04T12:40:29.507392+00:00",
+    "source": "pypistats.org/api/recent"
+  },
+  "pypi_recent": {
+    "attune-ai": {
+      "last_day": 265,
+      "last_month": 3973,
+      "last_week": 752
+    },
+    "attune-author": {
+      "last_day": 1,
+      "last_month": 919,
+      "last_week": 14
+    },
+    "attune-help": {
+      "last_day": 1441,
+      "last_month": 17236,
+      "last_week": 16331
+    },
+    "attune-rag": {
+      "last_day": 1853,
+      "last_month": 57667,
+      "last_week": 23429
+    },
+    "attune-verify": {
+      "last_day": 13,
+      "last_month": 24075,
+      "last_week": 595
+    }
+  },
+  "taken_at": "2026-08-04T12:40:29.507392+00:00"
+}


### PR DESCRIPTION
## Summary

Completes the US-5 AFTER snapshot for 11.2.0 + 11.2.1: **5/5, `manifest.complete: true`**.

- **attune-verify** captured fresh 2026-08-04 12:40 UTC (08:40 ET, inside the window) — it rate-limited through all three 08-03 attempts (#1928 shipped the 4/5 partial).
- The other four packages are **seeded from their 08-03 in-window captures** via the day-file seed recipe; this run made exactly one pypistats request, preserving the attempt budget.
- attune-verify numbers: last_day 13, last_week 595, last_month 24,075.
- GitHub signals on the completing run: stars 10, clones_14d 70,999, views_14d 740.

Whether the split-across-two-day-files capture satisfies US-5 formally remains a chair call, but the full 5-package set now exists — this supersedes the 4/5-partial question in #1928's body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
