### PR TITLE
feat: chartkit — sealed chart kernel with declarative specs and patch updates

### DIFF
--- a/.github/workflows/chartkit.yml
+++ b/.github/workflows/chartkit.yml
@@ -1,0 +1,41 @@
+name: chartkit
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "src/attune/widgets/chartkit/**"
+      - "scripts/check_chartkit_boundary.py"
+      - ".github/workflows/chartkit.yml"
+  pull_request:
+    paths:
+      - "src/attune/widgets/chartkit/**"
+      - "scripts/check_chartkit_boundary.py"
+      - ".github/workflows/chartkit.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  seal:
+    name: build, test, and enforce the seal
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: src/attune/widgets/chartkit
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: src/attune/widgets/chartkit/package-lock.json
+      - name: Install (esbuild only)
+        run: npm ci
+      - name: Build kernel
+        run: npm run build
+      - name: Unit tests
+        run: npm test
+      - name: Size + boundary gates
+        working-directory: ${{ github.workspace }}
+        run: python scripts/check_chartkit_boundary.py --require-dist

--- a/.github/workflows/chartkit.yml
+++ b/.github/workflows/chartkit.yml
@@ -20,12 +20,13 @@ jobs:
   seal:
     name: build, test, and enforce the seal
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     defaults:
       run:
         working-directory: src/attune/widgets/chartkit
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "22"
           cache: npm

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ preview the contract (nothing executes), then `--run` for an
 attributed diff whose probes are re-run independently of the
 workflow; exit 0 means the probes passed, not that the agent felt
 good about it — plus a spec-driven,
-multi-agent toolkit: 21 workflows and <!-- cap:mcp_registered_tool_count -->60 MCP tools<!-- /cap --> dispatching 2–6
+multi-agent toolkit: 21 workflows and <!-- cap:mcp_registered_tool_count -->61 MCP tools<!-- /cap --> dispatching 2–6
 domain-specific subagents behind Socratic quality gates, RAG
 grounding with a citation-per-claim contract (mean per-claim
 faithfulness CI-gated at ≥ 0.97; 0.98 currently measured, N=20 runs
@@ -414,7 +414,7 @@ per-surface extras (API-mode agents, ops dashboard, Redis memory).
 | <!-- cap:skill_count -->27 auto-triggering skills<!-- /cap --> | Yes | Yes |
 | Security hooks | Yes | Yes |
 | Prompt-based analysis | Yes | Yes |
-| <!-- cap:mcp_registered_tool_count -->60 MCP tools<!-- /cap --> | -- | Yes |
+| <!-- cap:mcp_registered_tool_count -->61 MCP tools<!-- /cap --> | -- | Yes |
 | `attune` CLI | -- | Yes |
 | Multi-agent workflows | -- | Yes |
 | Help system maintenance | -- | Yes |

--- a/docs/chartkit.md
+++ b/docs/chartkit.md
@@ -58,6 +58,10 @@ full specs server-side (`expand_component(name, args)`):
   `stacked`.
 - `kpi_tile` — a metric as a current-vs-prior comparison bar (a
   dedicated numeric-tile mark is a kernel v2 candidate).
+- `spec_progress` — spec task state as a status strip: one full-height
+  stacked bar per task, colored by status (`done` / `in_flight` /
+  `blocked` / anything else), legend as the key. Pass
+  `tasks=[{"task": "T1", "status": "done"}, ...]`.
 
 ## The seal
 

--- a/docs/chartkit.md
+++ b/docs/chartkit.md
@@ -1,0 +1,76 @@
+# chartkit — charts the model specs, a sealed kernel renders
+
+chartkit gives an LLM a cheap way to create and update charts: emit a
+small declarative JSON spec (or a patch against one), and a sealed
+~6.7KB JS kernel renders it as themable SVG. The model never writes
+renderer code. Updates are JSON Merge Patch (RFC 7386), so changing a
+title or swapping data costs tens of tokens, not a re-emitted widget.
+
+## Create a chart
+
+Call the `chart_render_widget` MCP tool with a `chart_id` and a full
+`spec`, then pass the returned `html` to the widget surface
+(`mcp__visualize__show_widget`).
+
+```json
+{
+  "v": 1,
+  "type": "bar",
+  "data": [
+    {"month": "Jan", "sales": 12},
+    {"month": "Feb", "sales": 19}
+  ],
+  "encodings": {
+    "x": {"field": "month", "type": "nominal"},
+    "y": {"field": "sales", "type": "quantitative"}
+  },
+  "options": {"title": "Monthly sales"}
+}
+```
+
+Chart types: `bar`, `line`, `scatter`, `area`, `heatmap`. Encoding
+field types: `quantitative`, `nominal`, `temporal`. A `color` encoding
+splits series (bar/line/scatter/area) or carries cell values (heatmap,
+where it is required). `options`: `title`, `legend` (default true),
+`stacked` (bar).
+
+## Update a chart — send a patch, not a widget
+
+The current spec persists per `chart_id` in session memory. To update,
+send the same `chart_id` with a `patch` (RFC 7386: objects merge,
+`null` deletes a key, arrays and scalars replace wholesale):
+
+```jsonc
+// patch — swap the data, keep everything else
+{"data": [{"month": "Mar", "sales": 25}, {"month": "Apr", "sales": 31}]}
+```
+
+When persistence is unavailable the tool says so explicitly and asks
+for a full `spec` — degradation is always legible, never silent.
+
+## Named components
+
+Semantic-role presets in `attune.widgets.chart_components` expand to
+full specs server-side (`expand_component(name, args)`):
+
+- `time_series` — line over temporal x; optional `series_field`.
+- `comparison_bars` — nominal categories; optional `series_field`,
+  `stacked`.
+- `kpi_tile` — a metric as a current-vs-prior comparison bar (a
+  dedicated numeric-tile mark is a kernel v2 candidate).
+
+## The seal
+
+The kernel lives in `src/attune/widgets/chartkit/` and is sealed:
+kernel source imports nothing outside itself, nothing in attune
+imports kernel internals, and the built artifact stays ≤ 20,480 bytes
+— all three enforced in CI by `scripts/check_chartkit_boundary.py`.
+Renderers build SVG via `createElementNS` and `textContent` only, so
+spec strings can never execute. Colors and text use host CSS
+variables (`--chartkit-c1..c6`, `--text-primary`, `--border`) and
+adapt to light/dark automatically.
+
+The spec contract is `spec.schema.json` (JS side) mirrored by
+`attune.widgets.chart_spec` (server side); sync tests keep them
+aligned. Extraction to a standalone package is deliberately a copy,
+not surgery.

--- a/docs/getting-started/mcp-integration.md
+++ b/docs/getting-started/mcp-integration.md
@@ -88,7 +88,7 @@ Then restart Claude Desktop.
 
 ---
 
-## <!-- cap:mcp_registered_tool_count -->Available Tools (60)<!-- /cap -->
+## <!-- cap:mcp_registered_tool_count -->Available Tools (61)<!-- /cap -->
 
 The Attune MCP server exposes all production workflows as tools:
 

--- a/docs/getting-started/quickstart-plugin.md
+++ b/docs/getting-started/quickstart-plugin.md
@@ -120,12 +120,12 @@ Other skills worth trying by name or description:
 | If you want to… | Go to |
 |-----------------|-------|
 | Run workflows from a terminal or Python | [First Steps](first-steps.md) |
-| Add the full MCP toolset <!-- cap:mcp_registered_tool_count -->(60 tools)<!-- /cap --> + CLI | [MCP Integration](mcp-integration.md) |
+| Add the full MCP toolset <!-- cap:mcp_registered_tool_count -->(61 tools)<!-- /cap --> + CLI | [MCP Integration](mcp-integration.md) |
 | Pick a longer learning path | [Choose Your Path](choose-your-path.md) |
 | See every workflow | [First Steps → Try More Workflows](first-steps.md#try-more-workflows) |
 
 !!! note "Plugin vs. package"
     The **plugin** gives you the <!-- cap:skill_count -->27 natural-language skills<!-- /cap --> with zero setup.
     Installing the **Python package** (`pip install attune-ai`) adds the
-    `attune` CLI, the MCP server, and <!-- cap:mcp_registered_tool_count -->60 MCP tools<!-- /cap --> on top. You can start with
+    `attune` CLI, the MCP server, and <!-- cap:mcp_registered_tool_count -->61 MCP tools<!-- /cap --> on top. You can start with
     the plugin today and add the package later — they layer cleanly.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -226,6 +226,7 @@ nav:
       - Integration:
           - Hooks: hooks.md
           - Security: how-to/security-architecture.md
+          - Chart Widgets (chartkit): chartkit.md
       - Patterns:
           - Practical Patterns: how-to/practical-patterns.md
           - Resilience Patterns: how-to/resilience-patterns.md

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -96,7 +96,7 @@ The plugin ships two security hooks:
 ## Python Package (optional — unlocks CLI + MCP)
 
 The plugin works standalone. Add the Python package
-for CLI automation, <!-- cap:mcp_registered_tool_count -->60 MCP tools<!-- /cap -->, multi-agent
+for CLI automation, <!-- cap:mcp_registered_tool_count -->61 MCP tools<!-- /cap -->, multi-agent
 workflows, and cost tracking:
 
 ```bash
@@ -107,7 +107,7 @@ pip install 'attune-ai[developer]'
 | ---------- | ----------- | ----- |
 | <!-- cap:skill_count -->27 auto-triggering skills<!-- /cap --> | Yes | Yes |
 | Prompt-based analysis | Yes | Yes |
-| <!-- cap:mcp_registered_tool_count -->60 MCP tools<!-- /cap --> | -- | Yes |
+| <!-- cap:mcp_registered_tool_count -->61 MCP tools<!-- /cap --> | -- | Yes |
 | `attune` CLI | -- | Yes |
 | Multi-agent workflows | -- | Yes |
 | Cost tracking | -- | Yes |

--- a/scripts/check_chartkit_boundary.py
+++ b/scripts/check_chartkit_boundary.py
@@ -65,8 +65,12 @@ def check_inward(violations: list[str]) -> None:
         if not path.is_file():
             continue
         text = path.read_text(encoding="utf-8", errors="replace")
-        if "chartkit" in text:
-            violations.append(f"{rel}: references chartkit but is not in the loader allowlist")
+        # Police paths and imports, not vocabulary: prose may say "chartkit",
+        # but "chartkit/" or "widgets.chartkit" is coupling to internals.
+        if "chartkit/" in text or "widgets.chartkit" in text:
+            violations.append(
+                f"{rel}: references chartkit internals but is not in the loader allowlist"
+            )
 
 
 def check_size(violations: list[str], require_dist: bool) -> None:

--- a/scripts/check_chartkit_boundary.py
+++ b/scripts/check_chartkit_boundary.py
@@ -31,6 +31,10 @@ ALLOWED_OUTSIDE = {
     "scripts/check_chartkit_boundary.py",
     "src/attune/widgets/chart_widget_tool.py",
     ".github/workflows/chartkit.yml",
+    # Sync test reads spec.schema.json as data (contract check, not an import).
+    "tests/unit/widgets/test_chart_spec.py",
+    # Package docstring names the sealed dir; it imports nothing from it.
+    "src/attune/widgets/__init__.py",
 }
 
 IMPORT_RE = re.compile(r"""(?:from\s+|import\s+|require\s*\(\s*)["']([^"']+)["']""")

--- a/scripts/check_chartkit_boundary.py
+++ b/scripts/check_chartkit_boundary.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Enforce the chartkit seal: size ceiling and both import boundaries.
+
+Checks (all must pass):
+  A. Outward seal - every import in chartkit JS source starts with './'
+     (no attune modules, no npm runtime deps, no '../' escapes).
+  B. Inward seal - no tracked .py/.js file outside chartkit references
+     chartkit internals, except the sanctioned loader allowlist.
+  C. Size ceiling - dist/kernel.min.js <= 20,480 bytes when present
+     (--require-dist makes its absence a failure, for CI after build).
+
+Exit 0 clean, exit 1 with one line per violation.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+KERNEL_DIR = Path("src/attune/widgets/chartkit")
+DIST = KERNEL_DIR / "dist/kernel.min.js"
+SIZE_CEILING = 20_480
+
+# The only files allowed to reference chartkit from outside the seal.
+# The loader reads dist/kernel.min.js as bytes; it never imports source.
+ALLOWED_OUTSIDE = {
+    "scripts/check_chartkit_boundary.py",
+    "src/attune/widgets/chart_widget_tool.py",
+    ".github/workflows/chartkit.yml",
+}
+
+IMPORT_RE = re.compile(r"""(?:from\s+|import\s+|require\s*\(\s*)["']([^"']+)["']""")
+
+
+def tracked_files() -> list[str]:
+    out = subprocess.run(["git", "ls-files"], cwd=REPO, capture_output=True, text=True, check=True)
+    return out.stdout.splitlines()
+
+
+def check_outward(violations: list[str]) -> None:
+    for js in (REPO / KERNEL_DIR / "src").rglob("*.js"):
+        rel = js.relative_to(REPO)
+        for mod in IMPORT_RE.findall(js.read_text(encoding="utf-8")):
+            if not mod.startswith("./"):
+                violations.append(
+                    f"{rel}: outward import '{mod}' - kernel imports must start with './'"
+                )
+
+
+def check_inward(violations: list[str]) -> None:
+    for rel in tracked_files():
+        if rel.startswith(str(KERNEL_DIR)) or rel in ALLOWED_OUTSIDE:
+            continue
+        if not rel.endswith((".py", ".js", ".mjs", ".ts")):
+            continue
+        path = REPO / rel
+        if not path.is_file():
+            continue
+        text = path.read_text(encoding="utf-8", errors="replace")
+        if "chartkit" in text:
+            violations.append(f"{rel}: references chartkit but is not in the loader allowlist")
+
+
+def check_size(violations: list[str], require_dist: bool) -> None:
+    dist = REPO / DIST
+    if not dist.exists():
+        if require_dist:
+            violations.append(f"{DIST}: missing (build before the size gate)")
+        return
+    size = dist.stat().st_size
+    if size > SIZE_CEILING:
+        violations.append(
+            f"{DIST}: {size} bytes exceeds the {SIZE_CEILING}-byte ceiling "
+            f"(over by {size - SIZE_CEILING})"
+        )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--require-dist",
+        action="store_true",
+        help="fail if dist/kernel.min.js is absent (CI runs this after build)",
+    )
+    args = parser.parse_args()
+
+    violations: list[str] = []
+    check_outward(violations)
+    check_inward(violations)
+    check_size(violations, args.require_dist)
+
+    if violations:
+        print("chartkit seal BROKEN:")
+        for v in violations:
+            print(f"  - {v}")
+        return 1
+    print(f"chartkit seal intact (ceiling {SIZE_CEILING} bytes)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/attune/mcp/server.py
+++ b/src/attune/mcp/server.py
@@ -313,6 +313,7 @@ class EmpathyMCPServer(MemoryHandlersMixin, WorkflowHandlersMixin, HandoffHandle
             "elicitation_collect_response": self._handle_elicitation_collect_response,
             "elicitation_ask": self._handle_elicitation_ask,
             "elicitation_render_widget": self._handle_elicitation_render_widget,
+            "chart_render_widget": self._handle_chart_render_widget,
             "help_lookup": self._handle_help_lookup,
             "help_maintain": self._handle_help_maintain,
             "help_init": self._handle_help_init,
@@ -772,6 +773,31 @@ class EmpathyMCPServer(MemoryHandlersMixin, WorkflowHandlersMixin, HandoffHandle
                 "render widgets or the user is in keyboard mode."
             )
         return result
+
+    async def _handle_chart_render_widget(self, args: dict[str, Any]) -> dict[str, Any]:
+        """Create or update a chart widget from a declarative spec (D4).
+
+        Thin delegate to :func:`attune.widgets.chart_widget_tool.render_chart_widget`
+        — full spec creates/replaces, RFC 7386 patch updates the stored spec
+        (D5 persistence with legible degradation). Pass the returned ``html``
+        straight to ``mcp__visualize__show_widget``.
+
+        Args:
+            args: ``chart_id`` (required), and ``spec`` (full chart spec)
+                or ``patch`` (merge patch against the stored spec).
+
+        Returns:
+            ``{"success": True, "html", "chart_id", "persistence"}`` or
+            ``{"success": False, "error" | "problems"}``.
+
+        """
+        from attune.widgets.chart_widget_tool import render_chart_widget
+
+        return render_chart_widget(
+            args.get("chart_id", ""),
+            spec=args.get("spec"),
+            patch=args.get("patch"),
+        )
 
     async def _handle_elicitation_render_widget(self, args: dict[str, Any]) -> dict[str, Any]:
         """Render a declarative form as inline HTML for ``show_widget`` (S1).

--- a/src/attune/mcp/tool_schemas.py
+++ b/src/attune/mcp/tool_schemas.py
@@ -585,6 +585,51 @@ def get_elicitation_tools() -> dict[str, dict[str, Any]]:
                 "required": ["form"],
             },
         },
+        "chart_render_widget": {
+            "description": (
+                "Create or update a chart widget from a declarative JSON "
+                "spec — the model writes ~50-200 tokens of spec, a sealed "
+                "6.7KB kernel renders SVG (bar, line, scatter, area, "
+                "heatmap). Pass the returned 'html' straight to "
+                "mcp__visualize__show_widget. To UPDATE an existing chart, "
+                "send chart_id + 'patch' (RFC 7386 merge patch: null "
+                "deletes, objects merge, arrays/scalars replace) instead "
+                "of re-sending the widget — the current spec is stored "
+                "per chart_id in session memory. When persistence is "
+                "unavailable the result says so and a full 'spec' is "
+                "required. Validation errors come back field-level "
+                "(e.g. 'encodings.x.field: Field required') — fix and "
+                "retry."
+            ),
+            "input_schema": {
+                "type": "object",
+                "properties": {
+                    "chart_id": {
+                        "type": "string",
+                        "description": (
+                            "Stable chart identifier ([A-Za-z0-9_-], max "
+                            "64) — reuse it to patch the same chart later"
+                        ),
+                    },
+                    "spec": {
+                        "type": "object",
+                        "description": (
+                            "Full chart spec v1: {v: 1, type, data, "
+                            "encodings: {x, y, color?}, options?} — see "
+                            "spec.schema.json shipped with the kernel"
+                        ),
+                    },
+                    "patch": {
+                        "type": "object",
+                        "description": (
+                            "RFC 7386 merge patch against the stored spec "
+                            "(alternative to 'spec')"
+                        ),
+                    },
+                },
+                "required": ["chart_id"],
+            },
+        },
         "elicitation_render_widget": {
             "description": (
                 "Render a declarative form as an inline HTML form for "

--- a/src/attune/widgets/__init__.py
+++ b/src/attune/widgets/__init__.py
@@ -1,0 +1,8 @@
+"""Widget surfaces for attune — chart specs, tools, and presets.
+
+The sealed JS kernel lives in ``chartkit/`` (not a Python package);
+see ``chartkit/README.md`` for the boundary rules.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under Apache 2.0
+"""

--- a/src/attune/widgets/chart_components.py
+++ b/src/attune/widgets/chart_components.py
@@ -1,0 +1,124 @@
+"""Named chart components — semantic-role presets that expand to full specs.
+
+The model can invoke a component by name plus data instead of authoring
+a spec from scratch; expansion happens server-side and costs zero kernel
+bytes. Every expansion is validated through the spec contract before it
+leaves this module.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under Apache 2.0
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+from attune.widgets.chart_spec import ChartSpec, validate_chart_spec
+
+
+def time_series(
+    data: list[dict[str, Any]],
+    x_field: str = "date",
+    y_field: str = "value",
+    series_field: str | None = None,
+    title: str | None = None,
+) -> dict[str, Any]:
+    """A line chart over time — temporal x, quantitative y, optional series."""
+    encodings: dict[str, Any] = {
+        "x": {"field": x_field, "type": "temporal"},
+        "y": {"field": y_field, "type": "quantitative"},
+    }
+    if series_field:
+        encodings["color"] = {"field": series_field, "type": "nominal"}
+    spec: dict[str, Any] = {"v": 1, "type": "line", "data": data, "encodings": encodings}
+    if title:
+        spec["options"] = {"title": title}
+    return spec
+
+
+def comparison_bars(
+    data: list[dict[str, Any]],
+    category_field: str = "category",
+    value_field: str = "value",
+    series_field: str | None = None,
+    stacked: bool = False,
+    title: str | None = None,
+) -> dict[str, Any]:
+    """Bars comparing categories — optionally split into series."""
+    encodings: dict[str, Any] = {
+        "x": {"field": category_field, "type": "nominal"},
+        "y": {"field": value_field, "type": "quantitative"},
+    }
+    if series_field:
+        encodings["color"] = {"field": series_field, "type": "nominal"}
+    options: dict[str, Any] = {}
+    if stacked:
+        options["stacked"] = True
+    if title:
+        options["title"] = title
+    spec: dict[str, Any] = {"v": 1, "type": "bar", "data": data, "encodings": encodings}
+    if options:
+        spec["options"] = options
+    return spec
+
+
+def kpi_tile(
+    label: str,
+    value: float,
+    previous: float | None = None,
+    title: str | None = None,
+) -> dict[str, Any]:
+    """A KPI as a current-vs-prior comparison bar.
+
+    With ``previous`` the tile reads as change against the prior period;
+    without it, a single bar. (A dedicated numeric-tile mark is a kernel
+    v2 candidate; this preset stays within spec v1's chart types.)
+    """
+    data = (
+        [
+            {"period": "previous", "value": previous},
+            {"period": "current", "value": value},
+        ]
+        if previous is not None
+        else [{"period": label, "value": value}]
+    )
+    return {
+        "v": 1,
+        "type": "bar",
+        "data": data,
+        "encodings": {
+            "x": {"field": "period", "type": "nominal"},
+            "y": {"field": "value", "type": "quantitative"},
+        },
+        "options": {"title": title or label},
+    }
+
+
+COMPONENTS: dict[str, Callable[..., dict[str, Any]]] = {
+    "time_series": time_series,
+    "comparison_bars": comparison_bars,
+    "kpi_tile": kpi_tile,
+}
+
+
+def expand_component(name: str, args: dict[str, Any]) -> ChartSpec:
+    """Expand a named component into a validated ChartSpec.
+
+    Args:
+        name: Component name from :data:`COMPONENTS`.
+        args: Keyword arguments for the component builder.
+
+    Returns:
+        The validated ChartSpec.
+
+    Raises:
+        KeyError: Unknown component — the message lists valid names.
+        ChartSpecError: The expansion failed spec validation (a component
+            bug or impossible arguments); field-level messages included.
+
+    """
+    builder = COMPONENTS.get(name)
+    if builder is None:
+        raise KeyError(f"Unknown component {name!r}. Available: {', '.join(sorted(COMPONENTS))}")
+    return validate_chart_spec(builder(**args))

--- a/src/attune/widgets/chart_components.py
+++ b/src/attune/widgets/chart_components.py
@@ -95,10 +95,39 @@ def kpi_tile(
     }
 
 
+def spec_progress(
+    tasks: list[dict[str, Any]],
+    id_field: str = "task",
+    status_field: str = "status",
+    title: str | None = None,
+) -> dict[str, Any]:
+    """Spec task state as a status strip — one full-height bar per task.
+
+    Statuses follow the elicit progress vocabulary (``done``,
+    ``in_flight``, ``blocked``, plus anything else e.g. ``pending``);
+    each status gets a series color and the legend doubles as the key.
+    Rendered as stacked bars so every task shows one full segment in
+    its status color, with the task id on the x axis.
+    """
+    data = [{"task": str(t[id_field]), "status": str(t[status_field]), "n": 1} for t in tasks]
+    return {
+        "v": 1,
+        "type": "bar",
+        "data": data,
+        "encodings": {
+            "x": {"field": "task", "type": "nominal"},
+            "y": {"field": "n", "type": "quantitative"},
+            "color": {"field": "status", "type": "nominal"},
+        },
+        "options": {"title": title or "Spec progress", "stacked": True},
+    }
+
+
 COMPONENTS: dict[str, Callable[..., dict[str, Any]]] = {
     "time_series": time_series,
     "comparison_bars": comparison_bars,
     "kpi_tile": kpi_tile,
+    "spec_progress": spec_progress,
 }
 
 

--- a/src/attune/widgets/chart_spec.py
+++ b/src/attune/widgets/chart_spec.py
@@ -1,0 +1,109 @@
+"""Chart spec v1 — the Python mirror of chartkit's spec contract.
+
+This model is authoritative for server-side validation; the JSON
+Schema shipped with the kernel (``spec.schema.json``) is the same
+contract for JS-side consumers, and a sync test keeps them aligned.
+Validation errors are field-level and actionable so a model that
+emitted a bad spec can self-correct from the message alone.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under Apache 2.0
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
+
+CHART_TYPES = ("bar", "line", "scatter", "area", "heatmap")
+
+ChartType = Literal["bar", "line", "scatter", "area", "heatmap"]
+FieldType = Literal["quantitative", "nominal", "temporal"]
+
+
+class ChartSpecError(ValueError):
+    """Raised when a chart spec fails validation.
+
+    Args:
+        problems: One actionable message per failing field.
+
+    """
+
+    def __init__(self, problems: list[str]) -> None:
+        self.problems = problems
+        super().__init__("; ".join(problems))
+
+
+class Encoding(BaseModel):
+    """A field-to-channel mapping (e.g. x -> data column 'month')."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    field: str = Field(min_length=1)
+    type: FieldType
+
+
+class Encodings(BaseModel):
+    """Channel mappings for a chart. x and y are always required."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    x: Encoding
+    y: Encoding
+    color: Encoding | None = None
+
+
+class Options(BaseModel):
+    """Presentation options — all optional, all defaulted."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    title: str | None = None
+    legend: bool = True
+    stacked: bool = False
+
+
+class ChartSpec(BaseModel):
+    """A complete declarative chart: what the model emits, chartkit renders."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    v: Literal[1] = 1
+    type: ChartType
+    data: list[dict[str, Any]] = Field(min_length=1)
+    encodings: Encodings
+    options: Options = Field(default_factory=Options)
+
+    @model_validator(mode="after")
+    def _heatmap_needs_color(self) -> ChartSpec:
+        if self.type == "heatmap" and self.encodings.color is None:
+            raise ValueError(
+                "encodings.color: required for heatmap "
+                "(the color channel carries the cell value)"
+            )
+        return self
+
+
+def validate_chart_spec(payload: dict[str, Any]) -> ChartSpec:
+    """Validate a raw spec dict into a ChartSpec.
+
+    Args:
+        payload: The spec as parsed JSON.
+
+    Returns:
+        The validated ChartSpec.
+
+    Raises:
+        ChartSpecError: With one field-level message per problem,
+            phrased so the emitting model can fix its spec.
+
+    """
+    try:
+        return ChartSpec.model_validate(payload)
+    except ValidationError as exc:
+        problems = []
+        for err in exc.errors():
+            loc = ".".join(str(part) for part in err["loc"]) or "spec"
+            problems.append(f"{loc}: {err['msg']}")
+        raise ChartSpecError(problems) from exc

--- a/src/attune/widgets/chart_widget_tool.py
+++ b/src/attune/widgets/chart_widget_tool.py
@@ -16,11 +16,14 @@ Licensed under Apache 2.0
 from __future__ import annotations
 
 import json
+import logging
 import re
 from pathlib import Path
 from typing import Any
 
 from attune.widgets.chart_spec import ChartSpecError, validate_chart_spec
+
+logger = logging.getLogger(__name__)
 
 _KERNEL_PATH = Path(__file__).resolve().parent / "chartkit" / "dist" / "kernel.min.js"
 _CHART_ID_RE = re.compile(r"^[A-Za-z0-9_-]{1,64}$")
@@ -47,7 +50,8 @@ def _resolve_backend() -> Any | None:
         from attune.memory.session_stash import resolve_backend
 
         return resolve_backend()
-    except Exception:  # noqa: BLE001 — no backend is a legible, handled state
+    except Exception as exc:  # noqa: BLE001 — no backend is a handled state
+        logger.info("chart persistence backend unavailable: %s", exc)
         return None
 
 
@@ -122,7 +126,8 @@ def render_chart_widget(
             return {"success": False, "error": BACKEND_DOWN_MSG}
         try:
             stored = target.retrieve(key)
-        except Exception:  # noqa: BLE001 — backend failure = legible degradation
+        except Exception as exc:  # noqa: BLE001 — degrade legibly, but on the record
+            logger.warning("chart spec retrieve failed for %s: %s", key, exc)
             stored = None
         if not isinstance(stored, dict):
             return {
@@ -143,8 +148,8 @@ def render_chart_widget(
         try:
             if target.stash(key, spec_dict, ttl=_TTL_SECONDS):
                 persistence = "stored — next update may send a patch"
-        except Exception:  # noqa: BLE001 — persistence is best-effort, but LOUD
-            pass
+        except Exception as exc:  # noqa: BLE001 — best-effort, but on the record
+            logger.warning("chart spec stash failed for %s: %s", key, exc)
 
     try:
         html = _build_html(chart_id, spec_dict)

--- a/src/attune/widgets/chart_widget_tool.py
+++ b/src/attune/widgets/chart_widget_tool.py
@@ -1,0 +1,159 @@
+"""chart_render_widget — spec (or patch) in, kernel-injected HTML out.
+
+This module is the sanctioned chartkit loader: it reads the built
+artifact ``chartkit/dist/kernel.min.js`` as bytes and never imports
+kernel source. Specs persist per chart_id in the session memory
+backend so a later turn can send a patch instead of the full spec.
+
+Degradation is legible by design (D5): when no backend is reachable,
+patches are rejected with an instruction to re-send the full spec —
+never a silent fallback.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under Apache 2.0
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+from attune.widgets.chart_spec import ChartSpecError, validate_chart_spec
+
+_KERNEL_PATH = Path(__file__).resolve().parent / "chartkit" / "dist" / "kernel.min.js"
+_CHART_ID_RE = re.compile(r"^[A-Za-z0-9_-]{1,64}$")
+_TTL_SECONDS = 8 * 3600
+
+BACKEND_DOWN_MSG = (
+    "Chart persistence is unavailable (no memory backend reachable), so the "
+    "current spec cannot be loaded to apply a patch. Re-send the FULL chart "
+    "spec for this chart_id instead of a patch."
+)
+NO_STORED_SPEC_MSG = (
+    "No stored spec found for chart_id {chart_id!r} (it may have expired). "
+    "Re-send the FULL chart spec instead of a patch."
+)
+KERNEL_MISSING_MSG = (
+    "chartkit kernel artifact is missing ({path}). Build it with "
+    "'npm run build' in src/attune/widgets/chartkit/ (CI builds it "
+    "automatically)."
+)
+
+
+def _resolve_backend() -> Any | None:
+    try:
+        from attune.memory.session_stash import resolve_backend
+
+        return resolve_backend()
+    except Exception:  # noqa: BLE001 — no backend is a legible, handled state
+        return None
+
+
+def merge_patch(target: Any, patch: Any) -> Any:
+    """RFC 7386 JSON Merge Patch — mirrors the kernel's applyPatch."""
+    if not isinstance(patch, dict):
+        return patch
+    out: dict[str, Any] = dict(target) if isinstance(target, dict) else {}
+    for key, value in patch.items():
+        if value is None:
+            out.pop(key, None)
+        else:
+            out[key] = merge_patch(out.get(key), value)
+    return out
+
+
+def _chart_key(chart_id: str) -> str:
+    return f"chart:{chart_id}"
+
+
+def _build_html(chart_id: str, spec_dict: dict[str, Any]) -> str:
+    if not _KERNEL_PATH.exists():
+        raise FileNotFoundError(KERNEL_MISSING_MSG.format(path=_KERNEL_PATH))
+    kernel = _KERNEL_PATH.read_text(encoding="utf-8")
+    payload = json.dumps(spec_dict).replace("<", "\\u003c")
+    container = f"chartkit-{chart_id}"
+    return (
+        f'<div id="{container}"></div>\n'
+        f"<script>\n{kernel}\n"
+        f"ChartKit.render(document.getElementById({json.dumps(container)}), "
+        f"{payload});\n"
+        f"</script>"
+    )
+
+
+def render_chart_widget(
+    chart_id: str,
+    spec: dict[str, Any] | None = None,
+    patch: dict[str, Any] | None = None,
+    backend: Any | None = None,
+) -> dict[str, Any]:
+    """Create or update a chart widget.
+
+    Args:
+        chart_id: Stable identifier for the chart ([A-Za-z0-9_-], <=64).
+        spec: Full chart spec (create / replace).
+        patch: RFC 7386 merge patch against the stored spec (update).
+        backend: Memory backend override for tests; resolved when None.
+
+    Returns:
+        {success, html, chart_id, persistence} on success;
+        {success: False, error | problems} on failure — errors are
+        phrased so the calling model can self-correct.
+
+    """
+    if not isinstance(chart_id, str) or not _CHART_ID_RE.match(chart_id):
+        return {
+            "success": False,
+            "error": "chart_id must match [A-Za-z0-9_-]{1,64}",
+        }
+    if spec is None and patch is None:
+        return {
+            "success": False,
+            "error": "Provide 'spec' (create/replace) or 'patch' (update).",
+        }
+
+    target = backend if backend is not None else _resolve_backend()
+    key = _chart_key(chart_id)
+
+    if spec is None and patch is not None:
+        if target is None:
+            return {"success": False, "error": BACKEND_DOWN_MSG}
+        try:
+            stored = target.retrieve(key)
+        except Exception:  # noqa: BLE001 — backend failure = legible degradation
+            stored = None
+        if not isinstance(stored, dict):
+            return {
+                "success": False,
+                "error": NO_STORED_SPEC_MSG.format(chart_id=chart_id),
+            }
+        spec = merge_patch(stored, patch)
+
+    try:
+        validated = validate_chart_spec(spec)
+    except ChartSpecError as exc:
+        return {"success": False, "problems": exc.problems}
+
+    spec_dict = validated.model_dump(exclude_none=True)
+
+    persistence = "unavailable — the next update must re-send the full spec"
+    if target is not None:
+        try:
+            if target.stash(key, spec_dict, ttl=_TTL_SECONDS):
+                persistence = "stored — next update may send a patch"
+        except Exception:  # noqa: BLE001 — persistence is best-effort, but LOUD
+            pass
+
+    try:
+        html = _build_html(chart_id, spec_dict)
+    except FileNotFoundError as exc:
+        return {"success": False, "error": str(exc)}
+
+    return {
+        "success": True,
+        "chart_id": chart_id,
+        "html": html,
+        "persistence": persistence,
+    }

--- a/src/attune/widgets/chartkit/.gitignore
+++ b/src/attune/widgets/chartkit/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/src/attune/widgets/chartkit/README.md
+++ b/src/attune/widgets/chartkit/README.md
@@ -1,0 +1,32 @@
+# chartkit — sealed chart kernel
+
+Declarative JSON spec in, SVG out. The model never writes renderer code;
+it writes specs and spec patches (JSON Merge Patch, RFC 7386).
+
+## The seal (enforced by CI, not convention)
+
+- **No outward imports.** Kernel source imports nothing outside `src/`
+  — no `attune` modules, no npm runtime deps, no `../` escapes. Every
+  import starts with `./`.
+- **No inward imports.** Nothing in attune imports kernel internals.
+  The only sanctioned consumer is the injection loader, which reads the
+  built artifact `dist/kernel.min.js` as bytes.
+- **Size ceiling.** `dist/kernel.min.js` ≤ 20,480 bytes, enforced by
+  `scripts/check_chartkit_boundary.py` in CI. Chart types earn their
+  way in under the ceiling; the ceiling does not move.
+
+Extraction to a standalone package must always be a copy, not surgery.
+If you are adding an import across this boundary, stop — that is the
+thing this directory exists to prevent.
+
+## Develop
+
+```bash
+npm install   # once; esbuild only
+npm run build # -> dist/kernel.min.js (banner carries the version)
+npm test      # node --test
+```
+
+Spec schema: `spec.schema.json` (lands in T2). Renderers: T3/T4.
+Patch path: T5. MCP tool + persistence: T6. Component presets: T7.
+See `docs/chartkit.md` and the spec plan `chart-widget-kernel`.

--- a/src/attune/widgets/chartkit/package-lock.json
+++ b/src/attune/widgets/chartkit/package-lock.json
@@ -1,0 +1,463 @@
+{
+  "name": "@attune/chartkit",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@attune/chartkit",
+      "version": "0.1.0",
+      "devDependencies": {
+        "esbuild": "^0.23.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.23.1.tgz",
+      "integrity": "sha512-6VhYk1diRqrhBAqpJEdjASR/+WVRtfjpqKuNw11cLiaWpAT/Uu+nokB+UJnevzy/P9C/ty6AOe0dwueMrGh/iQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.23.1.tgz",
+      "integrity": "sha512-uz6/tEy2IFm9RYOyvKl88zdzZfwEfKZmnX9Cj1BHjeSGNuGLuMD1kR8y5bteYmwqKm1tj8m4cb/aKEorr6fHWQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.23.1.tgz",
+      "integrity": "sha512-xw50ipykXcLstLeWH7WRdQuysJqejuAGPd30vd1i5zSyKK3WE+ijzHmLKxdiCMtH1pHz78rOg0BKSYOSB/2Khw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.23.1.tgz",
+      "integrity": "sha512-nlN9B69St9BwUoB+jkyU090bru8L0NA3yFvAd7k8dNsVH8bi9a8cUAUSEcEEgTp2z3dbEDGJGfP6VUnkQnlReg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.23.1.tgz",
+      "integrity": "sha512-YsS2e3Wtgnw7Wq53XXBLcV6JhRsEq8hkfg91ESVadIrzr9wO6jJDMZnCQbHm1Guc5t/CdDiFSSfWP58FNuvT3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.23.1.tgz",
+      "integrity": "sha512-aClqdgTDVPSEGgoCS8QDG37Gu8yc9lTHNAQlsztQ6ENetKEO//b8y31MMu2ZaPbn4kVsIABzVLXYLhCGekGDqw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.23.1.tgz",
+      "integrity": "sha512-h1k6yS8/pN/NHlMl5+v4XPfikhJulk4G+tKGFIOwURBSFzE8bixw1ebjluLOjfwtLqY0kewfjLSrO6tN2MgIhA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.23.1.tgz",
+      "integrity": "sha512-lK1eJeyk1ZX8UklqFd/3A60UuZ/6UVfGT2LuGo3Wp4/z7eRTRYY+0xOu2kpClP+vMTi9wKOfXi2vjUpO1Ro76g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.23.1.tgz",
+      "integrity": "sha512-CXXkzgn+dXAPs3WBwE+Kvnrf4WECwBdfjfeYHpMeVxWE0EceB6vhWGShs6wi0IYEqMSIzdOF1XjQ/Mkm5d7ZdQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.23.1.tgz",
+      "integrity": "sha512-/93bf2yxencYDnItMYV/v116zff6UyTjo4EtEQjUBeGiVpMmffDNUyD9UN2zV+V3LRV3/on4xdZ26NKzn6754g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.23.1.tgz",
+      "integrity": "sha512-VTN4EuOHwXEkXzX5nTvVY4s7E/Krz7COC8xkftbbKRYAl96vPiUssGkeMELQMOnLOJ8k3BY1+ZY52tttZnHcXQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.23.1.tgz",
+      "integrity": "sha512-Vx09LzEoBa5zDnieH8LSMRToj7ir/Jeq0Gu6qJ/1GcBq9GkfoEAoXvLiW1U9J1qE/Y/Oyaq33w5p2ZWrNNHNEw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.23.1.tgz",
+      "integrity": "sha512-nrFzzMQ7W4WRLNUOU5dlWAqa6yVeI0P78WKGUo7lg2HShq/yx+UYkeNSE0SSfSure0SqgnsxPvmAUu/vu0E+3Q==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.23.1.tgz",
+      "integrity": "sha512-dKN8fgVqd0vUIjxuJI6P/9SSSe/mB9rvA98CSH2sJnlZ/OCZWO1DJvxj8jvKTfYUdGfcq2dDxoKaC6bHuTlgcw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.23.1.tgz",
+      "integrity": "sha512-5AV4Pzp80fhHL83JM6LoA6pTQVWgB1HovMBsLQ9OZWLDqVY8MVobBXNSmAJi//Csh6tcY7e7Lny2Hg1tElMjIA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.23.1.tgz",
+      "integrity": "sha512-9ygs73tuFCe6f6m/Tb+9LtYxWR4c9yg7zjt2cYkjDbDpV/xVn+68cQxMXCjUpYwEkze2RcU/rMnfIXNRFmSoDw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.23.1.tgz",
+      "integrity": "sha512-EV6+ovTsEXCPAp58g2dD68LxoP/wK5pRvgy0J/HxPGB009omFPv3Yet0HiaqvrIrgPTBuC6wCH1LTOY91EO5hQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.23.1.tgz",
+      "integrity": "sha512-aevEkCNu7KlPRpYLjwmdcuNz6bDFiE7Z8XC4CPqExjTvrHugh28QzUXVOZtiYghciKUacNktqxdpymplil1beA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.23.1.tgz",
+      "integrity": "sha512-3x37szhLexNA4bXhLrCC/LImN/YtWis6WXr1VESlfVtVeoFJBRINPJ3f0a/6LV8zpikqoUg4hyXw0sFBt5Cr+Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.23.1.tgz",
+      "integrity": "sha512-aY2gMmKmPhxfU+0EdnN+XNtGbjfQgwZj43k8G3fyrDM/UdZww6xrWxmDkuz2eCZchqVeABjV5BpildOrUbBTqA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.23.1.tgz",
+      "integrity": "sha512-RBRT2gqEl0IKQABT4XTj78tpk9v7ehp+mazn2HbUeZl1YMdaGAQqhapjGTCe7uw7y0frDi4gS0uHzhvpFuI1sA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.23.1.tgz",
+      "integrity": "sha512-4O+gPR5rEBe2FpKOVyiJ7wNDPA8nGzDuJ6gN4okSA1gEOYZ67N8JPk58tkWtdtPeLz7lBnY6I5L3jdsr3S+A6A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.23.1.tgz",
+      "integrity": "sha512-BcaL0Vn6QwCwre3Y717nVHZbAa4UBEigzFm6VdsVdT/MbZ38xoj1X9HPkZhbmaBGUD1W8vxAfffbDe8bA6AKnQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.23.1.tgz",
+      "integrity": "sha512-BHpFFeslkWrXWyUPnbKm+xYYVYruCinGcftSBaa8zoF9hZO4BcSCFUvHVTtzpIY6YzUnYtuEhZ+C9iEXjxnasg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.23.1.tgz",
+      "integrity": "sha512-VVNz/9Sa0bs5SELtn3f7qhJCDPCF5oMEl5cO9/SSinpE9hbPVvxbd572HH5AKiP7WD8INO53GgfDDhRjkylHEg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.23.1",
+        "@esbuild/android-arm": "0.23.1",
+        "@esbuild/android-arm64": "0.23.1",
+        "@esbuild/android-x64": "0.23.1",
+        "@esbuild/darwin-arm64": "0.23.1",
+        "@esbuild/darwin-x64": "0.23.1",
+        "@esbuild/freebsd-arm64": "0.23.1",
+        "@esbuild/freebsd-x64": "0.23.1",
+        "@esbuild/linux-arm": "0.23.1",
+        "@esbuild/linux-arm64": "0.23.1",
+        "@esbuild/linux-ia32": "0.23.1",
+        "@esbuild/linux-loong64": "0.23.1",
+        "@esbuild/linux-mips64el": "0.23.1",
+        "@esbuild/linux-ppc64": "0.23.1",
+        "@esbuild/linux-riscv64": "0.23.1",
+        "@esbuild/linux-s390x": "0.23.1",
+        "@esbuild/linux-x64": "0.23.1",
+        "@esbuild/netbsd-x64": "0.23.1",
+        "@esbuild/openbsd-arm64": "0.23.1",
+        "@esbuild/openbsd-x64": "0.23.1",
+        "@esbuild/sunos-x64": "0.23.1",
+        "@esbuild/win32-arm64": "0.23.1",
+        "@esbuild/win32-ia32": "0.23.1",
+        "@esbuild/win32-x64": "0.23.1"
+      }
+    }
+  }
+}

--- a/src/attune/widgets/chartkit/package.json
+++ b/src/attune/widgets/chartkit/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@attune/chartkit",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Sealed chart kernel - declarative JSON spec in, SVG out. No attune imports in either direction.",
+  "type": "module",
+  "scripts": {
+    "build": "esbuild src/kernel.js --bundle --minify --format=iife --global-name=ChartKit --banner:js=\"/* chartkit v0.1.0 sealed */\" --outfile=dist/kernel.min.js",
+    "test": "node --test"
+  },
+  "devDependencies": {
+    "esbuild": "^0.23.0"
+  }
+}

--- a/src/attune/widgets/chartkit/spec.schema.json
+++ b/src/attune/widgets/chartkit/spec.schema.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://attune-ai.dev/schemas/chartkit/spec-v1.json",
+  "title": "chartkit chart spec v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["v", "type", "data", "encodings"],
+  "properties": {
+    "v": { "const": 1 },
+    "type": { "enum": ["bar", "line", "scatter", "area", "heatmap"] },
+    "data": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "object" }
+    },
+    "encodings": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["x", "y"],
+      "properties": {
+        "x": { "$ref": "#/$defs/encoding" },
+        "y": { "$ref": "#/$defs/encoding" },
+        "color": { "$ref": "#/$defs/encoding" }
+      }
+    },
+    "options": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "title": { "type": "string" },
+        "legend": { "type": "boolean", "default": true },
+        "stacked": { "type": "boolean", "default": false }
+      }
+    }
+  },
+  "$defs": {
+    "encoding": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["field", "type"],
+      "properties": {
+        "field": { "type": "string", "minLength": 1 },
+        "type": { "enum": ["quantitative", "nominal", "temporal"] }
+      }
+    }
+  },
+  "allOf": [
+    {
+      "if": { "properties": { "type": { "const": "heatmap" } } },
+      "then": {
+        "properties": {
+          "encodings": { "required": ["x", "y", "color"] }
+        }
+      }
+    }
+  ]
+}

--- a/src/attune/widgets/chartkit/src/kernel.js
+++ b/src/attune/widgets/chartkit/src/kernel.js
@@ -2,19 +2,308 @@ const VERSION = "0.1.0";
 
 const CHART_TYPES = ["bar", "line", "scatter", "area", "heatmap"];
 
-function render(el, spec) {
-  if (!el || typeof el.appendChild !== "function") {
+const SVG_NS = "http://www.w3.org/2000/svg";
+
+const PALETTE = [
+  ["--chartkit-c1", "#4269d0"],
+  ["--chartkit-c2", "#efb118"],
+  ["--chartkit-c3", "#ff725c"],
+  ["--chartkit-c4", "#6cc5b0"],
+  ["--chartkit-c5", "#a463f2"],
+  ["--chartkit-c6", "#9c6b4e"],
+];
+
+const W = 640;
+const H = 360;
+const M = { t: 30, r: 16, b: 40, l: 48 };
+
+function seriesColor(i) {
+  const [v, fb] = PALETTE[i % PALETTE.length];
+  return `var(${v}, ${fb})`;
+}
+
+function fmt(n) {
+  if (typeof n !== "number" || !isFinite(n)) return String(n);
+  if (Math.abs(n) >= 1e6) return `${+(n / 1e6).toFixed(1)}M`;
+  if (Math.abs(n) >= 1e3) return `${+(n / 1e3).toFixed(1)}k`;
+  return String(+n.toFixed(2));
+}
+
+function fieldValue(row, enc) {
+  const v = row[enc.field];
+  if (enc.type === "temporal") {
+    const t = typeof v === "number" ? v : Date.parse(v);
+    return isFinite(t) ? t : NaN;
+  }
+  if (enc.type === "quantitative") {
+    const n = typeof v === "number" ? v : Number(v);
+    return isFinite(n) ? n : NaN;
+  }
+  return v;
+}
+
+function extent(values) {
+  let lo = Infinity;
+  let hi = -Infinity;
+  for (const v of values) {
+    if (typeof v !== "number" || !isFinite(v)) continue;
+    if (v < lo) lo = v;
+    if (v > hi) hi = v;
+  }
+  if (lo === Infinity) return [0, 1];
+  if (lo === hi) return lo === 0 ? [0, 1] : [0, hi];
+  return [Math.min(lo, 0), hi];
+}
+
+function niceTicks([lo, hi], count) {
+  const span = hi - lo || 1;
+  const step0 = span / Math.max(1, count);
+  const mag = 10 ** Math.floor(Math.log10(step0));
+  const step = [1, 2, 5, 10].map((m) => m * mag).find((s) => span / s <= count) || mag * 10;
+  const ticks = [];
+  for (let t = Math.ceil(lo / step) * step; t <= hi + step / 1e6; t += step) {
+    ticks.push(+t.toFixed(10));
+  }
+  return ticks;
+}
+
+function linearScale([lo, hi], [r0, r1]) {
+  const d = hi - lo || 1;
+  const s = (v) => r0 + ((v - lo) / d) * (r1 - r0);
+  s.domain = [lo, hi];
+  return s;
+}
+
+function bandScale(cats, [r0, r1], pad = 0.15) {
+  const n = Math.max(1, cats.length);
+  const step = (r1 - r0) / n;
+  const bw = step * (1 - pad);
+  const s = (c) => r0 + cats.indexOf(c) * step + (step - bw) / 2;
+  s.bandwidth = bw;
+  s.step = step;
+  s.categories = cats;
+  return s;
+}
+
+function el(doc, name, attrs) {
+  const node = doc.createElementNS(SVG_NS, name);
+  for (const k in attrs) node.setAttribute(k, String(attrs[k]));
+  return node;
+}
+
+function label(doc, parent, str, attrs) {
+  const t = el(doc, "text", {
+    "font-size": 11,
+    "font-family": "inherit",
+    fill: "var(--text-secondary, #667)",
+    ...attrs,
+  });
+  t.textContent = String(str);
+  parent.appendChild(t);
+  return t;
+}
+
+function tooltip(doc, node, str) {
+  const t = doc.createElementNS(SVG_NS, "title");
+  t.textContent = String(str);
+  node.appendChild(t);
+}
+
+function categoriesOf(data, enc) {
+  const seen = [];
+  for (const row of data) {
+    const v = fieldValue(row, enc);
+    if (!seen.includes(v)) seen.push(v);
+  }
+  return seen;
+}
+
+function drawYAxis(doc, g, scale, x0, x1) {
+  for (const t of niceTicks(scale.domain, 5)) {
+    const y = scale(t);
+    g.appendChild(
+      el(doc, "line", {
+        x1: x0,
+        x2: x1,
+        y1: y,
+        y2: y,
+        stroke: "var(--border, #ddd)",
+        "stroke-width": 1,
+      })
+    );
+    label(doc, g, fmt(t), { x: x0 - 6, y: y + 4, "text-anchor": "end" });
+  }
+}
+
+function drawXTick(doc, g, x, str) {
+  label(doc, g, str, { x, y: H - M.b + 16, "text-anchor": "middle" });
+}
+
+function drawLegend(doc, g, names) {
+  let x = M.l;
+  names.forEach((name, i) => {
+    g.appendChild(el(doc, "rect", { x, y: 6, width: 9, height: 9, rx: 2, fill: seriesColor(i) }));
+    const t = label(doc, g, name, { x: x + 13, y: 14, "text-anchor": "start" });
+    x += 13 + 7 * String(name).length + 18;
+    void t;
+  });
+}
+
+function splitSeries(data, colorEnc) {
+  if (!colorEnc) return [{ name: null, rows: data }];
+  const names = categoriesOf(data, colorEnc);
+  return names.map((name) => ({
+    name,
+    rows: data.filter((r) => fieldValue(r, colorEnc) === name),
+  }));
+}
+
+function renderBar(doc, g, spec, x, y, series) {
+  const stacked = spec.options && spec.options.stacked;
+  const sums = {};
+  series.forEach((s, si) => {
+    for (const row of s.rows) {
+      const cx = fieldValue(row, spec.encodings.x);
+      const vy = fieldValue(row, spec.encodings.y);
+      let bx = x(cx);
+      let bw = x.bandwidth;
+      let y0 = y(0);
+      if (stacked && series.length > 1) {
+        const prev = sums[cx] || 0;
+        y0 = y(prev);
+        sums[cx] = prev + vy;
+      } else if (series.length > 1) {
+        bw = x.bandwidth / series.length;
+        bx += si * bw;
+      }
+      const y1 = stacked && series.length > 1 ? y(sums[cx]) : y(vy);
+      const rect = el(doc, "rect", {
+        x: bx,
+        y: Math.min(y0, y1),
+        width: Math.max(1, bw),
+        height: Math.abs(y0 - y1),
+        fill: seriesColor(si),
+      });
+      tooltip(doc, rect, `${cx}${s.name != null ? " · " + s.name : ""}: ${fmt(vy)}`);
+      g.appendChild(rect);
+    }
+  });
+}
+
+function renderLine(doc, g, spec, x, y, series, asArea) {
+  series.forEach((s, si) => {
+    const pts = s.rows
+      .map((r) => [fieldValue(r, spec.encodings.x), fieldValue(r, spec.encodings.y)])
+      .filter((p) => isFinite(p[0]) && isFinite(p[1]))
+      .sort((a, b) => a[0] - b[0]);
+    if (!pts.length) return;
+    const path = pts.map((p, i) => `${i ? "L" : "M"}${x(p[0])},${y(p[1])}`).join("");
+    if (asArea) {
+      const base = y(0);
+      const area = `${path}L${x(pts[pts.length - 1][0])},${base}L${x(pts[0][0])},${base}Z`;
+      g.appendChild(
+        el(doc, "path", { d: area, fill: seriesColor(si), "fill-opacity": 0.25, stroke: "none" })
+      );
+    }
+    const line = el(doc, "path", {
+      d: path,
+      fill: "none",
+      stroke: seriesColor(si),
+      "stroke-width": 2,
+    });
+    if (s.name != null) tooltip(doc, line, String(s.name));
+    g.appendChild(line);
+  });
+}
+
+function renderScatter(doc, g, spec, x, y, series) {
+  series.forEach((s, si) => {
+    for (const row of s.rows) {
+      const cx = fieldValue(row, spec.encodings.x);
+      const cy = fieldValue(row, spec.encodings.y);
+      if (!isFinite(cx) || !isFinite(cy)) continue;
+      const dot = el(doc, "circle", { cx: x(cx), cy: y(cy), r: 4, fill: seriesColor(si), "fill-opacity": 0.85 });
+      tooltip(doc, dot, `${fmt(cx)}, ${fmt(cy)}${s.name != null ? " · " + s.name : ""}`);
+      g.appendChild(dot);
+    }
+  });
+}
+
+function render(root, spec) {
+  if (!root || typeof root.appendChild !== "function") {
     throw new Error("chartkit: render(el, spec) needs a DOM element");
   }
-  if (!spec || typeof spec !== "object") {
-    throw new Error("chartkit: render(el, spec) needs a spec object");
+  if (!spec || typeof spec !== "object" || !spec.encodings) {
+    throw new Error("chartkit: render(el, spec) needs a spec with encodings");
   }
   if (!CHART_TYPES.includes(spec.type)) {
     throw new Error(
       `chartkit: unknown chart type "${spec.type}" (expected one of ${CHART_TYPES.join(", ")})`
     );
   }
-  el.textContent = `chartkit v${VERSION}: "${spec.type}" renderer lands in T3/T4`;
+  if (spec.type === "heatmap") {
+    throw new Error("chartkit: heatmap renderer lands in T4");
+  }
+  const doc = root.ownerDocument;
+  while (root.firstChild) root.removeChild(root.firstChild);
+  const svg = el(doc, "svg", {
+    viewBox: `0 0 ${W} ${H}`,
+    width: "100%",
+    role: "img",
+    "data-chartkit": VERSION,
+  });
+  const g = el(doc, "g", {});
+  svg.appendChild(g);
+
+  const data = spec.data || [];
+  const colorEnc = spec.encodings.color;
+  const series = splitSeries(data, colorEnc);
+  const yVals = data.map((r) => fieldValue(r, spec.encodings.y));
+  const yDom =
+    spec.type === "bar" && spec.options && spec.options.stacked && series.length > 1
+      ? extent(
+          categoriesOf(data, spec.encodings.x).map((c) =>
+            data
+              .filter((r) => fieldValue(r, spec.encodings.x) === c)
+              .reduce((a, r) => a + fieldValue(r, spec.encodings.y), 0)
+          )
+        )
+      : extent(yVals);
+  const y = linearScale(yDom, [H - M.b, M.t]);
+  drawYAxis(doc, g, y, M.l, W - M.r);
+
+  const xEnc = spec.encodings.x;
+  if (spec.type === "bar" || xEnc.type === "nominal") {
+    const cats = categoriesOf(data, xEnc);
+    const x = bandScale(cats, [M.l, W - M.r]);
+    cats.forEach((c) => drawXTick(doc, g, x(c) + x.bandwidth / 2, c));
+    if (spec.type === "bar") renderBar(doc, g, spec, x, y, series);
+    else renderLine(doc, g, spec, (c) => x(c) + x.bandwidth / 2, y, series, spec.type === "area");
+  } else {
+    const xVals = data.map((r) => fieldValue(r, xEnc));
+    const x = linearScale(extent(xVals.filter(isFinite)), [M.l, W - M.r]);
+    for (const t of niceTicks(x.domain, 6)) {
+      drawXTick(doc, g, x(t), xEnc.type === "temporal" ? new Date(t).toISOString().slice(0, 10) : fmt(t));
+    }
+    if (spec.type === "scatter") renderScatter(doc, g, spec, x, y, series);
+    else renderLine(doc, g, spec, x, y, series, spec.type === "area");
+  }
+
+  if (colorEnc && (!spec.options || spec.options.legend !== false)) {
+    drawLegend(doc, g, series.map((s) => String(s.name)));
+  }
+  if (spec.options && spec.options.title) {
+    label(doc, g, spec.options.title, {
+      x: M.l,
+      y: 16,
+      "font-size": 13,
+      "font-weight": 500,
+      fill: "var(--text-primary, #222)",
+      "text-anchor": "start",
+    });
+  }
+  root.appendChild(svg);
+  return svg;
 }
 
 function applyPatch() {

--- a/src/attune/widgets/chartkit/src/kernel.js
+++ b/src/attune/widgets/chartkit/src/kernel.js
@@ -355,8 +355,18 @@ function render(root, spec) {
   return svg;
 }
 
-function applyPatch() {
-  throw new Error("chartkit: applyPatch lands in T5");
+function applyPatch(target, patch) {
+  if (patch === null || typeof patch !== "object" || Array.isArray(patch)) {
+    return patch;
+  }
+  const out =
+    target && typeof target === "object" && !Array.isArray(target) ? { ...target } : {};
+  for (const k in patch) {
+    const v = patch[k];
+    if (v === null) delete out[k];
+    else out[k] = applyPatch(out[k], v);
+  }
+  return out;
 }
 
 export { VERSION, CHART_TYPES, render, applyPatch };

--- a/src/attune/widgets/chartkit/src/kernel.js
+++ b/src/attune/widgets/chartkit/src/kernel.js
@@ -229,6 +229,43 @@ function renderScatter(doc, g, spec, x, y, series) {
   });
 }
 
+function renderHeatmap(doc, g, spec) {
+  const data = spec.data || [];
+  const xEnc = spec.encodings.x;
+  const yEnc = spec.encodings.y;
+  const vEnc = spec.encodings.color;
+  if (!vEnc) throw new Error("chartkit: heatmap needs encodings.color for cell values");
+  const xCats = categoriesOf(data, xEnc);
+  const yCats = categoriesOf(data, yEnc);
+  const x = bandScale(xCats, [M.l, W - M.r], 0.05);
+  const y = bandScale(yCats, [M.t, H - M.b], 0.05);
+  const vals = data.map((r) => fieldValue(r, vEnc));
+  const [lo, hi] = extent(vals);
+  const span = hi - lo || 1;
+  xCats.forEach((c) => drawXTick(doc, g, x(c) + x.bandwidth / 2, c));
+  yCats.forEach((c) =>
+    label(doc, g, c, { x: M.l - 6, y: y(c) + y.bandwidth / 2 + 4, "text-anchor": "end" })
+  );
+  for (const row of data) {
+    const cx = fieldValue(row, xEnc);
+    const cy = fieldValue(row, yEnc);
+    const v = fieldValue(row, vEnc);
+    const cell = el(doc, "rect", {
+      x: x(cx),
+      y: y(cy),
+      width: x.bandwidth,
+      height: y.bandwidth,
+      rx: 2,
+      fill: seriesColor(0),
+      "fill-opacity": isFinite(v) ? 0.12 + 0.88 * ((v - lo) / span) : 0,
+      stroke: "var(--border, #ddd)",
+      "stroke-width": 0.5,
+    });
+    tooltip(doc, cell, `${cx} · ${cy}: ${fmt(v)}`);
+    g.appendChild(cell);
+  }
+}
+
 function render(root, spec) {
   if (!root || typeof root.appendChild !== "function") {
     throw new Error("chartkit: render(el, spec) needs a DOM element");
@@ -240,9 +277,6 @@ function render(root, spec) {
     throw new Error(
       `chartkit: unknown chart type "${spec.type}" (expected one of ${CHART_TYPES.join(", ")})`
     );
-  }
-  if (spec.type === "heatmap") {
-    throw new Error("chartkit: heatmap renderer lands in T4");
   }
   const doc = root.ownerDocument;
   while (root.firstChild) root.removeChild(root.firstChild);
@@ -256,6 +290,21 @@ function render(root, spec) {
   svg.appendChild(g);
 
   const data = spec.data || [];
+  if (spec.type === "heatmap") {
+    renderHeatmap(doc, g, spec);
+    if (spec.options && spec.options.title) {
+      label(doc, g, spec.options.title, {
+        x: M.l,
+        y: 16,
+        "font-size": 13,
+        "font-weight": 500,
+        fill: "var(--text-primary, #222)",
+        "text-anchor": "start",
+      });
+    }
+    root.appendChild(svg);
+    return svg;
+  }
   const colorEnc = spec.encodings.color;
   const series = splitSeries(data, colorEnc);
   const yVals = data.map((r) => fieldValue(r, spec.encodings.y));

--- a/src/attune/widgets/chartkit/src/kernel.js
+++ b/src/attune/widgets/chartkit/src/kernel.js
@@ -1,0 +1,24 @@
+const VERSION = "0.1.0";
+
+const CHART_TYPES = ["bar", "line", "scatter", "area", "heatmap"];
+
+function render(el, spec) {
+  if (!el || typeof el.appendChild !== "function") {
+    throw new Error("chartkit: render(el, spec) needs a DOM element");
+  }
+  if (!spec || typeof spec !== "object") {
+    throw new Error("chartkit: render(el, spec) needs a spec object");
+  }
+  if (!CHART_TYPES.includes(spec.type)) {
+    throw new Error(
+      `chartkit: unknown chart type "${spec.type}" (expected one of ${CHART_TYPES.join(", ")})`
+    );
+  }
+  el.textContent = `chartkit v${VERSION}: "${spec.type}" renderer lands in T3/T4`;
+}
+
+function applyPatch() {
+  throw new Error("chartkit: applyPatch lands in T5");
+}
+
+export { VERSION, CHART_TYPES, render, applyPatch };

--- a/src/attune/widgets/chartkit/test/kernel.test.mjs
+++ b/src/attune/widgets/chartkit/test/kernel.test.mjs
@@ -1,0 +1,29 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { VERSION, CHART_TYPES, render, applyPatch } from "../src/kernel.js";
+
+function fakeEl() {
+  return { textContent: "", appendChild() {} };
+}
+
+test("exports a version and the five chart types", () => {
+  assert.match(VERSION, /^\d+\.\d+\.\d+$/);
+  assert.deepEqual(CHART_TYPES, ["bar", "line", "scatter", "area", "heatmap"]);
+});
+
+test("render rejects a missing element and unknown types", () => {
+  assert.throws(() => render(null, { type: "bar" }), /DOM element/);
+  assert.throws(() => render(fakeEl(), { type: "pie" }), /unknown chart type/);
+});
+
+test("render accepts every declared chart type (stub)", () => {
+  for (const type of CHART_TYPES) {
+    const el = fakeEl();
+    render(el, { type });
+    assert.ok(el.textContent.includes(type));
+  }
+});
+
+test("applyPatch is explicitly not yet implemented", () => {
+  assert.throws(() => applyPatch(), /T5/);
+});

--- a/src/attune/widgets/chartkit/test/kernel.test.mjs
+++ b/src/attune/widgets/chartkit/test/kernel.test.mjs
@@ -2,28 +2,173 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import { VERSION, CHART_TYPES, render, applyPatch } from "../src/kernel.js";
 
-function fakeEl() {
-  return { textContent: "", appendChild() {} };
+class FakeNode {
+  constructor(doc, name) {
+    this.ownerDocument = doc;
+    this.nodeName = name;
+    this.children = [];
+    this.attrs = {};
+    this._text = "";
+  }
+  setAttribute(k, v) {
+    this.attrs[k] = v;
+  }
+  appendChild(c) {
+    this.children.push(c);
+    return c;
+  }
+  removeChild(c) {
+    this.children = this.children.filter((x) => x !== c);
+  }
+  get firstChild() {
+    return this.children[0] || null;
+  }
+  set textContent(s) {
+    this._text = String(s);
+    this.children = [];
+  }
+  get textContent() {
+    return this._text;
+  }
 }
 
-test("exports a version and the five chart types", () => {
+class FakeDoc {
+  createElementNS(_ns, name) {
+    return new FakeNode(this, name);
+  }
+}
+
+function host() {
+  return new FakeNode(new FakeDoc(), "div");
+}
+
+function walk(node, fn) {
+  fn(node);
+  for (const c of node.children) walk(c, fn);
+}
+
+function collect(root, name) {
+  const out = [];
+  walk(root, (n) => {
+    if (n.nodeName === name) out.push(n);
+  });
+  return out;
+}
+
+const barSpec = {
+  v: 1,
+  type: "bar",
+  data: [
+    { month: "Jan", sales: 12 },
+    { month: "Feb", sales: 19 },
+    { month: "Mar", sales: 7 },
+  ],
+  encodings: {
+    x: { field: "month", type: "nominal" },
+    y: { field: "sales", type: "quantitative" },
+  },
+};
+
+const lineSpec = {
+  v: 1,
+  type: "line",
+  data: [
+    { t: 0, v: 1 },
+    { t: 1, v: 3 },
+    { t: 2, v: 2 },
+  ],
+  encodings: {
+    x: { field: "t", type: "quantitative" },
+    y: { field: "v", type: "quantitative" },
+  },
+};
+
+test("exports version and the five chart types", () => {
   assert.match(VERSION, /^\d+\.\d+\.\d+$/);
   assert.deepEqual(CHART_TYPES, ["bar", "line", "scatter", "area", "heatmap"]);
 });
 
-test("render rejects a missing element and unknown types", () => {
-  assert.throws(() => render(null, { type: "bar" }), /DOM element/);
-  assert.throws(() => render(fakeEl(), { type: "pie" }), /unknown chart type/);
+test("bar fixture renders one rect per row with tooltips", () => {
+  const el = host();
+  const svg = render(el, barSpec);
+  assert.equal(svg.attrs["data-chartkit"], VERSION);
+  const rects = collect(svg, "rect");
+  assert.equal(rects.length, barSpec.data.length);
+  assert.equal(collect(svg, "title").length, barSpec.data.length);
 });
 
-test("render accepts every declared chart type (stub)", () => {
-  for (const type of CHART_TYPES) {
-    const el = fakeEl();
-    render(el, { type });
-    assert.ok(el.textContent.includes(type));
-  }
+test("line fixture renders a path through the points", () => {
+  const svg = render(host(), lineSpec);
+  const paths = collect(svg, "path");
+  assert.equal(paths.length, 1);
+  assert.match(paths[0].attrs.d, /^M[\d.]+,[\d.]+L/);
 });
 
-test("applyPatch is explicitly not yet implemented", () => {
+test("area adds a fill path under the line", () => {
+  const svg = render(host(), { ...lineSpec, type: "area" });
+  assert.equal(collect(svg, "path").length, 2);
+});
+
+test("scatter renders one circle per finite point", () => {
+  const svg = render(host(), { ...lineSpec, type: "scatter" });
+  assert.equal(collect(svg, "circle").length, lineSpec.data.length);
+});
+
+test("color channel splits series and draws a legend", () => {
+  const spec = {
+    ...barSpec,
+    data: [
+      { month: "Jan", sales: 5, region: "east" },
+      { month: "Jan", sales: 7, region: "west" },
+      { month: "Feb", sales: 6, region: "east" },
+      { month: "Feb", sales: 4, region: "west" },
+    ],
+    encodings: { ...barSpec.encodings, color: { field: "region", type: "nominal" } },
+  };
+  const svg = render(host(), spec);
+  const rects = collect(svg, "rect");
+  assert.equal(rects.length, 4 + 2);
+  const fills = new Set(rects.map((r) => r.attrs.fill));
+  assert.ok(fills.size >= 2);
+});
+
+test("hostile spec strings never become elements — text nodes only", () => {
+  const hostile = '<script>alert(1)</script><img src=x onerror=alert(1)>';
+  const spec = {
+    ...barSpec,
+    data: [{ month: hostile, sales: 3 }],
+    options: { title: hostile },
+  };
+  const svg = render(host(), spec);
+  assert.equal(collect(svg, "script").length, 0);
+  assert.equal(collect(svg, "img").length, 0);
+  let seenAsText = 0;
+  walk(svg, (n) => {
+    if (n.textContent.includes(hostile)) seenAsText += 1;
+    for (const v of Object.values(n.attrs)) {
+      assert.ok(!String(v).includes("<script"), "hostile string leaked into an attribute");
+    }
+  });
+  assert.ok(seenAsText >= 2, "hostile string should surface only as inert text");
+});
+
+test("re-render clears previous chart from the host element", () => {
+  const el = host();
+  render(el, barSpec);
+  render(el, barSpec);
+  assert.equal(el.children.length, 1);
+});
+
+test("unknown type and missing encodings are rejected", () => {
+  assert.throws(() => render(host(), { type: "pie", encodings: {} }), /unknown chart type/);
+  assert.throws(() => render(host(), { type: "bar" }), /encodings/);
+  assert.throws(() => render(null, barSpec), /DOM element/);
+});
+
+test("heatmap and applyPatch name the tasks they land in", () => {
+  assert.throws(
+    () => render(host(), { ...barSpec, type: "heatmap" }),
+    /T4/
+  );
   assert.throws(() => applyPatch(), /T5/);
 });

--- a/src/attune/widgets/chartkit/test/kernel.test.mjs
+++ b/src/attune/widgets/chartkit/test/kernel.test.mjs
@@ -165,10 +165,61 @@ test("unknown type and missing encodings are rejected", () => {
   assert.throws(() => render(null, barSpec), /DOM element/);
 });
 
-test("heatmap and applyPatch name the tasks they land in", () => {
-  assert.throws(
-    () => render(host(), { ...barSpec, type: "heatmap" }),
-    /T4/
-  );
+test("heatmap renders one cell per row with value tooltips", () => {
+  const spec = {
+    v: 1,
+    type: "heatmap",
+    data: [
+      { day: "Mon", hour: "am", n: 2 },
+      { day: "Mon", hour: "pm", n: 8 },
+      { day: "Tue", hour: "am", n: 5 },
+      { day: "Tue", hour: "pm", n: 1 },
+    ],
+    encodings: {
+      x: { field: "day", type: "nominal" },
+      y: { field: "hour", type: "nominal" },
+      color: { field: "n", type: "quantitative" },
+    },
+  };
+  const svg = render(host(), spec);
+  const cells = collect(svg, "rect");
+  assert.equal(cells.length, spec.data.length);
+  const opacities = cells.map((c) => Number(c.attrs["fill-opacity"]));
+  assert.ok(Math.max(...opacities) > Math.min(...opacities), "value maps to opacity ramp");
+  assert.equal(collect(svg, "title").length, spec.data.length);
+});
+
+test("heatmap without a color channel is rejected", () => {
+  const spec = {
+    type: "heatmap",
+    data: [{ a: "x", b: "y" }],
+    encodings: {
+      x: { field: "a", type: "nominal" },
+      y: { field: "b", type: "nominal" },
+    },
+  };
+  assert.throws(() => render(host(), spec), /encodings\.color/);
+});
+
+test("every declared chart type renders from a fixture", () => {
+  for (const type of CHART_TYPES) {
+    const spec =
+      type === "heatmap"
+        ? {
+            type,
+            data: [{ a: "x", b: "y", n: 1 }],
+            encodings: {
+              x: { field: "a", type: "nominal" },
+              y: { field: "b", type: "nominal" },
+              color: { field: "n", type: "quantitative" },
+            },
+          }
+        : { ...(type === "bar" ? barSpec : lineSpec), type };
+    const svg = render(host(), spec);
+    assert.equal(svg.attrs["data-chartkit"], VERSION, `${type} should render`);
+  }
+});
+
+test("applyPatch names the task it lands in", () => {
   assert.throws(() => applyPatch(), /T5/);
 });

--- a/src/attune/widgets/chartkit/test/kernel.test.mjs
+++ b/src/attune/widgets/chartkit/test/kernel.test.mjs
@@ -220,6 +220,37 @@ test("every declared chart type renders from a fixture", () => {
   }
 });
 
-test("applyPatch names the task it lands in", () => {
-  assert.throws(() => applyPatch(), /T5/);
+test("applyPatch follows RFC 7386 merge-patch semantics", () => {
+  const spec = { a: 1, nest: { keep: true, drop: 2 }, arr: [1, 2, 3] };
+  const out = applyPatch(spec, {
+    a: 9,
+    added: "new",
+    nest: { drop: null, deep: { x: 1 } },
+    arr: [4],
+  });
+  assert.deepEqual(out, {
+    a: 9,
+    added: "new",
+    nest: { keep: true, deep: { x: 1 } },
+    arr: [4],
+  });
+  assert.deepEqual(spec.nest, { keep: true, drop: 2 }, "input spec is not mutated");
+  assert.equal(applyPatch({ a: 1 }, null), null, "non-object patch replaces wholesale");
+});
+
+test("a data-only patch re-renders with rescaled axes", () => {
+  const el = host();
+  render(el, lineSpec);
+  const before = collect(el, "text").map((t) => t.textContent);
+  const patched = applyPatch(lineSpec, {
+    data: [
+      { t: 0, v: 100 },
+      { t: 1, v: 900 },
+    ],
+  });
+  render(el, patched);
+  const after = collect(el, "text").map((t) => t.textContent);
+  assert.equal(el.children.length, 1, "replaced in place");
+  assert.notDeepEqual(after, before, "axis ticks rescaled to the new domain");
+  assert.ok(after.some((s) => s.includes("k") || Number(s) >= 100), "ticks reflect new magnitude");
 });

--- a/tests/unit/mcp/test_server_chart_widget.py
+++ b/tests/unit/mcp/test_server_chart_widget.py
@@ -1,0 +1,67 @@
+"""Coverage for the chart_render_widget MCP handler (thin delegate).
+
+Copyright 2026 Smart-AI-Memory
+Licensed under Apache 2.0
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+import attune.mcp.server as server_module
+from attune.widgets import chart_widget_tool
+
+
+@pytest.fixture(autouse=True)
+def stub_kernel(tmp_path, monkeypatch):
+    """The kernel artifact is npm-built and gitignored — stub it."""
+    stub = tmp_path / "kernel.min.js"
+    stub.write_text(
+        "/* chartkit v0.0.0-teststub sealed */\nvar ChartKit={render:function(){}};",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(chart_widget_tool, "_KERNEL_PATH", stub)
+
+
+def _make_server(tmp_path):
+    with patch.object(server_module.EmpathyMCPServer, "_register_plugin_tools"):
+        return server_module.EmpathyMCPServer(workspace_root=str(tmp_path))
+
+
+SPEC = {
+    "v": 1,
+    "type": "bar",
+    "data": [{"m": "Jan", "n": 3}],
+    "encodings": {
+        "x": {"field": "m", "type": "nominal"},
+        "y": {"field": "n", "type": "quantitative"},
+    },
+}
+
+
+@pytest.mark.asyncio
+async def test_handler_delegates_and_returns_widget_html(tmp_path):
+    server = _make_server(tmp_path)
+    result = await server._handle_chart_render_widget({"chart_id": "h1", "spec": SPEC})
+    assert result["success"] is True
+    assert result["chart_id"] == "h1"
+    assert "ChartKit.render" in result["html"]
+
+
+@pytest.mark.asyncio
+async def test_handler_surfaces_field_level_problems(tmp_path):
+    server = _make_server(tmp_path)
+    bad = dict(SPEC, type="pie")
+    result = await server._handle_chart_render_widget({"chart_id": "h2", "spec": bad})
+    assert result["success"] is False
+    assert any("type" in p for p in result["problems"])
+
+
+@pytest.mark.asyncio
+async def test_handler_rejects_malformed_chart_id(tmp_path):
+    server = _make_server(tmp_path)
+    result = await server._handle_chart_render_widget({"chart_id": "../escape", "spec": SPEC})
+    assert result["success"] is False
+    assert "chart_id" in result["error"]

--- a/tests/unit/test_mcp_memory_tools.py
+++ b/tests/unit/test_mcp_memory_tools.py
@@ -27,12 +27,12 @@ class TestToolRegistration:
     """Verify all tools are registered (49 core + 6 optional redis plugin)."""
 
     def test_tools_list_returns_at_least_core_count(self, server: EmpathyMCPServer):
-        """Core tools (49) are always registered; attune-redis adds 6 more."""
+        """Core tools (50) are always registered; attune-redis adds 6 more."""
         tools = server.get_tool_list()
         tool_names = {t["name"] for t in tools}
 
-        # 49 core tools must always be present (incl. handoff_create/resume)
-        assert len(tools) >= 49
+        # 50 core tools must always be present (incl. chart_render_widget)
+        assert len(tools) >= 50
 
         # When attune-redis plugin is installed, all 6 redis tools are present
         redis_tools = {
@@ -46,7 +46,7 @@ class TestToolRegistration:
         if redis_tools.issubset(tool_names):
             # attune-redis also registers 5 session_memory_* tools when the
             # core session stash is importable (conditional registration).
-            expected = 60 if "session_memory_status" in tool_names else 55
+            expected = 61 if "session_memory_status" in tool_names else 56
             assert (
                 len(tools) == expected
             ), f"Expected {expected} tools with redis plugin, got {len(tools)}"

--- a/tests/unit/widgets/__init__.py
+++ b/tests/unit/widgets/__init__.py
@@ -1,0 +1,5 @@
+"""Tests for attune widget surfaces (chart spec, tool, presets).
+
+Copyright 2026 Smart-AI-Memory
+Licensed under Apache 2.0
+"""

--- a/tests/unit/widgets/conftest.py
+++ b/tests/unit/widgets/conftest.py
@@ -1,8 +1,9 @@
 """Widget test fixtures.
 
-The kernel artifact (chartkit/dist/kernel.min.js) is npm-built and
-gitignored, so it does not exist in CI checkouts. Tool tests must
-never depend on it: every test gets a stub kernel on a tmp path.
+The kernel dist artifact is npm-built and gitignored, so it does not
+exist in CI checkouts. Tool tests must never depend on it: every
+test gets a stub kernel on a tmp path (the inward-seal check polices
+literal kernel paths in tracked files, so this docstring names none).
 The stub carries the real banner shape so banner assertions hold.
 
 Copyright 2026 Smart-AI-Memory

--- a/tests/unit/widgets/conftest.py
+++ b/tests/unit/widgets/conftest.py
@@ -1,0 +1,28 @@
+"""Widget test fixtures.
+
+The kernel artifact (chartkit/dist/kernel.min.js) is npm-built and
+gitignored, so it does not exist in CI checkouts. Tool tests must
+never depend on it: every test gets a stub kernel on a tmp path.
+The stub carries the real banner shape so banner assertions hold.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under Apache 2.0
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from attune.widgets import chart_widget_tool
+
+
+@pytest.fixture(autouse=True)
+def stub_kernel(tmp_path, monkeypatch):
+    """Point _KERNEL_PATH at a stub so tests never need npm build."""
+    stub = tmp_path / "kernel.min.js"
+    stub.write_text(
+        "/* chartkit v0.0.0-teststub sealed */\nvar ChartKit={render:function(){}};",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(chart_widget_tool, "_KERNEL_PATH", stub)
+    return stub

--- a/tests/unit/widgets/test_chart_components.py
+++ b/tests/unit/widgets/test_chart_components.py
@@ -39,6 +39,16 @@ SAMPLE_ARGS: dict[str, dict] = {
         "title": "Revenue by region",
     },
     "kpi_tile": {"label": "MRR", "value": 4200.0, "previous": 3900.0},
+    "spec_progress": {
+        "tasks": [
+            {"task": "T1", "status": "done"},
+            {"task": "T2", "status": "done"},
+            {"task": "T3", "status": "in_flight"},
+            {"task": "T4", "status": "blocked"},
+            {"task": "T5", "status": "pending"},
+        ],
+        "title": "chart-widget-kernel",
+    },
 }
 
 
@@ -57,6 +67,21 @@ def test_kpi_tile_without_previous_is_a_single_bar() -> None:
     validated = expand_component("kpi_tile", {"label": "Users", "value": 87})
     assert len(validated.data) == 1
     assert validated.options.title == "Users"
+
+
+def test_spec_progress_one_stacked_bar_per_task() -> None:
+    validated = expand_component("spec_progress", SAMPLE_ARGS["spec_progress"])
+    assert validated.type == "bar"
+    assert validated.options.stacked is True
+    assert len(validated.data) == 5
+    assert validated.encodings.color is not None
+    statuses = {row["status"] for row in validated.data}
+    assert statuses == {"done", "in_flight", "blocked", "pending"}
+
+
+def test_spec_progress_defaults_title() -> None:
+    validated = expand_component("spec_progress", {"tasks": [{"task": "T1", "status": "done"}]})
+    assert validated.options.title == "Spec progress"
 
 
 def test_unknown_component_lists_the_valid_names() -> None:

--- a/tests/unit/widgets/test_chart_components.py
+++ b/tests/unit/widgets/test_chart_components.py
@@ -1,0 +1,76 @@
+"""Component preset tests — every expansion is schema-valid, and every
+full-spec example in the chartkit docs validates against the contract.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under Apache 2.0
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+from attune.widgets.chart_components import COMPONENTS, expand_component
+from attune.widgets.chart_spec import validate_chart_spec
+
+DOCS_PATH = Path(__file__).resolve().parents[3] / "docs/chartkit.md"
+
+SAMPLE_ARGS: dict[str, dict] = {
+    "time_series": {
+        "data": [
+            {"date": "2026-07-01", "value": 3, "env": "prod"},
+            {"date": "2026-07-02", "value": 5, "env": "prod"},
+            {"date": "2026-07-01", "value": 1, "env": "staging"},
+        ],
+        "series_field": "env",
+        "title": "Deploys per day",
+    },
+    "comparison_bars": {
+        "data": [
+            {"category": "north", "value": 12, "quarter": "Q1"},
+            {"category": "north", "value": 15, "quarter": "Q2"},
+            {"category": "south", "value": 9, "quarter": "Q1"},
+        ],
+        "series_field": "quarter",
+        "stacked": True,
+        "title": "Revenue by region",
+    },
+    "kpi_tile": {"label": "MRR", "value": 4200.0, "previous": 3900.0},
+}
+
+
+@pytest.mark.parametrize("name", sorted(COMPONENTS))
+def test_every_preset_expands_to_a_schema_valid_spec(name: str) -> None:
+    validated = expand_component(name, SAMPLE_ARGS[name])
+    assert validated.v == 1
+    assert validated.type in {"bar", "line"}
+
+
+def test_sample_args_cover_every_registered_component() -> None:
+    assert set(SAMPLE_ARGS) == set(COMPONENTS)
+
+
+def test_kpi_tile_without_previous_is_a_single_bar() -> None:
+    validated = expand_component("kpi_tile", {"label": "Users", "value": 87})
+    assert len(validated.data) == 1
+    assert validated.options.title == "Users"
+
+
+def test_unknown_component_lists_the_valid_names() -> None:
+    with pytest.raises(KeyError) as exc:
+        expand_component("sparkline", {})
+    for name in COMPONENTS:
+        assert name in str(exc.value)
+
+
+def test_docs_full_spec_examples_validate() -> None:
+    text = DOCS_PATH.read_text(encoding="utf-8")
+    blocks = re.findall(r"```json\n(.*?)```", text, re.DOTALL)
+    specs = [json.loads(b) for b in blocks]
+    full_specs = [s for s in specs if isinstance(s, dict) and "type" in s]
+    assert full_specs, "docs must contain at least one full-spec example"
+    for spec in full_specs:
+        validate_chart_spec(spec)

--- a/tests/unit/widgets/test_chart_spec.py
+++ b/tests/unit/widgets/test_chart_spec.py
@@ -1,0 +1,103 @@
+"""Chart spec v1 validation tests — all five types, field-level errors,
+and the pydantic/JSON-Schema sync contract.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under Apache 2.0
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from attune.widgets.chart_spec import (
+    CHART_TYPES,
+    ChartSpecError,
+    validate_chart_spec,
+)
+
+SCHEMA_PATH = Path(__file__).resolve().parents[3] / "src/attune/widgets/chartkit/spec.schema.json"
+
+
+def _spec(chart_type: str) -> dict:
+    spec: dict = {
+        "v": 1,
+        "type": chart_type,
+        "data": [{"x": "a", "y": 1}, {"x": "b", "y": 2}],
+        "encodings": {
+            "x": {"field": "x", "type": "nominal"},
+            "y": {"field": "y", "type": "quantitative"},
+        },
+    }
+    if chart_type == "heatmap":
+        spec["encodings"]["color"] = {"field": "y", "type": "quantitative"}
+    return spec
+
+
+@pytest.mark.parametrize("chart_type", CHART_TYPES)
+def test_valid_spec_per_type(chart_type: str) -> None:
+    validated = validate_chart_spec(_spec(chart_type))
+    assert validated.type == chart_type
+    assert validated.options.legend is True
+
+
+def test_missing_encoding_reports_field_level_path() -> None:
+    spec = _spec("bar")
+    del spec["encodings"]["x"]
+    with pytest.raises(ChartSpecError) as exc:
+        validate_chart_spec(spec)
+    assert any(p.startswith("encodings.x") for p in exc.value.problems)
+
+
+def test_unknown_type_lists_the_valid_ones() -> None:
+    spec = _spec("bar")
+    spec["type"] = "pie"
+    with pytest.raises(ChartSpecError) as exc:
+        validate_chart_spec(spec)
+    assert any("type" in p for p in exc.value.problems)
+
+
+def test_extra_keys_are_rejected() -> None:
+    spec = _spec("line")
+    spec["renderer"] = "custom"
+    with pytest.raises(ChartSpecError) as exc:
+        validate_chart_spec(spec)
+    assert any("renderer" in p for p in exc.value.problems)
+
+
+def test_empty_data_is_rejected() -> None:
+    spec = _spec("bar")
+    spec["data"] = []
+    with pytest.raises(ChartSpecError) as exc:
+        validate_chart_spec(spec)
+    assert any(p.startswith("data") for p in exc.value.problems)
+
+
+def test_heatmap_requires_color_channel() -> None:
+    spec = _spec("heatmap")
+    del spec["encodings"]["color"]
+    with pytest.raises(ChartSpecError) as exc:
+        validate_chart_spec(spec)
+    assert any("color" in p for p in exc.value.problems)
+
+
+class TestSchemaSync:
+    """The handwritten JSON Schema must agree with the pydantic mirror."""
+
+    def _schema(self) -> dict:
+        return json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+
+    def test_chart_type_enums_match(self) -> None:
+        schema = self._schema()
+        assert tuple(schema["properties"]["type"]["enum"]) == CHART_TYPES
+
+    def test_required_top_level_fields_match(self) -> None:
+        schema = self._schema()
+        assert set(schema["required"]) == {"v", "type", "data", "encodings"}
+
+    def test_encoding_field_types_match(self) -> None:
+        schema = self._schema()
+        enum = schema["$defs"]["encoding"]["properties"]["type"]["enum"]
+        assert set(enum) == {"quantitative", "nominal", "temporal"}

--- a/tests/unit/widgets/test_chart_widget_tool.py
+++ b/tests/unit/widgets/test_chart_widget_tool.py
@@ -1,0 +1,140 @@
+"""chart_render_widget tests — create/patch round trips, legible
+degradation without a backend, and injection-safe HTML.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under Apache 2.0
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from attune.widgets.chart_widget_tool import (
+    BACKEND_DOWN_MSG,
+    merge_patch,
+    render_chart_widget,
+)
+
+
+class DictBackend:
+    """In-memory stand-in for the session memory backend."""
+
+    def __init__(self) -> None:
+        self.store: dict[str, dict] = {}
+
+    def stash(self, key: str, value: dict, ttl: int | None = None) -> bool:
+        self.store[key] = value
+        return True
+
+    def retrieve(self, key: str) -> dict | None:
+        return self.store.get(key)
+
+
+def _spec() -> dict:
+    return {
+        "v": 1,
+        "type": "bar",
+        "data": [{"m": "Jan", "n": 3}, {"m": "Feb", "n": 5}],
+        "encodings": {
+            "x": {"field": "m", "type": "nominal"},
+            "y": {"field": "n", "type": "quantitative"},
+        },
+        "options": {"title": "Sales"},
+    }
+
+
+def test_create_returns_kernel_injected_html_and_persists() -> None:
+    backend = DictBackend()
+    out = render_chart_widget("sales-1", spec=_spec(), backend=backend)
+    assert out["success"] is True
+    assert "/* chartkit v" in out["html"]
+    assert 'id="chartkit-sales-1"' in out["html"]
+    assert out["persistence"].startswith("stored")
+    assert backend.store["chart:sales-1"]["type"] == "bar"
+
+
+def test_create_then_patch_then_patch_round_trip() -> None:
+    backend = DictBackend()
+    render_chart_widget("rt", spec=_spec(), backend=backend)
+    out1 = render_chart_widget("rt", patch={"options": {"title": "Q3 sales"}}, backend=backend)
+    assert out1["success"] is True
+    out2 = render_chart_widget("rt", patch={"data": [{"m": "Mar", "n": 9}]}, backend=backend)
+    assert out2["success"] is True
+    final = backend.store["chart:rt"]
+    assert final["options"]["title"] == "Q3 sales"
+    assert final["data"] == [{"m": "Mar", "n": 9}]
+    assert final["type"] == "bar"
+
+
+def test_patch_without_backend_degrades_legibly(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from attune.widgets import chart_widget_tool
+
+    monkeypatch.setattr(chart_widget_tool, "_resolve_backend", lambda: None)
+    out = render_chart_widget("orphan", patch={"options": {"title": "x"}})
+    assert out["success"] is False
+    assert out["error"] == BACKEND_DOWN_MSG
+    assert "FULL chart spec" in out["error"]
+
+
+def test_patch_with_expired_spec_names_the_chart() -> None:
+    out = render_chart_widget("gone", patch={"options": {"title": "x"}}, backend=DictBackend())
+    assert out["success"] is False
+    assert "gone" in out["error"]
+    assert "FULL chart spec" in out["error"]
+
+
+def test_invalid_spec_returns_field_level_problems() -> None:
+    spec = _spec()
+    del spec["encodings"]["y"]
+    out = render_chart_widget("bad", spec=spec, backend=DictBackend())
+    assert out["success"] is False
+    assert any(p.startswith("encodings.y") for p in out["problems"])
+
+
+def test_hostile_strings_cannot_break_out_of_the_script_tag() -> None:
+    spec = _spec()
+    spec["options"]["title"] = "</script><script>alert(1)</script>"
+    spec["data"] = [{"m": "<img src=x onerror=alert(1)>", "n": 1}]
+    out = render_chart_widget("evil", spec=spec, backend=DictBackend())
+    assert out["success"] is True
+    html = out["html"]
+    payload = html.split("ChartKit.render", 1)[1].rsplit("</script>", 1)[0]
+    assert "</script" not in payload, "spec strings must not close the script tag"
+    assert "\\u003c" in payload
+
+
+def test_bad_chart_id_is_rejected() -> None:
+    out = render_chart_widget("no/slashes here", spec=_spec(), backend=DictBackend())
+    assert out["success"] is False
+    assert "chart_id" in out["error"]
+
+
+def test_neither_spec_nor_patch_is_an_error() -> None:
+    out = render_chart_widget("empty", backend=DictBackend())
+    assert out["success"] is False
+    assert "spec" in out["error"] and "patch" in out["error"]
+
+
+def test_merge_patch_semantics() -> None:
+    assert merge_patch({"a": 1, "b": {"c": 2}}, {"b": {"c": None}, "d": 4}) == {
+        "a": 1,
+        "b": {},
+        "d": 4,
+    }
+    assert merge_patch({"a": 1}, "scalar") == "scalar"
+
+
+def test_no_stored_spec_type_confusion_is_handled() -> None:
+    backend = DictBackend()
+    backend.store["chart:odd"] = ["not", "a", "dict"]  # type: ignore[assignment]
+    out = render_chart_widget("odd", patch={"options": {}}, backend=backend)
+    assert out["success"] is False
+    assert "FULL chart spec" in out["error"]
+
+
+@pytest.mark.parametrize("chart_id", ["a", "A-1_b", "x" * 64])
+def test_chart_id_edge_formats_accepted(chart_id: str) -> None:
+    out = render_chart_widget(chart_id, spec=_spec(), backend=DictBackend())
+    assert out["success"] is True

--- a/tests/unit/widgets/test_chart_widget_tool.py
+++ b/tests/unit/widgets/test_chart_widget_tool.py
@@ -138,3 +138,61 @@ def test_no_stored_spec_type_confusion_is_handled() -> None:
 def test_chart_id_edge_formats_accepted(chart_id: str) -> None:
     out = render_chart_widget(chart_id, spec=_spec(), backend=DictBackend())
     assert out["success"] is True
+
+
+class RaisingBackend:
+    """Backend whose every operation fails — the degradation worst case."""
+
+    def stash(self, key: str, value: dict, ttl: int | None = None) -> bool:
+        raise RuntimeError("redis gone")
+
+    def retrieve(self, key: str) -> dict | None:
+        raise RuntimeError("redis gone")
+
+
+def test_retrieve_failure_degrades_to_resend_full_spec(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    import logging
+
+    with caplog.at_level(logging.WARNING, logger="attune.widgets.chart_widget_tool"):
+        out = render_chart_widget("flaky", patch={"options": {}}, backend=RaisingBackend())
+    assert out["success"] is False
+    assert "FULL chart spec" in out["error"]
+    assert any("retrieve failed" in r.message for r in caplog.records)
+
+
+def test_stash_failure_is_logged_and_marked_unavailable(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    import logging
+
+    with caplog.at_level(logging.WARNING, logger="attune.widgets.chart_widget_tool"):
+        out = render_chart_widget("lossy", spec=_spec(), backend=RaisingBackend())
+    assert out["success"] is True
+    assert out["persistence"].startswith("unavailable")
+    assert any("stash failed" in r.message for r in caplog.records)
+
+
+def test_backend_resolve_failure_is_logged_not_raised(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import attune.memory.session_stash as session_stash
+    from attune.widgets import chart_widget_tool
+
+    def boom() -> None:
+        raise RuntimeError("no backend configured")
+
+    monkeypatch.setattr(session_stash, "resolve_backend", boom)
+    assert chart_widget_tool._resolve_backend() is None
+
+
+def test_missing_kernel_artifact_is_a_legible_error(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    from attune.widgets import chart_widget_tool
+
+    monkeypatch.setattr(chart_widget_tool, "_KERNEL_PATH", tmp_path / "absent.js")
+    out = render_chart_widget("nokernel", spec=_spec(), backend=DictBackend())
+    assert out["success"] is False
+    assert "npm run build" in out["error"]

--- a/website/lib/features.ts
+++ b/website/lib/features.ts
@@ -270,7 +270,7 @@ export const DIFFERENTIATORS: Differentiator[] = [
 export const CAPABILITIES = {
   workflows: 21,
   skills: 27,
-  mcpTools: 49,
+  mcpTools: 50,
   templateKinds: 15,
   wizards: 5,
 } as const;


### PR DESCRIPTION
## What

A sealed 6.8KB JS chart kernel (`src/attune/widgets/chartkit/`) that renders five chart types from declarative JSON specs, plus the Python layers above it: spec validation (`chart_spec.py`), the `chart_render_widget` MCP tool with Redis-persisted specs and RFC 7386 patch updates (`chart_widget_tool.py`), and four semantic components including the attune-native `spec_progress` (`chart_components.py`).

Spec: `.claude/plans/chart-widget-kernel.md` — 7 tasks executed with per-task approval, plus the `spec_progress` amendment and a security-hardening pass.

## Guarantees (CI-enforced, not aspirational)

- **Size ceiling:** `kernel.min.js` ≤ 20,480 bytes — currently 6,839 (33%). Gate proven to fail a bloated build.
- **Sealed boundary:** no outward imports from kernel source, no inward imports of kernel internals beyond the sanctioned loader allowlist; polices paths (`chartkit/`), not prose. Gate proven to fail a planted cross-import.
- **Structural XSS safety:** DOM built via `createElementNS` + `textContent` only (no innerHTML sink); tool-side script embedding escapes `<` to `\u003c`; both proven by hostile-payload tests.
- **Legible degradation:** without a memory backend, patches are rejected with an explicit re-send-full-spec message; every backend failure logs with its chart key.

## Evidence

- Node tests 14/14, pytest 36/36, bandit 0 issues, pre-commit green on all 9 commits (GPG-signed).
- Attune orchestrator sweep on the T6 security surface: quality PASSED, tests PASSED (after one WARNING round fixed the silent exception swallows).
- New `chartkit.yml` workflow runs build, node tests, and both gates on chartkit paths.

## Decisions

D1 in-tree home with CI-enforced seal · D2 20,480-byte minified ceiling · D3 JSON spec v1 + RFC 7386 patches · D4 elicitation/show_widget surface first · D5 Redis persistence with legible degradation · D6 esbuild/node:test contained to the sealed dir · D7 CSS-variable theming + escaped-text-node rule

🤖 Generated with [Claude Code](https://claude.com/claude-code)