### PR TITLE
feat(elicitation): V7 form-template library — sculpt once, cast per fork

### DIFF
--- a/.agents/skills/elicit/SKILL.md
+++ b/.agents/skills/elicit/SKILL.md
@@ -33,6 +33,32 @@ question depends on an earlier answer, or batching would feel like a
 bureaucratic intake for a simple ask. The form never adds fields the
 ordinary Socratic-ambiguity judgement wouldn't already ask.
 
+## Step 0 — check the template library first (V7)
+
+Recurring fork classes are stored as named JSON templates
+(`src/attune/elicitation/templates/`). **Reach for a template before
+hand-building**: a reused template makes answers comparable across
+sessions (joinable on `FormResponse.template_id`).
+
+```python
+from attune.elicitation import form_from_template, list_templates
+
+form = form_from_template("session-contract", {"project": "attune-ai"})
+# ... render, then collect with the join key:
+response = collect_form_response(form, answers, template_id="session-contract")
+```
+
+Available templates:
+
+| Name | Construct | Purpose | Slots |
+|---|---|---|---|
+| `session-contract` | intake-form | Session-start protocol: mode, outcome, done-when, effort cap | `project` |
+
+Missing/extra slot values and malformed templates fail through the
+same every-problem-listed `FormValidationError` a hand-built dict
+gets. **Promote-on-repeat (R5):** a form earns templatehood on its
+SECOND recurrence — no speculative templates.
+
 ## Step 1 — build the declarative form (D3)
 
 A form is plain serializable data:

--- a/docs/specs/elicitation-form-surface/decisions.md
+++ b/docs/specs/elicitation-form-surface/decisions.md
@@ -842,6 +842,52 @@ thread on the board (TTL 7 days) and in the ruling, message 10.
 **Not done.** Wiring `surface_mix()` onto the ops Health tab — the
 counter and its reader ship here, the dashboard panel does not.
 
+## D22 — V7 built: template store, loader, catalog (R1–R4)
+
+**Date:** 2026-08-05 · **Status:** built (this PR) · executes the
+D20-ratified `v7-requirements.md` unchanged.
+
+- **R1 store:** `src/attune/elicitation/templates/` — JSON files in
+  the exact `form_from_dict` dict shape plus a top-level `"slots"`
+  declaration. Ships in the wheel via the existing `*.json`
+  package-data rule.
+- **R2 loader:** `template_store.form_from_template(name, slots)` —
+  name-validated (kebab-case only, no path separators), delegates
+  every definition problem to the one `form_from_dict` seam.
+  `list_templates()` enumerates the store.
+- **R3 slots:** `{slot}` placeholders in string fields, recursive
+  substitution; missing, extra, non-string, and undeclared-in-body
+  slot problems are all listed in one `FormValidationError` (AC-3
+  parity asserted by test: templated problems ==
+  hand-built-dict problems, byte-equal).
+- **R4 catalog:** `elicit` skill Step 0 documents the library and
+  the `template_id` join recipe; `.agents/` mirror re-projected.
+- **R5 seeding — ONE template, not two.** `session-contract`
+  (recurrence confirmed: the session-start protocol asks
+  mode/outcome/done-when every session; D20's worked sketch).
+  Release-gate sign-off was a draft-time *candidate* but no
+  recurring sign-off form artifact exists in the tree — recurrence
+  unconfirmed, NOT seeded. First template to recur twice gets
+  promoted per R5.
+- **Scope holds:** zero new QuestionTypes, zero validator/render
+  changes, no response-persistence store added (AC-2's join is
+  demonstrated through recorded response receipts, the D15/D16
+  pattern — a durable response log is a separate proposal if the
+  time-series claim earns it).
+- **Stale-claim fix in passing:** `reference_form.py`'s docstring
+  claimed it "becomes V7's first stored template verbatim" — that
+  pre-dated R5's promote-on-repeat rule; corrected to say the
+  reference stays a constant (documentation, not a recurring ask).
+
+**Receipts:** 20 new tests in
+`tests/unit/elicitation/test_template_store.py` (suite: 405 passed
+serially). AC-1 live round-trip: session-contract loaded via
+`form_from_template`, routed `widget` by `select_form_surface`,
+rendered via `form_to_widget_html` on the live widget surface —
+response id recorded below on submit. AC-2 first leg: this
+session's `FormResponse` (template_id `session-contract`); second
+leg owed by a future session asking the same template.
+
 ## Open
 
 - **Confirm CC elicitation support** — low priority (elicitation is

--- a/docs/specs/elicitation-form-surface/decisions.md
+++ b/docs/specs/elicitation-form-surface/decisions.md
@@ -883,10 +883,16 @@ D20-ratified `v7-requirements.md` unchanged.
 `tests/unit/elicitation/test_template_store.py` (suite: 405 passed
 serially). AC-1 live round-trip: session-contract loaded via
 `form_from_template`, routed `widget` by `select_form_surface`,
-rendered via `form_to_widget_html` on the live widget surface —
-response id recorded below on submit. AC-2 first leg: this
-session's `FormResponse` (template_id `session-contract`); second
+rendered via `form_to_widget_html` on the live widget surface,
+answered by Patrick, validated through `collect_form_response` —
+**receipt `resp-20260805-130002`** (2026-08-05T13:00:02, template_id
+`session-contract`). AC-2 first leg: that response record; second
 leg owed by a future session asking the same template.
+
+**Dogfood yield (same submission):** the answered contract declared
+the next scope — chart, form, and infographic widget types working
+with low latency, effort cap "a new spec" — i.e. the first live use
+of the template also produced the session's actual routing decision.
 
 ## Open
 

--- a/plugin/skills/elicit/SKILL.md
+++ b/plugin/skills/elicit/SKILL.md
@@ -35,6 +35,32 @@ question depends on an earlier answer, or batching would feel like a
 bureaucratic intake for a simple ask. The form never adds fields the
 ordinary Socratic-ambiguity judgement wouldn't already ask.
 
+## Step 0 — check the template library first (V7)
+
+Recurring fork classes are stored as named JSON templates
+(`src/attune/elicitation/templates/`). **Reach for a template before
+hand-building**: a reused template makes answers comparable across
+sessions (joinable on `FormResponse.template_id`).
+
+```python
+from attune.elicitation import form_from_template, list_templates
+
+form = form_from_template("session-contract", {"project": "attune-ai"})
+# ... render, then collect with the join key:
+response = collect_form_response(form, answers, template_id="session-contract")
+```
+
+Available templates:
+
+| Name | Construct | Purpose | Slots |
+|---|---|---|---|
+| `session-contract` | intake-form | Session-start protocol: mode, outcome, done-when, effort cap | `project` |
+
+Missing/extra slot values and malformed templates fail through the
+same every-problem-listed `FormValidationError` a hand-built dict
+gets. **Promote-on-repeat (R5):** a form earns templatehood on its
+SECOND recurrence — no speculative templates.
+
 ## Step 1 — build the declarative form (D3)
 
 A form is plain serializable data:

--- a/src/attune/elicitation/__init__.py
+++ b/src/attune/elicitation/__init__.py
@@ -58,6 +58,7 @@ from attune.elicitation.bridge import (
 )
 from attune.elicitation.elicitation_schema import form_to_elicitation_schema
 from attune.elicitation.reference_form import EXAMPLE_ANSWERS, REFERENCE_FORM
+from attune.elicitation.template_store import form_from_template, list_templates
 from attune.elicitation.widget import WIDGET_RESPONSE_MARKER, form_to_widget_html
 
 __all__ = [
@@ -67,6 +68,7 @@ __all__ = [
     "FormValidationError",
     "collect_form_response",
     "form_from_dict",
+    "form_from_template",
     "form_response_summary",
     "form_to_askuserquestion",
     "form_to_elicitation_schema",
@@ -75,6 +77,7 @@ __all__ = [
     "is_fully_inferred",
     "is_trivial_form",
     "keyboard_mode_enabled",
+    "list_templates",
     "needs_widget",
     "select_form_surface",
     "set_keyboard_mode",

--- a/src/attune/elicitation/reference_form.py
+++ b/src/attune/elicitation/reference_form.py
@@ -4,11 +4,11 @@ This module is the single, code-verified example of a *complete*
 declarative form: one field per :class:`~attune.meta_workflows.models.QuestionType`
 member, each with realistic example values, plus a matching set of valid
 answers. It is deliberately a plain data constant — importable and
-copy-from-able today — not a template-store entry or a
-``form_from_template`` invocation. Those belong to the V7 template
-library, which is design-frozen until 2026-07-28; this reference is the
-freeze-safe precursor that becomes V7's first stored template verbatim
-once the freeze lifts.
+copy-from-able — not a template-store entry or a ``form_from_template``
+invocation. The V7 template library (:mod:`.template_store`) exists, but
+per its promote-on-repeat rule (R5) only *recurring* fork classes earn a
+stored template; this reference is documentation, not a recurring ask,
+so it stays a constant.
 
 The paired :data:`REFERENCE_FORM` / :data:`EXAMPLE_ANSWERS` round-trip
 through the existing seams with no changes:

--- a/src/attune/elicitation/template_store.py
+++ b/src/attune/elicitation/template_store.py
@@ -1,0 +1,136 @@
+"""Form-template library (V7): sculpt a form once, cast per fork.
+
+A recurring fork class is persisted once as a JSON template under
+``templates/`` and later invocations load it with per-use slot values.
+Each template file is exactly the dict shape :func:`form_from_dict`
+accepts, plus a top-level ``"slots"`` list declaring the named
+substitution points (``{slot_name}`` placeholders in string fields).
+Validation stays in the one existing seam: a malformed template fails
+through :class:`FormValidationError` exactly like a hand-built dict,
+and slot problems are reported in the same every-problem-listed style.
+
+For the comparability frame, pass the template name as ``template_id``
+when collecting answers::
+
+    form = form_from_template("session-contract", {"project": "attune-ai"})
+    response = collect_form_response(form, answers, template_id="session-contract")
+
+Responses from the same template are then joinable on
+``FormResponse.template_id`` across sessions.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under Apache 2.0
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from importlib.resources import files
+from typing import Any
+
+from attune.elicitation.bridge import FormValidationError, form_from_dict
+from attune.meta_workflows.models import FormSchema
+
+#: Package directory holding the stored templates (monkeypatched in tests).
+_TEMPLATE_DIR = files("attune.elicitation") / "templates"
+
+#: Template names are bare kebab-case words — no path separators, so a
+#: name can never escape the store directory (path validation for the
+#: read below).
+_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9-]*$")
+
+#: A named substitution point inside a template string field.
+_SLOT_RE = re.compile(r"\{([a-z][a-z0-9_]*)\}")
+
+
+def list_templates() -> list[str]:
+    """Return the sorted names of all stored form templates."""
+    return sorted(
+        entry.name[: -len(".json")]
+        for entry in _TEMPLATE_DIR.iterdir()
+        if entry.name.endswith(".json")
+    )
+
+
+def form_from_template(name: str, slots: dict[str, Any] | None = None) -> FormSchema:
+    """Load a stored template, fill its slots, and validate it.
+
+    Args:
+        name: Template name — a ``templates/<name>.json`` store entry
+            (see :func:`list_templates`).
+        slots: A value for every slot the template declares. Missing or
+            extra values are definition errors.
+
+    Returns:
+        The validated :class:`FormSchema`.
+
+    Raises:
+        FormValidationError: If the name is unknown, the slot values do
+            not match the template's declaration, or the substituted
+            definition fails :func:`form_from_dict` validation — every
+            problem listed.
+    """
+    if not isinstance(name, str) or not _NAME_RE.match(name):
+        raise FormValidationError([f"invalid template name {name!r}"])
+    available = list_templates()
+    if name not in available:
+        raise FormValidationError(
+            [f"unknown template {name!r} — available: {', '.join(available)}"]
+        )
+    raw = (_TEMPLATE_DIR / f"{name}.json").read_text(encoding="utf-8")
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise FormValidationError([f"template {name!r} is not valid JSON: {exc}"]) from exc
+    if not isinstance(data, dict):
+        raise FormValidationError([f"template {name!r} must be a JSON object"])
+
+    declared = data.pop("slots", [])
+    values = slots or {}
+    problems = _slot_problems(name, declared, values, data)
+    if problems:
+        raise FormValidationError(problems)
+    return form_from_dict(_substitute(data, values))
+
+
+def _slot_problems(
+    name: str, declared: Any, values: dict[str, Any], data: dict[str, Any]
+) -> list[str]:
+    """Validate the slot declaration, provided values, and placeholder use."""
+    if not isinstance(declared, list) or not all(isinstance(s, str) for s in declared):
+        return [f"template {name!r} 'slots' must be a list of strings"]
+
+    problems: list[str] = []
+    for missing in sorted(set(declared) - set(values)):
+        problems.append(f"missing value for slot '{missing}'")
+    for extra in sorted(set(values) - set(declared)):
+        problems.append(f"unexpected slot value '{extra}' — template declares: {declared}")
+    for slot, value in sorted(values.items()):
+        if slot in declared and not isinstance(value, str):
+            problems.append(f"slot '{slot}' value must be a string, got {type(value).__name__}")
+    for placeholder in sorted(_placeholders(data) - set(declared)):
+        problems.append(f"template {name!r} uses undeclared placeholder '{{{placeholder}}}'")
+    return problems
+
+
+def _placeholders(value: Any) -> set[str]:
+    """Collect every ``{slot}`` placeholder used in string fields."""
+    if isinstance(value, str):
+        return set(_SLOT_RE.findall(value))
+    if isinstance(value, dict):
+        return set().union(set(), *(_placeholders(v) for v in value.values()))
+    if isinstance(value, list):
+        return set().union(set(), *(_placeholders(v) for v in value))
+    return set()
+
+
+def _substitute(value: Any, slots: dict[str, Any]) -> Any:
+    """Replace declared ``{slot}`` placeholders in every string field."""
+    if isinstance(value, str):
+        return _SLOT_RE.sub(lambda m: str(slots.get(m.group(1), m.group(0))), value)
+    if isinstance(value, dict):
+        return {k: _substitute(v, slots) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_substitute(v, slots) for v in value]
+    return value

--- a/src/attune/elicitation/templates/session-contract.json
+++ b/src/attune/elicitation/templates/session-contract.json
@@ -1,0 +1,38 @@
+{
+  "slots": ["project"],
+  "title": "Session contract — {project}",
+  "description": "The session-start protocol's fields. Fill before non-trivial work.",
+  "fields": [
+    {
+      "id": "mode",
+      "type": "single_select",
+      "text": "Which mode is this session in?",
+      "options": [
+        "Advancing a defined scope",
+        "Executing a planned spec",
+        "Firefighting a CI/release issue",
+        "Meta-reflection / planning"
+      ]
+    },
+    {
+      "id": "outcome",
+      "type": "text_input",
+      "text": "Outcome — what should be true after this session that isn't true now?",
+      "help_text": "One sentence."
+    },
+    {
+      "id": "done_when",
+      "type": "textarea",
+      "text": "Done when — the acceptance criteria.",
+      "help_text": "Cheap to write, expensive to skip.",
+      "max_length": 500
+    },
+    {
+      "id": "effort_cap",
+      "type": "text_input",
+      "text": "Effort cap — time or scope ceiling.",
+      "help_text": "e.g. '30 min', 'one PR', 'no scope expansion past Phase 1'.",
+      "required": false
+    }
+  ]
+}

--- a/tests/unit/elicitation/test_template_store.py
+++ b/tests/unit/elicitation/test_template_store.py
@@ -1,0 +1,181 @@
+"""Tests for the V7 form-template library (template_store.py).
+
+Covers R1–R3 (store, loader, slot substitution) and AC-3 (a malformed
+template fails with the same every-problem-listed FormValidationError a
+hand-built dict gets).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from attune.elicitation import (
+    FormValidationError,
+    collect_form_response,
+    form_from_dict,
+    form_from_template,
+    list_templates,
+    template_store,
+)
+
+SESSION_CONTRACT_ANSWERS: dict[str, Any] = {
+    "mode": "Executing a planned spec",
+    "outcome": "V7 template library shipped on a PR",
+    "done_when": "R1-R4 implemented, tests green, PR open",
+    "effort_cap": "one PR",
+}
+
+
+class TestListTemplates:
+    def test_session_contract_is_stored(self) -> None:
+        assert "session-contract" in list_templates()
+
+    def test_names_are_sorted(self) -> None:
+        names = list_templates()
+        assert names == sorted(names)
+
+
+class TestFormFromTemplate:
+    def test_loads_and_substitutes_slots(self) -> None:
+        form = form_from_template("session-contract", {"project": "attune-ai"})
+        assert form.title == "Session contract — attune-ai"
+        assert [q.id for q in form.questions] == [
+            "mode",
+            "outcome",
+            "done_when",
+            "effort_cap",
+        ]
+
+    def test_round_trip_carries_template_id(self) -> None:
+        """AC-2 join key: responses from the same template are joinable."""
+        form = form_from_template("session-contract", {"project": "attune-ai"})
+        response = collect_form_response(
+            form, SESSION_CONTRACT_ANSWERS, template_id="session-contract"
+        )
+        assert response.template_id == "session-contract"
+        assert response.responses["mode"] == "Executing a planned spec"
+
+    def test_missing_slot_value_listed(self) -> None:
+        with pytest.raises(FormValidationError) as exc:
+            form_from_template("session-contract", {})
+        assert any("missing value for slot 'project'" in p for p in exc.value.problems)
+
+    def test_extra_slot_value_listed(self) -> None:
+        with pytest.raises(FormValidationError) as exc:
+            form_from_template("session-contract", {"project": "x", "nonexistent": "y"})
+        assert any("unexpected slot value 'nonexistent'" in p for p in exc.value.problems)
+
+    def test_missing_and_extra_listed_together(self) -> None:
+        """Every problem listed in one raise, not fail-on-first."""
+        with pytest.raises(FormValidationError) as exc:
+            form_from_template("session-contract", {"nonexistent": "y"})
+        joined = "\n".join(exc.value.problems)
+        assert "missing value for slot 'project'" in joined
+        assert "unexpected slot value 'nonexistent'" in joined
+
+    def test_non_string_slot_value_listed(self) -> None:
+        with pytest.raises(FormValidationError) as exc:
+            form_from_template("session-contract", {"project": 42})
+        assert any("must be a string, got int" in p for p in exc.value.problems)
+
+    def test_unknown_template_names_available(self) -> None:
+        with pytest.raises(FormValidationError) as exc:
+            form_from_template("no-such-template")
+        assert any("session-contract" in p for p in exc.value.problems)
+
+    @pytest.mark.parametrize("bad_name", ["../escape", "a/b", "UPPER", "", "x.json"])
+    def test_invalid_names_rejected_before_any_read(self, bad_name: str) -> None:
+        with pytest.raises(FormValidationError) as exc:
+            form_from_template(bad_name)
+        assert any("invalid template name" in p for p in exc.value.problems)
+
+
+def _write_store(tmp_path: Path, name: str, content: Any) -> None:
+    text = content if isinstance(content, str) else json.dumps(content)
+    (tmp_path / f"{name}.json").write_text(text, encoding="utf-8")
+
+
+class TestMalformedTemplateParity:
+    """AC-3: malformed templates fail exactly like hand-built dicts."""
+
+    @pytest.fixture(autouse=True)
+    def _tmp_store(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(template_store, "_TEMPLATE_DIR", tmp_path)
+        self.store = tmp_path
+
+    def test_bad_type_and_duplicate_id_match_hand_built_errors(self) -> None:
+        malformed = {
+            "title": "Bad form",
+            "fields": [
+                {"id": "a", "type": "not-a-type", "text": "Q1"},
+                {"id": "a", "type": "boolean", "text": "Q2"},
+            ],
+        }
+        with pytest.raises(FormValidationError) as hand_built:
+            form_from_dict(malformed)
+
+        _write_store(self.store, "bad", {**malformed, "slots": []})
+        with pytest.raises(FormValidationError) as templated:
+            form_from_template("bad")
+
+        assert templated.value.problems == hand_built.value.problems
+
+    def test_invalid_json_fails_with_listed_problem(self) -> None:
+        _write_store(self.store, "broken", "{not json")
+        with pytest.raises(FormValidationError) as exc:
+            form_from_template("broken")
+        assert any("not valid JSON" in p for p in exc.value.problems)
+
+    def test_non_object_template_rejected(self) -> None:
+        _write_store(self.store, "listy", ["not", "a", "form"])
+        with pytest.raises(FormValidationError) as exc:
+            form_from_template("listy")
+        assert any("must be a JSON object" in p for p in exc.value.problems)
+
+    def test_undeclared_placeholder_rejected(self) -> None:
+        _write_store(
+            self.store,
+            "sneaky",
+            {
+                "slots": [],
+                "title": "Uses {undeclared}",
+                "fields": [{"id": "a", "type": "boolean", "text": "Q"}],
+            },
+        )
+        with pytest.raises(FormValidationError) as exc:
+            form_from_template("sneaky")
+        assert any("undeclared placeholder '{undeclared}'" in p for p in exc.value.problems)
+
+    def test_bad_slots_declaration_rejected(self) -> None:
+        _write_store(
+            self.store,
+            "badslots",
+            {
+                "slots": "project",
+                "title": "T",
+                "fields": [{"id": "a", "type": "boolean", "text": "Q"}],
+            },
+        )
+        with pytest.raises(FormValidationError) as exc:
+            form_from_template("badslots")
+        assert any("'slots' must be a list of strings" in p for p in exc.value.problems)
+
+    def test_valid_template_in_tmp_store_loads(self) -> None:
+        """The loader itself works against any store directory."""
+        _write_store(
+            self.store,
+            "minimal",
+            {
+                "slots": ["who"],
+                "title": "Hello {who}",
+                "fields": [{"id": "ok", "type": "boolean", "text": "Proceed for {who}?"}],
+            },
+        )
+        form = form_from_template("minimal", {"who": "Patrick"})
+        assert form.title == "Hello Patrick"
+        assert form.questions[0].text == "Proceed for Patrick?"
+        assert list_templates() == ["minimal"]


### PR DESCRIPTION
## Summary

Executes the D20-ratified [v7-requirements](docs/specs/elicitation-form-surface/v7-requirements.md) unchanged; ruling record in decisions.md **D22**.

- **R1 store:** `src/attune/elicitation/templates/` — JSON files in the exact `form_from_dict` dict shape plus a `slots` declaration; ships via the existing `*.json` package-data rule. Seeds **session-contract only** — release-gate sign-off recurrence unconfirmed in the tree, so per R5 it is not seeded.
- **R2 loader:** `form_from_template(name, slots)` + `list_templates()`; template names kebab-case-validated before any filesystem read; every definition problem fails through the one `form_from_dict` seam.
- **R3 slots:** `{slot}` placeholders in string fields, recursive substitution; missing / extra / non-string / undeclared-placeholder problems all listed in one `FormValidationError`.
- **R4 catalog:** `elicit` skill Step 0 documents the library + `template_id` join recipe; `.agents/` mirror re-projected.
- Stale-claim fix: `reference_form.py` docstring no longer claims future template-hood R5 superseded.

## Receipts

- 20 new tests in `tests/unit/elicitation/test_template_store.py`; elicitation suite **405 passed** serially.
- **AC-3 parity:** templated malformed-form problems asserted byte-equal to hand-built-dict problems.
- **AC-1 live round-trip:** session-contract loaded via `form_from_template`, routed `widget` by `select_form_surface`, rendered on the live widget surface — response id lands in a follow-up commit on this PR once submitted.
- **AC-2 first leg:** this session's `FormResponse` (template_id `session-contract`); second leg owed by a future session (D15/D16 receipt pattern).

## Scope holds (D19/D20 discipline)

Zero new QuestionTypes, zero validator/render changes, no response-persistence store added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)