### PR TITLE
test: assert full redis.io URL, resolving CodeQL alert #179

### DIFF
--- a/tests/unit/test_telemetry_features.py
+++ b/tests/unit/test_telemetry_features.py
@@ -98,7 +98,9 @@ class TestTelemetryFeatures:
             assert "Event streaming" in error_message
             assert "requires the redis package" in error_message
             assert "pip install" in error_message
-            assert "redis.io" in error_message.lower()
+            # Assert the exact URL rather than a bare-domain substring
+            # (CodeQL py/incomplete-url-substring-sanitization, alert #179).
+            assert "https://redis.io/docs/install/" in error_message
             # The fix offered must be able to work: `attune-ai[redis]` was
             # an empty alias, so suggesting it could never resolve a
             # missing import (the #758 trap).


### PR DESCRIPTION
Resolves code-scanning alert #179 (py/incomplete-url-substring-sanitization, warning/high): the telemetry-features test asserted bare `redis.io` as a substring of the error message; it now asserts the exact URL the source emits (`https://redis.io/docs/install/`).

Tests-only change; 13/13 pass locally.

The other three open code-scanning alerts are dismissed with reasons rather than code-fixed — see the session summary (local-path pip install has nothing to pin; the two Scorecard governance findings conflict with the repo's deliberate zero-required-review auto-merge workflow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)