### PR TITLE
fix: code-review High perf path + two Low security findings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Pending-writes API: one `git status` per project root** — the
+  dashboard's `/api/pending-writes` spawned a git subprocess and a
+  full file read per journal entry inside an async handler,
+  serializing the event loop (code-review High). Enrichment now
+  batches to a single `git status --porcelain -uall` per distinct
+  root and runs in FastAPI's threadpool (sync handler).
+- **Webhook delivery pins the vetted IP** — SSRF validation resolved
+  and checked the webhook hostname, but urllib re-resolved at
+  request time, leaving a DNS-rebinding TOCTOU (public→private
+  swap). Delivery now connects to the IP vetted at validation time;
+  TLS still verifies against the original hostname.
+- **Ghost-worktree commit refs validated** — `commit_ref` was passed
+  as a trailing positional to `git worktree add`; a leading `-`
+  could be parsed as a git flag (argument injection). Refs must now
+  start alphanumeric and match a conservative pattern.
+
 ## [11.2.1] — 2026-08-02
 
 Docs/metadata patch — no code changes. Ships the refreshed README

--- a/src/attune/monitoring/notifications.py
+++ b/src/attune/monitoring/notifications.py
@@ -11,19 +11,73 @@ Licensed under the Apache License, Version 2.0
 
 from __future__ import annotations
 
+import http.client
 import json
 import logging
 import smtplib
+import socket
+import ssl
 import urllib.error
+import urllib.parse
 import urllib.request
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 from urllib.request import HTTPRedirectHandler, build_opener
 
 from attune.monitoring.models import AlertChannel, AlertConfig, AlertEvent
-from attune.monitoring.validators import _validate_webhook_url
+from attune.monitoring.validators import _validate_webhook_url, resolve_pinned_ip
 
 logger = logging.getLogger(__name__)
+
+
+class _PinnedHTTPHandler(urllib.request.HTTPHandler):
+    """Open HTTP connections to a pre-vetted IP (DNS-rebinding guard).
+
+    The socket connects to the pinned IP while the request keeps the
+    original Host header, so the server routes normally. Webhook
+    delivery deliberately ignores system proxies — a proxy would
+    re-resolve the hostname and reopen the rebinding window.
+    """
+
+    def __init__(self, pinned_ip: str) -> None:
+        super().__init__()
+        self._pinned_ip = pinned_ip
+
+    def http_open(self, req):  # noqa: ANN001, ANN201 — urllib handler protocol
+        pinned_ip = self._pinned_ip
+
+        class _Conn(http.client.HTTPConnection):
+            def connect(self) -> None:
+                self.sock = socket.create_connection(
+                    (pinned_ip, self.port), self.timeout, self.source_address
+                )
+
+        return self.do_open(_Conn, req)
+
+
+class _PinnedHTTPSHandler(urllib.request.HTTPSHandler):
+    """HTTPS variant of :class:`_PinnedHTTPHandler`.
+
+    TLS still verifies against the original hostname (SNI +
+    certificate check use ``self.host``); only the TCP connect target
+    is pinned.
+    """
+
+    def __init__(self, pinned_ip: str) -> None:
+        super().__init__(context=ssl.create_default_context())
+        self._pinned_ip = pinned_ip
+
+    def https_open(self, req):  # noqa: ANN001, ANN201 — urllib handler protocol
+        pinned_ip = self._pinned_ip
+
+        class _Conn(http.client.HTTPSConnection):
+            def connect(self) -> None:
+                sock = socket.create_connection(
+                    (pinned_ip, self.port), self.timeout, self.source_address
+                )
+                self.sock = self._context.wrap_socket(sock, server_hostname=self.host)
+
+        return self.do_open(_Conn, req, context=self._context)
 
 
 def deliver_notification(alert: AlertConfig, event: AlertEvent) -> bool:
@@ -66,9 +120,13 @@ def deliver_webhook(alert: AlertConfig, event: AlertEvent) -> bool:
     if not alert.webhook_url:
         return False
 
-    # Validate webhook URL to prevent SSRF (CWE-918)
+    # Validate webhook URL to prevent SSRF (CWE-918), then pin the
+    # vetted IP so the request-time connection can't be swapped to a
+    # private address by a second DNS resolution (rebinding TOCTOU).
     try:
         validated_url = _validate_webhook_url(alert.webhook_url)
+        hostname = urllib.parse.urlparse(validated_url).hostname or ""
+        pinned_ip = resolve_pinned_ip(hostname)
     except ValueError as e:
         logger.warning(
             "invalid_webhook_url: url=%s error=%s",
@@ -132,7 +190,14 @@ def deliver_webhook(alert: AlertConfig, event: AlertEvent) -> bool:
                 fp,
             )
 
-    opener = build_opener(_NoRedirect)
+    # build_opener would normally add ProxyHandler from the
+    # environment; the pinned handlers take precedence for http/https
+    # so delivery always connects to the vetted IP.
+    opener = build_opener(
+        _NoRedirect,
+        _PinnedHTTPHandler(pinned_ip),
+        _PinnedHTTPSHandler(pinned_ip),
+    )
 
     try:
         with opener.open(

--- a/src/attune/monitoring/validators.py
+++ b/src/attune/monitoring/validators.py
@@ -15,11 +15,14 @@ import socket
 import urllib.parse
 
 
-def _resolve_and_check_ip(hostname: str) -> None:
+def _resolve_and_check_ip(hostname: str) -> list[str]:
     """Resolve hostname via DNS and reject unsafe IPs.
 
     Args:
         hostname: The hostname to resolve
+
+    Returns:
+        The vetted resolved IPs, in resolver order.
 
     Raises:
         ValueError: If any resolved IP is private, loopback,
@@ -31,6 +34,7 @@ def _resolve_and_check_ip(hostname: str) -> None:
     except socket.gaierror as e:
         raise ValueError(f"Cannot resolve hostname '{hostname}': {e}") from e
 
+    vetted: list[str] = []
     for _family, _type, _proto, _canonname, sockaddr in addrinfo:
         ip_str = sockaddr[0]
         ip = ipaddress.ip_address(ip_str)
@@ -44,6 +48,40 @@ def _resolve_and_check_ip(hostname: str) -> None:
         ):
             if getattr(ip, attr):
                 raise ValueError(f"Webhook URL resolves to unsafe IP {ip_str} ({attr})")
+        vetted.append(ip_str)
+    return vetted
+
+
+def resolve_pinned_ip(hostname: str) -> str:
+    """Resolve a hostname once and return a vetted IP to pin.
+
+    Closes the DNS-rebinding TOCTOU: callers must CONNECT to the
+    returned IP rather than re-resolving the hostname at request
+    time (a second resolution could return a private address after
+    validation passed).
+
+    Args:
+        hostname: Hostname or IP literal from an already-validated URL.
+
+    Returns:
+        The IP address to connect to.
+
+    Raises:
+        ValueError: If the name doesn't resolve or resolves to any
+            unsafe IP.
+
+    """
+    try:
+        ipaddress.ip_address(hostname)
+    except ValueError:
+        vetted = _resolve_and_check_ip(hostname)
+        if not vetted:
+            # `from None`: the outer ValueError only signalled
+            # "not an IP literal" — unrelated to this failure.
+            raise ValueError(f"Cannot resolve hostname '{hostname}'") from None
+        return vetted[0]
+    # IP literal — already vetted by _validate_webhook_url.
+    return hostname
 
 
 def _validate_webhook_url(url: str) -> str:

--- a/src/attune/ops/routes/pending_writes.py
+++ b/src/attune/ops/routes/pending_writes.py
@@ -84,39 +84,72 @@ def _is_dashboard_running(pid: int) -> bool:
     return True
 
 
-def _is_file_committed(file_path: Path, project_root: Path) -> bool | None:
-    """Does ``git status --porcelain`` show this file as clean?
+def _collect_dirty_paths(project_root: Path) -> set[str] | None:
+    """One ``git status --porcelain -uall`` for the whole root.
+
+    Replaces the previous per-entry ``git status -- <file>`` calls
+    (N subprocess spawns per request) with a single call per distinct
+    project root. ``-uall`` lists individual untracked files instead
+    of collapsing directories, so membership checks stay per-file.
 
     Returns:
-        True  — file exists, git treats it as committed (no dirty status)
-        False — file appears as modified / untracked / staged in git status
-        None  — couldn't determine (no git repo, git command failed, etc.)
+        Set of dirty paths (posix-style, relative to the root), or
+        None if the status couldn't be determined (no git repo, git
+        missing, timeout).
     """
     if not project_root.is_dir():
+        return None
+    try:
+        result = subprocess.run(  # noqa: S603 — fixed argv, validated root
+            ["git", "-C", str(project_root), "status", "--porcelain=v1", "-uall"],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=10,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError) as exc:
+        logger.warning("pending_writes: git status failed for %s: %s", project_root, exc)
+        return None
+    if result.returncode != 0:
+        return None
+    dirty: set[str] = set()
+    for line in result.stdout.splitlines():
+        if len(line) < 4:
+            continue
+        path_part = line[3:]
+        # Renames render as "old -> new"; both sides are dirty.
+        parts = path_part.split(" -> ") if " -> " in path_part else [path_part]
+        for part in parts:
+            cleaned = part.strip()
+            # git C-quotes paths with special characters.
+            if cleaned.startswith('"') and cleaned.endswith('"'):
+                cleaned = cleaned[1:-1]
+            if cleaned:
+                dirty.add(cleaned)
+    return dirty
+
+
+def _is_file_committed(
+    file_path: Path,
+    project_root: Path,
+    dirty_paths: set[str] | None,
+) -> bool | None:
+    """Is this file clean per the batched ``git status`` result?
+
+    Returns:
+        True  — file is under the root and not in the dirty set
+        False — file appears as modified / untracked / staged
+        None  — couldn't determine (git failed, file outside root)
+    """
+    if dirty_paths is None:
         return None
     try:
         rel = file_path.relative_to(project_root)
     except ValueError:
         # file is not under project_root — out of scope for this check
         return None
-    try:
-        result = subprocess.run(  # noqa: S603 — args are derived from validated paths
-            ["git", "-C", str(project_root), "status", "--porcelain", "--", str(rel)],
-            capture_output=True,
-            text=True,
-            encoding="utf-8",
-            errors="replace",
-            timeout=5,
-        )
-    except (FileNotFoundError, subprocess.TimeoutExpired, OSError) as exc:
-        logger.warning("pending_writes: git status check failed for %s: %s", file_path, exc)
-        return None
-    if result.returncode != 0:
-        # Not a git repo, or git couldn't read the file. Treat as unknown.
-        return None
-    # Empty output from `git status --porcelain -- <file>` means clean
-    # (no dirty status). Non-empty means modified/untracked/staged/etc.
-    return result.stdout.strip() == ""
+    return rel.as_posix() not in dirty_paths
 
 
 def _system_tmp_prefix() -> str:
@@ -184,7 +217,11 @@ def _is_real_entry(entry: dict[str, Any]) -> bool:
         return False
 
 
-def _enrich(entry: dict[str, Any], now: datetime) -> dict[str, Any]:
+def _enrich(
+    entry: dict[str, Any],
+    now: datetime,
+    dirty_by_root: dict[str, set[str] | None],
+) -> dict[str, Any]:
     """Add computed fields to a journal entry.
 
     Adds:
@@ -217,7 +254,9 @@ def _enrich(entry: dict[str, Any], now: datetime) -> dict[str, Any]:
         else False
     )
     enriched["is_committed"] = (
-        _is_file_committed(abs_file_path, project_root) if abs_file_path and project_root else None
+        _is_file_committed(abs_file_path, project_root, dirty_by_root.get(project_root_str))
+        if abs_file_path and project_root
+        else None
     )
 
     ts_raw = entry.get("ts", "")
@@ -245,7 +284,7 @@ def _summarize(enriched_entries: list[dict[str, Any]]) -> dict[str, int]:
 
 
 @router.get("/pending-writes")
-async def list_pending_writes(request: Request) -> dict[str, Any]:
+def list_pending_writes(request: Request) -> dict[str, Any]:
     """Return all journal entries enriched with computed status fields.
 
     See `docs/specs/dashboard-pending-writes-journal/design.md` for
@@ -254,6 +293,10 @@ async def list_pending_writes(request: Request) -> dict[str, Any]:
     Consumers should filter per their needs (e.g. dashboard UI chip
     uses ``uncommitted_count``; a session-start hook filters
     entries where ``is_committed`` is False).
+
+    Deliberately a sync (``def``) handler: FastAPI runs it in the
+    threadpool, keeping the git subprocess + sha256 file reads off
+    the event loop.
     """
     # Allow tests + dev to override the journal path via app.state.
     journal_path: Path = getattr(
@@ -265,7 +308,13 @@ async def list_pending_writes(request: Request) -> dict[str, Any]:
     # ``_is_real_entry`` for the heuristic. Skips expensive sha256 +
     # git-status computation for entries we'd just drop anyway.
     real_entries = [e for e in raw_entries if _is_real_entry(e)]
-    enriched = [_enrich(entry, now) for entry in real_entries]
+    # One `git status` per distinct project root (not per entry).
+    dirty_by_root: dict[str, set[str] | None] = {}
+    for entry in real_entries:
+        root = entry.get("project_root", "")
+        if isinstance(root, str) and root and root not in dirty_by_root:
+            dirty_by_root[root] = _collect_dirty_paths(Path(root))
+    enriched = [_enrich(entry, now, dirty_by_root) for entry in real_entries]
     return {
         "pending": enriched,
         "summary": _summarize(enriched),

--- a/src/attune/orchestration/ghosts/worktree.py
+++ b/src/attune/orchestration/ghosts/worktree.py
@@ -17,6 +17,11 @@ logger = logging.getLogger(__name__)
 
 _GHOST_ID_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
 
+# Commit refs are passed as a positional argument to `git worktree add`.
+# First char must be alphanumeric — a leading '-' would be parsed as a
+# git flag (argument injection). Covers HEAD~2, v1.0.0, feature/x, a@{u}.
+_COMMIT_REF_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._/@^~{}-]*$")
+
 
 class GhostWorktreeError(RuntimeError):
     """Raised when a ghost worktree cannot be created or removed."""
@@ -57,6 +62,8 @@ class GhostWorktreeManager:
         """
         if not _GHOST_ID_PATTERN.match(ghost_id):
             raise GhostWorktreeError(f"invalid ghost id: {ghost_id!r}")
+        if not _COMMIT_REF_PATTERN.match(commit_ref):
+            raise GhostWorktreeError(f"invalid commit ref: {commit_ref!r}")
 
         target_path = os.path.join(self.base_dir, ghost_id)
         os.makedirs(self.base_dir, exist_ok=True)

--- a/tests/unit/monitoring/test_notifications.py
+++ b/tests/unit/monitoring/test_notifications.py
@@ -192,8 +192,10 @@ class TestDeliverWebhook:
 
         captured: dict[str, type] = {}
 
-        def _capture_handler(handler_cls):
-            captured["handler_cls"] = handler_cls
+        def _capture_handler(*handler_classes):
+            # First handler is the redirect blocker; the pinned
+            # http/https handlers follow (DNS-rebinding guard).
+            captured["handler_cls"] = handler_classes[0]
             return mock_opener
 
         mock_build_opener.side_effect = _capture_handler
@@ -330,3 +332,51 @@ class TestDeliverStdout:
         result = deliver_stdout(event)
 
         assert result is True
+
+
+# ------------------------------------------------------------------
+# DNS-rebinding pin (code-review Low security finding)
+# ------------------------------------------------------------------
+
+
+class TestPinnedDelivery:
+    """The request-time connection must target the VETTED IP, not a
+    fresh DNS resolution (rebinding TOCTOU)."""
+
+    def test_resolve_pinned_ip_passes_through_ip_literal(self):
+        from attune.monitoring.validators import resolve_pinned_ip
+
+        assert resolve_pinned_ip("8.8.8.8") == "8.8.8.8"
+
+    def test_resolve_pinned_ip_rejects_private_resolution(self, monkeypatch):
+        import socket as socket_mod
+
+        from attune.monitoring import validators
+
+        def fake_getaddrinfo(host, *args, **kwargs):
+            return [(socket_mod.AF_INET, socket_mod.SOCK_STREAM, 6, "", ("10.0.0.5", 0))]
+
+        monkeypatch.setattr(validators.socket, "getaddrinfo", fake_getaddrinfo)
+        with pytest.raises(ValueError, match="unsafe IP"):
+            validators.resolve_pinned_ip("rebind.example")
+
+    def test_http_connection_targets_pinned_ip(self, monkeypatch):
+        """The socket connects to the pinned IP even though the URL
+        names a hostname — proven by capturing the connect target."""
+        import socket as socket_mod
+        import urllib.request as urlreq
+
+        from attune.monitoring.notifications import _PinnedHTTPHandler
+
+        connected: list[tuple] = []
+
+        def fake_create_connection(addr, *args, **kwargs):
+            connected.append(addr)
+            raise OSError("stop before real network I/O")
+
+        monkeypatch.setattr(socket_mod, "create_connection", fake_create_connection)
+        opener = urlreq.build_opener(_PinnedHTTPHandler("8.8.8.8"))
+        with pytest.raises(urllib.error.URLError):
+            opener.open("http://webhook.example/hook", timeout=1)
+
+        assert connected == [("8.8.8.8", 80)]

--- a/tests/unit/ops/test_cache_pending_writes_edges.py
+++ b/tests/unit/ops/test_cache_pending_writes_edges.py
@@ -200,15 +200,9 @@ class TestIsDashboardRunning:
         assert pw._is_dashboard_running(12345) is True
 
 
-class TestIsFileCommitted:
+class TestCollectDirtyPaths:
     def test_missing_project_root(self, tmp_path: Path) -> None:
-        assert pw._is_file_committed(tmp_path / "f.py", tmp_path / "absent") is None
-
-    def test_file_outside_root(self, tmp_path: Path) -> None:
-        root = tmp_path / "root"
-        root.mkdir()
-        outside = tmp_path / "elsewhere.py"
-        assert pw._is_file_committed(outside, root) is None
+        assert pw._collect_dirty_paths(tmp_path / "absent") is None
 
     def test_git_failure_returns_none(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -217,7 +211,7 @@ class TestIsFileCommitted:
             raise subprocess.TimeoutExpired(cmd="git", timeout=5)
 
         monkeypatch.setattr(pw.subprocess, "run", _boom)
-        assert pw._is_file_committed(tmp_path / "f.py", tmp_path) is None
+        assert pw._collect_dirty_paths(tmp_path) is None
 
     def test_nonzero_exit_returns_none(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -227,21 +221,39 @@ class TestIsFileCommitted:
             "run",
             lambda *a, **k: SimpleNamespace(returncode=128, stdout=""),
         )
-        assert pw._is_file_committed(tmp_path / "f.py", tmp_path) is None
+        assert pw._collect_dirty_paths(tmp_path) is None
 
-    def test_clean_and_dirty_outputs(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_parses_statuses_renames_and_quotes(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        stdout = ' M f.py\n?? new.txt\nR  old.py -> new.py\n?? "sp ace.md"\n'
         monkeypatch.setattr(
             pw.subprocess,
             "run",
-            lambda *a, **k: SimpleNamespace(returncode=0, stdout="\n"),
+            lambda *a, **k: SimpleNamespace(returncode=0, stdout=stdout),
         )
-        assert pw._is_file_committed(tmp_path / "f.py", tmp_path) is True
-        monkeypatch.setattr(
-            pw.subprocess,
-            "run",
-            lambda *a, **k: SimpleNamespace(returncode=0, stdout=" M f.py\n"),
-        )
-        assert pw._is_file_committed(tmp_path / "f.py", tmp_path) is False
+        assert pw._collect_dirty_paths(tmp_path) == {
+            "f.py",
+            "new.txt",
+            "old.py",
+            "new.py",
+            "sp ace.md",
+        }
+
+
+class TestIsFileCommitted:
+    def test_unknown_dirty_set_returns_none(self, tmp_path: Path) -> None:
+        assert pw._is_file_committed(tmp_path / "f.py", tmp_path, None) is None
+
+    def test_file_outside_root(self, tmp_path: Path) -> None:
+        root = tmp_path / "root"
+        root.mkdir()
+        outside = tmp_path / "elsewhere.py"
+        assert pw._is_file_committed(outside, root, set()) is None
+
+    def test_clean_and_dirty_membership(self, tmp_path: Path) -> None:
+        assert pw._is_file_committed(tmp_path / "f.py", tmp_path, set()) is True
+        assert pw._is_file_committed(tmp_path / "f.py", tmp_path, {"f.py"}) is False
 
 
 class TestIsRealEntry:
@@ -278,6 +290,7 @@ class TestEnrichEdges:
         enriched = pw._enrich(
             {"ts": "not-a-date", "dashboard_pid": "not-an-int"},
             now=datetime.now(timezone.utc),
+            dirty_by_root={},
         )
         assert enriched["age_seconds"] is None
         assert enriched["dashboard_still_running"] is False

--- a/tests/unit/ops/test_pending_writes_api.py
+++ b/tests/unit/ops/test_pending_writes_api.py
@@ -603,3 +603,52 @@ def test_journal_failure_does_not_block_put_status(
 
     # Journal failure was logged for separate investigation.
     assert any("journal append failed" in record.message for record in caplog.records)
+
+
+def test_git_status_runs_once_per_project_root(
+    tmp_project: Path,
+    client_factory,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression: N entries under one root spawn ONE git status.
+
+    The pre-batch implementation ran `git status -- <file>` per entry
+    (N+1 subprocess spawns on the event loop — the code-review High
+    perf finding). Enrichment must batch to one call per distinct
+    project root.
+    """
+    from attune.ops.routes import pending_writes as pw_routes
+
+    names = ["a.md", "b.md", "c.md"]
+    entries = []
+    for name in names:
+        target = tmp_project / name
+        target.write_text("x\n", encoding="utf-8")
+        entries.append(
+            _make_journal_dict(
+                project_root=tmp_project,
+                file_path=name,
+                after_sha256=pending_writes.compute_file_sha256(target),
+            )
+        )
+    journal_path = tmp_path / "journal.jsonl"
+    _write_journal(journal_path, entries)
+
+    git_status_calls: list[list[str]] = []
+    real_run = subprocess.run
+
+    def counting_run(cmd, *args, **kwargs):
+        if isinstance(cmd, list) and "status" in cmd:
+            git_status_calls.append(cmd)
+        return real_run(cmd, *args, **kwargs)
+
+    monkeypatch.setattr(pw_routes.subprocess, "run", counting_run)
+
+    client = client_factory(journal_path=journal_path)
+    body = client.get("/api/pending-writes").json()
+
+    assert len(body["pending"]) == len(names)
+    # All three files are untracked -> uncommitted.
+    assert body["summary"]["uncommitted_count"] == len(names)
+    assert len(git_status_calls) == 1

--- a/tests/unit/orchestration/test_ghost_simulator.py
+++ b/tests/unit/orchestration/test_ghost_simulator.py
@@ -225,3 +225,25 @@ class TestTrajectoryPromoter:
         # Regression: the original deleted the worktree on failure,
         # destroying the winning trajectory's work.
         assert ghost.exists()
+
+
+class TestCommitRefValidation:
+    """Regression: commit_ref is a trailing positional to `git worktree
+    add` — a leading '-' would be parsed as a git flag (argument
+    injection, code-review Low security finding)."""
+
+    def test_leading_dash_ref_rejected_before_git_runs(self, temp_repo: Path) -> None:
+        manager = GhostWorktreeManager(repo_root=str(temp_repo))
+        with pytest.raises(GhostWorktreeError, match="invalid commit ref"):
+            manager.create_ghost_worktree("t9", commit_ref="--upload-pack=/bin/sh")
+
+    def test_whitespace_and_empty_refs_rejected(self, temp_repo: Path) -> None:
+        manager = GhostWorktreeManager(repo_root=str(temp_repo))
+        for bad in ("", "HEAD; rm -rf x", "a b"):
+            with pytest.raises(GhostWorktreeError, match="invalid commit ref"):
+                manager.create_ghost_worktree("t9", commit_ref=bad)
+
+    def test_normal_refs_still_work(self, temp_repo: Path) -> None:
+        manager = GhostWorktreeManager(repo_root=str(temp_repo))
+        path = Path(manager.create_ghost_worktree("refok", commit_ref="HEAD"))
+        assert path.exists()


### PR DESCRIPTION
Triage + fixes from the 2026-08-06 code-review report (79/100). Every claim was verified against code before fixing.

## Fixed
| Finding | Severity | Fix |
|---|---|---|
| `pending_writes.py` N+1 blocking git subprocess in async handler | **High** perf | One `git status --porcelain -uall` per distinct project root; handler is now sync (`def`) so FastAPI threadpools all blocking I/O. Regression test asserts a single git spawn for N entries. |
| Webhook DNS-rebinding TOCTOU (validate-then-re-resolve) | Low sec | Delivery pins the IP vetted at validation time via custom `HTTP(S)Handler`s; TLS/SNI still verify the original hostname. Proxies deliberately bypassed for webhook delivery (a proxy would re-resolve). |
| `worktree.py` commit_ref argument injection (leading `-` parsed as flag) | Low sec | Conservative ref pattern, first char must be alphanumeric; rejected before any subprocess runs. |

## Declined with reason
- **git_extractor 2N spawns**: diff fetching is already skipped for non-fix commits, and hand-parsing interleaved `git log -p` output trades a bounded cost for parsing fragility.
- **cli_router map sync-guard**: the two maps genuinely diverge on `perf-audit` (`workflows run perf-audit` vs `dev perf-audit`) — a blind drift test would enshrine one behavior without an intent ruling.

## Deferred (tracked in the session plan)
Architecture Highs (ops layer inversion, config importlib hack, security package ownership) are spec-tier multi-PR moves; memory-handlers decorator, release-team enum, dashboard threadpool/parse-once are a mechanical follow-up; broad-except audit is owned by the broad-except-ratchet spec.

## Receipts
- 243 tests pass across ops / orchestration / monitoring suites (new regression tests for all three fixes)
- ruff + pinned black clean on all changed files

Windows-relevant (git subprocess paths) — holding for the full matrix before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)