### PR TITLE
docs: enable mermaid diagrams in mkdocs + first diagram on chartkit page

### DIFF
--- a/docs/chartkit.md
+++ b/docs/chartkit.md
@@ -10,6 +10,15 @@ New here? The hands-on walk-through — ask Claude for a chart, patch
 it, tour the 11.3.0 types, export SVG — is
 [Tutorial: Chart Widgets with Claude](tutorials/chart-widgets.md).
 
+```mermaid
+flowchart LR
+    M["model authors a<br/>~100-token JSON spec"] -->|chart_render_widget| V["validate<br/>(field-level errors)"]
+    V --> K["sealed ~10KB kernel<br/>renders themable SVG"]
+    V --> S[("session memory<br/>spec stored per chart_id")]
+    P["tens-of-bytes<br/>RFC 7386 patch"] -->|same chart_id| S
+    S -->|merged spec| V
+```
+
 ## Create a chart
 
 Call the `chart_render_widget` MCP tool with a `chart_id` and a full

--- a/docs/diagrams.md
+++ b/docs/diagrams.md
@@ -1,0 +1,96 @@
+# Diagrams — structure is mermaid's job
+
+chartkit draws *quantity* (nine chart types from a JSON spec — see
+[Chart Widgets](chartkit.md)). For *structure* — modules, flows,
+schemas, states — the ruled answer is **mermaid**: measured 1.2–2.1×
+cheaper to author than a widget spec, and it renders natively on
+GitHub (READMEs, PRs, issues), on this docs site, and in Claude
+artifacts. No build, no supplement. (The ruling and the measured
+probes live in `docs/specs/diagramkit/decisions.md`.)
+
+Every example below is a live render — view this page's source to
+copy the fence.
+
+## Software structure — `flowchart`
+
+Modules and their dependencies:
+
+```mermaid
+flowchart LR
+    tool[chart_widget_tool] --> spec[chart_spec]
+    comp[chart_components] --> spec
+    server[mcp.server] --> tool
+    kernel["chartkit kernel (sealed JS)"] -.reads dist.- tool
+```
+
+## Interactions — `sequenceDiagram`
+
+Who calls whom, in order — protocols, API flows:
+
+```mermaid
+sequenceDiagram
+    participant C as Claude
+    participant T as chart_render_widget
+    participant K as kernel
+    C->>T: chart_id + spec (~100 tokens)
+    T->>T: validate (field-level errors)
+    T-->>C: {success, html}
+    C->>K: html on the widget surface
+    K-->>C: rendered SVG
+    C->>T: chart_id + patch (tens of bytes)
+```
+
+## Databases — `erDiagram`
+
+Entities, relationships, cardinality:
+
+```mermaid
+erDiagram
+    FORM_TEMPLATE ||--o{ FORM_RESPONSE : "cast as"
+    SESSION ||--o{ FORM_RESPONSE : collects
+    FORM_TEMPLATE {
+        string name PK
+        json slots
+    }
+    FORM_RESPONSE {
+        string response_id PK
+        string template_id FK
+    }
+```
+
+## Lifecycles — `stateDiagram-v2`
+
+State machines — a spec's life, a job's phases:
+
+```mermaid
+stateDiagram-v2
+    [*] --> Draft
+    Draft --> Approved: chair review
+    Approved --> Probing: Phase-0 authorized
+    Probing --> Building: premise holds
+    Probing --> Closed: premise fails
+    Building --> Shipped
+    Closed --> Probing: reopen trigger fires
+```
+
+## More types
+
+`classDiagram` (UML), `gantt` (schedules), `gitGraph` (branch
+topology), `timeline`, C4 context diagrams, and network/cloud
+`architecture` diagrams — see the
+[mermaid documentation](https://mermaid.js.org/intro/) for the full
+set. All render anywhere the four above do.
+
+## When NOT mermaid
+
+- **Quantitative shape** — trends, distributions, comparisons:
+  that's [chartkit](chartkit.md); mermaid's chart types are
+  rudimentary.
+- **Diagrams a session updates in place** — a status DAG patched
+  turn by turn. That niche was probed and closed 2026-08-06
+  ("mermaid wins" — reopen on a second real occurrence; see the
+  diagramkit spec).
+- **Notation-exact standards** — symbol-true BPMN, vendor network
+  stencils. Mermaid approximates; if exactness is ever required,
+  that is an embed-a-specialized-renderer decision, not a mermaid
+  fence.

--- a/docs/tutorials/chart-widgets.md
+++ b/docs/tutorials/chart-widgets.md
@@ -278,6 +278,9 @@ response = collect_form_response(
 
 - [chartkit reference](../chartkit.md) — all nine types, row shapes,
   options, named components, and the kernel seal.
+- [Diagrams](../diagrams.md) — when you need *structure* (modules,
+  flows, schemas, states) instead of quantity, ask for a mermaid
+  diagram; that page shows the types with live examples.
 - [Elicitation forms](../reference/elicitation-forms.md) — the
   interactive grammar the template library builds on.
 - The `elicit` skill's Step 0 catalogs available templates; a form

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -362,7 +362,11 @@ plugins:
 markdown_extensions:
   - pymdownx.highlight:
       anchor_linenums: true
-  - pymdownx.superfences
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
   - pymdownx.tabbed:
       alternate_style: true
   - pymdownx.details

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -228,6 +228,7 @@ nav:
           - Hooks: hooks.md
           - Security: how-to/security-architecture.md
           - Chart Widgets (chartkit): chartkit.md
+          - Diagrams (mermaid): diagrams.md
       - Patterns:
           - Practical Patterns: how-to/practical-patterns.md
           - Resilience Patterns: how-to/resilience-patterns.md


### PR DESCRIPTION
## What

Enables mermaid diagram rendering across the docs site — the
adoption move ruled alongside the diagramkit closure (D4: mermaid
wins structural diagrams; this makes our own docs able to use it).

- `mkdocs.yml`: `pymdownx.superfences` gains the standard Material
  mermaid custom fence (`format: fence_code_format`), which Material
  renders natively via its bundled mermaid integration.
- First real diagram: the spec → validate → kernel/persist → patch
  loop on `docs/chartkit.md` (topical: the page describes exactly
  this flow in prose).

## Receipts

- `mkdocs build --strict` exit 0
- Built page carries `<pre class="mermaid">` (not a dead code block)
- Live render verified over HTTP: nodes, session-memory cylinder,
  and edge labels all draw (screenshot reviewed in session)

Noted in passing (chip filed, not this PR): the `ARCH*.md` glob in
`exclude_docs` silently excludes the nav-referenced
`ARCHITECTURE.md` — every build logs the INFO and the nav entry
drops.

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
