### PR TITLE
fix(docs): stop excluding ARCHITECTURE.md from the built site

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -119,7 +119,6 @@ exclude_docs: |
   ADAPTIVE_ROUTING_*.md
   AGENT_*.md
   ANTHROPIC_*.md
-  ARCH*.md
   AUTH_*.md
   BATCH_*.md
   BLOG_*.md


### PR DESCRIPTION
## Summary
- `mkdocs.yml`'s `exclude_docs` contained the glob `ARCH*.md`, which matched `docs/ARCHITECTURE.md` — the only ARCH-prefixed file left in `docs/` and the target of the nav entry **Architecture > Overview** (`Overview: ARCHITECTURE.md`).
- Every build logged `A reference to 'ARCHITECTURE.md' is included in the 'nav' configuration, but this file is excluded from the built site` and the Overview page silently dropped from the site.
- The junk files the glob was meant to catch no longer exist, so this removes the line.

## Verification
- Strict `mkdocs build` completes with the nav-exclusion INFO message gone.
- Built site contains `ARCHITECTURE/index.html` rendering the actual page content (`<h1>Attune AI - Architecture Overview</h1>`, title "Overview - Attune AI") — checked content, not just directory presence, since macOS's case-insensitive FS merges `ARCHITECTURE/` with `architecture/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)