### PR TITLE
docs(adoption): 15 mermaid conversions across 10 pages + live form embed in tutorial

### DIFF
--- a/docs/EXCEPTION_HANDLING_GUIDE.md
+++ b/docs/EXCEPTION_HANDLING_GUIDE.md
@@ -559,27 +559,22 @@ The hook configuration (`.pre-commit-config.yaml`):
 
 ## Quick Decision Tree
 
+```mermaid
+flowchart TD
+    Q1{"Optional feature?<br/>(wizard, plugin, tip)"}
+    Q2{"Security-related<br/>operation?"}
+    G["Graceful degradation (Example 2)<br/>specific catches first, broad last resort<br/>with logger.exception, return a default"]
+    FS["Fail-secure (Example 3)<br/>log all errors, create findings<br/>for scan failures, never silently skip"]
+    SP["Specific handlers<br/>catch expected exceptions, log at level,<br/>re-raise critical errors"]
+    Q1 -->|yes| G
+    Q1 -->|no| Q2
+    Q2 -->|yes| FS
+    Q2 -->|no| SP
 ```
-Is this an optional feature (wizard, plugin, tip)?
-├─ YES → Use graceful degradation pattern (Example 2)
-│         - Catch specific exceptions first
-│         - Broad Exception as last resort with logger.exception()
-│         - Document with comment
-│         - Return False/default value
-└─ NO → Is this a security-related operation?
-    ├─ YES → Use fail-secure pattern (Example 3)
-    │         - Log all errors
-    │         - Create findings for scan failures
-    │         - Never silently skip
-    └─ NO → Use specific exception handlers
-              - Catch expected exceptions
-              - Log at appropriate level
-              - Re-raise critical errors
-              - Add broad Exception ONLY if:
-                  * You log with logger.exception()
-                  * You document why
-                  * You use # noqa: BLE001
-```
+
+A broad `except Exception` is allowed on the specific-handlers path
+ONLY when all three hold: you log with `logger.exception()`, you
+document why, and you mark the line `# noqa: BLE001`.
 
 ---
 

--- a/docs/blog/10-building-agent-teams.md
+++ b/docs/blog/10-building-agent-teams.md
@@ -39,18 +39,14 @@ Three agents, three perspectives, no synthesis. Who resolves conflicts? Who prio
 
 Think of these as the verbs of agent orchestration—they describe *how* agents collaborate:
 
-```
-┌─────────────────────────────────────────────────────────────────┐
-│                     COMPOSITION PATTERNS                         │
-├─────────────────────────────────────────────────────────────────┤
-│  Sequential  │  A → B → C        │  Pipeline, dependencies     │
-│  Parallel    │  A ‖ B ‖ C        │  Independent, speed         │
-│  Debate      │  A ⇄ B → Synth    │  Multiple perspectives      │
-│  Teaching    │  Junior → Expert  │  Cost + quality             │
-│  Refinement  │  Draft → Polish   │  Iterative improvement      │
-│  Adaptive    │  Route → Spec     │  Right-size by complexity   │
-└─────────────────────────────────────────────────────────────────┘
-```
+| Pattern | Shape | Good for |
+|---|---|---|
+| Sequential | A → B → C | Pipeline, dependencies |
+| Parallel | A ‖ B ‖ C | Independent, speed |
+| Debate | A ⇄ B → Synth | Multiple perspectives |
+| Teaching | Junior → Expert | Cost + quality |
+| Refinement | Draft → Polish | Iterative improvement |
+| Adaptive | Route → Spec | Right-size by complexity |
 
 Let's explore each one.
 
@@ -131,23 +127,14 @@ result = await team.execute({
 
 **When to use:** Independent checks that can run simultaneously.
 
-```
-┌─────────────────────────────────────────┐
-│           START                          │
-└─────────────┬───────────────────────────┘
-              │
-    ┌─────────┼─────────┐
-    ↓         ↓         ↓
-┌───────┐ ┌───────┐ ┌───────┐
-│ Sec   │ │ Perf  │ │ Docs  │
-│ Audit │ │ Check │ │ Check │
-└───┬───┘ └───┬───┘ └───┬───┘
-    │         │         │
-    └─────────┼─────────┘
-              ↓
-    ┌─────────────────┐
-    │   AGGREGATOR    │
-    └─────────────────┘
+```mermaid
+flowchart TD
+    S([start]) --> A["security audit"]
+    S --> P["perf check"]
+    S --> D["docs check"]
+    A --> AG[aggregator]
+    P --> AG
+    D --> AG
 ```
 
 ### Implementation
@@ -232,18 +219,11 @@ result = await team.execute({"release_candidate": "v4.4.0"})
 
 **When to use:** Complex decisions needing multiple expert perspectives.
 
-```
-┌──────────────┐          ┌──────────────┐
-│  Architect   │ ⇄ ⇄ ⇄ ⇄  │  Architect   │
-│  (Scale)     │          │  (Cost)      │
-└──────┬───────┘          └──────┬───────┘
-       │                         │
-       └───────────┬─────────────┘
-                   ↓
-           ┌──────────────┐
-           │  Synthesizer │
-           │  (Decision)  │
-           └──────────────┘
+```mermaid
+flowchart TD
+    A1["architect (scale)"] <-->|debate rounds| A2["architect (cost)"]
+    A1 --> SY["synthesizer (decision)"]
+    A2 --> SY
 ```
 
 ### Implementation
@@ -349,15 +329,12 @@ result = await team.execute({
 
 **When to use:** Cost optimization with quality assurance.
 
-```
-┌─────────────────┐     ┌─────────────────┐     ┌─────────────────┐
-│  Junior Writer  │  →  │  Quality Gate   │  →  │  Expert Review  │
-│    (CHEAP)      │     │    (check)      │     │   (CAPABLE)     │
-└─────────────────┘     └─────────────────┘     └─────────────────┘
-                              ↓ pass                    ↓
-                         ┌─────────┐              ┌─────────┐
-                         │  DONE   │              │ REFINED │
-                         └─────────┘              └─────────┘
+```mermaid
+flowchart LR
+    J["junior writer<br/>(CHEAP)"] --> G{"quality<br/>gate"}
+    G -->|pass| DONE([done])
+    G -->|fail| E["expert review<br/>(CAPABLE)"]
+    E --> R([refined])
 ```
 
 ### Implementation
@@ -449,13 +426,10 @@ result = await strategy.execute([], {
 
 **When to use:** Iterative improvement for high-quality output.
 
-```
-┌──────────────┐     ┌──────────────┐     ┌──────────────┐
-│   Drafter    │  →  │   Reviewer   │  →  │   Polisher   │
-│   (CHEAP)    │     │  (CAPABLE)   │     │  (PREMIUM)   │
-└──────────────┘     └──────────────┘     └──────────────┘
-       ↓                    ↓                    ↓
-   "Raw draft"      "Improved + notes"    "Publication-ready"
+```mermaid
+flowchart LR
+    D["drafter (CHEAP)<br/>raw draft"] --> RV["reviewer (CAPABLE)<br/>improved + notes"]
+    RV --> P["polisher (PREMIUM)<br/>publication-ready"]
 ```
 
 ### Implementation
@@ -530,18 +504,11 @@ result = await strategy.execute([], {
 
 **When to use:** Variable complexity tasks that need right-sizing.
 
-```
-           ┌─────────────────┐
-           │   Classifier    │
-           │    (CHEAP)      │
-           └────────┬────────┘
-                    │
-        ┌───────────┼───────────┐
-        ↓           ↓           ↓
-   ┌─────────┐ ┌─────────┐ ┌─────────┐
-   │ Simple  │ │ Medium  │ │ Complex │
-   │ (CHEAP) │ │(CAPABLE)│ │(PREMIUM)│
-   └─────────┘ └─────────┘ └─────────┘
+```mermaid
+flowchart TD
+    C["classifier (CHEAP)"] --> S1["simple (CHEAP)"]
+    C --> S2["medium (CAPABLE)"]
+    C --> S3["complex (PREMIUM)"]
 ```
 
 ### Implementation

--- a/docs/guides/wizard-architecture.md
+++ b/docs/guides/wizard-architecture.md
@@ -8,27 +8,16 @@ How the wizard system works internally: components, step lifecycle, session stat
 
 The wizard system provides guided, multi-step AI workflows. Users interact with wizards through questions, and the system orchestrates LLM calls, task decomposition, and previews behind a consistent interface.
 
-```text
-┌─────────────────────────────────────────────────────┐
-│                    BaseWizard                        │
-│  ┌──────────┐  ┌──────────┐  ┌───────────────────┐  │
-│  │ WizardStep│  │ WizardStep│  │    WizardStep    │  │
-│  │ QUESTION  │→ │ LLM_CALL │→ │ TASK_DECOMPOSE   │→ ...
-│  └──────────┘  └────┬─────┘  └────────┬──────────┘  │
-│                     │                  │             │
-│              ┌──────▼──────┐   ┌───────▼──────────┐  │
-│              │ Internal    │   │  TaskDecomposer  │  │
-│              │ Workflow    │   │  (XML parsing)   │  │
-│              │ (LLM bridge)│   └──────────────────┘  │
-│              └─────────────┘                         │
-│                                                      │
-│  ┌──────────────────────┐                            │
-│  │    WizardSession     │  ← state shared across     │
-│  │  (collected_data,    │    all steps                │
-│  │   step_results,      │                            │
-│  │   tasks, cost)       │                            │
-│  └──────────────────────┘                            │
-└─────────────────────────────────────────────────────┘
+```mermaid
+flowchart LR
+    subgraph BaseWizard
+        Q["WizardStep<br/>QUESTION"] --> L["WizardStep<br/>LLM_CALL"]
+        L --> T["WizardStep<br/>TASK_DECOMPOSE"]
+        T --> More["..."]
+        L --> W["internal workflow<br/>(LLM bridge)"]
+        T --> D["TaskDecomposer<br/>(XML parsing)"]
+        S[("WizardSession<br/>collected_data, step_results,<br/>tasks, cost — shared across steps")]
+    end
 ```
 
 ---
@@ -202,27 +191,17 @@ Built-in wizards can delegate LLM steps to specialized workflow engines for deep
 
 ### How It Works
 
-```text
-BaseWizard._run_llm_step(step)
-         │
-         ▼
-BuiltinWizard._run_llm_step(step)    ← Override
-         │
-    ┌────┴─────────────────────┐
-    │ step.id == "analyze"?     │
-    │                           │
-    │ YES → _run_analysis_via_  │
-    │       workflow()          │
-    │   ┌──────────────────┐    │
-    │   │ WorkflowEngine   │    │
-    │   │ stage1 → stage2  │    │
-    │   │ → stage3 → ...   │    │
-    │   └──────────────────┘    │
-    │                           │
-    │ NO or EXCEPTION →         │
-    │   super()._run_llm_step() │
-    │   (fallback to basic LLM) │
-    └──────────────────────────┘
+```mermaid
+flowchart TD
+    B["BaseWizard._run_llm_step(step)"]
+    O["BuiltinWizard._run_llm_step(step)<br/>(override)"]
+    Q{"step.id ==<br/>&quot;analyze&quot;?"}
+    W["_run_analysis_via_workflow()<br/>WorkflowEngine: stage1 → stage2 → stage3"]
+    F["super()._run_llm_step()<br/>(fallback to basic LLM)"]
+    B --> O --> Q
+    Q -->|yes| W
+    Q -->|no, or exception| F
+    W -.exception.-> F
 ```
 
 ### Example: SecurityWizard

--- a/docs/how-to/learning-and-patterns.md
+++ b/docs/how-to/learning-and-patterns.md
@@ -14,30 +14,15 @@ how to access what Attune has learned.
 
 The learning pipeline has three stages:
 
-```
-Session ends
-     │
-     ▼
-┌──────────────────────────────┐
-│  SessionEvaluator             │
-│  Is this session worth        │
-│  learning from?               │
-└──────────────────┬───────────┘
-                   │ EXCELLENT / GOOD
-                   ▼
-┌──────────────────────────────┐
-│  PatternExtractor             │
-│  What patterns occurred?      │
-│  (corrections, workarounds,   │
-│   preferences, techniques)    │
-└──────────────────┬───────────┘
-                   │
-                   ▼
-┌──────────────────────────────┐
-│  LearnedSkillsStorage         │
-│  Persist patterns as skills   │
-│  for future sessions          │
-└──────────────────────────────┘
+```mermaid
+flowchart TD
+    E(["session ends"])
+    SE["SessionEvaluator<br/>is this session worth learning from?"]
+    PE["PatternExtractor<br/>what patterns occurred? corrections,<br/>workarounds, preferences, techniques"]
+    LS["LearnedSkillsStorage<br/>persist patterns as skills<br/>for future sessions"]
+    E --> SE
+    SE -->|EXCELLENT / GOOD| PE
+    PE --> LS
 ```
 
 The session end hook at `src/attune/hooks/scripts/evaluate_session.py`

--- a/docs/how-to/project-analysis-and-metrics.md
+++ b/docs/how-to/project-analysis-and-metrics.md
@@ -14,30 +14,13 @@ one-off analysis, `attune workflow run health-check` is simpler.
 
 ## What the Project Index Does
 
-```
-attune workflow run health-check
-         │
-         ▼
-┌──────────────────────────────┐
-│  ProjectScanner               │
-│  Walks the file tree          │
-│  Categorizes every .py file   │
-│  Computes per-file metrics    │
-└──────────────┬───────────────┘
-               │
-               ▼
-┌──────────────────────────────┐
-│  ProjectIndex                 │
-│  Builds searchable index      │
-│  Caches to .attune/           │
-└──────────────┬───────────────┘
-               │
-               ▼
-┌──────────────────────────────┐
-│  ReportGenerator              │
-│  Health score, risk files,    │
-│  dependency graph             │
-└──────────────────────────────┘
+```mermaid
+flowchart TD
+    CMD(["attune workflow run health-check"])
+    PS["ProjectScanner<br/>walks the file tree, categorizes every<br/>.py file, computes per-file metrics"]
+    PI["ProjectIndex<br/>builds searchable index,<br/>caches to .attune/"]
+    RG["ReportGenerator<br/>health score, risk files,<br/>dependency graph"]
+    CMD --> PS --> PI --> RG
 ```
 
 ---

--- a/docs/how-to/resilience-patterns.md
+++ b/docs/how-to/resilience-patterns.md
@@ -87,27 +87,16 @@ async def call_external_api():
 
 ### Circuit States
 
-```
-     ┌─────────┐
-     │ CLOSED  │ ◄─── Normal operation
-     └────┬────┘
-          │ failures >= threshold
-          ▼
-     ┌─────────┐
-     │  OPEN   │ ◄─── Fail immediately
-     └────┬────┘
-          │ after reset_timeout
-          ▼
-   ┌───────────────┐
-   │  HALF_OPEN    │ ◄─── Testing recovery
-   └───────┬───────┘
-           │
-     ┌─────┴─────┐
-     │           │
-   success    failure
-     │           │
-     ▼           ▼
-  CLOSED       OPEN
+```mermaid
+stateDiagram-v2
+    [*] --> CLOSED
+    CLOSED --> OPEN: failures >= threshold
+    OPEN --> HALF_OPEN: after reset_timeout
+    HALF_OPEN --> CLOSED: test call succeeds
+    HALF_OPEN --> OPEN: test call fails
+    note right of CLOSED: normal operation
+    note right of OPEN: fail immediately
+    note right of HALF_OPEN: testing recovery
 ```
 
 ### With Fallback

--- a/docs/how-to/smart-router.md
+++ b/docs/how-to/smart-router.md
@@ -22,18 +22,11 @@ print(f"Confidence: {decision.confidence}")        # → 0.85
 
 ## How It Works
 
-```
-┌─────────────────────────────────────────────────────────────────┐
-│                      SMART ROUTER                                │
-│   Developer: "Fix performance in auth.py"                        │
-│   → Routes to: PerformanceWizard + SecurityWizard               │
-└─────────────────────────────────────────────────────────────────┘
-                              │
-                              ▼
-┌─────────────────────────────────────────────────────────────────┐
-│                     WIZARD REGISTRY                              │
-│   17+ wizards with keywords, descriptions, and capabilities     │
-└─────────────────────────────────────────────────────────────────┘
+```mermaid
+flowchart TD
+    R["Smart router<br/>&quot;Fix performance in auth.py&quot;<br/>routes to PerformanceWizard + SecurityWizard"]
+    W["Wizard registry<br/>17+ wizards with keywords,<br/>descriptions, and capabilities"]
+    R --> W
 ```
 
 The router uses a keyword-based classifier to match requests to wizards. Each wizard is registered with:

--- a/docs/how-to/unified-memory-system.md
+++ b/docs/how-to/unified-memory-system.md
@@ -244,16 +244,12 @@ result = memory.persist_pattern(
 
 The pattern promotion workflow moves validated patterns from short-term to long-term memory:
 
-```
-  ┌─────────────┐         ┌──────────────┐         ┌─────────────┐
-  │  Discovery  │───────▶│   Staging    │───────▶│  Long-Term  │
-  │  (Agent)    │         │  (Review)    │         │  (Library)  │
-  └─────────────┘         └──────────────┘         └─────────────┘
-        │                       │                        │
-        │                       │                        │
-    Contributor            Validator                 Anyone
-    discovers              reviews &                can recall
-                           promotes
+```mermaid
+flowchart LR
+    D["Discovery (agent)<br/>contributor discovers"]
+    S["Staging (review)<br/>validator reviews and promotes"]
+    L["Long-term (library)<br/>anyone can recall"]
+    D --> S --> L
 ```
 
 ### Example Workflow

--- a/docs/reference/agent-factory-overview.md
+++ b/docs/reference/agent-factory-overview.md
@@ -10,31 +10,17 @@ resilience patterns, and cross-agent learning.
 
 ## Architecture
 
-```text
-┌───────────────────────────────────────────────┐
-│            AgentFactory (entry point)          │
-│  create_agent() / create_workflow()            │
-└──────────────────┬────────────────────────────┘
-                   │ delegates to
-                   ▼
-┌──────────────────────────────────────────────┐
-│          Framework Adapters                   │
-│  Native │ LangChain │ LangGraph │ AutoGen │  │
-│                                  Haystack │  │
-└──────────────────┬───────────────────────────┘
-                   │ creates
-                   ▼
-┌──────────────────────────────────────────────┐
-│            BaseAgent instance                 │
-└─────┬────────────────────┬───────────────────┘
-      │ optional wrap       │ optional wrap
-      ▼                     ▼
-┌─────────────┐  ┌──────────────────────┐
-│ MemoryAware │  │   ResilientAgent     │
-│   Agent     │  │  circuit breaker     │
-│  (inner)    │  │  retry + timeout     │
-└─────────────┘  │  fallback (outer)    │
-                 └──────────────────────┘
+```mermaid
+flowchart TD
+    F["AgentFactory (entry point)<br/>create_agent() / create_workflow()"]
+    A["Framework adapters<br/>Native · LangChain · LangGraph ·<br/>AutoGen · Haystack"]
+    B["BaseAgent instance"]
+    M["MemoryAwareAgent<br/>(inner wrap)"]
+    R["ResilientAgent (outer wrap)<br/>circuit breaker, retry + timeout, fallback"]
+    F -->|delegates to| A
+    A -->|creates| B
+    B -->|optional wrap| M
+    B -->|optional wrap| R
 ```
 
 When `resilience_enabled` is set, the framework adapter

--- a/docs/tutorials/chart-widgets.md
+++ b/docs/tutorials/chart-widgets.md
@@ -247,6 +247,108 @@ form.title  # "Session contract — acme-api"
 
 The cast form has four fields (mode, outcome, done-when, effort cap)
 and renders on the same widget surface as any hand-built form.
+Below is that exact cast, embedded live — this is the real renderer's
+output, not a screenshot (on this static page the submit button will
+tell you it needs a widget-capable session; that legible degradation
+is itself part of the design):
+
+<div style="border: 1px solid #d8b89a; border-radius: 8px; padding: 0 1rem; margin: 1rem 0;">
+<h2 class="sr-only">Session contract — acme-api — interactive form</h2>
+<form id="attune-elicit-form-d852a71d" data-form-title="Session contract — acme-api">
+<style>
+#attune-elicit-form-d852a71d { display:block; width:100%; padding:1rem 0;
+  color:var(--text-primary,#2c2c2a); line-height:1.5; }
+#attune-elicit-form-d852a71d .sr-only { position:absolute; width:1px; height:1px;
+  overflow:hidden; clip:rect(0 0 0 0); }
+#attune-elicit-form-d852a71d h3 { font-size:18px; font-weight:500; margin:0 0 .25rem; }
+#attune-elicit-form-d852a71d .ae-msg { margin:0 0 .5rem; color:var(--text-secondary,#5f5e59); }
+#attune-elicit-form-d852a71d .ae-desc { margin:0 0 1rem; color:var(--text-muted,#8a887f);
+  font-size:15px; }
+#attune-elicit-form-d852a71d .ae-field { margin:0 0 1rem; }
+#attune-elicit-form-d852a71d .ae-label { display:block; font-weight:500;
+  margin:0 0 .35rem; }
+#attune-elicit-form-d852a71d .ae-req { color:var(--text-accent,#a1571c); margin-left:2px; }
+#attune-elicit-form-d852a71d .ae-confirm { font-size:14px; color:var(--text-secondary,#5f5e59);
+  border-left:3px solid var(--border-accent,#d8b89a); border-radius:0;
+  padding:.35rem .6rem; margin:0 0 1rem; }
+#attune-elicit-form-d852a71d .ae-inferred { font-size:13px; color:var(--text-muted,#8a887f);
+  margin:0 0 .35rem; }
+#attune-elicit-form-d852a71d .ae-inferred-b { display:inline-block; font-size:11px;
+  font-weight:500; text-transform:uppercase; letter-spacing:.04em;
+  color:var(--text-accent,#a1571c); background:var(--bg-accent,#f3ece4);
+  border:1px solid var(--border-accent,#d8b89a); border-radius:var(--radius,8px);
+  padding:0 .35rem; margin-right:.4rem; }
+#attune-elicit-form-d852a71d .ae-help { font-size:13px; color:var(--text-muted,#8a887f);
+  margin:0 0 .35rem; }
+#attune-elicit-form-d852a71d .ae-submit { margin-top:.5rem; padding:.55rem 1.1rem;
+  font-size:15px; font-weight:500; cursor:pointer; color:var(--text-primary,#2c2c2a);
+  background:var(--bg-accent,#f3ece4); border:1px solid var(--border-accent,#d8b89a);
+  border-radius:var(--radius,8px); }
+#attune-elicit-form-d852a71d .ae-submit:disabled { opacity:.6; cursor:default; }
+#attune-elicit-form-d852a71d .ae-error { margin-top:.5rem; font-size:14px;
+  color:var(--text-accent,#a1571c); }
+#attune-elicit-form-d852a71d .ae-input { width:100%; box-sizing:border-box;
+  padding:.5rem .6rem; font-size:15px; color:var(--text-primary,#2c2c2a);
+  background:var(--surface-1,#f7f6f3); border:1px solid var(--border,#e3e1dc);
+  border-radius:var(--radius,8px); }
+#attune-elicit-form-d852a71d .ae-textarea { resize:vertical; min-height:3.5rem; }
+</style>
+<h3>Session contract — acme-api</h3>
+<p class="ae-desc">The session-start protocol&#x27;s fields. Fill before non-trivial work.</p>
+<div class="ae-field" data-fid="mode" data-ftype="single_select"><label class="ae-label">Which mode is this session in?<span class="ae-req" title="required">*</span></label><select data-control class="ae-input"><option value="">— choose —</option><option value="Advancing a defined scope">Advancing a defined scope</option><option value="Executing a planned spec">Executing a planned spec</option><option value="Firefighting a CI/release issue">Firefighting a CI/release issue</option><option value="Meta-reflection / planning">Meta-reflection / planning</option></select></div><div class="ae-field" data-fid="outcome" data-ftype="text_input"><label class="ae-label">Outcome — what should be true after this session that isn&#x27;t true now?<span class="ae-req" title="required">*</span></label><div class="ae-help">One sentence.</div><input type="text" data-control class="ae-input"></div><div class="ae-field" data-fid="done_when" data-ftype="textarea"><label class="ae-label">Done when — the acceptance criteria.<span class="ae-req" title="required">*</span></label><div class="ae-help">Cheap to write, expensive to skip.</div><textarea data-control class="ae-input ae-textarea" rows="3" maxlength="500"></textarea></div><div class="ae-field" data-fid="effort_cap" data-ftype="text_input"><label class="ae-label">Effort cap — time or scope ceiling.</label><div class="ae-help">e.g. &#x27;30 min&#x27;, &#x27;one PR&#x27;, &#x27;no scope expansion past Phase 1&#x27;.</div><input type="text" data-control class="ae-input"></div>
+<button type="button" id="ae-submit-d852a71d" class="ae-submit">Submit</button>
+<div id="ae-error-d852a71d" class="ae-error" role="alert"></div>
+<script>
+(function() {
+  var form = document.getElementById('attune-elicit-form-d852a71d');
+  var btn = document.getElementById('ae-submit-d852a71d');
+  var err = document.getElementById('ae-error-d852a71d');
+  if (!form || !btn) return;
+  btn.addEventListener('click', function() {
+    var answers = {};
+    form.querySelectorAll('.ae-field').forEach(function(f) {
+      var fid = f.getAttribute('data-fid');
+      var ftype = f.getAttribute('data-ftype');
+      if (ftype === 'multi_select') {
+        var vals = [];
+        f.querySelectorAll('[data-control]:checked').forEach(function(c) {
+          vals.push(c.value);
+        });
+        answers[fid] = vals;
+      } else if (ftype === 'decision' || ftype === 'pushback' || ftype === 'progress') {
+        // progress: the answer is the selected blocked item; when nothing
+        // is blocked there is no radio and no answer is posted (display-only).
+        var picked = f.querySelector('[data-control]:checked');
+        if (picked) answers[fid] = picked.value;
+      } else {
+        var el = f.querySelector('[data-control]');
+        if (!el) return;
+        if (el.type === 'radio') {
+          // single_select rendered as a list (list_style) — read the
+          // checked radio, not the first control.
+          var picked = f.querySelector('[data-control]:checked');
+          if (picked) answers[fid] = picked.value;
+        } else if (el.value !== '') {
+          answers[fid] = (ftype === 'number') ? Number(el.value) : el.value;
+        }
+      }
+    });
+    var payload = { '__elicitation_response__': true,
+      title: form.getAttribute('data-form-title'), answers: answers };
+    if (typeof sendPrompt === 'function') {
+      sendPrompt('Elicitation form submitted — parse and validate this '
+        + 'response:\n```json\n' + JSON.stringify(payload) + '\n```');
+      btn.disabled = true; btn.textContent = 'Submitted \u2713';
+    } else {
+      err.textContent = 'This surface cannot post back (sendPrompt '
+        + 'unavailable). Use the AskUserQuestion fallback.';
+    }
+  });
+})();
+</script>
+</form>
+</div>
+
 Validation is shared with hand-built forms — every problem listed,
 none silently accepted:
 

--- a/docs/tutorials/examples/simple-chatbot.md
+++ b/docs/tutorials/examples/simple-chatbot.md
@@ -35,27 +35,13 @@ tiers that make Attune AI's memory powerful:
 
 ## Why Two Tiers of Memory?
 
-```text
-┌─────────────────────────────────────────────────────────────┐
-│                    CODE REVIEW SESSION                       │
-├─────────────────────────────────────────────────────────────┤
-│                                                             │
-│  SESSION MEMORY (Redis)             PERSISTENT MEMORY       │
-│  ─────────────────────────          ────────────────        │
-│  • Files reviewed this session      • Historical bugs       │
-│  • Issues found so far              • Developer patterns    │
-│  • Current PR context               • Codebase weak spots   │
-│                                                             │
-│  Expires: End of session            Persists: Forever       │
-│                                                             │
-│          ↓                                   ↓              │
-│          └─────────────┬─────────────────────┘              │
-│                        ▼                                    │
-│              ANTICIPATORY INSIGHT                           │
-│         "This auth change looks similar to the              │
-│          bug we found in PR #98. Check line 42."            │
-│                                                             │
-└─────────────────────────────────────────────────────────────┘
+```mermaid
+flowchart TD
+    SM["Session memory (Redis) — expires with session<br/>files reviewed, issues found so far, current PR context"]
+    PM["Persistent memory — persists forever<br/>historical bugs, developer patterns, codebase weak spots"]
+    AI["Anticipatory insight<br/>&quot;This auth change looks similar to the<br/>bug we found in PR #98. Check line 42.&quot;"]
+    SM --> AI
+    PM --> AI
 ```
 
 ---


### PR DESCRIPTION
## What

Docs-wide adoption of the new communication features (Patrick-directed
2026-08-06), building on the mermaid enablement that merged in #1965.

**15 hand-judged ASCII-art → mermaid conversions across 10 shipped
pages** (batches 1+2 of the measured 14-page worklist):

- `how-to/resilience-patterns` — circuit breaker as a real
  `stateDiagram-v2`
- `EXCEPTION_HANDLING_GUIDE` — the quick decision tree as a flowchart
  with decision diamonds
- `how-to/{smart-router, unified-memory-system, learning-and-patterns,
  project-analysis-and-metrics}` — pipeline flows
- `blog/10-building-agent-teams` — all 5 pattern diagrams (the
  Teaching diagram now matches its own implementation; the ASCII was
  ambiguous about the pass/fail split), plus the boxed pattern list as
  a plain markdown table
- `guides/wizard-architecture` — 2 diagrams incl. the
  workflow-delegation fallback path
- `reference/agent-factory-overview`, `tutorials/examples/simple-chatbot`

**Live form embedded in the tutorial** — Step 5 now renders the actual
`session-contract` cast via `form_from_template` + `form_to_widget_html`
(6,482 B of real renderer output, not a screenshot); on the static
docs surface its submit button degrades legibly.

**Deliberate non-conversions:** directory trees, code-output trees,
and FAQ file layouts stay as text (idiomatic); PROJECT_OVERVIEW's hits
are all trees; `architecture/spec-engine`'s single hit is a code
annotation (master has none). Chart embeds beyond the tutorial's six:
no shipped page currently poses a shape question — the numeric
cost-analysis pages are site-excluded (see chip task_b959465c's
sibling issue).

## Receipts

- `mkdocs build --strict` exit 0
- Per-page mermaid block counts verified in built HTML
- Visual renders spot-checked over HTTP: circuit-breaker state
  machine, exception decision tree, parallel fan-out, embedded form
  (screenshots reviewed in session)

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
