### PR TITLE
docs(specs): approve broad-except-ratchet; rule Q1-Q3

### DIFF
--- a/docs/specs/broad-except-ratchet/decisions.md
+++ b/docs/specs/broad-except-ratchet/decisions.md
@@ -1,0 +1,77 @@
+# broad-except-ratchet — decisions
+
+## D1 — APPROVED; the three open questions ruled
+
+**Date:** 2026-08-06 · **Status:** approved (chair: Patrick, via the
+three-question approval form; Q2 answered with an explicit request
+for the lead's judgment and pushback)
+
+| Q | Ruling |
+|---|---|
+| Q1 — `# noqa: BLE001` sites | **Counted.** The annotation is not an exemption. |
+| Q2 — scope | **`src/attune` + `attune_redis` + `backend`.** |
+| Q3 — fires-on-violation receipt | **At implementation** — seeded and proven in the build PR. |
+
+### Measurement taken before ruling (2026-08-06)
+
+| Tree | Broad-except sites | Files | Of which `# noqa: BLE001` |
+|---|---|---|---|
+| `src/attune` | 586 | 247 | 580 |
+| `attune_redis` | 31 | 7 | 30 |
+| `backend` | 7 | 5 | 3 |
+
+**Q1 — the measurement invalidates the question's own premise, and
+the chair's answer is the one the data supports.** Q1 offered
+"treat the annotation as the documented-contract marker" as a
+plausible reading. It is not tenable: **580 of 586** `src/attune`
+sites carry `# noqa: BLE001`. The annotation records that ruff was
+satisfied, not that a contract was documented — it is what the lint
+made people write, applied near-universally. Excluding annotated
+sites would have left the ratchet policing **6 sites out of 586**,
+a guard in name only. Counting everything keeps the scan mechanical
+(R4's stated principle) and makes the baseline the sole escape
+hatch (R2/R3). Recorded because a future reader will otherwise
+re-litigate Q1 from the annotation's nominal meaning rather than
+its actual distribution.
+
+**Q2 — the lead was asked for judgment and has no pushback to
+offer; the widest scope is correct.** Reasons, in order of weight:
+
+1. **`backend/` is where a swallow costs most and the baseline
+   costs least.** It carries auth and subscription code
+   (`backend/api/auth.py`, `backend/services/auth_service.py`,
+   `backend/services/database/auth_db.py`) with its own security
+   suite (`tests/backend/test_auth_security.py`) — a silently
+   swallowed exception in an auth path is the worst instance of
+   the class the spec exists to police. And it is **7 sites**: the
+   entire tree costs less baseline than a single busy module in
+   `src/attune`.
+2. **`attune_redis` is the same product surface.** It ships
+   bundled in the `attune-ai` wheel, so excluding it would let debt
+   accumulate in shipped code purely because of a directory
+   boundary.
+3. **A shrink-only ratchet has no per-file carrying cost.** Wider
+   scope adds baseline entries, not maintenance; the only recurring
+   cost is on files someone edits, which is exactly where the guard
+   should fire.
+
+No counter-case survives contact with the numbers, so none is
+manufactured here. The one caveat worth recording rather than
+arguing: `backend/`'s last substantive commit is 2026-06-21 (a
+dependabot bump). If that tree is later retired, its baseline
+entries retire with it — the ratchet is not a reason to keep it
+alive. That question belongs to the subsystem-value gate, not here.
+
+**Q3 — receipt at implementation.** The acceptance criteria already
+require a fires-on-violation receipt; ruling it "at implementation"
+means the build PR must both seed the baseline AND demonstrate that
+adding one new `except Exception` fails the guard. Approval grants
+implementation authority; it does not waive the receipt.
+
+### Effect
+
+`requirements.md` moves draft → approved, with Q1–Q3 folded in as
+ratified clauses (R5–R7). Implementation may proceed. Seeding
+baseline: **624 sites across 259 files** at approval time — the
+build PR re-measures from its own commit rather than trusting this
+number.

--- a/docs/specs/broad-except-ratchet/requirements.md
+++ b/docs/specs/broad-except-ratchet/requirements.md
@@ -1,8 +1,9 @@
 # Broad-Except Ratchet — Requirements
 
-**Status:** draft (2026-08-02) — AWAITING CHAIR REVIEW. No
-implementation authority until the chair approves; this draft
-exists so the review has a concrete object.
+**Status:** approved (2026-08-06 — chair ruled Q1–Q3 via the
+approval form; D1 in [decisions.md](decisions.md)). Implementation
+authority granted; the fires-on-violation receipt is owed by the
+build PR.
 **Slug:** `broad-except-ratchet`
 **Provenance:** chair directive 2026-08-02 ("spec 3 and 4 for chair
 review") from the post-dry-run feedback exchange. Evidence base:
@@ -41,16 +42,18 @@ A shrink-only per-file baseline ratchet, modeled on
   counted (keeping the scan mechanical); the baseline is the escape
   hatch, not pattern-matching cleverness.
 
-## Open questions for the chair
+## Ratified clauses (from the Q1–Q3 rulings, D1 2026-08-06)
 
-- Q1. Count `# noqa: BLE001`-annotated sites too, or treat the
-  annotation as the documented-contract marker and exclude them?
-  (Excluding makes the ratchet weaker but aligns with the existing
-  lint vocabulary.)
-- Q2. Scope: `src/attune` only, or also `attune_redis/` and
-  `backend/`?
-- Q3. Is a fires-on-violation test (per the principles-impact
-  candidate) required at approval, or part of implementation?
+- R5. **`# noqa: BLE001`-annotated sites are COUNTED.** The
+  annotation is not an exemption: 580 of 586 `src/attune` sites
+  carry it, so excluding them would police 6 sites. The baseline is
+  the only escape hatch (R2/R3).
+- R6. **Scope is `src/attune` + `attune_redis` + `backend`.**
+  `attune_redis` ships bundled in the wheel; `backend` is 7 sites
+  and holds auth/subscription code where a swallow costs most.
+- R7. **The fires-on-violation receipt lands with the build**, not
+  with approval: the build PR seeds the baseline AND demonstrates
+  that one added `except Exception` fails the guard in CI.
 
 ## Acceptance criteria (when approved)
 


### PR DESCRIPTION
Chair approved the broad-except-ratchet spec on 2026-08-06 via the three-question form. Docs-only: a status flip plus the ruling record.

## Rulings

| Q | Ruling |
|---|---|
| Q1 — `# noqa: BLE001` sites | **Counted.** The annotation is not an exemption. |
| Q2 — scope | **`src/attune` + `attune_redis` + `backend`.** |
| Q3 — fires-on-violation receipt | **At implementation**, in the build PR. |

## The measurement that drove Q1

| Tree | Sites | Files | Of which annotated |
|---|---|---|---|
| `src/attune` | 586 | 247 | 580 |
| `attune_redis` | 31 | 7 | 30 |
| `backend` | 7 | 5 | 3 |

Q1 offered "treat the annotation as the documented-contract marker" as a plausible reading. It isn't tenable: **580 of 586** sites carry it. The annotation records that ruff was satisfied, not that a contract was documented. Excluding annotated sites would have left the ratchet policing **6 sites out of 586** — a guard in name only.

## On Q2

The chair picked the widest scope and explicitly asked the lead for judgment and pushback. The lead has **none to offer**, and says so rather than manufacturing a counter-case: `backend/` is 7 sites (cheaper than one busy `src/attune` module) and holds auth and subscription code where a swallowed exception is the worst instance of the class; `attune_redis` ships bundled in the wheel, so a directory boundary shouldn't shelter shipped code. One caveat recorded, not argued: `backend/`'s last substantive commit is 2026-06-21, so if that tree is later retired its baseline entries retire with it — the ratchet is not a reason to keep it alive.

Separated from #1970 deliberately: spec status flips are merge-now (docs-outbox R2) and shouldn't be gated behind a feature PR's CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

**Note:** supersedes #1971, which was blocked by a GitHub-side zombie workflow run (`status=queued`, `conclusion=null`, 0 jobs, uncancellable — "Cannot cancel a workflow run that is completed"). It permanently held the `Tests-<head_ref>` concurrency group, so no Tests run could ever be created for that branch name and its required contexts could never be produced. Identical content on a renamed branch to break the deadlock.
