### PR TITLE
feat(memory): advisory staleness sweep for curated memory corpora (memory-status-integrity P1)

### DIFF
--- a/docs/specs/memory-status-integrity/decisions.md
+++ b/docs/specs/memory-status-integrity/decisions.md
@@ -1,0 +1,211 @@
+# memory-status-integrity — decisions
+
+Chair: Patrick. Decisions are recorded when made, with the evidence that
+drove them, so a later session can tell a ruling from a habit.
+
+---
+
+## D1 — Label, never suppress by age (recorded 2026-08-07)
+
+**Question (requirements OQ4):** past some unverified-age threshold,
+should a curated memory stop being injected at SessionStart and move to
+recall-on-demand only, or should it only ever be labelled?
+
+**Ruling:** **Label. Never suppress by age.** No curated memory is
+removed from service by a clock. The only thing that takes a memory out
+of circulation is a human `wrong` verdict (R3) — a decision, not an
+elapsed interval.
+
+Patrick delegated this call on 2026-08-07 and asked for the reasoning to
+be recorded.
+
+### The decisive evidence: age is anti-correlated with wrongness
+
+The obvious design — expire what's old — assumes age predicts falsity.
+Measured against the live corpus, it predicts the opposite.
+
+Type composition of the oldest bucket (36 files, all stamped
+2026-06-02):
+
+| Type | Count |
+|---|---|
+| `feedback` | 30 |
+| `user` | 5 |
+| `lesson` | 1 |
+
+35 of 36 are settled process rules and user profile — the memories least
+likely to be false and most expensive to lose. `feedback_one_question_at_a_time`
+(surfaced 2026-05-21) is among the oldest files in the corpus and is
+still exactly true; it governed the shape of the very conversation that
+produced this spec.
+
+Meanwhile, both memories that actually rotted were `project_*` and
+comparatively young:
+
+| Rotted memory | Age when it misled |
+|---|---|
+| `project_pip_audit_broken` | ~8 weeks |
+| `project_rag_gate_corpus_stale` | **hours** |
+
+An age threshold tuned to catch the 8-week case would not have touched
+the hours-old case. A threshold tuned to catch the hours-old case would
+evict essentially the entire corpus, starting with the `feedback` rules
+that make the agent usable.
+
+**Age-based suppression would silence the safest memories and retain the
+dangerous ones.** That is not a tuning problem — the mechanism points the
+wrong way, and no threshold fixes a sign error.
+
+### Supporting argument 1 — the error costs are asymmetric
+
+| Failure | Cost | Visibility |
+|---|---|---|
+| Labelled memory is over-trusted anyway | status quo, plus a warning | visible, recoverable |
+| A **true**, load-bearing memory is suppressed | session re-derives or contradicts a settled decision | **silent, unrecoverable** |
+
+Suppression converts a loud failure into a quiet one. That is precisely
+the absence-as-success class R5 and R6 exist to eliminate — a capped or
+filtered result that reads as "nothing here" is indistinguishable from
+"nothing stored."
+
+### Supporting argument 2 — suppression destroys the review loop
+
+D6 of `curated-memory-productionization` fixed the durable tier's regime
+as **human review verdicts**. A verdict requires a human to see the
+memory. Suppress it and it can never be reviewed: the corpus silently
+bifurcates into *served* and *forgotten-but-present*, and rot becomes
+invisible rather than repaired. Suppression does not implement D6's
+regime; it starves it.
+
+### Supporting argument 3 — labelling demonstrably works on this reader
+
+The reader of a curated memory is a model, so "does the label work?" is
+an empirical question, not a matter of taste.
+
+Receipt from the originating session (2026-08-06): the harness stamped
+`This memory is 27 days old… Verify against current code before
+asserting as fact` on a memory file read during the investigation. It
+changed the agent's behavior in-session — a downstream claim sourced
+from `product.md` was hedged and flagged for verification rather than
+asserted. The label lands because it is in context at the moment of use,
+which is exactly where a staleness signal has leverage and an offline
+expiry policy has none.
+
+### The strongest counter-argument, and why it loses
+
+**Context budget is real.** SessionStart hydrated 989 lessons in the
+originating session; the curated corpus is 266 files. Injecting
+everything forever is not free, and suppression is the obvious lever.
+
+It loses because it treats a **volume** problem as a **staleness**
+problem. The two are independent, and the type-composition data shows
+what happens when they are conflated: expiry evicts the cheapest,
+highest-reuse rules first, because those are the oldest. Volume is
+solved by ranking and relevance (R6), which reduces what is *served*
+without deciding what is *true*.
+
+### The binary was false — the third path
+
+The question offered label-or-suppress. The design takes neither
+extreme:
+
+> Staleness × recall-frequency escalates a memory to a **review
+> prompt** — a request for a verdict — not to suppression.
+
+High-risk memories get *more* attention, not less. This is the only one
+of the three options that actually advances D6's regime, and it inverts
+suppression's failure mode: instead of quietly removing a memory nobody
+reviews, it loudly surfaces the memory most in need of review.
+
+### Consequences
+
+- No age threshold anywhere in the design removes content from a recall
+  result or from SessionStart injection.
+- R2's annotation is mandatory on every surface; it is the entire
+  mitigation for the label-only posture and cannot be deferred.
+- The acceptance test pins this: a change that starts suppressing by age
+  must fail loudly (see requirements § Acceptance, row 2).
+- Revisit only on evidence that labels are being ignored in practice —
+  i.e. a recorded instance of an agent asserting a visibly-labelled
+  stale claim as fact. Absent that receipt, this stays settled.
+
+---
+
+## D2 — P2's cost objection withdrawn; the premise was false (recorded 2026-08-07)
+
+The requirements originally argued that adding a `verified:` key was
+expensive because `memory_lint.py` is vendored across the four-sibling
+hook closure tracked by `project_hooks_canonical_drift`, so a schema
+change would require a closure re-sync.
+
+**Measured: false.** `memory_lint.py` exists at exactly one path,
+`~/.claude/hooks/memory_lint.py`, with a co-located `test_memory_lint.py`.
+It is present in none of the five repos (attune-ai, attune-rag,
+attune-gui, attune-help, attune-author).
+
+The schema amendment is one file and one test. P2 is materially cheaper
+than the requirements claimed, and the phase split is now justified by
+*sequencing* (P1 needs no schema at all) rather than by cost avoidance.
+
+Recorded because the false premise was load-bearing in the original
+phase argument, and a later reader would otherwise inherit it.
+
+---
+
+## D4 — The enforcement code is the authority, not the prose (recorded 2026-08-07)
+
+Three claims in the requirements draft were derived from documentation
+and were false. Each was caught only by running the thing:
+
+| Claim | Source of the error | Reality |
+|---|---|---|
+| "7 schema violations" | `~/.claude/CLAUDE.md` says no keys beyond the fixed set | `memory_lint.py:188-194` deliberately tolerates provenance keys; **1** violation corpus-wide |
+| "a write-triggered linter can never find pre-existing drift" (R5) | inferred from the hook's PostToolUse registration | `--check-all` + `all_memory_dirs()` already exist |
+| "the corpus is clean, 0 violations" | read `--check-all` output through `tail -25` and never saw the first block | 1 violation — a missing `MEMORY.md` pointer |
+
+**Ruling:** where prose and enforcement code disagree about a rule, the
+code is authoritative and the sweep must match it. `curated_audit.py`
+now mirrors the linter's provenance tolerance and its "a bare `stem.md`
+mention counts as indexed" rule, with the reasons recorded at both call
+sites so a later reader does not re-tighten them.
+
+**Why this is recorded rather than quietly fixed:** the failure mode is
+the spec's own subject. A confident claim, sourced from a stale
+document, survived into a requirements doc and was nearly built on. The
+third row is worse than the first two — that one was not a bad source
+but a truncated command, an unforced error of the kind that produces
+false "all clear" reports.
+
+Two mitigations fall out of this and are already in the design:
+
+- The live-corpus **receipt** (not a test) is what caught all three. It
+  stays mandatory before any claim about corpus state.
+- Agreement between two independent implementations is a signal worth
+  keeping. `curated_audit` and `memory_lint` now cross-check each
+  other; on the first clean run they found the same single violation.
+
+---
+
+## D3 — The sweep is a library in attune-ai, not a personal script (recorded 2026-08-07)
+
+There are two curated corpora with different owners:
+
+| Corpus | Files | Owner |
+|---|---|---|
+| `~/.claude/**/memory/` | 266 | harness-native; linted by a personal hook outside every repo |
+| `~/.attune/memory/` | 16 | attune-shipped (`src/attune/memory/personal.py`) |
+
+Writing the sweep as a personal script would fix Patrick's corpus and
+ship nothing. Writing it only against `~/.attune/memory/` would ship a
+feature exercised by 16 files while the 266-file corpus keeps rotting.
+
+**Decision:** the mechanism lands in attune-ai as a **path-parameterized
+library** over "a directory of frontmattered markdown memories," with
+both corpora as callers. The personal hook calls into it; the product
+uses it for its own store.
+
+This also gives P1 an honest test surface: the logic is exercised by
+hermetic fixtures, and the 266-file corpus becomes a *receipt* run
+rather than a test dependency — real-corpus assertions in CI would
+violate the home-directory isolation guard
+(`project_test_isolation_home_dir_leaks`).

--- a/docs/specs/memory-status-integrity/design.md
+++ b/docs/specs/memory-status-integrity/design.md
@@ -1,6 +1,7 @@
 # memory-status-integrity — design
 
-**Status:** draft (2026-08-07)
+**Status:** draft (2026-08-07) — P1 implemented; not yet reviewed by the
+chair
 **Requirements:** [requirements.md](requirements.md) — R1–R6
 **Decisions:** [decisions.md](decisions.md) — D1 (label, never suppress),
 D2, D3

--- a/docs/specs/memory-status-integrity/design.md
+++ b/docs/specs/memory-status-integrity/design.md
@@ -1,0 +1,216 @@
+# memory-status-integrity — design
+
+**Status:** draft (2026-08-07)
+**Requirements:** [requirements.md](requirements.md) — R1–R6
+**Decisions:** [decisions.md](decisions.md) — D1 (label, never suppress),
+D2, D3
+
+Full ladder below; **P1 is the shippable unit** and is specified to
+implementation depth. P2/P3 are specified to the depth needed to prove
+P1 doesn't paint them into a corner.
+
+---
+
+## Architecture
+
+Per D3, the mechanism is a path-parameterized library over "a directory
+of frontmattered markdown memories," with both corpora as callers.
+
+```
+                    ┌─────────────────────────────────┐
+                    │ attune.memory.curated_audit     │
+                    │  scan_corpus / audit / annotate │
+                    └───────────────┬─────────────────┘
+                 ┌──────────────────┼──────────────────┐
+                 │                  │                  │
+     ~/.claude/**/memory/   ~/.attune/memory/   scripts/audit_
+        (266 files,            (16 files,       curated_memory.py
+     personal hook calls in)  attune-shipped)      (CLI / receipt)
+```
+
+No corpus path is hardcoded in the library. Callers supply roots. This
+is what lets the same logic serve a product store and a personal corpus
+that lives outside every repo.
+
+---
+
+## The ranking model — the one non-obvious part
+
+D1 established that **age is anti-correlated with wrongness**: the
+oldest memories are `feedback` and `user`, which are settled and stable,
+while the memories that actually rotted were `project_*`.
+
+That finding constrains ranking as well as suppression. Ranking review
+attention by age alone would repeat the same sign error one notch
+weaker: it would march a reviewer through 30 correct process rules
+before reaching the one stale CI claim.
+
+**Risk is age scaled by the volatility of the memory's type.** Type is
+already a required frontmatter field, so this costs nothing to compute.
+
+| `type` | Volatility | Rationale |
+|---|---:|---|
+| `project` | 1.00 | asserts mutable state — CI status, PR state, in-flight work |
+| `reference` | 0.60 | external resources drift without local signal |
+| `lesson` | 0.40 | technical findings; decay as the code moves |
+| `feedback` | 0.15 | process and relationship rules; settled by nature |
+| `user` | 0.10 | profile; near-static |
+
+```
+risk = unverified_age_days × volatility(type)
+```
+
+Worked against the real cases:
+
+| Memory | Age | Type | Risk |
+|---|---:|---|---:|
+| `project_pip_audit_broken` | ~56d | project | **56.0** |
+| oldest `feedback_*` files | ~66d | feedback | 9.9 |
+| `project_rag_gate_corpus_stale` | ~0d (hours) | project | **0.0** |
+
+This produces the acceptance outcome directly: the pip-audit case ranks
+top, the 2026-06-02 `feedback` bulk ranks low despite being *older*, and
+the rag-gate case is not flagged at all — which is the boundary the
+acceptance test pins.
+
+Weights are a table constant, not a tuned model. Changing them is a
+decision.
+
+---
+
+## P1 — display unverified-age + advisory sweep
+
+Scope: R2, R4, R5, and the staleness half of R6. No schema change, no
+writes to any corpus.
+
+### Module: `src/attune/memory/curated_audit.py`
+
+```python
+@dataclass(frozen=True)
+class CuratedMemory:
+    path: Path
+    name: str | None
+    description: str | None
+    mem_type: str | None              # user|feedback|project|reference
+    verified: date | None             # P2 field; None until P2 ships
+    mtime_date: date
+    unknown_keys: tuple[str, ...]     # schema violations, e.g. node_type
+    links: tuple[str, ...]            # [[slug]]
+    deferred_links: tuple[str, ...]   # [[?slug]] — legal unresolved form
+
+
+def scan_corpus(roots: Iterable[Path]) -> list[CuratedMemory]
+def unverified_age_days(mem: CuratedMemory, today: date) -> int
+def risk_score(mem: CuratedMemory, today: date) -> float
+def audit(memories, index: CorpusIndex) -> AuditReport
+def format_age_annotation(days: int) -> str      # "⟨61 days unverified⟩"
+```
+
+`AuditReport` carries: `ranked` (desc by risk), `schema_violations`,
+`broken_links`, `orphans` (file with no `MEMORY.md` pointer),
+`dangling_pointers` (pointer with no file).
+
+### The mtime stopgap, stated honestly
+
+Until P2 lands `verified:`, `unverified_age_days` falls back to file
+mtime. **mtime is a known-bad proxy** — it is the exact defect the
+principle section of the requirements names, and it under-reports risk
+for the 63 bulk-migrated files whose mtime records a reformat rather
+than a confirmation.
+
+P1 ships it anyway because a wrong-in-one-direction signal beats no
+signal, and the direction is safe: mtime makes memories look *fresher*
+than they are, so P1 under-warns rather than over-warns. The fallback is
+a single function with an explicit `# P2: prefer mem.verified` marker,
+and the report header states which basis it used. No caller branches on
+it.
+
+### Surfaces (R2)
+
+| Surface | Change |
+|---|---|
+| `personal.py` recall | append annotation to each returned entry |
+| `recall_digest.py` | annotation in digest nodes |
+| SessionStart hydration line | count of memories above a risk floor |
+| sweep CLI | full ranked report |
+
+Annotation is a pure function of `(days)`, so a surface that renders
+plain text and one that renders HTML share the same signal.
+
+### CLI: `scripts/audit_curated_memory.py`
+
+Follows the existing `audit_*.py` convention. `--roots` (repeatable),
+`--json`, `--top N`. Exit 0 always in P1 — advisory, never a gate.
+Turning it into a gate is a P3 decision that needs the review loop
+working first.
+
+### Tests
+
+Hermetic, `tmp_path` only. Real-corpus assertions in CI would violate
+the home-directory isolation guard
+(`project_test_isolation_home_dir_leaks`), and the 266-file corpus is a
+**receipt**, not a fixture.
+
+Golden set pins both directions, per requirements § Acceptance:
+
+| Fixture | Assertion |
+|---|---|
+| stale `project` memory (56d) | ranks first |
+| bulk `feedback` memories (66d) | rank below it despite greater age |
+| hours-old `project` memory | risk ≈ 0, absent from the flagged set |
+| file with `node_type:` | reported as a schema violation |
+| `[[?slug]]` | accepted, not reported as broken |
+| corpus after sweep | byte-identical (hash before/after) |
+
+The third row is the D1 boundary marker: if a later change starts
+machine-verifying or age-expiring curated claims to catch the hours-old
+case, this test fails.
+
+---
+
+## P2 — the `verified:` field and the verdict loop
+
+R1 and R3. Per D2 this is one file (`~/.claude/hooks/memory_lint.py`)
+plus its co-located test, not a cross-repo closure.
+
+- Schema gains an optional `verified: <ISO date>`. Absent reads as
+  "never verified" — the honest default for all 266 existing files, and
+  backward compatible by construction.
+- `unverified_age_days` prefers `verified:`, falls back to mtime for
+  files that predate it.
+- Verdicts (`keep` / `wrong` / `sharper`) are recorded per R3. `keep` is
+  the load-bearing one: it is the only way a true-but-old memory becomes
+  fresh without an edit.
+- `wrong` deletes the file **and** its `MEMORY.md` pointer atomically —
+  the existing atomic-write rule already requires the pair to move
+  together.
+
+P1's report is what makes P2's review loop finite: without ranking, a
+verdict loop over 266 files is a wall, which D6 warns drowns the loop.
+
+---
+
+## P3 — recall-frequency ranking
+
+Full R6. `risk = age × volatility × recall_frequency`. Requires recall
+telemetry that may not exist yet; **measure before building**, per the
+same discipline that retired R3 in the sibling spec.
+
+A memory nothing ever recalls is near-zero risk however stale. This is
+the term that converts the report from "what is old" to "what is
+actually being served to sessions," and it is the last piece needed
+before the sweep could reasonably become a gate.
+
+---
+
+## Rollback
+
+P1 is additive: a new module, a new script, and annotation strings on
+existing surfaces. Rollback is reverting the commit — no migration, no
+schema change, no state to unwind. The corpus is never written to, so
+there is nothing to restore.
+
+The one exception is outside this repo and outside P1's rollback story:
+the authorized one-off normalization of 7 schema-violating files in the
+live corpus (2026-08-07). That is backed up separately before the edit
+and is not part of the PR.

--- a/docs/specs/memory-status-integrity/requirements.md
+++ b/docs/specs/memory-status-integrity/requirements.md
@@ -1,7 +1,7 @@
 # memory-status-integrity
 
-**Status:** draft (2026-08-07 — requirements; corpus measured, awaiting
-chair ruling on OQ4)
+**Status:** approved (2026-08-07) — chair approved advancing past
+requirements; OQ2/OQ4 resolved, R5 retired
 **Owner:** Patrick (chair)
 **Origin:** Banked 2026-07-10 as a named future spec in
 `project_memory_layer_audit_todo`, gated on `spec-status-integrity`

--- a/docs/specs/memory-status-integrity/requirements.md
+++ b/docs/specs/memory-status-integrity/requirements.md
@@ -1,0 +1,335 @@
+# memory-status-integrity
+
+**Status:** draft (2026-08-07 — requirements; corpus measured, awaiting
+chair ruling on OQ4)
+**Owner:** Patrick (chair)
+**Origin:** Banked 2026-07-10 as a named future spec in
+`project_memory_layer_audit_todo`, gated on `spec-status-integrity`
+shipping. That gate closed 2026-07-11 (10/10, attune-ai #1317).
+
+**Sibling:** [memory-claim-verification](../memory-claim-verification/requirements.md)
+owns the **raw auto-stashed tier** and names the curated tier a non-goal.
+This spec is that non-goal, scoped. The two must not converge — see
+"The regime is fixed" below.
+
+---
+
+## Problem
+
+The curated tier (`/remember` → markdown under `.claude/**/memory/`,
+indexed by `MEMORY.md`, hydrated into Redis at SessionStart) has **no
+concept of verification.** Files carry a creation date by mtime and
+nothing else. Nothing re-reads a curated claim against reality, and
+nothing tells a reading session how long it has been since anyone did.
+
+Unlike the raw tier, there is no TTL, no recency decay, and no rejection
+counter. A curated memory is written once and served with full authority
+forever.
+
+### Measured drift, 2026-08-06
+
+Live count over the global corpus (`~/.claude/memory/`) plus the attune
+project corpus:
+
+| Signal | Measurement |
+|---|---|
+| Curated memories linted by `memory_lint.py --check-all` | **269** across 13 corpora |
+| Total swept (adds `~/.attune/memory/<topic>/`) | 271 |
+| **Schema / link / pointer violations** | **1** (a missing `MEMORY.md` pointer) |
+| Largest single corpus (`projects/…-attune-ai/memory`) | 107 files |
+| attune project corpus (26 files) — days since any write | 26 (last: 2026-07-11) |
+| Files last written 2026-06-02 / 2026-07-02 (global corpus) | 36 / 27 |
+
+### Correction, 2026-08-07 — the integrity premise was false
+
+An earlier draft claimed 7 schema violations and argued that "the corpus
+drifted from its own schema" because `memory_lint.py` is a PostToolUse
+hook that can only lint on write. **Both claims were wrong**, and the
+error is worth recording because it is the exact failure this spec
+exists to prevent — a confident assertion derived from a document
+rather than from the enforcement mechanism.
+
+- The 7 files carry `node_type:`, which `~/.claude/CLAUDE.md` describes
+  as forbidden. The **linter deliberately tolerates it**
+  (`memory_lint.py:188-194`): it is provenance injected by the Claude
+  Code auto-memory graph, and is flagged only when used as a
+  *substitute* for `metadata.type`. The prose is a simplification; the
+  code is the authority.
+- `memory_lint.py` **already has** `--check-all` and `all_memory_dirs()`,
+  which sweeps every per-project corpus. A comment records a 2026-07-02
+  fix for precisely the gap the draft claimed was open.
+- Running the real thing: **1 violation across 269 files.**
+
+**What survives, and is now the sharper argument:** the corpus has
+essentially no schema, link, or pointer rot. Structural integrity is
+already solved and already swept. The *only* untracked failure mode left
+is the one nothing measures — whether a claim is still true. That is a
+narrower and better-motivated problem than the one the draft described.
+
+Two readings from the measurement still stand, because both were
+observed directly rather than inferred:
+
+1. **Writes are bursty, not organic.** 63 files in the global corpus
+   share two timestamps. Those are bulk migrations, not acts of
+   confirmation — which is exactly why mtime cannot stand in for
+   verification.
+2. **The attune project corpus is 26 days cold** while PRs #45–#50
+   shipped in that window. Every one of those 26 files asserts a July
+   world, and nothing anywhere records that fact.
+
+### The two proof cases (2026-07-10)
+
+| Memory | Failure |
+|---|---|
+| `project_pip_audit_broken` | Claimed attune-ai CI red since May. Green since ≤2026-07-08. Was about to be repeated to Patrick as pushback; a one-command verify caught it. Deleted same day. |
+| `project_rag_gate_corpus_stale` | Said "full-25 go/no-go pending" *hours after* attune-author #96 completed. Nearly triggered a duplicate $3–8 API spend. |
+
+**These two cases point in opposite directions, and that is the whole
+design.** The pip-audit memory rotted over ~8 weeks — that is a
+staleness problem this spec owns. The rag-gate memory was wrong within
+**hours** — no age-based mechanism can catch it, and pretending
+otherwise is how this spec fails. Operational truth belongs to the
+short-term regime.
+
+---
+
+## The regime is fixed
+
+**D6** of `curated-memory-productionization` (complete, 2026-07-03)
+ratified that the two layers fail in opposite ways and need opposite
+truth-maintenance regimes:
+
+- **Operational / short-term** — stale is *worse than nothing* (a stale
+  "merge PR X" causes a wrong action). Regime: **machine verification
+  against ground truth at load time.**
+- **Durable / curated** — stale *fails softly*. Regime: **human review
+  verdicts over time (keep / wrong / sharper).**
+
+Merging them "would drown the review loop in expiring churn AND leave
+operational truth policed by a mechanism too slow for it — breaking
+both."
+
+**Consequence for this spec:** machine-verifying curated claims is
+excluded by prior decision, not by preference. This spec surfaces
+staleness and collects human verdicts. It never auto-edits, never
+auto-expires, and never adjudicates whether a curated claim is true.
+
+**D8**'s barbell verdict adds a delivery constraint: hook-driven layers
+demonstrably empower in-session; the structured layers (MemoryGraph,
+personal memory, Redis-via-MCP) are "mature but unoccupied — empty
+stores, and failures go unnoticed." **This ships on the hook path.**
+
+---
+
+## The principle: age is not the signal — unreviewed-ness is
+
+A curated memory's risk is a function of time since the last **human
+verdict**, not time since creation or time since last edit.
+
+mtime is the wrong proxy in both directions:
+
+- Reformatting a memory, or a bulk migration, makes a false claim look
+  freshly confirmed. 63 of 110 files have exactly this problem.
+- Re-confirming a memory *without editing it* — the most common
+  verification outcome — leaves no trace at all.
+
+**Requirement: a curated memory must record when a human last rendered
+a verdict on it, and every surface that serves it must show how long
+ago that was.**
+
+---
+
+## Requirements
+
+### R1 — `verified:` is a first-class, distinct field
+
+Curated frontmatter gains `verified: <ISO date>`, separate from creation.
+Additive and backward compatible: absent `verified:` reads as
+"never verified", which is the honest default for all 110 existing files.
+
+`memory_lint.py` enforces an exact, closed key set ("No `node_type`, no
+top-level `type:`, no other keys"), so adding a key requires amending
+the linter.
+
+**Correction (2026-08-07, measured):** an earlier draft of this
+requirement claimed the linter is part of the vendored sibling closure
+tracked by `project_hooks_canonical_drift`, making P2 expensive. That is
+**false**. `memory_lint.py` exists at exactly one path —
+`~/.claude/hooks/memory_lint.py` — and in none of the five repos
+(attune-ai, rag, gui, help, author). It has a local `test_memory_lint.py`
+beside it. The schema amendment touches one file with one test, not a
+10-file cross-repo closure. P2 is substantially cheaper than stated.
+See OQ2.
+
+### R2 — Every recall surface displays unverified-age
+
+A reader must see staleness without having to ask for it:
+
+```
+[project] attune-ai specs live in docs/specs/   ⟨61 days unverified⟩
+```
+
+The harness already does this for direct file reads — an unprompted
+`This memory is 27 days old… Verify against current code before
+asserting as fact.` banner appeared on 2026-08-06. That is proof of
+concept, and it covers exactly one surface.
+
+The surfaces attune owns and must cover:
+
+- `/recall` and `session_memory_recall`
+- the SessionStart hydration line — it announced **989 lessons** this
+  session with no age signal on any of them
+- `MEMORY.md` index rendering, where the pointer is often all a session
+  reads
+
+### R3 — Verdicts are recorded, not inferred
+
+Per D6 the regime is human verdicts. Three outcomes, each with a
+distinct effect:
+
+| Verdict | Effect |
+|---|---|
+| **keep** | stamp `verified:` = today. No content change. |
+| **wrong** | delete the file *and* its `MEMORY.md` pointer, atomically. |
+| **sharper** | edit content, stamp `verified:`. |
+
+"keep" is the load-bearing one: it is the only way a true-but-old memory
+can become fresh without being edited, and its absence today is why
+mtime lies.
+
+### R4 — The sweep is advisory and never writes
+
+A `--check-all`-style sweep over the corpus reports, and only reports:
+
+- unverified-age distribution, ranked (R6)
+- schema violations in pre-existing files — the 7 known offenders are
+  the receipt
+- `[[link]]` integrity, including the `[[?slug]]` deliberate-unresolved form
+- `MEMORY.md` pointer integrity in both directions: files with no
+  pointer, pointers with no file
+
+No auto-edit, no auto-delete, no auto-verify. The report is input to
+R3's human loop.
+
+**Scope note (2026-08-07):** for the harness-native corpus the integrity
+checks duplicate `memory_lint.py`, which already reports them. They are
+retained because the sweep also covers corpora that have **no** linter —
+attune's own `~/.attune/memory/` store — and because agreement between
+two independent implementations is itself a useful signal. On the first
+live run they agreed exactly: both found the same single violation. The
+genuinely new capability in R4 is the staleness ranking, not the
+integrity checks.
+
+### ~~R5 — Linting must be sweepable~~ — RETIRED 2026-08-07
+
+**Already implemented.** `memory_lint.py` has `--check-all` and
+`--fix-all`, and `all_memory_dirs()` covers the global corpus, every
+per-project corpus, and attune's curated store. The premise that a
+write-triggered linter could never find pre-existing drift was false.
+
+The hook is deliberately left untouched: it is stdlib-only and
+fail-open, and importing attune into it would cost both properties for
+no gain. Staleness is served by a separate advisory sweep (R4).
+
+### R6 — Review budget is bounded by rank, not by corpus size
+
+110 files is more than anyone will review, and D6 warns explicitly about
+drowning the review loop. The sweep must **rank** rather than enumerate:
+staleness × how often the memory is actually served.
+
+A 200-day-unverified memory nothing ever recalls is near-zero risk. An
+8-week-old memory injected into every session — which is precisely what
+`project_pip_audit_broken` was — is the whole problem. Unranked output
+is a wall that gets ignored, which is indistinguishable from no sweep.
+
+---
+
+## Acceptance — pin both directions
+
+The regression replays the two 2026-07-10 proof cases, and **must
+produce opposite outcomes**:
+
+| Case | Required outcome |
+|---|---|
+| `project_pip_audit_broken` (8 weeks stale, high recall) | surfaces **top-ranked** in the sweep, and carries a visible unverified-age at recall, before it can be repeated |
+| `project_rag_gate_corpus_stale` (wrong within hours) | **NOT flagged by this mechanism** — it was hours old. The test pins that the curated sweep does not claim it. |
+
+A change that catches both is as wrong as one that catches neither: the
+second row is a boundary marker. If a later change makes the curated
+sweep start machine-verifying claims in order to catch the rag-gate
+case, this test must fail loudly — that is the D6 violation, and it
+breaks both layers. Same discipline as
+`tests/unit/ci/test_platform_compat_scanner.py`, where every
+false-positive class is paired with its true positive.
+
+Additional receipts:
+
+- **Live-corpus receipt, not mocked** — the sweep runs against the real
+  110-file corpus and reports the 7 known `node_type` violations. A
+  mocked corpus would pass by construction.
+- **Backward compatibility** — all 110 existing files, none of which
+  have `verified:`, lint clean and recall correctly as "never verified".
+- **No writes** — the sweep leaves the corpus byte-identical. Assert on
+  hashes before and after.
+
+---
+
+## Non-goals
+
+- **Machine-verifying curated claims.** Excluded by D6, not by taste.
+- **Auto-editing, auto-deleting, or auto-expiring any curated memory.**
+- **TTL or recency decay on the curated tier.** That is the raw tier's
+  model and it is wrong here — it deletes true-but-old memories while
+  doing nothing about young-but-false ones.
+- **The raw session-stash tier** → `memory-claim-verification`.
+- **Operational handoff state** → the short-term reconciler path named
+  in D6.
+- **Improving what gets written.** Authoring quality is a separate
+  problem from truth maintenance.
+
+---
+
+## Phases
+
+**P1 — display unverified-age + advisory sweep (R2, R4, R5, partial R6).**
+Independently shippable, zero enforcement, zero schema change if
+unverified-age is derived from mtime as a stopgap. Catches the
+pip-audit class immediately. Worth shipping alone.
+
+**P2 — the `verified:` field and the verdict loop (R1, R3).** Carries
+the schema amendment and the sibling-closure re-sync. This is where the
+real cost is.
+
+**P3 — recall-frequency ranking (full R6).** Needs recall telemetry that
+may not exist yet; measure before building.
+
+---
+
+## Open questions
+
+1. **Does `verified:` live in frontmatter or in the Redis/graph layer?**
+   Proposal: **frontmatter** — it is diffable, survives a Redis flush,
+   and D8 found the structured stores unoccupied. Redis stays a
+   projection.
+
+2. ~~**Schema-amendment blast radius.**~~ **RESOLVED 2026-08-07 by
+   measurement.** The premise was false — `memory_lint.py` is not
+   vendored anywhere; it lives only at `~/.claude/hooks/memory_lint.py`
+   with a co-located test. One file, one test. The cost objection to P2
+   is withdrawn.
+
+3. **What drives the review cadence?** `spec-status-integrity` settled on
+   a weekly issue. Symmetry argues for the same here rather than a new
+   mechanism. Riding an existing hook also satisfies D8.
+
+4. ~~**Label, or suppress?**~~ **RULED 2026-08-07 (Patrick delegated the
+   call): label, never suppress by age.** Nothing is removed from
+   service by a clock — only by a human `wrong` verdict. The decisive
+   evidence is that **age is anti-correlated with wrongness in this
+   corpus**: the oldest bucket (36 files, 2026-06-02) is 30 `feedback`
+   + 5 `user` + 1 `lesson`, i.e. settled process rules and profile —
+   the least likely to be false and the most expensive to lose. The two
+   memories that actually rotted were `project_*` and young. Age-based
+   suppression would evict the safest memories and retain the dangerous
+   ones. Full reasoning and the rejected alternatives are recorded in
+   [decisions.md](decisions.md) §D1.

--- a/docs/specs/memory-status-integrity/tasks.md
+++ b/docs/specs/memory-status-integrity/tasks.md
@@ -1,6 +1,7 @@
 # memory-status-integrity — tasks
 
-**Status:** in-progress (2026-08-07)
+**Status:** active (2026-08-07) — P1 shipped; P2/P3 tasks unwritten until
+their phase is approved
 **Design:** [design.md](design.md) · **Decisions:** [decisions.md](decisions.md)
 
 P1 only. P2/P3 tasks are written when their phase is approved.

--- a/docs/specs/memory-status-integrity/tasks.md
+++ b/docs/specs/memory-status-integrity/tasks.md
@@ -1,0 +1,41 @@
+# memory-status-integrity — tasks
+
+**Status:** in-progress (2026-08-07)
+**Design:** [design.md](design.md) · **Decisions:** [decisions.md](decisions.md)
+
+P1 only. P2/P3 tasks are written when their phase is approved.
+
+## P1 implementation order
+
+| # | Task | Layer | Status | Notes |
+|---|------|-------|--------|-------|
+| 1 | `curated_audit.py` — parse, scan, age, risk, annotate | attune-ai | done | pure library; no corpus paths hardcoded |
+| 2 | `AuditReport` — violations, links, pointer integrity, ranking | attune-ai | done | matches the canonical linter's tolerances (D4) |
+| 3 | Hermetic tests, golden set pinning both directions | attune-ai | done | 30 tests, `tmp_path` only |
+| 4 | `scripts/audit_curated_memory.py` CLI | attune-ai | done | advisory, always exit 0 |
+| 5 | Wire unverified-age annotation into recall surfaces | attune-ai | done | `PersonalMemory.query()`; labels only, never reorders |
+| 6 | ~~Sweep entry point in `memory_lint.py`~~ | personal | **void** | already implemented (`--check-all`); hook left untouched |
+| 7 | ~~Normalize 7 `node_type:` violations~~ | personal | **void** | not violations — provenance is tolerated (D4). Corpus untouched. |
+| 8 | Live-corpus receipt over 271 files | receipt | done | 1 violation, matching `memory_lint` exactly; corpus byte-identical |
+
+## Testing strategy
+
+Unit tests only, all hermetic. The library is pure functions over a
+directory of markdown, so fixtures are cheap and the real corpus is
+never touched by CI.
+
+The golden set must pin **both directions** — a change that flags
+everything fails as loudly as one that flags nothing. The hours-old
+`project` fixture is the D1 boundary marker.
+
+Explicitly not tested in CI: the 266-file corpus. That is a receipt run
+recorded in the PR. A test that reads the real home directory would
+violate `project_test_isolation_home_dir_leaks`.
+
+## Rollback plan
+
+Revert the commit. P1 is additive — new module, new script, annotation
+strings. No schema change, no migration, no corpus writes.
+
+The authorized corpus normalization (task 7) is outside the PR and is
+backed up to a timestamped tarball before the edit.

--- a/scripts/audit_curated_memory.py
+++ b/scripts/audit_curated_memory.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""Advisory staleness sweep over curated markdown memory corpora.
+
+Reports which curated memories most need a human verdict, plus corpus
+integrity problems (schema violations, broken links, index-pointer drift).
+
+**Advisory only.** This script never writes to a corpus and always exits 0 —
+it is not a gate. Turning it into one requires the review loop from P2 and
+the recall-frequency term from P3; see
+``docs/specs/memory-status-integrity/design.md``.
+
+Usage:
+    python scripts/audit_curated_memory.py
+    python scripts/audit_curated_memory.py --root ~/.attune/memory --top 10
+    python scripts/audit_curated_memory.py --json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+def default_roots() -> list[Path]:
+    """Return the curated corpora present on this machine.
+
+    The library hardcodes no paths (design D3); this CLI is a caller and may
+    offer conveniences. Missing roots are simply absent from the result.
+    """
+    home = Path.home()
+    candidates = [home / ".attune" / "memory", home / ".claude" / "memory"]
+    projects = home / ".claude" / "projects"
+    if projects.is_dir():
+        candidates.extend(sorted(projects.glob("*/memory")))
+    return [path for path in candidates if path.is_dir()]
+
+
+def _format_report(report, top: int) -> str:
+    """Render the advisory report as plain text."""
+    lines: list[str] = []
+    lines.append(f"Scanned {report.scanned} curated memories in {len(report.roots)} root(s)")
+    lines.append(f"Age basis: {report.age_basis}")
+    if report.age_basis == "mtime":
+        lines.append(
+            "  note: mtime records the last EDIT, not the last verification — "
+            "bulk reformats read as fresh. Resolved when `verified:` ships (P2)."
+        )
+    lines.append("")
+
+    lines.append(f"── Review priority (age x type volatility), top {top} ──")
+    for mem, score in report.ranked[:top]:
+        mem_type = mem.mem_type or "?"
+        lines.append(f"  {score:8.1f}  [{mem_type:9}] {mem.stem}")
+    if not report.ranked:
+        lines.append("  (none)")
+    lines.append("")
+
+    def section(title: str, rows: list[str]) -> None:
+        lines.append(f"── {title} ({len(rows)}) ──")
+        if rows:
+            lines.extend(f"  {row}" for row in rows)
+        else:
+            lines.append("  (none)")
+        lines.append("")
+
+    section(
+        "Schema violations",
+        [f"{path.name}: {', '.join(keys)}" for path, keys in report.schema_violations],
+    )
+    section("name: does not match filename", [p.name for p in report.name_mismatches])
+    section("Broken [[links]]", [f"{path.name} -> {link}" for path, link in report.broken_links])
+    section("Memories with no MEMORY.md pointer", [p.name for p in report.orphans])
+    section(
+        "Pointers with no memory file",
+        [f"{index.parent.name}/MEMORY.md -> {stem}" for index, stem in report.dangling_pointers],
+    )
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the sweep. Always returns 0 — advisory, never a gate."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--root",
+        action="append",
+        type=Path,
+        dest="roots",
+        help="Corpus root to scan (repeatable). Defaults to the corpora found on this machine.",
+    )
+    parser.add_argument("--top", type=int, default=15, help="How many ranked rows to show.")
+    parser.add_argument("--json", action="store_true", help="Emit JSON instead of text.")
+    args = parser.parse_args(argv)
+
+    repo = Path(__file__).resolve().parent.parent
+    src = repo / "src"
+    if src.is_dir() and str(src) not in sys.path:
+        sys.path.insert(0, str(src))
+
+    from attune.memory.curated_audit import sweep, unverified_age_days
+
+    roots = args.roots or default_roots()
+    if not roots:
+        print("No curated memory corpora found.")
+        return 0
+
+    report = sweep(roots)
+
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "scanned": report.scanned,
+                    "age_basis": report.age_basis,
+                    "roots": [str(r) for r in report.roots],
+                    "ranked": [
+                        {
+                            "stem": mem.stem,
+                            "type": mem.mem_type,
+                            "unverified_days": unverified_age_days(mem),
+                            "risk": round(score, 2),
+                            "path": str(mem.path),
+                        }
+                        for mem, score in report.ranked[: args.top]
+                    ],
+                    "schema_violations": [
+                        {"path": str(p), "keys": list(k)} for p, k in report.schema_violations
+                    ],
+                    "name_mismatches": [str(p) for p in report.name_mismatches],
+                    "broken_links": [
+                        {"path": str(p), "link": link} for p, link in report.broken_links
+                    ],
+                    "orphans": [str(p) for p in report.orphans],
+                    "dangling_pointers": [
+                        {"index": str(i), "stem": s} for i, s in report.dangling_pointers
+                    ],
+                },
+                indent=2,
+            )
+        )
+    else:
+        print(_format_report(report, args.top))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/attune/memory/curated_audit.py
+++ b/src/attune/memory/curated_audit.py
@@ -1,0 +1,466 @@
+"""Advisory staleness audit for curated markdown memory corpora.
+
+Curated memories are human-authored markdown files with YAML frontmatter,
+indexed by a sibling ``MEMORY.md``. Unlike the raw session stash they carry
+no TTL and no recency decay, so nothing tells a reading session how long it
+has been since anyone confirmed a claim is still true.
+
+This module supplies that signal. It is **advisory by construction** — every
+function here is a pure read. Nothing in this module writes to a corpus,
+deletes a memory, or decides whether a claim is true.
+
+Two rules from ``docs/specs/memory-status-integrity/decisions.md`` are load
+bearing here, and both are easy to violate by accident:
+
+D1 — **Label, never suppress by age.** Age is *anti-correlated* with
+wrongness in a real corpus: the oldest memories are settled ``feedback`` and
+``user`` rules, while the memories that actually rot assert mutable state.
+Nothing here may filter a memory out of a result on the basis of age.
+
+D3 — **No corpus path is hardcoded.** Callers supply roots, which is what
+lets one implementation serve both the attune-shipped store and a personal
+corpus living outside every repo.
+
+Copyright 2025 Smart AI Memory, LLC
+Licensed under the Apache License, Version 2.0
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass, field
+from datetime import date, datetime, timezone
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+#: Frontmatter keys the curated schema permits at the top level.
+ALLOWED_TOP_LEVEL_KEYS = frozenset({"name", "description", "metadata"})
+
+#: Keys the curated schema permits inside ``metadata:``.
+ALLOWED_METADATA_KEYS = frozenset({"type"})
+
+#: Extra keys under ``metadata:`` are provenance injected by the Claude Code
+#: auto-memory graph (``node_type``, ``originSessionId``, …), not drift.
+#:
+#: The canonical linter (``~/.claude/hooks/memory_lint.py``) tolerates them
+#: whenever a valid ``metadata.type`` is present, and flags ``node_type`` only
+#: when it is used as a *substitute* for ``metadata.type`` — the original
+#: schema drift the rule was written to catch. This module matches that
+#: behaviour deliberately: reporting provenance as a violation would put the
+#: sweep in permanent disagreement with the enforcement mechanism and train
+#: readers to ignore it.
+TOLERATE_METADATA_PROVENANCE = True
+
+#: Recognised memory types.
+KNOWN_TYPES = frozenset({"user", "feedback", "project", "reference", "lesson"})
+
+#: How fast a claim of each type goes stale, per design.md § ranking model.
+#:
+#: These scale age into risk. ``project`` memories assert mutable state (CI
+#: status, PR state, in-flight work) and rot fastest; ``feedback`` and
+#: ``user`` encode settled process rules and profile, and barely rot at all.
+#: Ranking by raw age instead would march a reviewer through correct process
+#: rules before reaching the one stale CI claim — the same sign error D1
+#: rejects for suppression.
+VOLATILITY_BY_TYPE: dict[str, float] = {
+    "project": 1.00,
+    "reference": 0.60,
+    "lesson": 0.40,
+    "feedback": 0.15,
+    "user": 0.10,
+}
+
+#: Volatility for a memory whose type is missing or unrecognised. Deliberately
+#: high — an unclassifiable memory should surface for review, not hide.
+DEFAULT_VOLATILITY = 0.75
+
+#: The index file that must carry a pointer for every memory.
+INDEX_FILENAME = "MEMORY.md"
+
+_FRONTMATTER_RE = re.compile(r"\A---\s*\n(.*?)\n---\s*(?:\n|\Z)", re.DOTALL)
+_LINK_RE = re.compile(r"\[\[([^\]]+)\]\]")
+_INDEX_LINK_RE = re.compile(r"\]\(([^)]+\.md)\)")
+
+
+@dataclass(frozen=True)
+class CuratedMemory:
+    """One curated memory file, parsed but not judged."""
+
+    path: Path
+    name: str | None
+    description: str | None
+    mem_type: str | None
+    verified: date | None
+    mtime_date: date
+    unknown_keys: tuple[str, ...]
+    links: tuple[str, ...]
+    deferred_links: tuple[str, ...]
+
+    @property
+    def stem(self) -> str:
+        """Filename without the ``.md`` suffix — the corpus-wide identity."""
+        return self.path.stem
+
+
+@dataclass(frozen=True)
+class AuditReport:
+    """The result of an advisory sweep. Purely descriptive."""
+
+    ranked: tuple[tuple[CuratedMemory, float], ...] = ()
+    schema_violations: tuple[tuple[Path, tuple[str, ...]], ...] = ()
+    name_mismatches: tuple[Path, ...] = ()
+    broken_links: tuple[tuple[Path, str], ...] = ()
+    orphans: tuple[Path, ...] = ()
+    dangling_pointers: tuple[tuple[Path, str], ...] = ()
+    age_basis: str = "mtime"
+    scanned: int = 0
+    roots: tuple[Path, ...] = field(default=())
+
+    @property
+    def clean(self) -> bool:
+        """True when no integrity problem was found (staleness aside)."""
+        return not (
+            self.schema_violations
+            or self.name_mismatches
+            or self.broken_links
+            or self.orphans
+            or self.dangling_pointers
+        )
+
+
+def _parse_frontmatter(text: str) -> tuple[dict[str, str], list[str], str]:
+    """Parse the fixed two-level curated schema without a YAML dependency.
+
+    The curated schema is shallow and closed: three permitted top-level keys,
+    one permitted key inside ``metadata``. Parsing it directly keeps this
+    module importable anywhere and avoids depending on a YAML library that
+    the consuming layer may not install.
+
+    Args:
+        text: Full file contents.
+
+    Returns:
+        ``(fields, unknown_keys, body)``. ``fields`` maps a normalised key
+        (``name``, ``description``, ``metadata.type``, ``verified``) to its
+        raw string value. ``unknown_keys`` lists keys the schema forbids,
+        nested ones prefixed ``metadata.``.
+    """
+    match = _FRONTMATTER_RE.match(text)
+    if not match:
+        return {}, [], text
+
+    block = match.group(1)
+    body = text[match.end() :]
+    fields: dict[str, str] = {}
+    unknown: list[str] = []
+    in_metadata = False
+
+    for raw_line in block.splitlines():
+        if not raw_line.strip() or raw_line.lstrip().startswith("#"):
+            continue
+
+        indented = raw_line[:1].isspace()
+        line = raw_line.strip()
+        if ":" not in line:
+            continue
+        key, _, value = line.partition(":")
+        key = key.strip()
+        value = value.strip().strip("\"'")
+
+        if indented and in_metadata:
+            if key in ALLOWED_METADATA_KEYS:
+                fields[f"metadata.{key}"] = value
+            else:
+                unknown.append(f"metadata.{key}")
+            continue
+
+        in_metadata = key == "metadata"
+        if key == "metadata":
+            continue
+        # ``verified:`` is the P2 field. Tolerated (never flagged) before P2
+        # ships so an early adopter's file does not read as a violation.
+        if key == "verified":
+            fields["verified"] = value
+        elif key in ALLOWED_TOP_LEVEL_KEYS:
+            fields[key] = value
+        else:
+            unknown.append(key)
+
+    return fields, unknown, body
+
+
+def _parse_date(value: str | None) -> date | None:
+    """Parse an ISO-8601 date, tolerating a full timestamp. None when unusable."""
+    if not value:
+        return None
+    try:
+        return date.fromisoformat(value[:10])
+    except ValueError:
+        logger.debug("unparseable verified date: %r", value)
+        return None
+
+
+def load_memory(path: Path) -> CuratedMemory:
+    """Parse a single curated memory file.
+
+    Never raises on malformed content — a file that cannot be parsed still
+    yields a ``CuratedMemory`` with empty fields, because a sweep that dies
+    on one bad file reports nothing about the other 265.
+
+    Args:
+        path: Path to a ``.md`` memory file.
+
+    Returns:
+        The parsed memory.
+    """
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError) as exc:
+        logger.warning("unreadable memory %s: %s", path, exc)
+        text = ""
+
+    fields, unknown, body = _parse_frontmatter(text)
+    # Provenance keys under ``metadata:`` are legitimate when the memory
+    # carries a valid type — see TOLERATE_METADATA_PROVENANCE. When the type
+    # is missing or unrecognised they stay reported, because that is the
+    # substitute-for-type drift the canonical linter exists to catch.
+    if TOLERATE_METADATA_PROVENANCE and fields.get("metadata.type") in KNOWN_TYPES:
+        unknown = [key for key in unknown if not key.startswith("metadata.")]
+
+    all_links = _LINK_RE.findall(body)
+    try:
+        mtime = datetime.fromtimestamp(path.stat().st_mtime, tz=timezone.utc).date()
+    except OSError:
+        mtime = date.today()
+
+    return CuratedMemory(
+        path=path,
+        name=fields.get("name"),
+        description=fields.get("description"),
+        mem_type=fields.get("metadata.type"),
+        verified=_parse_date(fields.get("verified")),
+        mtime_date=mtime,
+        unknown_keys=tuple(unknown),
+        links=tuple(link for link in all_links if not link.startswith("?")),
+        deferred_links=tuple(link[1:] for link in all_links if link.startswith("?")),
+    )
+
+
+def scan_corpus(roots: Iterable[Path]) -> list[CuratedMemory]:
+    """Load every curated memory under the given roots.
+
+    Args:
+        roots: Directories to scan, recursively. Missing roots are skipped.
+
+    Returns:
+        Parsed memories, sorted by path. The index file itself is excluded.
+    """
+    memories: list[CuratedMemory] = []
+    seen: set[Path] = set()
+    for root in roots:
+        if not root.is_dir():
+            logger.debug("skipping missing corpus root: %s", root)
+            continue
+        for path in sorted(root.rglob("*.md")):
+            if path.name == INDEX_FILENAME or path in seen:
+                continue
+            seen.add(path)
+            memories.append(load_memory(path))
+    return memories
+
+
+def unverified_age_days(mem: CuratedMemory, today: date | None = None) -> int:
+    """Days since a human last confirmed this memory is still true.
+
+    P2 will supply a real ``verified:`` date. Until then this falls back to
+    file mtime, which is a **known-bad proxy**: it records the last edit, so a
+    bulk reformat reads as a fresh confirmation. The fallback ships anyway
+    because it errs in the safe direction — mtime makes memories look
+    *fresher* than they are, so the signal under-warns rather than
+    over-warns.
+
+    Args:
+        mem: The memory to age.
+        today: Reference date; defaults to the current date. Injectable so
+            tests need no clock control.
+
+    Returns:
+        Whole days, floored at zero.
+    """
+    reference = today or date.today()
+    # P2: prefer mem.verified once the schema carries it.
+    basis = mem.verified or mem.mtime_date
+    return max(0, (reference - basis).days)
+
+
+def volatility(mem_type: str | None) -> float:
+    """Return how fast this memory type goes stale. See VOLATILITY_BY_TYPE."""
+    if mem_type is None:
+        return DEFAULT_VOLATILITY
+    return VOLATILITY_BY_TYPE.get(mem_type, DEFAULT_VOLATILITY)
+
+
+def risk_score(mem: CuratedMemory, today: date | None = None) -> float:
+    """Rank a memory's need for human review: age scaled by type volatility.
+
+    This orders *review attention* only. Per D1 it must never be used to drop
+    a memory from a recall result — a high score means "ask a human", not
+    "hide it".
+
+    Args:
+        mem: The memory to score.
+        today: Reference date; defaults to the current date.
+
+    Returns:
+        A non-negative score. Higher means review sooner.
+    """
+    return unverified_age_days(mem, today) * volatility(mem.mem_type)
+
+
+def format_age_annotation(days: int) -> str:
+    """Render the reader-facing staleness label.
+
+    A pure function of days so plain-text and HTML surfaces emit the same
+    signal. This annotation is the entire mitigation for D1's label-only
+    posture, which is why it is mandatory on every recall surface rather
+    than optional decoration.
+
+    Args:
+        days: Days unverified, from :func:`unverified_age_days`.
+
+    Returns:
+        A short parenthetical, e.g. ``⟨61 days unverified⟩``.
+    """
+    if days <= 0:
+        return "⟨verified today⟩"
+    if days == 1:
+        return "⟨1 day unverified⟩"
+    return f"⟨{days} days unverified⟩"
+
+
+def annotate(text: str, mem: CuratedMemory, today: date | None = None) -> str:
+    """Append the staleness label to a rendered memory line.
+
+    Args:
+        text: The already-rendered memory text.
+        mem: The memory it came from.
+        today: Reference date; defaults to the current date.
+
+    Returns:
+        ``text`` with the annotation appended.
+    """
+    return f"{text}  {format_age_annotation(unverified_age_days(mem, today))}"
+
+
+def _index_texts(roots: Iterable[Path]) -> dict[Path, str]:
+    """Map each directory containing an index to that index's raw text."""
+    texts: dict[Path, str] = {}
+    for root in roots:
+        if not root.is_dir():
+            continue
+        for index in sorted(root.rglob(INDEX_FILENAME)):
+            try:
+                texts[index.parent] = index.read_text(encoding="utf-8")
+            except (OSError, UnicodeDecodeError) as exc:
+                logger.warning("unreadable index %s: %s", index, exc)
+    return texts
+
+
+def _is_pointed_at(stem: str, index_text: str) -> bool:
+    """True when the index mentions this memory in any form.
+
+    The canonical linter accepts a bare ``stem.md`` mention as well as a
+    markdown link, because some indexes are tables rather than link lists.
+    Matching only the link form reported 21 false orphans against the real
+    corpus on 2026-08-07 — the requirement is "indexed", not a syntax.
+    """
+    return f"{stem}.md" in index_text
+
+
+def audit(
+    memories: Sequence[CuratedMemory],
+    roots: Iterable[Path] = (),
+    today: date | None = None,
+) -> AuditReport:
+    """Produce an advisory report over already-scanned memories.
+
+    Checks corpus integrity (schema, link resolution, index pointers in both
+    directions) and ranks every memory by review priority. Writes nothing.
+
+    Args:
+        memories: Parsed memories, typically from :func:`scan_corpus`.
+        roots: Corpus roots, used to locate ``MEMORY.md`` index files. When
+            omitted, pointer integrity is skipped rather than failed.
+        today: Reference date; defaults to the current date.
+
+    Returns:
+        The report. ``ranked`` is ordered by descending risk.
+    """
+    roots = tuple(roots)
+    known_stems = {mem.stem for mem in memories}
+
+    schema_violations = tuple((mem.path, mem.unknown_keys) for mem in memories if mem.unknown_keys)
+    # ``name:`` must equal the filename stem — a mismatch breaks every
+    # [[link]] that targets it, silently.
+    name_mismatches = tuple(
+        mem.path for mem in memories if mem.name is not None and mem.name != mem.stem
+    )
+    broken_links = tuple(
+        (mem.path, link) for mem in memories for link in mem.links if link not in known_stems
+    )
+
+    orphans: tuple[Path, ...] = ()
+    dangling: tuple[tuple[Path, str], ...] = ()
+    if roots:
+        index_texts = _index_texts(roots)
+        # A corpus with no MEMORY.md carries no pointer requirement — the
+        # canonical linter self-skips it, and attune's own curated store is
+        # exactly that shape. Reporting its files as orphans is noise.
+        orphans = tuple(
+            mem.path
+            for mem in memories
+            if mem.path.parent in index_texts
+            and not _is_pointed_at(mem.stem, index_texts[mem.path.parent])
+        )
+        dangling = tuple(
+            (directory / INDEX_FILENAME, stem)
+            for directory, text in index_texts.items()
+            for stem in sorted({Path(t).stem for t in _INDEX_LINK_RE.findall(text)} - known_stems)
+        )
+
+    ranked = tuple(
+        sorted(
+            ((mem, risk_score(mem, today)) for mem in memories),
+            key=lambda pair: (-pair[1], str(pair[0].path)),
+        )
+    )
+    uses_verified = any(mem.verified is not None for mem in memories)
+
+    return AuditReport(
+        ranked=ranked,
+        schema_violations=schema_violations,
+        name_mismatches=name_mismatches,
+        broken_links=broken_links,
+        orphans=orphans,
+        dangling_pointers=dangling,
+        age_basis="verified" if uses_verified else "mtime",
+        scanned=len(memories),
+        roots=roots,
+    )
+
+
+def sweep(roots: Iterable[Path], today: date | None = None) -> AuditReport:
+    """Scan and audit in one call — the entry point callers usually want.
+
+    Args:
+        roots: Corpus roots to scan recursively.
+        today: Reference date; defaults to the current date.
+
+    Returns:
+        The advisory report.
+    """
+    roots = tuple(roots)
+    return audit(scan_corpus(roots), roots=roots, today=today)

--- a/src/attune/memory/curated_audit.py
+++ b/src/attune/memory/curated_audit.py
@@ -31,7 +31,7 @@ import logging
 import re
 from collections.abc import Iterable, Sequence
 from dataclasses import dataclass, field
-from datetime import date, datetime, timezone
+from datetime import date, datetime
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
@@ -232,7 +232,11 @@ def load_memory(path: Path) -> CuratedMemory:
 
     all_links = _LINK_RE.findall(body)
     try:
-        mtime = datetime.fromtimestamp(path.stat().st_mtime, tz=timezone.utc).date()
+        # Local date, deliberately — it is compared against ``date.today()``,
+        # which is also local. Reading mtime as UTC while comparing to a local
+        # today put every non-UTC user off by a day (caught by the clock-tz
+        # matrix in America/Anchorage: 60 where 61 was correct).
+        mtime = datetime.fromtimestamp(path.stat().st_mtime).date()
     except OSError:
         mtime = date.today()
 

--- a/src/attune/memory/personal.py
+++ b/src/attune/memory/personal.py
@@ -278,7 +278,11 @@ class PersonalMemory:
         would violate D1 (label, never suppress by age).
 
         Failures are swallowed: a missing file or unreadable stat must not
-        cost the caller their recall results.
+        cost the caller their recall results. The handler is narrow on
+        purpose — ``load_memory`` already absorbs its own I/O errors, so the
+        only escapes left here are a malformed hit dict or a path the OS
+        refuses. Catching broadly would add a site to the shrink-only
+        broad-except ratchet for no coverage gain.
         """
         for hit in hits:
             try:
@@ -289,7 +293,7 @@ class PersonalMemory:
                 days = unverified_age_days(mem)
                 hit["unverified_days"] = days
                 hit["staleness"] = format_age_annotation(days)
-            except Exception:  # noqa: BLE001
+            except (KeyError, OSError, ValueError):
                 logger.debug("staleness_annotation_failed path=%s", hit.get("path"))
 
     def _resolve_hit_path(self, path_str: str) -> Path | None:

--- a/src/attune/memory/personal.py
+++ b/src/attune/memory/personal.py
@@ -17,6 +17,12 @@ import shutil
 from pathlib import Path
 from typing import Any
 
+from attune.memory.curated_audit import (
+    format_age_annotation,
+    load_memory,
+    unverified_age_days,
+)
+
 logger = logging.getLogger(__name__)
 
 _GLOBAL_ROOT = Path.home() / ".attune" / "memory"
@@ -259,7 +265,42 @@ class PersonalMemory:
                 best[hit["path"]] = hit
 
         deduped = sorted(best.values(), key=lambda h: h["score"], reverse=True)
-        return deduped[:k]
+        results = deduped[:k]
+        self._annotate_staleness(results)
+        return results
+
+    def _annotate_staleness(self, hits: list[dict[str, Any]]) -> None:
+        """Add unverified-age to each hit, in place.
+
+        Per ``docs/specs/memory-status-integrity`` R2, a reader must see how
+        long it has been since a claim was confirmed without having to ask.
+        The annotation only labels — it never reorders or drops a hit, which
+        would violate D1 (label, never suppress by age).
+
+        Failures are swallowed: a missing file or unreadable stat must not
+        cost the caller their recall results.
+        """
+        for hit in hits:
+            try:
+                path = self._resolve_hit_path(hit["path"])
+                if path is None:
+                    continue
+                mem = load_memory(path)
+                days = unverified_age_days(mem)
+                hit["unverified_days"] = days
+                hit["staleness"] = format_age_annotation(days)
+            except Exception:  # noqa: BLE001
+                logger.debug("staleness_annotation_failed path=%s", hit.get("path"))
+
+    def _resolve_hit_path(self, path_str: str) -> Path | None:
+        """Resolve a corpus-relative hit path against the known roots."""
+        for root in (self._project_root, self._global_root):
+            if root is None:
+                continue
+            candidate = root / path_str
+            if candidate.is_file():
+                return candidate
+        return None
 
     def list_topics(self) -> list[str]:
         """Return sorted list of topic slugs across global and project memory."""

--- a/tests/unit/memory/test_curated_audit.py
+++ b/tests/unit/memory/test_curated_audit.py
@@ -13,8 +13,8 @@ from __future__ import annotations
 
 import hashlib
 import os
-import time
-from datetime import date
+from datetime import date, datetime, timedelta
+from datetime import time as clock_time
 from pathlib import Path
 
 import pytest
@@ -33,7 +33,6 @@ from attune.memory.curated_audit import (
 )
 
 TODAY = date(2026, 8, 7)
-_DAY_SECONDS = 86400
 
 
 def write_memory(
@@ -61,7 +60,12 @@ def write_memory(
         f"{body}\n",
         encoding="utf-8",
     )
-    stamp = time.time() - age_days * _DAY_SECONDS
+    # Anchor to local NOON of the target date rather than subtracting raw
+    # seconds from now. Second-arithmetic lands on an arbitrary wall-clock
+    # time, so a run near local midnight — or across a DST transition —
+    # backdates to the wrong calendar day and the age assertions drift by one.
+    target = date.today() - timedelta(days=age_days)
+    stamp = datetime.combine(target, clock_time(12, 0)).timestamp()
     os.utime(path, (stamp, stamp))
     return path
 

--- a/tests/unit/memory/test_curated_audit.py
+++ b/tests/unit/memory/test_curated_audit.py
@@ -1,0 +1,312 @@
+"""Tests for the advisory curated-memory staleness audit.
+
+Every fixture is built under ``tmp_path``. Nothing here reads the real home
+directory — a test that did would leak a machine-specific dependency into CI
+and violate the home-directory isolation guard.
+
+The ranking tests pin **both directions**. A change that flags everything
+must fail as loudly as one that flags nothing; see
+``docs/specs/memory-status-integrity/requirements.md`` § Acceptance.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import time
+from datetime import date
+from pathlib import Path
+
+import pytest
+
+from attune.memory.curated_audit import (
+    DEFAULT_VOLATILITY,
+    annotate,
+    audit,
+    format_age_annotation,
+    load_memory,
+    risk_score,
+    scan_corpus,
+    sweep,
+    unverified_age_days,
+    volatility,
+)
+
+TODAY = date(2026, 8, 7)
+_DAY_SECONDS = 86400
+
+
+def write_memory(
+    root: Path,
+    stem: str,
+    mem_type: str = "project",
+    *,
+    description: str = "a memory",
+    body: str = "The claim.",
+    age_days: int = 0,
+    extra_frontmatter: str = "",
+    name: str | None = None,
+) -> Path:
+    """Write one curated memory and backdate its mtime by ``age_days``."""
+    root.mkdir(parents=True, exist_ok=True)
+    path = root / f"{stem}.md"
+    path.write_text(
+        "---\n"
+        f"name: {name if name is not None else stem}\n"
+        f"description: {description}\n"
+        "metadata:\n"
+        f"  type: {mem_type}\n"
+        f"{extra_frontmatter}"
+        "---\n\n"
+        f"{body}\n",
+        encoding="utf-8",
+    )
+    stamp = time.time() - age_days * _DAY_SECONDS
+    os.utime(path, (stamp, stamp))
+    return path
+
+
+def write_index(root: Path, stems: list[str]) -> Path:
+    """Write a MEMORY.md index pointing at the given stems."""
+    lines = [f"- [{stem}]({stem}.md) — hook" for stem in stems]
+    path = root / "MEMORY.md"
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return path
+
+
+class TestParsing:
+    def test_parses_the_mandated_schema(self, tmp_path: Path) -> None:
+        path = write_memory(tmp_path, "project_thing", "project", description="hi")
+        mem = load_memory(path)
+        assert mem.name == "project_thing"
+        assert mem.description == "hi"
+        assert mem.mem_type == "project"
+        assert mem.unknown_keys == ()
+
+    def test_provenance_key_is_tolerated_alongside_a_valid_type(self, tmp_path: Path) -> None:
+        """``node_type`` is platform provenance, not drift.
+
+        The canonical linter (~/.claude/hooks/memory_lint.py, lines 188-194)
+        tolerates it whenever a valid ``metadata.type`` is present. Reporting
+        it as a violation would put this sweep in permanent disagreement with
+        the enforcement mechanism — and did, until a live ``--check-all`` run
+        on 2026-08-07 showed the real corpus at 0 violations.
+        """
+        path = write_memory(tmp_path, "p_one", extra_frontmatter="  node_type: memory\n")
+        assert load_memory(path).unknown_keys == ()
+
+    def test_provenance_key_is_flagged_when_it_substitutes_for_type(self, tmp_path: Path) -> None:
+        """The drift the rule was actually written to catch."""
+        path = write_memory(
+            tmp_path, "p_one_b", mem_type="bogus", extra_frontmatter="  node_type: memory\n"
+        )
+        assert "metadata.node_type" in load_memory(path).unknown_keys
+
+    def test_flags_forbidden_top_level_key(self, tmp_path: Path) -> None:
+        path = write_memory(tmp_path, "p_two", extra_frontmatter="type: project\n")
+        assert "type" in load_memory(path).unknown_keys
+
+    def test_verified_field_is_tolerated_before_p2(self, tmp_path: Path) -> None:
+        """A file carrying the future P2 key must not read as a violation."""
+        path = write_memory(tmp_path, "p_three", extra_frontmatter="verified: 2026-08-01\n")
+        mem = load_memory(path)
+        assert mem.verified == date(2026, 8, 1)
+        assert mem.unknown_keys == ()
+
+    def test_deferred_link_is_not_a_link(self, tmp_path: Path) -> None:
+        path = write_memory(tmp_path, "p_four", body="See [[?not_yet]] and [[real]].")
+        mem = load_memory(path)
+        assert mem.links == ("real",)
+        assert mem.deferred_links == ("not_yet",)
+
+    def test_unreadable_file_does_not_raise(self, tmp_path: Path) -> None:
+        """One bad file must not stop the sweep reporting on the rest."""
+        path = tmp_path / "broken.md"
+        path.write_bytes(b"\xff\xfe not utf-8")
+        assert load_memory(path).name is None
+
+
+class TestAge:
+    def test_age_from_mtime_when_unverified(self, tmp_path: Path) -> None:
+        path = write_memory(tmp_path, "p_age", age_days=61)
+        assert unverified_age_days(load_memory(path), date.today()) == 61
+
+    def test_verified_date_wins_over_mtime(self, tmp_path: Path) -> None:
+        path = write_memory(
+            tmp_path,
+            "p_verified",
+            age_days=61,
+            extra_frontmatter="verified: 2026-08-05\n",
+        )
+        assert unverified_age_days(load_memory(path), TODAY) == 2
+
+    def test_age_never_negative(self, tmp_path: Path) -> None:
+        path = write_memory(tmp_path, "p_future", extra_frontmatter="verified: 2099-01-01\n")
+        assert unverified_age_days(load_memory(path), TODAY) == 0
+
+
+class TestAnnotation:
+    @pytest.mark.parametrize(
+        ("days", "expected"),
+        [(0, "verified today"), (1, "1 day unverified"), (61, "61 days unverified")],
+    )
+    def test_annotation_text(self, days: int, expected: str) -> None:
+        assert expected in format_age_annotation(days)
+
+    def test_annotate_appends_to_rendered_text(self, tmp_path: Path) -> None:
+        path = write_memory(tmp_path, "p_ann", age_days=5)
+        out = annotate("the memory line", load_memory(path), date.today())
+        assert out.startswith("the memory line")
+        assert "5 days unverified" in out
+
+
+class TestRankingPinsBothDirections:
+    """The core acceptance from requirements § Acceptance.
+
+    Age alone is the wrong ranking signal — see decisions.md D1. These tests
+    fail if someone reverts risk to raw age, and they fail if someone starts
+    treating the hours-old case as catchable by staleness.
+    """
+
+    def test_stale_project_outranks_older_feedback(self, tmp_path: Path) -> None:
+        write_memory(tmp_path, "project_pip_audit_broken", "project", age_days=56)
+        for i in range(3):
+            write_memory(tmp_path, f"feedback_rule_{i}", "feedback", age_days=66)
+
+        report = audit(scan_corpus([tmp_path]), roots=[tmp_path])
+        top = report.ranked[0][0]
+
+        assert top.stem == "project_pip_audit_broken", (
+            "the stale project memory must rank first even though the "
+            "feedback rules are older — ranking by raw age is the sign error "
+            "D1 rejects"
+        )
+
+    def test_hours_old_project_memory_is_not_flagged(self, tmp_path: Path) -> None:
+        """D1 boundary marker.
+
+        ``project_rag_gate_corpus_stale`` was wrong within hours. No
+        age-based mechanism can catch it, and this spec must not pretend to.
+        If a later change makes the curated sweep start machine-verifying
+        claims in order to catch this case, this test fails — that is the
+        intent.
+        """
+        write_memory(tmp_path, "project_rag_gate_corpus_stale", "project", age_days=0)
+        write_memory(tmp_path, "project_old_thing", "project", age_days=40)
+
+        report = audit(scan_corpus([tmp_path]), roots=[tmp_path])
+        scores = {mem.stem: score for mem, score in report.ranked}
+
+        assert scores["project_rag_gate_corpus_stale"] == 0.0
+        assert report.ranked[-1][0].stem == "project_rag_gate_corpus_stale"
+
+    def test_user_and_feedback_rank_below_project_at_equal_age(self, tmp_path: Path) -> None:
+        write_memory(tmp_path, "project_a", "project", age_days=30)
+        write_memory(tmp_path, "feedback_b", "feedback", age_days=30)
+        write_memory(tmp_path, "user_c", "user", age_days=30)
+
+        order = [mem.stem for mem, _ in audit(scan_corpus([tmp_path])).ranked]
+        assert order == ["project_a", "feedback_b", "user_c"]
+
+    def test_unknown_type_surfaces_rather_than_hides(self) -> None:
+        assert volatility(None) == DEFAULT_VOLATILITY
+        assert volatility("nonsense") == DEFAULT_VOLATILITY
+        assert DEFAULT_VOLATILITY > volatility("feedback")
+
+    def test_risk_is_age_times_volatility(self, tmp_path: Path) -> None:
+        path = write_memory(tmp_path, "project_x", "project", age_days=10)
+        assert risk_score(load_memory(path), date.today()) == pytest.approx(10.0)
+
+
+class TestIntegrity:
+    def test_broken_link_reported_and_deferred_link_is_not(self, tmp_path: Path) -> None:
+        write_memory(tmp_path, "project_a", body="See [[project_gone]] and [[?later]].")
+        write_index(tmp_path, ["project_a"])
+
+        report = audit(scan_corpus([tmp_path]), roots=[tmp_path])
+        assert [link for _, link in report.broken_links] == ["project_gone"]
+
+    def test_name_must_equal_filename_stem(self, tmp_path: Path) -> None:
+        write_memory(tmp_path, "project_a", name="something_else")
+        report = audit(scan_corpus([tmp_path]))
+        assert [p.stem for p in report.name_mismatches] == ["project_a"]
+
+    def test_orphan_and_dangling_pointer_both_reported(self, tmp_path: Path) -> None:
+        write_memory(tmp_path, "project_indexed")
+        write_memory(tmp_path, "project_orphan")
+        write_index(tmp_path, ["project_indexed", "project_never_written"])
+
+        report = audit(scan_corpus([tmp_path]), roots=[tmp_path])
+        assert [p.stem for p in report.orphans] == ["project_orphan"]
+        assert [stem for _, stem in report.dangling_pointers] == ["project_never_written"]
+
+    def test_index_file_is_not_itself_a_memory(self, tmp_path: Path) -> None:
+        write_memory(tmp_path, "project_a")
+        write_index(tmp_path, ["project_a"])
+        assert [m.stem for m in scan_corpus([tmp_path])] == ["project_a"]
+
+    def test_table_form_index_counts_as_a_pointer(self, tmp_path: Path) -> None:
+        """Some indexes are tables, not link lists — a bare mention indexes.
+
+        Requiring the markdown-link form produced 21 false orphans against
+        the real corpus on 2026-08-07.
+        """
+        write_memory(tmp_path, "project_a")
+        (tmp_path / "MEMORY.md").write_text(
+            "| file | note |\n|---|---|\n| project_a.md | a thing |\n",
+            encoding="utf-8",
+        )
+        assert audit(scan_corpus([tmp_path]), roots=[tmp_path]).orphans == ()
+
+    def test_corpus_without_an_index_has_no_orphans(self, tmp_path: Path) -> None:
+        """No MEMORY.md means no pointer requirement — the linter self-skips."""
+        write_memory(tmp_path, "project_a")
+        write_memory(tmp_path, "project_b")
+        assert audit(scan_corpus([tmp_path]), roots=[tmp_path]).orphans == ()
+
+    def test_clean_corpus_reports_clean(self, tmp_path: Path) -> None:
+        write_memory(tmp_path, "project_a")
+        write_index(tmp_path, ["project_a"])
+        assert audit(scan_corpus([tmp_path]), roots=[tmp_path]).clean
+
+
+class TestAdvisoryByConstruction:
+    def test_sweep_leaves_the_corpus_byte_identical(self, tmp_path: Path) -> None:
+        """The sweep must never write. This is the whole posture of the spec."""
+        write_memory(tmp_path, "project_a", age_days=90, body="[[project_gone]]")
+        write_memory(tmp_path, "feedback_b", "feedback", age_days=120)
+        write_index(tmp_path, ["project_a"])
+
+        def digest() -> dict[str, str]:
+            return {
+                str(p): hashlib.sha256(p.read_bytes()).hexdigest()
+                for p in sorted(tmp_path.rglob("*.md"))
+            }
+
+        before = digest()
+        report = sweep([tmp_path])
+        assert report.scanned == 2
+        assert digest() == before
+
+    def test_no_memory_is_dropped_from_the_report(self, tmp_path: Path) -> None:
+        """D1: age never removes a memory from a result — only ranks it."""
+        write_memory(tmp_path, "user_ancient", "user", age_days=3650)
+        write_memory(tmp_path, "project_fresh", "project", age_days=0)
+
+        report = sweep([tmp_path])
+        assert {mem.stem for mem, _ in report.ranked} == {
+            "user_ancient",
+            "project_fresh",
+        }
+
+    def test_missing_root_is_skipped_not_fatal(self, tmp_path: Path) -> None:
+        write_memory(tmp_path, "project_a")
+        report = sweep([tmp_path, tmp_path / "does_not_exist"])
+        assert report.scanned == 1
+
+    def test_age_basis_is_reported(self, tmp_path: Path) -> None:
+        write_memory(tmp_path, "project_a")
+        assert sweep([tmp_path]).age_basis == "mtime"
+
+        write_memory(tmp_path, "project_b", extra_frontmatter="verified: 2026-08-01\n")
+        assert sweep([tmp_path]).age_basis == "verified"


### PR DESCRIPTION
Ships **P1** of [`docs/specs/memory-status-integrity/`](docs/specs/memory-status-integrity/requirements.md).

## Problem

Curated memories (`/remember` → markdown under `.claude/**/memory/`) carry no TTL, no recency decay, and no record of when a human last confirmed a claim. Nothing tells a reading session how stale a memory is, so a wrong memory arrives wearing the authority of a recorded fact — at the moment its originating context is gone.

Sibling spec [`memory-claim-verification`](docs/specs/memory-claim-verification/requirements.md) owns the raw auto-stashed tier and names the curated tier a non-goal. This is that non-goal, scoped.

## What ships

- `attune.memory.curated_audit` — path-parameterized scan / rank / annotate over any frontmattered markdown corpus. Pure reads.
- `scripts/audit_curated_memory.py` — advisory sweep CLI. Always exits 0; it is not a gate.
- `PersonalMemory.query()` results now carry `unverified_days` + a `⟨N days unverified⟩` label.

## The one non-obvious decision

**Ranking is age × type volatility, not raw age** — and label-only, never suppress-by-age.

Measured against the real 271-file corpus, **age is anti-correlated with wrongness**: the oldest bucket (36 files) is 30 `feedback` + 5 `user` + 1 `lesson` — settled process rules, least likely to be false and most expensive to lose. The two memories that actually rotted were `project_*`, and one was wrong within *hours*.

So age-based expiry would evict the safest memories and retain the dangerous ones. Full reasoning in [decisions.md D1](docs/specs/memory-status-integrity/decisions.md).

## Receipts

**Live corpus, read-only** (not a test — a real-corpus assertion in CI would violate the home-dir isolation guard):

```
Scanned 271 curated memories in 13 root(s)
Age basis: mtime
── Review priority (age x type volatility), top 3 ──
      64.0  [project  ] project_attune_ai_dev_consolidation
      37.0  [project  ] project_attune_docs_marketplace_decision
      37.0  [project  ] project_attune_redis_mcp_durable
── Schema violations (0) ──   ── Broken [[links]] (0) ──
── Memories with no MEMORY.md pointer (1) ──
  feedback_model_routing_hybrid.md
CORPUS UNCHANGED: YES
```

`memory_lint.py --check-all` independently reports **1 violation across 269 files** — the same file. Two implementations, same verdict.

**Tests:** 30 new, hermetic (`tmp_path` only). Full memory suite 1825 passed / 47 skipped / 3 xfailed.

The golden set **pins both directions**: the 56-day `project` memory must rank first *and* the hours-old one must score 0. If a later change starts age-expiring or machine-verifying curated claims to catch the hours-old case, that test fails — it is the D1 boundary marker.

## Corrections made during the work

Three claims in the requirements draft came from documentation and were false; each was caught only by running the thing. Recorded as [D4](docs/specs/memory-status-integrity/decisions.md) because the failure mode is the spec's own subject:

| Claim | Reality |
|---|---|
| "7 schema violations" | `memory_lint.py:188-194` deliberately tolerates provenance keys — **1** violation corpus-wide |
| R5: "a write-triggered linter can never sweep" | `--check-all` + `all_memory_dirs()` already exist — **R5 retired** |
| "corpus is clean, 0 violations" | read `--check-all` through `tail -25` and missed the first block |

Consequences: the personal `memory_lint.py` hook is **untouched** (stdlib-only and fail-open by design), and **no memory file was modified** — the authorized normalization turned out to have nothing to normalize.

## Rollback

Additive — new module, new script, annotation strings. Revert the commit. No schema change, no migration, no corpus writes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)