### PR TITLE
fix(ci): stop the two security workflows cancelling each other

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -1,4 +1,4 @@
-name: Security Scan
+name: Security Audit (blocking)
 
 on:
   pull_request:
@@ -12,7 +12,11 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  # Literal group id, deliberately NOT ${{ github.workflow }} — see the same
+  # comment in security.yml. This workflow blocks on critical findings, so a
+  # name collision silently cancelling it is a security hole, not a cosmetic
+  # CI annoyance. Keep these literals unique per file.
+  group: security-attune-audit-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,4 +1,4 @@
-name: Security Scan
+name: Security Scan (Bandit + Safety)
 
 on:
   push:
@@ -11,7 +11,13 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  # Literal group id, deliberately NOT ${{ github.workflow }}: that expands to
+  # the workflow *name*, so two files sharing a name share a group. This file
+  # and security-scan.yml were both named "Security Scan" and so collided —
+  # with cancel-in-progress, whichever started second killed the other, and one
+  # of the two scans died at random on every PR (including, half the time, the
+  # blocking one). Keep these literals unique per file.
+  group: security-bandit-safety-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/tests/unit/gates/test_workflow_concurrency.py
+++ b/tests/unit/gates/test_workflow_concurrency.py
@@ -1,0 +1,126 @@
+"""Gate: no two workflows may share a name or a concurrency group.
+
+``${{ github.workflow }}`` expands to a workflow's **name**, not its filename.
+Two files sharing a ``name:`` therefore compute the *same* concurrency group,
+and with ``cancel-in-progress: true`` they cancel each other — nondeterministically,
+since it depends on which run GitHub starts second.
+
+This is not hypothetical. ``security.yml`` and ``security-scan.yml`` were both
+named "Security Scan". On every PR one of the two was cancelled at random, and
+``gh pr checks`` renders a cancelled run as ``fail``, so the symptom read as a
+flaky failure rather than a lost scan. Half the time the casualty was
+``security-scan.yml``, which *blocks on critical findings* — a PR could have
+merged past a gate that simply never ran.
+
+Parsing is a lightweight line scan rather than a YAML load, matching the
+convention used elsewhere in this repo for reading workflow and memory
+frontmatter without taking a dependency.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+WORKFLOWS = REPO_ROOT / ".github" / "workflows"
+
+_NAME_RE = re.compile(r"^name:\s*(.+?)\s*$", re.MULTILINE)
+_GROUP_RE = re.compile(r"^\s+group:\s*(.+?)\s*$", re.MULTILINE)
+
+#: Workflows deliberately sharing a concurrency group, mapped to the reason.
+#: Sharing is occasionally correct (a family of workflows that must serialize),
+#: but it must be a decision, not an accident from a duplicated ``name:``.
+_ALLOWED_SHARED_GROUPS: dict[str, str] = {}
+
+
+def _workflow_files() -> list[Path]:
+    if not WORKFLOWS.is_dir():  # pragma: no cover - repo layout guard
+        pytest.skip("no .github/workflows directory")
+    return sorted(p for p in WORKFLOWS.iterdir() if p.suffix in (".yml", ".yaml"))
+
+
+def _workflow_name(text: str, path: Path) -> str:
+    match = _NAME_RE.search(text)
+    return match.group(1) if match else path.stem
+
+
+def _concurrency_group(text: str) -> str | None:
+    """Return the raw ``group:`` expression inside a ``concurrency:`` block."""
+    lines = text.splitlines()
+    for i, line in enumerate(lines):
+        if line.rstrip() != "concurrency:":
+            continue
+        for follower in lines[i + 1 :]:
+            if follower and not follower[0].isspace():
+                break  # left the block without finding a group
+            found = _GROUP_RE.match(follower)
+            if found:
+                return found.group(1)
+    return None
+
+
+def test_workflow_names_are_unique() -> None:
+    """Two workflows sharing a name collide in ${{ github.workflow }}."""
+    by_name: dict[str, list[str]] = {}
+    for path in _workflow_files():
+        name = _workflow_name(path.read_text(encoding="utf-8"), path)
+        by_name.setdefault(name, []).append(path.name)
+
+    collisions = {name: files for name, files in by_name.items() if len(files) > 1}
+    assert not collisions, (
+        "workflow name collision — ${{ github.workflow }} expands to the name, "
+        "so these share a concurrency group and cancel each other: "
+        f"{collisions}"
+    )
+
+
+def test_concurrency_groups_are_unique() -> None:
+    """Distinct workflows must not compute the same concurrency group."""
+    by_group: dict[str, list[str]] = {}
+    for path in _workflow_files():
+        text = path.read_text(encoding="utf-8")
+        group = _concurrency_group(text)
+        if group is None:
+            continue
+        # Resolve the one expansion that silently unifies distinct files.
+        resolved = group.replace("${{ github.workflow }}", _workflow_name(text, path))
+        by_group.setdefault(resolved, []).append(path.name)
+
+    collisions = {
+        group: files
+        for group, files in by_group.items()
+        if len(files) > 1 and group not in _ALLOWED_SHARED_GROUPS
+    }
+    assert not collisions, (
+        "concurrency group collision — with cancel-in-progress these workflows "
+        f"kill each other at random: {collisions}. Give each file a literal, "
+        "unique group id, or record the sharing in _ALLOWED_SHARED_GROUPS."
+    )
+
+
+def test_the_two_security_workflows_stay_separated() -> None:
+    """Regression pin for the specific collision that motivated this gate.
+
+    Both files existed and both were named "Security Scan", so one died on
+    every PR. Naming them apart is the fix; this pins it so a later rename
+    cannot quietly restore the collision.
+    """
+    paths = [WORKFLOWS / "security.yml", WORKFLOWS / "security-scan.yml"]
+    present = [p for p in paths if p.is_file()]
+    if len(present) < 2:
+        pytest.skip("both security workflows are no longer present")
+
+    names, groups = set(), set()
+    for path in present:
+        text = path.read_text(encoding="utf-8")
+        names.add(_workflow_name(text, path))
+        groups.add(_concurrency_group(text))
+
+    assert len(names) == 2, f"security workflows must not share a name: {names}"
+    assert len(groups) == 2, f"security workflows must not share a group: {groups}"
+    assert not any(
+        g and "${{ github.workflow }}" in g for g in groups
+    ), "security workflow groups must be literals — github.workflow is the name"


### PR DESCRIPTION
## The bug

`security.yml` and `security-scan.yml` both declared `name: Security Scan`.

`${{ github.workflow }}` expands to the workflow **name**, not the filename, so both files computed the identical concurrency group `Security Scan-<ref>`. With `cancel-in-progress: true`, whichever run GitHub started second cancelled the other.

## Why it mattered

**One of the two security scans died on every PR**, and which one was a race. On #1975:

| SHA | run 1 | run 2 |
|---|---|---|
| `c9f18c62` | `31148608498` success | `31148608521` **cancelled** |
| `5c1e6f78` | `31149386653` **cancelled** | `31149386966` success |

Lower id won once, higher id the other time — nondeterministic.

The two workflows are **complementary, not duplicates**:

- `security.yml` — Bandit + Safety, uploads artifacts, non-blocking
- `security-scan.yml` — attune's own audit, posts results to the PR, honors a bypass label, and **blocks on critical findings**

So roughly half the time the casualty was the *blocking* scan. A PR carrying critical findings could sail past a gate that simply never ran.

It also read as a flaky CI failure rather than a lost scan, because `gh pr checks` renders a `cancelled` run as `fail`.

## Fix

- **Distinct names** — `Security Scan (Bandit + Safety)` and `Security Audit (blocking)`, which also makes the two legible in the checks list.
- **Literal, file-unique concurrency groups** — no longer derived from `${{ github.workflow }}`, so a future rename cannot silently reintroduce the collision. Both call sites carry a comment explaining why.

Workflow-level `name:` is not a check name, so **required status checks are unaffected** — verified against branch protection on `main`.

## Regression gate

`tests/unit/gates/test_workflow_concurrency.py` — no two workflows may share a name or resolve to the same concurrency group. An `_ALLOWED_SHARED_GROUPS` map exists for deliberate sharing, so it stays a decision rather than an accident.

**Proven to fire.** Restoring both files to their pre-fix content fails all three tests:

```
FAILED test_workflow_names_are_unique
FAILED test_the_two_security_workflows_stay_separated
FAILED test_concurrency_groups_are_unique
```

Green again once restored.

## Noted, not changed

Neither security job appears in `main`'s required status checks:

```
["pre-commit","lint","code-quality","coverage","platform-compat",
 "test (ubuntu-latest, 3.12)","CodeQL","default-install-smoke",
 "doc-import-audit","wiring-audit","test (windows-latest, 3.12)",
 "test-matrix-complete"]
```

So `security-scan.yml`'s "blocking" behavior relies on the job going red rather than on branch protection enforcing it. Worth deciding separately whether it should be required — out of scope for this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)