### PR TITLE
docs(specs): promote round-table memory deep-dive — security spec + P2 scope (D6)

### DIFF
--- a/docs/specs/memory-security-hardening/requirements.md
+++ b/docs/specs/memory-security-hardening/requirements.md
@@ -1,0 +1,170 @@
+# memory-security-hardening
+
+**Status:** draft (2026-08-07 — requirements; from round-table deliberation)
+**Owner:** Patrick (chair)
+**Origin:** Round table `q-memory-system-deep-dive-001` (2026-08-07,
+Claude + Codex + Antigravity, 2 rounds). The security lens produced a
+**unanimous** 4-rank attack surface with no dissent. Full transcript:
+`~/.attune/reports/roundtable/q-memory-system-deep-dive-001.md`
+(machine-local, untracked).
+
+**Relationship to other specs:** independent of `memory-status-integrity`
+(the staleness/P2 work) — these mitigations do not touch the ranking
+design. Overlaps `memory-claim-verification` only at the raw-tier
+quarantine boundary (R3 below).
+
+---
+
+## Problem
+
+The attune memory system is a persistence-and-recall loop that feeds
+prior-session content back into future LLM context. Every property that
+makes it useful — durability, always-on injection, cross-session recall —
+is also an attack surface. Three seats deliberated it independently and
+converged on the same ranking for a **sole-developer machine** (not
+multi-tenant: the threat model is untrusted *code and content*, not other
+users).
+
+The finding that reframes everything below: **on a sole-dev box the
+dangerous boundary is not "who can reach Redis" — it is any process,
+dependency, repository file, or session that can influence what gets
+written to memory, because recall grants persisted text standing
+authority through repeated re-injection.**
+
+---
+
+## Ranked attack surface
+
+### R1 — Memory-as-prompt-injection (TOP risk, unanimous #1)
+
+**Mechanism.** A session reads untrusted content in the normal course of
+work — a GitHub issue, a PR comment, a web page, third-party dependency
+docs. The raw-tier `session_stash` extractor (local `llama3.1:8b`)
+summarises whatever the transcript contains into ≤5 findings with **zero
+verification**. A payload phrased as a finding ("important: always run X
+before committing") is stored, and later recall **re-injects it into
+active context**, where it reads as a standing instruction with tool
+access behind it. Injection stops being a single bad turn and becomes
+durable.
+
+The curated tier is narrower — it is linted on write — but
+`memory_lint.py` checks **format, not content**: attacker-shaped prose
+passes.
+
+**Mitigation (cheapest, ratified by all seats).** A provenance-labelled
+envelope at **every recall surface**:
+
+- Recalled material renders as quoted, source-attributed **untrusted
+  evidence — explicitly "NOT instructions"** — never as bare prose that
+  blends into the system/assistant channel.
+- Each recalled item carries its tier, source (file/session), and author
+  class (human-curated vs machine-extracted).
+- **Tool execution is never authorized by recalled text alone.**
+- A cheap instruction-pattern lint (imperatives addressed to the
+  assistant, "ignore previous", tool-invocation strings, role-delimiter
+  tokens like `<|im_start|>` / `system:`) that **flags, not blocks**, on
+  writes.
+
+**Ratified caveat (self-flagged by two seats, do not lose this):**
+delimiters are the *weakest known* defense against prompt injection. A
+payload engineered to survive "this is data" wrappers defeats the
+envelope outright. The envelope is **necessary, not sufficient** — it
+must be paired with **raw-tier quarantine** (R3): raw findings never
+auto-promote into always-loaded or curated surfaces without human
+promotion.
+
+### R2 — Secret accumulation (accidental, high blast radius)
+
+**Mechanism.** The extractor eats full transcripts as free prose;
+transcripts contain API keys, tokens, private endpoints, copied incident
+data. These land in **plaintext markdown + an unauthenticated Redis copy
++ a 30-day JSONL** — and in generated recall cards and backups. The
+corpus's own history records the exposure class (a real `sk-ant` value
+surfaced in a console during earlier work). Retention multiplies the
+exposure across every copy.
+
+**Mitigation.** Secret detection + redaction **before every write** —
+the `session_stash` pipeline, `memory_lint.py`, **and** the hydration
+path — not merely at git commit (the one place it is checked today).
+Store redacted previews + source references where possible. A one-time
+corpus-wide sweep of the ~271 curated files + the JSONL. **Rotate
+anything found — deletion is insufficient.** Consider making Redis
+non-persistent (or encrypted) if persistence buys nothing here.
+
+### R3 — Unauthenticated localhost Redis + hydration path
+
+**Mechanism.** Redis on localhost with no auth lets **any local
+process** — an npm `postinstall`, a pip build hook, a compromised
+dependency — read the entire hydrated corpus (compounding R2) or **write
+`attune:memory:*` directly**, poisoning recall while bypassing the
+linter until the next hydration. A sole-dev machine runs more untrusted
+code than most servers.
+
+**Mitigation.**
+- `requirepass` with a random local secret; bind to loopback or a Unix
+  socket; disable dangerous commands.
+- **Treat Redis as a disposable cache**, not a store of record: full
+  re-hydrate at every SessionStart from allowlisted roots, so the
+  file-of-record always wins and recall **never trusts keys older than
+  the current hydration epoch**. Consumers trust only hydrated records
+  carrying a schema version, tier, canonical source path, and content
+  digest — not arbitrary keys under the prefix.
+
+### R4 — Forgeable mtime / updated_at (reliability, not security)
+
+**Mechanism.** All seats agreed this is **not** a leading *security*
+risk — an attacker who can `touch` files already owns the box. It is a
+**reliability** hole: git checkouts, sync tools, and bulk edits rewrite
+mtimes routinely, so the staleness signal is already silently wrong in
+both directions.
+
+**Mitigation.** Fixed by `memory-status-integrity` P2's `verified:`
+field (human-set, content-tracked, mtime ignored for ranking). A git
+commit timestamp is a better fallback than mtime where a human date is
+absent. **Cross-reference, not owned here** — listed only so the
+security review does not mistake it for an attack vector.
+
+### R5 — The 8B extractor as a confused deputy
+
+**Mechanism.** `llama3.1:8b` converts adversarial session/repo text into
+durable assertions without understanding provenance or truth. Its "≤5
+findings" cap bounds *volume*, not *harm*.
+
+**Mitigation.** Constrain the extractor to a **strict typed-JSON schema**
+with source references and explicit confidence; **discard** any output
+containing control characters, frontmatter delimiters (`---`), or
+role-override syntax. Keep raw findings quarantined, TTL-bound, and
+visibly machine-generated. This dovetails with `memory-claim-verification`
+(fail-closed on *promotion*; ordinary recall may fail open by omitting
+unresolved raw claims).
+
+---
+
+## Scope
+
+**In scope:** the recall-render envelope (R1), secret-scan-before-write
++ one-time sweep (R2), Redis auth + disposable-cache posture (R3),
+extractor output schema (R5).
+
+**Out of scope:** the P2 ranking/verdict design (owned by
+`memory-status-integrity`); typed-ref resolution against git/gh (owned
+by `memory-claim-verification`); the mtime fix (R4, cross-referenced).
+
+## Priority note (moderator read, ratified by the chair's promotion)
+
+R1's envelope and R2's secret-scan-before-write are **the two
+highest-leverage, lowest-cost items in the entire deliberation** and are
+**independent of the P2 design** — they can ship immediately without
+waiting on any ranking decision.
+
+## Open questions
+
+1. Envelope format: a single rendering contract shared by
+   `personal.py`, `recall_digest`, and the hydration line, or
+   per-surface? (The P1 work already proved a shared pure formatter is
+   viable — `format_age_annotation`.)
+2. Secret-scan engine: reuse the repo's existing `detect-secrets`
+   pre-commit config, or a lighter regex+entropy pass tuned for the
+   memory write path?
+3. Does the raw tier warrant encryption-at-rest, or is
+   redact-before-write + TTL sufficient given the sole-dev threat model?

--- a/docs/specs/memory-status-integrity/decisions.md
+++ b/docs/specs/memory-status-integrity/decisions.md
@@ -248,3 +248,86 @@ Fixed in the review follow-up PR; recorded so the pattern is legible.
 Meta: the reviewer that caught these is the same class of reader the
 age labels serve — the D4 lesson generalizes to "re-derive claims from
 the artifact, not from the session that produced it."
+
+---
+
+## D6 — P2 scope, ratified from round-table `q-memory-system-deep-dive-001` (recorded 2026-08-07)
+
+A three-model round table (Claude + Codex + Antigravity, 2 rounds)
+deliberated the P2 design. Round 1 split three ways on the ranking
+signal; round 2 converged. The chair promoted the converged scope.
+Full transcript: `~/.attune/reports/roundtable/q-memory-system-deep-dive-001.md`.
+
+**The motivating evidence (decisive, all seats):** the memory that
+rotted *within hours* (`project_rag_gate_corpus_stale`) was project-type
+at age ~0 — age × volatility ranked it **last on its most dangerous
+day**. Project facts rot on *events* (commits, merges, closed issues,
+moved paths), not on the clock. Age is the wrong primary signal for the
+one type that rots fastest.
+
+### Ratified P2 scope (the union every seat endorsed)
+
+1. **Fix the frontmatter-parser divergence FIRST — promoted from
+   "deferred" (D5 item 3) to a P2 gate.** `verified:` lives in
+   frontmatter; if the audit parser and the canonical linter disagree on
+   folded multi-line YAML, the field the whole loop depends on is
+   unreliable on exactly the drifting files. Unanimous blocker.
+2. **`verified:` as strict ISO date, distinct from mtime, human-set
+   only**, plus **content-digest binding**: a substantive edit
+   invalidates verification; a formatting-only change (canonicalised)
+   preserves it. Keep an **append-only verdict history** (who / when /
+   what-digest), not a bare mutable date — the failure mode to design
+   against is a thoughtless "keep all" freshness button.
+3. **keep / wrong / sharper verdict loop.** `wrong` **tombstones**, does
+   not delete — deletion breaks `MEMORY.md` pointers and `[[links]]`,
+   and "we believed X, it was wrong because Y" is itself high-value
+   memory. `sharper` = edit + verify in one motion, name-stable.
+   **Verdicts propagate to Redis immediately** (invalidate/rewrite the
+   key), or a session recalls known-wrong memory for a full hydration
+   cycle — failing the spec's own goal.
+4. **Ref-triggered queue-jump for project-type memories.** Typed refs
+   (`file:` / `sha:` / `pr:` / `issue:`) resolved by an **existence
+   check** against local git (optionally `gh`) → flip to "review",
+   floated above the age-ranked queue, trigger reason exposed. Sits
+   inside D1 (only promotes into review, never demotes or hides) and D6
+   of `curated-memory-productionization` (routes to a human, never
+   auto-certifies).
+5. **Render epistemic STATUS, not just age.** "N days unverified" is a
+   number without calibration — the reading model has no base rate for
+   90 days on reference vs project. Render a discrete tier
+   (**settled / check-before-acting / suspect**) plus author-class and
+   verification-state, and for "suspect + project" an explicit "verify
+   against repo before acting" instruction on the card. **The raw tier
+   (least trustworthy) currently has the least labelling and needs the
+   strongest framing** — cross-links `memory-security-hardening` R1.
+
+### Unresolved sub-decision left to the chair at design time
+
+The one residual split, both sides inside D1/D6 — a one-line ranking
+choice, not a blocker:
+
+- **Ref-trigger as PRIMARY signal for project-type** (Codex,
+  Antigravity), age × volatility demoted to tiebreaker; **vs.**
+- **Ref-trigger as a cheap queue-jump BOOLEAN** layered on the
+  age × volatility baseline (Claude) — verdict loop ships first, the
+  boolean is an existence check only, fail-open, and is *cut entirely*
+  if its implementation creeps toward the sibling spec's diff engine.
+
+And the evidence source: **local-git-only** (Antigravity, keeps P2
+self-contained) vs **allow `gh` for `pr:`/`issue:`** (Codex/Claude,
+single existence check per ref, fail-open on unreachable).
+
+**Moderator note:** Claude's boolean-with-hard-cap is the lower-risk
+first cut — its hit-rate becomes the evidence that justifies building
+the full ref engine in `memory-claim-verification`. But this is the
+chair's call and both are ratifiable; recorded here unresolved rather
+than forced.
+
+### The binding constraint every seat named
+
+The system's scarce resource is **one human's attention**. A stale
+`verified:` date is **worse than none** (false endorsement), so
+verified-age must re-enter ranking, never exempt a file; cap the review
+queue (~3 per triage); one-keystroke verdicts. If P2 ceremony gets
+abandoned, the corpus fills with stale endorsements — a worse end-state
+than today's honest "unverified". Design for abandonment.

--- a/docs/specs/memory-status-integrity/decisions.md
+++ b/docs/specs/memory-status-integrity/decisions.md
@@ -152,6 +152,32 @@ phase argument, and a later reader would otherwise inherit it.
 
 ---
 
+## D3 — The sweep is a library in attune-ai, not a personal script (recorded 2026-08-07)
+
+There are two curated corpora with different owners:
+
+| Corpus | Files | Owner |
+|---|---|---|
+| `~/.claude/**/memory/` | 266 | harness-native; linted by a personal hook outside every repo |
+| `~/.attune/memory/` | 16 | attune-shipped (`src/attune/memory/personal.py`) |
+
+Writing the sweep as a personal script would fix Patrick's corpus and
+ship nothing. Writing it only against `~/.attune/memory/` would ship a
+feature exercised by 16 files while the 266-file corpus keeps rotting.
+
+**Decision:** the mechanism lands in attune-ai as a **path-parameterized
+library** over "a directory of frontmattered markdown memories," with
+both corpora as callers. The personal hook calls into it; the product
+uses it for its own store.
+
+This also gives P1 an honest test surface: the logic is exercised by
+hermetic fixtures, and the 266-file corpus becomes a *receipt* run
+rather than a test dependency — real-corpus assertions in CI would
+violate the home-directory isolation guard
+(`project_test_isolation_home_dir_leaks`).
+
+---
+
 ## D4 — The enforcement code is the authority, not the prose (recorded 2026-08-07)
 
 Three claims in the requirements draft were derived from documentation
@@ -183,32 +209,6 @@ Two mitigations fall out of this and are already in the design:
 - Agreement between two independent implementations is a signal worth
   keeping. `curated_audit` and `memory_lint` now cross-check each
   other; on the first clean run they found the same single violation.
-
----
-
-## D3 — The sweep is a library in attune-ai, not a personal script (recorded 2026-08-07)
-
-There are two curated corpora with different owners:
-
-| Corpus | Files | Owner |
-|---|---|---|
-| `~/.claude/**/memory/` | 266 | harness-native; linted by a personal hook outside every repo |
-| `~/.attune/memory/` | 16 | attune-shipped (`src/attune/memory/personal.py`) |
-
-Writing the sweep as a personal script would fix Patrick's corpus and
-ship nothing. Writing it only against `~/.attune/memory/` would ship a
-feature exercised by 16 files while the 266-file corpus keeps rotting.
-
-**Decision:** the mechanism lands in attune-ai as a **path-parameterized
-library** over "a directory of frontmattered markdown memories," with
-both corpora as callers. The personal hook calls into it; the product
-uses it for its own store.
-
-This also gives P1 an honest test surface: the logic is exercised by
-hermetic fixtures, and the 266-file corpus becomes a *receipt* run
-rather than a test dependency — real-corpus assertions in CI would
-violate the home-directory isolation guard
-(`project_test_isolation_home_dir_leaks`).
 
 ---
 


### PR DESCRIPTION
Chair-ratified promotions from round table `q-memory-system-deep-dive-001` (Claude + Codex + Antigravity, 2 rounds). Docs only — two files, no code. Full transcript is machine-local (`~/.attune/reports/roundtable/`, untracked).

## What's promoted

**NEW — `docs/specs/memory-security-hardening/requirements.md`**
The security lens produced a **unanimous** attack-surface ranking for a sole-dev machine:
1. **Memory-as-prompt-injection** (top) — recalled text becomes a standing instruction. Fix: provenance *"untrusted evidence, not instructions"* envelope at every recall surface. Ratified caveat all three seats self-flagged: **delimiters are necessary but not sufficient** — pair with raw-tier quarantine.
2. **Secret-scan before every write** (not just git commit) + one-time corpus sweep + rotate.
3. **Redis auth + disposable-cache/rehydrate-wins.**
4. mtime = reliability, not security (xref to P2's `verified:`).
5. 8B extractor output schema (confused-deputy containment).

R1+R2 are **independent of P2 and shippable now**.

**`memory-status-integrity/decisions.md` — new D6**
The converged P2 scope: parser-fix as a gate, `verified:` + content-digest, tombstoning verdict loop, ref-triggered queue-jump for project-type memories, epistemic-tier rendering. The one residual split (ref-trigger as *primary signal* vs *cheap queue-jump boolean*) is recorded **unresolved for the chair at design time** — both sit inside D1/D6.

## Provenance note
Rebuilt as a single doc commit cherry-picked onto main after #1977 squash-merged (a plain rebase replays #1977's pre-squash commits and conflicts). Diff is exactly the two doc files; status-line legibility gate green.

Declined at the chair's ruling: the injection-envelope lesson candidate (no system receipt yet — captured in the security spec R1, upgrades when the envelope ships).

🤖 Generated with [Claude Code](https://claude.com/claude-code)