### PR TITLE
chore(release): prep 11.4.0 — changelog, README rotation, version bump

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "Spec-driven development for Claude Code — take an idea through requirements, design, tasks, and gated execution with an approval loop. Plus 28 auto-triggering skills: security audits, code review, test generation, release prep.",
-    "version": "11.3.0"
+    "version": "11.4.0"
   },
   "plugins": [
     {
       "name": "attune-ai",
       "description": "Spec-driven development is the core workflow: /spec carries an idea through brainstorm, requirements, design, and task execution with quality gates and your approval at each stage. Backed by 28 auto-triggering skills — security audits, code reviews, test generation, bug prediction, and release preparation. For help content tools, also install attune-help and attune-author from this marketplace.",
       "source": "./plugin",
-      "version": "11.3.0",
+      "version": "11.4.0",
       "author": {
         "name": "Smart AI Memory",
         "email": "patrick.roebuck@smartaimemory.com"

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,4 +1,4 @@
-# Attune AI Framework v11.3.0
+# Attune AI Framework v11.4.0
 
 AI-powered developer workflows with cost optimization and multi-agent orchestration.
 
@@ -556,7 +556,7 @@ attune_redis/          # Redis plugin — BUNDLED, ships in the attune-ai
 
 ---
 
-**Version:** 11.3.0 | **License:** Apache 2.0 | **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)
+**Version:** 11.4.0 | **License:** Apache 2.0 | **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)
 
 ## Lessons — core
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,14 @@ seeded at 613 sites.
   fail CI; the seeded count can only go down, and the gate ships
   with a proof-it-fires test.
 
+- **Mermaid diagrams across the docs site** (#1965, #1967): mermaid
+  rendering enabled in mkdocs, with 15 diagrams converted across 10
+  pages. A deliberate existing-tool choice: the diagramkit Phase-0
+  probe measured mermaid 1.2–2.1× cheaper to author than a custom
+  diagram kernel, so no kernel was built ("mermaid wins",
+  docs/specs/diagramkit D4) — data charts keep the sealed chart
+  kernel; diagrams ride an existing tool.
+
 ### Fixed
 
 - Memory P1 review follow-ups: staleness-sweep linter brought to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,15 @@ All notable changes to Attune AI (formerly Empathy Framework) will be documented
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
 ## [11.4.0] — 2026-08-07
+
+Docs outbox: small docs artifacts (lessons, reports, drafts, plans)
+now batch through a conflict-free outbox into one curated PR instead
+of shipping as micro-PRs. Plus an advisory staleness sweep for
+curated memory corpora and a shrink-only broad-except ratchet
+seeded at 613 sites.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to Attune AI (formerly Empathy Framework) will be documented
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [11.4.0] — 2026-08-07
 
 ### Added
 
@@ -21,6 +21,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   now; the Stop-hook lessons reminder routes through the outbox, and
   the ops Collaboration inbox gains a pending row with a 2-day stale
   warning. The pending-recall layer is deferred (R5).
+
+- **Advisory staleness sweep for curated memory corpora**
+  (memory-status-integrity P1, #1975): reads each curated memory's
+  claims against the current tree and flags the ones reality has
+  moved past — advisory by design, it never blocks or rewrites.
+
+- **Broad-except ratchet** (#1974): a shrink-only gate seeded with
+  613 existing broad `except Exception` sites. New broad excepts
+  fail CI; the seeded count can only go down, and the gate ships
+  with a proof-it-fires test.
+
+### Fixed
+
+- Memory P1 review follow-ups: staleness-sweep linter brought to
+  parity with the memory-lint rules, and R2 delivery claims
+  corrected to match what actually shipped (#1977).
+
+- CI: the two security workflows no longer cancel each other's
+  runs via a shared concurrency group (#1976).
 
 ## [11.3.0] — 2026-08-06
 

--- a/README.md
+++ b/README.md
@@ -92,32 +92,27 @@ routing, and [Installation Options](#installation-options) for extras.
      a permanent section below (see "Dynamic forms" for the pattern).
      Don't stack a second "New in" section here. -->
 
-## New in 11.3.0 — Chart widgets: specs in, SVG out
+## New in 11.4.0 — Docs outbox: many writers, one PR
 
-Your agent can now draw. The `chart_render_widget` MCP tool takes a
-**~50–200-token declarative JSON spec** and renders themable SVG
-through a sealed ~10KB kernel — the model never writes renderer
-code. Nine chart types (`bar` with stacked/grouped/horizontal,
-`line`, `scatter`, `area`, `heatmap`, `donut`, `box`, `waterfall`,
-`treemap`), and updates are RFC 7386 merge patches against the
-stored spec, so changing a title or swapping data costs tens of
-tokens instead of a re-emitted widget.
+Small docs artifacts — lessons, run reports, drafts, plans — no
+longer ship as their own micro-PRs. Writers drop per-artifact
+timestamped files into `~/.attune/docs-outbox/`:
 
-```json
-{"v": 1, "type": "donut",
- "data": [{"kind": "passed", "n": 96}, {"kind": "failed", "n": 4}],
- "encodings": {"x": {"field": "kind", "type": "nominal"},
-               "y": {"field": "n", "type": "quantitative"}}}
+```bash
+python -m attune.docs_outbox write --kind lesson \
+  --slug my-finding --file body.md
 ```
 
-The kernel is sealed and CI-enforced: no outward imports, nothing
-imports its internals, and the built artifact stays under a
-20,480-byte ceiling — chart types earn their way in; the ceiling
-does not move. Also in 11.3.0: the V7 elicitation form-template
-library (author a decision shape once, cast it per fork), and a
-security sweep that cleared **every** open dependabot and
-code-scanning alert (gitpython, aiohttp, and a cryptography major
-among them). Details: `docs/chartkit.md`.
+Concurrent sessions never conflict by construction. A curating
+sweep (`/docs-outbox`) dedupes, lints, flags core-worthy
+candidates, and composes ONE approved digest before a single
+batched PR opens — N writers, one review, one merge.
+
+Also in 11.4.0: an **advisory staleness sweep** for curated
+memory corpora — it reads each memory's claims against the
+current tree and flags the ones reality has moved past, advisory
+by design — and a **broad-except ratchet** seeded at 613 sites:
+the count only shrinks, and CI proves the gate fires.
 
 ## Goal-driven development — receipts, not promises
 
@@ -406,6 +401,19 @@ All constructs share one declarative form model and validator, render
 richly on widget-capable surfaces (e.g. claude.ai / Cowork) and degrade
 gracefully to a recommendation-first menu elsewhere. The terse reply
 vocab (`y` / `go` / `1`) answers any of them.
+
+## Chart widgets — specs in, SVG out
+
+The `chart_render_widget` MCP tool takes a **~50–200-token
+declarative JSON spec** and renders themable SVG through a sealed
+~10KB kernel — the model never writes renderer code. Nine chart
+types (`bar` with stacked/grouped/horizontal, `line`, `scatter`,
+`area`, `heatmap`, `donut`, `box`, `waterfall`, `treemap`), and
+updates are RFC 7386 merge patches against the stored spec, so
+changing a title costs tens of tokens instead of a re-emitted
+widget. The kernel is sealed and CI-enforced: no outward imports,
+and the built artifact stays under a 20,480-byte ceiling that
+does not move. Details: `docs/chartkit.md`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -111,8 +111,10 @@ batched PR opens — N writers, one review, one merge.
 Also in 11.4.0: an **advisory staleness sweep** for curated
 memory corpora — it reads each memory's claims against the
 current tree and flags the ones reality has moved past, advisory
-by design — and a **broad-except ratchet** seeded at 613 sites:
-the count only shrinks, and CI proves the gate fires.
+by design — a **broad-except ratchet** seeded at 613 sites (the
+count only shrinks, and CI proves the gate fires), and **mermaid
+diagrams across the docs site**: 15 diagrams converted on 10
+pages, riding an existing tool instead of a custom kernel.
 
 ## Goal-driven development — receipts, not promises
 
@@ -414,6 +416,11 @@ changing a title costs tens of tokens instead of a re-emitted
 widget. The kernel is sealed and CI-enforced: no outward imports,
 and the built artifact stays under a 20,480-byte ceiling that
 does not move. Details: `docs/chartkit.md`.
+
+Diagrams took the practical path: a measured probe found mermaid —
+an existing tool — 1.2–2.1× cheaper to author than a custom
+diagram kernel, so docs diagrams render via mermaid and no kernel
+was built. Charts earn a kernel; diagrams don't need one.
 
 ---
 

--- a/docs/reference/API_REFERENCE.md
+++ b/docs/reference/API_REFERENCE.md
@@ -1,6 +1,6 @@
 # Attune AI API Reference
 
-**Version:** 11.3.0
+**Version:** 11.4.0
 **License:** Apache License 2.0
 **Copyright:** 2025-2026 Smart AI Memory, LLC
 
@@ -1152,5 +1152,5 @@ msg = format_error(
 
 ---
 
-**Version:** 11.3.0 | **License:** Apache 2.0
+**Version:** 11.4.0 | **License:** Apache 2.0
 **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)

--- a/plugin/.claude-plugin/marketplace.json
+++ b/plugin/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "Spec-driven development for Claude Code — /spec plans, reviews, and executes with quality gates; plus security audits, code reviews, test generation, and release prep from /attune.",
-    "version": "11.3.0"
+    "version": "11.4.0"
   },
   "plugins": [
     {
       "name": "attune-ai",
       "description": "Spec-driven development for Claude Code — /spec plans, reviews, and executes with quality gates; plus security audits, code reviews, test generation, and release prep from /attune.",
       "source": "./",
-      "version": "11.3.0",
+      "version": "11.4.0",
       "author": {
         "name": "Smart AI Memory",
         "email": "patrick.roebuck@smartaimemory.com"

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "attune-ai",
-  "version": "11.3.0",
+  "version": "11.4.0",
   "description": "Spec-driven development for Claude Code — /spec plans, reviews, and executes with quality gates; plus security audits, code reviews, test generation, and release prep from /attune.",
   "author": {
     "name": "Smart AI Memory",

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -4,7 +4,7 @@ Spec-driven development for Claude Code — turn requirements
 into reliable software. <!-- cap:skill_count -->28 auto-triggering skills<!-- /cap -->, zero
 commands: say what you need and Claude picks the right skill.
 
-**Version:** 11.3.0 | **License:** Apache 2.0
+**Version:** 11.4.0 | **License:** Apache 2.0
 
 > **Fix Receipts** (`/fix`) — new in 11.2.0. Say `fix this and
 > prove it`.

--- a/plugin/core/__init__.py
+++ b/plugin/core/__init__.py
@@ -5,4 +5,4 @@ This module provides the core workflow functionality when the full
 attune-ai package is not installed via pip.
 """
 
-__version__ = "11.3.0"
+__version__ = "11.4.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "attune-ai"
-version = "11.3.0"
+version = "11.4.0"
 description = "AI-powered developer workflows for Claude with cost optimization, multi-agent orchestration, and workflow automation."
 readme = {file = "README.md", content-type = "text/markdown"}
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -299,7 +299,7 @@ wheels = [
 
 [[package]]
 name = "attune-ai"
-version = "11.3.0"
+version = "11.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "agent-memory-client" },

--- a/website/app/page.tsx
+++ b/website/app/page.tsx
@@ -58,7 +58,7 @@ export default function Home() {
             <div className="grid lg:grid-cols-2 gap-16 items-center">
               <div className="z-10">
                 <div className="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-[var(--surface-container-high)] text-[var(--primary)] text-xs font-bold tracking-widest mb-6 uppercase">
-                  <span>v11.3.0</span>
+                  <span>v11.4.0</span>
                   <span className="w-1 h-1 rounded-full bg-[var(--primary)]"></span>
                   <span className="opacity-80">Spec-driven development platform</span>
                 </div>

--- a/website/lib/features.ts
+++ b/website/lib/features.ts
@@ -32,7 +32,7 @@ export const PRODUCTS: Product[] = [
     id: "attune-ai",
     name: "Attune AI",
     pypiName: "attune-ai",
-    version: "11.3.0",
+    version: "11.4.0",
     tagline: "Generate, maintain, and serve help from your code",
     installCommand: "pip install attune-ai",
     marketplaceInstall:
@@ -101,7 +101,7 @@ export const PRODUCTS: Product[] = [
     id: "claude-code-plugin",
     name: "Claude Code Plugin",
     pypiName: "attune-ai",
-    version: "11.3.0",
+    version: "11.4.0",
     tagline: "Progressive help right in your terminal",
     installCommand:
       "claude plugin marketplace add Smart-AI-Memory/attune-ai",


### PR DESCRIPTION
## Release prep — 11.4.0

**Advisory verdict from `/release-prep`:** ready once this PR merges — CI green on main, 0 open dependabot alerts, codecov-gated coverage on all 23 post-11.3.0 merges.

### Changes

- **CHANGELOG**: stamped `[Unreleased]` as `[11.4.0] — 2026-08-07`; added the missing entries for #1974 (broad-except ratchet), #1975 (advisory memory staleness sweep), #1976 (security-workflow cancellation fix), #1977 (linter parity follow-ups). Docs-outbox entry was already present.
- **README**: rotating slot now headlines the docs outbox for 11.4.0; the displaced 11.3.0 chart-widgets section is condensed into a permanent section beside Dynamic forms (the two halves of the elicitation grammar).
- **Version bump** 11.3.0 → 11.4.0: pyproject, `.claude/CLAUDE.md`, `plugin/core/__init__.py`, plugin README, `plugin.json`, both `marketplace.json`, `uv.lock` (via `uv lock`).

### Receipts

- Preflight: 0 failed, 1 expected warning (dirty main checkout, untouched)
- Full pre-commit hook suite green on all changed files (pre-flighted pinned tools before staging)
- PyPI latest is 11.3.0 — 11.4.0 is free to take

After merge: tag from the merge SHA and publish via the release-execute flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
