### PR TITLE
chore(release): prep 11.5.0 — changelog, README rotation, version bump

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "Spec-driven development for Claude Code — take an idea through requirements, design, tasks, and gated execution with an approval loop. Plus 28 auto-triggering skills: security audits, code review, test generation, release prep.",
-    "version": "11.4.0"
+    "version": "11.5.0"
   },
   "plugins": [
     {
       "name": "attune-ai",
       "description": "Spec-driven development is the core workflow: /spec carries an idea through brainstorm, requirements, design, and task execution with quality gates and your approval at each stage. Backed by 28 auto-triggering skills — security audits, code reviews, test generation, bug prediction, and release preparation. For help content tools, also install attune-help and attune-author from this marketplace.",
       "source": "./plugin",
-      "version": "11.4.0",
+      "version": "11.5.0",
       "author": {
         "name": "Smart AI Memory",
         "email": "patrick.roebuck@smartaimemory.com"

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,4 +1,4 @@
-# Attune AI Framework v11.4.0
+# Attune AI Framework v11.5.0
 
 AI-powered developer workflows with cost optimization and multi-agent orchestration.
 
@@ -556,7 +556,7 @@ attune_redis/          # Redis plugin — BUNDLED, ships in the attune-ai
 
 ---
 
-**Version:** 11.4.0 | **License:** Apache 2.0 | **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)
+**Version:** 11.5.0 | **License:** Apache 2.0 | **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)
 
 ## Lessons — core
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,49 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [11.5.0] — 2026-08-08
+
+Redis config truth: Redis connection settings now flow through one
+canonical resolver with honest, classified degradation and a doctor
+diagnostic — the "requirepass read as Redis-down" incident class is
+closed at the seam. Plus memory-security hardening (provenance
+framing + secret gates) and post-release performance/honesty fixes.
+
+### Added
+
+- **Canonical Redis connection resolver** (redis-config-truth rct-1,
+  #1984): `resolve_redis_connection()` in `attune.memory.config` —
+  five-step precedence (credentialed URL > URL + `REDIS_PASSWORD` /
+  `REDIS_USER` merge > `REDIS_PRIVATE_URL`/`REDIS_PUBLIC_URL` >
+  host/port/db components > localhost default), a source-map
+  recording which env var supplied each component, and recorded
+  overrides instead of silent conflicts. Hardened via a codex
+  cross-review lane: credentialed URL vars outrank passwordless
+  earlier ones, URL-carried usernames survive password merges,
+  IPv6 hosts stay bracketed, `unix://` socket paths survive
+  credential merges, and non-numeric URL db paths raise actionable
+  errors.
+- **Classified loud-once degradation** (rct-2, #1985):
+  `MemoryFeatures.classify_redis_health()` returns a typed report —
+  `healthy` / `degraded_auth` / `degraded_connectivity` /
+  `disabled`. Auth rejection and malformed config (never
+  self-healing) warn exactly once per session with a redacted URL;
+  an absent server stays silent; `check_redis()` remains a
+  fail-open bool gate (never blocks work).
+- **Doctor diagnostic** (rct-3, #1987): `redis_health_check` now
+  reports the redacted effective config — which env vars resolved,
+  the URL shape, recorded overrides, and the classified health
+  state — derived from the resolver's source-map, with secrets
+  redacted throughout.
+- **Memory-security hardening** (#1979): provenance framing for
+  recalled content (R1) and secret gates on memory writes (R2).
+
+### Fixed
+
+- Post-release self-review act-now items (#1982): memory batch
+  primitives (MGET / variadic DEL), dashboard threadpool, specs
+  single-read, release-agent honesty fixes.
+
 ## [11.4.0] — 2026-08-07
 
 Docs outbox: small docs artifacts (lessons, reports, drafts, plans)

--- a/README.md
+++ b/README.md
@@ -92,29 +92,26 @@ routing, and [Installation Options](#installation-options) for extras.
      a permanent section below (see "Dynamic forms" for the pattern).
      Don't stack a second "New in" section here. -->
 
-## New in 11.4.0 — Docs outbox: many writers, one PR
+## New in 11.5.0 — Redis config truth: one resolver, honest degradation
 
-Small docs artifacts — lessons, run reports, drafts, plans — no
-longer ship as their own micro-PRs. Writers drop per-artifact
-timestamped files into `~/.attune/docs-outbox/`:
+Redis connection settings now flow through ONE canonical resolver,
+`resolve_redis_connection()`: five-step precedence across the
+`REDIS_URL` variants, credential merging (`REDIS_PASSWORD` merges
+into a password-less URL — the misconfiguration that used to read
+as "Redis down"), a source-map recording which env var supplied
+each component, and recorded overrides instead of silent conflicts.
 
-```bash
-python -m attune.docs_outbox write --kind lesson \
-  --slug my-finding --file body.md
-```
+On top of it sit **classified degradation** — auth failures and
+malformed config warn ONCE per session with a redacted URL, while
+an absent server stays quiet as before — and a **doctor
+diagnostic**: `redis_health_check` now reports the redacted
+effective config (which vars resolved, URL shape, overrides, and
+the classified health state), so "why isn't memory connecting?"
+is answerable at a glance without exposing a secret.
 
-Concurrent sessions never conflict by construction. A curating
-sweep (`/docs-outbox`) dedupes, lints, flags core-worthy
-candidates, and composes ONE approved digest before a single
-batched PR opens — N writers, one review, one merge.
-
-Also in 11.4.0: an **advisory staleness sweep** for curated
-memory corpora — it reads each memory's claims against the
-current tree and flags the ones reality has moved past, advisory
-by design — a **broad-except ratchet** seeded at 613 sites (the
-count only shrinks, and CI proves the gate fires), and **mermaid
-diagrams across the docs site**: 15 diagrams converted on 10
-pages, riding an existing tool instead of a custom kernel.
+Also in 11.5.0: **memory-security hardening** (provenance framing
+for recalled content + secret gates on memory writes) and
+post-release performance/honesty fixes.
 
 ## Goal-driven development — receipts, not promises
 
@@ -421,6 +418,25 @@ Diagrams took the practical path: a measured probe found mermaid —
 an existing tool — 1.2–2.1× cheaper to author than a custom
 diagram kernel, so docs diagrams render via mermaid and no kernel
 was built. Charts earn a kernel; diagrams don't need one.
+
+## Docs outbox — many writers, one PR
+
+Small docs artifacts — lessons, run reports, drafts, plans — don't
+ship as their own micro-PRs. Writers drop per-artifact timestamped
+files into `~/.attune/docs-outbox/`:
+
+```bash
+python -m attune.docs_outbox write --kind lesson \
+  --slug my-finding --file body.md
+```
+
+Concurrent sessions never conflict by construction. A curating
+sweep (`/docs-outbox`) dedupes, lints, flags core-worthy
+candidates, and composes ONE approved digest before a single
+batched PR opens — N writers, one review, one merge. Alongside it:
+an advisory staleness sweep for curated memory corpora and a
+broad-except ratchet (seeded at 613 sites; the count only
+shrinks, and CI proves the gate fires).
 
 ---
 

--- a/docs/reference/API_REFERENCE.md
+++ b/docs/reference/API_REFERENCE.md
@@ -1,6 +1,6 @@
 # Attune AI API Reference
 
-**Version:** 11.4.0
+**Version:** 11.5.0
 **License:** Apache License 2.0
 **Copyright:** 2025-2026 Smart AI Memory, LLC
 
@@ -1152,5 +1152,5 @@ msg = format_error(
 
 ---
 
-**Version:** 11.4.0 | **License:** Apache 2.0
+**Version:** 11.5.0 | **License:** Apache 2.0
 **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)

--- a/plugin/.claude-plugin/marketplace.json
+++ b/plugin/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "Spec-driven development for Claude Code — /spec plans, reviews, and executes with quality gates; plus security audits, code reviews, test generation, and release prep from /attune.",
-    "version": "11.4.0"
+    "version": "11.5.0"
   },
   "plugins": [
     {
       "name": "attune-ai",
       "description": "Spec-driven development for Claude Code — /spec plans, reviews, and executes with quality gates; plus security audits, code reviews, test generation, and release prep from /attune.",
       "source": "./",
-      "version": "11.4.0",
+      "version": "11.5.0",
       "author": {
         "name": "Smart AI Memory",
         "email": "patrick.roebuck@smartaimemory.com"

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "attune-ai",
-  "version": "11.4.0",
+  "version": "11.5.0",
   "description": "Spec-driven development for Claude Code — /spec plans, reviews, and executes with quality gates; plus security audits, code reviews, test generation, and release prep from /attune.",
   "author": {
     "name": "Smart AI Memory",

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -4,7 +4,7 @@ Spec-driven development for Claude Code — turn requirements
 into reliable software. <!-- cap:skill_count -->28 auto-triggering skills<!-- /cap -->, zero
 commands: say what you need and Claude picks the right skill.
 
-**Version:** 11.4.0 | **License:** Apache 2.0
+**Version:** 11.5.0 | **License:** Apache 2.0
 
 > **Fix Receipts** (`/fix`) — new in 11.2.0. Say `fix this and
 > prove it`.

--- a/plugin/core/__init__.py
+++ b/plugin/core/__init__.py
@@ -5,4 +5,4 @@ This module provides the core workflow functionality when the full
 attune-ai package is not installed via pip.
 """
 
-__version__ = "11.4.0"
+__version__ = "11.5.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "attune-ai"
-version = "11.4.0"
+version = "11.5.0"
 description = "AI-powered developer workflows for Claude with cost optimization, multi-agent orchestration, and workflow automation."
 readme = {file = "README.md", content-type = "text/markdown"}
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -299,7 +299,7 @@ wheels = [
 
 [[package]]
 name = "attune-ai"
-version = "11.4.0"
+version = "11.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "agent-memory-client" },

--- a/website/app/page.tsx
+++ b/website/app/page.tsx
@@ -58,7 +58,7 @@ export default function Home() {
             <div className="grid lg:grid-cols-2 gap-16 items-center">
               <div className="z-10">
                 <div className="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-[var(--surface-container-high)] text-[var(--primary)] text-xs font-bold tracking-widest mb-6 uppercase">
-                  <span>v11.4.0</span>
+                  <span>v11.5.0</span>
                   <span className="w-1 h-1 rounded-full bg-[var(--primary)]"></span>
                   <span className="opacity-80">Spec-driven development platform</span>
                 </div>

--- a/website/lib/features.ts
+++ b/website/lib/features.ts
@@ -32,7 +32,7 @@ export const PRODUCTS: Product[] = [
     id: "attune-ai",
     name: "Attune AI",
     pypiName: "attune-ai",
-    version: "11.4.0",
+    version: "11.5.0",
     tagline: "Generate, maintain, and serve help from your code",
     installCommand: "pip install attune-ai",
     marketplaceInstall:
@@ -101,7 +101,7 @@ export const PRODUCTS: Product[] = [
     id: "claude-code-plugin",
     name: "Claude Code Plugin",
     pypiName: "attune-ai",
-    version: "11.4.0",
+    version: "11.5.0",
     tagline: "Progressive help right in your terminal",
     installCommand:
       "claude plugin marketplace add Smart-AI-Memory/attune-ai",


### PR DESCRIPTION
## 11.5.0 release prep

- `scripts/bump_version.py 11.5.0` — all 10 version sites (drift-guard `test_all_versions_match` green locally).
- Changelog: `[Unreleased]` → `[11.5.0] — 2026-08-08` covering redis-config-truth rct-1..3 (#1984 #1985 #1987), memory-security R1/R2 (#1979), post-release fixes (#1982).
- README rotation: "New in 11.5.0 — Redis config truth"; docs-outbox content moved to a permanent section per the rotating-slot pattern.
- `uv lock`: version line only.
- `SKIP=check-docs-freshness` on the prep commit per release checklist (version-hash noise); `/coach maintain` queued post-release.

Tag will be cut from the merge SHA after `/attune-release-check` + `release_recall_gate` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)