### PR TITLE
perf(ops): eliminate help/dashboard N+1s from the 11.5.0 self-review

### DIFF
--- a/src/attune/ops/data.py
+++ b/src/attune/ops/data.py
@@ -859,6 +859,19 @@ def _parse_usage_event(line: str) -> tuple[float, float, str, str] | None:
     return cost, savings, workflow, ts
 
 
+#: Cache for the full usage.jsonl aggregation, keyed by file identity
+#: (mtime_ns, size) + the aggregation parameters. The file is
+#: append-only and unbounded, and every dashboard/telemetry request
+#: re-parsed it in full (11.5.0 self-review Medium). One entry per
+#: telemetry path; a new append changes mtime/size and invalidates.
+_telemetry_summary_cache: dict[str, tuple[tuple[int, int, int, str], TelemetrySummary]] = {}
+
+
+def _clear_telemetry_summary_cache() -> None:
+    """Test hook — flushes the per-process telemetry summary cache."""
+    _telemetry_summary_cache.clear()
+
+
 def read_telemetry_summary(
     config: Config,
     *,
@@ -878,6 +891,21 @@ def read_telemetry_summary(
     path = config.telemetry_path
     if not path.exists():
         return TelemetrySummary(0, 0.0, 0.0, [], [], None)
+
+    if today is None:
+        # UTC, not local — must match ``_to_day``'s clock authority.
+        today = datetime.now(timezone.utc).date()
+
+    cache_key: tuple[int, int, int, str] | None = None
+    try:
+        st = path.stat()
+        cache_key = (st.st_mtime_ns, st.st_size, recent_days, today.isoformat())
+    except OSError:
+        cache_key = None
+    if cache_key is not None:
+        cached = _telemetry_summary_cache.get(str(path))
+        if cached is not None and cached[0] == cache_key:
+            return cached[1]
 
     total_requests = 0
     total_cost = 0.0
@@ -941,10 +969,6 @@ def read_telemetry_summary(
     # Same output ordering since both sort by cost descending.
     by_workflow = heapq.nlargest(20, filtered, key=lambda row: row[2])
 
-    if today is None:
-        # UTC, not local: ``by_day_count`` keys are UTC dates (``_to_day``),
-        # so the rolling-window cutoff must use the same clock authority.
-        today = datetime.now(timezone.utc).date()
     cutoff = today.toordinal() - recent_days
     recent_days_data = sorted(
         (
@@ -955,7 +979,7 @@ def read_telemetry_summary(
         key=lambda row: row[0],
     )
 
-    return TelemetrySummary(
+    summary = TelemetrySummary(
         total_requests=total_requests,
         total_cost=round(total_cost, 4),
         total_savings=round(total_savings, 4),
@@ -963,6 +987,9 @@ def read_telemetry_summary(
         by_day=recent_days_data,
         last_event_at=last_event_at,
     )
+    if cache_key is not None:
+        _telemetry_summary_cache[str(path)] = (cache_key, summary)
+    return summary
 
 
 def read_memory_summary(path: Path | None = None) -> dict[str, Any]:

--- a/src/attune/ops/help_data.py
+++ b/src/attune/ops/help_data.py
@@ -325,6 +325,40 @@ def _first_paragraph(body: str, *, max_chars: int = 400) -> str:
     return text
 
 
+#: TTL for the full-corpus template-record walk. Matches the
+#: staleness cache: the dashboard hits coverage_gaps +
+#: recently_regenerated back-to-back per page load, and each walk is
+#: one file read per template (the N+1 the 11.5.0 self-review
+#: flagged).
+_RECORDS_CACHE_TTL_SECONDS = 5.0
+_records_cache: dict[str, tuple[float, list[TemplateRecord]]] = {}
+
+
+def _all_template_records(
+    config: Config, features: list[FeatureSummary] | None = None
+) -> list[TemplateRecord]:
+    """Every parseable template record — ONE corpus walk, TTL-cached."""
+    key = str(corpus_root(config))
+    now = time.monotonic()
+    cached = _records_cache.get(key)
+    if cached is not None and (now - cached[0]) < _RECORDS_CACHE_TTL_SECONDS:
+        return cached[1]
+    feats = features if features is not None else list_features(config)
+    records: list[TemplateRecord] = []
+    for feat in feats:
+        for kind in feat.kinds:
+            rec = get_template(config, feat.name, kind)
+            if rec is not None:
+                records.append(rec)
+    _records_cache[key] = (now, records)
+    return records
+
+
+def _clear_records_cache() -> None:
+    """Test hook — flushes the per-process record-walk cache."""
+    _records_cache.clear()
+
+
 def coverage_gaps(config: Config) -> GapsReport:
     """Compute incomplete sets + stale templates across the corpus."""
     features = list_features(config)
@@ -336,13 +370,7 @@ def coverage_gaps(config: Config) -> GapsReport:
     total_features = len(features)
     total_templates = sum(len(f.kinds) for f in features)
 
-    stale: list[TemplateRecord] = []
-    for feat in features:
-        for kind in feat.kinds:
-            rec = get_template(config, feat.name, kind)
-            if rec is None or not rec.is_stale:
-                continue
-            stale.append(rec)
+    stale = [r for r in _all_template_records(config, features) if r.is_stale]
     # Sort stale by oldest first (most-stale at top).
     stale.sort(key=lambda r: r.generated_at or "")
 
@@ -355,25 +383,31 @@ def coverage_gaps(config: Config) -> GapsReport:
     )
 
 
-def recently_regenerated(config: Config, *, limit: int = 5) -> list[TemplateRecord]:
-    """N most-recently-generated templates across the corpus."""
-    records: list[TemplateRecord] = []
-    for feat in list_features(config):
-        for kind in feat.kinds:
-            rec = get_template(config, feat.name, kind)
-            if rec is None or rec.generated_at is None:
-                continue
-            records.append(rec)
+def recently_regenerated(
+    config: Config,
+    *,
+    limit: int = 5,
+    features: list[FeatureSummary] | None = None,
+) -> list[TemplateRecord]:
+    """N most-recently-generated templates across the corpus.
+
+    Pass ``features`` when the caller already holds
+    :func:`list_features` output to avoid recomputing it.
+    """
+    records = [r for r in _all_template_records(config, features) if r.generated_at is not None]
     records.sort(key=lambda r: r.generated_at or "", reverse=True)
     return records[:limit]
 
 
-def featured_topics(config: Config) -> list[FeatureSummary]:
+def featured_topics(
+    config: Config, features: list[FeatureSummary] | None = None
+) -> list[FeatureSummary]:
     """Curated list of high-leverage features for the home page.
 
     v1: hard-coded shortlist of features the dashboard wants to
     nudge users toward. Falls back to "first N features" if any of
-    the curated picks aren't in the corpus.
+    the curated picks aren't in the corpus. Pass ``features`` when
+    the caller already holds :func:`list_features` output.
     """
     curated = (
         "security-audit",
@@ -382,11 +416,13 @@ def featured_topics(config: Config) -> list[FeatureSummary]:
         "deep-review",
         "release-prep",
     )
-    features = {f.name: f for f in list_features(config)}
-    out = [features[name] for name in curated if name in features]
+    if features is None:
+        features = list_features(config)
+    by_name = {f.name: f for f in features}
+    out = [by_name[name] for name in curated if name in by_name]
     if len(out) < 3:
         # Fallback — first few features alphabetically.
-        out = list(features.values())[:5]
+        out = list(by_name.values())[:5]
     return out
 
 

--- a/src/attune/ops/routes/dashboard.py
+++ b/src/attune/ops/routes/dashboard.py
@@ -112,7 +112,7 @@ async def home(request: Request) -> HTMLResponse:
 
 
 @router.get("/workflows", response_class=HTMLResponse)
-async def workflows_page(request: Request) -> HTMLResponse:
+def workflows_page(request: Request) -> HTMLResponse:
     workflows = data.list_workflows()
     cfg = request.app.state.config
     features = data.list_features(cfg.project_root)
@@ -177,7 +177,7 @@ async def workflows_page(request: Request) -> HTMLResponse:
 
 
 @router.get("/telemetry", response_class=HTMLResponse)
-async def telemetry_page(request: Request) -> HTMLResponse:
+def telemetry_page(request: Request) -> HTMLResponse:
     cfg = request.app.state.config
     summary = data.read_telemetry_summary(cfg, recent_days=14)
     # Phase 6.1 of ops-runner-tier2 — surface in-memory UI interaction
@@ -277,14 +277,16 @@ def _count_articles_for_kinds(features, kinds: tuple[str, ...]) -> int:
 
 
 @router.get("/help", response_class=HTMLResponse)
-async def help_home_page(request: Request) -> HTMLResponse:
+def help_home_page(request: Request) -> HTMLResponse:
     """Help home — user-first browse + search entry point."""
     from attune.ops import help_data
 
     cfg = request.app.state.config
+    # ONE list_features pass per request — featured_topics and
+    # recently_regenerated reuse it (11.5.0 self-review N+1 fix).
     features = help_data.list_features(cfg)
-    featured = help_data.featured_topics(cfg)
-    recent = help_data.recently_regenerated(cfg, limit=5)
+    featured = help_data.featured_topics(cfg, features=features)
+    recent = help_data.recently_regenerated(cfg, limit=5, features=features)
     intents = [
         dict(intent, count=_count_articles_for_kinds(features, intent["kinds"]))
         for intent in _HELP_INTENTS
@@ -308,7 +310,7 @@ async def help_home_page(request: Request) -> HTMLResponse:
 
 
 @router.get("/help/search", response_class=HTMLResponse)
-async def help_search_page(request: Request, q: str = "") -> HTMLResponse:
+def help_search_page(request: Request, q: str = "") -> HTMLResponse:
     """Help search results page."""
     from attune.ops import help_data
 
@@ -318,7 +320,7 @@ async def help_search_page(request: Request, q: str = "") -> HTMLResponse:
 
 
 @router.get("/help/admin", response_class=HTMLResponse)
-async def help_admin_page(request: Request) -> HTMLResponse:
+def help_admin_page(request: Request) -> HTMLResponse:
     """Admin tools — coverage gaps + stale templates."""
     from attune.ops import help_data
 
@@ -328,7 +330,7 @@ async def help_admin_page(request: Request) -> HTMLResponse:
 
 
 @router.get("/help/{feature}/{kind}", response_class=HTMLResponse)
-async def help_template_page(request: Request, feature: str, kind: str) -> HTMLResponse:
+def help_template_page(request: Request, feature: str, kind: str) -> HTMLResponse:
     """One template — markdown-rendered."""
     from fastapi import HTTPException
 
@@ -356,7 +358,7 @@ async def help_template_page(request: Request, feature: str, kind: str) -> HTMLR
 
 
 @router.get("/help/{feature}", response_class=HTMLResponse)
-async def help_feature_page(request: Request, feature: str) -> HTMLResponse:
+def help_feature_page(request: Request, feature: str) -> HTMLResponse:
     """Feature index — list of available kinds, click to read."""
     from fastapi import HTTPException
 
@@ -373,7 +375,7 @@ async def help_feature_page(request: Request, feature: str) -> HTMLResponse:
 
 
 @router.get("/runs/{run_id}/view", response_class=HTMLResponse)
-async def run_view_page(run_id: str, request: Request) -> HTMLResponse:
+def run_view_page(run_id: str, request: Request) -> HTMLResponse:
     """Full-page view for one workflow run.
 
     URL-bound: refreshing the page re-attaches to the existing run's SSE
@@ -452,7 +454,7 @@ async def run_view_page(run_id: str, request: Request) -> HTMLResponse:
 
 
 @router.get("/specs", response_class=HTMLResponse)
-async def specs_page(request: Request) -> HTMLResponse:
+def specs_page(request: Request) -> HTMLResponse:
     """Specs tab — federated listing of all specs across configured roots.
 
     Reuses the same root resolution + scanning logic as the JSON API so the
@@ -607,7 +609,7 @@ def _render_markdown_safe(text: str) -> str:
 
 
 @router.get("/specs/{slug}", response_class=HTMLResponse)
-async def spec_detail_page(slug: str, request: Request) -> HTMLResponse:
+def spec_detail_page(slug: str, request: Request) -> HTMLResponse:
     """Drill-in for a single spec: show every phase file's content (read-only)."""
     from fastapi import HTTPException
 

--- a/tests/unit/ops/test_perf_nplus1_fixes.py
+++ b/tests/unit/ops/test_perf_nplus1_fixes.py
@@ -1,0 +1,141 @@
+"""Regression tests for the 11.5.0 post-release perf fixes.
+
+Pins the N+1 eliminations the self-review flagged: one
+``list_features`` pass per help-home request, one TTL-cached corpus
+walk shared by ``coverage_gaps`` / ``recently_regenerated``, and the
+``(mtime, size)``-keyed cache for the unbounded ``usage.jsonl``
+aggregation.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under Apache 2.0
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from unittest.mock import patch
+
+import pytest
+
+from attune.ops import data, help_data
+from attune.ops.config import Config
+
+
+@pytest.fixture(autouse=True)
+def _fresh_caches():
+    help_data._clear_records_cache()
+    help_data._clear_staleness_cache()
+    data._clear_telemetry_summary_cache()
+    yield
+    help_data._clear_records_cache()
+    help_data._clear_staleness_cache()
+    data._clear_telemetry_summary_cache()
+
+
+def _make_corpus(root, features=("alpha", "beta"), kinds=("concept", "task")):
+    for feat in features:
+        d = root / ".help" / "templates" / feat
+        d.mkdir(parents=True)
+        for kind in kinds:
+            (d / f"{kind}.md").write_text(
+                f"---\ngenerated_at: 2026-08-0{1 + len(feat) % 5}\n---\n\n# {feat} {kind}\n",
+                encoding="utf-8",
+            )
+
+
+def _cfg(tmp_path) -> Config:
+    return Config(project_root=tmp_path, attune_home=tmp_path / ".attune")
+
+
+class TestRecordWalkCache:
+    def test_gaps_and_recent_share_one_corpus_walk(self, tmp_path):
+        """Back-to-back coverage_gaps + recently_regenerated must not
+        double the per-template file reads (the flagged N+1)."""
+        _make_corpus(tmp_path)
+        cfg = _cfg(tmp_path)
+        calls = 0
+        real = help_data.get_template
+
+        def counting(config, feature, kind):
+            nonlocal calls
+            calls += 1
+            return real(config, feature, kind)
+
+        with patch.object(help_data, "get_template", side_effect=counting):
+            help_data.coverage_gaps(cfg)
+            help_data.recently_regenerated(cfg, limit=5)
+        assert calls == 4, f"expected ONE walk (4 templates), got {calls} reads"
+
+    def test_cache_scoped_per_corpus_root(self, tmp_path):
+        a = tmp_path / "a"
+        b = tmp_path / "b"
+        _make_corpus(a, features=("only-a",), kinds=("concept",))
+        _make_corpus(b, features=("only-b",), kinds=("concept",))
+        recs_a = help_data._all_template_records(_cfg(a))
+        recs_b = help_data._all_template_records(_cfg(b))
+        assert [r.feature for r in recs_a] == ["only-a"]
+        assert [r.feature for r in recs_b] == ["only-b"]
+
+
+class TestFeaturesReuse:
+    def test_featured_and_recent_reuse_passed_features(self, tmp_path):
+        """With ``features=`` supplied, list_features is NOT recomputed."""
+        _make_corpus(tmp_path)
+        cfg = _cfg(tmp_path)
+        features = help_data.list_features(cfg)
+        with patch.object(help_data, "list_features", side_effect=AssertionError("recomputed")):
+            help_data.featured_topics(cfg, features=features)
+            help_data.recently_regenerated(cfg, limit=5, features=features)
+
+
+class TestTelemetrySummaryCache:
+    def _write_events(self, path, n=3):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("a", encoding="utf-8") as f:
+            for _ in range(n):
+                f.write(
+                    json.dumps(
+                        {"total_cost": 1.0, "workflow": "code-review", "ts": "2026-08-08T00:00:00"}
+                    )
+                    + "\n"
+                )
+
+    def test_unchanged_file_parsed_once(self, tmp_path):
+        cfg = _cfg(tmp_path)
+        self._write_events(cfg.telemetry_path)
+        calls = 0
+        real = data._parse_usage_event
+
+        def counting(line):
+            nonlocal calls
+            calls += 1
+            return real(line)
+
+        with patch.object(data, "_parse_usage_event", side_effect=counting):
+            first = data.read_telemetry_summary(cfg)
+            second = data.read_telemetry_summary(cfg)
+        assert first.total_requests == 3
+        assert second is first, "unchanged file must serve the cached summary"
+        assert calls == 3, "second call must not re-parse the file"
+
+    def test_append_invalidates_cache(self, tmp_path):
+        cfg = _cfg(tmp_path)
+        self._write_events(cfg.telemetry_path)
+        first = data.read_telemetry_summary(cfg)
+        assert first.total_requests == 3
+        self._write_events(cfg.telemetry_path, n=2)
+        # mtime granularity guard: force a distinct identity.
+        st = cfg.telemetry_path.stat()
+        os.utime(cfg.telemetry_path, ns=(st.st_atime_ns, st.st_mtime_ns + 1))
+        second = data.read_telemetry_summary(cfg)
+        assert second.total_requests == 5
+
+    def test_today_change_invalidates_cache(self, tmp_path):
+        from datetime import date
+
+        cfg = _cfg(tmp_path)
+        self._write_events(cfg.telemetry_path)
+        d1 = data.read_telemetry_summary(cfg, today=date(2026, 8, 8))
+        d2 = data.read_telemetry_summary(cfg, today=date(2026, 8, 9))
+        assert d1 is not d2, "different rolling-window anchors must not share a cache entry"


### PR DESCRIPTION
## Summary

The performance cluster from the 11.5.0 step-16 self-review (code-review run `031085bf659a`; triage in `docs/reports/post-release-self-review-11.5.0.md`):

- **help home [High ×2]**: ONE `list_features` pass per request (`featured_topics` / `recently_regenerated` take the precomputed list), and `coverage_gaps` + `recently_regenerated` now share a single 5s-TTL corpus walk instead of one file read per template per caller.
- **`read_telemetry_summary` [Medium]**: `(mtime_ns, size, recent_days, today)`-keyed cache — the unbounded `usage.jsonl` is parsed once per change instead of on every dashboard/telemetry request; appends invalidate by file identity.
- **event-loop blocking [Medium]**: the 10 no-await `async def` dashboard handlers become sync-`def`, so FastAPI runs their filesystem/render I/O in its threadpool (only `home` awaits; its billing fetch was already offloaded).

**Scoped out with reason**: `pattern_review`'s per-key Redis retrieve loop needs a batch primitive on the `MemoryBackend` protocol's implementers (FileStash + AMS) — that's backend-seam work, queued as a follow-up rather than bolted onto a presentation-layer PR.

## Receipts

- 6 new regression tests (`tests/unit/ops/test_perf_nplus1_fixes.py`): one-walk assertion via call counting (4 reads, not 8), features-reuse (recompute raises), parse-once + append-invalidates + window-anchor-invalidates for the telemetry cache.
- Full ops suite + ratchet sweep serially: 1845 passed.

Not a D11 risk class (presentation-layer perf; no memory/persistence/security surface). Merge on explicit go.

🤖 Generated with [Claude Code](https://claude.com/claude-code)