### PR TITLE
perf(memory): batch retrieve_many for pattern library loads (self-review 031085bf)

### DIFF
--- a/attune_redis/memory.py
+++ b/attune_redis/memory.py
@@ -231,6 +231,39 @@ class AMSMemoryBackend:
             logger.error("retrieve_failed: key=%s error=%s", key, e)
             return None
 
+    def retrieve_many(self, keys: list[str], agent_id: str | None = None) -> dict[str, Any]:
+        """Retrieve several working-memory keys in one AMS round-trip.
+
+        :meth:`retrieve` fetches the session's whole working-memory
+        ``data`` dict per call, so N lookups cost N HTTP round-trips —
+        one fetch serves them all. Missing keys map to ``None``; on an
+        AMS error every key maps to ``None`` (graceful degradation,
+        matching :meth:`retrieve`).
+
+        Args:
+            keys: Storage keys to retrieve.
+            agent_id: Session ID override.
+
+        Returns:
+            Mapping of each requested key to its stored value or None.
+        """
+        if not keys:
+            return {}
+        session_id = agent_id or self._session_id
+        try:
+            _, response = _run_sync(
+                self._client.get_or_create_working_memory(
+                    session_id=session_id,
+                    namespace=self._namespace,
+                )
+            )
+            data = response.data or {}
+        except Exception as e:  # noqa: BLE001
+            # INTENTIONAL: Graceful degradation for AMS HTTP errors
+            logger.error("retrieve_many_failed: keys=%d error=%s", len(keys), e)
+            return dict.fromkeys(keys)
+        return {k: data.get(k) for k in keys}
+
     def delete(self, key: str) -> bool:
         """Delete a key from AMS working memory.
 

--- a/attune_redis/tests/test_memory.py
+++ b/attune_redis/tests/test_memory.py
@@ -97,6 +97,36 @@ class TestStashRetrieve:
 # =================================================================
 
 
+class TestRetrieveMany:
+    """Batched working-memory reads — one fetch serves every key."""
+
+    def test_round_trip_many(self, backend):
+        """Present keys map to values, missing keys to None."""
+        backend.stash("a", 1)
+        backend.stash("b", {"v": 2})
+        got = backend.retrieve_many(["a", "b", "missing"])
+        assert got == {"a": 1, "b": {"v": 2}, "missing": None}
+
+    def test_single_fetch_for_many_keys(self, backend, mock_ams_client):
+        """N keys cost exactly one working-memory fetch, not N."""
+        backend.stash("a", 1)
+        backend.stash("b", 2)
+        mock_ams_client.get_or_create_working_memory.reset_mock()
+        backend.retrieve_many(["a", "b"])
+        assert mock_ams_client.get_or_create_working_memory.call_count == 1
+
+    def test_empty_keys_skip_the_client(self, backend, mock_ams_client):
+        """No keys, no round-trip."""
+        mock_ams_client.get_or_create_working_memory.reset_mock()
+        assert backend.retrieve_many([]) == {}
+        mock_ams_client.get_or_create_working_memory.assert_not_called()
+
+    def test_error_degrades_to_all_none(self, backend, mock_ams_client):
+        """AMS errors map every key to None, matching retrieve()."""
+        mock_ams_client.get_or_create_working_memory.side_effect = ConnectionError("down")
+        assert backend.retrieve_many(["a", "b"]) == {"a": None, "b": None}
+
+
 class TestDelete:
     """Test key deletion."""
 

--- a/src/attune/memory/backend.py
+++ b/src/attune/memory/backend.py
@@ -33,6 +33,15 @@ class MemoryBackend(Protocol):
             def retrieve(self, key, agent_id=None):
                 ...
             # ... remaining methods
+
+    Optional batch extension: backends MAY additionally provide
+    ``retrieve_many(keys, agent_id=None) -> dict[str, Any]``, returning
+    each requested key's stored value (missing keys map to ``None``) in
+    a single backend round-trip. Callers probe for it with ``getattr``
+    and fall back to per-key ``retrieve``. It is deliberately NOT a
+    protocol member: this protocol is ``@runtime_checkable``, so adding
+    a member would fail ``isinstance`` checks for existing backends
+    that predate the extension.
     """
 
     def stash(

--- a/src/attune/memory/file_stash.py
+++ b/src/attune/memory/file_stash.py
@@ -350,6 +350,15 @@ class FileStashBackend:
         """Retrieve a key/value pair."""
         return self._load_kv().get(key)
 
+    def retrieve_many(self, keys: list[str], agent_id: str | None = None) -> dict[str, Any]:
+        """Retrieve several key/value pairs in one KV-file read.
+
+        Batch counterpart of :meth:`retrieve`, which re-reads the KV file
+        on every call. Missing keys map to ``None``.
+        """
+        data = self._load_kv()
+        return {k: data.get(k) for k in keys}
+
     def delete(self, key: str) -> bool:
         """Delete a key/value pair. Returns False if absent."""
         data = self._load_kv()

--- a/src/attune/pattern_review.py
+++ b/src/attune/pattern_review.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 import logging
 import os
 from datetime import datetime
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from attune.memory.types import StagedPattern
 from attune.pattern_library import Pattern, PatternLibrary
@@ -42,6 +42,20 @@ GRAPH_KEY = "pattern_graph"
 REVIEW_ENABLED_ENV = "ATTUNE_PATTERN_REVIEW"
 #: Truthy spellings that turn review routing on.
 _TRUTHY = frozenset({"1", "true", "yes", "on"})
+
+
+def _retrieve_all(backend: MemoryBackend, keys: list[str]) -> dict[str, Any]:
+    """Fetch many keys from the backend, batched when it supports it.
+
+    Uses the optional ``retrieve_many`` batch extension when the backend
+    provides one (a single backend round-trip — see
+    :class:`~attune.memory.backend.MemoryBackend`); falls back to per-key
+    ``retrieve`` otherwise. Missing keys map to ``None`` either way.
+    """
+    retrieve_many = getattr(backend, "retrieve_many", None)
+    if callable(retrieve_many):
+        return retrieve_many(keys)
+    return {key: backend.retrieve(key) for key in keys}
 
 
 def _default_backend() -> MemoryBackend:
@@ -100,8 +114,8 @@ class PatternReviewQueue:
         ``min_confidence``. Unparseable entries are skipped, not fatal.
         """
         out: list[StagedPattern] = []
-        for key in self._backend.keys(STAGED_PREFIX + "*"):
-            raw = self._backend.retrieve(key)
+        staged_keys = self._backend.keys(STAGED_PREFIX + "*")
+        for key, raw in _retrieve_all(self._backend, staged_keys).items():
             if not raw:
                 continue
             staged = _parse(raw, key)
@@ -285,9 +299,15 @@ class PersistentPatternLibrary(PatternLibrary):
         self._load()
 
     def _load(self) -> None:
-        """Reconstruct the in-memory library from the backend (no re-persist)."""
-        for key in self._backend.keys(ACTIVE_PREFIX + "*"):
-            pattern = _pattern_from_dict(self._backend.retrieve(key))
+        """Reconstruct the in-memory library from the backend (no re-persist).
+
+        Values are fetched through :func:`_retrieve_all`, so a backend with
+        the ``retrieve_many`` batch extension serves the whole library in
+        one round-trip instead of one ``retrieve`` per stored pattern.
+        """
+        active_keys = self._backend.keys(ACTIVE_PREFIX + "*")
+        for value in _retrieve_all(self._backend, active_keys).values():
+            pattern = _pattern_from_dict(value)
             if pattern is None:
                 continue
             try:

--- a/tests/unit/gates/test_broad_except_ratchet.py
+++ b/tests/unit/gates/test_broad_except_ratchet.py
@@ -60,7 +60,11 @@ _BASELINE: dict[str, int] = {
     # diagnostic's classifier guard — the effective-config section must
     # never flip an otherwise-healthy health-tool response to failure.
     "attune_redis/mcp_tools.py": 13,
-    "attune_redis/memory.py": 13,
+    # memory.py raised 13 -> 14 for the retrieve_many batch extension
+    # (PR #1991): the batched working-memory read degrades AMS errors to
+    # all-None instead of raising, matching retrieve()'s must-not-crash
+    # memory-layer contract (collaboration principle 15).
+    "attune_redis/memory.py": 14,
     "attune_redis/plugin.py": 1,
     "attune_redis/signals.py": 2,
     "attune_redis/tests/test_integration.py": 1,

--- a/tests/unit/memory/test_file_stash.py
+++ b/tests/unit/memory/test_file_stash.py
@@ -163,6 +163,18 @@ def test_kv_delete_and_keys(backend):
     assert backend.keys() == ["b"]
 
 
+def test_retrieve_many_matches_per_key_retrieve(backend):
+    backend.stash("a", 1)
+    backend.stash("b", {"v": 2})
+    got = backend.retrieve_many(["a", "b", "missing"])
+    assert got == {"a": 1, "b": {"v": 2}, "missing": None}
+    assert got == {k: backend.retrieve(k) for k in ["a", "b", "missing"]}
+
+
+def test_retrieve_many_empty_keys(backend):
+    assert backend.retrieve_many([]) == {}
+
+
 def test_is_fallback_and_protocol_surface(backend):
     assert FileStashBackend.is_fallback is True
     assert backend.is_connected() is True

--- a/tests/unit/test_pattern_review.py
+++ b/tests/unit/test_pattern_review.py
@@ -257,3 +257,97 @@ class TestInternals:
         be.stash(ACTIVE_PREFIX + "k2", d)  # same id under a second key
         lib = PersistentPatternLibrary(backend=be)
         assert "dup" in lib.patterns  # loaded once, dup skipped without error
+
+
+class _NoBatchBackend:
+    """Delegates to a real backend but HIDES ``retrieve_many``.
+
+    Models a backend predating the batch extension, forcing
+    ``_retrieve_all``'s per-key fallback; counts calls so tests can prove
+    which path actually ran.
+    """
+
+    def __init__(self, inner):
+        self._inner = inner
+        self.retrieve_calls = 0
+
+    def stash(self, key, value, ttl=None, agent_id=None):
+        return self._inner.stash(key, value, ttl, agent_id)
+
+    def retrieve(self, key, agent_id=None):
+        self.retrieve_calls += 1
+        return self._inner.retrieve(key, agent_id)
+
+    def keys(self, pattern="*"):
+        return self._inner.keys(pattern)
+
+    def delete(self, key):
+        return self._inner.delete(key)
+
+
+class _CountingBatchBackend(_NoBatchBackend):
+    """Delegating wrapper that also counts ``retrieve_many`` calls."""
+
+    def __init__(self, inner):
+        super().__init__(inner)
+        self.retrieve_many_calls = 0
+
+    def retrieve_many(self, keys, agent_id=None):
+        self.retrieve_many_calls += 1
+        return self._inner.retrieve_many(keys, agent_id)
+
+
+class TestBatchRetrieve:
+    """The batch (retrieve_many) and fallback (per-key) paths are equivalent."""
+
+    def _seed(self, tmp_path, n=3):
+        """Persist n patterns plus a graph edge into a tmp_path-backed store."""
+        lib = PersistentPatternLibrary(backend=FileStashBackend(base_dir=str(tmp_path)))
+        for i in range(n):
+            lib.contribute_pattern(
+                "a1",
+                Pattern(
+                    id=f"p{i}",
+                    agent_id="a1",
+                    pattern_type="behavioral",
+                    name=f"n{i}",
+                    description="d",
+                ),
+            )
+        lib.link_patterns("p0", "p1")
+
+    def test_batch_and_fallback_load_identical_libraries(self, tmp_path):
+        import attune.pattern_review as pr
+
+        self._seed(tmp_path)
+        batch_lib = PersistentPatternLibrary(backend=FileStashBackend(base_dir=str(tmp_path)))
+        fallback_be = _NoBatchBackend(FileStashBackend(base_dir=str(tmp_path)))
+        loop_lib = PersistentPatternLibrary(backend=fallback_be)
+        assert fallback_be.retrieve_calls > 0  # the per-key path really ran
+        assert set(batch_lib.patterns) == set(loop_lib.patterns) == {"p0", "p1", "p2"}
+        for pid, pat in batch_lib.patterns.items():
+            assert pr._pattern_to_dict(pat) == pr._pattern_to_dict(loop_lib.patterns[pid])
+        assert batch_lib.pattern_graph == loop_lib.pattern_graph
+
+    def test_load_uses_one_batch_call_not_per_key_retrieves(self, tmp_path):
+        self._seed(tmp_path)
+        be = _CountingBatchBackend(FileStashBackend(base_dir=str(tmp_path)))
+        PersistentPatternLibrary(backend=be)
+        assert be.retrieve_many_calls == 1  # all patterns in one round-trip
+        assert be.retrieve_calls == 1  # only the single GRAPH_KEY read remains
+
+    def test_queue_list_batch_and_fallback_agree(self, tmp_path):
+        batch_q = PatternReviewQueue(
+            backend=_CountingBatchBackend(FileStashBackend(base_dir=str(tmp_path)))
+        )
+        for i in range(3):
+            batch_q.stage(_staged(f"s{i}", confidence=0.5 + i / 10))
+        loop_q = PatternReviewQueue(
+            backend=_NoBatchBackend(FileStashBackend(base_dir=str(tmp_path)))
+        )
+        batch_ids = [p.pattern_id for p in batch_q.list()]
+        loop_ids = [p.pattern_id for p in loop_q.list()]
+        assert batch_ids == loop_ids == ["s2", "s1", "s0"]  # confidence desc
+        assert batch_q._backend.retrieve_many_calls == 1
+        assert batch_q._backend.retrieve_calls == 0
+        assert loop_q._backend.retrieve_calls == 3


### PR DESCRIPTION
## Summary

Fixes the Medium finding from the 2026-08-08 post-release self-review (run `031085bf659a`, triaged in `docs/reports/post-release-self-review-11.5.0.md`): `PersistentPatternLibrary._load` did one `backend.retrieve()` per key from `keys("pattern:*")` on every library construction — N Redis round-trips under AMS, N KV-file reads under the file backend.

## Changes

- **`src/attune/memory/backend.py`** — documents the optional `retrieve_many(keys, agent_id=None) -> dict[str, Any]` batch extension on the `MemoryBackend` protocol docstring. Deliberately **not** a protocol member: the protocol is `@runtime_checkable`, so a new member would fail `isinstance` checks for backends predating the extension (`FileSessionMemory`, `RedisShortTermMemory`, feedback_loop's in-memory store). Follows the `forget`/`recent` getattr-probe convention.
- **`src/attune/memory/file_stash.py`** — `FileStashBackend.retrieve_many`: one `_load_kv()` read serves all keys (`retrieve()` re-reads the KV file per call).
- **`attune_redis/memory.py`** — `AMSMemoryBackend.retrieve_many`: one `get_or_create_working_memory` fetch serves all keys; missing keys map to `None`; AMS errors degrade to all-`None`, matching `retrieve()`. *Deviation from the review note:* the suggested `_mget` (#1982) lives in the short_term raw-Redis layer, which the AMS backend doesn't sit on — it talks HTTP to AMS, where `retrieve()` already fetches the whole working-memory `data` dict per call. The single working-memory fetch **is** the MGET-class batch on that surface.
- **`src/attune/pattern_review.py`** — `_retrieve_all` helper (getattr probe → per-key fallback), wired into `PersistentPatternLibrary._load` **and** `PatternReviewQueue.list`, which had the identical N+1 shape in the same file (CLI + ops dashboard listing path).

## Tests

- Batch and fallback paths produce **identical libraries** (patterns + graph) and identical queue listings, with call-counting wrappers proving which path ran.
- `_load` via a batch-capable backend: exactly 1 `retrieve_many` + 1 graph-key `retrieve`.
- File backend: `retrieve_many` matches per-key `retrieve`, empty-keys → `{}`.
- AMS backend: 1 client fetch for N keys, no client call on empty keys, all-`None` on AMS errors.

Receipt (suite, serial): `tests/unit/memory tests/unit/test_pattern_review.py tests/unit/test_pattern_review_routing.py tests/unit/cli_commands/test_pattern_review_cli.py attune_redis/tests` → **2156 passed, 50 skipped, 3 xfailed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
