### PR TITLE
test(memory): close memory-security-hardening R1-followup — injector fail-closed receipt

### DIFF
--- a/docs/specs/memory-security-hardening/tasks.md
+++ b/docs/specs/memory-security-hardening/tasks.md
@@ -1,8 +1,9 @@
 # memory-security-hardening — tasks
 
-**Status:** active (2026-08-07) — design gate passed; decisions ratified.
-R1 shipped (PR #1979) but the envelope does NOT cover all recall surfaces
-(R1-followup below). Full pass in flight: R1-followup + R2 + R3 + R5.
+**Status:** active (2026-08-08) — design gate passed; decisions ratified.
+R1 shipped (PR #1979); R1-followup COMPLETE 2026-08-08 (task 2 void by
+the D1 narrowing, task 4 receipted — see rows). Remaining: R3 #2/#5/#6/#7
+(machine-gated + reader/writer co-design) and R5 #2.
 **Requirements:** [requirements.md](requirements.md) · **Design:** [design.md](design.md)
 · **Decisions:** [decisions.md](decisions.md)
 
@@ -19,15 +20,15 @@ dependency order — in-repo, low-risk items first; machine-infra last (gated).
 | 3 | Live SessionStart injector renders through the envelope | done | `session_recall.py::_format` |
 | 4 | Tests + payload verification | done | |
 
-## R1-followup — envelope coverage on the other model-context surfaces (D1)
+## R1-followup — envelope coverage on the other model-context surfaces (D1) — COMPLETE (2026-08-08)
 
 | # | Task | Layer | Status | Notes |
 |---|------|-------|--------|-------|
 | 1 | MCP `personal_memory_recall` returns framed `context`; bare summary/excerpt stripped from results | attune-ai | done | `memory_handlers.py:344`; fails closed if provenance absent |
-| 2 | MCP `memory_retrieve` — stamp provenance + wrap; fail closed if unavailable | attune-ai | pending | `memory_handlers.py:127`; no provenance today |
+| 2 | ~~MCP `memory_retrieve` — stamp provenance + wrap; fail closed if unavailable~~ | attune-ai | **void** | superseded by 2b — the D1 narrowing (chair-ratified) replaced the prose envelope with the trust annotation for keyed structured data; a fail-closed dimension does not exist for inline constants |
 | 2b | MCP `memory_retrieve` trust annotation (D1 narrowed) | attune-ai | done | keyed structured data → light trust annotation, not the prose envelope; chair-ratified narrowing |
 | 3 | `PersonalMemory.query` — render at the consumer | attune-ai | done (by boundary) | rendered in the MCP handler (CONSUMER CONTRACT); no separate helper needed |
-| 4 | Tests: each surface frames a payload, content preserved, fails closed | attune-ai | pending | hermetic |
+| 4 | Tests: each surface frames a payload, content preserved, fails closed | attune-ai | done | receipted 2026-08-08: `test_memory_handlers.py` (retrieve both paths content+trust; recall frames/preserves/withholds), `test_session_memory_hooks.py` (frames+preserves+flags, budget, stamped context_block verbatim; fail-closed added — `test_format_fails_closed_when_renderer_unavailable`) |
 
 ## R2 — secret-scan at every write path (D2, D3) — ~2/3 SHIPPED
 

--- a/tests/unit/hooks/test_session_memory_hooks.py
+++ b/tests/unit/hooks/test_session_memory_hooks.py
@@ -478,6 +478,20 @@ def test_format_respects_budget(recall_mod, monkeypatch):
     assert rendered_ids == ["kept"]  # over-budget entries yield no id either
 
 
+def test_format_fails_closed_when_renderer_unavailable(recall_mod, monkeypatch):
+    # R1-followup task 4: when attune.memory.provenance cannot import
+    # (older attune during rollout), the injector surfaces NOTHING — an
+    # empty block and no rendered ids — rather than leaking unframed text.
+    payload = "must never reach context unframed"
+    monkeypatch.setattr(recall_mod, "render_recall_for_context", None)
+    block, rendered_ids = recall_mod._format(
+        [{"id": "abc", "text": payload, "topics": ["type:note"]}]
+    )
+    assert block == ""
+    assert rendered_ids == []
+    assert payload not in block
+
+
 def test_format_wraps_injection_payload_as_flagged_untrusted(recall_mod):
     # R1 verification: a recalled finding carrying an injection payload must
     # reach context wrapped as untrusted evidence, flagged, content preserved.


### PR DESCRIPTION
## memory-security-hardening — R1-followup phase CLOSED

Advances the spec one phase per the session contract (the ladder is
chair-ratified and active; D6 exempts in-repo work from the machine
gate — no new chair gate required to execute these rows).

### What closed the phase

**Task 4** ("tests: each surface frames a payload, content
preserved, fails closed") — audited all three model-context recall
surfaces against the three dimensions:

| Surface | Frames | Content preserved | Fails closed |
|---|---|---|---|
| MCP `personal_memory_recall` | already tested | already tested | already tested |
| MCP `memory_retrieve` (D1-narrowed trust annotation) | already tested (both paths) | already tested | N/A by design — inline constants |
| SessionStart injector `session_recall._format` | already tested | already tested | **GAP → test added** |

The one genuine gap: no test pinned the injector's fail-closed
branch (`render_recall_for_context` unavailable → `("", [])`, never
unframed prose). Added
`test_format_fails_closed_when_renderer_unavailable`.

**Task 2** flipped to **void**: superseded by task 2b's
chair-ratified D1 narrowing — `memory_retrieve` returns keyed,
structured data and carries the light trust annotation instead of
the prose envelope; the "fail closed if unavailable" clause has no
referent for inline constants.

**tasks.md header** now records R1-followup COMPLETE (2026-08-08);
remaining spec scope is R3 #2/#5/#6/#7 (machine-gated + reader/
writer co-design) and R5 #2.

### Receipts

- `tests/unit/gates/ + tests/unit/quality/ +
  tests/unit/hooks/test_session_memory_hooks.py`: **285 passed**,
  run serially (no xdist).
- Pinned black + ruff pre-flighted clean.

Tests + spec-docs only; no production code changed. D11 note for the
chair: this is a memory-spec deliverable but a tests-only diff — no
cross-review lane was spent; flag if you want one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
