### PR TITLE
chore(release): 11.6.0 — redis config truth + self-review fixes

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "Spec-driven development for Claude Code — take an idea through requirements, design, tasks, and gated execution with an approval loop. Plus 28 auto-triggering skills: security audits, code review, test generation, release prep.",
-    "version": "11.5.0"
+    "version": "11.6.0"
   },
   "plugins": [
     {
       "name": "attune-ai",
       "description": "Spec-driven development is the core workflow: /spec carries an idea through brainstorm, requirements, design, and task execution with quality gates and your approval at each stage. Backed by 28 auto-triggering skills — security audits, code reviews, test generation, bug prediction, and release preparation. For help content tools, also install attune-help and attune-author from this marketplace.",
       "source": "./plugin",
-      "version": "11.5.0",
+      "version": "11.6.0",
       "author": {
         "name": "Smart AI Memory",
         "email": "patrick.roebuck@smartaimemory.com"

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,4 +1,4 @@
-# Attune AI Framework v11.5.0
+# Attune AI Framework v11.6.0
 
 AI-powered developer workflows with cost optimization and multi-agent orchestration.
 
@@ -556,7 +556,7 @@ attune_redis/          # Redis plugin — BUNDLED, ships in the attune-ai
 
 ---
 
-**Version:** 11.5.0 | **License:** Apache 2.0 | **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)
+**Version:** 11.6.0 | **License:** Apache 2.0 | **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)
 
 ## Lessons — core
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,64 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [11.6.0] — 2026-08-09
+
+Redis config truth-telling completes: every Redis connection-env
+reader now derives from one resolver, consumers authenticate
+consistently, and an AST drift guard keeps it that way. Plus the
+11.5.0 post-release self-review's security and performance fixes.
+
+### Changed — Redis connection behavior (redis-config-truth rct-4, #1993)
+
+- **Consumers that previously ignored `REDIS_PASSWORD` now
+  authenticate.** Every direct Redis connection-env reader derives
+  from `resolve_redis_connection()`. Stale passwords in staging/CI
+  surface loudly via the `degraded_auth` loud-once notice instead
+  of failing silently.
+- **`EMPATHY_REDIS_HOST`/`EMPATHY_REDIS_PORT` compatibility retired
+  for connection variables** — canonical `REDIS_*` names only
+  (feature toggles keep their compat aliases).
+- **`REDIS_PORT`/`REDIS_DB` without `REDIS_HOST` are no longer
+  honored** — connection resolution is host-anchored.
+- `redis_config.py` is now a delegator over the resolver;
+  `REDIS_MODE`, SSL, and timeout semantics are preserved.
+
+### Security (11.5.0 self-review act-now items, #1989)
+
+- Hook executor: command templates tokenize before substitution —
+  context values can no longer inject extra argv tokens.
+- Hook executor webhooks: connections pin the validated IP
+  (DNS-rebinding TOCTOU closed); TLS still verifies the hostname.
+- Ops runner: `run_id` validated before any filesystem walk
+  (traversal-shaped ids return None without disk access).
+
+### Fixed
+
+- `AttuneConfig` regains a real module identity
+  (`attune.config.legacy`) — isinstance checks across import
+  paths, pickling, and registry lookups work again (#1992).
+- Memory URL helpers are `ParseResult`-typed at the credential
+  seam; the Redis auto-detect module cache is lock-guarded (#1989).
+
+### Performance
+
+- Help home renders with one `list_features` pass and one shared
+  5s-TTL corpus walk (was per-template file reads); telemetry
+  summary parses `usage.jsonl` once per file change; dashboard
+  handlers moved off the event loop into the threadpool (#1990).
+- Pattern library loads batch via `retrieve_many` instead of
+  per-key round-trips (#1991).
+
+### Testing
+
+- AST-based Redis env-access drift guard: any new direct read of
+  the eight connection names outside the resolver fails CI, with
+  eight planted access forms proven caught (#1993).
+- Self-provisioning requirepass regression lane exercises the
+  authenticated-Redis path end-to-end (#1994).
+- memory-security-hardening R1-followup closed: the SessionStart
+  recall injector's fail-closed path is pinned by test (#1997).
+
 ## [11.5.0] — 2026-08-08
 
 Redis config truth: Redis connection settings now flow through one

--- a/docs/reference/API_REFERENCE.md
+++ b/docs/reference/API_REFERENCE.md
@@ -1,6 +1,6 @@
 # Attune AI API Reference
 
-**Version:** 11.5.0
+**Version:** 11.6.0
 **License:** Apache License 2.0
 **Copyright:** 2025-2026 Smart AI Memory, LLC
 
@@ -1152,5 +1152,5 @@ msg = format_error(
 
 ---
 
-**Version:** 11.5.0 | **License:** Apache 2.0
+**Version:** 11.6.0 | **License:** Apache 2.0
 **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)

--- a/plugin/.claude-plugin/marketplace.json
+++ b/plugin/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "Spec-driven development for Claude Code — /spec plans, reviews, and executes with quality gates; plus security audits, code reviews, test generation, and release prep from /attune.",
-    "version": "11.5.0"
+    "version": "11.6.0"
   },
   "plugins": [
     {
       "name": "attune-ai",
       "description": "Spec-driven development for Claude Code — /spec plans, reviews, and executes with quality gates; plus security audits, code reviews, test generation, and release prep from /attune.",
       "source": "./",
-      "version": "11.5.0",
+      "version": "11.6.0",
       "author": {
         "name": "Smart AI Memory",
         "email": "patrick.roebuck@smartaimemory.com"

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "attune-ai",
-  "version": "11.5.0",
+  "version": "11.6.0",
   "description": "Spec-driven development for Claude Code — /spec plans, reviews, and executes with quality gates; plus security audits, code reviews, test generation, and release prep from /attune.",
   "author": {
     "name": "Smart AI Memory",

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -4,7 +4,7 @@ Spec-driven development for Claude Code — turn requirements
 into reliable software. <!-- cap:skill_count -->28 auto-triggering skills<!-- /cap -->, zero
 commands: say what you need and Claude picks the right skill.
 
-**Version:** 11.5.0 | **License:** Apache 2.0
+**Version:** 11.6.0 | **License:** Apache 2.0
 
 > **Fix Receipts** (`/fix`) — new in 11.2.0. Say `fix this and
 > prove it`.

--- a/plugin/core/__init__.py
+++ b/plugin/core/__init__.py
@@ -5,4 +5,4 @@ This module provides the core workflow functionality when the full
 attune-ai package is not installed via pip.
 """
 
-__version__ = "11.5.0"
+__version__ = "11.6.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "attune-ai"
-version = "11.5.0"
+version = "11.6.0"
 description = "AI-powered developer workflows for Claude with cost optimization, multi-agent orchestration, and workflow automation."
 readme = {file = "README.md", content-type = "text/markdown"}
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -299,7 +299,7 @@ wheels = [
 
 [[package]]
 name = "attune-ai"
-version = "11.5.0"
+version = "11.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "agent-memory-client" },

--- a/website/app/page.tsx
+++ b/website/app/page.tsx
@@ -58,7 +58,7 @@ export default function Home() {
             <div className="grid lg:grid-cols-2 gap-16 items-center">
               <div className="z-10">
                 <div className="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-[var(--surface-container-high)] text-[var(--primary)] text-xs font-bold tracking-widest mb-6 uppercase">
-                  <span>v11.5.0</span>
+                  <span>v11.6.0</span>
                   <span className="w-1 h-1 rounded-full bg-[var(--primary)]"></span>
                   <span className="opacity-80">Spec-driven development platform</span>
                 </div>

--- a/website/lib/features.ts
+++ b/website/lib/features.ts
@@ -32,7 +32,7 @@ export const PRODUCTS: Product[] = [
     id: "attune-ai",
     name: "Attune AI",
     pypiName: "attune-ai",
-    version: "11.5.0",
+    version: "11.6.0",
     tagline: "Generate, maintain, and serve help from your code",
     installCommand: "pip install attune-ai",
     marketplaceInstall:
@@ -101,7 +101,7 @@ export const PRODUCTS: Product[] = [
     id: "claude-code-plugin",
     name: "Claude Code Plugin",
     pypiName: "attune-ai",
-    version: "11.5.0",
+    version: "11.6.0",
     tagline: "Progressive help right in your terminal",
     installCommand:
       "claude plugin marketplace add Smart-AI-Memory/attune-ai",


### PR DESCRIPTION
Release prep for 11.6.0: version bump across all 10 sites, changelog promoted (headline: redis-config-truth rct-4 behavior changes — consumers authenticate, EMPATHY_REDIS_HOST/PORT connection-var compat retired, REDIS_PORT/DB without REDIS_HOST no longer honored — plus the 11.5.0 self-review security/perf fixes), uv.lock self-version only.

Receipts: version drift test green; pinned black clean; SKIP=check-docs-freshness sanctioned on release-prep commits (version-hash noise; /coach maintain queued post-release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)