### PR TITLE
docs(lessons): redis rotation — never render the secret

### DIFF
--- a/.claude/lessons.md
+++ b/.claude/lessons.md
@@ -21569,4 +21569,15 @@ conf — modules also must not be listed in both places, duplicate
 registration aborts redisearch). The service only worked for 15
 days because it never restarted into the bug — treat any
 long-uptime service as "restart untested" before depending on a
-restart mid-change.
+restart mid-change. **Handling rule: never render the secret —
+`echo $REDIS_PASSWORD` is how it leaks.** It reached an agent
+transcript TWICE in the 2026-08-08 session: once from an agent's
+own `${VAR:+SET}${VAR:-UNSET}` probe (the `:-` branch prints the
+VALUE when the var IS set — use `${VAR:+SET}` alone), once
+hand-pasted from a terminal after an `echo`. Move it
+clipboard-direct so the plaintext never reaches a screen or a
+scrollback: `grep '^export REDIS_PASSWORD=' ~/.zshenv | sed
+'s/.*="\(.*\)"/\1/' | tr -d '\n' | pbcopy`. There is no lookup
+path back — the conf stores only the sha256 — so a value lost
+before it reaches the password manager costs a full five-surface
+rotation, exactly what a leaked one costs.


### PR DESCRIPTION
Adds a closing handling rule to the `redis-rotation-five-surfaces` lesson.

**Not a sixth surface.** The five surfaces are places the password must be *written* during a rotation; this is a rule about how it is *read*. Folding it into the list would mix two categories and break the "FIVE surfaces" hook.

### Why

The local Redis password reached an agent transcript twice in the 2026-08-08 session, by two different mechanisms:

1. A `${VAR:+SET}${VAR:-UNSET}` presence probe — the `:-` branch prints the **value** precisely when the variable *is* set. It reads like a safe presence-check; it is not. The safe form is `${VAR:+SET}` alone.
2. `echo $REDIS_PASSWORD` in a terminal, then hand-pasted.

Both credentials were rotated out and are dead. The rule records the clipboard-direct read so plaintext never reaches a screen or scrollback:

```bash
grep '^export REDIS_PASSWORD=' ~/.zshenv | sed 's/.*="\(.*\)"/\1/' | tr -d '\n' | pbcopy
```

Verified byte-exact — the extraction half yields 43 chars, the correct length for `token_urlsafe(32)`.

### Also recorded

Losing the value costs the same as leaking it. The conf stores only the `sha256`, so there is no lookup path back; either case means a full five-surface rotation.

### Scope

Docs only — one paragraph appended to `.claude/lessons.md`. No code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)