### PR TITLE
test(gates): ratchet against unbucketed spec dirs

### DIFF
--- a/tests/unit/gates/test_status_line_gate.py
+++ b/tests/unit/gates/test_status_line_gate.py
@@ -85,3 +85,55 @@ def test_corpus_sweep_every_spec_dir_is_legible(spec_dir):
     """CI enforcer: every spec dir passes the status-line gate."""
     receipt = status_line_gate(spec_dir)
     assert receipt.state == "PASS", "\n".join(receipt.findings)
+
+
+# Dirs that legitimately carry .md content without a canonical phase
+# file. Seeded EMPTY 2026-08-09 (the corpus had no counter-example) and
+# shrink-only: never add an entry to silence a new unbucketed dir — add
+# a decisions.md (or other phase file) so the dir becomes visible to
+# the lifecycle detector and the sweep above.
+_UNBUCKETED_ALLOWLIST: frozenset[str] = frozenset()
+
+
+def _unbucketed_spec_dirs() -> list[Path]:
+    """Non-archive dirs under docs/specs/ with .md content but no phase file.
+
+    These are invisible to ``_list_specs_in_root`` and therefore to the
+    corpus sweep above — the product-direction-review trap: nine files
+    and eight weeks of executed work, entirely unbucketed until the
+    2026-08-08 triage hand-added a decisions.md.
+    """
+    if not SPECS_ROOT.is_dir():
+        return []
+    return sorted(
+        d
+        for d in SPECS_ROOT.iterdir()
+        if d.is_dir()
+        and d.name != "archive"
+        and d.name not in _UNBUCKETED_ALLOWLIST
+        and not any((d / f).is_file() for f in _PHASE_FILES)
+        and any(d.rglob("*.md"))
+    )
+
+
+def test_no_unbucketed_spec_dirs():
+    """CI enforcer: every spec dir with .md content carries a phase file."""
+    offenders = _unbucketed_spec_dirs()
+    assert not offenders, (
+        "docs/specs/ dirs with .md content but none of "
+        f"{', '.join(_PHASE_FILES)} are invisible to the lifecycle "
+        "detector and the status-line sweep. Add a decisions.md (or "
+        "another phase file) to: " + ", ".join(d.name for d in offenders)
+    )
+
+
+def test_unbucketed_allowlist_is_not_stale():
+    """Shrink-only ratchet: drop allowlist entries once they gain a
+    phase file or disappear."""
+    stale = sorted(
+        name
+        for name in _UNBUCKETED_ALLOWLIST
+        if not (SPECS_ROOT / name).is_dir()
+        or any((SPECS_ROOT / name / f).is_file() for f in _PHASE_FILES)
+    )
+    assert not stale, "Remove stale _UNBUCKETED_ALLOWLIST entries: " + ", ".join(stale)


### PR DESCRIPTION
## Summary

- Adds a corpus sweep to `tests/unit/gates/test_status_line_gate.py` that fails when a non-archive dir directly under `docs/specs/` contains any `.md` file (recursively) but none of the canonical phase files (`decisions.md`/`requirements.md`/`design.md`/`tasks.md`).
- Such dirs are invisible to both the lifecycle detector (`_spec_dirs()` mirrors `_list_specs_in_root`) and the existing status-line sweep — the `product-direction-review` trap: nine files and eight weeks of executed work, entirely unbucketed until the 2026-08-08 triage hand-added a `decisions.md` (see `docs/specs/archive/spec-backlog-triage-2026-08-08/matrix.md`, follow-up item 2).
- Allowlist seeded **empty** — the current corpus has no counter-example (verified recursively). Shrink-only, with a staleness guard test that forces removal of entries once they gain a phase file or disappear.

## Receipts

- Gates suite serial: `pytest tests/unit/gates/ -p no:xdist` → **222 passed**.
- Ratchet fires: planted `docs/specs/zz-ratchet-probe/notes.md` → `test_no_unbucketed_spec_dirs` **FAILED** naming the dir; removed probe → 60/60 pass in the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)