### PR TITLE
docs(fable-premium-tier): task 9 — retroactive 2x premium-price callout + tier-docs regen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Documentation
+
+- **Retroactive premium-price callout** (fable-premium-tier task 9):
+  the [10.5.0] entry below now carries the prominent callout for the
+  premium tier's switch to `claude-fable-5` at 2× the former Opus
+  pricing (#1361), omitted at release time. The generated
+  tier-routing help concept no longer claims premium means Opus
+  (regenerated via `scripts/generate_concept_templates.py`). Also
+  records the 2026-07-29 amendment: editing/polish passes run a
+  dedicated editing model (`ATTUNE_MODEL_EDITING`, default
+  `claude-opus-5`, #1770, shipped in 11.1.0); PREMIUM stays
+  `claude-fable-5`.
+
 ## [11.6.0] — 2026-08-09
 
 Redis config truth-telling completes: every Redis connection-env
@@ -739,6 +752,27 @@ elicitation form surface gained its canonical reference form and
 cheaper rendering paths, and the packaging surface was made honest —
 empty placeholder extras deleted and every install remediation now
 names a command that can actually fix the stated problem.
+
+### Changed — ⚠️ Premium tier now runs Claude Fable 5 at 2× Opus pricing (#1361)
+
+> Callout added retroactively 2026-08-09 (fable-premium-tier task
+> 9): this change shipped in 10.5.0 but was omitted from the
+> changelog at release time.
+
+- **The PREMIUM tier resolves to `claude-fable-5`** — $10 input /
+  $50 output per MTok (prompt-cache write $12.50/MTok, read
+  $1/MTok): **2× the former Opus premium pricing**. Premium-tier
+  workflow stages therefore cost twice what they did on Opus. Pin
+  the tier back with `ATTUNE_MODEL_PREMIUM` (e.g.
+  `claude-opus-4-8`) if the old price point matters more than
+  Fable-class output.
+- **`BASELINE_MODEL` moved to `claude-fable-5`** so savings math
+  stays truthful on premium calls; historical telemetry records
+  keep the opus baseline frozen at log time.
+- Amendment (2026-07-29, #1770, shipped in 11.1.0): editing/polish
+  passes later split to a dedicated editing model
+  (`ATTUNE_MODEL_EDITING`, default `claude-opus-5`); PREMIUM stays
+  `claude-fable-5`.
 
 ### Added
 

--- a/docs/specs/fable-premium-tier/tasks.md
+++ b/docs/specs/fable-premium-tier/tasks.md
@@ -5,19 +5,20 @@
 > Execution plan for Claude Code:
 > [.claude/plans/fable-premium-tier.md](../../../.claude/plans/fable-premium-tier.md).
 
-**Status:** active (2026-08-08 triage — the 2026-07-28 resume
-trigger ELAPSED; releases 11.0.0–11.5.0 shipped since). Tasks 1–8
-done and live in the merged tree (#1361, 2026-07-13: model_tiers
-premium=claude-fable-5, registry entry,
-BASELINE_MODEL=claude-fable-5). Task 9 OUTSTANDING and overdue:
-the premium-price callout never reached CHANGELOG.md (no
-`claude-fable-5` entry) and generated tier docs still say premium
-= Opus (`plugin/help/generated/concepts/tier-routing.md`) —
-user-visible doc drift on a 2× price change already in released
-builds. Amended 2026-07-29: editing passes split to
-`ATTUNE_MODEL_EDITING` (claude-opus-5, #1770); PREMIUM stays
-claude-fable-5. Phase-1/Phase-2 approvals in requirements.md and
-design.md remain accurate as recorded.
+**Status:** complete (2026-08-09 — task 9 closed, all 9 tasks
+done). Tasks 1–8 live in the merged tree (#1361, 2026-07-13:
+model_tiers premium=claude-fable-5, registry entry,
+BASELINE_MODEL=claude-fable-5). Task 9's docs half landed
+2026-08-09: retroactive 2× premium-price callout in CHANGELOG's
+[10.5.0] entry (+ [Unreleased] note), and the tier-routing help
+concept corrected at its source
+(`scripts/generate_concept_templates.py`) and regenerated —
+premium = claude-fable-5, no longer Opus. The version-bump/release
+half was satisfied by the standard release train (10.5.0–11.6.0
+all shipped with the fable tier live). Amended 2026-07-29: editing
+passes split to `ATTUNE_MODEL_EDITING` (claude-opus-5, #1770);
+PREMIUM stays claude-fable-5. Phase-1/Phase-2 approvals in
+requirements.md and design.md remain accurate as recorded.
 
 ## Implementation order
 
@@ -31,7 +32,7 @@ design.md remain accurate as recorded.
 | 6 | Route all premium literals through `resolve_model("premium")` — the 12-surface table in design §3 (incl. `RoutingConfig` `default_factory`, template_defs literals → `claude-fable-5`) | attune-ai | done | All 12 surfaces routed: curator `_CURATOR_MODEL` → `_curator_model()` (per-call), escalation ladder built per instance (class attr removed), release `MODEL_CONFIG` resolves at import (comment notes it), YAML-in-string surfaces → literal `claude-fable-5`. Deviations: `model_router.py` has NO live literal (tier map is registry-sourced — task 7); docstring example updated. `test_agent_factory.py:393` left asserting opus — it exercises the registry-backed router path, which flips in task 7. 6 test files updated. Suite: 17,613 passed, 1 pre-existing live-Ollama failure. |
 | 7 | Registry + pricing: `claude-fable-5` entries in `models/registry.py`, provider pricing table, `cost_tracker` ($10/$50 per MTok; cache write $12.50 / read $1) + tests. **AMENDED 2026-07-10 (Patrick):** `BASELINE_MODEL` moves to `claude-fable-5` — with fable premium at 2× opus pricing, an opus baseline yields negative savings on every premium call ("routing lost money" when the user deliberately upgraded). Safe because `baseline_cost` is computed at log time and stored per record (`cost_tracker.py:383-394`) — history stays frozen at opus math; only new records use fable. Also make the report label at `cost_tracker.py:521` (`"Baseline (Opus)"`) dynamic. | attune-ai | done | Supersedes design §3 "BASELINE_MODEL stays opus-4-8"; design.md carries the matching amendment note. Done: premium tier entry → fable-5 ($10/$50, 128K out); opus-4-8 kept by-id via ADDITIONAL_MODELS (batch target + history); TIER_PRICING/provider table/analytics baseline all consistent (analytics now registry-sourced); BASELINE_MODEL → fable-5 with dynamic report label; `_get_tier` knows fable; drift-guard suite `tests/unit/models/test_fable_pricing_consistency.py`. |
 | 8 | Scattered premium call sites adopt the `fable_call` helper: `curator/core.py`, `workflows/escalation/chain.py`, `agents/release/base_agent.py`, `meta_workflows/llm_execution.py`; add `fable_refusal` telemetry event in workflow error handling | attune-ai | done | curator/base_agent/llm_execution swap `messages.create` → `(a)create_with_fable` (escalation chain already rides the fable-wired provider — no own client; it now RE-RAISES `ModelRefusalError` instead of retrying). base_agent + llm_execution fixed to read the first TEXT block, not `content[0]`. New `log_fable_refusal` helper (models/telemetry) emits the event wherever the refusal stops propagating: execution_mixin, curator degrade, agent fallback, meta_workflow failure dict. LangChain/LangGraph adapters out of scope v1 (design §4c). Mock-only tests via `fake_module`. |
-| 9 | Docs + release: regenerate `plugin/help/generated/` tier docs, CHANGELOG entry with prominent premium price callout, version bump (pyproject.toml + plugin.json + uv.lock together), release | attune-ai | pending | Release via the standard publish flow (approval-gated). |
+| 9 | Docs + release: regenerate `plugin/help/generated/` tier docs, CHANGELOG entry with prominent premium price callout, version bump (pyproject.toml + plugin.json + uv.lock together), release | attune-ai | done | Docs landed 2026-08-09: retroactive ⚠️ 2× price callout in CHANGELOG [10.5.0] + [Unreleased] note; tier-routing concept corrected at its `_CONCEPTS` source and regenerated via `scripts/generate_concept_templates.py` (premium = claude-fable-5; editing split `ATTUNE_MODEL_EDITING` → claude-opus-5 noted, #1770). Version-bump/release element satisfied by the standard release train — 10.5.0 through 11.6.0 shipped with the fable tier live; no dedicated release needed. |
 
 ## Testing strategy
 

--- a/plugin/help/generated/concepts/tier-routing.md
+++ b/plugin/help/generated/concepts/tier-routing.md
@@ -2,22 +2,22 @@
 type: concept
 name: tier-routing
 tags: [architecture, cost-optimization]
-source: src/attune/workflows/base.py
+source: src/attune/model_tiers.py
 ---
 
 # Concept: Model tier routing
 
 ## What
 
-Tier routing automatically selects the right Claude model (Haiku, Sonnet, or Opus) based on task complexity. Simple tasks use cheap models; complex tasks escalate to premium.
+Tier routing automatically selects the right Claude model based on task complexity: CHEAP resolves to Haiku, CAPABLE to Sonnet, and PREMIUM to Claude Fable 5 (`claude-fable-5`). Simple tasks use cheap models; complex tasks escalate to premium.
 
 ## Why
 
-Reduces API costs by 80-96% without sacrificing quality. Most workflow stages don't need the most expensive model.
+Reduces API costs without sacrificing quality — most workflow stages don't need the most expensive model. Note the premium tier runs `claude-fable-5` at 2x the former Opus pricing ($10 input / $50 output per MTok), so premium-tier stages cost twice what they did on Opus.
 
 ## How
 
-Each workflow defines a `tier_map` mapping stages to tiers (CHEAP, CAPABLE, PREMIUM). The authentication strategy resolves each tier to a specific model ID. Tier fallback escalates automatically if a cheaper tier fails.
+Each workflow defines a `tier_map` mapping stages to tiers (CHEAP, CAPABLE, PREMIUM). `attune.model_tiers` resolves each tier to a model ID per call, honoring env overrides (`ATTUNE_MODEL_PREMIUM`, `ATTUNE_MODEL_CAPABLE`, `ATTUNE_MODEL_CHEAP`). Tier fallback escalates automatically if a cheaper tier fails. Editing/polish passes are deliberately not a tier: they run a dedicated editing model (`ATTUNE_MODEL_EDITING`, default `claude-opus-5`).
 
 ## Example
 

--- a/scripts/generate_concept_templates.py
+++ b/scripts/generate_concept_templates.py
@@ -42,22 +42,32 @@ _CONCEPTS: list[dict] = [
         "title": "Model tier routing",
         "what": (
             "Tier routing automatically selects the right Claude model "
-            "(Haiku, Sonnet, or Opus) based on task complexity. Simple "
-            "tasks use cheap models; complex tasks escalate to premium."
+            "based on task complexity: CHEAP resolves to Haiku, CAPABLE "
+            "to Sonnet, and PREMIUM to Claude Fable 5 "
+            "(`claude-fable-5`). Simple tasks use cheap models; complex "
+            "tasks escalate to premium."
         ),
         "why": (
-            "Reduces API costs by 80-96% without sacrificing quality. "
-            "Most workflow stages don't need the most expensive model."
+            "Reduces API costs without sacrificing quality — most "
+            "workflow stages don't need the most expensive model. Note "
+            "the premium tier runs `claude-fable-5` at 2x the former "
+            "Opus pricing ($10 input / $50 output per MTok), so "
+            "premium-tier stages cost twice what they did on Opus."
         ),
         "how": (
             "Each workflow defines a `tier_map` mapping stages to tiers "
-            "(CHEAP, CAPABLE, PREMIUM). The authentication strategy "
-            "resolves each tier to a specific model ID. Tier fallback "
-            "escalates automatically if a cheaper tier fails."
+            "(CHEAP, CAPABLE, PREMIUM). `attune.model_tiers` resolves "
+            "each tier to a model ID per call, honoring env overrides "
+            "(`ATTUNE_MODEL_PREMIUM`, `ATTUNE_MODEL_CAPABLE`, "
+            "`ATTUNE_MODEL_CHEAP`). Tier fallback escalates "
+            "automatically if a cheaper tier fails. Editing/polish "
+            "passes are deliberately not a tier: they run a dedicated "
+            "editing model (`ATTUNE_MODEL_EDITING`, default "
+            "`claude-opus-5`)."
         ),
         "example": '`tier_map = {"initial_scan": ModelTier.CHEAP, "deep_review": ModelTier.PREMIUM}`',
         "tags": ["architecture", "cost-optimization"],
-        "source": "src/attune/workflows/base.py",
+        "source": "src/attune/model_tiers.py",
     },
     {
         "name": "socratic-discovery",


### PR DESCRIPTION
Closes fable-premium-tier **Task 9** — the overdue release-docs task
(spec status line 2026-08-08 recorded the evidence; this PR lands the
fix and flips the spec to complete).

## What

- **CHANGELOG `[10.5.0]`** — prominent retroactive callout (marked as
  added 2026-08-09): PREMIUM tier = `claude-fable-5` at $10/$50 per
  MTok (**2× the former Opus pricing**; cache write $12.50, read $1),
  `BASELINE_MODEL` move, `ATTUNE_MODEL_PREMIUM` pin-back escape
  hatch, and the 2026-07-29 amendment — editing/polish passes split
  to `ATTUNE_MODEL_EDITING` (default `claude-opus-5`, #1770);
  PREMIUM stays `claude-fable-5`.
- **CHANGELOG `[Unreleased]`** — documentation note recording the
  retroactive addition.
- **tier-routing help concept** — corrected at its `_CONCEPTS` source
  in `scripts/generate_concept_templates.py` and regenerated via the
  proper regen path (no hand-edit of generated output). Premium no
  longer claims "Haiku, Sonnet, or Opus"; tier env overrides and the
  editing-model split are named. Softened the unqualified "80-96%"
  savings claim in the concept (2× premium pricing changed the math).
- **Spec `tasks.md`** — task 9 → done; status header → complete
  (all 9 tasks). The version-bump/release element of task 9 was
  satisfied by the standard release train (10.5.0–11.6.0 shipped
  with the fable tier live); no dedicated release needed.

## Receipts

- `python scripts/generate_concept_templates.py --check` →
  `[  OK] tier-routing: in sync`
- `pytest tests/unit/plugins/ tests/unit/help/` → 575 passed,
  5 skipped, 3 xfailed
- Pricing/env facts verified against `src/attune/model_tiers.py`,
  `src/attune/models/registry.py`, `src/attune/models/editing.py`
- Pre-commit pinned hooks pre-flighted on all four files — all pass

## Out of scope (chips spawned)

- `--check` already fails on main for 13 auto-discovered `tool-*`
  concepts never generated (pre-existing; not made worse here).
- The "80-96% savings" claim also lives in two published blog posts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
