### PR TITLE
chore(help): regenerate 13 missing skill concepts + drift-guard the --check

### DIFF
--- a/plugin/help/generated/concepts/tool-author-feature.md
+++ b/plugin/help/generated/concepts/tool-author-feature.md
@@ -1,0 +1,24 @@
+---
+type: concept
+name: tool-author-feature
+tags: [skill, auto-discovered]
+source: plugin/skills/author-feature/SKILL.md
+---
+
+# Concept: Author Feature
+
+## What
+
+Author a single-source feature page — a code-verified master that projects to .help kinds + docs pages, no API credits
+
+## Why
+
+See the full reference for details on what this tool checks and when to use it.
+
+## How
+
+Run `/author-feature` to get started.
+
+## Related Topics
+
+_No related topics yet._

--- a/plugin/help/generated/concepts/tool-bulk.md
+++ b/plugin/help/generated/concepts/tool-bulk.md
@@ -1,0 +1,24 @@
+---
+type: concept
+name: tool-bulk
+tags: [skill, auto-discovered]
+source: plugin/skills/bulk/SKILL.md
+---
+
+# Concept: Bulk
+
+## What
+
+Batch API processing for 50% cost savings on non-urgent bulk analysis
+
+## Why
+
+See the full reference for details on what this tool checks and when to use it.
+
+## How
+
+Run `/bulk` to get started.
+
+## Related Topics
+
+_No related topics yet._

--- a/plugin/help/generated/concepts/tool-catalog.md
+++ b/plugin/help/generated/concepts/tool-catalog.md
@@ -1,0 +1,24 @@
+---
+type: concept
+name: tool-catalog
+tags: [skill, auto-discovered]
+source: plugin/skills/catalog/SKILL.md
+---
+
+# Concept: Catalog
+
+## What
+
+Enumerate everything attune offers — every workflow, wizard, and tool, read live from the registries
+
+## Why
+
+See the full reference for details on what this tool checks and when to use it.
+
+## How
+
+Run `/catalog` to get started.
+
+## Related Topics
+
+_No related topics yet._

--- a/plugin/help/generated/concepts/tool-cross-review.md
+++ b/plugin/help/generated/concepts/tool-cross-review.md
@@ -1,0 +1,24 @@
+---
+type: concept
+name: tool-cross-review
+tags: [skill, auto-discovered]
+source: plugin/skills/cross-review/SKILL.md
+---
+
+# Concept: Cross Review
+
+## What
+
+One-shot second-opinion review of a real diff by a DIFFERENT model (Codex or Antigravity) — advisory only, board-recorded
+
+## Why
+
+See the full reference for details on what this tool checks and when to use it.
+
+## How
+
+Run `/cross-review` to get started.
+
+## Related Topics
+
+_No related topics yet._

--- a/plugin/help/generated/concepts/tool-discovery-sweep.md
+++ b/plugin/help/generated/concepts/tool-discovery-sweep.md
@@ -1,0 +1,24 @@
+---
+type: concept
+name: tool-discovery-sweep
+tags: [skill, auto-discovered]
+source: plugin/skills/discovery-sweep/SKILL.md
+---
+
+# Concept: Discovery Sweep
+
+## What
+
+Run every audit at once and triage the findings into act-now / needs-a-look / dismissed buckets
+
+## Why
+
+See the full reference for details on what this tool checks and when to use it.
+
+## How
+
+Run `/discovery-sweep` to get started.
+
+## Related Topics
+
+_No related topics yet._

--- a/plugin/help/generated/concepts/tool-docs-outbox.md
+++ b/plugin/help/generated/concepts/tool-docs-outbox.md
@@ -1,0 +1,24 @@
+---
+type: concept
+name: tool-docs-outbox
+tags: [skill, auto-discovered]
+source: plugin/skills/docs-outbox/SKILL.md
+---
+
+# Concept: Docs Outbox
+
+## What
+
+Sweep the docs outbox — dedupe, lint, and digest pending small docs (lessons, reports, drafts), then chair-approve via chip into ONE batched PR
+
+## Why
+
+See the full reference for details on what this tool checks and when to use it.
+
+## How
+
+Run `/docs-outbox` to get started.
+
+## Related Topics
+
+_No related topics yet._

--- a/plugin/help/generated/concepts/tool-elicit.md
+++ b/plugin/help/generated/concepts/tool-elicit.md
@@ -1,0 +1,24 @@
+---
+type: concept
+name: tool-elicit
+tags: [skill, auto-discovered]
+source: plugin/skills/elicit/SKILL.md
+---
+
+# Concept: Elicit
+
+## What
+
+Form-driven Socratic discovery — batch independent decision dimensions into one multi-select-capable form instead of N button-turns
+
+## Why
+
+See the full reference for details on what this tool checks and when to use it.
+
+## How
+
+Run `/elicit` to get started.
+
+## Related Topics
+
+_No related topics yet._

--- a/plugin/help/generated/concepts/tool-fix.md
+++ b/plugin/help/generated/concepts/tool-fix.md
@@ -1,0 +1,24 @@
+---
+type: concept
+name: tool-fix
+tags: [skill, auto-discovered]
+source: plugin/skills/fix/SKILL.md
+---
+
+# Concept: Fix
+
+## What
+
+Fix Receipts — outcome-first fixing: guided intake picks scope and probes, previews the contract, runs with a verified receipt
+
+## Why
+
+See the full reference for details on what this tool checks and when to use it.
+
+## How
+
+Run `/fix` to get started.
+
+## Related Topics
+
+_No related topics yet._

--- a/plugin/help/generated/concepts/tool-image-analysis.md
+++ b/plugin/help/generated/concepts/tool-image-analysis.md
@@ -1,0 +1,24 @@
+---
+type: concept
+name: tool-image-analysis
+tags: [skill, auto-discovered]
+source: plugin/skills/image-analysis/SKILL.md
+---
+
+# Concept: Image Analysis
+
+## What
+
+Analyze an image — screenshot, diagram, UI mockup, or chart — with Claude's vision
+
+## Why
+
+See the full reference for details on what this tool checks and when to use it.
+
+## How
+
+Run `/image-analysis` to get started.
+
+## Related Topics
+
+_No related topics yet._

--- a/plugin/help/generated/concepts/tool-personal-memory.md
+++ b/plugin/help/generated/concepts/tool-personal-memory.md
@@ -1,0 +1,24 @@
+---
+type: concept
+name: tool-personal-memory
+tags: [skill, auto-discovered]
+source: plugin/skills/personal-memory/SKILL.md
+---
+
+# Concept: Personal Memory
+
+## What
+
+Capture and recall curated cross-session personal memory — decisions, preferences, findings by topic
+
+## Why
+
+See the full reference for details on what this tool checks and when to use it.
+
+## How
+
+Run `/personal-memory` to get started.
+
+## Related Topics
+
+_No related topics yet._

--- a/plugin/help/generated/concepts/tool-recall.md
+++ b/plugin/help/generated/concepts/tool-recall.md
@@ -1,0 +1,24 @@
+---
+type: concept
+name: tool-recall
+tags: [skill, auto-discovered]
+source: plugin/skills/recall/SKILL.md
+---
+
+# Concept: Recall
+
+## What
+
+Pull relevant findings stashed from past sessions — on demand
+
+## Why
+
+See the full reference for details on what this tool checks and when to use it.
+
+## How
+
+Run `/recall` to get started.
+
+## Related Topics
+
+_No related topics yet._

--- a/plugin/help/generated/concepts/tool-roundtable.md
+++ b/plugin/help/generated/concepts/tool-roundtable.md
@@ -1,0 +1,24 @@
+---
+type: concept
+name: tool-roundtable
+tags: [skill, auto-discovered]
+source: plugin/skills/roundtable/SKILL.md
+---
+
+# Concept: Roundtable
+
+## What
+
+Convene the multi-LLM round table — Claude, Antigravity, and Codex deliberate a question; the user chairs promotion
+
+## Why
+
+See the full reference for details on what this tool checks and when to use it.
+
+## How
+
+Run `/roundtable` to get started.
+
+## Related Topics
+
+_No related topics yet._

--- a/plugin/help/generated/concepts/tool-verify.md
+++ b/plugin/help/generated/concepts/tool-verify.md
@@ -1,0 +1,24 @@
+---
+type: concept
+name: tool-verify
+tags: [skill, auto-discovered]
+source: plugin/skills/verify/SKILL.md
+---
+
+# Concept: Verify
+
+## What
+
+Fact-check LLM-generated content against source-of-truth — confirm imports import, CLI flags are real, links resolve, counts match
+
+## Why
+
+See the full reference for details on what this tool checks and when to use it.
+
+## How
+
+Run `/verify` to get started.
+
+## Related Topics
+
+_No related topics yet._

--- a/tests/unit/help/test_concept_templates_drift.py
+++ b/tests/unit/help/test_concept_templates_drift.py
@@ -1,0 +1,48 @@
+"""Drift guard: plugin/help/generated/concepts matches the generator.
+
+Skills added under plugin/skills/ auto-derive ``tool-<name>`` concept
+templates via scripts/generate_concept_templates.py. Adding a skill
+without re-running the generator leaves the generated corpus stale;
+before this guard nothing in CI ran the ``--check`` (13 skills shipped
+without their concept files, 2026-08-09).
+
+Scoped to the concept generator ONLY: the lessons-derived generators
+(errors/faqs/warnings/notes/comparisons) drift with every lessons.md
+append and refresh deliberately at release-prep cadence, so gating the
+full ``generate_all.py --check`` here would be perpetually red. The
+other skill-reading generators (reference/task/quickstart) carry
+pre-existing drift and can join this gate once regenerated.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCRIPT = REPO_ROOT / "scripts" / "generate_concept_templates.py"
+
+
+@pytest.mark.unit
+def test_generated_concepts_in_sync() -> None:
+    """``generate_concept_templates.py --check`` reports zero stale files."""
+    if not SCRIPT.exists():
+        pytest.skip("scripts/generate_concept_templates.py not found")
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), "--check"],
+        capture_output=True,
+        text=True,
+        timeout=120,
+        check=False,
+        cwd=REPO_ROOT,
+    )
+    assert result.returncode == 0, (
+        "Generated concept templates are out of sync with their sources "
+        "(plugin/skills/*/SKILL.md + curated _CONCEPTS). Run:\n"
+        "  python scripts/generate_concept_templates.py\n"
+        "and commit the changes under plugin/help/generated/concepts/.\n\n"
+        f"--check output:\n{result.stdout[-2000:]}\n{result.stderr[-800:]}"
+    )


### PR DESCRIPTION
## What

`python scripts/generate_concept_templates.py --check` fails on main: 13 skills were added to `plugin/skills/` without re-running the concept generator, and nothing in CI runs the `--check`.

- Regenerates the 13 missing auto-discovered concepts under `plugin/help/generated/concepts/` (tool-author-feature, tool-bulk, tool-catalog, tool-cross-review, tool-discovery-sweep, tool-docs-outbox, tool-elicit, tool-fix, tool-image-analysis, tool-personal-memory, tool-recall, tool-roundtable, tool-verify). Deterministic Jinja from SKILL.md frontmatter — the 11 existing concepts were already in sync, so there is zero unrelated churn.
- Adds `tests/unit/help/test_concept_templates_drift.py` — runs the script's `--check` as a subprocess inside the existing unit lanes, so the next skill added without regen fails CI with the exact fix command in the assertion message.

## CI-gate scoping (the "consider" part)

- **No new workflow.** The gate is a unit test in the existing `tests` lanes — same pattern as `test_sync_agents_skills.py`. `jinja2` + `python-frontmatter` are core deps, `template_utils` reads/writes explicit utf-8, so Windows lanes are safe.
- **Concepts only, deliberately.** Full `generate_all.py --check` is perpetually red from lessons-corpus drift (errors/faqs/warnings regenerate at release-prep cadence) — gating it would break CI immediately. The other skill-reading generators (reference/task/quickstart) carry large pre-existing drift (~90 missing/out-of-sync entries) and can join this gate after a dedicated regen chore PR.
- **help-freshness.yml untouched** — its report-only ruling (2026-06-10) is about LLM-polish regeneration of `.help/`; this gate spends no LLM.

## Receipts

- `--check` before: 11 ok, 13 failed → after regen: 24 ok, 0 failed.
- New test passes; verified it FIRES: removing one generated file turns it red, restoring turns it green.
- Pinned black/ruff pre-flighted; all pre-commit hooks passed on commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
