### PR TITLE
docs(blog): retire stale 80-96% savings claim for fable-era tier pricing

### DIFF
--- a/content/blog/17-ai-workflows-every-developer-needs-2026.md
+++ b/content/blog/17-ai-workflows-every-developer-needs-2026.md
@@ -9,11 +9,13 @@ published: true
 
 # 17 AI Workflows Every Developer Needs in 2026
 
+*Updated 2026-08-09: savings figures revised for the premium tier's switch to Claude Fable 5 at 2× the former Opus pricing (Attune AI v10.5.0).*
+
 If you're still spending hours on code reviews, test writing, and security audits, you're doing it wrong. Modern developers should delegate these tedious tasks to AI. The problem? Most AI tools are expensive, closed-source, or buried behind subscriptions.
 
 Not anymore.
 
-[Attune AI](https://github.com/Smart-AI-Memory/attune-ai) is an open-source framework that brings production-ready AI workflows directly to your CLI. These aren't toy demos—they're multi-stage pipelines built for real teams, with intelligent cost optimization that saves 80-96% on API costs.
+[Attune AI](https://github.com/Smart-AI-Memory/attune-ai) is an open-source framework that brings production-ready AI workflows directly to your CLI. These aren't toy demos—they're multi-stage pipelines built for real teams, with intelligent cost optimization that saves up to 90% on API costs.
 
 This guide walks you through all 17 workflows available today, with CLI commands and practical examples for each.
 
@@ -37,9 +39,9 @@ They're perfect for:
 
 Not feeling ready to configure? Try [Wizards](/wizards/) instead—they're interactive, guided experiences that ask you questions before executing.
 
-### Cost Optimization: 80-96% Savings
+### Cost Optimization: Up to 90% Savings
 
-All Attune workflows use **progressive tier escalation**. They start with Haiku (cheap, fast), perform the analysis, then only escalate to Sonnet or Opus when deeper thinking is truly needed. Result: enterprise-grade analysis at a fraction of the cost.
+All Attune workflows use **progressive tier escalation**. They start with Haiku (cheap, fast), perform the analysis, then only escalate to Sonnet or Claude Fable 5 (the premium tier, priced at 2× the former Opus rate) when deeper thinking is truly needed. Result: enterprise-grade analysis at a fraction of the cost — and the pricier the premium tier gets, the more that discipline matters.
 
 All workflows are completely free and open source under Apache 2.0. Self-host them or run with your own API keys.
 
@@ -483,7 +485,7 @@ Want to use your own API keys instead of the default? See [Framework Getting Sta
 ## What Makes These Workflows Different
 
 1. **Open Source.** Inspect every line. Fork and customize. Run anywhere.
-2. **Cost-Optimized.** Smart tier escalation saves 80-96% vs. running everything on Opus.
+2. **Cost-Optimized.** Smart tier escalation saves up to 90% vs. running everything on the premium tier.
 3. **Production-Ready.** These workflows power real teams. Not toys or demos.
 4. **No Lock-in.** All output is standard formats (JSON, Markdown, pytest-compatible Python). Use the results anywhere.
 5. **Collaborative.** Designed for team workflows. Save results, share reports, integrate with CI/CD.

--- a/content/blog/attune-ai-vs-crewai-vs-langchain.md
+++ b/content/blog/attune-ai-vs-crewai-vs-langchain.md
@@ -9,6 +9,8 @@ published: true
 
 # Attune AI vs CrewAI vs LangChain: Which AI Agent Framework Should You Choose in 2026?
 
+*Updated 2026-08-09: tier prices and savings figures revised for the premium tier's switch to Claude Fable 5 at 2× the former Opus pricing (Attune AI v10.5.0).*
+
 If you're building AI agents or multi-step workflows, you've probably heard of CrewAI, LangChain, and possibly Attune AI. But which one is actually right for your project? This post breaks down the honest trade-offs between these three frameworks.
 
 I'm biased (I built Attune AI), but I'll try to be fair about where each framework excels and where it falls short.
@@ -92,11 +94,11 @@ This is where Attune AI's design philosophy really shows.
 
 Attune AI's progressive tier system is designed to minimize cost:
 
-- **Tier 1 (Haiku)**: $0.80 per 1M input tokens. Use for fast, simple tasks
+- **Tier 1 (Haiku)**: $1 per 1M input tokens. Use for fast, simple tasks
 - **Tier 2 (Sonnet)**: $3 per 1M input tokens. Use when Haiku hits complexity limits
-- **Tier 3 (Opus)**: $15 per 1M input tokens. Use only when Sonnet isn't smart enough
+- **Tier 3 (Claude Fable 5)**: $10 per 1M input tokens (2× the former Opus premium rate). Use only when Sonnet isn't smart enough
 
-A typical workflow starts with Haiku, and escalates only on demand. In practice, this cuts costs by 80-96% compared to always using Opus.
+A typical workflow starts with Haiku, and escalates only on demand. In practice, this cuts costs by up to 90% compared to always using the premium tier.
 
 On top of that, Attune AI integrates Anthropic's **prompt caching**:
 
@@ -190,7 +192,7 @@ Smaller community, but extremely focused. We're not trying to integrate with eve
 | Feature | Attune AI | CrewAI | LangChain |
 |---------|-----------|--------|-----------|
 | **Pre-built Workflows** | 17 ready-to-use | 0 (build from scratch) | 0 (build from scratch) |
-| **Cost Optimization** | 80-96% savings via tier escalation + caching | No built-in optimization | No built-in optimization |
+| **Cost Optimization** | Up to 90% savings via tier escalation (more with caching) | No built-in optimization | No built-in optimization |
 | **Model Coverage** | Claude only | Any LLM | Any LLM |
 | **Claude Code Integration** | Native CLI | Requires server | Requires server |
 | **Agent Templates** | 14 templates | 0 | 0 |

--- a/content/blog/claude-code-workflows-complete-guide-2026.md
+++ b/content/blog/claude-code-workflows-complete-guide-2026.md
@@ -9,6 +9,8 @@ published: true
 
 # Claude Code Workflows: The Complete Guide (2026)
 
+*Updated 2026-08-09: savings figures revised for the premium tier's switch to Claude Fable 5 at 2× the former Opus pricing (Attune AI v10.5.0).*
+
 Claude Code workflows represent a paradigm shift in how developers approach repetitive code tasks. Instead of manually reviewing, testing, and documenting code, teams can now invoke intelligent workflows that automatically escalate from cost-effective models to premium reasoning engines only when needed. This complete guide covers all 17 available Claude Code workflows in Attune AI, how they work, and how to master them for maximum productivity and cost savings.
 
 ## What Are Claude Code Workflows?
@@ -17,8 +19,8 @@ Claude Code workflows are multi-stage automation pipelines that combine natural 
 
 - Starts with **Haiku** (fast, cheap) for triage and analysis
 - Escalates to **Sonnet** (capable) for implementation and complex reasoning
-- Escalates to **Opus** (premium) for architectural decisions and synthesis
-- Delivers **80-96% cost savings** compared to using premium models exclusively
+- Escalates to **Claude Fable 5** (premium, priced at 2× the former Opus rate) for architectural decisions and synthesis
+- Delivers **up to 90% cost savings** compared to using premium models exclusively
 
 This intelligent tier escalation is the core innovation of Attune AI. Instead of paying for Opus on every task, you pay for what you actually need.
 
@@ -650,7 +652,7 @@ Attune AI combines the best of all: accuracy of manual review, speed of automati
 
 ### Q: How much can I save?
 
-**A:** Typical savings are 80-96% compared to using premium models for everything. On an enterprise project running 100 code reviews/week, that's $1,000/week in savings.
+**A:** Savings of up to 90% compared to using premium models for everything, depending on how much of your workload stays on the cheap tier. On an enterprise project running 100 code reviews/week, that can be $1,000/week in savings.
 
 ### Q: Will workflows replace code reviewers?
 

--- a/plugin/help/generated/comparisons/lite-vs-full.md
+++ b/plugin/help/generated/comparisons/lite-vs-full.md
@@ -19,7 +19,7 @@ Choosing between the lightweight plugin (no dependencies) and the full framework
 | Agent templates | 0 | 14 |
 | MCP tools | 0 | 31 |
 | CLI | No | Yes (attune command) |
-| Tier routing | No | Yes (80-96% savings) |
+| Tier routing | No | Yes (up to 90% savings) |
 | Telemetry | No | Yes (cost tracking) |
 
 ## Recommendation

--- a/scripts/generate_comparison_templates.py
+++ b/scripts/generate_comparison_templates.py
@@ -70,7 +70,7 @@ _COMPARISONS: list[dict] = [
             ComparisonRow("Agent templates", ["0", "14"]),
             ComparisonRow("MCP tools", ["0", "31"]),
             ComparisonRow("CLI", ["No", "Yes (attune command)"]),
-            ComparisonRow("Tier routing", ["No", "Yes (80-96% savings)"]),
+            ComparisonRow("Tier routing", ["No", "Yes (up to 90% savings)"]),
             ComparisonRow("Telemetry", ["No", "Yes (cost tracking)"]),
         ],
         "recommendation": "Start with **Attune Lite** if you just want Claude Code skills with zero setup. Upgrade to **Attune AI** when you need CLI workflows, cost optimization, or the full MCP toolset.",


### PR DESCRIPTION
## Summary

The **80-96% savings** claim in published blog content predates the premium tier's switch to `claude-fable-5` at 2× the former Opus pricing (#1361, shipped 10.5.0). With current tier pricing (cheap $1/$5, capable $3/$15, premium $10/$50 per MTok), the routing-only savings ceiling vs always-premium is exactly **90%** (cheap = 1/10 of premium on both input and output), so the old range overstates.

**Decision: update in place, not annotate-only.** Blog posts are living claim surfaces (unlike the CHANGELOG, which task 9 correctly annotated retroactively) — an editor's-note-only approach would leave the wrong number in the text readers act on. Each post gets both the corrected claim and a one-line dated editor's note for transparency, following the fable-premium-tier task 9 precedent (correct at source + prominent callout).

## Changes

- **content/blog/17-ai-workflows-every-developer-needs-2026.md** — claim at 3 sites → "up to 90%"; savings-section premium reference updated to Claude Fable 5 @ 2× former Opus rate; editor's note.
- **content/blog/attune-ai-vs-crewai-vs-langchain.md** — claim at 2 sites; the tier price list feeding the claim corrected (Haiku 4.5 $1, Fable 5 $10 — was Haiku $0.80 / Opus $15); editor's note. The $12→$0.50 caching-inclusive worked example stays (still constructible at current prices; it credits caching, not routing alone).
- **content/blog/claude-code-workflows-complete-guide-2026.md** — surfaced by grep beyond the two named posts (same claim): 2 sites + premium-tier bullet corrected; editor's note.
- **scripts/generate_comparison_templates.py** + regenerated **plugin/help/generated/comparisons/lite-vs-full.md** — the generator still projected "Yes (80-96% savings)" into the lite-vs-full tier-routing row; fixed at the generator source and re-projected.

## Gate check

`tests/unit/gates/test_claim_drift.py` (G1) does **not** govern this claim — its manifest asserts registry-derivable counts/versions only; a % savings figure has no live registry value to derive from, so no manifest change. No remaining `80-96` sites outside historical records (CHANGELOG, lessons, spec docs).

Pre-existing quirk noted, not touched (out of scope): `generate_comparison_templates.py --check` fails on ALL four comparison files even at HEAD — raw generator output carries trailing whitespace that pre-commit strips from committed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)