### PR TITLE
docs(website): retire attune-author from live-product surfaces

### DIFF
--- a/website/app/page.tsx
+++ b/website/app/page.tsx
@@ -8,12 +8,12 @@ import { installCommand } from '@/lib/install-command';
 import { CAPABILITIES, PILLARS, RELIABILITY_LOOP } from '@/lib/features';
 
 // Doc-toolchain code sample. attune-ai is the parent
-// framework (headlined in the hero); the four packages
-// below are the standalone documentation toolchain we
-// built with it.
-const codeExample = `# 1. attune-author — generate polished, source-grounded
+// framework (headlined in the hero); authoring ships
+// inside it, and the three standalone packages below
+// complete the documentation toolchain we built with it.
+const codeExample = `# 1. attune-ai authoring — generate polished, source-grounded
 #    templates from your codebase (CI or dev time)
-from attune_author.generator import generate_feature_templates
+from attune.authoring.generator import generate_feature_templates
 generate_feature_templates(feature, help_dir=".help", project_root=".")
 
 # 2. attune-rag — keyword + semantic retrieval keeps
@@ -362,18 +362,20 @@ export default function Home() {
                   AI, then grew into an engineering toolkit focused on
                   Claude &mdash; and later Redis. The documentation
                   toolchain came after, built with the same development
-                  discipline, and split off as four standalone packages
-                  forming an end-to-end author &rarr; reader loop. Use
-                  the full stack, or drop in just the piece you need.
+                  discipline: authoring ships inside attune-ai, and
+                  three standalone packages complete the end-to-end
+                  author &rarr; reader loop. Use the full stack, or
+                  drop in just the piece you need.
                 </p>
                 <ul className="space-y-5">
                   <li className="flex items-start gap-3">
                     <span className="inline-flex items-center justify-center w-7 h-7 rounded-full bg-[var(--accent)]/15 text-[var(--accent)] font-bold text-xs shrink-0 mt-0.5">1</span>
                     <div>
-                      <div className="font-semibold text-sm"><code className="font-mono">attune-author</code></div>
+                      <div className="font-semibold text-sm"><code className="font-mono">attune.authoring</code></div>
                       <p className="text-xs text-[var(--text-secondary)] leading-relaxed mt-1">
-                        Generates 15 kinds of source-grounded templates with
-                        per-type LLM polish. Runs at dev time or in CI.
+                        Ships with attune-ai &mdash; generates 15 kinds of
+                        source-grounded templates with per-type LLM polish.
+                        Runs at dev time or in CI.
                       </p>
                     </div>
                   </li>
@@ -410,7 +412,7 @@ export default function Home() {
                 </ul>
                 <div className="mt-8 pt-6 border-t border-[var(--border)]/40">
                   <p className="text-xs text-[var(--text-muted)]">
-                    All four are open source &mdash; Apache 2.0.
+                    Everything is open source &mdash; Apache 2.0.
                   </p>
                 </div>
               </div>
@@ -436,10 +438,10 @@ export default function Home() {
         <section className="py-32 px-6 max-w-7xl mx-auto" aria-label="Products">
           <div className="text-center mb-20">
             <span className="text-xs font-bold text-[var(--primary)] tracking-[0.2em] uppercase mb-4 block">Core Capabilities</span>
-            <h2 className="text-4xl md:text-5xl font-extrabold">Six Ways to Use It</h2>
+            <h2 className="text-4xl md:text-5xl font-extrabold">Five Ways to Use It</h2>
             <p className="text-[var(--text-secondary)] mt-4 max-w-2xl mx-auto">
               The attune-ai framework, its Claude Code plugin, and the
-              four-package documentation toolchain we built with it.
+              three-package documentation toolchain we built with it.
               Pick the piece that fits the job.
             </p>
           </div>
@@ -463,17 +465,6 @@ export default function Home() {
               <h3 className="text-xl font-bold mb-3">attune-help</h3>
               <p className="text-[var(--text-secondary)] leading-relaxed text-sm">
                 Lightweight reader. 1 dependency, 6 files. Embed progressive help in any CLI tool, notebook, or internal app.
-              </p>
-            </div>
-
-            {/* attune-author */}
-            <div className="group bg-[var(--surface)] rounded-2xl p-7 hover:bg-[var(--surface-container-low)] transition-all duration-300 hover:scale-[1.02]">
-              <div className="w-14 h-14 rounded-xl bg-[var(--accent)]/10 flex items-center justify-center mb-6 group-hover:bg-[var(--accent)] transition-colors">
-                <span className="text-3xl group-hover:brightness-0 group-hover:invert transition-all" aria-hidden="true">&#9999;&#65039;</span>
-              </div>
-              <h3 className="text-xl font-bold mb-3">attune-author</h3>
-              <p className="text-[var(--text-secondary)] leading-relaxed text-sm">
-                AI authoring companion. Generates 15 kinds of source-grounded templates with per-type polish prompts.
               </p>
             </div>
 

--- a/website/components/Footer.tsx
+++ b/website/components/Footer.tsx
@@ -118,16 +118,6 @@ export default function Footer() {
               </li>
               <li>
                 <a
-                  href="https://pypi.org/project/attune-author/"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-sm text-[var(--text-secondary)] hover:text-[var(--primary)] transition-colors"
-                >
-                  attune-author on PyPI
-                </a>
-              </li>
-              <li>
-                <a
                   href="https://pypi.org/project/attune-rag/"
                   target="_blank"
                   rel="noopener noreferrer"

--- a/website/lib/features.ts
+++ b/website/lib/features.ts
@@ -5,11 +5,13 @@
  * Update counts and descriptions here when features change.
  *
  * Marketplace mapping (consolidated 2026-06-22, retiring the
- * 2026-04-10 attune-docs split): all three plugins now live in the
- * single Smart-AI-Memory/attune-ai marketplace.
- *   attune-ai     → Smart-AI-Memory/attune-ai marketplace
- *   attune-help   → Smart-AI-Memory/attune-ai marketplace
- *   attune-author → Smart-AI-Memory/attune-ai marketplace
+ * 2026-04-10 attune-docs split): both plugins live in the single
+ * Smart-AI-Memory/attune-ai marketplace.
+ *   attune-ai   → Smart-AI-Memory/attune-ai marketplace
+ *   attune-help → Smart-AI-Memory/attune-ai marketplace
+ * (attune-author retired 2026-07: its authoring capabilities were
+ * consolidated into attune-ai, the PyPI package is archived, and
+ * the marketplace plugin was removed — see the docs page FAQ.)
  */
 
 // --- Products ---
@@ -70,31 +72,6 @@ export const PRODUCTS: Product[] = [
       "Renderers: plain, CLI, Claude Code, marketplace",
       "Precursor warnings for files being edited",
       "Embeddable in any Python tool",
-    ],
-  },
-  {
-    id: "attune-author",
-    name: "Attune Author",
-    pypiName: "attune-author",
-    version: "0.25.0",
-    tagline: "Author and polish help content with AI",
-    installCommand: "pip install 'attune-author[plugin]'",
-    marketplaceInstall:
-      "claude plugin install attune-author@attune-ai",
-    description:
-      "The AI authoring companion for attune-help. Generates 15 kinds " +
-      "of source-grounded templates — concept, task, reference, " +
-      "how-to, tutorial, architecture, cli-reference, error, warning, " +
-      "troubleshooting, faq, quickstart, tip, note, and comparison — " +
-      "with per-type LLM polish prompts and typed source summaries so " +
-      "the output stays accurate.",
-    features: [
-      "15 meta-template kinds (up from 3 in v0.1.0)",
-      "Per-type LLM polish prompts with anti-pattern lists",
-      "Signature-aware source summaries (typed args + return)",
-      "Strict polish mode for CI (ATTUNE_AUTHOR_STRICT_POLISH)",
-      "Staleness detection via source file hashing",
-      "Works with attune-help for the full author → reader loop",
     ],
   },
   {
@@ -260,7 +237,7 @@ export const DIFFERENTIATORS: Differentiator[] = [
  *     release-prep/release-gate count once — deliberate alias pair.)
  *   skills: plugin/skills/ directory count (test_skill_count)
  *   mcpTools: attune.mcp.tool_schemas get_*_tools() total
- *   templateKinds: attune_author.generator._ALL_TEMPLATE_NAMES length
+ *   templateKinds: attune.authoring.generator._ALL_TEMPLATE_NAMES length
  *   wizards: attune.wizards.list_wizards() length
  *
  * (agentTemplates / compositionPatterns were dropped 2026-06-11:
@@ -462,7 +439,6 @@ export function getPricingSummary(): string {
 const PRODUCT_ICONS: Record<string, string> = {
   "attune-ai": "🛠️",
   "attune-help": "📖",
-  "attune-author": "✍️",
   "claude-code-plugin": "⚡",
 };
 

--- a/website/test/capabilities-accuracy.test.ts
+++ b/website/test/capabilities-accuracy.test.ts
@@ -60,7 +60,7 @@ const INTROSPECT = [
   'from attune.mcp import tool_schemas as ts',
   "d['mcpTools'] = sum(len(getattr(ts, n)()) for n in dir(ts) if n.startswith('get_') and n.endswith('_tools'))",
   'try:',
-  '    from attune_author.generator import _ALL_TEMPLATE_NAMES',
+  '    from attune.authoring.generator import _ALL_TEMPLATE_NAMES',
   "    d['templateKinds'] = len(_ALL_TEMPLATE_NAMES)",
   'except Exception:',
   '    pass',
@@ -96,7 +96,7 @@ describe('website CAPABILITIES accuracy', () => {
       expect(CAPABILITIES.wizards).toBe(real.wizards);
       expect(CAPABILITIES.mcpTools).toBe(real.mcpTools);
 
-      // attune_author is a separate package; only assert when present.
+      // authoring needs the full attune install; only assert when present.
       if (typeof real.templateKinds === 'number') {
         expect(CAPABILITIES.templateKinds).toBe(real.templateKinds);
       }


### PR DESCRIPTION
## What

Retires attune-author from every live-product surface on the website. The PyPI package was archived 2026-07-27 (attune-author-consolidation D12) and the marketplace plugin deletion is in flight in #2002 (D13), but the site still sold it as a live product with install commands that fail or point at an archived package.

- **website/lib/features.ts** (canonical per website-content-accuracy rule): dropped the attune-author `PRODUCTS` entry (`pip install 'attune-author[plugin]'` + `claude plugin install attune-author@attune-ai`), its product-icon entry, and updated the marketplace-mapping header comment; `templateKinds` derivation comment now names the consolidated `attune.authoring.generator`
- **website/app/page.tsx**: code example step 1 imports `attune.authoring.generator.generate_feature_templates` (verified importable in `src/attune/authoring/generator.py`); Sister Family copy now says authoring ships inside attune-ai with three standalone packages; product cards go "Six Ways" → "Five Ways"
- **website/components/Footer.tsx**: removed the attune-author PyPI link
- **website/test/capabilities-accuracy.test.ts**: templateKinds introspection now imports from `attune.authoring.generator` (matching `tests/unit/test_website_version_accuracy.py`), so the assertion stays live instead of silently skipping on the retired package
- **website/app/docs/page.tsx**: unchanged on purpose — it already carries the "What happened to attune-author?" FAQ and retirement section; verified the rendered page has no stale install commands

## Sequencing note

#2002 (the plugin deletion) is still open/BLOCKED — this PR doesn't depend on it (no file overlap; the PyPI archive already makes the retirement copy correct), but the docs FAQ's story is fully true once both land.

## Receipts

- website vitest: 28/28 passed
- `next build` (build:vercel): green
- `tests/unit/test_website_version_accuracy.py`: 15/15 locally (website-only PRs skip the Python suite in CI, so this local run is the guard)
- Rendered pages verified in dev server: homepage has zero attune-author mentions, "Five Ways to Use It", three-package toolchain copy, footer link gone; docs page retains retirement FAQ

Website-only change: no CHANGELOG entry per the `website_only` policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
