### PR TITLE
docs: 11.6.0 premium-price callout (R4) + reach snapshot 2026-08-09

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,20 @@ reader now derives from one resolver, consumers authenticate
 consistently, and an AST drift guard keeps it that way. Plus the
 11.5.0 post-release self-review's security and performance fixes.
 
+### Pricing — ⚠️ Premium tier runs Claude Fable 5 at 2× Opus pricing
+
+> Callout added retroactively 2026-08-09 (feedback-close-out R4):
+> 11.6.0 shipped without it. The switch itself landed in 10.5.0
+> (#1361) — the full entry lives there.
+
+- Premium-tier workflow stages run `claude-fable-5` at $10 input /
+  $50 output per MTok — **2× the former Opus premium pricing**. Pin
+  the tier back with `ATTUNE_MODEL_PREMIUM` (e.g. `claude-opus-4-8`)
+  if the old price point matters more than Fable-class output.
+- Editing/polish passes run the dedicated editing model
+  (`ATTUNE_MODEL_EDITING`, default `claude-opus-5`, since 11.1.0)
+  at Opus-tier pricing; PREMIUM stays `claude-fable-5`.
+
 ### Changed — Redis connection behavior (redis-config-truth rct-4, #1993)
 
 - **Consumers that previously ignored `REDIS_PASSWORD` now

--- a/docs/specs/usage-signals/snapshots/2026-08-09.json
+++ b/docs/specs/usage-signals/snapshots/2026-08-09.json
@@ -1,0 +1,65 @@
+{
+  "attempts": [
+    {
+      "at": "2026-08-09T13:17:09.626534+00:00",
+      "captured": 1,
+      "outcome": "rate-limited"
+    },
+    {
+      "at": "2026-08-09T14:23:34.658057+00:00",
+      "captured": 3,
+      "outcome": "rate-limited"
+    },
+    {
+      "at": "2026-08-09T15:30:58.519985+00:00",
+      "captured": 4,
+      "outcome": "rate-limited"
+    }
+  ],
+  "date": "2026-08-09",
+  "github": {},
+  "manifest": {
+    "captured": [
+      "attune-ai",
+      "attune-rag",
+      "attune-help",
+      "attune-author"
+    ],
+    "complete": false,
+    "expected": [
+      "attune-ai",
+      "attune-rag",
+      "attune-help",
+      "attune-author",
+      "attune-verify"
+    ],
+    "missing": [
+      "attune-verify"
+    ],
+    "observed_at": "2026-08-09T15:30:58.520266+00:00",
+    "source": "pypistats.org/api/recent"
+  },
+  "pypi_recent": {
+    "attune-ai": {
+      "last_day": 210,
+      "last_month": 2450,
+      "last_week": 739
+    },
+    "attune-author": {
+      "last_day": 0,
+      "last_month": 570,
+      "last_week": 38
+    },
+    "attune-help": {
+      "last_day": 2725,
+      "last_month": 23574,
+      "last_week": 8140
+    },
+    "attune-rag": {
+      "last_day": 3709,
+      "last_month": 63848,
+      "last_week": 10680
+    }
+  },
+  "taken_at": "2026-08-09T15:30:58.520266+00:00"
+}


### PR DESCRIPTION
Two owed docs items from the 2026-08-09 session starter, verified against current state before writing:

## 11.6.0 premium-price callout (feedback-close-out R4)

Chip PR #2001 (fable Task 9) landed the retroactive callout on the [10.5.0] entry — where #1361 actually shipped — plus an Unreleased doc note. The 11.6.0 section itself still carried no callout, which is exactly R4's write-directly condition ("this spec verifies that PR lands with the callout and only writes it directly if the chip … misses the placement"). The chip is merged, so there is no parallel-CHANGELOG-edit risk. Added a compact callout in the 11.6.0 section pointing at the full 10.5.0 entry.

Note: the feedback-close-out spec's tasks.md lives on open PR #2007 (chair merge read owed) — its T4 row flip is left to that branch; this PR only executes the R4 write.

## usage-signals reach snapshot 2026-08-09

The day file was stranded uncommitted in the prior session's worktree (`spec-backlog-2783b7`). Copied here and retried once for the missing `attune-verify` — the script's 3/day attempt budget is exhausted (US-4), so 4/5 is final for the date, incomplete-receipt warning attached. Cross-day resume + the 11.6.0 AFTER leg are owed 08-10/08-11.

Class 1 (docs-only) → auto-merge-when-green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
