### PR TITLE
docs(specs): memory-status-integrity P2 complete — verified-basis live receipt

### DIFF
--- a/docs/specs/memory-status-integrity/tasks.md
+++ b/docs/specs/memory-status-integrity/tasks.md
@@ -1,12 +1,11 @@
 # memory-status-integrity — tasks
 
-**Status:** active (2026-08-09) — P1 shipped; **P2 attune-ai side
-COMPLETE** (tasks 1/2/4-9 done across #2013/#2014/#2017/#2018 + the
-task-9 receipt, every code PR through a codex D11 lane). P2 stays open
-on **task 3 only** (canonical `memory_lint.py` accepts `verified:` —
-in flight as chip session task_47bd4a3b). **P3 OPENED** (chair
-2026-08-09; the phase's measure-first gate executed at authoring —
-findings in decisions D8).
+**Status:** active (2026-08-09) — P1 shipped; **P2 COMPLETE** (tasks
+1/2/4-9 across #2013/#2014/#2017/#2018 + the task-9 receipts, every
+code PR through a codex D11 lane; task 3 landed on the chair's machine
+and flipped in #2020, lifting the `keep` gate on `~/.claude` corpora).
+**P3 OPENED** (chair 2026-08-09; the phase's measure-first gate
+executed at authoring — findings in decisions D8).
 **Design:** [design.md](design.md) · **Decisions:** [decisions.md](decisions.md)
 
 ## P1 implementation order
@@ -36,7 +35,7 @@ findings in decisions D8).
 | 6 | Verdict propagation to Redis immediately (invalidate/rewrite the key) | attune-ai | done | `verdict_log.propagate_verdict` — DELETE-only of the derived `attune:memory:node:<stem>` (index stays derived, never authored; next hydration rebuilds keep/sharper); fail-open (P15, ratchet-baselined); durable tombstone respect for `wrong` belongs to the external hydrator (reader/writer co-design) |
 | 7 | Ref-triggered queue-jump boolean for project-type: `file:`/`sha:` via local git, `pr:`/`issue:` via `gh`, fail-open (D7 ruling) | attune-ai | done | `attune.memory.ref_triggers` — EXPLICIT typed refs only (`pr:123` etc.; bare `#N` deliberately untreated — no state-at-write, would false-fire on shipped-PR provenance); bounded 5 refs/memory, 10 memories/triage, 5s probes; review CLI floats triggered rows with ⚑ reasons + `queue-jumped` count (the hit-rate signal); CUT-line documented in the module |
 | 8 | Epistemic status tiers (settled / check-before-acting / suspect) + author-class on render surfaces; strongest framing on the raw tier | attune-ai | done | `epistemic_tier` + `format_status_annotation` (thresholds 10/45 over age × volatility; tombstoned/invalidated always suspect); wired: `PersonalMemory.query` hits gain `status` (verdict-aware basis), digest cards render tier, sweep CLI shows tier column; suspect+project carries the explicit verify-first instruction; raw-tier framing stays memory-security-hardening R1's provenance envelope (cross-linked) |
-| 9 | Live-corpus receipt with verified-basis reporting | receipt | done | 2026-08-09, post-#2018 machinery: **273 files / 13 roots**; bases all `mtime` (zero `verified:` in the wild — honest pre-adoption baseline); tiers 134 settled / 138 check-before-acting / 1 suspect (`project_attune_ai_dev_consolidation`, 66d — matches its known-parked status); integrity 0 schema / 0 type / 0 broken links / 0 dangling; the ONE orphan found (`feedback_model_routing_hybrid.md`, missing MEMORY.md pointer) was fixed in the same session — the sweep caught a real atomic-write violation on its first receipt run |
+| 9 | Live-corpus receipt with verified-basis reporting | receipt | done | 2026-08-09, post-#2018 machinery: **273 files / 13 roots**; bases all `mtime` (zero `verified:` in the wild — honest pre-adoption baseline); tiers 134 settled / 138 check-before-acting / 1 suspect (`project_attune_ai_dev_consolidation`, 66d — matches its known-parked status); integrity 0 schema / 0 type / 0 broken links / 0 dangling; the ONE orphan found (`feedback_model_routing_hybrid.md`, missing MEMORY.md pointer) was fixed in the same session — the sweep caught a real atomic-write violation on its first receipt run. **Post-adoption follow-up (same day, after #2020 lifted the `keep` gate):** first live triage on `~/.claude` corpora recorded 1 keep + 2 sharper (digest-bound, `.verdicts.jsonl` in the attune-ai per-project corpus); the re-run sweep reports basis distribution **270 `mtime` / 3 `verified`** — the sharpened pair binds against POST-edit digests (reads `verified`, not `verified-unbound`) — with 0 violations in every category and the corpus byte-identical across the sweep (287 files sha256-compared, incl. the verdict log) |
 
 ## P3 implementation order (opened 2026-08-09, D8 — full R6: recall-frequency ranking)
 


### PR DESCRIPTION
## Summary

Reconciliation after #2020 merged in parallel with the task-9 baseline receipt (recorded by another session the same day):

1. **Header fix** — the status line still read "P2 stays open on task 3 only", but #2020 closed task 3. P2 is now COMPLETE end-to-end.
2. **Task 9 receipt append** — the baseline receipt was honestly pre-adoption (all 273 files on `mtime` basis, zero `verified:` in the wild). This adds the post-adoption follow-up run:

## Receipt (chair's machine, same day, post-#2020)

- First live triage on `~/.claude` corpora via the verdict machinery: **1 keep + 2 sharper**, digest-bound records in `.verdicts.jsonl` (attune-ai per-project corpus), `verified: 2026-08-09` stamped by `set_verified`
- Re-run sweep (`scripts/audit_curated_memory.py`): **273 files / 13 roots**, basis distribution **270 `mtime` / 3 `verified`** — the two sharpened files bind against their POST-edit digests (basis reads `verified`, not `verified-unbound`), exercising the task-4 digest binding live
- Integrity: 0 schema / 0 type / 0 broken links / 0 orphans / 0 dangling pointers
- Read-only proof: corpus byte-identical across the sweep — 287 files (memories + MEMORY.md indexes + verdict log) sha256-compared before/after

Docs-only (one spec file). Auto-merge-when-green per the D9 standing authorization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
