### PR TITLE
docs(usage-signals): AFTER reach snapshot 2026-08-10 — 5/5 complete

### DIFF
--- a/docs/specs/usage-signals/snapshots/2026-08-10.json
+++ b/docs/specs/usage-signals/snapshots/2026-08-10.json
@@ -1,0 +1,64 @@
+{
+  "attempts": [
+    {
+      "at": "2026-08-10T01:16:58.948381+00:00",
+      "captured": 5,
+      "outcome": "complete"
+    }
+  ],
+  "date": "2026-08-10",
+  "github": {
+    "clones_14d": 52069,
+    "forks": 0,
+    "stars": 10,
+    "views_14d": 781
+  },
+  "manifest": {
+    "captured": [
+      "attune-ai",
+      "attune-rag",
+      "attune-help",
+      "attune-author",
+      "attune-verify"
+    ],
+    "complete": true,
+    "expected": [
+      "attune-ai",
+      "attune-rag",
+      "attune-help",
+      "attune-author",
+      "attune-verify"
+    ],
+    "missing": [],
+    "observed_at": "2026-08-10T01:16:58.948668+00:00",
+    "source": "pypistats.org/api/recent"
+  },
+  "pypi_recent": {
+    "attune-ai": {
+      "last_day": 210,
+      "last_month": 2450,
+      "last_week": 739
+    },
+    "attune-author": {
+      "last_day": 0,
+      "last_month": 570,
+      "last_week": 38
+    },
+    "attune-help": {
+      "last_day": 2725,
+      "last_month": 23574,
+      "last_week": 8140
+    },
+    "attune-rag": {
+      "last_day": 3709,
+      "last_month": 63848,
+      "last_week": 10680
+    },
+    "attune-verify": {
+      "last_day": 101,
+      "last_month": 20068,
+      "last_week": 338
+    }
+  },
+  "taken_at": "2026-08-10T01:16:58.948668+00:00"
+}


### PR DESCRIPTION
The AFTER leg for the 08-09→08-11 window, serving all THREE pairs (11.4.0 full pair; 11.5.0 and 11.6.0 tag-vs-after). Cross-day resume per the US-5 recipe: 2026-08-09 ended FINAL at 4/5 with the 3/day budget exhausted (attune-verify rate-limited through all attempts); today's file was seeded with yesterday's `pypi_recent` (attempts stripped), and the single fresh fetch cleared attune-verify — **5/5 complete**, GitHub metrics included. Output READ, not exit-code-trusted.

Closes the reach obligations from the 2026-08-09 starter (cross-day resume + 11.6.0 AFTER leg — one run serves both).

Docs-only → D9, auto-merge-when-green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)