### PR TITLE
fix(hooks): format-on-save never strips unused imports

### DIFF
--- a/plugin/hooks/format_on_save.py
+++ b/plugin/hooks/format_on_save.py
@@ -99,7 +99,12 @@ def main() -> None:
         return
 
     _run_formatter(["black", "--quiet", "--line-length=100"], str(validated))
-    _run_formatter(["ruff", "check", "--fix", "--quiet"], str(validated))
+    # `--ignore F401,F811`: never strip "unused" imports on save. An agent
+    # editing in two steps (import first, usage next) loses the import to
+    # this hook in the gap — hit 4x in one session (2026-08-09) despite a
+    # same-edit discipline rule. Genuinely dead imports are still caught
+    # at commit time by pre-commit ruff, where the file is complete.
+    _run_formatter(["ruff", "check", "--fix", "--quiet", "--ignore", "F401,F811"], str(validated))
 
 
 if __name__ == "__main__":

--- a/src/attune/hooks/scripts/format_on_save.py
+++ b/src/attune/hooks/scripts/format_on_save.py
@@ -104,7 +104,12 @@ def main() -> None:
         return
 
     _run_formatter(["black", "--quiet", "--line-length=100"], str(validated))
-    _run_formatter(["ruff", "check", "--fix", "--quiet"], str(validated))
+    # `--ignore F401,F811`: never strip "unused" imports on save. An agent
+    # editing in two steps (import first, usage next) loses the import to
+    # this hook in the gap — hit 4x in one session (2026-08-09) despite a
+    # same-edit discipline rule. Genuinely dead imports are still caught
+    # at commit time by pre-commit ruff, where the file is complete.
+    _run_formatter(["ruff", "check", "--fix", "--quiet", "--ignore", "F401,F811"], str(validated))
 
 
 if __name__ == "__main__":

--- a/tests/unit/hooks/test_hook_scripts.py
+++ b/tests/unit/hooks/test_hook_scripts.py
@@ -720,7 +720,15 @@ class TestFormatOnSaveMain:
             main()
 
         ruff_call = mock_run.call_args_list[1][0][0]
-        assert ruff_call == ["ruff", "check", "--fix", "--quiet", str(target)]
+        assert ruff_call == [
+            "ruff",
+            "check",
+            "--fix",
+            "--quiet",
+            "--ignore",
+            "F401,F811",
+            str(target),
+        ]
 
     def test_uses_path_key_when_file_path_absent(self, tmp_path: Path) -> None:
         from attune.hooks.scripts.format_on_save import main
@@ -784,3 +792,35 @@ class TestHasSessionWorkGitFailure:
             from attune.hooks.scripts.lessons_reminder import has_session_work
 
             assert has_session_work() is True
+
+
+class TestFormatOnSaveNeverStripsImports:
+    """The on-save ruff pass must never remove 'unused' imports (F401/F811).
+
+    An agent editing in two steps — import first, usage in the next edit —
+    loses the import to this hook in the gap between them (hit 4x in one
+    session, 2026-08-09). Dead imports are pre-commit's job, where the
+    file is complete. This pins the --ignore flags on the live invocation.
+    """
+
+    def test_ruff_invocation_ignores_unused_import_rules(self, tmp_path: Path) -> None:
+        import io
+        import sys
+
+        from attune.hooks.scripts import format_on_save
+
+        target = tmp_path / "sample.py"
+        target.write_text("import os\n", encoding="utf-8")
+        payload = {"tool_name": "Edit", "tool_input": {"file_path": str(target)}}
+
+        calls: list[list[str]] = []
+        with (
+            patch.object(format_on_save, "_run_formatter", lambda cmd, path: calls.append(cmd)),
+            patch.object(sys, "stdin", io.StringIO(json.dumps(payload))),
+        ):
+            format_on_save.main()
+
+        ruff_calls = [c for c in calls if c and c[0] == "ruff"]
+        assert ruff_calls, f"ruff was not invoked; calls={calls}"
+        joined = " ".join(ruff_calls[0])
+        assert "--ignore" in joined and "F401" in joined and "F811" in joined


### PR DESCRIPTION
Implements the session-close feedback item Patrick directed ("implement your suggestion"): the PostToolUse format hook ran `ruff check --fix` with default rules, which REMOVES unused imports — so an agent editing in two steps (import in edit 1, usage in edit 2) loses the import in the gap. This recurred 4x in one session on 2026-08-09 despite the existing same-edit JIT rule; the durable fix is mechanical, not disciplinary.

- Both copies updated (the live `src/attune/hooks/scripts/` hook this repo's settings run, and the `plugin/hooks/` copy consumers get): `--ignore F401,F811` on the save-time pass only.
- Genuinely dead imports still fail at commit time via pre-commit ruff, where the file is complete — the floor doesn't move, only the mid-edit trap.
- Pinned both directions: the existing exact-argv test updated, plus a new regression asserting the ignore flags on the live invocation.

290 tests green serially (hook suite + gates + quality). Not D11-class (developer-convenience formatting hook — not a gate, guard, or persistence surface); not auto-merge-armed since it's hook code — your read when convenient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)