### PR TITLE
feat(hooks): JIT recall rule — zsh does not word-split unquoted $var

### DIFF
--- a/plugin/hooks/_recall_map.py
+++ b/plugin/hooks/_recall_map.py
@@ -131,6 +131,20 @@ RECALL_MAP: dict[str, list[dict[str, str]]] = {
                 "('===' separators, `=value` args)."
             ),
         },
+        # zsh no-word-split (added 2026-08-10): a `SAFE="a b c"; for w
+        # in $SAFE` loop in the 2026-08-09 worktree-prune session ran
+        # ONCE over the whole string and printed a bogus ABSENT — the
+        # bash idiom silently produces garbage rather than erroring.
+        {
+            "rule_id": "zsh-no-word-split",
+            "match_regex": r"for\s+\w+\s+in\s+\$\{?[A-Za-z_]\w*\}?\s*[;\n]",
+            "text": (
+                "zsh does NOT word-split unquoted `$var` — `for w in "
+                "$LIST` loops ONCE over the whole string (bash idiom, "
+                "silent garbage). Use `${(z)LIST}`, `${=LIST}`, or an "
+                "explicit word list. (`$(...)` output still splits.)"
+            ),
+        },
         {
             "rule_id": "zsh-status-readonly",
             "match_substring": "status=",

--- a/tests/unit/hooks/test_jit_recall.py
+++ b/tests/unit/hooks/test_jit_recall.py
@@ -148,6 +148,43 @@ def test_zsh_eqword_silent_on_flag_assignment(jit_mod, monkeypatch, capsys):
     assert "PATH lookup" not in out
 
 
+def test_zsh_word_split_fires_on_scalar_for_loop(jit_mod, monkeypatch, capsys):
+    # `for w in $LIST` — bash idiom; zsh loops once over the whole string.
+    rc, out = _run(
+        jit_mod,
+        monkeypatch,
+        capsys,
+        _bash_payload('SAFE="a b c"; for w in $SAFE; do echo $w; done'),
+    )
+    assert rc == 0
+    assert "word-split" in out
+
+
+def test_zsh_word_split_fires_on_braced_var(jit_mod, monkeypatch, capsys):
+    rc, out = _run(
+        jit_mod, monkeypatch, capsys, _bash_payload("for f in ${FILES}; do wc -l $f; done")
+    )
+    assert rc == 0
+    assert "word-split" in out
+
+
+def test_zsh_word_split_silent_on_safe_shapes(jit_mod, monkeypatch, capsys):
+    # Command substitution DOES split in zsh; explicit word lists and
+    # array expansions are fine — none of these may trip the rule.
+    rc, out = _run(
+        jit_mod,
+        monkeypatch,
+        capsys,
+        _bash_payload(
+            "for f in $(ls); do echo $f; done; "
+            "for w in a b c; do echo $w; done; "
+            'for x in "${arr[@]}"; do echo $x; done'
+        ),
+    )
+    assert rc == 0
+    assert "word-split" not in out
+
+
 def test_zsh_status_readonly_fires_on_assignment(jit_mod, monkeypatch, capsys):
     rc, out = _run(jit_mod, monkeypatch, capsys, _bash_payload("status=$(gh pr checks 1)"))
     assert rc == 0


### PR DESCRIPTION
## Summary

Retro-ratified friction fix from the 2026-08-09 attune-workspace session: an unquoted `for w in $SAFE` loop (bash idiom) silently ran ONCE over the whole 14-item string in zsh and reported one bogus `ABSENT` — nearly feeding garbage into a worktree-prune verification. zsh doesn't word-split unquoted `$var`; the existing JIT rules cover `=word`, `[ \< ]`, `status=`, and `:modifier` traps but not this one.

- New `zsh-no-word-split` rule in `plugin/hooks/_recall_map.py`, firing on the scalar-for-loop shape (`for w in $LIST;` / `${LIST};`), recommending `${(z)LIST}` / `${=LIST}` / explicit word lists
- Silent on the safe shapes: `$(...)` (command substitution *does* split in zsh), explicit word lists, `"${arr[@]}"`
- 3 new tests in `tests/unit/hooks/test_jit_recall.py` — 43/43 green

🤖 Generated with [Claude Code](https://claude.com/claude-code)