### PR TITLE
chore(deps): widen attune-rag cap <0.10 → <2.0 — v1.0.0-release M0.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,7 @@ dependencies = [
     "langsmith>=0.7.31,<2.0.0",  # GHSA-rr7j-v2q5-chgv (transitive via langchain-core)
     "jinja2>=3.1.0,<4.0.0",  # Meta template rendering for help system
     "python-frontmatter>=1.0.0,<2.0.0",  # YAML frontmatter parsing for help templates — required by attune.help.engine which backs the help_lookup MCP tool (progressive/workflow_help/precursor/search_tag modes all parse template files). Vanilla pip install attune-ai without this breaks every help_lookup mode except `preamble`.
-    "attune-rag>=0.1.5,<0.10",  # RAG grounding for rag-code-gen workflow + rag_knowledge_query MCP tool. Core dep (not optional) — required for acceptable retrieval accuracy. Cap is <0.10: re-validated against attune-rag 0.9.0 (lock bumped 0.8.0->0.9.0; KeywordRetriever ranking change — preview drops frontmatter aliases block, ALIASES_WEIGHT 1.5->2.0 — re-validated via the lessons golden-query suite (26 passed, real corpus/real ranking; attune.lessons imports KeywordRetriever directly) + consumer suites (personal memory, ops help_data, rag_code_gen, curator: 284 passed) + full consumed-symbol import sweep; alias-home migration satisfied by locked attune-help 0.13.0, in 0.9.0's required >=0.13,<0.14 window); next minor (0.10.0) still requires explicit re-validation before lifting the cap.
+    "attune-rag>=0.1.5,<2.0",  # RAG grounding for rag-code-gen workflow + rag_knowledge_query MCP tool. Core dep (not optional) — required for acceptable retrieval accuracy. Cap widened <0.10 -> <2.0 (attune-rag v1.0.0-release M0.2, 2026-08-10): the coming 1.0.0 is surface-identical to the already-validated 0.9.0 (freeze policy; surface-lock test is the evidence) and 1.x semantics forbid removals until 2.0.0, so the cap admits 1.x safely. Locked version stays 0.9.0 until 1.0.0 publishes. Re-validated at widening via the 0.9.0 recipe: lessons golden-query suite (real corpus/real ranking; attune.lessons imports KeywordRetriever directly) + consumer suites (personal memory, ops help_data, rag_code_gen, curator) + full consumed-symbol import sweep. Residual exposure: a hypothetical 0.10.x under 0.x semver could remove symbols — none is planned (roadmap goes 0.9.x -> 1.0.0); if one ships, re-validate before lock-bumping onto it.
     "attune-verify>=0.1.0,<0.3",  # Generation fact-checker backing the /verify skill (deterministic entity checks: imports/flags/links/counts). Core dep — stdlib-only (zero transitive deps), so promoting to core is cheap and lets /verify work out of the box without an extra. Semantic layer is opt-in (the skill acts as the ambient judge). Cap raised to <0.3 to admit 0.2.0 (full dotted-path import resolution — catches private-submodule hallucinations the 0.1.0 top-level-only checker missed; purely additive, no API break).
     "tomli>=2.0.0; python_version < '3.11'",  # tomllib fallback for Python 3.10. Used by attune.utils.coverage (loaded transitively from release-prep + orchestrated-health-check workflows). Without this, those workflows fail to load on 3.10.
     # Redis memory runtime — CORE as of the 2026-07-04 packaging
@@ -219,7 +219,7 @@ dev = [
     # branches (rag tests use pytest.importorskip). Floor
     # matches the [rag] extra so dev + runtime deps stay in
     # lock-step.
-    "attune-rag>=0.1.5,<0.10",
+    "attune-rag>=0.1.5,<2.0",
     # attune-help backs the rag_knowledge_query MCP tool and the
     # help-corpus tests. Moved here from the retired [author] extra
     # (author-consolidation T4, 2026-07-27).
@@ -403,7 +403,7 @@ dev = [
     # branches (rag tests use pytest.importorskip). Floor
     # matches the [rag] extra so dev + runtime deps stay in
     # lock-step.
-    "attune-rag>=0.1.5,<0.10",
+    "attune-rag>=0.1.5,<2.0",
     # attune-help backs the rag_knowledge_query MCP tool and the
     # help-corpus tests. Moved here from the retired [author] extra
     # (author-consolidation T4, 2026-07-27).

--- a/uv.lock
+++ b/uv.lock
@@ -528,8 +528,8 @@ requires-dist = [
     { name = "anthropic", marker = "extra == 'full'", specifier = ">=0.40.0" },
     { name = "anthropic", marker = "extra == 'llm'", specifier = ">=0.40.0" },
     { name = "attune-help", marker = "extra == 'dev'", specifier = ">=0.10.0" },
-    { name = "attune-rag", specifier = ">=0.1.5,<0.10" },
-    { name = "attune-rag", marker = "extra == 'dev'", specifier = ">=0.1.5,<0.10" },
+    { name = "attune-rag", specifier = ">=0.1.5,<2.0" },
+    { name = "attune-rag", marker = "extra == 'dev'", specifier = ">=0.1.5,<2.0" },
     { name = "attune-verify", specifier = ">=0.1.0,<0.3" },
     { name = "bandit", marker = "extra == 'all'", specifier = ">=1.7,<2.0" },
     { name = "bandit", marker = "extra == 'dev'", specifier = ">=1.7,<2.0" },
@@ -675,7 +675,7 @@ provides-extras = ["anthropic", "llm", "memdocs", "agents", "backend", "lsp", "w
 [package.metadata.requires-dev]
 dev = [
     { name = "attune-help", specifier = ">=0.10.0" },
-    { name = "attune-rag", specifier = ">=0.1.5,<0.10" },
+    { name = "attune-rag", specifier = ">=0.1.5,<2.0" },
     { name = "bandit", specifier = ">=1.7,<2.0" },
     { name = "black", specifier = ">=24.3.0,<27.0" },
     { name = "coverage", specifier = ">=7.0,<8.0" },


### PR DESCRIPTION
## Summary

Executes attune-rag v1.0.0-release task **M0.2** ([rag#201](https://github.com/Smart-AI-Memory/attune-rag/pull/201) decisions.md D3): every consumer must admit 1.0.0 *before* the cut, and attune-ai's `<0.10` cap excludes it. All three pin sites (core dep line 78, dev extra, dev group) widened to `<2.0`; **locked version stays 0.9.0** until 1.0.0 publishes.

**Why the widening is safe by construction:** 1.0.0's public surface is identical to the already-validated 0.9.0 (freeze policy, surface-lock test), and 1.x semantics forbid removals until 2.0.0.

## Re-validation (the line-78 recipe, re-run at widening)

- Lessons golden-query suite + lessons unit — **78 passed, 3 xfailed** (real corpus, real ranking; `attune.lessons` imports `KeywordRetriever` directly)
- Consumer suites (personal memory, ops help_data, rag_code_gen, curator) — **308 passed**
- Full consumed-symbol import sweep (9 symbols across `attune_rag`, `.provenance`, `.eval.faithfulness`) — **clean**

Residual exposure documented inline: a hypothetical 0.10.x under 0.x semver could remove symbols — none planned (roadmap goes 0.9.x → 1.0.0); re-validate before any lock bump onto one.

## Spec

attune-rag `docs/specs/v1.0.0-release/` — M0.2 in tasks.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)