### PR TITLE
chore(deps): lock attune-rag 1.0.0 + JIT rule — --admin only after checks settle

### DIFF
--- a/plugin/hooks/_recall_map.py
+++ b/plugin/hooks/_recall_map.py
@@ -98,6 +98,20 @@ RECALL_MAP: dict[str, list[dict[str, str]]] = {
                 "retrying; a retry 404s because it is already merged."
             ),
         },
+        # Checks-settled gate (added 2026-08-10): merging attune-rag
+        # #203 with 17 checks pending put a broken generated file on
+        # main and turned the next PR red. The admin bypass skips
+        # REVIEW on sole-dev repos, never CI.
+        {
+            "rule_id": "admin-merge-checks-settled",
+            "match_substring": "pr merge",
+            "text": (
+                "`--admin` merge ONLY after checks have SETTLED (zero "
+                "pending in `gh pr checks`) — a green-so-far PR is not a "
+                "green PR; the bypass is for skipping review, never CI. "
+                "Arm a Monitor on the checks instead of merging early."
+            ),
+        },
         # Rebase drops GPG signatures (T2.1, added 2026-06-20): replayed
         # commits come back unsigned; pushing them loses the signature.
         {

--- a/tests/unit/hooks/test_jit_recall.py
+++ b/tests/unit/hooks/test_jit_recall.py
@@ -337,6 +337,21 @@ def test_admin_merge_rule_fires_on_pr_merge(jit_mod, monkeypatch, capsys):
     assert "already merged" in ctx
 
 
+def test_admin_merge_checks_settled_rule_fires(jit_mod, monkeypatch, capsys):
+    # Both pr-merge rules ride the same trigger: the settled-checks gate
+    # (rag #203 lesson) must arrive alongside the retry-404 warning.
+    rc, out = _run(
+        jit_mod,
+        monkeypatch,
+        capsys,
+        _bash_payload("gh pr merge 203 --squash --admin --delete-branch"),
+    )
+    assert rc == 0
+    ctx = json.loads(out)["hookSpecificOutput"]["additionalContext"]
+    assert "SETTLED" in ctx
+    assert "never CI" in ctx
+
+
 def test_rebase_rule_fires_on_rebase(jit_mod, monkeypatch, capsys):
     rc, out = _run(jit_mod, monkeypatch, capsys, _bash_payload("git rebase main"))
     assert rc == 0

--- a/uv.lock
+++ b/uv.lock
@@ -715,7 +715,7 @@ wheels = [
 
 [[package]]
 name = "attune-rag"
-version = "0.9.0"
+version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jinja2" },
@@ -724,9 +724,9 @@ dependencies = [
     { name = "rich" },
     { name = "structlog" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5f/fe/3028c782ac2808edfb5827de43367bf009bf3a99bbbfcdd4a6c5e652344e/attune_rag-0.9.0.tar.gz", hash = "sha256:eedd8909c632241f1ca358069afd470830598d4bbc07b61c5ac0c8305745a903", size = 129596, upload-time = "2026-07-18T00:44:19.715Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/80/73/eba4066055eb78ee8ff280a598e982ac415d548f4d2094757651a1ca16c2/attune_rag-1.0.0.tar.gz", hash = "sha256:c991e39024d1dfd06f9da774a41938490fdfb63e9e95e716257b9162d8454f81", size = 129328, upload-time = "2026-08-10T05:33:12.859Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1f/aa/77b4da4c089ff6515b971460ea2323da515cc5acdc10960762831050bedd/attune_rag-0.9.0-py3-none-any.whl", hash = "sha256:d4e5be798cbabe732d72502adbce6e48136febc217150dbc38f064ed61e90596", size = 139957, upload-time = "2026-07-18T00:44:18.027Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/22/35eb96d912c013ef769e96279f6f57330f4e5733e1e8a3dc9af68a5d1def/attune_rag-1.0.0-py3-none-any.whl", hash = "sha256:e91bfb53e514aefb2944c4c894adf29df7519647816fc1893bedbb8e33abf87a", size = 137795, upload-time = "2026-08-10T05:33:11.434Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Two retro-ratified items:

**1. First consumer validation of attune-rag 1.0.0.** `uv.lock` bumps 0.9.0 → 1.0.0 (the `<2.0` range from [#2032](https://github.com/Smart-AI-Memory/attune-ai/pull/2032) admits it). Re-validated per the `pyproject:78` recipe against the published wheel: JIT + golden + lessons + curator **259 passed**; consumer suites **171 passed**; consumed-symbol sweep **clean**. Surface is 0.9.x-identical minus the five `editor._*` shims — which nothing here imported (verified at rag M1.4).

**2. `admin-merge-checks-settled` recall rule.** Merging rag #203 with 17 checks pending put a broken generated file on main and turned the next stacked PR red. New rule fires on `pr merge`: *"`--admin` merge ONLY after checks have SETTLED — the bypass is for skipping review, never CI."* Test asserts it arrives alongside the existing retry-404 rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)