### PR TITLE
docs(specs): archive the R6 handoff packet artifact into session-handoff receipts

### DIFF
--- a/docs/specs/cross-provider-session-handoff/r6-packet-claude-handoff-t4-docs.md
+++ b/docs/specs/cross-provider-session-handoff/r6-packet-claude-handoff-t4-docs.md
@@ -1,0 +1,29 @@
+---
+base_ref: "origin/main"
+branch: "claude/handoff-t4-docs"
+changed_files: []
+created_at: "2026-07-28T03:01:42.717461+00:00"
+head_sha: "3fed725b7396603f0aec41284593f4474b0a85f9"
+merge_base: "3fed725b7396603f0aec41284593f4474b0a85f9"
+provider: "claude-code"
+---
+
+# Agent work handoff
+
+## Goal
+
+T4 R6 live receipt: prove a packet created in Claude Code resumes in a live Codex session
+
+## Current state
+
+Feature master authored and projected (session-handoff); gates green; this packet is the R6 artifact itself
+
+## Verification
+
+| Claim | Failure-sensitive probe | Result |
+| --- | --- | --- |
+| packet resumes cross-provider | codex: call handoff_resume, expect ok:true with verified.branch claude/handoff-t4-docs | not run |
+
+## Next action
+
+From a Codex session in this repo, call handoff_resume and read the drift report

--- a/docs/specs/cross-provider-session-handoff/receipts.md
+++ b/docs/specs/cross-provider-session-handoff/receipts.md
@@ -117,3 +117,17 @@ two of the three drift codes the launch article names.
 
 Cosmetic, already chipped: `voice_summary` returned the generic
 "Here's what I found." on this call too.
+
+## 2026-08-10 — R6 packet artifact archived
+
+The packet the R6-CLOSED run resumed lived only as an UNCOMMITTED
+file in the `attune-ai-github-issues-0aeac3` worktree
+(`docs/handoffs/claude-handoff-t4-docs.md` on `qa/memory-events`,
+whose upstream is gone). Per the 2026-08-09 at-risk-worktree
+triage, it is preserved verbatim as
+[r6-packet-claude-handoff-t4-docs.md](r6-packet-claude-handoff-t4-docs.md)
+— frontmatter (`head_sha 3fed725b7…`, `created_at
+2026-07-28T03:01:42Z`) and body unmodified, including the
+verification row's honest `result: "not run"` (the sending agent's
+claim; the resume receipts above hold the verified facts). The
+source worktree is now safe to remove.


### PR DESCRIPTION
## What

Preserves the T4/R6 handoff packet — the artifact the R6-CLOSED cross-provider resume run consumed — into the cross-provider-session-handoff spec directory, verbatim, with a dated pointer entry in receipts.md.

## Why

The packet existed only as an UNCOMMITTED file in the at-risk `attune-ai-github-issues-0aeac3` worktree (`qa/memory-events`, upstream gone). The 2026-08-09 at-risk-worktree triage flagged it preserve-or-discard; preserved per this morning's ruling. The source worktree is now safe to remove.

Docs-only; no source changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)