### PR TITLE
chore: weekly report 2026-08-10

### DIFF
--- a/weekly-reports/2026-08-10.md
+++ b/weekly-reports/2026-08-10.md
@@ -1,0 +1,207 @@
+# Anthropic Ecosystem Weekly — 2026-08-10
+
+## Summary
+
+A security-heavy week for Claude Code (v2.1.222-226): three classes of
+permission-bypass were patched, PreToolUse hooks now fire in background
+agent tasks (passive win for attune's security guard), and the 200-subagent
+cap was removed. On the API side: Managed Agents gained session budgets and
+an advisor model; self-hosted environments hit public beta; Opus 4.1 is now
+retired; and the API no longer bills for `stop_reason: "refusal"` with no
+output — which quietly downgrades one of the longest-standing open
+carry-overs. Workbench sunset is in 7 days; stack is clean but mark it
+closed.
+
+---
+
+## Recommendations
+
+**1. Workbench sunset in 7 days — close the watch item (URGENT, by Aug 17)**
+
+`platform.claude.com/workbench` shuts down August 17. The three experimental
+prompt-gen endpoints (`/v1/experimental/generate_prompt`,
+`/v1/experimental/improve_prompt`, `/v1/experimental/templatize_prompt`)
+retire the same day and will return errors.
+
+Search across the full stack confirms no attune package calls these
+endpoints — the only "experimental" token in `src/` is a version comment in
+`meta_workflows/__init__.py`. No attune-author, attune-rag, or attune-help
+references found. If you have saved prompts, variables, or evals in the
+console Workbench, export them before Aug 17; after that the data is gone.
+
+- **Applies to:** Workbench console export (manual action). No code changes.
+- **Urgency:** Urgent (7 days). Console-only, not code.
+- **Action:** Export any saved prompts/evals before Aug 17 if you have any.
+
+---
+
+**2. PreToolUse hooks now fire in background tasks — verify attune hooks are
+safe there (MEDIUM)**
+
+v2.1.222 (Aug 4) fixed a bug where `PreToolUse` auto-allow hooks were
+bypassing tool restrictions in background agent tasks. The fix means
+`security_guard.py` and `worktree_path_guard.py` now run in background
+agent and subagent contexts where they previously did not. That is passive
+good news — the hooks have always been correct, they were just silently
+skipped.
+
+The action: confirm that both hooks are idempotent in background contexts.
+Neither reads session state beyond the tool call payload; both exit 0 on
+pass. That is fine. The risk would be if a hook has side effects that
+accumulate (logging to a session file, etc.) — check `telemetry_hook.py`
+specifically, since it is a `PostToolUse` hook on `Bash|Edit|Write` that
+fires on every matching tool call and now fires more often.
+
+- **Applies to:** `src/attune/hooks/scripts/telemetry_hook.py`, plus the
+  PreToolUse hooks above
+- **Urgency:** Medium — no breach, but new execution surface for hooks
+
+---
+
+**3. No billing on `stop_reason: "refusal"` with no output — July-6 Rec
+#2 downgraded (INFO)**
+
+The API now waives the charge when a request returns `stop_reason:
+"refusal"` without Claude having generated any tokens. This eliminates the
+cost-burn risk that made July-6 Rec #2 HIGH.
+
+The underlying code gap remains: `AnthropicProvider.generate()` passes
+`stop_reason` through to the caller as `finish_reason` without branching on
+`"refusal"`. Fable models raise `ModelRefusalError` explicitly via
+`acreate_with_fable`; non-Fable models (including Sonnet 5, Haiku 4.5) do
+not. If a Sonnet 5 call is refused the caller gets an `LLMResponse` with
+`finish_reason="refusal"` and must handle it. The billing is no longer an
+issue, but silent refusal pass-through is still an error-handling gap.
+
+Downgrading from HIGH to LOW because: (a) billing risk is gone, (b) Fable
+models — the actual refusal-prone tier — are already covered. A one-line
+`if response.stop_reason == "refusal": raise ModelRefusalError(...)` in the
+non-Fable path remains worthwhile but is not urgent.
+
+- **Applies to:** `src/attune/llm/providers/anthropic.py`
+- **Urgency:** Low (was HIGH; downgraded)
+
+---
+
+**4. Bash command padding bypass + invisible Unicode fixed — audit prompt in
+security guard (LOW)**
+
+v2.1.223 (Aug 6) patched two permission-check bypasses: (a) crafted Bash
+commands could pad content so the visible text differed from what was
+executed; (b) invisible Unicode in permission dialogs could hide command
+text visually while passing the check.
+
+These were Claude Code harness bugs, not attune code bugs. Both are fixed in
+v2.1.223+. However, `security_guard.py` does its own text scanning of Bash
+commands. Its current regex scan would have missed zero-width/invisible
+Unicode — it operates on the raw string but doesn't normalize Unicode before
+searching for `eval(` / `exec(`. Worth a one-line `unicodedata.normalize`
+pass at the top of `validate_bash_command()` as defense-in-depth, since the
+harness fix is in the layer above attune's guard.
+
+- **Applies to:**
+  `src/attune/hooks/scripts/security_guard.py:validate_bash_command()`
+- **Urgency:** Low — defense-in-depth; harness already patched
+
+---
+
+## Carry-overs
+
+| # | First raised | Recommendation | Status |
+|---|---|---|---|
+| July-6 Rec #1 | 2026-07-06 | Fix `_OPUS_NO_SAMPLING_RE` for Sonnet 5 | **CLOSED** — renamed `_NO_SAMPLING_MODELS_RE`; regex now covers all `[a-z]+-5` models including Sonnet 5 |
+| July-6 Rec #2 | 2026-07-06 | Handle `stop_reason: "refusal"` in `AnthropicProvider.generate()` | **Downgraded LOW** — API no longer bills zero-output refusals; Fable covered; non-Fable pass-through remains |
+| July-6 Rec #3 | 2026-07-06 | Bump `max_tokens=8192` for Opus 4.8 / Sonnet 5 | Partially done — `claude-opus-5` registry entry correct; Opus 4.8 entry unchanged |
+| July-6 Rec #4 | 2026-07-06 | Audit `max_tokens` call sites for adaptive thinking | Open (HIGH) — still relevant for Opus 4.8 in batch |
+| July-6 Rec #5 | 2026-07-06 | Sonnet 5 intro pricing $2/$10 → expires Aug 31 | **ESCALATED (21 days)** — if benchmark hasn't started, this week is the last realistic window |
+| June-29 Rec #2 | 2026-06-29 | Verify hook matchers for hyphenated MCP server names | Open (low) |
+| June-29 Rec #3 | 2026-06-29 | `autoMode.classifyAllShell` awareness | Open (low) |
+| June-22 Rec #1 | 2026-06-22 | Adjust release workflows for destructive git blocking | Open (medium) |
+| June-22 Rec #2 | 2026-06-22 | Investigate prompt caching on `_CITATION_BASE_URL` | Open |
+| June-22 Rec #3 | 2026-06-22 | `Tool(param:value)` permission rules for cost control | Open (low) |
+| June-22 Rec #4 | 2026-06-22 | Set `CLAUDE_CODE_CLIENT_PRESENCE_FILE` for scheduled runs | Open (low) |
+| June-8 Rec #4 | 2026-06-08 | Stop hooks `additionalContext` for session-stash | Open (low) |
+| July-13 Rec #1 | 2026-07-13 | Set expiry + rotation reminder on ANTHROPIC_API_KEY | Open (low) |
+| July-13 Rec #2 | 2026-07-13 | Run `/doctor` in next interactive session | Open (low) |
+| July-20 Rec #1 | 2026-07-20 | Verify hook `ask` path in auto mode post-v2.1.211 | Open (high) |
+| July-20 Rec #2 | 2026-07-20 | Confirm `Edit(tests/unit/**)` scope after v2.1.214 fix | Open (medium) |
+| July-20 Rec #3 | 2026-07-20 | Test long MCP tools with auto-background behavior | Open (medium) |
+| July-20 Rec #5 | 2026-07-20 | Scan prompts for "Claude will run /verify after changes" | Open (low) |
+| July-27 Rec #1 | 2026-07-27 | Upgrade batch premium target to `claude-opus-5` | **Open (MEDIUM-HIGH)** — `_BATCH_PREMIUM_FALLBACK = "claude-opus-4-8"` unchanged |
+| July-27 Rec #2 | 2026-07-27 | Escalated max_tokens urgency for Opus 5 | Partially mitigated — registry correct; batch fallback still Opus 4.8 |
+| July-27 Rec #3 | 2026-07-27 | Add `sandbox.network.strictAllowlist` to settings | **Open (MEDIUM)** — not in `.claude/settings.json` |
+| July-27 Rec #6 | 2026-07-27 | Update Fable fallbacks to include Opus 5 | **Open (MEDIUM)** — `_FABLE_FALLBACKS = [{"model": "claude-opus-4-8"}]` unchanged |
+| Aug-03 Rec #1 | 2026-08-03 | `mcp_server_errors` in headless init events | Open (medium) |
+| Aug-03 Rec #2 | 2026-08-03 | Nested subagent depth 3 — design space for crew layer | Open (low) |
+| Aug-03 Rec #3 | 2026-08-03 | Set `workflowSizeGuideline` in `.claude/settings.json` | Open (low) |
+| Aug-03 Rec #4 | 2026-08-03 | Track Python MCP SDK for spec 2026-07-28 compliance | Open (medium) |
+
+**State check this week** (files confirmed against live tree):
+
+- `_BATCH_PREMIUM_FALLBACK = "claude-opus-4-8"` — `anthropic_batch.py:20`,
+  unchanged (July-27 Rec #1)
+- `_FABLE_FALLBACKS = [{"model": "claude-opus-4-8"}]` — `model_tiers.py:58`,
+  unchanged (July-27 Rec #6)
+- `_NO_SAMPLING_MODELS_RE` — **updated**, covers all Claude 5 models
+  (July-6 Rec #1 closed)
+- `analytics.py:210,237` — `claude-opus-5` absent from both model-id lists
+  (July-6 Rec #3 partial)
+- `.claude/settings.json` — no `sandbox.network.strictAllowlist` (July-27
+  Rec #3 open)
+
+---
+
+## Watch list
+
+- **Sonnet 5 intro pricing ends Aug 31 (21 days).** $2/$10 → $3/$15 per MTok.
+  At current Sonnet 5 usage as the capable-tier default, the delta is
+  material. The benchmark window to decide whether Haiku 4.5 can absorb
+  cheap-tier calls closes this month. Last week said "this is the week to
+  start." It is now the week you are running out of.
+- **Self-hosted environments (public beta).** `claude self-hosted-runner`
+  (v2.1.224) is Anthropic's native answer to what attune-ops does for
+  scheduled sessions — session hosts you control, on your infra. Team/Enterprise
+  plans only. Not a drop-in replacement for attune-ops (which has richer
+  dashboard and memory integration), but the compute model overlaps. Worth a
+  look if infrastructure cost is a consideration.
+- **Managed Agents session budgets (Aug 7).** Hard spend caps per session with
+  `stop_reason: "budget_reached"`. Relevant if the attune crew layer ever
+  routes through Managed Agents. Not currently in use — track for design.
+- **`fallbacks: "default"` mode (still beta).** Server-side fallback with
+  Anthropic's recommended models by refusal category. Could simplify
+  `_FABLE_FALLBACKS`. Not yet GA.
+- **Mid-conversation tool changes (beta, Jul 24).** Add/remove tools mid-turn
+  while preserving the prompt cache. Could reduce re-send overhead in
+  attune's multi-turn workflows. Still beta.
+
+---
+
+## No-ops
+
+| Item | Why skipped |
+|---|---|
+| v2.1.226 "bug fixes" (Aug 8) | No itemized changes published |
+| Managed Agents advisor `max_tokens` param | Stack doesn't use Managed Agents |
+| Managed Agents inference geo (data residency) | No residency requirement |
+| Managed Agents GitHub skills discovery | No Managed Agents in use |
+| Enterprise inference hooks beta | Not an Enterprise org concern in current stack |
+| Admin API member management (Enterprise beta) | Not Enterprise |
+| API key expiration settings | Operational convenience; no code change needed |
+| Fable 5 biology safeguards improvement (Aug 7) | No biology-adjacent use cases |
+| Self-hosted runner ANTHROPIC_BEDROCK_REGION_PREFIX | Stack uses direct API, not Bedrock |
+| `CLAUDE_CODE_DISABLE_1M_CONTEXT` behavior change | Not set in any attune config |
+| Leadership announcement (Cuéllar, CGO) | Org news, not technical |
+| Opus 4.1 retirement (Aug 5) | No callsites found; watch list item confirmed closed |
+
+---
+
+## Sources checked
+
+- `platform.claude.com/docs/en/release-notes/overview` — Aug 5, 7 entries
+- `raw.githubusercontent.com/anthropics/claude-code/main/CHANGELOG.md`
+  — v2.1.222 through v2.1.226
+- `anthropic.com/news` — Aug 4, 7 entries
+- Stack: `anthropic_batch.py`, `model_tiers.py`, `analytics.py`,
+  `anthropic.py`, `security_guard.py`, `.claude/settings.json`,
+  `src/attune/meta_workflows/__init__.py`
+- Prior report: `weekly-reports/2026-08-03.md`


### PR DESCRIPTION
## Description

Anthropic ecosystem weekly report for the week of 2026-08-10.

---

# Anthropic Ecosystem Weekly — 2026-08-10

## Summary

A security-heavy week for Claude Code (v2.1.222-226): three classes of
permission-bypass were patched, PreToolUse hooks now fire in background
agent tasks (passive win for attune's security guard), and the 200-subagent
cap was removed. On the API side: Managed Agents gained session budgets and
an advisor model; self-hosted environments hit public beta; Opus 4.1 is now
retired; and the API no longer bills for `stop_reason: "refusal"` with no
output — which quietly downgrades one of the longest-standing open
carry-overs. Workbench sunset is in 7 days; stack is clean but mark it
closed.

---

## Recommendations

**1. Workbench sunset in 7 days — close the watch item (URGENT, by Aug 17)**

`platform.claude.com/workbench` shuts down August 17. The three experimental
prompt-gen endpoints (`/v1/experimental/generate_prompt`,
`/v1/experimental/improve_prompt`, `/v1/experimental/templatize_prompt`)
retire the same day and will return errors.

Search across the full stack confirms no attune package calls these
endpoints. No attune-author, attune-rag, or attune-help references found.
If you have saved prompts, variables, or evals in the console Workbench,
export them before Aug 17; after that the data is gone. No code changes needed.

**2. PreToolUse hooks now fire in background tasks — verify telemetry_hook.py (MEDIUM)**

v2.1.222 (Aug 4) fixed a bug where `PreToolUse` auto-allow hooks were
bypassing tool restrictions in background agent tasks. `security_guard.py`
and `worktree_path_guard.py` now run in background agent and subagent
contexts where they previously did not. Good news — but check
`telemetry_hook.py` specifically since it fires on every matching tool call
and now fires more often in background contexts.

**3. No billing on `stop_reason: "refusal"` with no output — July-6 Rec #2 downgraded (INFO)**

The API now waives the charge when a request returns `stop_reason: "refusal"`
without Claude having generated any tokens. This eliminates the cost-burn
risk that made July-6 Rec #2 HIGH. The code gap remains (non-Fable models
pass refusal through as `finish_reason`), but it's now LOW urgency.

**4. Bash command padding bypass + invisible Unicode fixed — audit security_guard.py (LOW)**

v2.1.223 patched two permission-check bypasses in the harness. Defense-in-depth
suggestion: add a `unicodedata.normalize` pass at the top of
`validate_bash_command()` in `security_guard.py` since the guard scans raw
strings and wouldn't catch zero-width Unicode before the harness fix.

## Type of Change

- [x] 📝 Documentation update

## Related Issues

N/A

## Changes Made

- Add `weekly-reports/2026-08-10.md` with full Anthropic ecosystem analysis
- Closes July-6 Rec #1 (`_NO_SAMPLING_MODELS_RE` now covers Sonnet 5)
- Downgrades July-6 Rec #2 (no billing on zero-output refusals)
- Confirms Workbench stack is clean (Aug 17 sunset, no code changes needed)

## Testing

- [x] Pre-commit hooks pass without errors (markdown-only change, Python hooks skipped)

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] Pre-commit hooks pass without errors

## License Acknowledgment

- [x] I confirm that my contributions are made under the Apache License 2.0

---
_Generated by [Claude Code](https://claude.ai/code/session_012GXTc37BCGyrsKSeLhTuYm)_