### PR TITLE
docs(rules): D11 pre-flight checklist tail-rule (chair-read)

### DIFF
--- a/.claude/rules-tail/attune/d11-preflight-checklist.md
+++ b/.claude/rules-tail/attune/d11-preflight-checklist.md
@@ -1,0 +1,66 @@
+# D11 Pre-Flight Checklist — lead diffs, before the review lane
+
+**Created:** 2026-08-10 (chair: "sounds promising", 2026-08-09)
+**Source:** repeat-class taxonomy from the 2026-08-09 seven-lane
+R5 run — the classes different-model lanes keep re-finding in
+lead-authored diffs.
+
+---
+
+## When this fires
+
+Before pushing any lead-authored diff that touches src/ or tests/
+— mandatory when the diff will enter a D11b different-model review
+lane (risk classes: security, persistence, release,
+governance/enforcement, external boundaries, disputed findings).
+Run the checklist BEFORE the lane launches, so lanes spend their
+attention on novel findings instead of re-finding these classes.
+
+## The checklist
+
+Walk the diff once per class. Each check names the concrete probe.
+
+1. **Fail-open paths that crash on legal-but-unexpected input.**
+   For every `except`/fallback/degraded branch: feed it the full
+   legal input domain (None, empty string, empty list, zero-length
+   corpus, unicode). A fail-open path that raises on legal input
+   is fail-closed in disguise.
+2. **Unbounded / off-by-one windows.** For every slice, window,
+   limit, or pagination bound: probe both ends, the empty window,
+   and N == limit exactly. Check that "last N" and "since T"
+   agree on inclusivity.
+3. **Record-before-stamp ordering.** For every persistence write
+   that also flips a status/stamp: the durable record must land
+   BEFORE the stamp flips. A crash between the two must leave a
+   recoverable, honest state — never a stamp pointing at a record
+   that doesn't exist.
+4. **String-prefix path containment.** Never
+   `str(path).startswith(str(root))` — `/a/bc` passes a `/a/b`
+   prefix check. Use `Path.is_relative_to()` on resolved paths
+   (or the project's `_validate_file_path()` helper).
+5. **Cross-corpus key collisions.** Any dict/index keyed on a
+   name, stem, or slug derived from user content: confirm the key
+   carries its corpus/namespace. Two corpora sharing a stem must
+   not share a row.
+6. **Windows USERPROFILE in home-isolating fixtures.** A fixture
+   that redirects `HOME` must also set `USERPROFILE` —
+   `Path.home()` on Windows reads the latter, and the fixture
+   silently stops isolating on the Windows lanes.
+
+## Measurement (the testability answer)
+
+Efficacy is measured in the R5 dogfood ledger
+(`docs/specs/cross-review/receipts.md`): repeat-class findings per
+lane, before vs after this rule's adoption. A class that keeps
+being found by lanes despite the checklist is a candidate for a
+mechanical gate; a class lanes stop finding is the checklist
+working (or the class going extinct — the ledger can't tell, and
+doesn't need to).
+
+## Cross-references
+
+- D11/D11b–d rulings:
+  `docs/specs/feature-lead-governance/decisions.md` (2026-07-29)
+  and the collaboration contract's "Lead programmer and
+  delegation" section.
+- R5 ledger: `docs/specs/cross-review/receipts.md`.

--- a/.claude/rules/attune/INDEX.md
+++ b/.claude/rules/attune/INDEX.md
@@ -10,6 +10,10 @@ the one-liner here is the trip-wire, not the rule.
 - **Deleting, surfacing, or "fixing access to" a registered
   capability** → `removing-dead-code.md` — the should-this-exist
   gate; never surface before dogfooding the real run path.
+- **Pushing a lead-authored src/tests diff (esp. into a D11b
+  review lane)** → `d11-preflight-checklist.md` — six repeat-class
+  probes (fail-open, windows, record-before-stamp, path prefix,
+  key collisions, USERPROFILE) run BEFORE the lane.
 - **Writing/reviewing Python style, exceptions, path validation,
   security patterns** → `coding-standards-index.md` — expanded
   quick-ref; the binding rules are already in CLAUDE.md Critical


### PR DESCRIPTION
## What

Authors the **D11 pre-flight checklist** as a tail-tier rule (`.claude/rules-tail/attune/d11-preflight-checklist.md`) + INDEX trip-wire — the ~20-min unit green-lit 2026-08-09.

Six repeat-class probes the lead runs on its own diff BEFORE a D11b different-model lane: fail-open-crashes-on-legal-input, unbounded/off-by-one windows, record-before-stamp ordering, string-prefix path containment, cross-corpus key collisions, Windows USERPROFILE in home-isolating fixtures.

## Receipts

- Taxonomy recovered VERBATIM from the 2026-08-09 starter (transcript archaeology; the file itself was overwritten 2026-08-10).
- `tests/unit/rules/test_rules_residency_budget.py` 4/4 (tail tier never auto-loads; INDEX delta only).
- Pre-commit hooks green on both files.

## Governance note

Rule text → chair-read per D9; NOT armed. Testability answer recorded in the rule: R5 ledger, repeat-class findings per lane before/after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)