### PR TITLE
docs(specs): Monday chair rulings — D7 ref-binding, D23 V6 approval, G4(c) extension

### DIFF
--- a/docs/specs/claim-drift-gates/decisions.md
+++ b/docs/specs/claim-drift-gates/decisions.md
@@ -369,3 +369,13 @@ construction — run
 locally before merging one. Whether to close it (e.g. always run the
 claim guards regardless of path filter) is a live question for this
 spec, not a ruled decision.
+
+## 2026-08-10 — G4(c) stays advisory; promotion check moved to 2026-09-07 (chair)
+
+**Ruled** via the Monday chair-rulings form ("Keep advisory, new
+check date"): `contributing-smoke.yml` keeps
+`continue-on-error: true` past the original ~2026-08-04 promotion
+check. New promotion check: **2026-09-07** (date lead-proposed at
+recording time — a four-week window matching the original cadence;
+chair may amend). At that check the same three-way fork applies:
+promote to required, extend advisory again, or retire the lane.

--- a/docs/specs/claim-drift-gates/requirements.md
+++ b/docs/specs/claim-drift-gates/requirements.md
@@ -7,8 +7,8 @@ decisions.md). G1 (#1497), G2 (#1501), G5 (#1502) and G4 a+b+c
 all on main. REMAINING: G3 only, still blocked on
 hook-timeout-budget Phase 0.2 values (no `hook-timeout-budgets`
 spec dir exists; no `WORST_CASE_MS` declared anywhere). Open
-follow-ups: G4(c) `contributing-smoke.yml` still
-`continue-on-error: true` past its ~2026-08-04 promotion check;
+follow-ups: G4(c) `contributing-smoke.yml` advisory by ruling
+(2026-08-10), promotion check 2026-09-07;
 website-only-PR guard gap (decisions.md 2026-07-28) unruled. D4
 ratified 2026-07-12 (option a, "20 workflows"); D7, D8 ruled
 2026-07-20 (CI-only test gates; report-only inverse).

--- a/docs/specs/elicitation-form-surface/decisions.md
+++ b/docs/specs/elicitation-form-surface/decisions.md
@@ -902,3 +902,15 @@ of the template also produced the session's actual routing decision.
 - **Revisit the `socratic-ambiguity-calibration` "ask only when
   genuinely ambiguous" rule** — Patrick endorses it now but is open to
   changing it with more feedback. Future discussion, not a v1 change.
+
+## D23 — V6 (MCP Apps adapter) requirements APPROVED (chair, 2026-08-10)
+
+**Ruled** via the Monday chair-rulings form ("Approve (build after
+V7)"): the V6 requirements (`v6-requirements.md`, draft since
+2026-07-16) are approved as written. Build authority remains
+SEQUENCED — V6 starts after V7's templates exist to supply its
+round-trip payloads (D20's ordering, unchanged). The distribution
+premise stays named and falsifiable per the requirements' own
+terms: if MCP Apps host support regresses or directory access
+gates, the premise weakens and the spec re-enters review before
+build.

--- a/docs/specs/elicitation-form-surface/requirements.md
+++ b/docs/specs/elicitation-form-surface/requirements.md
@@ -6,7 +6,7 @@ tools); v2-1/v2-2 shipped 2026-06-27 (#1131/#1132:
 number/date/textarea + `form_to_elicitation_schema` +
 `elicitation_ask` — the 2026-07-14 "recommit" of v2 was already
 built); V4 (#1178), V5 (#1181), forms-by-default (#1652), V7
-template library (2026-08-06, #1945). OPEN: V6 (MCP Apps adapter)
+template library (2026-08-06, #1945). V6 (MCP Apps adapter) APPROVED 2026-08-10 (D23, builds after V7)
 still "awaiting Patrick approval" — its 2026-07-28 freeze lapsed
 and its V7 predecessor shipped; needs an approve-or-drop ruling.
 Deferred by design: `slider` / `color` controls.

--- a/docs/specs/elicitation-form-surface/v6-requirements.md
+++ b/docs/specs/elicitation-form-surface/v6-requirements.md
@@ -1,6 +1,7 @@
 # Elicitation Form Surface — V6 Requirements: the MCP Apps adapter
 
-**Status:** draft (2026-07-16) — awaiting Patrick approval.
+**Status:** approved (2026-08-10, chair via the Monday rulings
+form) — build sequenced AFTER V7 per D20; see decisions.md D23.
 **Freeze:** design-only until 2026-07-28 (ratified with the
 standards-landscape sequence); no code before the freeze lifts.
 **Sequencing:** V7 (`v7-requirements.md`) was ratified 2026-07-17 and

--- a/docs/specs/memory-claim-verification/decisions.md
+++ b/docs/specs/memory-claim-verification/decisions.md
@@ -1,9 +1,8 @@
 # memory-claim-verification — decisions
 
-**Status:** parked (2026-07-26; file-level line added at the
-2026-08-08 triage) — D1–D5 ruled; D6 sends the ref-binding fork to
-the round table. Resume-Trigger: the ref-binding table sitting
-(precondition cleared 2026-07-28).
+**Status:** active (2026-08-10) — D1–D7 ruled; the ref-binding
+table sat 2026-08-10 (thread `q-ref-binding-001`) and D7 resolves
+the fork. Next: the D7 rider-(c) measurement probe, then P1.
 
 ## D1 (2026-07-26): the extraction prompt is NOT the control
 
@@ -167,3 +166,43 @@ The three candidate bindings to put to the table:
    binding entirely; changes what `grounding` in R4 means.
 
 No implementation starts before that ruling.
+
+## D7 (2026-08-10): ref-binding = per-finding matching, with three riders (table unanimous, chair adopted)
+
+**Ruled (chair, via the promotion form + "go with the
+recommendations of the roundtable").** The D6 table sat 2026-08-10
+(thread `q-ref-binding-001`, halted after round 1 of 3 on
+unanimous convergence; full transcript machine-local at
+`~/.attune/reports/roundtable/q-ref-binding-001.md`). All three
+seats (claude, antigravity, codex) independently picked candidate
+2 and rejected 1 (inherited refs produce false verification
+outcomes) and 3 (verification consumes findings, not sessions).
+
+The binding model: a finding binds only to refs deterministically
+matched between its own text/payload and the session-derived ref
+set — closed-set exact/basename/symbol matching, no LLM in the
+raw-tier binding path. Riders, adopted with the ruling:
+
+- **(a) Unbound is first-class.** A finding matching nothing is
+  stored ungrounded/unbound — honest state, never presented as
+  grounded, never papered over. Verification distinguishes
+  `bound` / `unbound` / `stale-missing-ref`.
+- **(b) Session provenance, not session binding.** Every finding
+  carries its session-id; the session ref-set stays derivable as
+  an explicitly-labeled WEAKER view (candidate 1 as a lens, never
+  a stored binding). Later deterministic evidence may promote
+  `unbound` → `bound` with the original finding unchanged and
+  binding provenance recorded (codex follow-up, admitted).
+- **(c) Measure before building.** An OQ1-style probe on the
+  existing stashed corpus runs BEFORE the P1 matcher build: what
+  fraction of real raw-tier findings textually name at least one
+  ref derivable from their session's tool_use records? A low hit
+  rate (<50%) reopens the design conversation (2-with-fallback vs
+  3) before the build cost is paid — the vacuous-verification-layer
+  risk all three seats flagged.
+
+Seat risk register, preserved: matchability as a hidden quality
+gate biasing recall toward easily-named entities (codex); matcher
+recall on prose findings + over-matching on short/common tokens
+(claude); abstract findings staying ungrounded and going stale
+undetected (antigravity).

--- a/docs/specs/memory-claim-verification/requirements.md
+++ b/docs/specs/memory-claim-verification/requirements.md
@@ -1,15 +1,13 @@
 # memory-claim-verification
 
-**Status:** parked (2026-08-08 triage — requirements authored
+**Status:** active (2026-08-10) — the ref-binding fork is RULED:
+the table sat 2026-08-10 and D7 adopts per-finding matching with
+three riders (unbound first-class; session provenance as a
+derivable weaker view; measure-first probe). Requirements authored
 2026-07-26; OQ1 measured at n=18: 28.1% of model-authored refs
 grounded, 10.1% heuristic-backfillable — R3-as-written retired by
-D6. No implementation starts before the round table rules the
-ref-binding fork; three candidates in decisions.md D6.)
-Resume-Trigger: convene the ref-binding round table — the blocking
-precondition (the 2026-07-27 roundtable fire) CLEARED on
-2026-07-28 (agent-round-table decisions.md, thread
-`routine-clean-run-20260728-1020`), so the sitting is convenable
-now and is this spec's only gate.
+D6. Next gate: the D7 rider-(c) probe runs before the P1 matcher
+build.
 **Owner:** Patrick (chair)
 **Origin:** 2026-07-25 session — 2 of 4 auto-stashed findings were wrong
 enough that Patrick had to ask for them to be deleted.


### PR DESCRIPTION
Records three chair rulings from today's forms, verbatim provenance in each entry:

1. **memory-claim-verification D7** — the D6 ref-binding table sat today (thread `q-ref-binding-001`, halted round 1/3 on unanimous convergence; transcript machine-local per local-first-reports). Candidate 2 (per-finding matching) adopted with riders: unbound first-class, session provenance as derivable weaker view (+ legal unbound→bound promotion), measure-first probe BEFORE the P1 matcher build. Spec status parked → active.
2. **elicitation-form-surface D23** — V6 (MCP Apps adapter) requirements approved; build sequenced after V7 (D20 unchanged).
3. **claim-drift-gates** — G4(c) stays advisory; promotion check re-set to 2026-09-07 (lead-proposed date, chair may amend).

Docs-only; ruling records and status flips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)