### PR TITLE
feat(scripts): rider-(c) probe + D8 record — bind rate 22.9%, design reopened (chair-read)

### DIFF
--- a/docs/specs/memory-claim-verification/decisions.md
+++ b/docs/specs/memory-claim-verification/decisions.md
@@ -1,8 +1,12 @@
 # memory-claim-verification — decisions
 
-**Status:** active (2026-08-10) — D1–D7 ruled; the ref-binding
-table sat 2026-08-10 (thread `q-ref-binding-001`) and D7 resolves
-the fork. Next: the D7 rider-(c) measurement probe, then P1.
+**Status:** active (2026-08-10) — D1–D9 ruled. The ref-binding
+table ran all three rounds (thread `q-ref-binding-001`): D7
+per-finding matching, D8 probe FAILED the gate (22.9%), D9 adopts
+C-hardened (propose-at-extraction, validate-at-binding). Next:
+design phase — extractor refs field + binder + re-probe (with the
+chair-adopted adversarial salted subset); the inventory-vs-anchor
+fork settles empirically.
 
 ## D1 (2026-07-26): the extraction prompt is NOT the control
 
@@ -245,3 +249,59 @@ Honest limits recorded in the local report: basename multi-bind
 (SKILL.md class), symbol-kind underivation (unmeasured), spec-slug
 min-length gap, Ollama run-to-run nondeterminism (noise dwarfed by
 the 22.9-vs-50 margin), zero sha binds.
+
+## D9 (2026-08-10): C-hardened ADOPTED — propose-at-extraction, validate-at-binding; rounds 2-3 of the table
+
+**Ruled (chair, final-ruling form: "Adopt; design phase settles
+inventory-vs-anchor via re-probe"; follow-up triage delivered in
+chat after a widget multi-select fault).** After D8 failed the
+gate, the chair directed rounds 2 and 3 on thread
+`q-ref-binding-001` (D3 ceiling reached; transcript
+machine-local). Round 2: all three seats independently converged
+on option C. Round 3 (attack-then-harden, chair-directed before
+ruling): C SURVIVED 3/3 under adversarial pressure, each seat
+emitting a build-ready hardened design.
+
+**The settled core (mandated verbatim, all three seats agree):**
+
+- Refs are PROPOSED at extraction (structured field, chosen from
+  the session's artifacts) and VALIDATED at binding —
+  deterministic set-membership/exact only; fuzzy prose matching
+  stays retired (D8 showed it caused both failure modes).
+- Empty refs is a PREFERRED, first-class success state; "a
+  convenience reference is a defect"; prompts instruct
+  refs-last-finding-first so the field cannot displace finding
+  quality.
+- Corpus is versioned: legacy v1 "not collected" is DISTINCT from
+  v2 "explicitly unbound"; no backfill, no mutation, no blended
+  metrics across versions.
+- The re-probe (same 40 transcripts as D8) reports bind rate ONLY
+  alongside (i) an extraction-quality regression guard
+  (findings-per-transcript, length, dedup; blind paired
+  comparison) and (ii) a MANUAL aboutness-precision audit
+  (stratified sample, independent judges). Thresholds stay the
+  chair's, set AFTER numbers (ruled on the round-2 form: "Decide
+  after re-probe numbers").
+- **Adversarial subset (chair-adopted, codex follow-up):** the
+  re-probe includes a salted subset — transcripts carrying highly
+  salient but unrelated artifacts (incl. cross-repo) — reported
+  separately.
+- Refs are forever described as "extractor-proposed,
+  inventory-validated" — never fully-verified evidence.
+
+**The one open fork, sent to the design phase with the re-probe as
+the deciding instrument (cheapest shape first):** codex's opaque
+inventory-ID selection vs claude's anchored refs (verbatim
+transcript anchor, locality-checked, demotion-rate observable) vs
+antigravity's plain strict-prompting + exact membership. The
+designs compose; each addition costs tokens and failure surface.
+
+**Not adopted now (design-phase options, unmandated):**
+demoted-ref visibility handling in session view; `ref_rejected`
+events into UsageTracker telemetry.
+
+**Risk register (round 3, per seat, preserved):** human precision
+review cannot mechanically prove aboutness (codex);
+anchor-locality over-rejection creating pressure to loosen — fuzzy
+matching's back door (claude); prompt-compliance variance across
+model families (antigravity).

--- a/docs/specs/memory-claim-verification/decisions.md
+++ b/docs/specs/memory-claim-verification/decisions.md
@@ -206,3 +206,42 @@ gate biasing recall toward easily-named entities (codex); matcher
 recall on prose findings + over-matching on short/common tokens
 (claude); abstract findings staying ungrounded and going stale
 undetected (antigravity).
+## D8 (2026-08-10): rider-(c) probe MEASURED — 22.9% bind rate, design conversation REOPENED
+
+**Measured, same day as D7** (`scripts/probe_ref_binding.py
+--samples 40`; full data machine-local at
+`~/.attune/reports/memory-claim-verification/rider-c-probe.md`).
+Real shipped extractor (session_stash._extract_via_ollama,
+llama3.1:8b), ref-sets derived from each session's tool_use
+records, matching purely deterministic (exact path / basename /
+pr-number / sha-prefix / spec-slug, stoplist + min-basename
+guards).
+
+| Metric | Value |
+|---|---|
+| transcripts scored | 40 |
+| findings extracted | 192 |
+| findings bound (>=1 derived ref) | 44 (**22.9%**) |
+| by kind | pr=21, sha=0, file=43, spec=4 |
+| D7 gate (50%) | **FAILED — reopen design** |
+
+The over-match spot-check LOWERS true precision further: among
+the 44 are a generic security-posture finding bound to
+`ops/security.py` by the word "security", a bare repo-directory
+ref, and a 2-char `spec:v1` slug bind. The number is consistent
+with OQ1's 28.1% grounded — prose findings summarize decisions,
+they do not name artifacts. The vacuity risk all three D7 seats
+flagged is measured fact, not speculation.
+
+**Consequence (mechanical, per D7 rider c):** the P1 matcher
+build does NOT proceed. The reopened fork — candidate
+2-with-fallback (findings mostly consumed through rider-(b)'s
+weaker session-view lens) vs candidate 3 (session as the grounded
+unit, redefining R4) — awaits a chair ruling; re-convening the
+table with these numbers is the moderator-recommended path, since
+the seats deliberated without them.
+
+Honest limits recorded in the local report: basename multi-bind
+(SKILL.md class), symbol-kind underivation (unmeasured), spec-slug
+min-length gap, Ollama run-to-run nondeterminism (noise dwarfed by
+the 22.9-vs-50 margin), zero sha binds.

--- a/scripts/probe_ref_binding.py
+++ b/scripts/probe_ref_binding.py
@@ -1,0 +1,239 @@
+#!/usr/bin/env python3
+"""Measure the D7 rider-(c) gate: can findings bind to derived refs?
+
+memory-claim-verification D7 adopted per-finding matching (candidate
+2) with rider (c): BEFORE the P1 matcher is built, measure what
+fraction of real raw-tier findings deterministically match at least
+one ref derivable from their session's tool_use records. A low hit
+rate (<50%) reopens the design conversation (2-with-fallback vs 3).
+
+This is a MEASUREMENT, not a test (same discipline as OQ1's
+measure_stash_refs.py). It replays real session transcripts through
+the REAL shipped extraction path (session_stash._extract_via_ollama),
+derives each session's ref-set from its tool_use records, and matches
+finding text against the derived set with deterministic rules only —
+no LLM anywhere in the binding path.
+
+    python scripts/probe_ref_binding.py --samples 40
+
+Copyright 2026 Smart-AI-Memory
+Licensed under the Apache License, Version 2.0
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import random
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+HOOK = REPO_ROOT / "plugin" / "hooks" / "session_stash.py"
+
+#: Ref kinds derivable from tool_use records (mirrors the OQ1 probe's
+#: third-mechanism analysis; symbol-kind is deliberately NOT probed —
+#: honest limit, P1 may add it).
+COMMAND_PATTERNS: list[tuple[str, re.Pattern[str]]] = [
+    ("pr", re.compile(r"(?:#|pull/)(\d{2,6})\b")),
+    ("sha", re.compile(r"\b([0-9a-f]{8,40})\b")),
+    ("file", re.compile(r"\b((?:src|tests|scripts|docs|plugin|content)/[\w./-]+\.\w+)")),
+    ("spec", re.compile(r"docs/specs/([\w-]+)")),
+]
+
+#: Basenames too generic to bind on — the claude-seat over-match guard.
+STOPLIST = {
+    "main",
+    "test",
+    "tests",
+    "src",
+    "docs",
+    "init",
+    "setup",
+    "index",
+    "utils",
+    "readme",
+    "claude",
+    "config",
+    "requirements",
+    "design",
+    "tasks",
+    "decisions",
+}
+MIN_BASENAME = 5
+
+
+def load_hook():
+    """Load the Stop-hook module so the REAL extraction path is used."""
+    spec = importlib.util.spec_from_file_location("_stash_hook", HOOK)
+    if spec is None or spec.loader is None:  # pragma: no cover - env guard
+        raise RuntimeError(f"cannot load {HOOK}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["_stash_hook"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def derive_refs(transcript: Path) -> dict[str, set[str]]:
+    """Derive the session ref-set from tool_use records (deterministic).
+
+    Walks every JSONL line, collects tool_use inputs: file-path keys
+    directly, and pr/sha/file/spec patterns from command strings.
+    """
+    refs: dict[str, set[str]] = {"pr": set(), "sha": set(), "file": set(), "spec": set()}
+    with open(transcript, encoding="utf-8", errors="replace") as fh:
+        for line in fh:
+            if '"tool_use"' not in line:
+                continue
+            try:
+                record = json.loads(line)
+            except (json.JSONDecodeError, ValueError):
+                continue
+            content = record.get("message", {}).get("content")
+            if not isinstance(content, list):
+                continue
+            for block in content:
+                if not isinstance(block, dict) or block.get("type") != "tool_use":
+                    continue
+                inputs = block.get("input")
+                if not isinstance(inputs, dict):
+                    continue
+                for key, value in inputs.items():
+                    if not isinstance(value, str):
+                        continue
+                    if key in ("file_path", "path", "notebook_path"):
+                        refs["file"].add(value)
+                        continue
+                    for kind, pattern in COMMAND_PATTERNS:
+                        for match in pattern.findall(value):
+                            refs[kind].add(match)
+    return refs
+
+
+def match_finding(content: str, refs: dict[str, set[str]]) -> list[str]:
+    """Deterministic per-finding matching (the D7 matcher family).
+
+    Exact path / basename / pr-number / sha-prefix / spec-slug only.
+    Returns the matched refs as "kind:value" strings.
+    """
+    matched: list[str] = []
+    lower = content.lower()
+    words = set(re.findall(r"[\w.-]+", lower))
+
+    for number in refs["pr"]:
+        if re.search(rf"(?:#|\bpr[ #]?){number}\b", lower):
+            matched.append(f"pr:{number}")
+
+    hex_tokens = re.findall(r"\b[0-9a-f]{7,40}\b", lower)
+    for sha in refs["sha"]:
+        if any(sha.startswith(token) or token.startswith(sha) for token in hex_tokens):
+            matched.append(f"sha:{sha[:12]}")
+
+    for path in refs["file"]:
+        base = Path(path).name.lower()
+        stem = Path(path).stem.lower()
+        if path.lower() in lower:
+            matched.append(f"file:{path}")
+        elif (
+            len(stem) >= MIN_BASENAME and stem not in STOPLIST and (base in words or stem in words)
+        ):
+            matched.append(f"file:{path}")
+
+    for slug in refs["spec"]:
+        if slug.lower() in lower:
+            matched.append(f"spec:{slug}")
+    return matched
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--samples", type=int, default=40)
+    parser.add_argument("--min-bytes", type=int, default=20_000)
+    parser.add_argument(
+        "--projects",
+        default=str(Path.home() / ".claude" / "projects"),
+        help="Claude Code projects dir holding transcript JSONL",
+    )
+    args = parser.parse_args()
+
+    hook = load_hook()
+    root = Path(args.projects)
+    transcripts = sorted(
+        (p for p in root.rglob("*.jsonl") if p.stat().st_size > args.min_bytes),
+        key=lambda p: p.stat().st_mtime,
+        reverse=True,
+    )[: args.samples]
+    if not transcripts:
+        print(f"no transcripts found under {root}", file=sys.stderr)
+        return 1
+
+    n_scored = 0
+    n_findings = 0
+    n_bound = 0
+    kind_hits = {"pr": 0, "sha": 0, "file": 0, "spec": 0}
+    bound_samples: list[tuple[str, list[str]]] = []
+    unbound_samples: list[str] = []
+
+    print(f"samples={len(transcripts)}  (real extractor + deterministic matcher)\n")
+    for index, path in enumerate(transcripts, 1):
+        tail = hook._read_transcript_tail(str(path))
+        if not tail.strip():
+            continue
+        findings = hook._extract_via_ollama(tail)
+        if not findings:
+            print(f"  [{index:2}] no-findings/ollama-miss  {path.name[:44]}")
+            continue
+        n_scored += 1
+        refs = derive_refs(path)
+        bound_here = 0
+        for finding in findings:
+            content = str(finding.get("content", ""))
+            if not content:
+                continue
+            n_findings += 1
+            matches = match_finding(content, refs)
+            if matches:
+                n_bound += 1
+                bound_here += 1
+                for m in matches:
+                    kind_hits[m.split(":", 1)[0]] += 1
+                bound_samples.append((content, matches))
+            else:
+                unbound_samples.append(content)
+        print(
+            f"  [{index:2}] ok  findings={len(findings)} bound={bound_here}  "
+            f"refs(pr={len(refs['pr'])} sha={len(refs['sha'])} "
+            f"file={len(refs['file'])} spec={len(refs['spec'])})  {path.name[:36]}"
+        )
+
+    def pct(numerator: int, denominator: int) -> str:
+        return f"{100.0 * numerator / denominator:5.1f}%" if denominator else "  n/a"
+
+    print("\n" + "=" * 62)
+    print("D7 rider-(c) — per-finding deterministic bind rate")
+    print("=" * 62)
+    print(f"transcripts scored      {n_scored}")
+    print(f"findings extracted      {n_findings}")
+    print(f"findings BOUND (>=1)    {n_bound}  ({pct(n_bound, n_findings)})   <-- the gate number")
+    print(
+        f"  by kind: pr={kind_hits['pr']} sha={kind_hits['sha']} file={kind_hits['file']} spec={kind_hits['spec']}"
+    )
+    print(
+        f"gate verdict            {'PROCEED to P1' if n_findings and n_bound / n_findings >= 0.5 else 'REOPEN design (<50%)'}"
+    )
+
+    rng = random.Random(42)
+    print("\n--- over-match spot-check (10 random bound findings) ---")
+    for content, matches in rng.sample(bound_samples, min(10, len(bound_samples))):
+        print(f"  BOUND {matches}\n        {content[:160]}")
+    print("\n--- lossiness sample (5 random unbound findings) ---")
+    for content in rng.sample(unbound_samples, min(5, len(unbound_samples))):
+        print(f"  UNBOUND {content[:160]}")
+    print("=" * 62)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What

The full D7→D9 arc, one coherent chair-read unit (rebased onto main after #2040):

- `scripts/probe_ref_binding.py` — the rider-(c) probe: real shipped extractor, per-session ref-sets from `tool_use` records, deterministic matching, over-match guards, seeded spot-checks.
- **D8**: n=40, 192 findings, **22.9% bound** vs the ruled 50% gate → design reopened (mechanical consequence per D7). Spot-check shows over-matches among the bound; consistent with OQ1's 28.1%.
- **D9**: rounds 2–3 of the table (unanimous option C in round 2; attack-then-harden in round 3, C survived 3/3). Chair adopted **C-hardened**: propose-at-extraction, validate-at-binding; settled core mandated (empty-refs-preferred, versioned corpus, quality-regression + aboutness-precision audits alongside bind rate, chair-adopted adversarial salted subset); inventory-vs-anchor fork to the design phase, settled empirically by the re-probe.

## Receipts

Metric receipt: full-stream measurement, raw + curated reports machine-local. Board thread `q-ref-binding-001` (20 messages, D3 ceiling reached, promotions marked). Rebase conflict with #2040 resolved keeping D7+D8 in sequence; commits re-signed (verified `G`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)