### PR TITLE
fix(elicitation): required-field gate in the widget submit script

### DIFF
--- a/src/attune/elicitation/theme.py
+++ b/src/attune/elicitation/theme.py
@@ -61,6 +61,8 @@ CSS_BASE = """#attune-elicit-form { display:block; width:100%; padding:1rem 0;
 #attune-elicit-form .ae-submit:disabled { opacity:.6; cursor:default; }
 #attune-elicit-form .ae-error { margin-top:.5rem; font-size:14px;
   color:var(--text-accent,#a1571c); }
+#attune-elicit-form .ae-field-missing { border-left:3px solid
+  var(--text-accent,#a1571c); padding-left:.6rem; }
 """
 
 #: INPUT — text_input, textarea, number, date, boolean, non-list single_select.

--- a/src/attune/elicitation/widget.py
+++ b/src/attune/elicitation/widget.py
@@ -384,9 +384,10 @@ def _field_html(q: FormQuestion) -> str:
         else ""
     )
     inferred_attr = ' data-inferred="1"' if q.inferred_from else ""
+    required_attr = ' data-required="1"' if q.required else ""
     return (
         f'<div class="ae-field" data-fid="{_esc(q.id)}" '
-        f'data-ftype="{_esc(q.type.value)}"{inferred_attr}>'
+        f'data-ftype="{_esc(q.type.value)}"{inferred_attr}{required_attr}>'
         f'<label class="ae-label">{_esc(q.text)}{req}</label>'
         f"{help_html}{inferred_html}{_control_html(q)}{rationale_html}</div>"
     )
@@ -525,6 +526,26 @@ def form_to_widget_html(
         }}
       }}
     }});
+    // Required-field gate: an unanswered required field must surface a
+    // visible error and leave the button alive — never post a payload
+    // the server-side validator will reject after the widget is dead.
+    var missing = [];
+    form.querySelectorAll('.ae-field[data-required]').forEach(function(f) {{
+      var v = answers[f.getAttribute('data-fid')];
+      var empty = v === undefined || v === '' ||
+        (Array.isArray(v) && v.length === 0);
+      f.classList.toggle('ae-field-missing', empty);
+      if (empty) {{
+        var lbl = f.querySelector('.ae-label');
+        missing.push(lbl ? lbl.textContent.replace(/\\*$/, '')
+          : f.getAttribute('data-fid'));
+      }}
+    }});
+    if (missing.length) {{
+      err.textContent = 'Required: ' + missing.join(', ');
+      return;
+    }}
+    err.textContent = '';
     var payload = {{ {WIDGET_RESPONSE_MARKER!r}: true,
       title: form.getAttribute('data-form-title'), answers: answers }};
     if (typeof sendPrompt === 'function') {{

--- a/src/attune/ops/static/form-theme.css
+++ b/src/attune/ops/static/form-theme.css
@@ -29,6 +29,8 @@
 #attune-elicit-form .ae-submit:disabled { opacity:.6; cursor:default; }
 #attune-elicit-form .ae-error { margin-top:.5rem; font-size:14px;
   color:var(--text-accent,#a1571c); }
+#attune-elicit-form .ae-field-missing { border-left:3px solid
+  var(--text-accent,#a1571c); padding-left:.6rem; }
 #attune-elicit-form .ae-input { width:100%; box-sizing:border-box;
   padding:.5rem .6rem; font-size:15px; color:var(--text-primary,#2c2c2a);
   background:var(--surface-1,#f7f6f3); border:1px solid var(--border,#e3e1dc);

--- a/tests/unit/elicitation/test_widget.py
+++ b/tests/unit/elicitation/test_widget.py
@@ -188,6 +188,66 @@ class TestPostback:
         assert "Number(el.value)" in html
 
 
+class TestRequiredGate:
+    """Regression guard for the 2026-08-10 live failure: a required
+    multi_select with nothing checked posted ``[]``, the submit script
+    disabled the button and showed "Submitted", and the server-side
+    reject then landed on a dead widget — the user had to answer in
+    chat. The submit script must gate on required fields BEFORE
+    posting: visible error, button stays alive.
+    """
+
+    _FIELDS = [
+        {
+            "id": "scope",
+            "text": "Scope?",
+            "type": "single_select",
+            "options": ["narrow", "broad"],
+        },
+        {
+            "id": "probes",
+            "text": "Probes?",
+            "type": "multi_select",
+            "options": ["unit", "behavioral"],
+        },
+        {
+            "id": "notes",
+            "text": "Notes?",
+            "type": "text_input",
+            "required": False,
+        },
+    ]
+
+    def test_required_fields_carry_data_required(self):
+        html = _render(self._FIELDS)
+        # scope + probes are required (the default); notes is not.
+        assert html.count('data-required="1"') == 2
+        assert 'data-fid="notes" data-ftype="text_input">' in html
+
+    def test_multi_select_checked_boxes_post_as_array(self):
+        html = _render(self._FIELDS)
+        script = html[html.index("<script>") :]
+        # The multi_select branch collects every checked control into an
+        # array and posts it under the field id.
+        assert "ftype === 'multi_select'" in script
+        assert "[data-control]:checked" in script
+        assert "answers[fid] = vals" in script
+
+    def test_missing_required_blocks_send_with_visible_error(self):
+        html = _render(self._FIELDS)
+        script = html[html.index("<script>") :]
+        # The gate reads data-required fields, treats undefined / '' /
+        # empty-array as unanswered, and shows the error in the alert div.
+        assert ".ae-field[data-required]" in script
+        assert "Array.isArray(v) && v.length === 0" in script
+        assert "'Required: '" in script
+        assert "ae-field-missing" in script
+        # Ordering: the gate fires BEFORE sendPrompt, and the button is
+        # only disabled after a successful send — never on a rejection.
+        assert script.index("'Required: '") < script.index("sendPrompt(")
+        assert script.index("sendPrompt(") < script.index("btn.disabled = true")
+
+
 class TestEscaping:
     def test_malicious_label_is_escaped(self):
         html = _render([{"id": "a", "text": "<script>alert(1)</script>", "type": "text_input"}])


### PR DESCRIPTION
## Summary

Fixes the 2026-08-10 live elicitation-widget failure: a required
`multi_select` form would not usably submit, forcing the answer back
into chat prose (chair-visible — ruling forms are the D21
communication-grammar surface).

**Root cause (reproduced in a real browser, suspect (a) confirmed):**
the submit script had **no client-side required-field validation**.
With zero boxes checked on a required `multi_select` it posted
`probes: []`, disabled the button, and showed "Submitted ✓". The
server-side `collect_form_response` correctly rejects `[]` as
missing-required — but by then the widget was dead, so the user could
not fix and resubmit. The checked-boxes collector itself was never
broken: N checked boxes always posted a correct array.

## Fix (renderer only)

- `_field_html` stamps `data-required="1"` on required fields.
- The submit script gates before posting: any unanswered required
  field (undefined / `''` / empty array) surfaces
  `Required: <field labels>` in the existing `ae-error` alert div,
  highlights the offending fields (`.ae-field-missing`), and returns
  with the button **still alive**. The button only disables after a
  successful `sendPrompt`.
- `theme.py` adds the `.ae-field-missing` rule (5,688 B — under the
  6,144 B D1 cap); `ops/static/form-theme.css` re-projected
  byte-equal from the master.

## Receipts

- **Live-fire (real browser, pre-fix):** zero-checked required
  multi_select → posted `[]`, button dead, "Submitted ✓" — the
  reported failure, reproduced.
- **Live-fire (real browser, post-fix):** nothing answered → no
  send, visible "Required: Pick a scope, Pick probes", button
  enabled; scope answered → error narrows to the multi_select; two
  boxes checked → payload posts
  `{"scope": "narrow", "probes": ["unit", "live-fire"]}` on the SAME
  widget, error cleared.
- **Suite:** 408 passed in `tests/unit/elicitation/` (includes new
  `TestRequiredGate` pinning data-required stamping, the
  checked→array collector, the visible-error path, and gate-before-
  send / disable-only-after-send ordering); 47 passed in
  `tests/unit/mcp -k "widget or elicit"`; theme budget + byte-equal
  projection tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
