### PR TITLE
fix(ci): chair-read gate — Class-1 auto-merge skips read-gated PRs (chair-read)

### DIFF
--- a/.github/workflows/auto-merge-safe.yml
+++ b/.github/workflows/auto-merge-safe.yml
@@ -8,7 +8,10 @@ name: Auto-merge safe (tests/docs only)
 # root-level *.md, the author is the repo owner, and the `coverage`
 # required check is green. Admin-bypasses only the REDUNDANT hung
 # lane (e.g. `test (ubuntu-latest, 3.12)`) — never the `coverage`
-# gate, which re-runs the full suite.
+# gate, which re-runs the full suite. Chair-read carve-out
+# (2026-08-10, #2043): a PR titled "(chair-read)" or labeled
+# `chair-read` is never auto-labeled or auto-merged by this lane —
+# it merges only on the chair's own authorization (D10 flow).
 #
 # Class 2 (opt-in, HUMAN-labeled `auto-merge-when-green`, D8):
 # labeling means "this PR is final; merge when fully green." The
@@ -82,8 +85,25 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
+          # Title/labels via env (never inline interpolation) so PR
+          # text cannot inject into the script.
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          CHAIR_LABELED: >-
+            ${{ contains(github.event.pull_request.labels.*.name,
+            'chair-read') }}
         run: |
           set -euo pipefail
+          # Chair-read gate: a PR marked for a chair read is NEVER
+          # auto-labeled — the read gate must hold mechanically, not
+          # socially (2026-08-10: #2043 was chair-read by title only
+          # and auto-merged ~1.7h before authorization). Marker =
+          # "(chair-read)" in the title OR a `chair-read` label.
+          if [[ "$PR_TITLE" == *"(chair-read)"* || \
+                "$CHAIR_LABELED" == "true" ]]; then
+            echo "chair-read marker -> never auto-labeling; removing label if present"
+            gh pr edit "$PR" --remove-label auto-merge-safe || true
+            exit 0
+          fi
           mapfile -t paths < <(
             gh api --paginate "repos/$REPO/pulls/$PR/files" \
               --jq '.[] | .filename, (.previous_filename // empty)'
@@ -200,7 +220,9 @@ jobs:
               head_repo: .head.repo.full_name,
               base_repo: .base.repo.full_name,
               head_sha: .head.sha,
-              has_label: ([.labels[].name] | index("auto-merge-safe") != null)
+              has_label: ([.labels[].name] | index("auto-merge-safe") != null),
+              chair_read: ((.title | contains("(chair-read)")) or
+                           ([.labels[].name] | index("chair-read") != null))
             }')
             state=$(echo "$meta" | jq -r .state)
             base_ref=$(echo "$meta" | jq -r .base_ref)
@@ -210,6 +232,7 @@ jobs:
             base_repo=$(echo "$meta" | jq -r .base_repo)
             head_sha=$(echo "$meta" | jq -r .head_sha)
             has_label=$(echo "$meta" | jq -r .has_label)
+            chair_read=$(echo "$meta" | jq -r .chair_read)
 
             if [ "$state" != "open" ]; then
               echo "skip: PR state=$state (not open)"; echo "::endgroup::"; continue
@@ -228,6 +251,15 @@ jobs:
             fi
             if [ "$has_label" != "true" ]; then
               echo "skip: no auto-merge-safe label"; echo "::endgroup::"; continue
+            fi
+            # Chair-read gate, re-verified INDEPENDENT of the label job
+            # (fail-closed: anything but a clean "false" skips). A PR
+            # titled "(chair-read)" or labeled `chair-read` merges only
+            # by chair authorization, never by this lane (2026-08-10,
+            # #2043 incident).
+            if [ "$chair_read" != "false" ]; then
+              echo "skip: chair-read marker (title/label) — read gate holds"
+              echo "::endgroup::"; continue
             fi
 
             # Re-verify the path class INDEPENDENT of the label, so a

--- a/docs/specs/archive/auto-merge-safe-class/decisions.md
+++ b/docs/specs/archive/auto-merge-safe-class/decisions.md
@@ -281,3 +281,42 @@ workflow invariants (`tests/unit/ci/test_workflow_yaml.py`:
 owner+label gate, `--auto` never `--admin`, guard re-verification,
 disarm on unlabeled) landed red first; the implementation commits
 in the same PR turned them green.
+
+## D11 — chair-read gate: read-gated PRs are out of the Class-1 lane
+
+**Date:** 2026-08-10
+**Status:** implemented (incident-driven)
+
+(D9 — standing docs-only authorization — and D10 — chair's
+"merge N" message as label authorization — are chair rulings from
+2026-08-09, recorded in session memory/governance notes; numbered
+here to keep one sequence for this class.)
+
+**Incident.** PR #2043 (spec design/tasks text) was deliberately
+opened chair-read — "(chair-read)" in the title, no
+`auto-merge-when-green` label — but its diff was docs-only, so the
+Class-1 auto-labeler applied `auto-merge-safe` and the merge job
+squashed it ~1.7h before the chair's authorization. The read gate
+held only socially; nothing mechanical knew "chair-read" existed.
+
+**Decision.** A PR whose title contains `(chair-read)` OR which
+carries a `chair-read` label is skipped by BOTH Class-1 jobs:
+
+- the `label` job never applies `auto-merge-safe` to it (and
+  removes the label if present);
+- the `merge` job re-verifies the marker independently, from a
+  fresh API read (label = necessary, not sufficient — same
+  philosophy as the path-class re-check), fail-closed: anything
+  but a clean `false` skips.
+
+Class 2 (`when-green`) is deliberately NOT gated on the marker:
+per D10 the chair's "merge N" is executed by applying
+`auto-merge-when-green` to a PR that still carries "(chair-read)"
+in its title — gating that lane would break the authorized merge
+path.
+
+**Receipt.** Drift guard
+`tests/unit/ci/test_workflow_yaml.py::TestAutoMergeChairReadGate`
+pins: title-marker check in the label job, `chair-read` label
+honored, independent fail-closed re-check in the merge job, and
+when-green left ungated.

--- a/tests/unit/ci/test_workflow_yaml.py
+++ b/tests/unit/ci/test_workflow_yaml.py
@@ -582,3 +582,77 @@ class TestAutoMergeWhenGreen:
         # Regression guard: adding Class 2 must not remove Class 1's jobs.
         jobs = self._workflow()["jobs"]
         assert "label" in jobs and "merge" in jobs
+
+
+# ---------------------------------------------------------------------------
+# auto-merge-safe.yml — chair-read gate (incident 2026-08-10, PR #2043)
+#
+# A PR deliberately opened for a chair read (marked by "(chair-read)"
+# in the title or a `chair-read` label) must NEVER be auto-labeled or
+# auto-merged by the Class-1 lane. #2043 carried the title marker only
+# socially — the auto-labeler applied `auto-merge-safe` and the lane
+# merged it ~1.7h before the chair's authorization. These tests pin the
+# mechanical skip in BOTH jobs (label = necessary, not sufficient — the
+# merge job re-verifies independently, matching the path-class design).
+#
+# Class 2 (`when-green`) is deliberately NOT gated: per D10 the chair's
+# "merge N" authorization is executed by applying the
+# `auto-merge-when-green` label to a still-chair-read-titled PR, so the
+# marker must not block that lane.
+# ---------------------------------------------------------------------------
+
+
+class TestAutoMergeChairReadGate:
+    """Drift guard: chair-read PRs are out of the Class-1 auto-merge lane."""
+
+    TITLE_MARKER = "(chair-read)"
+    LABEL_NAME = "chair-read"
+
+    @staticmethod
+    def _job(job_id: str) -> dict:
+        return ALL_WORKFLOWS["auto-merge-safe.yml"]["jobs"][job_id]
+
+    @classmethod
+    def _run_text(cls, job_id: str) -> str:
+        return "\n".join(step.get("run", "") or "" for step in cls._job(job_id).get("steps", []))
+
+    def test_label_job_checks_title_marker(self):
+        assert self.TITLE_MARKER in self._run_text("label"), (
+            "the label job must skip PRs whose title contains "
+            f"{self.TITLE_MARKER!r} — without this the auto-labeler puts "
+            "chair-read PRs into the Class-1 merge lane (#2043 incident)."
+        )
+
+    def test_label_job_checks_chair_read_label(self):
+        # The label check rides in via the CHAIR_LABELED env expression.
+        step_envs = "\n".join(
+            str(step.get("env", "")) for step in self._job("label").get("steps", [])
+        )
+        assert self.LABEL_NAME in step_envs or self.LABEL_NAME in self._run_text("label"), (
+            "the label job must also honor a `chair-read` LABEL, so the "
+            "gate works even when a title omits the marker."
+        )
+
+    def test_merge_job_reverifies_chair_read_independently(self):
+        run_text = self._run_text("merge")
+        assert self.TITLE_MARKER in run_text and self.LABEL_NAME in run_text, (
+            "the merge job must re-verify the chair-read marker (title AND "
+            "label) independent of the label job — label is necessary, not "
+            "sufficient, same as the path-class re-check."
+        )
+
+    def test_merge_job_chair_read_skip_is_fail_closed(self):
+        assert '"$chair_read" != "false"' in self._run_text("merge"), (
+            "the merge job's chair-read skip must be fail-closed: anything "
+            'but a clean "false" (including a jq error) skips the merge.'
+        )
+
+    def test_when_green_job_not_gated_on_chair_read(self):
+        # D10: the chair's "merge N" is executed by labeling a PR that
+        # still carries "(chair-read)" in its title. Gating Class 2 on
+        # the marker would break the authorized merge path.
+        assert self.TITLE_MARKER not in self._run_text("when-green"), (
+            "when-green must NOT skip chair-read PRs — applying "
+            "`auto-merge-when-green` after the read IS the chair's "
+            "authorized merge mechanism (D10)."
+        )


### PR DESCRIPTION
## What

Mechanical chair-read gate for the Class-1 auto-merge lane.

**Incident (2026-08-10):** PR #2043 (spec design/tasks text) was
deliberately opened chair-read — "(chair-read)" in the title, no
`auto-merge-when-green` label — but its diff was docs-only, so the
auto-labeler applied `auto-merge-safe` and the merge job squashed it
~1.7h before the chair's authorization. The read gate held only
socially.

## Fix

A PR whose **title contains `(chair-read)`** OR which **carries a
`chair-read` label** is skipped by BOTH Class-1 jobs:

- **`label` job** — never applies `auto-merge-safe` (removes it if
  present). Title/labels enter via env, never inline interpolation.
- **`merge` job** — re-verifies the marker independently from a fresh
  API read (label = necessary, not sufficient — same philosophy as
  the path-class re-check), fail-closed: anything but a clean
  `"false"` skips.

**Class 2 (`when-green`) is deliberately NOT gated:** per D10 the
chair's "merge N" is executed by applying `auto-merge-when-green` to
a PR that still carries "(chair-read)" in its title — gating that
lane would break the authorized merge path.

Everything unmarked is untouched — the Class-1 lane behaves exactly
as before.

## Receipts

- Drift guard `tests/unit/ci/test_workflow_yaml.py::TestAutoMergeChairReadGate`
  (5 tests: title marker in label job, chair-read label honored,
  independent fail-closed re-check in merge job, when-green ungated).
- Full `tests/unit/ci/` + `tests/unit/github_scripts/test_auto_merge_guard.py`:
  412 passed, 1 skipped.
- jq expression and bash gate exercised locally against three payload
  shapes (title-marker, label-only, unmarked): gated / gated / passed.
- Decision recorded as D11 in
  `docs/specs/archive/auto-merge-safe-class/decisions.md`.

## Note

This PR touches `.github/` — out-of-class for both auto-merge lanes
by construction, so it cannot self-merge; chair merge requested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
