### PR TITLE
docs(specs): mcv design+tasks approved — chair ruling D10 recorded

### DIFF
--- a/docs/specs/memory-claim-verification/decisions.md
+++ b/docs/specs/memory-claim-verification/decisions.md
@@ -319,3 +319,11 @@ granted (T1+T2 had already shipped in PR #2045 under the chair's
 explicit merge authorization, so no unauthorized code landed), and
 T4+ (P1) stays gated on T3's re-probe numbers plus the chair's
 threshold ruling, per the tasks doc.
+
+Scope confirmed by the chair via pushback form (2026-08-10,
+D11d COUNTER-CASE raised by the lead): "approve task for 2043"
+covers BOTH design.md and tasks.md — not tasks-only. The chair
+also confirmed the standing policy that recordings of explicit
+in-session chair rulings merge unmarked (transcription, not new
+governance text); interpretive doubt is handled by draft-holds,
+as was done with this PR.

--- a/docs/specs/memory-claim-verification/decisions.md
+++ b/docs/specs/memory-claim-verification/decisions.md
@@ -305,3 +305,17 @@ review cannot mechanically prove aboutness (codex);
 anchor-locality over-rejection creating pressure to loosen — fuzzy
 matching's back door (claude); prompt-compliance variance across
 model families (antigravity).
+
+## D10 (2026-08-10): design + tasks APPROVED — the read #2043's merge outran
+
+Chair message: "approve task for 2043". Context: PR #2043 carried
+design.md + tasks.md chair-read, but the Class-1 auto-merge lane
+took it ~1.7h before the read (the lane had no mechanical notion
+of chair-read; fixed same day in PR #2044 — "(chair-read)" title
+or `chair-read` label now skips Class 1, drift-guarded). This
+ruling completes the read after the fact: design.md and tasks.md
+statuses flip to approved, T1–T2 implementation authority is
+granted (T1+T2 had already shipped in PR #2045 under the chair's
+explicit merge authorization, so no unauthorized code landed), and
+T4+ (P1) stays gated on T3's re-probe numbers plus the chair's
+threshold ruling, per the tasks doc.

--- a/docs/specs/memory-claim-verification/design.md
+++ b/docs/specs/memory-claim-verification/design.md
@@ -1,9 +1,10 @@
 # memory-claim-verification — Design (post-D9)
 
-**Status:** draft (2026-08-10) — awaiting chair review. Authored
-under D9's authorization ("design phase — extractor refs field +
-binder + re-probe"); implementation authority begins at this gate,
-and P1 implementation is additionally gated on the D-5 re-probe.
+**Status:** approved (2026-08-10 — chair, "approve task for
+2043"). Authored under D9's authorization ("design phase —
+extractor refs field + binder + re-probe"); implementation
+authority granted at this gate (T1+T2 shipped in PR #2045), and
+P1 implementation is additionally gated on the D-5 re-probe.
 **Rulings this design executes:** D7 (per-finding matching, riders
 a–c), D8 (22.9% measured — fuzzy matching retired), D9 (C-hardened:
 propose-at-extraction, validate-at-binding; settled core mandated;

--- a/docs/specs/memory-claim-verification/tasks.md
+++ b/docs/specs/memory-claim-verification/tasks.md
@@ -1,9 +1,9 @@
 # memory-claim-verification — Tasks (post-D9 design phase)
 
-**Status:** draft (2026-08-10) — awaiting chair approval of
-[design.md](design.md). T1–T2 implementation authority begins at
-that gate; T4+ (P1) is ADDITIONALLY gated on T3's numbers plus the
-chair's threshold ruling.
+**Status:** approved (2026-08-10 — chair, "approve task for
+2043"). T1–T2 implementation authority granted (T1+T2 shipped in
+PR #2045); T4+ (P1) remains ADDITIONALLY gated on T3's numbers
+plus the chair's threshold ruling.
 
 ## T1 — Extractor v2: refs field (impl)
 


### PR DESCRIPTION
Records the chair's approval ("approve task for 2043") of the memory-claim-verification design + tasks that PR #2043 carried: status lines flip to approved, T1–T2 authority granted (already shipped in #2045 under explicit merge authorization), T4+ stays gated on T3's re-probe numbers + threshold ruling. Ruling logged as D10 in the spec's decisions.md with the premature-merge context (#2043 outran its read; gate mechanized in #2044).

Docs-only; expected to auto-merge via Class 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)