### PR TITLE
ci: key pip caches on pyproject.toml + uv.lock

### DIFF
--- a/.github/workflows/build-help-site.yml
+++ b/.github/workflows/build-help-site.yml
@@ -41,6 +41,9 @@ jobs:
         with:
           python-version: "3.12"
           cache: 'pip'
+          cache-dependency-path: |
+            pyproject.toml
+            uv.lock
 
       - name: Install (core + markdown-it-py)
         run: |

--- a/.github/workflows/contributing-smoke.yml
+++ b/.github/workflows/contributing-smoke.yml
@@ -43,6 +43,9 @@ jobs:
         with:
           python-version: '3.12'
           cache: 'pip'
+          cache-dependency-path: |
+            pyproject.toml
+            uv.lock
 
       - name: Extract the documented setup commands
         run: |

--- a/.github/workflows/cross-platform.yml
+++ b/.github/workflows/cross-platform.yml
@@ -59,6 +59,9 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip
+          cache-dependency-path: |
+            pyproject.toml
+            uv.lock
 
       - name: Install package + test deps
         run: |

--- a/.github/workflows/cross-repo-compat.yml
+++ b/.github/workflows/cross-repo-compat.yml
@@ -38,6 +38,9 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
+          cache-dependency-path: |
+            pyproject.toml
+            uv.lock
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -98,6 +98,9 @@ jobs:
         with:
           python-version: '3.11'
           cache: 'pip'
+          cache-dependency-path: |
+            pyproject.toml
+            uv.lock
 
       # v1 was stdlib-only; v1.1's mkdocstrings check resolves live
       # symbols against the package, and the nav/features checks read
@@ -138,6 +141,9 @@ jobs:
         with:
           python-version: '3.11'
           cache: 'pip'
+          cache-dependency-path: |
+            pyproject.toml
+            uv.lock
 
       - name: Install package (import graph must resolve)
         if: needs.changes.outputs.docs == 'true'
@@ -164,6 +170,9 @@ jobs:
         with:
           python-version: '3.11'
           cache: 'pip'
+          cache-dependency-path: |
+            pyproject.toml
+            uv.lock
 
       - name: Install dependencies
         run: |
@@ -213,6 +222,9 @@ jobs:
         with:
           python-version: '3.11'
           cache: 'pip'
+          cache-dependency-path: |
+            pyproject.toml
+            uv.lock
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/help-freshness.yml
+++ b/.github/workflows/help-freshness.yml
@@ -28,6 +28,9 @@ jobs:
         with:
           python-version: '3.11'
           cache: 'pip'
+          cache-dependency-path: |
+            pyproject.toml
+            uv.lock
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/integration-auth.yml
+++ b/.github/workflows/integration-auth.yml
@@ -49,6 +49,9 @@ jobs:
         with:
           python-version: '3.12'
           cache: 'pip'
+          cache-dependency-path: |
+            pyproject.toml
+            uv.lock
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -43,6 +43,9 @@ jobs:
         with:
           python-version: '3.12'
           cache: 'pip'
+          cache-dependency-path: |
+            pyproject.toml
+            uv.lock
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/pip-audit.yml
+++ b/.github/workflows/pip-audit.yml
@@ -32,6 +32,9 @@ jobs:
         with:
           python-version: '3.12'
           cache: 'pip'
+          cache-dependency-path: |
+            pyproject.toml
+            uv.lock
 
       - name: Install pip-audit
         run: pip install pip-audit

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -25,6 +25,9 @@ jobs:
       with:
         python-version: '3.11'
         cache: 'pip'
+        cache-dependency-path: |
+          pyproject.toml
+          uv.lock
 
     - name: Cache pre-commit hooks
       uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -27,6 +27,9 @@ jobs:
         with:
           python-version: '3.11'
           cache: 'pip'
+          cache-dependency-path: |
+            pyproject.toml
+            uv.lock
 
       - name: Install build dependencies
         run: pip install build uv

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,9 @@ jobs:
       with:
         python-version: '3.11'
         cache: 'pip'
+        cache-dependency-path: |
+          pyproject.toml
+          uv.lock
 
     - name: Install build dependencies
       run: |

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -41,6 +41,9 @@ jobs:
         with:
           python-version: '3.10'
           cache: 'pip'
+          cache-dependency-path: |
+            pyproject.toml
+            uv.lock
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -35,6 +35,9 @@ jobs:
       with:
         python-version: '3.11'
         cache: 'pip'
+        cache-dependency-path: |
+          pyproject.toml
+          uv.lock
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/test-attune-redis.yml
+++ b/.github/workflows/test-attune-redis.yml
@@ -30,6 +30,9 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
+          cache-dependency-path: |
+            pyproject.toml
+            uv.lock
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -130,6 +130,9 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
         cache: 'pip'
+        cache-dependency-path: |
+          pyproject.toml
+          uv.lock
 
     - name: Skip notice (website-only PR)
       if: needs.changes.outputs.website_only == 'true'
@@ -260,6 +263,9 @@ jobs:
       with:
         python-version: '3.12'
         cache: 'pip'
+        cache-dependency-path: |
+          pyproject.toml
+          uv.lock
 
     - name: Install dependencies
       if: needs.changes.outputs.website_only != 'true'
@@ -307,6 +313,9 @@ jobs:
       with:
         python-version: '3.11'
         cache: 'pip'
+        cache-dependency-path: |
+          pyproject.toml
+          uv.lock
 
     - name: Install dependencies
       if: needs.changes.outputs.website_only != 'true'
@@ -422,6 +431,9 @@ jobs:
       with:
         python-version: '3.11'
         cache: 'pip'
+        cache-dependency-path: |
+          pyproject.toml
+          uv.lock
 
     - name: Install dependencies
       run: |
@@ -561,6 +573,9 @@ jobs:
       with:
         python-version: '3.11'
         cache: 'pip'
+        cache-dependency-path: |
+          pyproject.toml
+          uv.lock
 
     - name: Install dependencies
       run: |
@@ -652,6 +667,9 @@ jobs:
       with:
         python-version: '3.11'
         cache: 'pip'
+        cache-dependency-path: |
+          pyproject.toml
+          uv.lock
 
     - name: Install build tooling
       run: python -m pip install --upgrade pip build

--- a/.github/workflows/tier-pattern-analysis.yml
+++ b/.github/workflows/tier-pattern-analysis.yml
@@ -33,6 +33,9 @@ jobs:
         with:
           python-version: '3.10'
           cache: 'pip'
+          cache-dependency-path: |
+            pyproject.toml
+            uv.lock
 
       - name: Install dependencies
         run: |
@@ -166,6 +169,9 @@ jobs:
         with:
           python-version: '3.10'
           cache: 'pip'
+          cache-dependency-path: |
+            pyproject.toml
+            uv.lock
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/website-accuracy.yml
+++ b/.github/workflows/website-accuracy.yml
@@ -40,6 +40,9 @@ jobs:
         with:
           python-version: '3.12'
           cache: 'pip'
+          cache-dependency-path: |
+            pyproject.toml
+            uv.lock
       - name: PyPI version audit (external packages)
         # Stdlib-only (urllib/json/re) — no pip install needed.
         run: python scripts/audit_website_versions.py

--- a/.github/workflows/windows-debug.yml
+++ b/.github/workflows/windows-debug.yml
@@ -62,6 +62,9 @@ jobs:
         with:
           python-version: ${{ inputs.python_version }}
           cache: 'pip'
+          cache-dependency-path: |
+            pyproject.toml
+            uv.lock
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
## Summary
Adds `cache-dependency-path: pyproject.toml + uv.lock` to all 28 `setup-python` steps carrying `cache: 'pip'` (19 workflow files).

## Why
Without a dependency path, the pip cache key never rotates, giving the worst of both worlds (receipt: run 31454637010, same install step):
- Deps **newer than the frozen snapshot** re-download on **every lane of every run** — `Downloading attune_rag-1.1.0`, `Downloading attune_help-0.13.0` (~2–4k downloads/day each on pypistats, dwarfing real users).
- Deps **inside the snapshot** never refresh — `Using cached attune_verify-0.2.2` (this is the 7/21 attune-verify "download plunge": a measurement artifact, not lost users).

Keying on `pyproject.toml` + `uv.lock` rotates the cache exactly when the dep set changes: one download per lane per change, then warm. Faster installs; attune-* pypistats stop being dominated by our own matrix.

## Receipts
- All workflows `yaml.safe_load` clean.
- `tests/unit/ci/test_workflow_yaml.py` + `test_ci_spend_guard.py`: 330 passed, 1 skipped (serial).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
