### PR TITLE
fix(docs-outbox): lesson bullet-form lint + skill version preflight

### DIFF
--- a/.agents/skills/docs-outbox/SKILL.md
+++ b/.agents/skills/docs-outbox/SKILL.md
@@ -28,6 +28,12 @@ Invariants:
 
 ## Step 1 — status
 
+Version preflight first: if `python -m attune.docs_outbox status`
+fails with "No module named attune.docs_outbox", the installed
+`attune-ai` wheel predates this module — upgrade it
+(`pip install --upgrade attune-ai`) before continuing rather than
+working around it with PYTHONPATH.
+
 Run `python -m attune.docs_outbox status`. If the outbox is empty,
 say so and stop. If the status line says STALE (oldest 2+ days),
 surface the warning prominently.

--- a/plugin/help/generated/references/skill-docs-outbox.md
+++ b/plugin/help/generated/references/skill-docs-outbox.md
@@ -33,6 +33,12 @@ Invariants:
 
 ## Step 1 — status
 
+Version preflight first: if `python -m attune.docs_outbox status`
+fails with "No module named attune.docs_outbox", the installed
+`attune-ai` wheel predates this module — upgrade it
+(`pip install --upgrade attune-ai`) before continuing rather than
+working around it with PYTHONPATH.
+
 Run `python -m attune.docs_outbox status`. If the outbox is empty,
 say so and stop. If the status line says STALE (oldest 2+ days),
 surface the warning prominently.

--- a/plugin/skills/docs-outbox/SKILL.md
+++ b/plugin/skills/docs-outbox/SKILL.md
@@ -30,6 +30,12 @@ Invariants:
 
 ## Step 1 — status
 
+Version preflight first: if `python -m attune.docs_outbox status`
+fails with "No module named attune.docs_outbox", the installed
+`attune-ai` wheel predates this module — upgrade it
+(`pip install --upgrade attune-ai`) before continuing rather than
+working around it with PYTHONPATH.
+
 Run `python -m attune.docs_outbox status`. If the outbox is empty,
 say so and stop. If the status line says STALE (oldest 2+ days),
 surface the warning prominently.

--- a/src/attune/docs_outbox/store.py
+++ b/src/attune/docs_outbox/store.py
@@ -34,6 +34,23 @@ _NAME_RE = re.compile(
 )
 
 
+def lesson_body_problem(kind: str, body: str) -> str | None:
+    """The lint reason an outbox body can't enter the lessons corpus.
+
+    The lessons index (:mod:`attune.lessons`) anchors entry parsing on
+    RAW lines starting ``- **`` — an unbulleted or indented first line
+    appends cleanly but is invisible to recall. Shared by the
+    author-time gate (:func:`write_artifact`) and the sweep lint so the
+    two cannot drift.
+    """
+    if kind != "lesson":
+        return None
+    first = next((ln for ln in body.splitlines() if ln.strip()), "")
+    if not first.startswith("- **"):
+        return "lesson body must start with '- **' at column 0 (bulleted bold title)"
+    return None
+
+
 @dataclass
 class Artifact:
     """One parsed outbox artifact."""
@@ -111,6 +128,9 @@ def write_artifact(
         raise ValueError(f"kind {kind!r} has no default target — pass one explicitly")
     if not body.strip():
         raise ValueError("artifact body is empty")
+    problem = lesson_body_problem(kind, body)
+    if problem:
+        raise ValueError(problem)
 
     out_dir = outbox_dir(attune_home)
     stamp = (now or datetime.now()).strftime("%Y%m%d-%H%M")

--- a/src/attune/docs_outbox/sweep.py
+++ b/src/attune/docs_outbox/sweep.py
@@ -27,6 +27,7 @@ from attune.docs_outbox.store import (
     OutboxStatus,
     _atomic_write,
     archive_swept,
+    lesson_body_problem,
     list_artifacts,
     outbox_dir,
     outbox_status,
@@ -132,11 +133,10 @@ def _lint(artifact: Artifact, repo_root: Path, claimed: set[str]) -> list[str]:
                 claimed.add(artifact.target)
     if not artifact.body.strip():
         issues.append("empty body")
-    elif artifact.kind == "lesson" and not artifact.body.lstrip().startswith("- **"):
-        # The lessons index (attune.lessons) anchors entry parsing on
-        # lines starting "- **"; an unbulleted entry appends cleanly
-        # but is invisible to recall.
-        issues.append("lesson body must start with '- **' (bulleted bold title)")
+    else:
+        problem = lesson_body_problem(artifact.kind, artifact.body)
+        if problem:
+            issues.append(problem)
     return issues
 
 

--- a/src/attune/docs_outbox/sweep.py
+++ b/src/attune/docs_outbox/sweep.py
@@ -132,6 +132,11 @@ def _lint(artifact: Artifact, repo_root: Path, claimed: set[str]) -> list[str]:
                 claimed.add(artifact.target)
     if not artifact.body.strip():
         issues.append("empty body")
+    elif artifact.kind == "lesson" and not artifact.body.lstrip().startswith("- **"):
+        # The lessons index (attune.lessons) anchors entry parsing on
+        # lines starting "- **"; an unbulleted entry appends cleanly
+        # but is invisible to recall.
+        issues.append("lesson body must start with '- **' (bulleted bold title)")
     return issues
 
 

--- a/tests/unit/docs_outbox/test_cli.py
+++ b/tests/unit/docs_outbox/test_cli.py
@@ -57,7 +57,7 @@ def test_status_empty(capsys):
 
 def test_sweep_and_apply_round_trip(tmp_path, repo, capsys):
     body = tmp_path / "body.md"
-    body.write_text("- CLI lesson.\n", encoding="utf-8")
+    body.write_text("- **CLI**: CLI lesson.\n", encoding="utf-8")
     main(["write", "--kind", "lesson", "--slug", "cli-sweep", "--file", str(body)])
     assert main(["sweep", "--repo-root", str(repo)]) == 0
     assert "cli-sweep" in capsys.readouterr().out

--- a/tests/unit/docs_outbox/test_cli.py
+++ b/tests/unit/docs_outbox/test_cli.py
@@ -32,7 +32,7 @@ def repo(tmp_path):
 
 def test_write_then_status_and_list(tmp_path, capsys):
     body = tmp_path / "body.md"
-    body.write_text("A lesson.\n", encoding="utf-8")
+    body.write_text("- **A lesson.**\n", encoding="utf-8")
     assert main(["write", "--kind", "lesson", "--slug", "cli-one", "--file", str(body)]) == 0
     assert main(["status", "--json"]) == 0
     out = capsys.readouterr().out.strip().splitlines()
@@ -74,7 +74,7 @@ def test_apply_refuses_non_git_repo_root(tmp_path, capsys):
     """Guard: apply from the wrong cwd would create ~/.claude/lessons.md
     and archive every artifact as swept, silently emptying the outbox."""
     body = tmp_path / "body.md"
-    body.write_text("- Lesson.\n", encoding="utf-8")
+    body.write_text("- **Lesson.**\n", encoding="utf-8")
     main(["write", "--kind", "lesson", "--slug", "guard", "--file", str(body)])
     not_a_repo = tmp_path / "elsewhere"
     not_a_repo.mkdir()

--- a/tests/unit/docs_outbox/test_store.py
+++ b/tests/unit/docs_outbox/test_store.py
@@ -20,17 +20,19 @@ NOW = datetime(2026, 8, 6, 14, 32)
 
 
 def test_write_lesson_uses_default_target_and_timestamp_name(tmp_path):
-    path = write_artifact("lesson", "browser-pane-svg", "Body.", attune_home=tmp_path, now=NOW)
+    path = write_artifact(
+        "lesson", "browser-pane-svg", "- **Body.**", attune_home=tmp_path, now=NOW
+    )
     assert path.name == "20260806-1432-lesson-browser-pane-svg.md"
     text = path.read_text(encoding="utf-8")
     assert "kind: lesson" in text
     assert "target: .claude/lessons.md" in text
-    assert text.endswith("Body.\n")
+    assert text.endswith("- **Body.**\n")
 
 
 def test_concurrent_writers_never_collide(tmp_path):
-    a = write_artifact("lesson", "same-slug", "First.", attune_home=tmp_path, now=NOW)
-    b = write_artifact("lesson", "same-slug", "Second.", attune_home=tmp_path, now=NOW)
+    a = write_artifact("lesson", "same-slug", "- **First.**", attune_home=tmp_path, now=NOW)
+    b = write_artifact("lesson", "same-slug", "- **Second.**", attune_home=tmp_path, now=NOW)
     assert a != b
     assert len(list_artifacts(tmp_path)) == 2
 
@@ -65,17 +67,19 @@ def test_empty_body_is_refused(tmp_path):
 
 
 def test_list_artifacts_sorted_and_parsed(tmp_path):
-    write_artifact("lesson", "later", "L.", attune_home=tmp_path, now=NOW + timedelta(minutes=5))
-    write_artifact("lesson", "earlier", "E.", attune_home=tmp_path, now=NOW)
+    write_artifact(
+        "lesson", "later", "- **L.**", attune_home=tmp_path, now=NOW + timedelta(minutes=5)
+    )
+    write_artifact("lesson", "earlier", "- **E.**", attune_home=tmp_path, now=NOW)
     artifacts = list_artifacts(tmp_path)
     assert [a.slug for a in artifacts] == ["earlier", "later"]
     assert artifacts[0].created == NOW
-    assert artifacts[0].body == "E.\n"
+    assert artifacts[0].body == "- **E.**\n"
     assert not artifacts[0].issues
 
 
 def test_list_ignores_digest_and_swept(tmp_path):
-    write_artifact("lesson", "one", "Body.", attune_home=tmp_path, now=NOW)
+    write_artifact("lesson", "one", "- **Body.**", attune_home=tmp_path, now=NOW)
     (outbox_dir(tmp_path) / "digest.md").write_text("# digest\n", encoding="utf-8")
     assert len(list_artifacts(tmp_path)) == 1
 
@@ -91,9 +95,9 @@ def test_status_empty_then_stale(tmp_path):
     empty = outbox_status(tmp_path)
     assert (empty.count, empty.stale) == (0, False)
     write_artifact(
-        "lesson", "old", "Body.", attune_home=tmp_path, now=datetime.now() - timedelta(days=3)
+        "lesson", "old", "- **Body.**", attune_home=tmp_path, now=datetime.now() - timedelta(days=3)
     )
-    write_artifact("lesson", "new", "Body.", attune_home=tmp_path, now=datetime.now())
+    write_artifact("lesson", "new", "- **Body.**", attune_home=tmp_path, now=datetime.now())
     status = outbox_status(tmp_path)
     assert status.count == 2
     assert status.oldest_days >= 2.9
@@ -101,12 +105,12 @@ def test_status_empty_then_stale(tmp_path):
 
 
 def test_status_fresh_is_not_stale(tmp_path):
-    write_artifact("lesson", "new", "Body.", attune_home=tmp_path, now=datetime.now())
+    write_artifact("lesson", "new", "- **Body.**", attune_home=tmp_path, now=datetime.now())
     assert outbox_status(tmp_path).stale is False
 
 
 def test_archive_swept_moves_files(tmp_path):
-    write_artifact("lesson", "one", "Body.", attune_home=tmp_path, now=NOW)
+    write_artifact("lesson", "one", "- **Body.**", attune_home=tmp_path, now=NOW)
     artifacts = list_artifacts(tmp_path)
     dest = archive_swept(artifacts, tmp_path)
     assert not list_artifacts(tmp_path)
@@ -124,7 +128,7 @@ class TestLineEndings:
 
     def test_artifact_bytes_use_lf(self, tmp_path):
         path = write_artifact(
-            "lesson", "crlf", "line one\nline two\n", attune_home=tmp_path, now=NOW
+            "lesson", "crlf", "- **T**\nline one\nline two\n", attune_home=tmp_path, now=NOW
         )
         raw = path.read_bytes()
         assert b"\r\n" not in raw
@@ -138,6 +142,6 @@ class TestLineEndings:
         (repo / ".git").mkdir()
         corpus = repo / ".claude" / "lessons.md"
         corpus.write_bytes(b"# Lessons\n")
-        write_artifact("lesson", "appended", "- A\n- B\n", attune_home=tmp_path, now=NOW)
+        write_artifact("lesson", "appended", "- **A**\n- B\n", attune_home=tmp_path, now=NOW)
         apply_sweep(repo, attune_home=tmp_path)
         assert b"\r\n" not in corpus.read_bytes()

--- a/tests/unit/docs_outbox/test_sweep.py
+++ b/tests/unit/docs_outbox/test_sweep.py
@@ -45,9 +45,13 @@ def test_empty_outbox_sweep(tmp_path):
 
 
 def test_exact_duplicates_dropped_keep_earliest(tmp_path):
-    write_artifact("lesson", "dup", "Same body.", attune_home=tmp_path, now=NOW)
+    write_artifact("lesson", "dup", "- **Same body.**", attune_home=tmp_path, now=NOW)
     write_artifact(
-        "lesson", "dup-again", "Same body.", attune_home=tmp_path, now=NOW + timedelta(minutes=1)
+        "lesson",
+        "dup-again",
+        "- **Same body.**",
+        attune_home=tmp_path,
+        now=NOW + timedelta(minutes=1),
     )
     result = run_sweep(_repo(tmp_path), attune_home=tmp_path)
     assert [a.slug for a in result.kept] == ["dup"]
@@ -56,9 +60,9 @@ def test_exact_duplicates_dropped_keep_earliest(tmp_path):
 
 
 def test_related_slugs_flagged(tmp_path):
-    write_artifact("lesson", "same", "Body one.", attune_home=tmp_path, now=NOW)
+    write_artifact("lesson", "same", "- **Body one.**", attune_home=tmp_path, now=NOW)
     write_artifact(
-        "lesson", "same", "Body two.", attune_home=tmp_path, now=NOW + timedelta(minutes=1)
+        "lesson", "same", "- **Body two.**", attune_home=tmp_path, now=NOW + timedelta(minutes=1)
     )
     result = run_sweep(_repo(tmp_path), attune_home=tmp_path)
     assert result.related_slugs == ["lesson/same"]
@@ -66,8 +70,10 @@ def test_related_slugs_flagged(tmp_path):
 
 
 def test_core_worthy_flagging(tmp_path):
-    write_artifact("lesson", "leaky", "A secret key leaked.", attune_home=tmp_path, now=NOW)
-    write_artifact("lesson", "benign", "Plain formatting note.", attune_home=tmp_path, now=NOW)
+    write_artifact("lesson", "leaky", "- **A secret key leaked.**", attune_home=tmp_path, now=NOW)
+    write_artifact(
+        "lesson", "benign", "- **Plain formatting note.**", attune_home=tmp_path, now=NOW
+    )
     result = run_sweep(_repo(tmp_path), attune_home=tmp_path)
     assert result.core_worthy == ["20260806-1432-lesson-leaky.md"]
     assert "core-worthy?" in result.digest
@@ -100,13 +106,25 @@ def test_lint_rejects_absolute_target_and_overwrite(tmp_path):
 
 
 def test_lint_rejects_unbulleted_lesson_body(tmp_path):
-    """The lessons index anchors on '- **'; a bare entry appends
-    cleanly but is invisible to recall (2026-08-11 retro, two swept
-    artifacts drifted in exactly this way)."""
+    """The lessons index anchors on RAW lines starting '- **'; a bare,
+    indented, or prose first line appends cleanly but is invisible to
+    recall (2026-08-11 retro, two swept artifacts drifted exactly this
+    way). Hand-authored files bypass write_artifact's gate, so the
+    sweep lint must catch them off disk."""
     repo = _repo(tmp_path)
-    write_artifact("lesson", "bare", "**Title**: no bullet.", attune_home=tmp_path, now=NOW)
-    write_artifact(
-        "lesson", "prose", "Plain prose.", attune_home=tmp_path, now=NOW + timedelta(minutes=1)
+    _raw(
+        tmp_path,
+        "20260806-1432-lesson-bare.md",
+        "lesson",
+        ".claude/lessons.md",
+        "**Title**: no bullet.\n",
+    )
+    _raw(
+        tmp_path,
+        "20260806-1433-lesson-indent.md",
+        "lesson",
+        ".claude/lessons.md",
+        "  - **Title**: indented, invisible to the raw-line anchor.\n",
     )
     write_artifact(
         "lesson",
@@ -116,7 +134,7 @@ def test_lint_rejects_unbulleted_lesson_body(tmp_path):
         now=NOW + timedelta(minutes=2),
     )
     result = run_sweep(repo, attune_home=tmp_path)
-    for name in ("20260806-1432-lesson-bare.md", "20260806-1433-lesson-prose.md"):
+    for name in ("20260806-1432-lesson-bare.md", "20260806-1433-lesson-indent.md"):
         assert any("must start with '- **'" in i for i in result.lint_issues[name])
     assert "20260806-1434-lesson-good.md" not in result.lint_issues
     changed = apply_sweep(repo, attune_home=tmp_path)
@@ -124,11 +142,24 @@ def test_lint_rejects_unbulleted_lesson_body(tmp_path):
     assert "bulleted." in text and "no bullet." not in text
     assert changed == [repo / ".claude" / "lessons.md"]
     # The linty pair stays pending rather than being archived as applied.
-    assert sorted(a.slug for a in list_artifacts(tmp_path)) == ["bare", "prose"]
+    assert sorted(a.slug for a in list_artifacts(tmp_path)) == ["raw", "raw"]
+
+
+def test_write_artifact_rejects_unbulleted_lesson_body(tmp_path):
+    """Author-time arm of the same gate: refuse at write, don't strand
+    a doomed artifact as forever-pending at sweep."""
+    import pytest
+
+    with pytest.raises(ValueError, match="must start with '- \\*\\*'"):
+        write_artifact("lesson", "bare", "Plain prose.", attune_home=tmp_path, now=NOW)
+    with pytest.raises(ValueError, match="must start with '- \\*\\*'"):
+        write_artifact("lesson", "indent", "  - **Indented.**", attune_home=tmp_path, now=NOW)
+    # Non-lesson kinds are exempt — reports keep free-form bodies.
+    write_artifact("report", "free", "Prose.", target="docs/r.md", attune_home=tmp_path, now=NOW)
 
 
 def test_sweep_writes_digest_file(tmp_path):
-    write_artifact("lesson", "one", "Body.", attune_home=tmp_path, now=NOW)
+    write_artifact("lesson", "one", "- **Body.**", attune_home=tmp_path, now=NOW)
     result = run_sweep(_repo(tmp_path), attune_home=tmp_path)
     digest_path = outbox_dir(tmp_path) / DIGEST_NAME
     assert digest_path.read_text(encoding="utf-8") == result.digest
@@ -137,7 +168,7 @@ def test_sweep_writes_digest_file(tmp_path):
 
 def test_stale_warning_in_digest(tmp_path):
     write_artifact(
-        "lesson", "old", "Body.", attune_home=tmp_path, now=datetime.now() - timedelta(days=3)
+        "lesson", "old", "- **Body.**", attune_home=tmp_path, now=datetime.now() - timedelta(days=3)
     )
     result = run_sweep(_repo(tmp_path), attune_home=tmp_path)
     assert "STALE" in result.digest

--- a/tests/unit/docs_outbox/test_sweep.py
+++ b/tests/unit/docs_outbox/test_sweep.py
@@ -99,6 +99,34 @@ def test_lint_rejects_absolute_target_and_overwrite(tmp_path):
     )
 
 
+def test_lint_rejects_unbulleted_lesson_body(tmp_path):
+    """The lessons index anchors on '- **'; a bare entry appends
+    cleanly but is invisible to recall (2026-08-11 retro, two swept
+    artifacts drifted in exactly this way)."""
+    repo = _repo(tmp_path)
+    write_artifact("lesson", "bare", "**Title**: no bullet.", attune_home=tmp_path, now=NOW)
+    write_artifact(
+        "lesson", "prose", "Plain prose.", attune_home=tmp_path, now=NOW + timedelta(minutes=1)
+    )
+    write_artifact(
+        "lesson",
+        "good",
+        "- **Title**: bulleted.",
+        attune_home=tmp_path,
+        now=NOW + timedelta(minutes=2),
+    )
+    result = run_sweep(repo, attune_home=tmp_path)
+    for name in ("20260806-1432-lesson-bare.md", "20260806-1433-lesson-prose.md"):
+        assert any("must start with '- **'" in i for i in result.lint_issues[name])
+    assert "20260806-1434-lesson-good.md" not in result.lint_issues
+    changed = apply_sweep(repo, attune_home=tmp_path)
+    text = (repo / ".claude" / "lessons.md").read_text(encoding="utf-8")
+    assert "bulleted." in text and "no bullet." not in text
+    assert changed == [repo / ".claude" / "lessons.md"]
+    # The linty pair stays pending rather than being archived as applied.
+    assert sorted(a.slug for a in list_artifacts(tmp_path)) == ["bare", "prose"]
+
+
 def test_sweep_writes_digest_file(tmp_path):
     write_artifact("lesson", "one", "Body.", attune_home=tmp_path, now=NOW)
     result = run_sweep(_repo(tmp_path), attune_home=tmp_path)
@@ -118,9 +146,13 @@ def test_stale_warning_in_digest(tmp_path):
 def test_apply_appends_lessons_in_timestamp_order_and_archives(tmp_path):
     repo = _repo(tmp_path)
     write_artifact(
-        "lesson", "second", "- Lesson B.", attune_home=tmp_path, now=NOW + timedelta(minutes=1)
+        "lesson",
+        "second",
+        "- **B**: Lesson B.",
+        attune_home=tmp_path,
+        now=NOW + timedelta(minutes=1),
     )
-    write_artifact("lesson", "first", "- Lesson A.", attune_home=tmp_path, now=NOW)
+    write_artifact("lesson", "first", "- **A**: Lesson A.", attune_home=tmp_path, now=NOW)
     changed = apply_sweep(repo, attune_home=tmp_path)
     text = (repo / ".claude" / "lessons.md").read_text(encoding="utf-8")
     assert text.index("Lesson A.") < text.index("Lesson B.")
@@ -237,7 +269,7 @@ class TestReviewRegressions:
         so the successful ones re-applied (and duplicated) next run."""
         repo = _repo(tmp_path)
         (repo / "blocker").write_text("i am a file\n", encoding="utf-8")
-        write_artifact("lesson", "good", "- Good lesson.", attune_home=tmp_path, now=NOW)
+        write_artifact("lesson", "good", "- **Good lesson.**", attune_home=tmp_path, now=NOW)
         write_artifact(
             "report",
             "bad",
@@ -271,7 +303,7 @@ class TestReviewRegressions:
         """A stale digest.md used to linger, so the chip could render an
         already-applied batch."""
         repo = _repo(tmp_path)
-        write_artifact("lesson", "one", "- Body.", attune_home=tmp_path, now=NOW)
+        write_artifact("lesson", "one", "- **One**: body.", attune_home=tmp_path, now=NOW)
         run_sweep(repo, attune_home=tmp_path)
         assert (outbox_dir(tmp_path) / DIGEST_NAME).exists()
         apply_sweep(repo, attune_home=tmp_path)

--- a/tests/unit/ops/test_collab_inbox.py
+++ b/tests/unit/ops/test_collab_inbox.py
@@ -273,7 +273,7 @@ class TestOutboxRow:
 
         _board(monkeypatch, FakeBoardRedis({}))
         home = tmp_path / "home"
-        write_artifact("lesson", "fresh", "Body.", attune_home=home)
+        write_artifact("lesson", "fresh", "- **Body.**", attune_home=home)
         inbox = read_inbox(project, attune_home=home)
         assert inbox.docs_outbox is not None
         assert inbox.docs_outbox.count == 1
@@ -291,7 +291,7 @@ class TestOutboxRow:
         _board(monkeypatch, FakeBoardRedis({}))
         home = tmp_path / "home"
         write_artifact(
-            "lesson", "old", "Body.", attune_home=home, now=datetime.now() - timedelta(days=3)
+            "lesson", "old", "- **Body.**", attune_home=home, now=datetime.now() - timedelta(days=3)
         )
         inbox = read_inbox(project, attune_home=home)
         assert inbox.docs_outbox is not None
@@ -305,7 +305,7 @@ class TestOutboxRow:
 
         _board(monkeypatch, FakeBoardRedis({}))
         cfg = Config(project_root=project, attune_home=tmp_path / "attune-home")
-        write_artifact("lesson", "pending", "Body.", attune_home=cfg.attune_home)
+        write_artifact("lesson", "pending", "- **Body.**", attune_home=cfg.attune_home)
         client = TestClient(create_app(cfg))
         client.headers["Host"] = f"{cfg.host}:{cfg.port}"
         resp = client.get("/collab")


### PR DESCRIPTION
Two retro items from the 2026-08-11 attune-verify session, both ratified for execution:

**1. Lesson bullet-form lint.** The lessons index (`src/attune/lessons/__init__.py`) anchors entry parsing on lines starting `- **` — an unbulleted lesson body appends cleanly but is invisible to recall. Two of the six artifacts in the 2026-08-11 sweep (#2054) drifted exactly this way (the corpus is 997 bulleted vs 28 not). `_lint` now blocks `kind: lesson` bodies whose first content doesn't start with `- **`; linty artifacts stay pending per the existing contract. New test covers reject/pass/stays-pending; existing lesson fixtures updated to the bulleted form.

**2. Skill version preflight.** The docs-outbox skill assumed the installed wheel has the module; 11.1.0 didn't, costing a diagnosis cycle and a PYTHONPATH workaround. Step 1 now names the failure signature and the fix (upgrade, don't work around). `.agents/skills` mirror regenerated via `sync_agents_skills.py --write` (`--check`: 45/45 in sync).

Tests: `tests/unit/docs_outbox/` + `tests/unit/lessons/` — 77 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)