### PR TITLE
test: scrub ambient Redis connection env so the unit lane is hermetic

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,6 +33,30 @@ import pytest
 #: must not touch these — see its docstring for the failure it caused.
 _SUITE_MANAGED_ENV = frozenset({"ATTUNE_HOME", "ATTUNE_HELP_TELEMETRY"})
 
+#: The eight Redis connection components (redis-config-truth R1) that
+#: ``resolve_redis_connection`` reads, minus ``REDIS_HOST``.
+#:
+#: ``REDIS_HOST`` is suite-managed: the loopback pin above sets it at
+#: conftest import time so no unit test can reach
+#: ``getaddrinfo("localhost")`` (the windows-exit139 hang class).
+#: Scrubbing it per-test would defeat that pin and fail its guard,
+#: ``test_unit_lane_pins_redis_host_to_loopback`` — the same
+#: owned-by-another-fixture hazard ``_SUITE_MANAGED_ENV`` documents.
+#: Dropping it costs nothing here: with the seven below cleared, an
+#: ambient ``REDIS_HOST`` only ever reaches the component branch, which
+#: the pin has already forced to loopback.
+_REDIS_CONNECTION_ENV = frozenset(
+    {
+        "REDIS_URL",
+        "REDIS_PRIVATE_URL",
+        "REDIS_PUBLIC_URL",
+        "REDIS_PORT",
+        "REDIS_DB",
+        "REDIS_PASSWORD",
+        "REDIS_USER",
+    }
+)
+
 
 # =============================================================================
 # Redis host guard — literal loopback, never a resolvable name
@@ -303,6 +327,28 @@ def _scrub_attune_env(monkeypatch):
     for name in [k for k in os.environ if k.startswith("ATTUNE_")]:
         if name not in _SUITE_MANAGED_ENV:
             monkeypatch.delenv(name, raising=False)
+
+
+@pytest.fixture(autouse=True)
+def _scrub_redis_connection_env(monkeypatch):
+    """Clear the eight Redis connection components for the same reason.
+
+    Same class as ``_scrub_attune_env``, but the leak is subtler: the
+    resolver MERGES what the test did not set. A test that patches a
+    passwordless ``REDIS_URL`` and asserts the URL reaches ``from_url``
+    verbatim still fails on a developer shell exporting
+    ``REDIS_PASSWORD`` — tier 2 of the precedence merges the ambient
+    secret in, so the assertion sees
+    ``redis://:<secret>@host`` and the real password lands in pytest
+    output. Found 2026-08-11 on
+    ``test_client_built_from_redis_url_and_transport_error_degrades``;
+    CI exports none of these and stayed green throughout.
+
+    A test that wants any of them sets it itself via monkeypatch, which
+    still wins — this fixture only removes what the shell leaked.
+    """
+    for name in _REDIS_CONNECTION_ENV:
+        monkeypatch.delenv(name, raising=False)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit/gates/test_redis_env_access_gate.py
+++ b/tests/unit/gates/test_redis_env_access_gate.py
@@ -189,3 +189,30 @@ def test_allowlist_is_empty():
     """rct-4 AC: the allowlist ships empty. Additions are exceptional
     and need a justifying comment at the entry."""
     assert ALLOWLIST == frozenset()
+
+
+def test_suite_scrubs_every_guarded_connection_var():
+    """Drift guard for ``_scrub_redis_connection_env`` (tests/conftest.py).
+
+    A developer shell exporting any of the eight leaks into resolution:
+    the resolver MERGES what a test did not set, so a passwordless
+    ``REDIS_URL`` patched by a test silently becomes
+    ``redis://:<ambient secret>@host`` — the assertion fails and the real
+    password lands in pytest output. Asserted on ``os.environ`` because
+    the autouse fixture has already run for this test.
+    """
+    import os
+
+    from tests.conftest import _REDIS_CONNECTION_ENV
+
+    # REDIS_HOST is the one deliberate exclusion: the conftest loopback
+    # pin owns it (windows-exit139 hang class). Asserted as an exact set
+    # difference so ADDING a guarded name without scrubbing it fails here.
+    assert GUARDED_NAMES - _REDIS_CONNECTION_ENV == {"REDIS_HOST"}, (
+        "the conftest scrub list and this gate's GUARDED_NAMES have drifted "
+        "— a guarded name that is not scrubbed is an unscrubbed leak"
+    )
+    still_set = sorted(n for n in _REDIS_CONNECTION_ENV if n in os.environ)
+    assert still_set == [], f"suite isolation regressed — still set: {still_set}"
+    # The excluded one must still be pinned, not merely absent.
+    assert os.environ.get("REDIS_HOST") not in (None, "", "localhost")


### PR DESCRIPTION
## The bug

`tests/unit/diagnosis/test_store_priors_edges.py::TestRecallPriorsClientConstruction::test_client_built_from_redis_url_and_transport_error_degrades` fails on any machine whose shell exports `REDIS_PASSWORD` — **and prints the real password into pytest output**. Pre-existing on main; invisible in CI, which exports none of these.

The test patches a passwordless `REDIS_URL` and asserts it reaches `from_url` verbatim. But tier 2 of the resolver's documented precedence merges `REDIS_PASSWORD` into any URL lacking one, so the assertion actually sees `redis://:<secret>@example.invalid:7000/3`.

**The resolver is correct — the suite was under-isolated.** Patching one connection var isn't enough when the resolver merges the ones you didn't patch.

## The fix

New autouse fixture in `tests/conftest.py` clearing seven of the eight connection components, directly mirroring the existing `_scrub_attune_env` (same class of bug, same rationale: fix the class centrally rather than per-test). A test that wants any of them still sets it via monkeypatch and still wins.

`REDIS_HOST` is deliberately excluded: the conftest loopback pin owns it, keeping every unit test off `getaddrinfo("localhost")` (the windows-exit139 hang class that wedged Windows workers for 20 minutes). Scrubbing it per-test defeats that pin and fails its guard — the same owned-by-another-fixture hazard `_SUITE_MANAGED_ENV` already documents. The exclusion is safe: with the other seven cleared, an ambient `REDIS_HOST` only reaches the component branch the pin has already forced to loopback.

## The guard

Added to `tests/unit/gates/test_redis_env_access_gate.py` (which already owns the canonical `GUARDED_NAMES` list), asserting: the two lists differ by exactly `{REDIS_HOST}` — so adding a guarded name without scrubbing it fails here; none of the seven survive into a test; and `REDIS_HOST` is still pinned, not merely absent.

Proven load-bearing, not vacuous: sabotaging the fixture fails both the new guard and the original test; restoring it passes both.

## Verification

Full unit suite green in both conditions — **20658 passed**, 101 skipped, 7 xfailed — with `REDIS_PASSWORD` exported (the repro condition) and with a clean env (the CI condition).

🤖 Generated with [Claude Code](https://claude.com/claude-code)