### PR TITLE
chore(hooks): allowlist sibling project repos in the worktree path guard

### DIFF
--- a/src/attune/hooks/scripts/worktree_path_guard.py
+++ b/src/attune/hooks/scripts/worktree_path_guard.py
@@ -54,7 +54,24 @@ METRICS_LOG = Path.home() / ".attune" / "enforcement-metrics.jsonl"
 # Roots OUTSIDE any session worktree that are legitimate Write/Edit
 # targets. ~/.attune/memory is the curated-memory repo — a deliberate
 # second git tree (docs/specs/curated-memory-productionization/, D4).
-DEFAULT_ALLOWED_EXTERNAL_ROOTS: tuple[str, ...] = ("~/.attune/memory",)
+DEFAULT_ALLOWED_EXTERNAL_ROOTS: tuple[str, ...] = (
+    "~/.attune/memory",
+    # Sibling project repos (retro 2026-08-12: the attune-forms
+    # extraction had to script around the guard for every write into
+    # the new repo; attune-verify hit the same wall 2026-06-02).
+    # Writes into a DIFFERENT project repo from an attune-ai session
+    # are near-always deliberate cross-repo work. ~/attune-ai itself
+    # stays deliberately ABSENT: worktree-vs-main-checkout confusion
+    # is the accident class this guard exists to catch.
+    "~/attune-author",
+    "~/attune-docs",
+    "~/attune-forms",
+    "~/attune-help",
+    "~/attune-lite",
+    "~/attune-marketing",
+    "~/attune-rag",
+    "~/attune-verify",
+)
 
 # Extend the allowlist without editing code: an os.pathsep-separated
 # list of additional allowed root directories.

--- a/tests/unit/hooks/test_worktree_path_guard.py
+++ b/tests/unit/hooks/test_worktree_path_guard.py
@@ -168,6 +168,19 @@ class TestAllowlist:
         roots = hook_module._allowed_external_roots()
         assert Path.home() / ".attune" / "memory" in roots
 
+    def test_default_allowlist_covers_sibling_project_repos(self, hook_module):
+        """Sibling project repos are allowlisted (retro 2026-08-12) —
+        cross-repo work from an attune-ai session is deliberate."""
+        roots = hook_module._allowed_external_roots()
+        for repo in ("attune-forms", "attune-author", "attune-help", "attune-verify"):
+            assert Path.home() / repo in roots
+
+    def test_main_checkout_stays_off_the_allowlist(self, hook_module):
+        """~/attune-ai must NEVER be allowlisted: worktree-vs-main
+        confusion is the accident class this guard exists to catch."""
+        roots = hook_module._allowed_external_roots()
+        assert Path.home() / "attune-ai" not in roots
+
     def test_default_attune_memory_write_passes(
         self, hook_module, isolated_metrics_log, two_git_trees, monkeypatch, tmp_path
     ):


### PR DESCRIPTION
## Summary

Retro item (2026-08-12 dynamic-forms-library session, ratified by the chair's "proceed with implementation"): the attune-forms extraction had to script around the worktree path guard for every write into the new sibling repo — the same wall attune-verify hit 2026-06-02.

Adds the eight sibling project repos to `DEFAULT_ALLOWED_EXTERNAL_ROOTS`. `~/attune-ai` (the main checkout) stays deliberately ABSENT — worktree-vs-main confusion is the accident class the guard exists to catch — and a new test pins that it never gets allowlisted.

**Note for the chair (CHAIR-ARMS):** this diff expands the lead's own write authority and touches an enforcement surface — I am not arming auto-merge; merge is yours after reading.

## Receipts

- `tests/unit/hooks/test_worktree_path_guard.py`: 24 passed serial-keyless (2 new: sibling-repos covered, main-checkout-never-allowlisted).
- ruff + black clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)