### PR TITLE
chore(hooks): pin help-regen pre-commit to --frozen resolve

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -147,7 +147,13 @@ repos:
       # (docs/specs/polish-cost-reduction/, lever 1).
       - id: regenerate-help-templates
         name: Regenerate .help/templates for changed source files
-        entry: uv run python scripts/regenerate_help_templates.py
+        # --frozen: use the existing lockfile without re-resolving —
+        # a plain `uv run` re-resolves against the registry on every
+        # commit (minutes of wall-clock) and HARD-FAILS the commit
+        # when pyproject names a dependency not yet on PyPI (the
+        # first-publish chicken-and-egg, hit live 2026-08-12 on the
+        # attune-forms extraction; retro item 6, chair-ruled).
+        entry: uv run --frozen python scripts/regenerate_help_templates.py
         language: system
         pass_filenames: true
         files: ^(src/.*\.py|\.help/features\.yaml)$


### PR DESCRIPTION
Retro item 6, chair-ruled 2026-08-12 (`y go`): the hook's plain `uv run` re-resolves against the registry on every commit — minutes of wall-clock (one 5-minute commit timeout this session) and a hard commit failure whenever pyproject names a not-yet-published dependency (the first-publish chicken-and-egg from the attune-forms extraction). `--frozen` uses the existing lockfile without re-resolving; the regen script is check-only.

Receipt: `uv run --frozen python scripts/regenerate_help_templates.py <file>` exits 0 in seconds on this tree.

**Enforcement-infra diff — not arming auto-merge (CHAIR-ARMS); merge is yours.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)