### PR TITLE
chore(hooks): rename regenerate-help-templates to check-help-freshness

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -145,8 +145,13 @@ repos:
       # Never regenerates, never spends LLM budget, never blocks the
       # commit — polish-bearing regen runs at release-prep cadence
       # (docs/specs/polish-cost-reduction/, lever 1).
-      - id: regenerate-help-templates
-        name: Regenerate .help/templates for changed source files
+      # Renamed from regenerate-help-templates (chair ruling
+      # 2026-08-12, docs-regen-cadence pushback): the hook is
+      # CHECK-ONLY and the old name advertised regeneration it
+      # doesn't do. Regen runs only at release-prep (/coach
+      # maintain) — polish-cost-reduction lever 1.
+      - id: check-help-freshness
+        name: Check .help/templates freshness (check-only; regen at release-prep)
         # --frozen: use the existing lockfile without re-resolving —
         # a plain `uv run` re-resolves against the registry on every
         # commit (minutes of wall-clock) and HARD-FAILS the commit


### PR DESCRIPTION
Chair ruling 2026-08-12 (docs-regen-cadence pushback form): regeneration stays at release-prep cadence only; the check-only hook stops advertising regeneration it doesn't do. Behavior unchanged — `entry`/script untouched, renamed id live-fired green. Historical mentions of the old id (CHANGELOG, lessons, archived specs) left as-is; the queued outbox lesson referencing `SKIP=` was updated to the new id.

**Enforcement-infra diff — not arming auto-merge (CHAIR-ARMS); merge is yours.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)