### PR TITLE
docs: forms-grammar session artifacts + convergence thread queued

### DIFF
--- a/docs/reports/roundtable/q-forms-grammar-expansion-001.md
+++ b/docs/reports/roundtable/q-forms-grammar-expansion-001.md
@@ -1,0 +1,41 @@
+# Round table — q-forms-grammar-expansion-001 (curated stub)
+
+**Question (chair, 2026-08-14):** which new form/widget constructs and
+surfaces should attune-forms add for users across Claude, Antigravity,
+and Codex hosts? Seeds: deliberation construct, triage construct,
+portable markdown surface.
+
+One round, all three seats present (claude 36s, antigravity 47s,
+codex 25s); halted on convergence. Full transcript (moderator
+development data, never tracked):
+`~/.attune/reports/roundtable/q-forms-grammar-expansion-001.md`.
+
+## Promoted content (chair-approved: board msgs 2, 3, 4, 8)
+
+- **3/3:** the markdown surface ships first and is only real with a
+  specified return path (wire-format + validation loop). Shipped in the
+  attune-forms grammar-expansion PR as the sentinel-marked JSON answer
+  skeleton emitted by `form_to_markdown`.
+- **3/3:** triage is the strongest new construct. Amendment applied:
+  answers key on stable per-item ids (label fallback), not labels.
+- **Split on deliberation:** fold into decision (claude) / keep with
+  strict summary degradation (antigravity) / defer for a consumer
+  (codex). The strict degradation and the synthesis-pick-is-not-the-
+  answer separation were applied regardless.
+- **Member-originated candidates:** confirm construct (claude + codex
+  independently), tolerant markdown ingestion (all three seats' shared
+  parser concern), ranking (codex), hunk_review (antigravity),
+  assumption-review (codex), surface capability contract (codex).
+
+## Chair rulings (form receipt resp-20260814-211025)
+
+Collected through the live deliberation + triage widget rendered by the
+constructs under ruling — their first human-validated round-trip.
+
+1. **Deliberation: KEEP as its own construct** as built (pushback
+   precedent: a distinct communicative act earns a construct even when
+   the answer path is decision-shaped).
+2. **confirm construct → spec next. tolerant markdown ingestion → spec
+   next.** ranking / hunk_review / assumption-review / capability
+   contract → backlog. Nothing declined.
+3. Digest promoted to this stub; rulings recorded here.

--- a/docs/specs/confirm-construct/decisions.md
+++ b/docs/specs/confirm-construct/decisions.md
@@ -1,0 +1,67 @@
+# Confirm Construct — decisions
+
+Decision log for [requirements.md](requirements.md). Append-only;
+newest at the bottom.
+
+## D1 — Intake rulings (form-accepted, 2026-08-14)
+
+**Date:** 2026-08-14 · **Status:** decided (Patrick — chair accepted
+the intake form as prefilled: "proceed as indicated by my form
+submissions"; validated receipt `resp-20260814-212130`).
+
+Provenance chain: round table `q-forms-grammar-expansion-001` — the
+claude seat ("confirm construct — action preview with explicit
+consequences list, approve/abort, degrading to boolean with the
+receipt in description") and the codex seat ("confirmation of
+consequences: compact summary plus explicit acknowledgement for
+destructive, costly, or externally visible actions") converged
+independently; chair ruled it "spec next" via the live
+deliberation+triage widget (receipt `resp-20260814-211025`).
+
+1. **Answer shape = two-way** (approve/abort; exactly two
+   author-nameable labels). Three-way and typed-acknowledgment lanes
+   declined for v1; typed-ack named as a possible v2 needing its own
+   ruling and a flat-surface answer.
+2. **Consequences = structured items** `{label, severity?, detail?}`
+   — the `triage_items` shape; severity a free tag with a conventional
+   vocabulary named in docs, not enforced.
+3. **Slug = `confirm-construct`**, spec home attune-ai `docs/specs/`
+   (attune-forms carries no specs tree — extraction-era precedent).
+4. **Done-when** recorded verbatim in requirements.
+
+## D2 — Lead-proposed rule flagged for ratification: no pre-selected approval (2026-08-14)
+
+**Date:** 2026-08-14 · **Status:** RATIFIED — chair approved the
+requirements ("requirements approved") immediately after the lead's
+explicit disclosure of this rule and the R5a collision in response to
+"any pushback?". The approval covers the amended text carrying both;
+the rule stands as written (no `default`, no `recommended` on a
+confirm).
+
+R1 forbids `default` and `recommended` on a confirm: a pre-selected or
+pre-badged approval defeats the gate. This was added by the lead
+beyond the intake forks. When the chair asked "any pushback?", the
+lead disclosed it rather than letting it ride (the widget-kernel-family
+D2 counter-case discipline: lead-added rulings must be traceable and
+chair-ratified, never laundered into a spec the chair already
+skimmed). Also disclosed at the same time: the skill-text collision
+now recorded as R5a (bare confirmations stay conversational; the
+construct is reserved for consequence-bearing actions).
+
+Chair options: ratify as written / strike (allow recommended) /
+narrow (allow default=abort only). Recorded here when ruled.
+
+## D3 — AC-3 live receipt + ship approval (chair via confirm card, 2026-08-14)
+
+**Date:** 2026-08-14 · **Status:** decided.
+
+The construct's first human-validated round-trip was its own ship
+gate: a live `confirm` card ("Push claude/confirm-construct and open
+the PR?") with three severity-tagged consequences, rendered from the
+working tree, answered **Approve** by the chair, validated through
+`collect_form_response` — receipt `resp-20260814-213355` (AC-3
+satisfied by construction). During execution the widget CSS family was
+renamed `.ae-gate-*` after a semantic collision with the BASE
+fully-inferred banner class `.ae-confirm` (same name, different rule)
+— caught by eyeball, not by the class-coverage guard, which only
+detects unstyled classes. Theme lands at 8,158 B, under the 8 KB cap.

--- a/docs/specs/confirm-construct/requirements.md
+++ b/docs/specs/confirm-construct/requirements.md
@@ -1,0 +1,124 @@
+# Confirm Construct — requirements
+
+**Status:** approved (chair, 2026-08-14 — "requirements approved",
+given after the lead's D2/R5a disclosure); task ladder under review.
+Intake rulings in [decisions.md](decisions.md) D1; D2 ratified.
+**Slug:** `confirm-construct` · **Repo:** attune-forms (spec home here
+by the extraction-era precedent — attune-forms carries no specs tree).
+**Provenance:** round table `q-forms-grammar-expansion-001` — the
+claude and codex seats independently proposed a consequences-preview
+approval gate; chair ruled it "spec next" (receipt
+`resp-20260814-211025`). Intake accepted as prefilled
+(receipt `resp-20260814-212130`).
+
+## Outcome (from the intake)
+
+attune-forms gains a `confirm` construct — communication-grammar
+member #7: an **action preview with an explicit consequences list and
+an approve/abort gate**. Today a side-effectful step (release, merge,
+delete, spend) is improvised with a `boolean`, which loses the "here
+is exactly what will happen" structure; the construct makes the
+consequences first-class and the approval an explicit act.
+
+## Done when (intake, verbatim)
+
+confirm construct merged to attune-forms main with CI green:
+definition validation, all four surfaces (widget / AskUserQuestion /
+elicitation schema / markdown), answer validation through
+`collect_form_response`, reference-form + round-trip drift guards
+extended, and one live human-validated receipt recorded.
+
+## Ruled constraints (D1 — re-open only by new ruling)
+
+- **Two-way answer** (intake fork 1): the answer is exactly one of two
+  author-nameable option labels, default `["Approve", "Abort"]` —
+  always exactly two. No third lane, no typed-acknowledgment ceremony
+  in v1.
+- **Structured consequences** (intake fork 2): `consequences` is a
+  non-empty list of `{label, severity?, detail?}` — the `triage_items`
+  shape, so the grammar stays one family. `severity` is a free tag;
+  the conventional vocabulary (`low` / `medium` / `high` /
+  `irreversible`) is named in the skill doc, not enforced.
+- **Degradation** (round-table ruling, both proposing seats): flat
+  surfaces render a two-option single-select with the consequences
+  folded compactly into the description/help text. Never a silent
+  boolean that hides the receipt.
+- **No pre-selected approval (LEAD-PROPOSED — chair ratification
+  pending, flagged 2026-08-14):** R1 forbids `default`/`recommended`
+  on a confirm. This rule was added by the lead beyond the intake
+  forks; it stands only once the chair ratifies it (decisions.md D2
+  records the disposition).
+
+## Requirements
+
+- **R1 — model + definition validation.** `QuestionType.CONFIRM` with
+  `consequences` (required, non-empty, validated like `triage_items`
+  minus ids) and exactly two `options` (defaulted to
+  `["Approve", "Abort"]` when omitted; any other count is a definition
+  error). **No `default` and no `recommended` are permitted on a
+  confirm** — a pre-selected or pre-badged approval defeats the gate;
+  the definition validator rejects them. Approving must be an explicit
+  act on every surface.
+- **R2 — widget render.** The question text is the action headline;
+  consequences render as rows with their severity tag visibly badged
+  (reusing the triage row/tag styling family where possible); the two
+  options render as unchecked controls. Submit script reads it like
+  the other construct radios; the CSS-family trimmer and the
+  round-trip DOM simulator learn the type.
+- **R3 — flat surfaces.** `to_ask_user_format`: single-select of the
+  two labels, consequences folded into help text
+  (`"Will: X (irreversible); Y — detail"` style, compact). Elicitation
+  schema: string enum of the two labels (not JSON boolean — labels
+  carry meaning). Markdown surface: consequences as bullets with
+  severity tags, skeleton value `null` (never prefilled — R1's
+  no-default rule projected to S4).
+- **R4 — answer validation.** Membership over the two options via the
+  existing `_validate_membership`; empty/missing answer on a required
+  confirm is a named problem. No fold logic needed (scalar answer).
+- **R5a — skill-rule reconciliation.** The shipped forms skill rules
+  "a user's bare confirmation is never a form". The confirm construct
+  inverts that for consequence-bearing actions, so the skill text MUST
+  draw the boundary explicitly: bare re-confirmations ("go", "yes")
+  stay conversational; the construct is reserved for actions whose
+  consequences deserve enumeration (destructive, costly,
+  outward-facing). Without this line the two rules contradict and the
+  construct's failure mode is ceremony inflation.
+- **R5 — drift guards.** Reference form + `EXAMPLE_ANSWERS` gain a
+  confirm field; needs-widget partition, CSS-family exhaustive test,
+  widget round-trip, and markdown conformance guards all extend; the
+  MCP field schema documents the type (names/shapes unchanged, same
+  boundary as PR #14).
+
+## Out of scope
+
+- Typed-acknowledgment friction for irreversible actions (named as a
+  possible v2 in D1; needs its own ruling and a flat-surface answer).
+- Any auto-wiring into attune-ai workflows (release-execute etc.) —
+  consumers adopt in their own repos/rulings.
+- Tolerant markdown ingestion (its own "spec next" thread).
+
+## Acceptance criteria
+
+- **AC-1** Definition validation: missing/empty `consequences`, a
+  non-2 option count, or a `default`/`recommended` on a confirm each
+  raise `FormValidationError` naming the field.
+- **AC-2** All four surfaces render the reference confirm; the widget
+  round-trip and markdown-skeleton round-trip validate through
+  `collect_form_response`.
+- **AC-3** One live human-validated receipt: a real confirm rendered,
+  answered, validated (the D15/D16 receipt pattern — same as the
+  deliberation/triage tranche's chair-ruling form).
+- **AC-4** Full suite + lint green on CI (3 OS × 2 Python legs).
+
+## Tasks
+
+1. **Model + validation** (R1, R4, AC-1): enum member, fields, parser
+   (`_parse_confirm_extras`), option-count/no-default/no-recommended
+   rules, membership validation, unit tests.
+2. **Widget surface** (R2): renderer + severity badges + CSS
+   (budget-aware — stay under the 8 KB cap or raise with a ruling),
+   submit-script branch, round-trip simulator support.
+3. **Flat surfaces** (R3): ask-format fold, elicitation enum, markdown
+   render + skeleton, per-surface tests.
+4. **Guards + docs + receipt** (R5, AC-2..4): reference form, drift
+   guards, skill doc section, CHANGELOG, live receipt, PR.

--- a/docs/specs/markdown-ingestion/decisions.md
+++ b/docs/specs/markdown-ingestion/decisions.md
@@ -1,0 +1,44 @@
+# Tolerant Markdown Ingestion — decisions
+
+Decision log for [requirements.md](requirements.md). Append-only;
+newest at the bottom.
+
+## D1 — Intake rulings (form-collected, 2026-08-14)
+
+**Date:** 2026-08-14 · **Status:** decided (Patrick, via decision-card
+intake form; validated receipt `resp-20260814-213951`).
+
+Provenance chain: round table `q-forms-grammar-expansion-001` — the
+Claude seat's follow-up ("is the parser code or model-assisted, and
+where does the validation truth live?") and the Antigravity seat's
+follow-up (inline response template vs extraction schema) posed the
+central fork; the Codex seat demanded a deterministic round-trip
+protocol. Chair ruled the lane "spec next" (receipt
+`resp-20260814-211025`, board msg 9).
+
+1. **Normalization owner = hybrid**: deterministic library parser
+   (`markdown_to_answers`) for the shorthand grammar; the host agent
+   owns the free-text lane as a skill-taught proposal. Validation
+   truth stays `collect_form_response` for both — this answers the
+   seats' follow-up questions directly.
+2. **Shorthand scope = minimal**: `field_id: value`, `N: value`
+   (1-based), dotted triage ids, filled JSON block; EXACT option
+   matching. Prefix/case-insensitive matching deferred to a v2 ruling
+   backed by real transcripts.
+3. **Slug = `markdown-ingestion`**; done-when recorded verbatim in
+   requirements.
+
+## D2 — AC-4 live receipt: both lanes fired (chair via typed reply, 2026-08-14)
+
+**Date:** 2026-08-14 · **Status:** decided.
+
+The ship gate rendered on the markdown surface itself (a `confirm`
+form via `form_to_markdown` — no widget, the exact Codex/Antigravity
+experience). The chair typed the free-text reply "approve". The
+deterministic lane behaved per D1: `markdown_to_answers` returned
+`unparseable line: 'approve'` — not shorthand, not the exact option,
+NO guess. The host-agent lane then proposed the mapping
+`{pr_gate: "Approve"}`, validated through `collect_form_response` —
+receipt `resp-20260814-214817`. AC-4 satisfied with BOTH ruled lanes
+demonstrated in one exchange, including the parser's refusal — the
+honesty half of the design — observed live.

--- a/docs/specs/markdown-ingestion/requirements.md
+++ b/docs/specs/markdown-ingestion/requirements.md
@@ -1,0 +1,110 @@
+# Tolerant Markdown Ingestion — requirements
+
+**Status:** draft (2026-08-14) — awaiting chair review of the task
+ladder; intake rulings in [decisions.md](decisions.md) D1.
+**Slug:** `markdown-ingestion` · **Repo:** attune-forms.
+**Provenance:** round table `q-forms-grammar-expansion-001` — all
+three seats independently flagged rendering-without-ingestion as the
+S4 surface's missing half ("documentation, not a surface"); chair
+ruled it "spec next" (receipt `resp-20260814-211025`). Intake ruled
+via decision form (receipt `resp-20260814-213951`).
+
+## Outcome
+
+Replies on the markdown surface (Codex CLI, Antigravity, plain chat)
+parse into validated answers without demanding perfect JSON. The S4
+surface becomes a full round-trip: render (`form_to_markdown`, shipped
+attune-forms #14) → user types a reply → parse → validate → re-ask
+only what failed.
+
+## Done when (intake, verbatim)
+
+markdown_to_answers merged to attune-forms main with CI green:
+shorthand + JSON-block parsing round-trips the full reference form,
+malformed replies produce named per-field re-asks rendered back as
+markdown (error echo loop), skill text teaches the free-text lane, and
+one live receipt of a typed shorthand reply validating end-to-end is
+recorded.
+
+## Ruled constraints (D1 — re-open only by new ruling)
+
+- **Hybrid normalization** (intake fork 1): the library ships a
+  DETERMINISTIC parser for the shorthand grammar; free-text replies
+  are the HOST AGENT's lane (skill-taught proposal). Validation truth
+  is `collect_form_response` for both — the parser proposes raw
+  answers, never a validated response.
+- **Minimal shorthand grammar** (intake fork 2): `field_id: value`
+  lines, `N: value` lines (1-based field position), dotted triage ids
+  (`field.item: disposition`), and a filled JSON answer block. Option
+  matching is EXACT — a miss is a named re-ask, never a guess.
+  Case-insensitive/prefix matching is out of scope until real
+  transcripts justify its ambiguity rules.
+- **No silent guesses**: every unparseable line and every unknown id
+  is a named problem in the result — the parser's honesty mirrors the
+  validator's.
+
+## Requirements
+
+- **R1 — `markdown_to_answers(form, reply)`.** Pure function returning
+  `(answers, problems)`. Accepts, in precedence order: (1) the last
+  fenced JSON block in the reply (either the full sentinel payload or
+  a bare answers object); (2) shorthand lines — `field_id: value`,
+  `N: value` (1-based), `field_id.item_key: disposition` for triage.
+  Type-aware value handling: exact option membership for select-likes,
+  Yes/No for boolean, numeric parse for number, comma-separated exact
+  options for multi_select. Lines that parse nowhere and ids that
+  match no field become problems; nothing is guessed or dropped
+  silently.
+- **R2 — error echo loop.** `problems_to_markdown(form, problems)`
+  renders the offending fields ONLY, as markdown (reusing the S4 field
+  renderer), headed by the named problems — the re-ask a text-only
+  host relays verbatim. Fields that validated are never re-asked
+  (mirrors the widget discipline).
+- **R3 — free-text lane (skill).** The skill teaches the host agent:
+  try `markdown_to_answers` first; for free text, propose a mapping
+  and validate it through `elicitation_collect_response`; when a value
+  is uncertain, re-ask that field rather than guess. The
+  `form_to_markdown` reply footer documents the shorthand so users
+  discover it without reading docs.
+- **R4 — validator untouched.** No changes to
+  `collect_form_response` semantics; the parser and echo loop are
+  pure additions.
+- **R5 — drift guard.** A conformance test types a shorthand reply
+  covering EVERY QuestionType (the reference form) and round-trips it
+  to a validated `FormResponse`; the reference answers stay the single
+  fixture.
+
+## Out of scope
+
+- Prefix/fuzzy option matching (named v2 lane, needs its own ruling).
+- Any new MCP tool (the D3 four-tool mirror holds; parser is reachable
+  through the library and, later, convergence work).
+- Localization of the shorthand keywords.
+
+## Acceptance criteria
+
+- **AC-1** Shorthand round-trip: a typed reply using id lines, an N
+  line, a dotted triage line, and a comma-separated multi-select
+  parses and validates for the full reference form.
+- **AC-2** JSON-block round-trip: the S4 skeleton, filled and pasted
+  back, parses identically (payload or bare-answers form).
+- **AC-3** Echo loop: a reply with one bad option and one unknown id
+  yields problems naming both, and `problems_to_markdown` re-renders
+  exactly the offending fields.
+- **AC-4** Live receipt: one real typed shorthand reply validated
+  end-to-end in a session, recorded in decisions.md.
+- **AC-5** Full suite + lint green on CI.
+
+## Tasks
+
+1. **Parser core** (R1, AC-1, AC-2): `markdown_ingestion.py` [[?markdown-ingestion]]
+   (not yet built — this spec's deliverable): JSON-block extraction +
+   shorthand lines + type-aware values; exhaustive unit tests
+   including the no-silent-guess cases.
+2. **Error echo loop** (R2, AC-3): `problems_to_markdown` reusing the
+   S4 field renderer; problem-to-field attribution; tests.
+3. **Skill + footer + guards** (R3, R5): shorthand documented in the
+   `form_to_markdown` reply footer; skill free-text lane; reference
+   conformance test; CHANGELOG.
+4. **Receipt + PR** (AC-4, AC-5): live typed-reply receipt, full
+   suite, PR with the spec linked.


### PR DESCRIPTION
Session artifacts from the 2026-08-14 attune-forms grammar expansion (attune-forms #14/#15/#16, all merged):

- **Two executed specs**: `confirm-construct` and `markdown-ingestion` — full receipt chains (intake, chair approvals, live-gate AC receipts) recorded in their decisions files.
- **Roundtable curated stub**: `q-forms-grammar-expansion-001` (chair-promoted content + rulings; full transcript machine-local).

## Convergence thread (queued, not started)

attune-forms now leads its attune-ai mirror by: `deliberation` / `triage` / `confirm` constructs, `form_to_markdown` (S4), and `markdown_to_answers` + `problems_to_markdown`. Follow-ups this PR queues but does not do:

1. R2.3 thin-delegation convergence (attune-forms-plugin spec): attune-ai's elicitation MCP tools delegate to the attune-forms package instead of the drifting mirror.
2. elicit skill + field-schema parity for the three new constructs.
3. Ops dashboard `/static/form-theme.css` projection refresh (byte-equal drift test will trip at the next attune-forms bump — theme is now 8,158 B).

🤖 Generated with [Claude Code](https://claude.com/claude-code)