### PR TITLE
test(hooks): executor.py 82.52% → 100% — un-skip the webhook security suite

### DIFF
--- a/docs/COVERAGE_BUG_LOG.md
+++ b/docs/COVERAGE_BUG_LOG.md
@@ -1559,3 +1559,20 @@ missing from this table until 2026-07-24 — it was recorded in the
 session-49f snapshot above but never propagated here.)
 
 Modules at 100%: 99 (cumulative across all sessions; +4 from the 2026-08-01 fleet — facade and fix_intake closed at 99% with their remainders classified: one dead-code region, one unreachable-without-mocking guard).
+
+## 2026-08-16 — hooks/executor.py lane (weekly-report Tier 1)
+
+One environment bug, security-relevant:
+
+- **Webhook test suite silently skipped in EVERY environment,
+  CI included — classification: dead.** `aiohttp` lived only in the
+  `[all]` extra; CI installs `.[dev]` and local venvs sync the `dev`
+  dependency group, so `tests/unit/hooks/test_executor_webhook_security.py`
+  — the SSRF and DNS-rebinding-pin guards for `_execute_webhook` —
+  `importorskip`'d away everywhere since the suite was written. The
+  dev-group mirror guard was innocent (extra ≡ group held; both
+  lacked aiohttp). Fix: aiohttp added to the `[dev]` extra + `dev`
+  group (CVE floor pinned per `[all]`); the 15 webhook tests now run,
+  plus 3 new tests for the branches they never reached (WEBHOOK
+  dispatch through `execute()`, ≥400 raise, non-JSON fallback).
+  Module 82.52% → 100%.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -236,6 +236,7 @@ dev = [
     # (redis entry removed 2026-07-04 — core dep now)
     "langchain-anthropic>=0.3.0,<2.0.0",
     "tiktoken>=0.7.0,<1.0.0",
+    "aiohttp>=3.14.3,<4.0.0",  # webhook hooks + their SSRF/DNS-pinning tests; CVE floor per [all]
 ]
 
 # Individual developers - lightweight, software development focused
@@ -420,6 +421,7 @@ dev = [
     # (redis entry removed 2026-07-04 — core dep now)
     "langchain-anthropic>=0.3.0,<2.0.0",
     "tiktoken>=0.7.0,<1.0.0",
+    "aiohttp>=3.14.3,<4.0.0",  # webhook hooks + their SSRF/DNS-pinning tests; CVE floor per [all]
 ]
 
 [project.scripts]

--- a/tests/unit/hooks/test_executor_webhook_security.py
+++ b/tests/unit/hooks/test_executor_webhook_security.py
@@ -143,6 +143,9 @@ class TestWebhookDNSPinning:
         resolved = await connector._resolver.resolve("hooks.example.com", 443)
         assert resolved[0]["host"] == "93.184.216.34"
         assert resolved[0]["hostname"] == "hooks.example.com"
+        # The resolver's own close() is part of the AbstractResolver
+        # contract aiohttp calls on connector teardown — exercise it.
+        await connector._resolver.close()
         await connector.close()
 
 
@@ -169,3 +172,76 @@ class TestCommandArgvInjection:
     async def test_missing_context_variable_still_raises_value_error(self, executor):
         with pytest.raises(ValueError, match="Missing context variable"):
             await executor._execute_command("echo {absent}", {})
+
+
+def _mock_session_returning(response: AsyncMock) -> MagicMock:
+    """Session context-manager mock whose post() yields ``response``."""
+    mock_session = MagicMock()
+    mock_post_cm = AsyncMock()
+    mock_post_cm.__aenter__ = AsyncMock(return_value=response)
+    mock_post_cm.__aexit__ = AsyncMock(return_value=False)
+    mock_session.post = MagicMock(return_value=mock_post_cm)
+    mock_session_cm = MagicMock()
+    mock_session_cm.__aenter__ = AsyncMock(return_value=mock_session)
+    mock_session_cm.__aexit__ = AsyncMock(return_value=False)
+    return mock_session_cm
+
+
+class TestWebhookResponseHandling:
+    """The response branches past the pinned connect: error status,
+    JSON body, and the non-JSON fallback."""
+
+    @pytest.mark.asyncio
+    async def test_error_status_raises_with_body(self, executor):
+        """A >=400 response raises RuntimeError carrying status + text —
+        never returns a payload the caller would mistake for success."""
+        mock_response = AsyncMock()
+        mock_response.status = 503
+        mock_response.text = AsyncMock(return_value="upstream down")
+        with (
+            patch("attune.monitoring.validators._resolve_and_check_ip"),
+            patch("aiohttp.ClientSession", return_value=_mock_session_returning(mock_response)),
+        ):
+            with pytest.raises(RuntimeError, match="status 503.*upstream down"):
+                await executor._execute_webhook(
+                    "https://hooks.example.com/notify", {"event": "test"}
+                )
+
+    @pytest.mark.asyncio
+    async def test_non_json_response_falls_back_to_status_and_text(self, executor):
+        """A 2xx body that isn't JSON degrades to {status, text} instead
+        of raising out of the hook."""
+        mock_response = AsyncMock()
+        mock_response.status = 200
+        mock_response.json = AsyncMock(side_effect=ValueError("not json"))
+        mock_response.text = AsyncMock(return_value="OK\n")
+        with (
+            patch("attune.monitoring.validators._resolve_and_check_ip"),
+            patch("aiohttp.ClientSession", return_value=_mock_session_returning(mock_response)),
+        ):
+            result = await executor._execute_webhook(
+                "https://hooks.example.com/notify", {"event": "test"}
+            )
+        assert result == {"status": 200, "text": "OK\n"}
+
+    @pytest.mark.asyncio
+    async def test_webhook_hook_dispatches_through_execute(self, executor):
+        """A HookDefinition of type WEBHOOK routes through execute() to
+        the webhook path and comes back in the success envelope."""
+        from attune.hooks.config import HookDefinition, HookType
+
+        mock_response = AsyncMock()
+        mock_response.status = 200
+        mock_response.json = AsyncMock(return_value={"ok": True})
+        hook = HookDefinition(
+            type=HookType.WEBHOOK,
+            command="https://hooks.example.com/notify",
+            description="test webhook dispatch",
+        )
+        with (
+            patch("attune.monitoring.validators._resolve_and_check_ip"),
+            patch("aiohttp.ClientSession", return_value=_mock_session_returning(mock_response)),
+        ):
+            result = await executor.execute(hook, {"event": "test"})
+        assert result["success"] is True
+        assert result["output"] == {"ok": True}

--- a/uv.lock
+++ b/uv.lock
@@ -387,6 +387,7 @@ backend = [
     { name = "uvicorn" },
 ]
 dev = [
+    { name = "aiohttp" },
     { name = "attune-help" },
     { name = "attune-rag" },
     { name = "bandit" },
@@ -490,6 +491,7 @@ windows = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "aiohttp" },
     { name = "attune-help" },
     { name = "attune-rag" },
     { name = "bandit" },
@@ -521,6 +523,7 @@ dev = [
 requires-dist = [
     { name = "agent-memory-client", specifier = ">=0.14.0,<0.15" },
     { name = "aiohttp", marker = "extra == 'all'", specifier = ">=3.14.3,<4.0.0" },
+    { name = "aiohttp", marker = "extra == 'dev'", specifier = ">=3.14.3,<4.0.0" },
     { name = "anthropic", specifier = ">=0.40.0,<1.0.0" },
     { name = "anthropic", marker = "extra == 'all'", specifier = ">=0.40.0" },
     { name = "anthropic", marker = "extra == 'anthropic'", specifier = ">=0.40.0" },
@@ -676,6 +679,7 @@ provides-extras = ["anthropic", "llm", "memdocs", "agents", "backend", "lsp", "w
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "aiohttp", specifier = ">=3.14.3,<4.0.0" },
     { name = "attune-help", specifier = ">=0.10.0" },
     { name = "attune-rag", specifier = ">=0.1.5,<2.0" },
     { name = "bandit", specifier = ">=1.7,<2.0" },


### PR DESCRIPTION
## Summary

The weekly modules-needing-work report's one real Tier 1 lane (#2072: `hooks/executor.py`, 82.52%, 17 missed lines).

**The hole had a structural cause, not a missing-tests cause:** `aiohttp` lived only in the `[all]` extra — CI installs `.[dev]`, local venvs sync the `dev` group, so the entire `test_executor_webhook_security.py` module (the SSRF + DNS-rebinding-pin guards for `_execute_webhook`) has `importorskip`'d away in **every** environment since it was written. Bug-logged as **dead** in `docs/COVERAGE_BUG_LOG.md` — security guard tests that never ran anywhere.

- `aiohttp>=3.14.3,<4.0.0` added to the `[dev]` extra **and** the `dev` dependency group (the mirror guard's equality holds; CVE floor pinned per `[all]`). `uv.lock` +4 lines.
- 3 new tests for the branches the suite never reached: `HookType.WEBHOOK` dispatch through `execute()` (success envelope asserted), ≥400 → `RuntimeError` with status + body, non-JSON 2xx → `{status, text}` fallback.
- The DNS-pinning test now exercises the resolver's `close()` contract line.

## Verification

- `tests/unit/hooks/`: **850 passed** (was 833 passed + silent skips)
- `attune.hooks.executor` coverage: **100.00%** (was 82.52% on Codecov / 83.74% local)
- `test_dev_dependency_group_mirror` + `test_extras_honesty`: pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)