### PR TITLE
test(widgets): chart_components.py 83.78% → 100% — bare-default branches

### DIFF
--- a/tests/unit/widgets/test_chart_components.py
+++ b/tests/unit/widgets/test_chart_components.py
@@ -91,6 +91,44 @@ def test_unknown_component_lists_the_valid_names() -> None:
         assert name in str(exc.value)
 
 
+def test_time_series_bare_defaults_omit_color_and_options() -> None:
+    """The minimal call — no series, no title — must not grow phantom
+    keys in the RAW spec (zero kernel bytes for defaults); the validated
+    model then materializes options with its own defaults."""
+    from attune.widgets.chart_components import time_series
+
+    raw = time_series(data=[{"date": "2026-07-01", "value": 3}])
+    assert "options" not in raw
+    assert "color" not in raw["encodings"]
+    validated = expand_component("time_series", {"data": [{"date": "2026-07-01", "value": 3}]})
+    assert validated.encodings.color is None
+    assert validated.options.title is None
+
+
+def test_comparison_bars_bare_defaults_omit_color_and_options() -> None:
+    """Same guarantee for bars: unstacked, untitled, single-series input
+    emits no options dict at all — dropped, not sent empty."""
+    from attune.widgets.chart_components import comparison_bars
+
+    raw = comparison_bars(data=[{"category": "north", "value": 12}])
+    assert "options" not in raw
+    assert "color" not in raw["encodings"]
+    validated = expand_component("comparison_bars", {"data": [{"category": "north", "value": 12}]})
+    assert validated.encodings.color is None
+    assert validated.options.stacked is False
+
+
+def test_comparison_bars_stacked_without_title() -> None:
+    """Options carrying only ``stacked`` still validate — title stays
+    unset rather than defaulting."""
+    validated = expand_component(
+        "comparison_bars",
+        {"data": [{"category": "north", "value": 12}], "stacked": True},
+    )
+    assert validated.options.stacked is True
+    assert validated.options.title is None
+
+
 def test_docs_full_spec_examples_validate() -> None:
     text = DOCS_PATH.read_text(encoding="utf-8")
     blocks = re.findall(r"```json\n(.*?)```", text, re.DOTALL)


### PR DESCRIPTION
## Summary

The weekly report's second (and last) Tier 1 lane: `widgets/chart_components.py`, 83.78%, zero missed lines — six partial branches, all the same shape: every existing test passes the optional args, so the bare-default paths never executed.

Three tests pin the default behavior that IS the module's design ("costs zero kernel bytes"): a bare `time_series` / `comparison_bars` emits no `color` encoding and no `options` key in the raw spec (validated model materializes defaults on top), and `stacked` without `title` keeps title unset. All 14 branches now covered — module at **100.00%** (branch mode), 51 widgets tests green.

No bug-log entry: the partials were untested defaults, not defects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)