### PR TITLE
chore(website): nanoid 3.3.18 — clear Dependabot high (alert 120)

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -8604,9 +8604,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.17",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
-      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
Lockfile-only bump of the transitive nanoid (postcss range `^3.3.16` already admits it): 3.3.17 → 3.3.18, closing [alert 120](https://github.com/Smart-AI-Memory/attune-ai/security/dependabot/120) (infinite loop in custom generators when size is 0).

Verified in a clean worktree: `npm ci` clean, `npm audit` 0 vulnerabilities, 28 vitest tests pass, `next build` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)