### PR TITLE
docs(reports): weekly modules-needing-work refresh

### DIFF
--- a/docs/reports/modules-needing-work.md
+++ b/docs/reports/modules-needing-work.md
@@ -1,24 +1,12 @@
 # Modules needing work
 
-**Generated:** 2026-08-16 07:01 UTC by `scripts/modules_needing_work.py` — regenerate in place, don't hand-edit (the dated 2026-07-30 report is the historical first edition).
+**Generated:** 2026-08-17 13:09 UTC by `scripts/modules_needing_work.py` — regenerate in place, don't hand-edit (the dated 2026-07-30 report is the historical first edition).
 
-**Source:** Codecov main — project total 96.13% across 717 files. Candidate list for coverage lanes (test-quality program #1569).
+**Source:** Codecov main — project total 96.16% across 717 files. Candidate list for coverage lanes (test-quality program #1569).
 
-## Tier 1 — measured below the 85% bar (2 modules)
+## Tier 1 — measured below the 85% bar (0 modules)
 
-### Clusters by miss volume
-
-| Cluster | Modules | Missed lines |
-|---|---|---|
-| `hooks` | 1 | 17 |
-| `widgets` | 1 | 0 |
-
-### Full list (ascending coverage)
-
-| Cover | Lines | Miss | Module |
-|---|---|---|---|
-| 82.52% | 103 | 17 | `src/attune/hooks/executor.py` |
-| 83.78% | 37 | 0 | `src/attune/widgets/chart_components.py` |
+Nothing below 85% — the floor is the ceiling today.
 
 ## Tier 2 — omitted from measurement (un-omit-audit candidates)
 


### PR DESCRIPTION
Weekly refresh of the standing modules-needing-work report (scheduled task, regenerated in place from Codecov's public per-file API for `main` — read-only, no API spend, no local suite run).

## Delta

Project total **96.13% → 96.16%** across 717 files.

**Tier 1 is empty** — the first time since the report was mechanized. Both prior entries climbed out to 100%:

| Module | Before | Now | Landed by |
|---|---|---|---|
| `src/attune/hooks/executor.py` | 82.52% (17 miss) | 100% | #2074 |
| `src/attune/widgets/chart_components.py` | 83.78% | 100% | #2075 |

- **Newly below the 85% bar:** none.
- **Climbed out:** the two above.
- **Tier 2** (omit-list un-audit candidates): unchanged, 27 entries.

## Next lane candidates

Tier 1 no longer names lanes, so the next targets come from missed-line volume above the bar (miss + partial, from the same Codecov payload):

| Miss+partial | Cover | Module |
|---|---|---|
| 97 | 86.65% | `src/attune/ops/data.py` |
| 55 | 88.46% | `src/attune/ops/runner.py` |
| 43 | 93.09% | `src/attune/authoring/generator.py` |

True floor across production files is now **85.00%** (`src/attune/test_generator/generator.py`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
