### PR TITLE
chore: weekly report 2026-08-17

### DIFF
--- a/weekly-reports/2026-08-17.md
+++ b/weekly-reports/2026-08-17.md
@@ -1,0 +1,182 @@
+# Anthropic Ecosystem Weekly — 2026-08-17
+
+## Summary
+
+The Sonnet 5 $2/$10 pricing is now permanent — no September 1 increase.
+That closes a six-week escalating carry-over. Claude Code shipped seven
+versions (v2.1.227-2.1.233) with two stack-relevant behavioral changes:
+todo/task tools are deprecated on newer models, and subagent forking is
+now on by default.
+
+---
+
+## Recommendations
+
+**1. Todo/task tools deprecated on newer models — assess CLAUDE.md guidance
+(MEDIUM)**
+
+v2.1.233 deprecated `TaskCreate`, `TaskUpdate`, `TaskList`, `TaskStop`,
+`TaskGet`, and `TaskOutput` on newer models (Fable 5 / Opus 5). The tools
+still appear in sessions running on Sonnet 4.6 (confirmed in this session's
+deferred-tools list), so the immediate impact is only on attune crew sessions
+that escalate to Fable 5 or Opus 5. Set `CLAUDE_CODE_ENABLE_TODO_TOOLS=1` in
+the project environment or `.claude/settings.json` to restore them.
+
+The longer view: the existing CLAUDE.md already favors XML-task format for
+3+ task work and the decision-routine explicitly prefers XML prompts. The
+task tools were baked into Claude Code's own system prompt as a planning
+primitive. Their removal on newer models suggests Anthropic is moving toward
+a different pattern (most likely inline planning or native context). Now is a
+reasonable time to confirm whether attune's crew/agent sessions rely on task
+tools implicitly (via the harness system prompt) and whether restoring them
+is the right call or whether XML-first is good enough.
+
+- **Applies to:** attune crew sessions on Fable 5 / Opus 5; review
+  `.claude/settings.json` and crew session configurations
+- **Action:** If crew sessions use Fable 5 or Opus 5, add
+  `CLAUDE_CODE_ENABLE_TODO_TOOLS=1` to the environment or test without and
+  verify planning quality holds
+- **Urgency:** Medium — doesn't affect Sonnet 4.6 sessions yet
+
+---
+
+**2. Subagent forking now on by default — verify crew layer (MEDIUM)**
+
+v2.1.232: non-teammate agents now run backgrounded by default. Previously
+this required an explicit opt-in. Any attune crew orchestration that assumed
+synchronous subagent completion needs to be verified under the new default.
+Background agents complete independently; results arrive via notification
+rather than inline. The crew layer's `team.py` and `release_prep_team.py`
+are the most likely to be affected.
+
+Also in v2.1.232: `@mention` in prompts enables direct session-to-session
+messaging. This is a new multi-agent communication primitive that is now
+available alongside the `SendMessage` tool already in the harness. No
+required action, but it's a design option for future crew work.
+
+- **Applies to:** `src/attune/agents/team.py`,
+  `src/attune/agents/release/release_prep_team.py`
+- **Action:** Run a test crew session and confirm results arrive as expected
+  under backgrounded-by-default behavior
+- **Urgency:** Medium
+
+---
+
+**3. Server-supplied hooks for self-hosted runner (LOW)**
+
+v2.1.229: self-hosted runner sessions now accept server-supplied Claude Code
+hooks. This means `security_guard.py` and other attune hooks don't need to
+be present in every repository; they can be configured centrally at the
+runner level. Relevant if attune-ops is running self-hosted runner sessions.
+No code change required now, but worth knowing for infrastructure planning.
+
+- **Applies to:** attune-ops self-hosted runner configuration (if active)
+- **Urgency:** Low
+
+---
+
+**4. `anthropic-workspace-id` header for telemetry (INFO)**
+
+The API now returns `anthropic-workspace-id: wrkspc_xxx` on every response,
+identifying which workspace the API key resolved to. The attune telemetry
+layer could record this field to disambiguate usage across workspaces without
+any extra API calls. No urgency; file as a future telemetry enhancement.
+
+- **Applies to:** `src/attune/telemetry/` if workspace-level cost tracking
+  is desired
+- **Urgency:** Informational
+
+---
+
+## Carry-overs
+
+| # | First raised | Recommendation | Status |
+|---|---|---|---|
+| July-6 Rec #2 | 2026-07-06 | Handle `stop_reason: "refusal"` in `AnthropicProvider.generate()` | Low — billing risk gone; Fable covered; non-Fable pass-through remains |
+| July-6 Rec #3 | 2026-07-06 | Bump `max_tokens=8192` for Opus 4.8 / Sonnet 5 | Partial — `claude-opus-5` registry correct; Opus 4.8 unchanged |
+| July-6 Rec #4 | 2026-07-06 | Audit `max_tokens` call sites for adaptive thinking | **Open (HIGH)** |
+| July-6 Rec #5 | 2026-07-06 | Sonnet 5 intro pricing ends Aug 31 | **CLOSED** — pricing locked permanently at $2/$10 |
+| June-29 Rec #2 | 2026-06-29 | Verify hook matchers for hyphenated MCP server names | Open (low) |
+| June-29 Rec #3 | 2026-06-29 | `autoMode.classifyAllShell` awareness | Open (low) |
+| June-22 Rec #1 | 2026-06-22 | Adjust release workflows for destructive git blocking | Open (medium) |
+| June-22 Rec #2 | 2026-06-22 | Investigate prompt caching on `_CITATION_BASE_URL` | Open |
+| June-22 Rec #3 | 2026-06-22 | `Tool(param:value)` permission rules for cost control | Open (low) |
+| June-22 Rec #4 | 2026-06-22 | Set `CLAUDE_CODE_CLIENT_PRESENCE_FILE` for scheduled runs | Open (low) |
+| June-8 Rec #4 | 2026-06-08 | Stop hooks `additionalContext` for session-stash | Open (low) |
+| July-13 Rec #1 | 2026-07-13 | Set expiry + rotation reminder on ANTHROPIC_API_KEY | Open (low) |
+| July-13 Rec #2 | 2026-07-13 | Run `/doctor` in next interactive session | Open (low) |
+| July-20 Rec #1 | 2026-07-20 | Verify hook `ask` path in auto mode post-v2.1.211 | **Open (HIGH)** |
+| July-20 Rec #2 | 2026-07-20 | Confirm `Edit(tests/unit/**)` scope after v2.1.214 fix | Open (medium) |
+| July-20 Rec #3 | 2026-07-20 | Test long MCP tools with auto-background behavior | Open (medium) — more urgent now that backgrounding is default |
+| July-20 Rec #5 | 2026-07-20 | Scan prompts for "Claude will run /verify after changes" | Open (low) |
+| July-27 Rec #1 | 2026-07-27 | Upgrade batch premium target to `claude-opus-5` | **Open (MEDIUM-HIGH)** — `_BATCH_PREMIUM_FALLBACK = "claude-opus-4-8"` confirmed unchanged |
+| July-27 Rec #2 | 2026-07-27 | Escalated max_tokens for Opus 5 | Partial — registry correct; batch fallback still Opus 4.8 |
+| July-27 Rec #3 | 2026-07-27 | Add `sandbox.network.strictAllowlist` to settings | **Open (MEDIUM)** — not in `.claude/settings.json` |
+| July-27 Rec #6 | 2026-07-27 | Update Fable fallbacks to include Opus 5 | **Open (MEDIUM)** — `_FABLE_FALLBACKS = [{"model": "claude-opus-4-8"}]` confirmed unchanged |
+| Aug-03 Rec #1 | 2026-08-03 | `mcp_server_errors` in headless init events | Open (medium) |
+| Aug-03 Rec #2 | 2026-08-03 | Nested subagent depth 3 — design space for crew layer | Open (low) |
+| Aug-03 Rec #3 | 2026-08-03 | Set `workflowSizeGuideline` in `.claude/settings.json` | **Open (low)** — not in settings, confirmed |
+| Aug-03 Rec #4 | 2026-08-03 | Track Python MCP SDK for spec 2026-07-28 compliance | Open (medium) |
+| Aug-10 Rec #1 | 2026-08-10 | Workbench sunset by Aug 17 — export saved prompts | **CLOSED** — sunset complete today |
+| Aug-10 Rec #2 | 2026-08-10 | Verify hook idempotency in background agent contexts | **OPEN (LOW)** — hooks have been running in background for 2 weeks; urgency reduced |
+| Aug-10 Rec #3 | 2026-08-10 | Refusal pass-through in non-Fable `AnthropicProvider` | Open (low) |
+| Aug-10 Rec #4 | 2026-08-10 | Unicode normalization in `validate_bash_command()` | Open (low) |
+
+**State check this week (live tree):**
+
+- `_BATCH_PREMIUM_FALLBACK = "claude-opus-4-8"` —
+  `src/attune/llm/providers/anthropic_batch.py:20`, unchanged (July-27
+  Rec #1 open)
+- `_FABLE_FALLBACKS = [{"model": "claude-opus-4-8"}]` —
+  `src/attune/model_tiers.py:58`, unchanged (July-27 Rec #6 open)
+- `.claude/settings.json` — only `permissions` and `hooks` keys; no
+  `sandbox.network.strictAllowlist` or `workflowSizeGuideline` (Rec #3
+  and Aug-03 Rec #3 open)
+
+---
+
+## Watch list
+
+- **Subagent backgrounding is now default.** July-20 Rec #3 (test long MCP
+  tools with auto-background) is more urgent now. Background is no longer
+  opt-in; any orchestration that didn't test under background-default
+  conditions should.
+- **`forward_user_identity` setting (v2.1.233).** New opt-in for Anthropic
+  upstreams to track per-user spend. If attune-ai serves multi-user
+  environments, this is the spend-attribution primitive. No action required
+  yet.
+- **"@" mention cross-session messaging (v2.1.232).** New primitive for
+  session-to-session communication. Complements `SendMessage`. Could
+  simplify crew coordination patterns.
+- **Todo/task tool deprecation trajectory.** If Anthropic removes them from
+  Sonnet 4.6 in a future version, the `CLAUDE_CODE_ENABLE_TODO_TOOLS=1`
+  env var becomes the only restoration path. Monitor.
+
+---
+
+## No-ops
+
+| Item | Why skipped |
+|---|---|
+| Compliance API local transcript retrieval (Aug 11) | Enterprise beta only; attune is not Enterprise |
+| v2.1.231 MCP OAuth redirect URI fix | Attune MCP uses non-OAuth connections |
+| v2.1.228-2.1.229 Windows Git/Git Bash fixes | No Windows deployment in stack |
+| v2.1.232 GitLab token redaction / marketplace | Stack uses GitHub, not GitLab |
+| v2.1.233 GitLab MR URL support | Stack uses GitHub |
+| v2.1.232 Remote Control session fixes | Not in use in attune stack |
+| v2.1.229 SSE keepalive pings | Passive improvement; no action |
+| v2.1.233 `CLAUDE_CODE_TOOL_MEMORY_LIMIT` (Linux cgroups) | No memory-capped Bash use case currently |
+| v2.1.233 `CLAUDE_CODE_WEBFETCH_CACHE_TTL_MS` | No custom TTL need identified |
+| v2.1.227 Feature flag / expired login token fix | No expired-token scenario in attune |
+
+---
+
+## Sources checked
+
+- `platform.claude.com/docs/en/release-notes/overview` — Aug 10-11 entries
+- `raw.githubusercontent.com/anthropics/claude-code/main/CHANGELOG.md`
+  — v2.1.227 through v2.1.233
+- GitHub release pages for v2.1.227, v2.1.228, v2.1.229
+- `src/attune/llm/providers/anthropic_batch.py`,
+  `src/attune/model_tiers.py`, `.claude/settings.json`
+- Prior report: `weekly-reports/2026-08-10.md`


### PR DESCRIPTION
# Anthropic Ecosystem Weekly — 2026-08-17

## Summary

The Sonnet 5 $2/$10 pricing is now permanent — no September 1 increase.
That closes a six-week escalating carry-over. Claude Code shipped seven
versions (v2.1.227-2.1.233) with two stack-relevant behavioral changes:
todo/task tools are deprecated on newer models, and subagent forking is
now on by default.

---

## Recommendations

**1. Todo/task tools deprecated on newer models — assess CLAUDE.md guidance
(MEDIUM)**

v2.1.233 deprecated `TaskCreate`, `TaskUpdate`, `TaskList`, `TaskStop`,
`TaskGet`, and `TaskOutput` on newer models (Fable 5 / Opus 5). The tools
still appear in sessions running on Sonnet 4.6 (confirmed in this session's
deferred-tools list), so the immediate impact is only on attune crew sessions
that escalate to Fable 5 or Opus 5. Set `CLAUDE_CODE_ENABLE_TODO_TOOLS=1` in
the project environment or `.claude/settings.json` to restore them.

The longer view: the existing CLAUDE.md already favors XML-task format for
3+ task work and the decision-routine explicitly prefers XML prompts. The
task tools were baked into Claude Code's own system prompt as a planning
primitive. Their removal on newer models suggests Anthropic is moving toward
a different pattern (most likely inline planning or native context). Now is a
reasonable time to confirm whether attune's crew/agent sessions rely on task
tools implicitly (via the harness system prompt) and whether restoring them
is the right call or whether XML-first is good enough.

- **Applies to:** attune crew sessions on Fable 5 / Opus 5; review
  `.claude/settings.json` and crew session configurations
- **Action:** If crew sessions use Fable 5 or Opus 5, add
  `CLAUDE_CODE_ENABLE_TODO_TOOLS=1` to the environment or test without and
  verify planning quality holds
- **Urgency:** Medium — doesn't affect Sonnet 4.6 sessions yet

---

**2. Subagent forking now on by default — verify crew layer (MEDIUM)**

v2.1.232: non-teammate agents now run backgrounded by default. Previously
this required an explicit opt-in. Any attune crew orchestration that assumed
synchronous subagent completion needs to be verified under the new default.
Background agents complete independently; results arrive via notification
rather than inline. The crew layer's `team.py` and `release_prep_team.py`
are the most likely to be affected.

Also in v2.1.232: `@mention` in prompts enables direct session-to-session
messaging. This is a new multi-agent communication primitive that is now
available alongside the `SendMessage` tool already in the harness. No
required action, but it's a design option for future crew work.

- **Applies to:** `src/attune/agents/team.py`,
  `src/attune/agents/release/release_prep_team.py`
- **Action:** Run a test crew session and confirm results arrive as expected
  under backgrounded-by-default behavior
- **Urgency:** Medium

---

**3. Server-supplied hooks for self-hosted runner (LOW)**

v2.1.229: self-hosted runner sessions now accept server-supplied Claude Code
hooks. This means `security_guard.py` and other attune hooks don't need to
be present in every repository; they can be configured centrally at the
runner level. Relevant if attune-ops is running self-hosted runner sessions.
No code change required now, but worth knowing for infrastructure planning.

- **Applies to:** attune-ops self-hosted runner configuration (if active)
- **Urgency:** Low

---

**4. `anthropic-workspace-id` header for telemetry (INFO)**

The API now returns `anthropic-workspace-id: wrkspc_xxx` on every response,
identifying which workspace the API key resolved to. The attune telemetry
layer could record this field to disambiguate usage across workspaces without
any extra API calls. No urgency; file as a future telemetry enhancement.

- **Applies to:** `src/attune/telemetry/` if workspace-level cost tracking
  is desired
- **Urgency:** Informational

---

## Carry-overs

| # | First raised | Recommendation | Status |
|---|---|---|---|
| July-6 Rec #2 | 2026-07-06 | Handle `stop_reason: "refusal"` in `AnthropicProvider.generate()` | Low — billing risk gone; Fable covered; non-Fable pass-through remains |
| July-6 Rec #3 | 2026-07-06 | Bump `max_tokens=8192` for Opus 4.8 / Sonnet 5 | Partial — `claude-opus-5` registry correct; Opus 4.8 unchanged |
| July-6 Rec #4 | 2026-07-06 | Audit `max_tokens` call sites for adaptive thinking | **Open (HIGH)** |
| July-6 Rec #5 | 2026-07-06 | Sonnet 5 intro pricing ends Aug 31 | **CLOSED** — pricing locked permanently at $2/$10 |
| June-29 Rec #2 | 2026-06-29 | Verify hook matchers for hyphenated MCP server names | Open (low) |
| June-29 Rec #3 | 2026-06-29 | `autoMode.classifyAllShell` awareness | Open (low) |
| June-22 Rec #1 | 2026-06-22 | Adjust release workflows for destructive git blocking | Open (medium) |
| June-22 Rec #2 | 2026-06-22 | Investigate prompt caching on `_CITATION_BASE_URL` | Open |
| June-22 Rec #3 | 2026-06-22 | `Tool(param:value)` permission rules for cost control | Open (low) |
| June-22 Rec #4 | 2026-06-22 | Set `CLAUDE_CODE_CLIENT_PRESENCE_FILE` for scheduled runs | Open (low) |
| June-8 Rec #4 | 2026-06-08 | Stop hooks `additionalContext` for session-stash | Open (low) |
| July-13 Rec #1 | 2026-07-13 | Set expiry + rotation reminder on ANTHROPIC_API_KEY | Open (low) |
| July-13 Rec #2 | 2026-07-13 | Run `/doctor` in next interactive session | Open (low) |
| July-20 Rec #1 | 2026-07-20 | Verify hook `ask` path in auto mode post-v2.1.211 | **Open (HIGH)** |
| July-20 Rec #2 | 2026-07-20 | Confirm `Edit(tests/unit/**)` scope after v2.1.214 fix | Open (medium) |
| July-20 Rec #3 | 2026-07-20 | Test long MCP tools with auto-background behavior | Open (medium) — more urgent now that backgrounding is default |
| July-20 Rec #5 | 2026-07-20 | Scan prompts for "Claude will run /verify after changes" | Open (low) |
| July-27 Rec #1 | 2026-07-27 | Upgrade batch premium target to `claude-opus-5` | **Open (MEDIUM-HIGH)** — `_BATCH_PREMIUM_FALLBACK = "claude-opus-4-8"` confirmed unchanged |
| July-27 Rec #2 | 2026-07-27 | Escalated max_tokens for Opus 5 | Partial — registry correct; batch fallback still Opus 4.8 |
| July-27 Rec #3 | 2026-07-27 | Add `sandbox.network.strictAllowlist` to settings | **Open (MEDIUM)** — not in `.claude/settings.json` |
| July-27 Rec #6 | 2026-07-27 | Update Fable fallbacks to include Opus 5 | **Open (MEDIUM)** — `_FABLE_FALLBACKS = [{"model": "claude-opus-4-8"}]` confirmed unchanged |
| Aug-03 Rec #1 | 2026-08-03 | `mcp_server_errors` in headless init events | Open (medium) |
| Aug-03 Rec #2 | 2026-08-03 | Nested subagent depth 3 — design space for crew layer | Open (low) |
| Aug-03 Rec #3 | 2026-08-03 | Set `workflowSizeGuideline` in `.claude/settings.json` | Open (low) — not in settings, confirmed |
| Aug-03 Rec #4 | 2026-08-03 | Track Python MCP SDK for spec 2026-07-28 compliance | Open (medium) |
| Aug-10 Rec #1 | 2026-08-10 | Workbench sunset by Aug 17 — export saved prompts | **CLOSED** — sunset complete today |
| Aug-10 Rec #2 | 2026-08-10 | Verify hook idempotency in background agent contexts | Open (low) — urgency reduced after 2 weeks without incident |
| Aug-10 Rec #3 | 2026-08-10 | Refusal pass-through in non-Fable `AnthropicProvider` | Open (low) |
| Aug-10 Rec #4 | 2026-08-10 | Unicode normalization in `validate_bash_command()` | Open (low) |

**State check this week (live tree):**

- `_BATCH_PREMIUM_FALLBACK = "claude-opus-4-8"` —
  `src/attune/llm/providers/anthropic_batch.py:20`, unchanged
- `_FABLE_FALLBACKS = [{"model": "claude-opus-4-8"}]` —
  `src/attune/model_tiers.py:58`, unchanged
- `.claude/settings.json` — only `permissions` and `hooks` keys; no
  `sandbox.network.strictAllowlist` or `workflowSizeGuideline`

---

## Watch list

- **Subagent backgrounding is now default.** July-20 Rec #3 (test long MCP
  tools with auto-background) is more urgent now. Background is no longer
  opt-in; any orchestration that didn't test under background-default
  conditions should.
- **`forward_user_identity` setting (v2.1.233).** New opt-in for Anthropic
  upstreams to track per-user spend. If attune-ai serves multi-user
  environments, this is the spend-attribution primitive. No action required
  yet.
- **`@` mention cross-session messaging (v2.1.232).** New primitive for
  session-to-session communication. Complements `SendMessage`. Could
  simplify crew coordination patterns.
- **Todo/task tool deprecation trajectory.** If Anthropic removes them from
  Sonnet 4.6 in a future version, the `CLAUDE_CODE_ENABLE_TODO_TOOLS=1`
  env var becomes the only restoration path. Monitor.

---

## No-ops

| Item | Why skipped |
|---|---|
| Compliance API local transcript retrieval (Aug 11) | Enterprise beta only; attune is not Enterprise |
| v2.1.231 MCP OAuth redirect URI fix | Attune MCP uses non-OAuth connections |
| v2.1.228-2.1.229 Windows Git/Git Bash fixes | No Windows deployment in stack |
| v2.1.232 GitLab token redaction / marketplace | Stack uses GitHub, not GitLab |
| v2.1.233 GitLab MR URL support | Stack uses GitHub |
| v2.1.232 Remote Control session fixes | Not in use in attune stack |
| v2.1.229 SSE keepalive pings | Passive improvement; no action |
| v2.1.233 `CLAUDE_CODE_TOOL_MEMORY_LIMIT` (Linux cgroups) | No memory-capped Bash use case currently |
| v2.1.233 `CLAUDE_CODE_WEBFETCH_CACHE_TTL_MS` | No custom TTL need identified |
| v2.1.227 Feature flag / expired login token fix | No expired-token scenario in attune |

---
_Generated by [Claude Code](https://claude.ai/code/session_01CSwaJXxDTtarJjp8szQg4i)_