### PR TITLE
test(hooks): close the #2086 patch-coverage gaps in the starter hooks

### DIFF
--- a/tests/unit/hooks/test_starter_prompt_nudge.py
+++ b/tests/unit/hooks/test_starter_prompt_nudge.py
@@ -12,6 +12,7 @@ Covers:
 from __future__ import annotations
 
 import importlib.util
+import subprocess
 import sys
 import time
 from pathlib import Path
@@ -229,6 +230,19 @@ class TestFindHandoff:
         (tmp_path / ".git").mkdir()
         assert hook_module.find_handoff(tmp_path) is None
 
+    def test_empty_branch_handoff_falls_through_to_newest(self, hook_module, tmp_path, monkeypatch):
+        """An empty branch-slug file must not win — the newest
+        non-empty handoff is surfaced instead."""
+        repo = self._make_repo(tmp_path)
+        d = repo / "docs" / "handoffs"
+        (d / "claude-my-branch.md").write_text("", encoding="utf-8")
+        (d / "other.md").write_text("fallback\n", encoding="utf-8")
+        monkeypatch.setattr(hook_module, "_current_branch", lambda root: "claude/my-branch")
+        found = hook_module.find_handoff(repo)
+        assert found is not None
+        assert found[0].name == "other.md"
+        assert found[1] == "handoff:newest"
+
     def test_handoff_emitted_first_by_main(self, hook_module, tmp_path, monkeypatch, capsys):
         repo = self._make_repo(tmp_path)
         d = repo / "docs" / "handoffs"
@@ -273,6 +287,85 @@ class TestAgeFormatter:
         real_now = time.time()
         # 90 minutes ago → comfortably in the hours bucket [60m, 24h).
         assert hook_module._format_age(real_now - 5400) == "1h ago"
+
+
+class TestRepoRoot:
+    """Cover _repo_root (found, not-found, default-cwd)."""
+
+    def test_finds_git_toplevel(self, hook_module, tmp_path):
+        (tmp_path / ".git").mkdir()
+        nested = tmp_path / "a" / "b"
+        nested.mkdir(parents=True)
+        assert hook_module._repo_root(start=nested) == tmp_path
+
+    def test_none_when_no_repo(self, hook_module, tmp_path):
+        assert hook_module._repo_root(start=tmp_path) is None
+
+    def test_default_start_uses_cwd(self, hook_module, tmp_path, monkeypatch):
+        (tmp_path / ".git").mkdir()
+        monkeypatch.chdir(tmp_path)
+        assert hook_module._repo_root() == tmp_path
+
+
+class TestCurrentBranch:
+    """_current_branch returns the branch, degrading to None on every
+    git failure shape (error exit, detached HEAD, timeout)."""
+
+    class _Proc:
+        def __init__(self, returncode: int, stdout: str) -> None:
+            self.returncode = returncode
+            self.stdout = stdout
+
+    def test_returns_branch_name(self, hook_module, monkeypatch):
+        monkeypatch.setattr(
+            hook_module.subprocess,
+            "run",
+            lambda *a, **k: self._Proc(0, "claude/my-branch\n"),
+        )
+        assert hook_module._current_branch(Path("/repo")) == "claude/my-branch"
+
+    def test_none_on_nonzero_exit(self, hook_module, monkeypatch):
+        monkeypatch.setattr(
+            hook_module.subprocess,
+            "run",
+            lambda *a, **k: self._Proc(128, ""),
+        )
+        assert hook_module._current_branch(Path("/repo")) is None
+
+    def test_none_on_detached_head_empty_stdout(self, hook_module, monkeypatch):
+        monkeypatch.setattr(
+            hook_module.subprocess,
+            "run",
+            lambda *a, **k: self._Proc(0, "\n"),
+        )
+        assert hook_module._current_branch(Path("/repo")) is None
+
+    def test_none_on_timeout(self, hook_module, monkeypatch):
+        def raise_timeout(*a, **k):
+            raise subprocess.TimeoutExpired(cmd="git", timeout=3)
+
+        monkeypatch.setattr(hook_module.subprocess, "run", raise_timeout)
+        assert hook_module._current_branch(Path("/repo")) is None
+
+
+class TestStatDegrade:
+    """Cross-review F4: a handoff vanishing mid-scan degrades to
+    0 / 0.0 instead of crashing the hook."""
+
+    class _VanishingPath:
+        """Duck-typed path whose stat() raises after is_file() says True."""
+
+        def is_file(self) -> bool:
+            return True
+
+        def stat(self):
+            raise OSError("vanished mid-scan")
+
+    def test_size_oserror_returns_zero(self, hook_module):
+        assert hook_module._size_or_zero(self._VanishingPath()) == 0
+
+    def test_mtime_missing_file_returns_zero(self, hook_module, tmp_path):
+        assert hook_module._mtime_or_zero(tmp_path / "missing.md") == 0.0
 
 
 class TestErrorHandling:

--- a/tests/unit/hooks/test_starter_reconciler.py
+++ b/tests/unit/hooks/test_starter_reconciler.py
@@ -783,3 +783,88 @@ class TestStampPathGuard:
         assert hook_module.main() == 1
         assert target.read_text(encoding="utf-8") == "{}"
         assert "refusing to stamp" in capsys.readouterr().err
+
+
+class TestStarterAgeNaiveStamp:
+    """A naive (tz-less) written_at is treated as UTC, not rejected."""
+
+    def test_naive_written_at_treated_as_utc(self, hook_module):
+        age = hook_module.starter_age_hours({"written_at": "2020-01-01T00:00:00"})
+        assert age is not None
+        assert age > 0
+
+
+class TestStampProvenanceDegrade:
+    """With no derivable git identity (no repo root, every git call
+    failing) the stamp still writes — provenance degrades to the
+    written_at field alone rather than erroring (D2: absence soft)."""
+
+    def test_stamps_written_at_only(self, hook_module, tmp_path, monkeypatch):
+        monkeypatch.setattr(hook_module, "_run", lambda *a, **k: None)
+        target = tmp_path / "starter.md"
+        target.write_text("body\n", encoding="utf-8")
+
+        block = hook_module.stamp_provenance(target, None)
+
+        assert "written_at:" in block
+        for absent in ("repo:", "branch:", "head_sha:"):
+            assert absent not in block
+        text = target.read_text(encoding="utf-8")
+        assert text.startswith("---\n")
+        assert text.endswith("body\n")
+
+
+class TestSpecLinesNoClosed:
+    """Specs line renders without the closed-spec warning when no
+    mentioned spec is in a terminal status."""
+
+    def test_active_specs_render_without_warning(self, hook_module):
+        lines = hook_module._spec_lines({"my-spec": "active: in progress"})
+        assert lines == ["  specs: my-spec=active: in progress"]
+
+
+class TestStampMainDefaultTargets:
+    """main() --stamp with no explicit target derives the default:
+    the project-local starter when a repo root exists, else the
+    global starter — creating the file when absent."""
+
+    def test_defaults_to_project_starter(self, hook_module, tmp_path, monkeypatch, capsys):
+        monkeypatch.setattr(hook_module.sys, "argv", ["prog", "--stamp"])
+        monkeypatch.setattr(hook_module, "_repo_root", lambda *a, **k: tmp_path)
+        monkeypatch.setattr(hook_module, "_run", lambda *a, **k: None)
+
+        assert hook_module.main() == 0
+
+        target = tmp_path / ".attune" / "next_session_starter.md"
+        assert target.is_file()
+        text = target.read_text(encoding="utf-8")
+        assert text.startswith("---\n")
+        assert "written_at:" in text
+        assert f"stamped {target}" in capsys.readouterr().out
+
+    def test_explicit_existing_target_keeps_body(self, hook_module, tmp_path, monkeypatch, capsys):
+        target = tmp_path / "starter.md"
+        target.write_text("existing body\n", encoding="utf-8")
+        monkeypatch.setattr(hook_module.sys, "argv", ["prog", "--stamp", str(target)])
+        monkeypatch.setattr(hook_module, "_repo_root", lambda *a, **k: None)
+        monkeypatch.setattr(hook_module, "_run", lambda *a, **k: None)
+
+        assert hook_module.main() == 0
+
+        text = target.read_text(encoding="utf-8")
+        assert text.startswith("---\n")
+        assert text.endswith("existing body\n")
+        assert "stamped" in capsys.readouterr().out
+
+    def test_defaults_to_global_when_no_repo(self, hook_module, tmp_path, monkeypatch, capsys):
+        monkeypatch.setattr(hook_module.sys, "argv", ["prog", "--stamp"])
+        monkeypatch.setattr(hook_module, "_repo_root", lambda *a, **k: None)
+        monkeypatch.setattr(hook_module, "_run", lambda *a, **k: None)
+        global_starter = tmp_path / "home" / ".attune" / "next_session_starter.md"
+        monkeypatch.setattr(hook_module, "STARTER_PATH", global_starter)
+
+        assert hook_module.main() == 0
+
+        assert global_starter.is_file()
+        assert "written_at:" in global_starter.read_text(encoding="utf-8")
+        assert f"stamped {global_starter}" in capsys.readouterr().out


### PR DESCRIPTION
## Description

Closes the Codecov patch-coverage debt left by #2086 (merged at 75.9% patch against the 80% gate). The two flagged hook scripts — `starter_prompt_nudge.py` (65.4% patch) and `starter_reconciler.py` (82.0% patch) — now measure **100.00% lines and branches**. Tests only, no source changes (Class 1).

The missing regions were exactly the pieces every existing test stubbed out, plus degrade branches:

- `starter_prompt_nudge.py`: the `_repo_root` walk (found / not-found / default-cwd), `_current_branch` against subprocess stubs (branch name, non-zero exit, detached-HEAD empty stdout, timeout), the `_size_or_zero` / `_mtime_or_zero` OSError degrades (cross-review F4), and an empty branch-slug handoff falling through to `handoff:newest`
- `starter_reconciler.py`: naive `written_at` treated as UTC, `stamp_provenance` degrading to `written_at`-only when no git identity is derivable (D2: absence soft), `_spec_lines` without terminal-status specs emitting no warning, and `main --stamp` default-target derivation (project starter with a repo root, global starter without) plus stamping an existing explicit target

## Type of Change

- [x] ✅ Test update

## Related Issues

Related to #2086 (the merge that carried the debt) and #1569 (test-quality program — the patch-debt pattern is recorded there).

## Changes Made

- `tests/unit/hooks/test_starter_prompt_nudge.py`: three new classes (`TestRepoRoot`, `TestCurrentBranch`, `TestStatDegrade`) plus an empty-branch-handoff fallthrough case in `TestFindHandoff` — 9 new tests
- `tests/unit/hooks/test_starter_reconciler.py`: four new classes (`TestStarterAgeNaiveStamp`, `TestStampProvenanceDegrade`, `TestSpecLinesNoClosed`, `TestStampMainDefaultTargets`) — 7 new tests

## Testing

- [x] All existing tests pass
- [x] Added new tests for new functionality
- [ ] Tested on multiple Python versions (3.10, 3.11, 3.12) — CI matrix
- [ ] Tested on multiple platforms (Linux, macOS, Windows) — CI matrix; new tests are subprocess-stubbed, no new platform surface
- [x] Manual testing performed (coverage measured, see below)

### Test Commands Run

```bash
# Serial, exact tail: 117 passed
.venv/bin/python -m pytest tests/unit/hooks/test_starter_prompt_nudge.py \
  tests/unit/hooks/test_starter_reconciler.py -p no:xdist -o addopts= -q

# Coverage receipt — both scripts 100.00% lines + branches:
#   add --cov=src/attune/hooks/scripts --cov-report=term-missing
```

## Checklist

- [x] My code follows the project's code style (Black, Ruff) — pinned hooks pre-flighted before staging
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Pre-commit hooks pass without errors

## Additional Context

Coverage-measurement note for future hook lanes: these scripts are loaded via `spec_from_file_location`, so module-name `--cov` collects nothing and misreads as "tests don't exercise the module" — measure by path (`--cov=src/attune/hooks/scripts`). Routed through the docs outbox as a lesson.

## License Acknowledgment

- [x] I confirm that my contributions are made under the Apache License 2.0
- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X4DaG8bXMKvC1nnzFnnZ37

---
_Generated by [Claude Code](https://claude.ai/code/session_01X4DaG8bXMKvC1nnzFnnZ37)_