### PR TITLE
feat(context): ladder-outcome telemetry on fit_source

### DIFF
--- a/src/attune/context/allocator.py
+++ b/src/attune/context/allocator.py
@@ -22,6 +22,12 @@ class TokenBudgetAllocator:
         """
         self.default_token_limit = default_token_limit
         self.generator = ASTSkeletonGenerator()
+        #: Outcome of the most recent :meth:`fit_source` call, or None
+        #: before the first call. Keys: ``rung`` (``full`` /
+        #: ``skeleton`` / ``truncated_skeleton`` / ``plain_truncation``),
+        #: ``token_limit``, ``source_tokens`` (estimate), and
+        #: ``result_tokens`` (estimate of what was returned).
+        self.last_fit: dict[str, int | str] | None = None
 
     def allocate_context(
         self,
@@ -101,12 +107,42 @@ class TokenBudgetAllocator:
             whichever is the richest representation within budget.
         """
         limit = token_limit or self.default_token_limit
-        if self._estimate_tokens(source) <= limit:
+        source_tokens = self._estimate_tokens(source)
+        if source_tokens <= limit:
+            self._record_fit("full", limit, source_tokens, source_tokens)
             return source
         skeleton = self.generator.generate_skeleton(source)
-        if self._estimate_tokens(skeleton) <= limit:
+        skeleton_tokens = self._estimate_tokens(skeleton)
+        if skeleton_tokens <= limit:
+            self._record_fit("skeleton", limit, source_tokens, skeleton_tokens)
             return skeleton
+        # A skeleton identical to the source means the AST step could
+        # not help (non-Python or unparseable) — the truncation below
+        # is then plain truncation, not a truncated skeleton.
+        rung = "plain_truncation" if skeleton == source else "truncated_skeleton"
+        self._record_fit(rung, limit, source_tokens, limit)
         return skeleton[: limit * 4] + f"\n# ... truncated at token limit {limit}\n"
+
+    def _record_fit(self, rung: str, limit: int, source_tokens: int, result_tokens: int) -> None:
+        """Record a fit_source outcome on the instance and the log.
+
+        The log line is the durable measurement surface (grep
+        ``context_fit`` across run logs to see rung frequency and
+        truncation rates); ``last_fit`` is the programmatic one.
+        """
+        self.last_fit = {
+            "rung": rung,
+            "token_limit": limit,
+            "source_tokens": source_tokens,
+            "result_tokens": result_tokens,
+        }
+        logger.info(
+            "context_fit rung=%s token_limit=%d source_tokens=%d result_tokens=%d",
+            rung,
+            limit,
+            source_tokens,
+            result_tokens,
+        )
 
     def _estimate_tokens(self, text: str) -> int:
         """Heuristic token estimation (approx 4 chars per token)."""

--- a/tests/unit/context/test_fit_telemetry.py
+++ b/tests/unit/context/test_fit_telemetry.py
@@ -1,0 +1,87 @@
+"""Ladder-outcome telemetry for TokenBudgetAllocator.fit_source.
+
+Roundtable q-context-mgmt-features-001 consensus item 1 (the
+evidence base): every fit_source call records which rung of the
+budget ladder fired — on the instance (``last_fit``) and as a
+``context_fit`` log line — so budget starvation and truncation
+frequency are measurable instead of folklore.
+"""
+
+import logging
+
+from attune.context import TokenBudgetAllocator
+
+PY_SOURCE = '''
+def alpha(x: int) -> int:
+    """Adds one."""
+    return x + 1
+
+
+def beta(y: int) -> int:
+    """Doubles."""
+    return y * 2
+'''
+
+
+class TestFitTelemetry:
+    """Each ladder rung records an accurate last_fit outcome."""
+
+    def test_no_call_yet_is_none(self):
+        assert TokenBudgetAllocator().last_fit is None
+
+    def test_full_rung(self):
+        allocator = TokenBudgetAllocator()
+        result = allocator.fit_source(PY_SOURCE, token_limit=4000)
+        assert result == PY_SOURCE
+        assert allocator.last_fit is not None
+        assert allocator.last_fit["rung"] == "full"
+        assert allocator.last_fit["token_limit"] == 4000
+        assert allocator.last_fit["source_tokens"] == len(PY_SOURCE) // 4
+        assert allocator.last_fit["result_tokens"] == allocator.last_fit["source_tokens"]
+
+    def test_skeleton_rung(self):
+        allocator = TokenBudgetAllocator()
+        big = PY_SOURCE + "\n" + ("# pad\n" * 200)
+        limit = (len(big) // 4) - 1
+        result = allocator.fit_source(big, token_limit=limit)
+        assert result != big
+        assert allocator.last_fit is not None
+        assert allocator.last_fit["rung"] == "skeleton"
+        assert allocator.last_fit["source_tokens"] > limit
+        assert allocator.last_fit["result_tokens"] <= limit
+
+    def test_truncated_skeleton_rung(self):
+        allocator = TokenBudgetAllocator()
+        many = "\n".join(
+            f'def f{i}(x: int) -> int:\n    """Doc {i}."""\n    return x' for i in range(200)
+        )
+        result = allocator.fit_source(many, token_limit=50)
+        assert "truncated at token limit 50" in result
+        assert allocator.last_fit is not None
+        assert allocator.last_fit["rung"] == "truncated_skeleton"
+
+    def test_plain_truncation_rung_for_non_python(self):
+        allocator = TokenBudgetAllocator()
+        prose = "word " * 500
+        result = allocator.fit_source(prose, token_limit=20)
+        assert "truncated at token limit 20" in result
+        assert allocator.last_fit is not None
+        assert allocator.last_fit["rung"] == "plain_truncation"
+
+    def test_context_fit_log_line_emitted(self, caplog):
+        allocator = TokenBudgetAllocator()
+        with caplog.at_level(logging.INFO, logger="attune.context.allocator"):
+            allocator.fit_source(PY_SOURCE, token_limit=4000)
+        fit_records = [r for r in caplog.records if "context_fit" in r.getMessage()]
+        assert len(fit_records) == 1
+        message = fit_records[0].getMessage()
+        assert "rung=full" in message
+        assert "token_limit=4000" in message
+
+    def test_last_fit_overwritten_per_call(self):
+        allocator = TokenBudgetAllocator()
+        allocator.fit_source(PY_SOURCE, token_limit=4000)
+        assert allocator.last_fit is not None
+        assert allocator.last_fit["rung"] == "full"
+        allocator.fit_source("word " * 500, token_limit=20)
+        assert allocator.last_fit["rung"] == "plain_truncation"


### PR DESCRIPTION
Realizes consensus item 1 from roundtable q-context-mgmt-features-001 (promoted stub: PR #2094): the evidence base for the chars÷4 budgets.

Every `fit_source` call now records which ladder rung fired — `full` / `skeleton` / `truncated_skeleton` / `plain_truncation` (skeleton-identical-to-source detection separates the last two) — with token-estimate fields, both as a `context_fit` log line (grep across run logs for rung frequency and truncation rates) and as an `allocator.last_fit` dict (programmatic, no API break).

**Consumer-survey receipt (consensus item 2):** the table's candidate consumer list is EMPTY in current code — deep_review / refactor_plan / bug_predict are SDK-native (path + Read/Grep tools, no source in prompts), document_gen's remaining stages use structured AST extraction, and batch_processing's `{code}` has no truncation to fix. #2088's four sites were the complete set. Cross-file stays design-gated; cache stays deferred; inflation stays dead — all per the promoted consensus.

7 new tests (each rung + log emission + overwrite semantics); context suite 39 passed serially.

🤖 Generated with [Claude Code](https://claude.com/claude-code)