### PR TITLE
docs(outbox): sweep 24 artifacts

### DIFF
--- a/.claude/lessons.md
+++ b/.claude/lessons.md
@@ -22256,3 +22256,489 @@ the numbers.
   tool calls from a different repo's worktree. Receipts beat
   mockups, and the provenance chain (decisions.md D-records →
   demo script → fresh response ID) comes along free.
+
+- **A skill's documented headless-browser `executablePath` is a
+  SANDBOX path — resolve the host's real playwright binary by
+  globbing `~/Library/Caches/ms-playwright/`, and expect the
+  arm64 Mac binary to be named "Google Chrome for Testing", not
+  "Chromium"**: hit 2026-08-11 on the scheduled morning-brief run,
+  whose skill prescribes
+  `chromium.launch({executablePath:'/opt/pw-browsers/chromium'})`
+  for its render check. That path is the skill sandbox's, not the
+  host's, so the launch failed. Three attempts were burned
+  guessing: (1) the documented `/opt/pw-browsers/chromium`;
+  (2) `~/Library/Caches/ms-playwright/chromium-1217/chrome-mac/
+  Chromium.app/...` — wrong on BOTH segments; (3) the same with
+  `chrome-mac-arm64` but still `Chromium.app`. The working path
+  on Apple Silicon is
+  `~/Library/Caches/ms-playwright/chromium-<rev>/chrome-mac-arm64/
+  Google Chrome for Testing.app/Contents/MacOS/Google Chrome for
+  Testing` — the `.app` and the binary inside it are BOTH named
+  "Google Chrome for Testing", and the parent dir carries the
+  `-arm64` suffix. Note also that a sibling
+  `chromium_headless_shell-<rev>/chrome-headless-shell-mac-arm64/
+  chrome-headless-shell` exists and is a valid alternative
+  target. **Rule:** never hand-construct a playwright browser
+  path from a doc or from memory — one `ls`/`find` over
+  `~/Library/Caches/ms-playwright/<pkg>-<rev>/` before the first
+  launch costs seconds and settles the revision, the arch suffix,
+  and the binary name at once. `chromium.launch()` with no
+  `executablePath` is NOT the fallback: it resolves a bundled
+  revision that may not be installed and suggests
+  `playwright install`, whose download is commonly blocked.
+  Generalizes past playwright: when a skill or doc hands you an
+  absolute binary path, treat it as authored against the author's
+  environment and verify it resolves before building a command
+  around it.
+
+- **The worktree-path-guard blocks Edit/Write to ANY tree outside the
+  session worktree — deliberate external-tree work (a new sibling repo,
+  e.g. the attune-forms extraction) must go through Bash-scripted
+  writes or an `ATTUNE_WORKTREE_GUARD_ALLOW` extension**: hit
+  2026-08-12 creating `~/attune-forms`. The guard's purpose is
+  catching ACCIDENTAL cross-tree writes (the Write-to-main-checkout
+  bug class), so a chair-ruled new repo outside the worktree is a
+  legitimate bypass case — python-heredoc/`sed` edits via Bash are the
+  low-friction path, since the env-var allowlist can't be set for the
+  hook process mid-session. If new-repo work becomes common, add the
+  parent dir to `DEFAULT_ALLOWED_EXTERNAL_ROOTS` in
+  `worktree_path_guard.py` instead of scripting around it repeatedly.
+
+- **Adding a dependency that is not yet on PyPI makes `git commit`
+  fail via the help-freshness pre-commit hook (`check-help-freshness`, formerly `regenerate-help-templates`) — its `uv`
+  resolve of the whole project cannot satisfy the new requirement, and
+  the commit dies on state orthogonal to the diff**: hit 2026-08-12
+  landing the attune-forms extraction (pyproject gained
+  `attune-forms>=0.1.0` before the package existed on PyPI). The
+  failure looks like a hook bug but is the extraction chicken-and-egg:
+  any PR that introduces a first-publish dependency cannot resolve
+  until the package is live. Interim commit path:
+  `SKIP=check-help-freshness git commit …` (hook renamed from `regenerate-help-templates` 2026-08-12) (surgical, defensible
+  — the hook fails on registry state, not the commit's content); CI
+  stays red for the same reason until the dependency publishes, so
+  sequence publish-first, PR-second. Also note the commit can take
+  >5 min wall-clock because that hook's resolve runs on every commit —
+  run it in the background rather than assuming a hang.
+
+- **`gh repo create --source . --push` can error "Name already exists
+  on this account" while having ALREADY created the repo and pushed —
+  verify with `gh repo view` before retrying or diagnosing**: hit
+  2026-08-12 creating `Smart-AI-Memory/attune-forms`. The command
+  printed only the GraphQL name-exists error, but `gh repo view
+  --json isEmpty,pushedAt` + a commits read showed the repo existed
+  WITH the local HEAD already pushed (a partial-success/retry race
+  inside the one invocation). Same family as "gh pr merge errored but
+  the remote merge succeeded": for any gh command with remote side
+  effects, an error message is not evidence the side effect didn't
+  happen — read the remote state before acting on the error. Also
+  note: the auto-created default branch follows the LOCAL branch name
+  (`master` from a bare `git init`), so rename to `main` + `gh api
+  -X PATCH -f default_branch=main` + delete the stray branch, or set
+  `init.defaultBranch` before the first commit.
+
+- **A `sys.modules` alias alone does NOT make the submodule reachable
+  as a parent-package ATTRIBUTE — the full os.path pattern requires
+  BOTH bindings, and the gap only surfaced on the Python 3.10 CI
+  lanes**: hit 2026-08-12 on the attune-forms extraction (PR #2058).
+  `sys.modules["attune.telemetry.form_events"] = attune_forms.form_events`
+  made every `import` form work, but plain attribute access
+  (`attune.telemetry.form_events.log_submission`, which
+  `monkeypatch.setattr` string targets also use) raised
+  `AttributeError` — 9 tests failed on all three OS lanes, 3.10 only,
+  while 3.12 lanes passed via a side-door import path and the local
+  3.11 suite was green (20,625 passed!). What os.py actually does is
+  BOTH: register the sys.modules entry AND bind the module as an
+  attribute (`path = posixpath`). Rule for any module-relocation shim:
+  set `sys.modules[f"{__name__}.{name}"] = mod` AND `<name> = mod` in
+  the package `__init__`; a synthetic two-file repro
+  (`uv run --python 3.10 --no-project`) confirms the mechanism in
+  seconds. Local-suite-green + one-CI-lane-green is NOT
+  version-portability evidence — the failure was invisible everywhere
+  except 3.10.
+
+- **AMENDS the core pre-commit lesson's pinned-tool command: `uv run
+  --with pre-commit pre-commit run <hook> --files <f>` fails
+  resolution in this repo (multi-python-version constraint solve);
+  the working form is `uvx pre-commit run <hook> --files <f>`**:
+  chair-ratified 2026-08-12 (retro item 7). `uv run --with` resolves
+  the WHOLE project plus the extra package across every supported
+  python version and dies on the same class of resolution error the
+  help-regen hook hits; `uvx` runs pre-commit in its own isolated
+  tool environment, reads `.pre-commit-config.yaml`, and uses the
+  PINNED hook revs exactly as the pre-flight discipline intends.
+  Wherever the corpus or CLAUDE.md core mirror prescribes
+  `uv run --with pre-commit …`, replace with `uvx pre-commit …`
+  (keep both copies in sync per the core-mirror drift guard).
+
+- **A docs-only PR red on TEST lanes usually means a projection
+  drift guard — check `test_help_bundle_sync` first: editing
+  `.help/templates/<feature>/` requires `scripts/sync_help_bundle.py`
+  in the same commit**: 2026-08-12, PR #2062 (a chip session's docs
+  refresh naming attune-forms as the substrate's home). The session
+  edited the `.help` single-source but never re-projected, so three
+  `plugin/help/generated/` files drifted and every OS lane failed the
+  same 2 tests. The failure looks alarming (6 red checks on a docs
+  PR) but the fix is mechanical: run `scripts/sync_help_bundle.py`,
+  commit the regenerated bundle + manifest/cross-links, done —
+  verified by `pytest tests/unit/help/test_help_bundle_sync.py`
+  locally before pushing. Prompt-authors: any chip/task prompt that
+  says "edit .help templates" should also say "then run
+  scripts/sync_help_bundle.py and commit the generated files".
+
+- **Fixing a PR whose branch is checked out in ANOTHER agent's
+  worktree: `git checkout <branch>` fails ("already exists" /
+  held-by-worktree) — stage on a local fix branch off the fetched
+  remote tip and push to the PR ref, never touch their tree**:
+  2026-08-12, fixing #2062 while the chip session's worktree held
+  `claude/hungry-spence-d79988`. Recipe: `git fetch origin <branch>`
+  → `git checkout -b fix/<n> origin/<branch>` → make the fix, commit
+  → `git push origin fix/<n>:<branch>`. The PR updates, the other
+  worktree is untouched (it can `git pull` if it resumes). Two
+  gotchas: (a) the failed `checkout` falls through SILENTLY — verify
+  `git log --oneline -1` shows the PR tip, not your previous branch,
+  before editing (the first sync ran against the wrong branch and
+  reported a meaningless "0 files synced"); (b) right after the
+  push, `gh pr view --json headRefOid` can still serve the OLD head
+  (propagation race) — confirm with `git ls-remote origin <branch>`
+  before diagnosing a failed push.
+
+- **`pre-commit run | grep -c Passed` is not a lint receipt — the
+  count reads healthy while a Failed auto-fix hook sits in the
+  output, and the unstaged fixes then fail CI's lint gate**: hit
+  2026-08-12 on the attune-forms P2 PR: local run showed "6" (six
+  Passed lines) while black had FAILED and reformatted two files;
+  the commit shipped the unformatted versions and CI's lint job
+  (added that same morning) went red — one full CI cycle burned.
+  The receipt is the FULL hook output (`grep -E "Failed|Passed"`)
+  plus `git status --short` afterward showing no modified files.
+  Same family as "exited 0 is not a receipt": a derived count that
+  can't go DOWN on failure measures nothing.
+
+- **`mcp` SDK 2.0 removed the decorator-based low-level Server API —
+  a server written for 1.x dies at import (`AttributeError: 'Server'
+  object has no attribute 'list_tools'`), and a fresh `uv pip install
+  mcp` now resolves 2.0**: hit 2026-08-12 building the attune-forms
+  standalone server. The 1.x style (`@server.list_tools()` /
+  `@server.call_tool()`, `mcp.server.stdio.stdio_server`) is what
+  attune-ai's server uses (pinned `mcp>=1.23.0`, lockfile 1.27); 2.0
+  replaced it with `add_request_handler`-style registration. The
+  protocol is wire-compatible — a 2.0 CLIENT talks to a 1.x server
+  fine, so the failure surfaces only server-side and only at spawn
+  ("MCPError: Connection closed" from the client is the visible
+  symptom; the real traceback is in the SERVER's stderr — capture it
+  with a direct `subprocess.Popen` probe, not through the client).
+  Rule: any new MCP server in this ecosystem pins `mcp>=1.23,<2.0`
+  until attune-ai's server migrates — matching SDK generations is
+  what keeps server convergence a pure swap.
+
+- **Post-publish verification, two traps in one chain: (a) `gh run
+  list --workflow=publish.yml --limit 1` right after a tag push can
+  return the PREVIOUS tag's completed run — "publish: success" then
+  describes the wrong release; (b) even the VERSION-SPECIFIC PyPI
+  endpoint (`/pypi/<pkg>/<ver>/json`) can 404 for minutes after a
+  genuinely successful upload**: hit 2026-08-12 on attune-forms
+  0.3.0 (same-day third release, runs seconds apart). The
+  authoritative receipt chain, in order: (1) the publish JOB's raw
+  log shows the PyPI `200 OK` + "View at: .../<ver>/" lines; (2) the
+  watched run's `headBranch` equals the tag you just pushed (match
+  the run to the tag — never trust bare `--limit 1` after a push);
+  (3) the version endpoint resolves (poll with an `until curl -sf`
+  loop in the background; it lags CDN-side). The simple index can
+  ALSO lag — a 404 + zero simple-index hits minutes after upload is
+  propagation, not failure, once the job log shows the 200.
+
+- **A locally-GREEN `uvx pre-commit run` can still lose to CI's lint
+  gate on the same pinned hook rev — settle formatter disputes by
+  running the EXACT pinned tool directly (`uvx black==<rev> <files>`),
+  not by re-running pre-commit**: hit twice same evening 2026-08-12 in
+  attune-forms (PRs #3, #5). On #5 the local `uvx pre-commit
+  run --all-files` reported black Passed while CI's `pipx run
+  pre-commit` reformatted a file — and the direct invocation
+  `uvx black==24.10.0 tests/test_version_sync.py` reproduced CI's
+  view immediately (the repo's `[tool.black] line-length = 100`
+  inlines calls the local pre-commit env's black left wrapped).
+  Mechanism unproven (cached pre-commit hook env is the suspect);
+  the durable rule doesn't need it: (1) after ADDING or changing a
+  formatter config section, pre-flight new files with the direct
+  pinned tool, not just pre-commit; (2) when CI lint disagrees with
+  a green local pre-commit, the tiebreaker is the direct pinned
+  invocation — whatever it produces is what CI wants.
+
+- **Headless-browser render checks on this Mac: the skill-documented
+  `/opt/pw-browsers/chromium` path does not exist, the `playwright`
+  npm package is not installed, and the binary is named `Google
+  Chrome for Testing.app` — not `Chromium.app`**: hit 2026-08-14 on
+  the scheduled `/morning` brief, whose Build section prescribes
+  `chromium.launch({executablePath:'/opt/pw-browsers/chromium'})`
+  (a sandbox path) and says to `npm install playwright` if the module
+  is missing. On this machine all three assumptions are wrong in a
+  way that costs a round-trip each: (1) `/opt/pw-browsers` is absent;
+  the browsers live under `~/Library/Caches/ms-playwright/`
+  (`chromium-1217`, `chromium_headless_shell-1217`, `ffmpeg-1011`);
+  (2) `playwright` resolves from nowhere — not globally
+  (`npm ls -g playwright` → empty), not from `~/node_modules`; (3)
+  the obvious guess at the binary path,
+  `chromium-1217/chrome-mac-arm64/Chromium.app/Contents/MacOS/
+  Chromium`, is a `no such file or directory` — the app bundle is
+  actually `Google Chrome for Testing.app/Contents/MacOS/Google
+  Chrome for Testing` (spaces in the path; quote it).
+  **Cheapest working recipe — skip playwright entirely**, since a
+  render check only needs a screenshot:
+  ```
+  "$HOME/Library/Caches/ms-playwright/chromium-1217/chrome-mac-arm64/Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing" \
+    --headless --disable-gpu --no-sandbox --hide-scrollbars \
+    --force-device-scale-factor=1 --window-size=960,2000 \
+    --screenshot=out.png "file:///abs/path.html"
+  ```
+  Headless Chrome's `--screenshot` captures the window box, not the
+  full document, so size `--window-size` past the expected page
+  height (or shoot twice) — a too-short window silently crops the
+  bottom of the page, which for a verify step means passing a
+  checklist against content you never saw. **Discovery move that
+  settles it in one command** rather than guessing bundle names:
+  `find ~/Library/Caches/ms-playwright/<rev> -maxdepth 5 -name "*.app"`.
+  Generalizes past this one skill: any skill authored against the
+  Anthropic sandbox may name absolute tool paths (`/mnt/skills/...`,
+  `/opt/...`) that do not exist on a local Claude Code host — treat a
+  skill's hard-coded binary path as a hypothesis to `ls` before
+  invoking, especially inside a SCHEDULED task where nobody is
+  watching the failure.
+
+- **Starter-reconciler PR lines can be cross-repo false verifications —
+`#N` references resolve against the CURRENT repo, not the repo the
+starter was written about**: found 2026-08-18 during a session-start
+context test. The global starter (`~/.attune/next_session_starter.md`)
+was written for a different project (IndianRailroadTicketing; its PRs
+#1–#8), but `starter_reconciler.py` extracts bare `#N` references and
+checks them against whatever repo the session opens in. In attune-ai
+that resolved to attune-ai's ancient PRs #1–#8 and printed
+"PRs: #1 MERGED · #2 MERGED · #3 CLOSED …" — a plausible-looking line
+that verified the WRONG repo's PRs. Until the reconciler is repo-aware
+(skip or mark `unverified` when the starter's subject repo doesn't
+match), treat its PR-status lines as trustworthy ONLY when the starter
+was written for the current repo; a starter that names another project
+in its title/heading is the tell. Companion finding, personal infra
+(fixed separately, not repo code): `~/.claude/hooks/
+session_start_orientation.sh` grepped `**Status**:` while specs write
+`**Status:**`, so 53/55 spec statuses rendered "(unknown)" — when an
+orientation surface shows near-uniform unknowns, suspect the parser's
+format assumption before concluding the corpus lacks the field.
+
+- **A targeted-suite green run is NOT a gate-suite green run — the
+  repo's drift-guard gates scan ALL of `src/attune/`, so any diff
+  adding file ops/subprocess/identifiers there can fail a gate you
+  never executed locally**: 2026-08-18, PR #2086. All four touched
+  test suites passed serially; CI then failed EVERY lane on
+  `tests/unit/gates/test_path_validation_gate.py` — the new
+  `--stamp` writer added `write_text` calls to a hook module, and
+  the AST gate (which scans src/attune wholesale) flagged the module
+  as an unvalidated file-op surface. The fix was honest naming
+  (extract the guard as `_validate_stamp_path`, which the gate's
+  `*valid*path*` identifier scan recognizes), not an allowlist entry.
+  Rule: before pushing any `src/attune/` diff, run the gate battery
+  (`pytest tests/unit/gates/ tests/unit/rules/ tests/unit/ci/
+  tests/unit/lessons/ -q`, ~8s) alongside the targeted suites — the
+  gates are corpus-scoped by design, so "my tests pass" never
+  implies "the gates pass". Bonus receipt: per-job CI logs ARE
+  fetchable mid-run via `gh api .../actions/jobs/<id>/logs` for
+  COMPLETED jobs even while the run is in_progress — faster than
+  waiting for `gh run view --log-failed`.
+
+- **zsh does NOT word-split unquoted `$VAR` — a space-joined file
+  list in one variable reaches `git add`/`pre-commit --files` as ONE
+  pathspec, and both failures masquerade as success-shaped output**:
+  2026-08-18, staging a multi-file commit with `FILES="a.py b.py …"`
+  then `git add $FILES` + `pre-commit run black --files $FILES`.
+  Under bash that splits; under zsh (this machine's shell) it stays
+  one argument: pre-commit printed "(no files to check) Skipped"
+  (reads like a pass), and `git add` errored with the whole list as
+  one quoted pathspec — the subsequent `git commit` then reported
+  "no changes added" and the prior commit still showed as HEAD.
+  Diagnostic tell: "did not match any files" quoting the ENTIRE list
+  as one string. Fixes: list files explicitly in the command, use an
+  array (`files=(a.py b.py); git add $files`), or `${=FILES}` to
+  force splitting. Pairs with the existing zsh lessons (`status`
+  read-only variable, `=word` PATH expansion) — same family: zsh is
+  not bash, and its failures often look like clean skips.
+
+- **Mass stale-branch sweeps: one batched `gh pr list --state merged -L 3000 --json headRefName` call replaces N per-branch PR lookups, and the deletion receipt is `diff(remaining, protected+held)`** — 2026-08-18, sweeping 649 local branches in attune-ai down to 87. The working recipe: (1) protect `main` + every branch named by `git worktree list --porcelain` (pairs with the prune-self-deletion-hazard memory); (2) fetch ALL merged-PR head names in ONE `gh` call to a file — 1,962 names, no rate-limit exposure — instead of `gh pr list --head <b>` per branch; (3) classify in a DRY RUN first: `git rev-list --count origin/main..<b>` == 0 → ancestor-merged (`-d`, with `-D` fallback justified because ahead=0 is already proven — `-d` can refuse when HEAD isn't main), name in merged-heads file → squash-merged (`-D`), else → hold for review, never delete; (4) after deleting, the receipt is a set equality check: `git for-each-ref refs/heads` sorted must diff-equal protected+held exactly — catches both over-deletion and misses in one comparison. Also check `gh pr list --state open` once so the hold list can be annotated: a repo with zero open PRs proves no held branch backs an in-flight PR. Result: 96 `-d` + 466 `-D`, 0 errors, 85 held. Pairs with the existing "squash-merged branch reports NOT-merged via merge-base by design" lesson — this is the fleet-scale procedure built on that fact.
+
+- **API-removal sweeps must grep ATTRIBUTE and METHOD names, not just
+  class names — mock-based tests exercise removed APIs without ever
+  naming the class**: hit 2026-08-18 on the context-compaction
+  removal (PR #2093). The reference survey grepped for the deleted
+  class names (`ContextManager`, `CompactState`, …) and found 26
+  files; `tests/unit/commands/test_context.py` was NOT among them
+  because it builds the manager as `MagicMock()` and exercises the
+  removed surface purely through attribute/kwarg names
+  (`context_manager=`, `save_context_state()`, `enable_context=`) —
+  11 deterministic failures invisible to the class-name grep, caught
+  only by the scoped codex follow-up lane. Rule: when deleting or
+  renaming an API, run a SECOND sweep on the attribute, kwarg, and
+  method names (`\.attr`, `attr=`, `method_name`) across src/ AND
+  tests/; mocked call sites are exactly the ones the class-name grep
+  cannot see. Pairs with the "spec-named work-scope drifts from code
+  reality" lesson — same grep-the-actual-property discipline, applied
+  to the removal direction.
+
+- **A kwarg your API accepts can be a silent no-op — grep the FULL
+  path from caller to provider before trusting it; a live A/B run
+  catches what thousands of mocked tests cannot**: found 2026-08-18
+  running the fit_source budget A/B. `_call_llm(max_tokens=...)`
+  accepted the parameter and stored it on `WorkflowStepConfig`, but
+  `run_step_with_executor` never forwarded `step.max_tokens` to
+  `executor.run()`, and `EmpathyLLM.interact()` could not accept it
+  anyway — so EVERY workflow LLM call in the framework ran at the
+  empathy level's recommendation (typically 1536 tokens), which
+  Claude 5's adaptive thinking can fully consume → intermittently
+  EMPTY LLM outputs written as if successful. 3,688 unit tests were
+  green throughout: each layer honored its own contract; only the
+  SEAM dropped the value, and only a live call showed 0-byte
+  results. Rules: (1) when a parameter's effect matters, trace it
+  hop-by-hop to the boundary (`grep` each layer for the name — a
+  config field nothing reads is the smell); (2) pin the thread-through
+  with a regression test at EACH seam (caller→executor kwargs,
+  interact→provider.generate kwargs), not just end-to-end; (3) an
+  A/B or live-fire receipt on real output size is the cheap detector
+  for silently-capped/empty LLM output classes. Fix + seam tests:
+  fix/llm-max-tokens-threading branch.
+
+- **macOS screenshot filenames contain U+202F (narrow no-break
+  space) before AM/PM — a path typed with a regular space fails
+  "file does not exist" while `ls` output LOOKS identical**: hit
+  2026-08-18 cataloging `~/Desktop/Screenshot 2026-08-15 at
+  2.46.50 PM (2).png`. Diagnose with `ls | cat -v` (U+202F renders
+  as `M-bM-^@M-/`). Workarounds: glob around the space
+  (`Screenshot*2.46.50*"(2)".png`) or copy to safe names before
+  tooling that takes literal paths. Applies to any filename with
+  invisible Unicode (NBSP, U+202F, zero-width) — when a
+  visually-correct path errors as missing, byte-inspect before
+  doubting the file's existence.
+
+- **Before "correcting" a doc count claim, read the claim-drift
+  gate's derivation — the gate encodes the ratified counting
+  convention, and a raw registry read can use the wrong measure**:
+  2026-08-18, 12.0.0 release prep (PR #2096). README said "21
+  workflows"; a live `list_workflows()` check returned 23, so the
+  claim was "fixed" to 23 in three places. CI's
+  `tests/unit/gates/test_claim_drift.py` failed all four ubuntu
+  lanes: by ruling D4 (2026-07-12) workflow totals quote the
+  DISTINCT CLASS count (`len(set(discover_workflows().values()))` =
+  21), not the slug count (23 — `health-check`/
+  `orchestrated-health-check` and `release-prep`/`release-gate` are
+  alias pairs). The original claim was correct by convention; the
+  "verification" used the wrong measure. Rule: when a gated claim
+  looks stale, open the gate test FIRST and reproduce its exact
+  derivation; the gate is the spec for how the number is counted.
+  Cost: one extra CI round-trip and a merge re-authorization (the
+  fix push moved the PR head, invalidating the chair's SHA-bound
+  merge word). Pairs with "enforcer-adjacent lessons decay" — same
+  family, opposite direction: there the enforcer regressed under
+  the claim; here the enforcer was right and the fresh measurement
+  was wrong.
+
+- **A launchd job's install receipt is not a running-job receipt —
+  re-verify the service on a LATER day before relying on it**:
+  2026-08-19 traffic review: the D18 daily reach-snapshot job
+  (`com.smartaimemory.attune.reach-snapshot`) was recorded in
+  `docs/specs/usage-signals/decisions.md` as installed 2026-08-10 —
+  "plist copied to ~/Library/LaunchAgents/, launchctl bootstrap
+  succeeded, launchctl print shows the job loaded, chair-verified."
+  Nine days later the plist was ABSENT from `~/Library/
+  LaunchAgents/`, `launchctl print gui/$UID/<label>` returned
+  "Could not find service", no `~/.attune/logs/reach-snapshot.log`
+  ever existed, and zero snapshots landed after 08-10. Consequence:
+  12.0.0 tagged 2026-08-19 with no BEFORE snapshot in its 24-72h
+  window — the exact failure class the D18 daily-cadence amendment
+  existed to kill. The install-time receipt was real but did not
+  survive: something (cleanup, migration, or the copy landing
+  elsewhere) removed the plist without any signal. Rules:
+  - An install-time `launchctl print` proves the bootstrap, not the
+    standing service. For any recurring launchd job, the receipt
+    that matters is taken on a LATER day: (a) plist still present
+    in `~/Library/LaunchAgents/`, (b) `launchctl print` finds the
+    service, (c) the job's LOG file exists and has a recent entry,
+    (d) the artifact it produces (here: a dated snapshot file) is
+    accruing. (d) is the cheapest and strongest — check the output
+    stream first.
+  - When a review depends on scheduled data ("daily snapshots exist
+    by construction"), verify the newest artifact's date before
+    reasoning from the schedule. Here the snapshots directory
+    itself (`ls snapshots/ | tail -1` → 2026-08-10) exposed the
+    dead job in one command.
+  - Companion to the existing "reach_snapshot.py exits 0 on
+    rate-limit — the daily receipt is the LOG" lesson: that one
+    guards a running job's silent partials; this one guards the job
+    silently not existing at all.
+
+- **Directory/awesome-list submission mechanics vary — read
+  CONTRIBUTING before opening a PR, and use issue-form prefill URLs
+  for human-must-file cases**: 2026-08-19, submitting attune-ai to
+  discovery surfaces. Three different mechanisms in one afternoon:
+  - **hesreallyhim/awesome-claude-code** (52k stars): PRs are
+    FORBIDDEN and `gh` CLI submissions "risk being restricted" —
+    recommendations must be human-filed via their web-UI issue form
+    (`.github/ISSUE_TEMPLATE/recommend-resource.yml`), which
+    includes honesty checkboxes and a deliberate TRAP checkbox ("Do
+    not check the following box") to catch automated filers. The
+    right agent move: build a PREFILLED issue-form URL and open it
+    for the human — GitHub issue forms accept query params by field
+    id (`issues/new?template=<file>.yml&title=...&<field_id>=
+    <value>` — dropdowns take the exact option string; checkboxes
+    cannot be prefilled). Style rules: descriptive not promotional,
+    one line, no emojis; eligibility 14 days active dev OR 100
+    stars.
+  - **composio-community/awesome-claude-plugins** (1.9k stars):
+    standard fork-and-PR, external-link entries accepted alongside
+    their bundled plugin dirs (precedents: kaggle-skill, AgentLint,
+    backlog). Note the canonical org is `composio-community` even
+    though search surfaces `ComposioHQ`.
+  - **Anthropic community marketplace** (`anthropics/
+    claude-plugins-community`, 2,281 plugins): NO repo PR path —
+    submission is the Console form `platform.claude.com/plugins/
+    submit` (individual authors) or the claude.ai admin-settings
+    form (Team/Enterprise orgs only). Pre-submit receipt: `claude
+    plugin validate <plugin-dir>` — the review pipeline runs the
+    same check. Listing receipt: search the catalog's
+    `.claude-plugin/marketplace.json` on GitHub, not code search
+    (code search returned 0 hits for a name that WAS in the file —
+    attune-lite). Catalog syncs nightly, so approval → visibility
+    has up to a day of lag.
+  - Meta-rule: "submit to the list" is not one action — each list's
+    CONTRIBUTING/template defines the only accepted channel, and
+    using the wrong one (PR where forms are required) can get the
+    account restricted. Check the mechanism BEFORE drafting the
+    artifact.
+
+- **The tagline lives on SEVEN hand-maintained surfaces — a rebrand
+  must touch all of them or it ships a new inconsistency**:
+  2026-08-19 traffic-review execution: the marketing review found
+  FOUR different taglines live at once ("nobody can quote you").
+  Unifying on one sentence ("Persistent memory and receipt-verified
+  workflows for Claude Code") required edits on every one of these
+  surfaces — none is projected from another, and no gate checks
+  them for consistency:
+  1. GitHub repo description (`gh api -X PATCH repos/<o>/<r>
+     -f description=...`) — plus topics via `PUT .../topics`.
+  2. `README.md` (tagline line under the H1).
+  3. `pyproject.toml` `description =` (reaches PyPI only at the
+     next release).
+  4. `.claude-plugin/marketplace.json` — BOTH `metadata.description`
+     and the plugin entry's `description` (two spots in one file).
+  5. `plugin/.claude-plugin/plugin.json` `description`.
+  6. `attune-ai-dev/index.html` (title + meta description +
+     og:description + hero) AND `attune-ai-dev/build_og.py` (the
+     tagline is hardcoded in the OG-image generator — regenerate
+     og.png after editing).
+  7. `website/lib/metadata.ts` (default title/description),
+     `website/components/Footer.tsx`, and the hero eyebrow in
+     `website/app/page.tsx`.
+  Related trap fixed the same day: `attune-ai-dev/index.html`
+  carried a hand-maintained `v8.5.0` eyebrow that had drifted 3.5
+  major versions — a hand-maintained version string on a marketing
+  page is a staleness class; either wire it to a build step or
+  remove the version entirely (removed, 2026-08-19). Claim-drift
+  gates cover COUNTS on some of these surfaces
+  (`tests/unit/gates/test_claim_drift.py`) but nothing checks
+  tagline consistency — if taglines drift again, this list is the
+  checklist.


### PR DESCRIPTION
Batched docs-outbox sweep, chair-approved in-session 2026-08-19 (morning-cleanup follow-up).

- 24 pending lessons (oldest 8.1d, sweep overdue) appended to `.claude/lessons.md` in timestamp order via `python -m attune.docs_outbox apply`.
- Four artifacts were reformatted to the required `- **Title**:` shape before apply (claim-gate-derivation-before-count-fix, launchd-install-receipt-not-running-receipt, directory-submission-mechanics-vary, tagline-lives-on-seven-surfaces); zero artifacts skipped, zero duplicates dropped.
- Docs-only diff: one file, +486 lines, no src/tests/CI changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)