### PR TITLE
fix(gates): path-validation gate now sees the path.open() write idiom

### DIFF
--- a/tests/unit/gates/test_path_validation_gate.py
+++ b/tests/unit/gates/test_path_validation_gate.py
@@ -4,7 +4,8 @@ file operations" (collaboration contract; feature-lead-governance
 principles draft, principle 4). Until 2026-07-29 this rule had no
 mechanical enforcer — it relied on review discipline.
 The scan (AST-based, so prose/comments can never false-positive):
-- A module "does file ops" when it calls ``open()`` with a
+- A module "does file ops" when it calls ``open()`` (builtin or the
+  ``path.open(...)`` / ``Path.open`` attribute form) with a
   write-capable mode, ``.write_text()`` / ``.write_bytes()``, a
   mutating ``shutil`` function, or a mutating ``os`` function.
 - A module "has validation" when any identifier it references
@@ -43,6 +44,10 @@ _OS_FUNCS = {"remove", "unlink", "rename", "replace"}
 #: seeding (2026-07-29): each writes only internal/derived paths
 #: (state stores, telemetry sinks, generated docs). Remove entries as
 #: modules adopt ``_validate_file_path``; add only with review.
+#: Re-seeded 2026-08-19 when the scanner learned the ``path.open("a")``
+#: attribute form (previously invisible): 11 writers became visible,
+#: each reviewed as internal/derived-path only (JSONL ledgers,
+#: telemetry sinks, hook metrics, env-gated debug dumps).
 ALLOWLIST = frozenset(
     {
         "src/attune/authoring/fact_check/__init__.py",
@@ -54,7 +59,9 @@ ALLOWLIST = frozenset(
         "src/attune/authoring/spec_workflow.py",
         "src/attune/curator/cache.py",
         "src/attune/gates/envelope.py",
+        "src/attune/gates/lifecycle/ledger.py",
         "src/attune/handoff/packet.py",
+        "src/attune/hooks/scripts/worktree_path_guard.py",
         "src/attune/help/feedback.py",
         "src/attune/help/generator.py",
         "src/attune/help/manifest.py",
@@ -67,25 +74,38 @@ ALLOWLIST = frozenset(
         "src/attune/ops/dismiss_store.py",
         "src/attune/ops/health_snapshot.py",
         "src/attune/ops/ops_config_store.py",
+        "src/attune/ops/pending_writes.py",
         "src/attune/ops/routes/specs.py",
         "src/attune/ops/sweep_results.py",
         "src/attune/orchestration/ghosts/worktree.py",
+        "src/attune/pipeline_learner/decisions.py",
         "src/attune/pipeline_learner/scaffold.py",
+        "src/attune/roundtable/countersign.py",
         "src/attune/roundtable/gate_triage.py",
+        "src/attune/roundtable/role_telemetry.py",
         "src/attune/roundtable/triage_appendix.py",
+        "src/attune/telemetry/help_tracker.py",
+        "src/attune/telemetry/memory_events.py",
         "src/attune/telemetry/usage_ping.py",
         "src/attune/telemetry/usage_tracker.py",
+        "src/attune/workflows/agent_sdk_adapter.py",
+        "src/attune/workflows/migration.py",
         "src/attune/workflows/progress_reporters.py",
+        "src/attune/workflows/progressive/telemetry.py",
         "src/attune/workflows/suggestions.py",
     }
 )
 
 
-def _open_mode_is_write(call: ast.Call) -> bool:
-    """True when an ``open()`` call's mode string enables writing."""
+def _open_mode_is_write(call: ast.Call, mode_arg_index: int = 1) -> bool:
+    """True when an ``open()`` call's mode string enables writing.
+
+    ``mode_arg_index`` is 1 for builtin ``open(path, mode)`` and 0 for
+    the ``path.open(mode)`` attribute form.
+    """
     mode = None
-    if len(call.args) >= 2 and isinstance(call.args[1], ast.Constant):
-        mode = call.args[1].value
+    if len(call.args) > mode_arg_index and isinstance(call.args[mode_arg_index], ast.Constant):
+        mode = call.args[mode_arg_index].value
     for kw in call.keywords:
         if kw.arg == "mode" and isinstance(kw.value, ast.Constant):
             mode = kw.value.value
@@ -115,7 +135,10 @@ def scan_source(source: str) -> tuple[list[str], bool]:
                 if _open_mode_is_write(node):
                     ops.append(f"open-for-write at line {node.lineno}")
             elif isinstance(func, ast.Attribute):
-                if func.attr in _WRITE_ATTRS:
+                if func.attr == "open":
+                    if _open_mode_is_write(node, mode_arg_index=0):
+                        ops.append(f".open()-for-write at line {node.lineno}")
+                elif func.attr in _WRITE_ATTRS:
                     ops.append(f".{func.attr}() at line {node.lineno}")
                 elif (
                     isinstance(func.value, ast.Name)
@@ -182,6 +205,17 @@ def test_scanner_detects_write_open() -> None:
 
 def test_scanner_ignores_read_open() -> None:
     ops, _ = scan_source('f = open(p)\ng = open(p, "r")\n')
+    assert ops == []
+
+
+def test_scanner_detects_attribute_write_open() -> None:
+    """The ``path.open("a")`` idiom is a write, same as builtin open."""
+    ops, _ = scan_source('with p.open("a") as f:\n    f.write(x)\n')
+    assert ops == [".open()-for-write at line 1"]
+
+
+def test_scanner_ignores_attribute_read_open() -> None:
+    ops, _ = scan_source('f = p.open()\ng = p.open("r")\n')
     assert ops == []
 
 


### PR DESCRIPTION
## Summary

The path-validation gate (`tests/unit/gates/test_path_validation_gate.py`) only matched **builtin** `open()` by name, so modules writing via the `path.open("a")` / `Path.open` attribute idiom were invisible to it. Discovered 2026-08-19 when the ALLOWLIST entry for `src/attune/context/allocator.py` failed `test_allowlist_entries_are_still_needed` as "not needed" — the module (before the compaction-stack retirement removed the code) appended to a JSONL via `path.open("a")` that the gate could not see.

## Changes

- `scan_source()` now matches attribute calls named `open` with a write-capable mode. Subtlety: `Path.open(mode)` carries the mode as the **first** positional argument, while builtin `open(path, mode)` has it second — `_open_mode_is_write()` takes a `mode_arg_index` for this.
- Two scanner self-tests pin the attribute form (write detected, read ignored).
- **ALLOWLIST re-seed:** the extended scan surfaced 11 previously invisible writers. Each call site was reviewed and writes only internal/derived paths:

| Module | What it writes |
|---|---|
| `gates/lifecycle/ledger.py` | `~/.attune/ops/gates/verdicts.jsonl` append |
| `pipeline_learner/decisions.py` | decision ledger append |
| `ops/pending_writes.py` | ops write journal (O_APPEND) |
| `hooks/scripts/worktree_path_guard.py` | hook metrics log |
| `telemetry/help_tracker.py` | telemetry JSONL sink |
| `telemetry/memory_events.py` | telemetry JSONL sink |
| `roundtable/role_telemetry.py` | telemetry JSONL sink |
| `roundtable/countersign.py` | exclusive-create (`"x"`) artifact with symlink check |
| `workflows/agent_sdk_adapter.py` | debug dump gated on `ATTUNE_SDK_STREAM_DUMP` env |
| `workflows/migration.py` | `cwd/.attune/migration.json` |
| `workflows/progressive/telemetry.py` | `~/.attune/telemetry/` events |

The allowlist stays shrink-only in spirit: this is a one-time **visibility** re-seed, not growth — the ratchet resumes from the new, wider floor.

## Receipts

- `pytest tests/unit/gates/test_path_validation_gate.py -p no:xdist -o addopts=` → **9 passed** (both gate tests + 7 scanner self-tests, serial run).
- Pinned black + ruff pre-flighted clean.
- A lesson on the blind spot is already in the docs outbox (slug `path-validation-gate-blind-to-path-open`).
- Closure note: `src/attune/context/allocator.py` has no file ops at all anymore (compaction-stack retirement, 12.0.0), so its allowlist entry was correctly removed — no restore needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
