### PR TITLE
fix(gates): allowlist context/allocator.py under the widened path.open scan

### DIFF
--- a/tests/unit/gates/test_path_validation_gate.py
+++ b/tests/unit/gates/test_path_validation_gate.py
@@ -57,6 +57,7 @@ ALLOWLIST = frozenset(
         "src/attune/authoring/polish.py",
         "src/attune/authoring/projector.py",
         "src/attune/authoring/spec_workflow.py",
+        "src/attune/context/allocator.py",
         "src/attune/curator/cache.py",
         "src/attune/gates/envelope.py",
         "src/attune/gates/lifecycle/ledger.py",


### PR DESCRIPTION
Main is red: the gate-widening PR (Path.open blind spot chip) re-seeded the allowlist from a branch cut before #2103 merged the `allocator.py` `path.open("a")` telemetry append — the merged tree fails `test_no_new_unvalidated_file_op_modules` on every unit-suite lane (receipt: reproduced locally on origin/main, 1 failed; green with this entry, 9 passed).

The entry qualifies per the gate's own comment: internal/derived path only (`$ATTUNE_HOME/telemetry/context_fit.jsonl`), reviewed — codex D11 lane on #2103 + chair ruling B (context-compaction-retirement D3). Also the collision the widened scanner exists to catch, working as intended one merge too late.

Unblocks armed PRs #2105 and #2106.

🤖 Generated with [Claude Code](https://claude.com/claude-code)