### PR TITLE
fix(telemetry): reserved keys can't be clobbered via log_memory_event fields

### DIFF
--- a/plugin/hooks/_memory_telemetry.py
+++ b/plugin/hooks/_memory_telemetry.py
@@ -104,6 +104,8 @@ def log_memory_event(event: str, session_id: str | None = None, **fields: object
         }
         if session_id:
             record["session_id"] = str(session_id)[:64]
+        for reserved in ("v", "ts", "event", "session_id"):
+            fields.pop(reserved, None)
         record.update(fields)
         chars = record.get("injected_chars")
         if isinstance(chars, int) and "est_tokens" not in record:

--- a/src/attune/telemetry/memory_events.py
+++ b/src/attune/telemetry/memory_events.py
@@ -85,6 +85,8 @@ def log_memory_event(event: str, session_id: str | None = None, **fields: object
         }
         if session_id:
             record["session_id"] = str(session_id)[:64]
+        for reserved in ("v", "ts", "event", "session_id"):
+            fields.pop(reserved, None)
         record.update(fields)
 
         path = _events_path()

--- a/tests/unit/hooks/test_memory_telemetry.py
+++ b/tests/unit/hooks/test_memory_telemetry.py
@@ -72,6 +72,21 @@ def test_log_writes_one_json_line_with_schema_fields(telem_mod, tmp_path, monkey
     assert e["ts"].endswith("Z")
 
 
+def test_log_reserved_keys_cannot_be_clobbered(telem_mod, tmp_path, monkeypatch):
+    """Regression: library review checkpoint-1 R2 hit — **fields must not
+    overwrite the reserved v/ts/event/session_id schema keys."""
+    monkeypatch.setenv("ATTUNE_HOME", str(tmp_path / ".attune"))
+    telem_mod.log_memory_event(
+        "jit_recall", session_id="real", v="FORGED", ts="1970-01-01T00:00:00Z", tool="Bash"
+    )
+    (e,) = _events(tmp_path)
+    assert e["v"] == "1.0"
+    assert e["ts"] != "1970-01-01T00:00:00Z"
+    assert e["event"] == "jit_recall"
+    assert e["session_id"] == "real"
+    assert e["tool"] == "Bash"
+
+
 def test_log_appends_multiple_events(telem_mod, tmp_path, monkeypatch):
     monkeypatch.setenv("ATTUNE_HOME", str(tmp_path / ".attune"))
     telem_mod.log_memory_event("session_recall", entries=3)

--- a/tests/unit/telemetry/test_memory_events.py
+++ b/tests/unit/telemetry/test_memory_events.py
@@ -45,6 +45,23 @@ class TestAppend:
         assert record["count"] == 2
         assert record["ts"].endswith("Z")
 
+    def test_reserved_keys_cannot_be_clobbered_by_fields(self, home: Path) -> None:
+        """Regression: library review checkpoint-1 R2 hit (forms form_events
+        sibling class) — **fields must not overwrite v/ts/event/session_id."""
+        log_memory_event(
+            "memory_feedback",
+            session_id="real",
+            v="FORGED",
+            ts="1970-01-01T00:00:00Z",
+            verdict="keep",
+        )
+        (record,) = _lines(home)
+        assert record["v"] == "1.0"
+        assert record["ts"] != "1970-01-01T00:00:00Z"
+        assert record["event"] == "memory_feedback"
+        assert record["session_id"] == "real"
+        assert record["verdict"] == "keep"
+
     def test_lines_are_compact_json(self, home: Path) -> None:
         log_memory_event("memory_feedback", source="review")
         raw = _events_file(home).read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

First fix-on-confirmation from the attune-ai library review
(Checkpoint 1, thread `q-attune-ai-review-checkpoint1-001`, chair
ruling S2): `**fields` could overwrite the reserved `v`/`ts` schema
keys in BOTH memory-event writers — the src module
(`attune/telemetry/memory_events.py:88`) and its hook-side sibling
(`plugin/hooks/_memory_telemetry.py:107`).

This is the exact defect class confirmed **live** in attune-forms
(`form_events.py:131`, where a probe polluted real telemetry; fixed
there in attune-forms PR #42). Found here by the frozen
`sweep_suite_v1` R2 rule during the Checkpoint-0 mechanized sweep;
empirically confirmed by executed repro (forged `v`/`ts` landed in
the JSONL pre-fix; blocked post-fix).

- Filter reserved keys (`v`, `ts`, `event`, `session_id`) from
  `fields` before `record.update` in both siblings
- Regression tests in both suites (`tests/unit/telemetry/
  test_memory_events.py`, `tests/unit/hooks/test_memory_telemetry.py`)
- Both suites green: 31 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
