### PR TITLE
fix: library-review confirmation-pass-1 — two never-raises holes + corrupt-store crash

### DIFF
--- a/src/attune/context/allocator.py
+++ b/src/attune/context/allocator.py
@@ -51,7 +51,10 @@ def _append_fit_event(payload: dict[str, int | str]) -> None:
         line = json.dumps(record, separators=(",", ":")) + "\n"
         with path.open("a", encoding="utf-8") as fh:
             fh.write(line)
-    except OSError as e:
+    except Exception as e:  # noqa: BLE001
+        # INTENTIONAL: the docstring promises never-raises — a TypeError
+        # from an unserializable payload must not block a fit any more
+        # than an OSError from the filesystem (library-review R5).
         logger.debug("context_fit telemetry append failed: %s", e)
 
 

--- a/src/attune/memory/summary_index.py
+++ b/src/attune/memory/summary_index.py
@@ -24,6 +24,20 @@ from typing import Any
 from .short_term import RedisShortTermMemory
 
 
+def _loads_list(raw: str) -> list:
+    """Parse a stored JSON list field; corrupt data degrades to ``[]``.
+
+    Principle 15: the memory layer degrades, it never blocks — a corrupt
+    or hand-edited hash field must not crash recall (library-review R1,
+    confirmed via representative repro 2026-08-20).
+    """
+    try:
+        data = json.loads(raw)
+    except (json.JSONDecodeError, TypeError):
+        return []
+    return data if isinstance(data, list) else []
+
+
 @dataclass
 class AgentContext:
     """Compact context package for sub-agent handoff.
@@ -322,25 +336,25 @@ class ConversationSummaryIndex:
 
         # Append to decisions list
         if event_type == "decision":
-            decisions = json.loads(summary.get("decisions", "[]"))
+            decisions = _loads_list(summary.get("decisions", "[]"))
             decisions.append(content)
             summary["decisions"] = json.dumps(decisions[-20:])  # Keep last 20
 
         # Append to open questions
         if event_type == "question":
-            questions = json.loads(summary.get("open_questions", "[]"))
+            questions = _loads_list(summary.get("open_questions", "[]"))
             questions.append(content)
             summary["open_questions"] = json.dumps(questions[-10:])
 
         # Clear question if answered
         if event_type == "answered":
-            questions = json.loads(summary.get("open_questions", "[]"))
+            questions = _loads_list(summary.get("open_questions", "[]"))
             questions = [q for q in questions if content.lower() not in q.lower()]
             summary["open_questions"] = json.dumps(questions)
 
         # Update files list
         if event_type == "file_modified":
-            files = json.loads(summary.get("key_files", "[]"))
+            files = _loads_list(summary.get("key_files", "[]"))
             if content not in files:
                 files.append(content)
             summary["key_files"] = json.dumps(files[-20:])
@@ -348,7 +362,7 @@ class ConversationSummaryIndex:
         # Extract and index topics
         topics = self._extract_topics(content)
         if topics:
-            existing_topics = json.loads(summary.get("topics", "[]"))
+            existing_topics = _loads_list(summary.get("topics", "[]"))
             for topic in topics:
                 if topic not in existing_topics:
                     existing_topics.append(topic)
@@ -408,10 +422,10 @@ class ConversationSummaryIndex:
 
         # Parse summary fields
         working_on = summary.get("working_on", "")
-        decisions = json.loads(summary.get("decisions", "[]"))
-        open_questions = json.loads(summary.get("open_questions", "[]"))
-        key_files = json.loads(summary.get("key_files", "[]"))
-        topics = json.loads(summary.get("topics", "[]"))
+        decisions = _loads_list(summary.get("decisions", "[]"))
+        open_questions = _loads_list(summary.get("open_questions", "[]"))
+        key_files = _loads_list(summary.get("key_files", "[]"))
+        topics = _loads_list(summary.get("topics", "[]"))
         updated_at = summary.get("updated_at", "")
 
         # Filter by focus topics if provided
@@ -481,7 +495,7 @@ class ConversationSummaryIndex:
                     pass
 
             # Get decisions
-            decisions = json.loads(summary.get("decisions", "[]"))
+            decisions = _loads_list(summary.get("decisions", "[]"))
 
             for decision in decisions:
                 if topic.lower() in decision.lower():
@@ -490,7 +504,7 @@ class ConversationSummaryIndex:
                             "session": session_id,
                             "decision": decision,
                             "date": updated_at,
-                            "topics": json.loads(summary.get("topics", "[]")),
+                            "topics": _loads_list(summary.get("topics", "[]")),
                         },
                     )
 
@@ -524,7 +538,7 @@ class ConversationSummaryIndex:
 
         # Get topics to clean up topic indexes
         summary = self._hgetall(summary_key)
-        topics = json.loads(summary.get("topics", "[]"))
+        topics = _loads_list(summary.get("topics", "[]"))
 
         # Remove from topic indexes
         for topic in topics:

--- a/src/attune/roundtable/role_telemetry.py
+++ b/src/attune/roundtable/role_telemetry.py
@@ -64,7 +64,10 @@ def record(
         dest.parent.mkdir(parents=True, exist_ok=True)
         with dest.open("a", encoding="utf-8") as f:
             f.write(json.dumps(row) + "\n")
-    except OSError as exc:
+    except Exception as exc:  # noqa: BLE001
+        # INTENTIONAL: the docstring promises logged-and-swallowed — a
+        # TypeError from an unserializable field must not break the pass
+        # being observed any more than an OSError (library-review R5).
         logger.warning("role-telemetry: write failed (%s); event dropped", exc)
     return dest
 

--- a/tests/unit/context/test_fit_telemetry.py
+++ b/tests/unit/context/test_fit_telemetry.py
@@ -125,6 +125,15 @@ class TestFitEventStream:
         TokenBudgetAllocator().fit_source(PY_SOURCE, token_limit=4000)
         assert not path.exists()
 
+    def test_unserializable_payload_never_raises(self, tmp_path, monkeypatch):
+        """Regression (library-review R5): a TypeError from an
+        unserializable payload is swallowed like an OSError — the
+        docstring's never-raises promise holds for both."""
+        self._stream(tmp_path, monkeypatch)
+        from attune.context.allocator import _append_fit_event
+
+        _append_fit_event({"rung": object()})  # must not raise
+
     def test_append_failure_never_breaks_fit(self, tmp_path, monkeypatch):
         """An unwritable stream degrades to the log line, never raises."""
         self._stream(tmp_path, monkeypatch)

--- a/tests/unit/gates/test_broad_except_ratchet.py
+++ b/tests/unit/gates/test_broad_except_ratchet.py
@@ -116,6 +116,10 @@ _BASELINE: dict[str, int] = {
     "src/attune/commands/parser.py": 2,
     "src/attune/config/legacy.py": 1,
     "src/attune/config/xml_config.py": 1,
+    # allocator.py added 1 for library-review R5 (PR #2112): the
+    # context-fit telemetry's never-raises docstring must hold for a
+    # TypeError from an unserializable payload, not only OSError.
+    "src/attune/context/allocator.py": 1,
     "src/attune/cost_tracker.py": 1,
     "src/attune/curator/core.py": 3,
     "src/attune/curator/sources/bulletin.py": 2,
@@ -239,6 +243,10 @@ _BASELINE: dict[str, int] = {
     "src/attune/resilience/health.py": 4,
     "src/attune/roundtable/producing.py": 1,
     "src/attune/roundtable/review.py": 1,
+    # role_telemetry.py added 1 for library-review R5 (PR #2112):
+    # the logged-and-swallowed record() contract must hold for a
+    # TypeError from an unserializable field, not only OSError.
+    "src/attune/roundtable/role_telemetry.py": 1,
     "src/attune/roundtable/solutions.py": 1,
     "src/attune/roundtable/triage_appendix.py": 2,
     "src/attune/routing/classifier.py": 1,

--- a/tests/unit/memory/test_summary_index.py
+++ b/tests/unit/memory/test_summary_index.py
@@ -1,0 +1,50 @@
+"""Tests for ConversationSummaryIndex corrupt-store tolerance.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under Apache 2.0
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from attune.memory.summary_index import ConversationSummaryIndex, _loads_list
+
+
+class _StubClient:
+    """Redis stand-in serving one corrupt summary hash."""
+
+    def __init__(self, summary: dict[str, str]) -> None:
+        self._summary = summary
+
+    def hgetall(self, key: str) -> dict[str, str]:
+        return dict(self._summary)
+
+    def smembers(self, key: str) -> set[str]:
+        return {"sess-1"}
+
+
+class TestLoadsList:
+    def test_valid_list_round_trips(self) -> None:
+        assert _loads_list('["a", "b"]') == ["a", "b"]
+
+    def test_corrupt_json_degrades_to_empty(self) -> None:
+        assert _loads_list("{corrupt json") == []
+
+    def test_non_list_json_degrades_to_empty(self) -> None:
+        assert _loads_list('{"not": "a list"}') == []
+
+    def test_none_degrades_to_empty(self) -> None:
+        assert _loads_list(None) == []  # type: ignore[arg-type]
+
+
+class TestCorruptStoreDegrades:
+    def test_recall_decisions_survives_corrupt_field(self) -> None:
+        """Regression (library-review R1 representative repro,
+        2026-08-20): one corrupt Redis hash field must degrade per
+        Principle 15, not crash recall with JSONDecodeError."""
+        client = _StubClient({"decisions": "{corrupt json", "updated_at": "2026-08-20T00:00:00"})
+        memory = SimpleNamespace(use_mock=False, _client=client)
+        index = ConversationSummaryIndex(memory)
+        result = index.recall_decisions("auth")
+        assert result == []

--- a/tests/unit/roundtable/test_role_telemetry.py
+++ b/tests/unit/roundtable/test_role_telemetry.py
@@ -1,0 +1,34 @@
+"""Tests for the roundtable role-telemetry append surface.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under Apache 2.0
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from attune.roundtable import role_telemetry
+
+
+def test_record_appends_one_json_line(tmp_path: Path) -> None:
+    dest = tmp_path / "roles.jsonl"
+    role_telemetry.record("drafter", "claude", "t1", "served", path=dest, note="ok")
+    (line,) = dest.read_text(encoding="utf-8").splitlines()
+    row = json.loads(line)
+    assert row["role"] == "drafter"
+    assert row["seat"] == "claude"
+    assert row["thread"] == "t1"
+    assert row["event"] == "served"
+    assert row["note"] == "ok"
+    assert "at" in row
+
+
+def test_unserializable_field_is_swallowed(tmp_path: Path) -> None:
+    """Regression (library-review R5): the docstring promises
+    logged-and-swallowed — a TypeError from an unserializable field
+    must not escape any more than an OSError."""
+    dest = tmp_path / "roles.jsonl"
+    role_telemetry.record("drafter", "claude", "t1", "served", path=dest, extra=object())
+    assert not dest.exists() or dest.read_text(encoding="utf-8") == ""


### PR DESCRIPTION
## Summary

Confirmation-pass-1 of the attune-ai library review (checkpoint-1
rulings, thread `q-attune-ai-review-checkpoint1-001`). All 23 R5
sites probed per the chair-strengthened ruling; R2/R6/R4/R1 sets
dispositioned. Three confirmed-by-executed-probe fixes ship here:

- **`context/allocator._append_fit_event`** — docstring promises
  never-raises; probe with an unserializable payload RAISED
  TypeError (handler was `except OSError` only). Widened.
- **`roundtable/role_telemetry.record`** — logged-and-swallowed
  contract, same narrow handler, same confirmed escape. Widened.
- **`memory/summary_index`** — representative R1 repro (ruling S3):
  one corrupt Redis hash field crashed `recall_decisions` with
  JSONDecodeError, violating Principle 15. The file's 12 unguarded
  `json.loads` sites now degrade via a `_loads_list` helper.

Regression tests for all three (18 new/passing; context+roundtable
suites 316 passed).

**Full pass disposition** (ledgered in
`~/.attune/reports/attune-ai-review/`): R5 = 2 fixed / 3 chipped
(cleanup-parity ×2, CLI return contract) / 18 dismissed-with-reason;
R2 provider sites dismissed (named-param protection + documented
extension point), one needs-a-look folded to brief 16; R6 dismissed
(bounded local provenance, verbatim DEL); R4 redis_auto_detect
downgraded (interactive surface), ghosts/index folded to briefs;
R1's remaining 24 sites carry to brief 12 with the confirmed prior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
