### PR TITLE
fix(telemetry,agents): cleanup-parity on non-OSError save failures

### DIFF
--- a/src/attune/agents/state/store.py
+++ b/src/attune/agents/state/store.py
@@ -417,11 +417,13 @@ class AgentStateStore:
         validated_path.parent.mkdir(parents=True, exist_ok=True)
         try:
             _atomic_write_text(validated_path, json.dumps(record.to_dict(), indent=2))
-        except OSError:
+        except Exception:  # noqa: BLE001
             # The record was mutated in place before this save. Dropping
             # the cache entry forces the next load to re-read the last
             # good on-disk state, so the failed update can't be silently
-            # persisted by a later successful mutation.
+            # persisted by a later successful mutation. Not just OSError:
+            # a TypeError from json.dumps on an unserializable value needs
+            # the same cleanup.
             self._cache.pop(record.agent_id, None)
             raise
 

--- a/src/attune/telemetry/usage_tracker.py
+++ b/src/attune/telemetry/usage_tracker.py
@@ -514,7 +514,9 @@ class UsageTracker:
 
         Raises:
             OSError: If writing to disk fails. Entries are returned to the
-                    buffer so no data is lost.
+                    buffer so no data is lost. Any other exception (e.g. a
+                    TypeError from an unserializable entry) also restores
+                    the buffer before propagating.
 
         """
         with self._lock:
@@ -528,8 +530,10 @@ class UsageTracker:
                 for entry in entries:
                     json.dump(entry, f, separators=(",", ":"))
                     f.write("\n")
-        except OSError:
-            # Restore entries to buffer so they are not lost
+        except Exception:  # noqa: BLE001
+            # Restore entries to buffer so they are not lost — not just
+            # OSError: a TypeError/ValueError from json.dump on an
+            # unserializable entry must not silently drop the buffer.
             with self._lock:
                 self._buffer = entries + self._buffer
             raise

--- a/tests/unit/agents/state/test_state_store.py
+++ b/tests/unit/agents/state/test_state_store.py
@@ -501,3 +501,29 @@ class TestAgentStateStoreConcurrency:
         assert state is not None
         assert state.total_executions == 1  # the failed second start is gone
         assert state.last_checkpoint == {"step": 9}
+
+    def test_failed_serialization_evicts_cache(self, tmp_path: Path) -> None:
+        """A TypeError from json.dumps must run the same cache cleanup
+        as an OSError.
+
+        Library-review R5 finding (2026-08-20): only OSError popped the
+        mutated record from the cache, so an unserializable checkpoint
+        stayed cached and cached reads served the failed update.
+        """
+        store = AgentStateStore(storage_dir=str(tmp_path))
+        store.record_start("serial-agent", "Auditor")
+
+        with pytest.raises(TypeError):
+            store.save_checkpoint("serial-agent", {"bad": object()})
+
+        # A cached read must not see the failed checkpoint
+        state = store.get_agent_state("serial-agent")
+        assert state is not None
+        assert state.last_checkpoint == {}  # on-disk default, not the bad dict
+
+        # And a later successful mutation must not resurrect it
+        store.save_checkpoint("serial-agent", {"step": 1})
+        fresh = AgentStateStore(storage_dir=str(tmp_path))
+        persisted = fresh.get_agent_state("serial-agent")
+        assert persisted is not None
+        assert persisted.last_checkpoint == {"step": 1}

--- a/tests/unit/gates/test_broad_except_ratchet.py
+++ b/tests/unit/gates/test_broad_except_ratchet.py
@@ -86,7 +86,10 @@ _BASELINE: dict[str, int] = {
     "src/attune/agents/release/quality_agent.py": 1,
     "src/attune/agents/release/release_prep_team.py": 2,
     "src/attune/agents/release/security_agent.py": 1,
-    "src/attune/agents/state/store.py": 1,
+    # store.py raised 1 -> 2 for the library-review R5 cleanup-parity
+    # chip (PR #2114): _save's cache-pop cleanup must run for a
+    # TypeError from an unserializable record, not only OSError.
+    "src/attune/agents/state/store.py": 2,
     "src/attune/agents/team.py": 1,
     "src/attune/agents_md/loader.py": 1,
     "src/attune/authoring/fact_check/cli_refs.py": 1,
@@ -252,7 +255,10 @@ _BASELINE: dict[str, int] = {
     "src/attune/telemetry/lessons/__init__.py": 1,
     "src/attune/telemetry/memory_events.py": 1,
     "src/attune/telemetry/usage_ping.py": 4,
-    "src/attune/telemetry/usage_tracker.py": 3,
+    # usage_tracker raised 3 -> 4 for the library-review R5
+    # cleanup-parity chip (PR #2114): flush must restore the buffer
+    # on ANY exception before re-raising, not only OSError.
+    "src/attune/telemetry/usage_tracker.py": 4,
     "src/attune/tools.py": 1,
     "src/attune/utils/tokens.py": 4,
     "src/attune/validation/xml_validator.py": 2,

--- a/tests/unit/telemetry/test_usage_tracker.py
+++ b/tests/unit/telemetry/test_usage_tracker.py
@@ -1337,6 +1337,27 @@ class TestFlushOsErrorBranch:
         # Entries should be back in buffer
         assert len(tracker._buffer) >= 1
 
+    def test_flush_non_oserror_restores_buffer(self, temp_dir):
+        """A non-OSError during write (TypeError from json.dump on an
+        unserializable entry) must also restore the buffer.
+
+        Library-review R5 finding (2026-08-20): the restore path only
+        covered OSError, so a serialization failure silently dropped
+        every buffered entry.
+        """
+        tracker = UsageTracker(telemetry_dir=temp_dir)
+        good_entry = {"ts": "2026-08-20T00:00:00", "workflow": "wf"}
+        bad_entry = {"ts": "2026-08-20T00:00:01", "payload": object()}
+        with tracker._lock:
+            tracker._buffer.extend([good_entry, bad_entry])
+
+        with pytest.raises(TypeError):
+            tracker.flush()
+
+        # Both entries restored — including the good one flushed alongside
+        assert good_entry in tracker._buffer
+        assert bad_entry in tracker._buffer
+
 
 @pytest.mark.unit
 class TestBufferFullExceptionBranches:


### PR DESCRIPTION
## Summary

Cleanup-parity fixes for two library-review R5 findings (checkpoint-1, thread `q-attune-ai-review-checkpoint1-001`, probe pass 2026-08-20, `~/.attune/reports/attune-ai-review/`). Both latent (no public-API repro), same class: the failure-cleanup handler only covered `OSError`, so a `TypeError`/`ValueError` from JSON serialization escaped without running it.

- **`usage_tracker.flush()`** — `self._buffer` is cleared before the write. The restore path now covers all exceptions (restore buffer, then re-raise), so a serialization failure no longer silently drops every buffered entry. `OSError` behavior unchanged.
- **`AgentStateStore._save()`** — the cache-pop that prevents a failed update from being silently persisted by a later successful mutation now runs for all exceptions, not just `OSError`.

## Regression tests

Both inject an unserializable value (`object()`) directly and prove the cleanup runs on the non-OSError path:

- `test_flush_non_oserror_restores_buffer` — both buffered entries restored after the `TypeError`.
- `test_failed_serialization_evicts_cache` — cached read after the failure serves the on-disk state, and a later mutation doesn't resurrect the bad checkpoint.

## Receipts

- Both new tests **fail** against the pre-fix code (verified via `git stash` round-trip) and pass with the fix.
- Full files serial: `137 passed` (`tests/unit/telemetry/test_usage_tracker.py` + `tests/unit/agents/state/test_state_store.py`).
- Pinned black + ruff pre-flighted clean on all four files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
