### PR TITLE
docs(roundtable): fix main's docs build — de-link machine-local transcript reference

### DIFF
--- a/docs/reports/roundtable/q-attune-ai-library-review-plan-001.md
+++ b/docs/reports/roundtable/q-attune-ai-library-review-plan-001.md
@@ -6,7 +6,7 @@ convergence. Chair-promoted sections only; full transcript is
 machine-local (`~/.attune/reports/roundtable/`).
 
 Adapts the attune-forms process-v2
-([q-forms-review-process-v2-001](q-forms-review-process-v2-001.md),
+(`q-forms-review-process-v2-001`, transcript machine-local,
 outcome: 23 confirmed act-now defects fixed across 13 modules) to
 attune-ai scale: 741 Python files, ~192k LOC, ~70 packages, plus
 `attune_redis`. Scale-independent parts of process-v2 carry over


### PR DESCRIPTION
## Summary

Main's `build` (mkdocs strict) check has been red since [#2110](https://github.com/Smart-AI-Memory/attune-ai/pull/2110) landed: the library-review plan stub links `q-forms-review-process-v2-001.md`, but that transcript is machine-local (`~/.attune/reports/roundtable/`, per the local-first reports carve) and was never a docs file. Strict mode aborts on the unresolved link, so every PR (including #2113) inherits a failing `build` check.

## Change

One line: the reference becomes plain thread-name text — `(\`q-forms-review-process-v2-001\`, transcript machine-local, …)` — matching how the stub already describes its own transcript.

## Receipt

Local `mkdocs build --strict` passes on this tree (INFO-level notes only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)