### PR TITLE
fix(agents): serialize ComplianceDatabase writes with shared per-path lock

### DIFF
--- a/agents/compliance_db.py
+++ b/agents/compliance_db.py
@@ -9,6 +9,7 @@ Licensed under the Apache License, Version 2.0
 
 import logging
 import sqlite3
+import threading
 from collections.abc import Generator
 from contextlib import contextmanager
 from datetime import datetime
@@ -16,6 +17,19 @@ from pathlib import Path
 from typing import Any
 
 logger = logging.getLogger(__name__)
+
+# Process-wide locks keyed by resolved db path: serializes access across
+# threads AND across instances pointing at the same file (SQLite's own file
+# locking is not reliable under concurrent writers on Windows).
+_DB_LOCKS: dict[str, threading.Lock] = {}
+_DB_LOCKS_GUARD = threading.Lock()
+
+
+def _lock_for_db(db_path: str) -> threading.Lock:
+    """Return the process-wide lock for a resolved database path."""
+    key = str(Path(db_path).resolve())
+    with _DB_LOCKS_GUARD:
+        return _DB_LOCKS.setdefault(key, threading.Lock())
 
 
 class ComplianceDatabase:
@@ -49,11 +63,22 @@ class ComplianceDatabase:
             db_path = str(data_dir / "compliance.db")
 
         self.db_path = db_path
+        self._lock = _lock_for_db(db_path)
         self._init_schema()
 
     @contextmanager
     def _get_connection(self) -> Generator[sqlite3.Connection, None, None]:
-        """Get database connection with automatic cleanup."""
+        """Get database connection with automatic cleanup.
+
+        Holds the process-wide per-db-path lock for the whole
+        connect-execute-commit cycle so concurrent threads (or instances
+        sharing a path) never contend inside SQLite's file locking.
+        """
+        with self._lock:
+            yield from self._connection_cycle()
+
+    def _connection_cycle(self) -> Generator[sqlite3.Connection, None, None]:
+        """One locked connect-execute-commit-close cycle."""
         conn = None
         try:
             conn = sqlite3.connect(self.db_path, check_same_thread=False)

--- a/tests/agents/test_compliance_db.py
+++ b/tests/agents/test_compliance_db.py
@@ -241,7 +241,10 @@ class TestThreadSafety:
         # Record 10 audits concurrently
         with concurrent.futures.ThreadPoolExecutor(max_workers=5) as executor:
             futures = [executor.submit(record_audit, i) for i in range(10)]
-            concurrent.futures.wait(futures)
+            # result() re-raises worker exceptions — a failed write must fail
+            # loudly here, not surface later as a bare count mismatch
+            for future in concurrent.futures.as_completed(futures):
+                future.result()
 
         # Verify all 10 audits were recorded
         with temp_compliance_db._get_connection() as conn:


### PR DESCRIPTION
## Summary

`tests/agents/test_compliance_db.py::TestThreadSafety::test_concurrent_writes` failed on CI windows-latest/Python 3.13 (run 32344769386, job 96351254257) with `assert 7 == 10` — 3 of 10 concurrent writes lost. All other lanes passed: a race, not deterministic.

## Diagnosis

This is **not** the #2101 cache-staleness class — `ComplianceDatabase` has no cache and no instance lock at all. It opens a fresh SQLite connection per call and delegates all concurrency control to SQLite's file locking, which intermittently raises `sqlite3.OperationalError` under concurrent writers on Windows (lock contention / transient open failure in a tempdir). The test then swallowed those worker exceptions: `executor.submit(...)` + `concurrent.futures.wait(futures)` never calls `.result()`, so 3 raised writes surfaced only as a short row count.

## Fix (both sides)

- **Product:** `ComplianceDatabase` now takes a process-wide `threading.Lock` keyed by resolved db path — the same shared-lock pattern PR #2101 applied to `AgentStateStore` — held across each connect–execute–commit cycle. Threads and same-path instances never contend inside SQLite's file locking, making the class's existing "Thread-safe operations" claim true.
- **Test:** iterates `as_completed()` and calls `future.result()`, so any future write failure fails loudly with the real exception instead of a bare count mismatch.

## Receipts

- `tests/agents/test_compliance_db.py`: 12/12 passed serially.
- `TestThreadSafety` stressed 30/30 consecutive local runs.
- Pinned black/ruff pre-flighted clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
