### PR TITLE
fix(hooks): ambient hook scripts fail open on malformed stdin

### DIFF
--- a/src/attune/hooks/scripts/format_on_save.py
+++ b/src/attune/hooks/scripts/format_on_save.py
@@ -77,7 +77,12 @@ def main() -> None:
             return
 
         data = json.loads(raw)
-    except (json.JSONDecodeError, ValueError):
+    except (json.JSONDecodeError, ValueError, RecursionError):
+        return
+
+    # A non-dict payload (list/int/str/null) has no tool fields; the
+    # contract is exit-0-always, so degrade instead of crashing (L3).
+    if not isinstance(data, dict):
         return
 
     tool_name = data.get("tool_name", "")
@@ -119,4 +124,10 @@ if __name__ == "__main__":
     from _sdk_gate import exit_if_sdk_subprocess
 
     exit_if_sdk_subprocess()
-    main()
+    try:
+        main()
+    except Exception:  # noqa: BLE001
+        # PostToolUse best-effort: wrong-typed nested fields (e.g.
+        # tool_input=[...] or file_path=5) must not crash the
+        # exit-0-always contract (library-review L3).
+        pass

--- a/src/attune/hooks/scripts/security_guard.py
+++ b/src/attune/hooks/scripts/security_guard.py
@@ -399,8 +399,14 @@ def _read_stdin_context() -> dict[str, Any]:
             else sys.stdin.read()
         ).strip()
         if raw:
-            return json.loads(raw)
-    except (json.JSONDecodeError, ValueError) as e:
+            parsed = json.loads(raw)
+            # A successfully-parsed non-dict (list/int/str/null) has no
+            # tool fields to validate; treat it as a parse error so the
+            # fail-open path below fires instead of crashing main()
+            # (library-review L1: a blocking guard must not exit 1).
+            if isinstance(parsed, dict):
+                return parsed
+    except (json.JSONDecodeError, ValueError, RecursionError) as e:
         logger.warning("Could not parse stdin JSON (fail-closed): %s", e)
     return {"_parse_error": True}
 
@@ -419,7 +425,19 @@ if __name__ == "__main__":
     if context.get("_parse_error"):
         sys.exit(0)
 
-    result = main(context)
+    try:
+        result = main(context)
+    except Exception as exc:  # noqa: BLE001
+        # Wrong-typed fields inside an otherwise-valid dict (e.g.
+        # tool_name=123) leave no parseable command to guard; a crash
+        # here exits 1, which the harness treats as non-blocking anyway
+        # — so fail open EXPLICITLY, consistent with the parse-error
+        # path and worktree_path_guard (library-review L1).
+        print(
+            f"[security-guard] hook error (allowing): {type(exc).__name__}: {exc}",
+            file=sys.stderr,
+        )
+        sys.exit(0)
 
     if not result.get("allowed", False):
         # Block: print reason to stderr, exit 2

--- a/src/attune/hooks/scripts/telemetry_hook.py
+++ b/src/attune/hooks/scripts/telemetry_hook.py
@@ -53,8 +53,13 @@ def _read_stdin_context() -> dict[str, Any]:
         _buf = getattr(sys.stdin, "buffer", None)  # None when tests patch stdin
         raw = (_buf.read().decode("utf-8", errors="replace") if _buf else sys.stdin.read()).strip()
         if raw:
-            return json.loads(raw)
-    except (json.JSONDecodeError, ValueError) as e:
+            parsed = json.loads(raw)
+            # A non-dict payload (list/int/str/null) has no telemetry
+            # fields; degrade to {} so record_telemetry's .get calls
+            # can't crash the exit-0 contract (library-review L2).
+            if isinstance(parsed, dict):
+                return parsed
+    except (json.JSONDecodeError, ValueError, RecursionError) as e:
         logger.debug("Could not parse stdin JSON: %s", e)
     return {}
 
@@ -68,6 +73,10 @@ if __name__ == "__main__":
     exit_if_sdk_subprocess()
     logging.basicConfig(level=logging.WARNING, format="%(message)s")
     ctx = _read_stdin_context()
-    record_telemetry(ctx)
-    # Telemetry is fire-and-forget — always exit 0
+    try:
+        record_telemetry(ctx)
+    except Exception as e:  # noqa: BLE001
+        # Telemetry is fire-and-forget; the PostToolUse contract is
+        # exit-0-always, so no internal error may crash it (L2).
+        logger.debug("telemetry_hook error (ignored): %s", e)
     sys.exit(0)

--- a/src/attune/hooks/scripts/worktree_path_guard.py
+++ b/src/attune/hooks/scripts/worktree_path_guard.py
@@ -244,9 +244,13 @@ def _read_stdin_context() -> dict[str, Any]:
     if not raw:
         return {}
     try:
-        return json.loads(raw)
-    except json.JSONDecodeError:
+        parsed = json.loads(raw)
+    except (json.JSONDecodeError, RecursionError):
+        # RecursionError: deeply-nested JSON overflows the parser; this
+        # reader is called BEFORE main()'s crash guard, so it must
+        # absorb it here (library-review L4).
         return {}
+    return parsed if isinstance(parsed, dict) else {}
 
 
 if __name__ == "__main__":

--- a/tests/unit/gates/test_broad_except_ratchet.py
+++ b/tests/unit/gates/test_broad_except_ratchet.py
@@ -131,10 +131,22 @@ _BASELINE: dict[str, int] = {
     "src/attune/hooks/executor.py": 2,
     "src/attune/hooks/registry.py": 1,
     "src/attune/hooks/scripts/evaluate_session.py": 3,
+    # format_on_save added 1 for library-review L3 (PR #2117): the
+    # PostToolUse exit-0-always contract must survive wrong-typed
+    # nested fields (tool_input/file_path), not only OSError.
+    "src/attune/hooks/scripts/format_on_save.py": 1,
     "src/attune/hooks/scripts/help_freshness_nudge.py": 1,
     "src/attune/hooks/scripts/lessons_reminder.py": 1,
+    # security_guard added 1 for library-review L1 (PR #2117): a
+    # blocking guard must fail OPEN on wrong-typed fields, so main()
+    # is wrapped to exit 0 instead of crashing to a non-blocking 1.
+    "src/attune/hooks/scripts/security_guard.py": 1,
     "src/attune/hooks/scripts/starter_prompt_nudge.py": 1,
     "src/attune/hooks/scripts/starter_reconciler.py": 3,
+    # telemetry_hook added 1 for library-review L2 (PR #2117): the
+    # PostToolUse exit-0-always contract must survive a non-dict
+    # payload reaching record_telemetry, not only OSError.
+    "src/attune/hooks/scripts/telemetry_hook.py": 1,
     "src/attune/hooks/scripts/worktree_path_guard.py": 1,
     "src/attune/llm/fable_call.py": 2,
     "src/attune/llm/interaction.py": 1,

--- a/tests/unit/hooks/test_hook_scripts.py
+++ b/tests/unit/hooks/test_hook_scripts.py
@@ -824,3 +824,27 @@ class TestFormatOnSaveNeverStripsImports:
         assert ruff_calls, f"ruff was not invoked; calls={calls}"
         joined = " ".join(ruff_calls[0])
         assert "--ignore" in joined and "F401" in joined and "F811" in joined
+
+
+def test_format_on_save_malformed_stdin_exits_0():
+    """Library-review L3: non-dict top-level or non-dict tool_input /
+    non-str file_path must not crash format_on_save's exit-0 contract."""
+    import subprocess
+    import sys
+
+    for payload in (
+        "[1,2,3]",
+        "42",
+        "null",
+        '"hi"',
+        '{"tool_name":"Edit","tool_input":[1]}',
+        '{"tool_name":"Write","tool_input":null}',
+        '{"tool_name":"Edit","tool_input":{"file_path":5}}',
+    ):
+        result = subprocess.run(
+            [sys.executable, "src/attune/hooks/scripts/format_on_save.py"],
+            input=payload,
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, f"{payload!r} -> exit {result.returncode}"

--- a/tests/unit/hooks/test_security_guard.py
+++ b/tests/unit/hooks/test_security_guard.py
@@ -293,3 +293,62 @@ class TestMainEntryPointExitCodes:
             text=True,
         )
         assert result.returncode == 0
+
+
+class TestMalformedPayloadFailsOpen:
+    """Library-review L1/L4: a blocking guard must fail OPEN (exit 0),
+    never crash to exit 1, on any parsed-but-malformed stdin."""
+
+    @pytest.mark.parametrize(
+        "payload",
+        [
+            "[1,2,3]",
+            "42",
+            "null",
+            '{"tool_name":123,"tool_input":{"command":"x"}}',
+            '{"tool_name":"Bash","tool_input":[1,2]}',
+            '{"tool_name":"Bash","tool_input":{"command":999}}',
+            '{"tool_name":"Bash","tool_input":null}',
+            '{"tool_name":"Write","tool_input":{"file_path":123}}',
+        ],
+    )
+    def test_malformed_stdin_exits_0(self, payload: str) -> None:
+        import subprocess
+        import sys
+
+        result = subprocess.run(
+            [sys.executable, "src/attune/hooks/scripts/security_guard.py"],
+            input=payload,
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, f"{payload!r} -> exit {result.returncode}"
+
+    def test_deeply_nested_json_exits_0(self) -> None:
+        import subprocess
+        import sys
+
+        payload = '{"a":' * 3000 + "1" + "}" * 3000
+        result = subprocess.run(
+            [sys.executable, "src/attune/hooks/scripts/security_guard.py"],
+            input=payload,
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0
+
+    def test_real_block_still_fires_after_guard(self) -> None:
+        """The fail-open hardening must NOT neuter a real block."""
+        import subprocess
+        import sys
+
+        payload = json.dumps(
+            {"tool_name": "Bash", "tool_input": {"command": "python -c 'ev" + "al(x)'"}}
+        )
+        result = subprocess.run(
+            [sys.executable, "src/attune/hooks/scripts/security_guard.py"],
+            input=payload,
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 2

--- a/tests/unit/hooks/test_telemetry_hook.py
+++ b/tests/unit/hooks/test_telemetry_hook.py
@@ -111,3 +111,19 @@ def test_main_block_reads_records_and_exits_zero(monkeypatch):
         runpy.run_path(str(SCRIPT_PATH), run_name="__main__")
 
     assert exc.value.code == 0
+
+
+def test_malformed_stdin_exits_0_telemetry():
+    """Library-review L2: non-dict/wrong-typed stdin must not crash
+    the exit-0 contract of telemetry_hook."""
+    import subprocess
+    import sys
+
+    for payload in ("[1,2,3]", "42", "null", '"hi"', '{"tool_name":"Bash","tool_input":[1]}'):
+        result = subprocess.run(
+            [sys.executable, "src/attune/hooks/scripts/telemetry_hook.py"],
+            input=payload,
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, f"{payload!r} -> exit {result.returncode}"

--- a/tests/unit/hooks/test_worktree_path_guard.py
+++ b/tests/unit/hooks/test_worktree_path_guard.py
@@ -441,3 +441,20 @@ class TestScriptMainEntry:
         captured = capsys.readouterr()
         assert "hook error" in captured.err
         assert "AttributeError" in captured.err
+
+
+def test_deeply_nested_json_exits_0():
+    """Library-review L4: 3000-deep JSON overflows the parser (which
+    runs before main()'s guard); the reader must absorb the
+    RecursionError and fail open (exit 0)."""
+    import subprocess
+    import sys
+
+    payload = '{"a":' * 3000 + "1" + "}" * 3000
+    result = subprocess.run(
+        [sys.executable, "src/attune/hooks/scripts/worktree_path_guard.py"],
+        input=payload,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0


### PR DESCRIPTION
## Summary

Batch-1 (ambient) findings from the attune-ai library review
(thread `q-attune-ai-review-checkpoint1-001`), chair-ruled fix-now.
Every case independently re-reproduced through the real subprocess
boundary with an isolated `ATTUNE_HOME`.

- **L1 (severe) `security_guard.py`** — a **blocking** PreToolUse
  guard exited 1 on parsed non-dict / wrong-typed stdin, which the
  harness treats as non-blocking, so the guard **silently failed
  open**. A non-dict parse now routes to the existing fail-open path
  and `main()` is wrapped to exit 0 on wrong-typed fields. Real
  eval/exec blocks still fire (control exit 2 preserved); valid
  commands still allow.
- **L2 `telemetry_hook.py` / L3 `format_on_save.py`** — crashed exit 1
  vs their "exit 0 always" PostToolUse contract on non-dict stdin /
  `tool_input` / `file_path`. Guarded + wrapped.
- **L4 `worktree_path_guard.py` + `security_guard.py`** — 3000-deep
  JSON overflowed the parser (which runs before the crash guard) →
  `RecursionError` exit 1. Readers now absorb it and fail open.

Regression tests through the real boundary in all four suites
(154 passed). Same-class sibling `plugin/hooks/format_on_save.py`
carried to the review ledger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
