### PR TITLE
fix(mcp): validate help_init names before save; restore personal polish

### DIFF
--- a/src/attune/mcp/server.py
+++ b/src/attune/mcp/server.py
@@ -336,6 +336,10 @@ class EmpathyMCPServer(MemoryHandlersMixin, WorkflowHandlersMixin, HandoffHandle
         """
         if not self._rate_limiter.check(tool_name):
             return {
+                # Every other dispatch error path carries `success`;
+                # clients key on it, so the rate-limit branch must too
+                # (library-review M3).
+                "success": False,
                 "error": f"Rate limit exceeded for '{tool_name}'. " "Try again shortly.",
             }
 
@@ -1263,6 +1267,17 @@ class EmpathyMCPServer(MemoryHandlersMixin, WorkflowHandlersMixin, HandoffHandle
                     return {
                         "success": False,
                         "error": "Each accepted proposal must have 'name' and 'description'.",
+                    }
+                # Validate the name BEFORE save_manifest writes to disk;
+                # otherwise one bad entry poisons the persisted manifest
+                # and every later status/update run drags it, while
+                # generate_feature_templates' own guard raises after the
+                # write has already landed (library-review M1). Mirrors
+                # the generator's guard (help/generator.py).
+                if "/" in name or "\\" in name or ".." in name or "\x00" in name:
+                    return {
+                        "success": False,
+                        "error": f"Invalid feature name: {name!r}",
                     }
                 proposals.append(
                     ProposedFeature(

--- a/src/attune/memory/personal.py
+++ b/src/attune/memory/personal.py
@@ -491,7 +491,12 @@ class PersonalMemory:
         if polish_fn is None:
             return text
         try:
-            result = polish_fn(text, template_type=kind)
+            # polish_template(content, feature_name, source_summary, ...):
+            # the two positionals are required — omitting them raised
+            # TypeError on every call, silently killing the polish pass
+            # (library-review M2). Personal memories have no feature or
+            # source summary, so pass empty strings.
+            result = polish_fn(text, "", "", template_type=kind)
             if not result:
                 return text
             if not result.endswith("\n"):

--- a/tests/unit/mcp/test_help_handlers.py
+++ b/tests/unit/mcp/test_help_handlers.py
@@ -784,3 +784,29 @@ class TestHelpLookupUnmatchedLogging:
             await server._handle_help_lookup({"topic": "x"})
 
         assert self._events(tracker) == []
+
+
+@pytest.mark.unit
+class TestHelpInitValidatesBeforeSave:
+    """Library-review M1: help_init accept must reject an invalid
+    feature name BEFORE save_manifest writes it, so one bad entry
+    cannot poison the persisted manifest."""
+
+    async def test_traversal_name_rejected_and_manifest_not_written(self, tmp_path: Any) -> None:
+        server = _make_server(tmp_path)
+        help_dir = tmp_path / ".help"
+        result = await server._handle_help_init(
+            {
+                "action": "accept",
+                "accepted": [
+                    {"name": "../evil", "description": "bad"},
+                    {"name": "good-feature", "description": "ok"},
+                ],
+                "help_dir": str(help_dir),
+                "project_root": str(tmp_path),
+            }
+        )
+        assert result["success"] is False
+        assert "Invalid feature name" in result["error"]
+        # The poisoned manifest must not have been written.
+        assert not (help_dir / "features.yaml").exists()

--- a/tests/unit/mcp/test_server_handlers.py
+++ b/tests/unit/mcp/test_server_handlers.py
@@ -532,3 +532,14 @@ def test_runtime_registered_shapes_match_protocol_contract(tmp_path):
         "test-gen",
         "cost-report",
     }
+
+
+async def test_rate_limited_dispatch_carries_success_key(tmp_path):
+    """Library-review M3: the rate-limit branch of _dispatch_tool must
+    return a dict with success=False, like every other error path."""
+    server = _make_server(tmp_path)
+    # Force the limiter to reject.
+    server._rate_limiter.check = lambda tool_name: False
+    result = await server._dispatch_tool("attune_get_level", {})
+    assert result["success"] is False
+    assert "Rate limit exceeded" in result["error"]

--- a/tests/unit/memory/test_personal_internals.py
+++ b/tests/unit/memory/test_personal_internals.py
@@ -102,7 +102,7 @@ class TestPolish:
     def test_empty_polish_result_returns_original(self, monkeypatch):
         monkeypatch.setattr(
             "attune.memory.personal._load_author",
-            lambda: (lambda text, template_type: ""),
+            lambda: (lambda text, feature_name, source_summary, template_type="generic": ""),
         )
         pm = PersonalMemory()
 
@@ -111,14 +111,16 @@ class TestPolish:
     def test_appends_trailing_newline(self, monkeypatch):
         monkeypatch.setattr(
             "attune.memory.personal._load_author",
-            lambda: (lambda text, template_type: "polished"),
+            lambda: (
+                lambda text, feature_name, source_summary, template_type="generic": "polished"
+            ),
         )
         pm = PersonalMemory()
 
         assert pm._polish("RAW", "decision", strict=False) == "polished\n"
 
     def test_strict_reraises_on_polish_error(self, monkeypatch):
-        def boom(text, template_type):
+        def boom(text, feature_name, source_summary, template_type="generic"):
             raise RuntimeError("polish failed")
 
         monkeypatch.setattr("attune.memory.personal._load_author", lambda: boom)
@@ -128,7 +130,7 @@ class TestPolish:
             pm._polish("RAW", "decision", strict=True)
 
     def test_non_strict_swallows_polish_error(self, monkeypatch):
-        def boom(text, template_type):
+        def boom(text, feature_name, source_summary, template_type="generic"):
             raise RuntimeError("polish failed")
 
         monkeypatch.setattr("attune.memory.personal._load_author", lambda: boom)
@@ -169,3 +171,23 @@ class TestSummariesSidecar:
 
         # Corrupt file is left untouched (nothing to remove).
         assert sidecar.read_text(encoding="utf-8") == "{not valid json"
+
+
+def test_polish_passes_required_positionals(monkeypatch):
+    """Library-review M2: _polish must call polish_template with its two
+    required positionals (feature_name, source_summary) — omitting them
+    raised TypeError on every call and silently killed the polish pass."""
+    import attune.memory.personal as personal
+
+    seen = {}
+
+    def spy(content, feature_name, source_summary, *, template_type="generic", **kw):
+        seen["args"] = (content, feature_name, source_summary, template_type)
+        return content + " [polished]"
+
+    monkeypatch.setattr(personal, "_load_author", lambda: spy)
+    pm = personal.PersonalMemory.__new__(personal.PersonalMemory)
+    out = pm._polish("hello", "decision", strict=True)
+    assert out.strip() == "hello [polished]"
+    assert seen["args"][0] == "hello"
+    assert seen["args"][3] == "decision"


### PR DESCRIPTION
## Summary

Batch-1 MCP-boundary findings from the attune-ai library review
(thread `q-attune-ai-review-checkpoint1-001`), chair-ruled fix-now.

- **M1 `server.py` `help_init(accept)`** — `save_manifest` wrote the
  manifest to disk **before** `generate_feature_templates` validated
  names, so one bad entry (e.g. `../evil`) persisted a poisoned
  manifest that every later status/update run dragged, while the
  generator's `ValueError` (uncaught — `except OSError` only) failed
  the whole call. Now each name is validated in the accept loop before
  the write.
- **M2 `memory/personal.py` `_polish`** — the call omitted
  `polish_template`'s two required positionals → **TypeError on every
  call**, swallowed by the best-effort except; the tool schema's
  "Content is polished and stored" never happened. Pass the required
  args. The existing `TestPolish` spies encoded the *buggy* signature
  (which is why the defect went uncaught) — updated to the real one.
- **M3 `server.py` `_dispatch_tool`** — the rate-limit branch returned
  a bare `{"error": ...}` missing the `success` key every other error
  path carries. Added `success=False`.

Regression tests: M1 through the real handler (manifest not written +
`success: false`), M2 asserts the positional arity, M3 drives dispatch
past the limiter. 95 passed across the affected suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
