### PR TITLE
fix(mcp): read pattern owner at correct nesting level in _check_ownership (M4)

### DIFF
--- a/src/attune/mcp/memory_handlers.py
+++ b/src/attune/mcp/memory_handlers.py
@@ -119,14 +119,22 @@ class MemoryHandlersMixin:
     # Ownership check
     # ------------------------------------------------------------------
 
-    def _check_ownership(self, metadata: dict[str, Any]) -> bool:
+    def _check_ownership(self, pattern: dict[str, Any]) -> bool:
         """Check if the current user owns a pattern.
 
-        Returns True if ownership cannot be determined (no
-        ``created_by`` field) so that legacy data remains
-        accessible.
+        ``recall_pattern`` returns ``{"content": ..., "metadata": {...}}``,
+        so ``created_by`` lives under ``metadata`` — not at the top level.
+        Read the nested value first, falling back to a top-level key for any
+        flat backend shape. Returns True only when ownership genuinely cannot
+        be determined (no ``created_by`` anywhere) so legacy data without
+        ownership info stays accessible.
         """
-        created_by = metadata.get("created_by", "")
+        nested = pattern.get("metadata")
+        created_by = ""
+        if isinstance(nested, dict):
+            created_by = nested.get("created_by") or ""
+        if not created_by:
+            created_by = pattern.get("created_by") or ""
         if not created_by:
             return True  # Legacy data without ownership info
         return str(created_by) == getattr(self, "_user_id", "mcp-session")

--- a/tests/unit/mcp/handlers/test_memory_handlers.py
+++ b/tests/unit/mcp/handlers/test_memory_handlers.py
@@ -275,24 +275,41 @@ class TestHandleMemoryRetrieve:
 
     @pytest.mark.asyncio
     async def test_retrieve_long_term_owned_pattern_returns_data(self):
-        """Pattern with created_by matching the current user is returned."""
+        """Pattern with created_by matching the current user is returned.
+
+        Uses the REAL ``recall_pattern`` return shape — ``created_by`` nested
+        under ``metadata`` — so the ownership gate is exercised against the
+        data it actually receives, not a flat fiction.
+        """
         mem = _make_unified_memory()
         mem.retrieve.return_value = None
         server = _make_server(memory=mem)
-        mem.recall_pattern.return_value = {"content": "mine", "created_by": server._user_id}
+        mem.recall_pattern.return_value = {
+            "content": "mine",
+            "metadata": {"created_by": server._user_id},
+        }
 
         result = await server._handle_memory_retrieve({"key": "k"})
 
         assert result["success"] is True
         assert result["source"] == "long_term"
-        assert result["data"]["created_by"] == server._user_id
+        assert result["data"]["metadata"]["created_by"] == server._user_id
 
     @pytest.mark.asyncio
     async def test_retrieve_long_term_unowned_pattern_denied(self):
-        """Pattern owned by a different user is reported as not found."""
+        """Pattern owned by a different user is reported as not found.
+
+        Regression for the M4 cross-user leak: ``recall_pattern`` returns
+        ``created_by`` nested under ``metadata``. The gate must read that
+        nesting level and deny — the old top-level read always legacy-passed
+        and leaked another user's pattern.
+        """
         mem = _make_unified_memory()
         mem.retrieve.return_value = None
-        mem.recall_pattern.return_value = {"content": "theirs", "created_by": "someone-else"}
+        mem.recall_pattern.return_value = {
+            "content": "theirs",
+            "metadata": {"created_by": "someone-else"},
+        }
         server = _make_server(memory=mem)
 
         result = await server._handle_memory_retrieve({"key": "k"})
@@ -312,6 +329,44 @@ class TestHandleMemoryRetrieve:
 
         assert result["success"] is False
         assert "retrieve boom" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# _check_ownership (M4 shape-read regression)
+# ---------------------------------------------------------------------------
+
+
+class TestCheckOwnership:
+    """Direct tests for _check_ownership() against the real pattern shape.
+
+    ``recall_pattern`` returns ``{"content": ..., "metadata": {...}}``.
+    Regression for M4: the gate previously read ``created_by`` from the top
+    level, which never exists there, so it always legacy-passed and leaked
+    other users' patterns cross-user.
+    """
+
+    def test_nested_metadata_foreign_owner_denied(self):
+        """Foreign owner under metadata → not owned (the leak that was fixed)."""
+        server = _make_server(memory=_make_unified_memory())
+        pattern = {"content": "theirs", "metadata": {"created_by": "someone-else"}}
+        assert server._check_ownership(pattern) is False
+
+    def test_nested_metadata_own_pattern_owned(self):
+        """created_by under metadata matching the user → owned."""
+        server = _make_server(memory=_make_unified_memory())
+        pattern = {"content": "mine", "metadata": {"created_by": server._user_id}}
+        assert server._check_ownership(pattern) is True
+
+    def test_nested_metadata_no_owner_legacy_passes(self):
+        """No created_by anywhere → legacy data stays accessible."""
+        server = _make_server(memory=_make_unified_memory())
+        pattern = {"content": "legacy", "metadata": {"classification": "PUBLIC"}}
+        assert server._check_ownership(pattern) is True
+
+    def test_flat_shape_foreign_owner_still_denied(self):
+        """Top-level created_by fallback keeps flat backend shapes gated."""
+        server = _make_server(memory=_make_unified_memory())
+        assert server._check_ownership({"created_by": "someone-else"}) is False
 
 
 # ---------------------------------------------------------------------------
@@ -491,7 +546,28 @@ class TestHandleMemoryForget:
         result = await server._handle_memory_forget({"key": "k", "scope": "persistent"})
 
         assert result["success"] is True
-        assert "persistent" not in result["removed_from"]
+
+    @pytest.mark.asyncio
+    async def test_forget_persistent_foreign_owner_refused(self):
+        """A persistent delete of another user's pattern is refused, not silent.
+
+        Regression for M4: with the real nested ``recall_pattern`` shape and a
+        delete-capable backend, the ownership gate must deny — returning
+        success=False and never calling delete_pattern. The old top-level
+        created_by read legacy-passed and let one user delete another's data.
+        """
+        mem = _make_unified_memory()
+        mem.recall_pattern.return_value = {
+            "content": "theirs",
+            "metadata": {"created_by": "someone-else"},
+        }
+        server = _make_server(memory=mem)
+
+        result = await server._handle_memory_forget({"key": "pat-x", "scope": "persistent"})
+
+        assert result["success"] is False
+        assert "authorized" in result["error"].lower()
+        mem.delete_pattern.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_forget_import_error_returns_error_dict(self):


### PR DESCRIPTION
## Summary

Library-review batch 1, finding **M4** (`q-attune-ai-review-checkpoint1-001`).
**Verdict: REAL — reproduced, fixed, regression-guarded.**

`src/attune/mcp/memory_handlers.py::_check_ownership` read
`created_by` from the **top level** of `recall_pattern()`'s return, but that
value lives one level down under `metadata`:

```python
recall_pattern(pattern_id) -> {"content": ..., "metadata": {"created_by": "alice@corp", ...}}
```

So the gate always saw `""` → legacy-passed → **one MCP user could retrieve
another user's pattern.**

## How it was settled

The review orchestrator couldn't reproduce (two confounds: recall by the
*human* key returns `None` because human key ≠ generated `pattern_id`; and
separate mock backends share no state). A clean **single shared long-term
backend** probe — two `UnifiedMemory` (alice/bob) over one `storage_dir`,
driving the real handlers — reproduced it:

| Probe (as bob) | Before | After |
|---|---|---|
| `_check_ownership(alice_pattern)` | `True` (bug) | `False` |
| retrieve by `pattern_id` | **leaked alice's content** | `data: None` |

The suspected core gate does **not** back-stop: access control is
classification-based (`PUBLIC = all users`), `memory_store` patterns
auto-classify to PUBLIC, and the cited `long_term_operations.py:145` gate is
inside `delete_pattern` — which `UnifiedMemory` doesn't even expose.

## Fix

Read `created_by` from the nested `metadata` sub-dict first, top-level
fallback for flat shapes, legacy-pass only when genuinely absent everywhere.
Also makes the persistent-forget ownership refusal actually fire on
delete-capable backends.

## Tests

The two existing ownership tests mocked a **flat** shape the real code never
returns — the mock diverged from reality and green-lit the broken gate.
Updated to the real nested shape; added `TestCheckOwnership` and a
forget-refusal regression. **All three decisive guards fail against the
pre-fix source and pass after.** `tests/unit/mcp/` + `test_mcp_memory_tools.py`:
495 pass.

## Scope note (not overclaiming)

Defense-in-depth correctness fix, **not** a complete cross-user boundary. Two
adjacent findings are carried separately, deliberately unbundled:

- `memory_search` returns every matching pattern's content **unfiltered by
  user** — a wider read hole this fix does not close.
- Persistent `memory_forget` is a **silent no-op** on `UnifiedMemory` (no
  `delete_pattern`) yet reports `success: true`.

Full evidence: `~/.attune/reports/attune-ai-review/M4-ownership-gate-verdict-2026-08-20.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
