### PR TITLE
fix(config,wizards,authoring): triage the 8 yaml.safe_load widening sites — 3 fixed, 5 dismissed

### DIFF
--- a/src/attune/authoring/manifest.py
+++ b/src/attune/authoring/manifest.py
@@ -162,7 +162,14 @@ def load_manifest(help_dir: str | Path) -> FeatureManifest:
     if not manifest_path.exists():
         raise FileNotFoundError(f"No {_MANIFEST_FILENAME} in {help_dir}")
 
-    raw = yaml.safe_load(manifest_path.read_text(encoding="utf-8"))
+    try:
+        raw = yaml.safe_load(manifest_path.read_text(encoding="utf-8"))
+    except yaml.YAMLError as exc:
+        # The docstring promises ValueError for a malformed manifest, and
+        # ops/help_data.py degrades on (OSError, ValueError). yaml raises
+        # its own class, which is not a ValueError subclass and defeated
+        # that caller (library-review F2 twin).
+        raise ValueError(f"Invalid manifest YAML in {manifest_path}: {exc}") from exc
     if not isinstance(raw, dict):
         raise ValueError(
             f"Invalid manifest at {manifest_path}: expected mapping, " f"got {type(raw).__name__}"

--- a/src/attune/wizards/config_driven.py
+++ b/src/attune/wizards/config_driven.py
@@ -184,7 +184,13 @@ class ConfigDrivenWizard(BaseWizard):
             raise FileNotFoundError(f"Wizard definition not found: {yaml_path}")
 
         with path.open() as f:
-            data = yaml.safe_load(f)
+            try:
+                data = yaml.safe_load(f)
+            except yaml.YAMLError as exc:
+                # The docstring promises ValueError for invalid YAML;
+                # yaml.YAMLError is not a ValueError subclass, so without
+                # this the documented contract is violated.
+                raise ValueError(f"Invalid wizard YAML in {yaml_path}: {exc}") from exc
 
         if not isinstance(data, dict):
             raise ValueError(f"Invalid wizard YAML: expected a mapping, got {type(data).__name__}")

--- a/src/attune/workflows/config.py
+++ b/src/attune/workflows/config.py
@@ -208,6 +208,11 @@ class WorkflowConfig:
         Raises:
             ImportError: If YAML file is given but PyYAML is not
                 installed.
+            ValueError: If the file is not parseable. The JSON branch
+                raises ``json.JSONDecodeError`` (a ``ValueError``); the
+                YAML branch normalizes ``yaml.YAMLError`` — which is NOT
+                a ``ValueError`` subclass — to the same class, so one
+                ``except ValueError`` covers a broken config either way.
 
         """
         content = path.read_text()
@@ -215,7 +220,10 @@ class WorkflowConfig:
         if path.suffix in (".yaml", ".yml"):
             if not YAML_AVAILABLE:
                 raise ImportError("PyYAML required for YAML config. Install: pip install pyyaml")
-            data = yaml.safe_load(content)
+            try:
+                data = yaml.safe_load(content)
+            except yaml.YAMLError as exc:
+                raise ValueError(f"Invalid YAML config in {path}: {exc}") from exc
         else:
             data = json.loads(content)
 

--- a/tests/unit/authoring/test_manifest.py
+++ b/tests/unit/authoring/test_manifest.py
@@ -471,3 +471,36 @@ def test_save_manifest_omits_empty_docs_bucket(tmp_path):
     save_manifest(manifest, help_dir)
     raw = (help_dir / "features.yaml").read_text(encoding="utf-8")
     assert "_docs" not in raw
+
+
+def test_load_manifest_malformed_yaml_raises_valueerror(tmp_path):
+    """A syntactically-broken features.yaml raises the DOCUMENTED ValueError.
+
+    Regression guard: ``yaml.YAMLError`` is not a ``ValueError`` subclass,
+    so before the fix it escaped ``load_manifest``'s documented contract
+    and defeated ``ops/help_data.py``'s ``except (OSError, ValueError)``
+    degrade path (library-review batch-2 F2 twin).
+    """
+    help_dir = tmp_path / ".help"
+    help_dir.mkdir()
+    (help_dir / "features.yaml").write_text(
+        "features:\n  - foo: [unclosed\n bad: : :\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="Invalid manifest YAML"):
+        load_manifest(help_dir)
+
+
+def test_load_manifest_malformed_yaml_caught_by_degrade_callers(tmp_path):
+    """The (OSError, ValueError) degrade shape used by callers holds."""
+    help_dir = tmp_path / ".help"
+    help_dir.mkdir()
+    (help_dir / "features.yaml").write_text("a: [1, 2\nb: : :\n", encoding="utf-8")
+
+    try:
+        load_manifest(help_dir)
+    except (OSError, ValueError):
+        pass  # degrade path reached, as ops/help_data.py expects
+    else:
+        pytest.fail("malformed manifest did not raise")

--- a/tests/unit/test_workflow_config.py
+++ b/tests/unit/test_workflow_config.py
@@ -558,3 +558,46 @@ class TestModelConfig:
         assert config.max_tokens == 4096
         assert config.supports_vision is False
         assert config.supports_tools is True
+
+
+@pytest.mark.unit
+@pytest.mark.skipif(not YAML_AVAILABLE, reason="PyYAML not installed")
+class TestWorkflowConfigMalformedFile:
+    """Regression: both _load_file branches fail with the same class.
+
+    JSON raises ``json.JSONDecodeError`` (a ``ValueError``); YAML raised
+    ``yaml.YAMLError``, which is NOT a ``ValueError`` subclass, so no
+    single ``except`` clause covered "the config file is broken"
+    (library-review batch-2 widening triage).
+    """
+
+    def test_malformed_yaml_raises_valueerror(self, tmp_path):
+        """Broken YAML config surfaces as ValueError, not yaml.YAMLError."""
+        path = tmp_path / "workflows.yaml"
+        path.write_text("features:\n  - foo: [unclosed\n bad: : :\n")
+
+        with pytest.raises(ValueError, match="Invalid YAML config"):
+            WorkflowConfig.load(path)
+
+    def test_malformed_json_raises_valueerror(self, tmp_path):
+        """The JSON branch already raised a ValueError subclass."""
+        path = tmp_path / "workflows.json"
+        path.write_text("{ not json ")
+
+        with pytest.raises(ValueError):
+            WorkflowConfig.load(path)
+
+    def test_both_branches_share_one_except_clause(self, tmp_path):
+        """One ``except ValueError`` covers a broken config either way."""
+        bad_yaml = tmp_path / "a.yaml"
+        bad_yaml.write_text("a: [1, 2\nb: : :\n")
+        bad_json = tmp_path / "a.json"
+        bad_json.write_text("{ nope ")
+
+        caught = []
+        for path in (bad_yaml, bad_json):
+            try:
+                WorkflowConfig.load(path)
+            except ValueError:
+                caught.append(path.suffix)
+        assert caught == [".yaml", ".json"]

--- a/tests/unit/wizards/test_wizard_config_driven.py
+++ b/tests/unit/wizards/test_wizard_config_driven.py
@@ -1075,3 +1075,21 @@ class TestSessionVariableInterpolationNested:
         assert "Review auth.py" in ctx.instructions
         assert "Focus on security" in ctx.instructions
         assert "Plain instruction" in ctx.instructions
+
+
+@pytest.mark.unit
+class TestConfigDrivenWizardMalformedYAML:
+    """Regression: the documented ValueError contract covers bad YAML."""
+
+    def test_from_yaml_malformed_raises_valueerror(self, tmp_path):
+        """Syntactically-broken YAML raises the DOCUMENTED ValueError.
+
+        ``yaml.YAMLError`` is not a ``ValueError`` subclass, so before the
+        fix ``from_yaml`` violated its own ``Raises: ValueError: If the
+        YAML is invalid`` contract (library-review batch-2 widening).
+        """
+        yaml_path = tmp_path / "broken.yaml"
+        yaml_path.write_text("features:\n  - foo: [unclosed\n bad: : :\n")
+
+        with pytest.raises(ValueError, match="Invalid wizard YAML"):
+            ConfigDrivenWizard.from_yaml(str(yaml_path))


### PR DESCRIPTION
Per-site triage of the 8 `yaml.safe_load` widening candidates the chair
held back from PR #2121 (thread `q-attune-ai-review-checkpoint1-001`).
The ruling was explicit: triage each, **do not bulk-add catches**.

**3 fixed, 5 dismissed with executed evidence.** Every verdict is backed
by a repro that writes a real malformed YAML file
(`features:\n  - foo: [unclosed\n bad: : :\n`) and drives the site's real
public entry point.

## Verdicts

| Site | Contract | Repro (pre-fix) | Verdict |
|---|---|---|---|
| [authoring/manifest.py:165](src/attune/authoring/manifest.py#L165) | docstring: `ValueError: If the manifest is malformed` | `ParserError` escapes; caller's `except (OSError, ValueError)` **defeated** | **FIX** |
| [wizards/config_driven.py:187](src/attune/wizards/config_driven.py#L187) | docstring: `ValueError: If the YAML is invalid` | `ParserError` escapes → contract violated | **FIX** |
| [workflows/config.py:218](src/attune/workflows/config.py#L218) | two branches, two incompatible failure types | YAML→`YAMLError`, JSON→`JSONDecodeError` (a `ValueError`) | **FIX (type only)** |
| [cli_router.py:241](src/attune/cli_router.py#L241) | best-effort, optional prefs | warning printed, `preferences={}`, router still routes | dismissed |
| [bug_predict_patterns.py:50](src/attune/workflows/bug_predict_patterns.py#L50) | already `except (yaml.YAMLError, OSError)` | returns defaults | dismissed |
| [routing/chain_executor.py:106](src/attune/routing/chain_executor.py#L106) | already `except (yaml.YAMLError, OSError)` | constructs, `configs=[]` | dismissed |
| [config/legacy.py:133](src/attune/config/legacy.py#L133) | explicit user-named path, no degrade caller | propagates | dismissed — by design |
| [hooks/config.py:286](src/attune/hooks/config.py#L286) | "present but invalid → raise" already established | propagates | dismissed — by design |

Two of the eight (`bug_predict_patterns`, `chain_executor`) were already
correct — the widening list over-counted; that is what per-site triage
is for.

## The three fixes

**`authoring/manifest.py` is a near-verbatim twin of the
`help/manifest.py` F2 site fixed in #2121**, and it has a live defeated
caller: [`ops/help_data.py:552`](src/attune/ops/help_data.py#L552)
catches `(OSError, ValueError)` to fall back to age-based staleness
rather than 500-ing the dashboard. `yaml.YAMLError` walked straight
through it. Same idiom as #2121 (re-raise as the documented `ValueError`).

**`wizards/config_driven.py`** violates its own docstring. `registry.py:299`
masks it with a broad `except Exception`, so there is no live crash —
but the documented contract is the thing being fixed, and any future
narrow-except caller inherits the hole.

**`workflows/config.py`** is the one judgment call worth the chair's eye.
The defect I fixed is that `_load_file`'s two branches disagree on the
failure type for the *same* failure mode, so no caller can write one
`except` clause for "the config file is broken". I normalized YAML to
`ValueError` and documented it. **I deliberately did NOT change
propagate-vs-degrade policy** — `WorkflowConfig.load()` still raises.
See the open question below.

## Open question for the chair (not actioned)

`WorkflowConfig.load()` **auto-discovers** `attune.config.yml` from the
cwd and is called implicitly from `BaseWorkflow.__init__`
([base.py:380](src/attune/workflows/base.py#L380)) — so a malformed
config the user never named at that call site crashes *every* workflow
construction. Meanwhile `_load_bug_predict_config` reads **the same
auto-discovered file** and degrades to defaults. The repo is
inconsistent about this file. Whether `load()` should degrade is a
policy call I left to the chair; the type normalization here makes
either policy a one-line change.

## Adjacent finding, reported not fixed (out of the 8-site class)

`AttuneConfig.from_yaml` ([config/legacy.py:140](src/attune/config/legacy.py#L140))
crashes with `AttributeError: 'NoneType' object has no attribute 'items'`
on an **empty or comment-only** YAML file. That is sub-shape (A) of the
batch-2 dominant class, not the YAMLError class, and the sibling
`WorkflowConfig._load_file` already handles it explicitly (`if data is
None: data = {}`, commented "Handle empty files"). One-line fix ready on
request — held back because the chair scoped this pass to the YAML
parse-error class.

## Receipts

- **behavioral** — repro harness, all 8 sites, pre- and post-fix. Every
  fixed site now raises the documented `ValueError`; the
  `(OSError, ValueError)` degrade shape at the `help_data` caller now
  holds.
- **regression-guard** — 6 new tests. Verified to **fail on pre-fix
  source**: 5 fail, and the 1 that passes is the JSON control
  (`json` already raised a `ValueError` subclass — that is the point of
  the asymmetry).
- **suite** — serial, `-p no:xdist`:
  `tests/unit/{authoring,wizards,help,ops,gates,rules}` → **3603 passed,
  2 skipped, 3 xfailed**;
  `tests/unit/{workflows,routing,hooks}` + `test_workflow_config.py` +
  `test_config_path_security.py` → **3992 passed**.
- **no caller regressions** — grepped `src/` and `tests/`: nothing
  catches `yaml.YAMLError` from any of these three entry points, so no
  existing handler is orphaned by the type change.

No overlap with the files in #2121.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
