### PR TITLE
test(hooks): dedupe overlapping shared-deadline tests

### DIFF
--- a/tests/unit/hooks/test_starter_reconciler.py
+++ b/tests/unit/hooks/test_starter_reconciler.py
@@ -901,22 +901,11 @@ class TestSharedDeadline:
         monkeypatch.setattr(hook_module, "_DEADLINE", None)
         assert hook_module._remaining(4) == 4
 
-    def test_remaining_zero_when_deadline_passed(self, hook_module, monkeypatch):
-        monkeypatch.setattr(hook_module, "_DEADLINE", time.monotonic() - 1)
-        assert hook_module._remaining(4) == 0.0
-
     def test_remaining_clamps_to_time_left(self, hook_module, monkeypatch):
         monkeypatch.setattr(hook_module, "_DEADLINE", time.monotonic() + 0.5)
         remaining = hook_module._remaining(hook_module.SUBPROC_TIMEOUT)
         assert 0 < remaining <= 0.5
         assert remaining < hook_module.SUBPROC_TIMEOUT
-
-    def test_run_skips_subprocess_once_budget_spent(self, hook_module, monkeypatch):
-        calls: list = []
-        monkeypatch.setattr(hook_module.subprocess, "run", lambda *a, **k: calls.append(1))
-        monkeypatch.setattr(hook_module, "_DEADLINE", time.monotonic() - 1)
-        assert hook_module._run(["git", "status"], None) is None
-        assert calls == []  # never spawned — the deadline already passed
 
     def test_run_clamps_timeout_to_remaining_budget(self, hook_module, monkeypatch):
         captured: dict = {}
@@ -999,20 +988,13 @@ class TestSharedDeadlineSkipPaths:
     These pin the *skip* half of the shared-deadline contract: once the
     global budget is spent, remaining work is not started at all (rather
     than started with a fresh per-call ceiling, which is what pushed the
-    hook past its registered SessionStart timeout).
+    hook past its registered SessionStart timeout). The clamp/passthrough
+    half of ``_remaining`` is covered by ``TestSharedDeadline`` above.
     """
-
-    def test_remaining_returns_ceiling_when_no_deadline(self, hook_module):
-        hook_module._DEADLINE = None
-        assert hook_module._remaining(4.0) == 4.0
 
     def test_remaining_is_zero_once_deadline_passed(self, hook_module, monkeypatch):
         monkeypatch.setattr(hook_module, "_DEADLINE", hook_module.time.monotonic() - 1)
         assert hook_module._remaining(4.0) == 0.0
-
-    def test_remaining_clamps_to_time_left(self, hook_module, monkeypatch):
-        monkeypatch.setattr(hook_module, "_DEADLINE", hook_module.time.monotonic() + 1)
-        assert 0 < hook_module._remaining(4.0) <= 1.0
 
     def test_pypi_lookup_skipped_when_budget_spent(self, hook_module, monkeypatch):
         """The PyPI call must be SKIPPED, not started, past the deadline."""


### PR DESCRIPTION
## What

Test-only cleanup. When the budget=8→6 headroom fix landed (#2120), its
`TestSharedDeadlineSkipPaths` class re-covered three behaviors the
original `TestSharedDeadline` already pinned: `_remaining` passthrough,
`_remaining` clamp, and the `_run` budget-spent skip.

## Change

Give each class one non-overlapping theme so every behavior is asserted
exactly once:

- **`TestSharedDeadline`** — clamp/measurement + contract boundary:
  `_remaining` passthrough & clamp, `_run` timeout-clamp, budget < the
  registered SessionStart timeout, and the end-to-end slow-git receipt.
- **`TestSharedDeadlineSkipPaths`** — the budget-spent **skip** half
  only: `_remaining` zero-past-deadline, plus `_run` and `pypi_latest`
  skipping (not starting) work once the budget is spent. Retains the
  unique PyPI-skip case.

Kept the stronger copy of each duplicate (monkeypatch-restored fixtures,
the `< SUBPROC_TIMEOUT` clamp assertion). No production code touched;
`test_starter_reconciler.py` stays green (92 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
