### PR TITLE
fix: dict-guard the 7 external-input parse sites (library-review C3)

### DIFF
--- a/src/attune/agents/release/security_agent.py
+++ b/src/attune/agents/release/security_agent.py
@@ -155,7 +155,12 @@ class SecurityAuditorAgent(ReleaseAgent):
 
         try:
             data = json.loads(stdout)
-        except json.JSONDecodeError:
+            if not isinstance(data, dict):
+                # A bandit build that emits an array or scalar takes the
+                # same degrade path as unparseable output — data.get()
+                # below is outside this try (library-review C3).
+                raise ValueError("bandit output was not a JSON object")
+        except ValueError:  # includes json.JSONDecodeError
             return {
                 "critical_issues": 0,
                 "high_issues": 0,

--- a/src/attune/workflows/bug_predict_patterns.py
+++ b/src/attune/workflows/bug_predict_patterns.py
@@ -48,7 +48,10 @@ def _load_bug_predict_config() -> dict:
             try:
                 with open(config_path) as f:
                     config = yaml.safe_load(f)
-                    if config and "bug_predict" in config:
+                    # A scalar config makes `"bug_predict" in config`
+                    # raise TypeError; only a mapping can carry the key
+                    # (library-review C3).
+                    if isinstance(config, dict) and "bug_predict" in config:
                         bug_config = config["bug_predict"]
                         return {
                             "risk_threshold": bug_config.get(

--- a/src/attune/workflows/config.py
+++ b/src/attune/workflows/config.py
@@ -231,6 +231,15 @@ class WorkflowConfig:
         if data is None:
             data = {}
 
+        if not isinstance(data, dict):
+            # A list or scalar config reaches `data.get(...)` below and
+            # raises AttributeError; the YAML branch above already
+            # reports malformed config as ValueError, so match it
+            # (library-review C3).
+            raise ValueError(
+                f"Invalid config in {path}: expected a mapping, got {type(data).__name__}"
+            )
+
         result: dict[str, Any] = {}
 
         # Handle root-level provider from attune.config.yml

--- a/src/attune/workflows/dependency_check_parsers.py
+++ b/src/attune/workflows/dependency_check_parsers.py
@@ -243,6 +243,12 @@ class DependencyParserMixin:
             with open(path) as f:
                 data = json.load(f)
 
+            # An npm manifest that is not an object reaches data.get()
+            # below and raises AttributeError past this method's
+            # (OSError, JSONDecodeError) handler (library-review C3).
+            if not isinstance(data, dict):
+                return deps
+
             for dep_type in ["dependencies", "devDependencies"]:
                 for name, version in data.get(dep_type, {}).items():
                     deps.append(
@@ -300,6 +306,11 @@ class DependencyParserMixin:
         try:
             with open(path) as f:
                 data = json.load(f)
+
+            # Same guard as _parse_package_json: a non-object lock file
+            # would escape the handler below (library-review C3).
+            if not isinstance(data, dict):
+                return deps
 
             # npm v7+ format (packages)
             packages = data.get("packages", {})

--- a/src/attune/workflows/escalation/evaluator.py
+++ b/src/attune/workflows/escalation/evaluator.py
@@ -195,8 +195,15 @@ Respond with JSON only:
                 max_tokens=self.max_tokens,
             )
             result = json.loads(llm_response.content)
-        except json.JSONDecodeError:
-            logger.warning("SemanticEvaluator: evaluator response was not valid JSON")
+            if not isinstance(result, dict):
+                # An evaluator that answers with a JSON array or scalar
+                # is an evaluator failure, not a verdict: the .get calls
+                # below sit outside this try, so without the guard a
+                # non-object answer breaks the chain that the handler
+                # right here promises never to block (library-review C3).
+                raise ValueError(f"evaluator returned {type(result).__name__}, not an object")
+        except ValueError:  # includes json.JSONDecodeError
+            logger.warning("SemanticEvaluator: evaluator response was not a JSON object")
             return True, None  # Don't block on evaluator failure
         except Exception:  # noqa: BLE001
             # INTENTIONAL: Evaluator errors should not block the chain.

--- a/src/attune/workflows/test_audit/coverage_parser.py
+++ b/src/attune/workflows/test_audit/coverage_parser.py
@@ -69,6 +69,15 @@ def parse_coverage_json(json_path: str) -> list[ModuleCoverage]:
     except json.JSONDecodeError as exc:
         raise ValueError(f"Invalid coverage JSON at {json_path}: {exc}") from exc
 
+    if not isinstance(data, dict):
+        # The docstring promises ValueError for invalid coverage JSON;
+        # without this a non-object file raised AttributeError from the
+        # .get below instead (library-review C3).
+        raise ValueError(
+            f"Unexpected coverage JSON structure in {json_path}: "
+            f"expected an object, got {type(data).__name__}"
+        )
+
     files = data.get("files", {})
     if not isinstance(files, dict):
         raise ValueError(

--- a/tests/unit/gates/test_external_input_dict_guard.py
+++ b/tests/unit/gates/test_external_input_dict_guard.py
@@ -1,0 +1,144 @@
+"""C3 group A: external bytes must be dict-guarded before a ``.get``.
+
+Library-review class C3 is "a parsed non-dict reaches a ``.get``/``[]``
+chain". The reachability triage
+(``~/.attune/reports/attune-ai-review/C3-triage-2026-08-20.md``) cut 60
+sweep hits to the 7 where the parsed bytes are genuinely **external** —
+LLM output, external-tool stdout, ecosystem manifests, user-authored
+config — and where nothing catches the resulting exception.
+
+Each test drives the site's own entry point with a valid-JSON/YAML
+payload of the wrong top-level type and asserts the site's OWN declared
+behaviour, which differs per site by design:
+
+- degrade quietly (evaluator, security agent, npm parsers)
+- raise the DOCUMENTED ``ValueError`` (coverage parser, workflow config)
+
+A uniform assertion here would have been wrong; the point of the triage
+was that these contracts are not the same.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under Apache 2.0
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+NON_OBJECT_JSON = ["[1,2,3]", '"a string"', "42", "null"]
+
+
+# ---------------------------------------------------------------------------
+# Degrade-quietly contracts
+# ---------------------------------------------------------------------------
+
+
+def test_evaluator_does_not_block_the_chain_on_a_non_object_answer() -> None:
+    """The highest-value site: the LLM answer is untrusted by definition.
+
+    ``result.get("passed")`` sits OUTSIDE the try that wraps the parse,
+    so before the fix a JSON array from the evaluator raised
+    ``AttributeError`` past a handler whose own comment says
+    "Don't block on evaluator failure".
+    """
+    from attune.workflows.escalation.evaluator import SemanticEvaluator
+
+    evaluator = SemanticEvaluator.__new__(SemanticEvaluator)
+    evaluator.evaluator_model = "test-model"
+    evaluator.max_tokens = 16
+
+    class _Executor:
+        async def run(self, **_kwargs):
+            return SimpleNamespace(content="[1, 2, 3]")
+
+    evaluator._get_executor = lambda: _Executor()
+
+    params = list(inspect.signature(SemanticEvaluator.evaluate).parameters)[1:]
+    passed, feedback = asyncio.run(
+        SemanticEvaluator.evaluate(evaluator, **dict.fromkeys(params, "x"))
+    )
+
+    assert passed is True
+    assert feedback is None
+
+
+@pytest.mark.parametrize("payload", NON_OBJECT_JSON)
+def test_bandit_output_that_is_not_an_object_degrades(payload: str) -> None:
+    """An external tool emitting an array takes the unparseable path."""
+    from attune.agents.release import security_agent as module
+
+    agent_cls = next(
+        value
+        for value in vars(module).values()
+        if isinstance(value, type) and hasattr(value, "_parse_bandit_output")
+    )
+    result = agent_cls.__new__(agent_cls)._parse_bandit_output(payload, 1)
+
+    assert result["note"] == "Could not parse bandit output"
+
+
+@pytest.mark.parametrize("payload", NON_OBJECT_JSON)
+def test_npm_manifests_that_are_not_objects_yield_no_deps(payload: str, tmp_path: Path) -> None:
+    """package.json / package-lock.json come from another ecosystem."""
+    from attune.workflows import dependency_check_parsers as module
+
+    parser_cls = next(
+        value
+        for value in vars(module).values()
+        if isinstance(value, type) and hasattr(value, "_parse_package_json")
+    )
+    parser = parser_cls.__new__(parser_cls)
+
+    manifest = tmp_path / "package.json"
+    manifest.write_text(payload, encoding="utf-8")
+    lockfile = tmp_path / "package-lock.json"
+    lockfile.write_text(payload, encoding="utf-8")
+
+    assert parser._parse_package_json(manifest) == []
+    assert parser._parse_package_lock_json(lockfile) == []
+
+
+def test_scalar_bug_predict_config_is_ignored(tmp_path: Path, monkeypatch) -> None:
+    """`"key" in config` raises TypeError on a scalar, so guard the type."""
+    from attune.workflows.bug_predict_patterns import _load_bug_predict_config
+
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "attune.config.yml").write_text("42\n", encoding="utf-8")
+
+    # Falls back to defaults rather than raising TypeError.
+    assert isinstance(_load_bug_predict_config(), dict)
+
+
+# ---------------------------------------------------------------------------
+# Documented-ValueError contracts
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("payload", NON_OBJECT_JSON)
+def test_coverage_json_that_is_not_an_object_raises_value_error(
+    payload: str, tmp_path: Path
+) -> None:
+    """The docstring promises ValueError for invalid coverage JSON."""
+    from attune.workflows.test_audit.coverage_parser import parse_coverage_json
+
+    path = tmp_path / "coverage.json"
+    path.write_text(payload, encoding="utf-8")
+
+    with pytest.raises(ValueError):
+        parse_coverage_json(str(path))
+
+
+def test_non_mapping_workflow_config_raises_value_error(tmp_path: Path) -> None:
+    """Matches the YAML branch, which already reports ValueError."""
+    from attune.workflows.config import WorkflowConfig
+
+    config = tmp_path / "attune.config.yaml"
+    config.write_text("- just\n- a\n- list\n", encoding="utf-8")
+
+    with pytest.raises(ValueError):
+        WorkflowConfig._load_file(config)


### PR DESCRIPTION
## Summary

The C3 reachability triage cut **60 sweep hits to the 7** where the
parsed bytes are genuinely **external** — LLM output, external-tool
stdout, another ecosystem's manifests, user-authored config — *and*
nothing catches the resulting exception.

The other 53 are dismissed with recorded reasons (12 already degrade
behind a catch-all `try`; ~25 parse this codebase's own same-process
writes, where a non-dict means the *writer* is broken and a guard would
hide that) or handed to **batch 3** (15 stored/replayed-later sites —
that batch's whole thesis).

Full reasoning: `~/.attune/reports/attune-ai-review/C3-triage-2026-08-20.md`.

## Each fix matches the site's own contract

That difference is the entire point of triaging rather than bulk-adding
guards.

**Degrade quietly**
- **`workflows/escalation/evaluator.py`** — the headline.
  `result.get("passed")` sits **outside** the `try`, so an evaluator
  answering with a JSON array (an ordinary LLM failure mode) raised
  `AttributeError` past a handler whose own comment reads *"Don't block
  on evaluator failure."* Verified: a hostile array now returns
  `passed=True`, chain not blocked.
- `agents/release/security_agent.py` — bandit emitting a non-object
  takes the existing "Could not parse bandit output" path.
- `workflows/dependency_check_parsers.py` (×2) — a non-object
  `package.json` / `package-lock.json` yields no deps.
- `workflows/bug_predict_patterns.py` — `"key" in config` raises
  `TypeError` on a scalar; guard the type, fall back to defaults.

**Raise the documented `ValueError`**
- `workflows/test_audit/coverage_parser.py` — its docstring promises
  `ValueError` for invalid coverage JSON; a non-object gave
  `AttributeError`.
- `workflows/config.py` — matches the YAML branch directly above it,
  which already reports malformed config as `ValueError`.

## Deliberately not fixed

`mcp/version_check.py` parses a live **PyPI network response** — the
most external source in the tree — and is dismissed because every
`.get` sits inside its `try` behind a catch-all. Provenance alone does
not make a defect; the handler decides.

## Tests

`tests/unit/gates/test_external_input_dict_guard.py` drives each site's
real entry point with wrong-top-level-type payloads and asserts *that
site's own* behaviour — a uniform assertion would have been wrong.
289 gate tests and 3139 workflows/agents tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
