### PR TITLE
fix(memory): atomic lock acquisition and bounded recall connects (library-review tier 3)

### DIFF
--- a/attune_redis/signals.py
+++ b/attune_redis/signals.py
@@ -40,7 +40,16 @@ class RedisSignalBus:
         """
         import redis
 
-        self._redis = redis.from_url(redis_url, decode_responses=True)
+        # Explicit bounds: without them the never-block contract is
+        # decided by the installed redis-py, and the declared pin floor
+        # (5.0.1) supplies none — a blackholed host blocks ~75s
+        # (library-review H5).
+        self._redis = redis.from_url(
+            redis_url,
+            decode_responses=True,
+            socket_connect_timeout=2.0,
+            socket_timeout=5.0,
+        )
         self._closed = False
 
     def send(self, channel: str, message: dict[str, Any]) -> int:

--- a/src/attune/memory/cross_session/conflicts.py
+++ b/src/attune/memory/cross_session/conflicts.py
@@ -101,10 +101,12 @@ def resolve_first_write(
 
     # Try to get lock on resource
     lock_key = f"empathy:lock:{resource_key}"
-    acquired = client.setnx(lock_key, agent_id)
+    # One atomic command: a crash between SETNX and EXPIRE would leave an
+    # immortal lock and hand every later conflict to a dead agent
+    # (library-review H2).
+    acquired = client.set(lock_key, agent_id, nx=True, ex=300)  # 5 minute lock
 
     if acquired:
-        client.expire(lock_key, 300)  # 5 minute lock
         winner = agent_id
         loser = other_session.agent_id if other_session else "unknown"
         reason = "First to acquire lock"

--- a/src/attune/memory/cross_session/coordinator.py
+++ b/src/attune/memory/cross_session/coordinator.py
@@ -367,10 +367,12 @@ class CrossSessionCoordinator:
             return False
 
         lock_key = f"empathy:lock:{resource_key}"
-        acquired = client.setnx(lock_key, self._agent_id)
+        # SET nx+ex is ONE command. SETNX followed by EXPIRE is two, and a
+        # crash in the window leaves an immortal lock with no reaper —
+        # acquire_lock() then returns False forever (library-review H2).
+        acquired = client.set(lock_key, self._agent_id, nx=True, ex=timeout_seconds)
 
         if acquired:
-            client.expire(lock_key, timeout_seconds)
             logger.debug(
                 "lock_acquired",
                 resource_key=resource_key,

--- a/src/attune/memory/cross_session/service.py
+++ b/src/attune/memory/cross_session/service.py
@@ -150,10 +150,11 @@ class BackgroundService:
         if client is None:
             return False
 
-        # Use SETNX for atomic lock acquisition
-        acquired = client.setnx(KEY_SERVICE_LOCK, os.getpid())
-        if acquired:
-            client.expire(KEY_SERVICE_LOCK, SERVICE_LOCK_TTL_SECONDS)
+        # SET nx+ex — genuinely atomic. SETNX then EXPIRE is two commands,
+        # and a crash in the window left this singleton lock immortal, so
+        # the background service could never start again (library-review H2:
+        # the comment here used to claim SETNX was the atomic form).
+        acquired = client.set(KEY_SERVICE_LOCK, os.getpid(), nx=True, ex=SERVICE_LOCK_TTL_SECONDS)
         return bool(acquired)
 
     def _release_service_lock(self) -> None:

--- a/src/attune/memory/recall_redis.py
+++ b/src/attune/memory/recall_redis.py
@@ -39,6 +39,14 @@ def resolve_url(url: str | None = None) -> str:
     return resolve_redis_connection().url
 
 
+#: Seconds to wait for the TCP connect. A recall reader that cannot
+#: reach Redis promptly must degrade, not stall the caller.
+DEFAULT_CONNECT_TIMEOUT = 2.0
+
+#: Seconds to wait for a reply once connected.
+DEFAULT_SOCKET_TIMEOUT = 5.0
+
+
 def connect_recall_redis(url: str | None = None, **kwargs: Any) -> Any:
     """Construct an auth-aware ``redis.Redis`` for a recall/ops reader.
 
@@ -48,6 +56,10 @@ def connect_recall_redis(url: str | None = None, **kwargs: Any) -> Any:
     an explicit kwarg. ``decode_responses`` defaults to True (the
     readers expect ``str``). Extra ``kwargs`` (e.g.
     ``socket_connect_timeout``) pass straight through to ``from_url``.
+
+    Connect and read timeouts default to
+    :data:`DEFAULT_CONNECT_TIMEOUT` / :data:`DEFAULT_SOCKET_TIMEOUT`
+    rather than to whatever the installed redis-py happens to use.
 
     Raises:
         ImportError: If the ``redis`` package is not installed — the caller
@@ -67,4 +79,13 @@ def connect_recall_redis(url: str | None = None, **kwargs: Any) -> Any:
         if password:
             kwargs.setdefault("password", password)
     kwargs.setdefault("decode_responses", True)
+    # Bound the connect and the read HERE, not in each caller. Every
+    # consumer of this factory is on a documented never-block path, and
+    # without an explicit value the contract is decided by whichever
+    # redis-py happens to be installed: on the project's declared pin
+    # floor (redis 5.0.1) there is no default at all, and a blackholed
+    # endpoint blocks ~75s (library-review H5). A caller needing tighter
+    # bounds still passes its own — setdefault never overrides.
+    kwargs.setdefault("socket_connect_timeout", DEFAULT_CONNECT_TIMEOUT)
+    kwargs.setdefault("socket_timeout", DEFAULT_SOCKET_TIMEOUT)
     return redis.Redis.from_url(resolved, **kwargs)

--- a/tests/unit/memory/cross_session/test_conflicts.py
+++ b/tests/unit/memory/cross_session/test_conflicts.py
@@ -115,25 +115,32 @@ class TestResolveFirstWrite:
         r = resolve_first_write("me", None, "res", None)
         assert r.loser_agent_id == "unknown"
 
-    def test_lock_acquired_self_wins_and_sets_expiry(self):
+    def test_lock_acquired_self_wins_with_the_ttl_in_one_command(self):
+        """The TTL rides on the acquisition, not on a follow-up EXPIRE.
+
+        Library-review H2: a crash between SETNX and EXPIRE left the lock
+        immortal. That the TTL is *reached* through a single command is
+        proven server-side in ``test_lock_liveness.py``; here it is the
+        call shape that must not regress.
+        """
         client = MagicMock()
-        client.setnx.return_value = True
+        client.set.return_value = True
         other = session("other", AccessTier.CONTRIBUTOR)
         r = resolve_first_write("me", client, "res", other)
         assert (r.winner_agent_id, r.loser_agent_id) == ("me", "other")
         assert r.reason == "First to acquire lock"
-        client.setnx.assert_called_once_with("empathy:lock:res", "me")
-        client.expire.assert_called_once_with("empathy:lock:res", 300)
+        client.set.assert_called_once_with("empathy:lock:res", "me", nx=True, ex=300)
+        client.expire.assert_not_called()
 
     def test_lock_acquired_no_other_session_loser_unknown(self):
         client = MagicMock()
-        client.setnx.return_value = True
+        client.set.return_value = True
         r = resolve_first_write("me", client, "res", None)
         assert (r.winner_agent_id, r.loser_agent_id) == ("me", "unknown")
 
     def test_lock_held_bytes_owner_decoded(self):
         client = MagicMock()
-        client.setnx.return_value = False
+        client.set.return_value = None
         client.get.return_value = b"owner_agent"
         r = resolve_first_write("me", client, "res", None)
         assert (r.winner_agent_id, r.loser_agent_id) == ("owner_agent", "me")
@@ -141,14 +148,14 @@ class TestResolveFirstWrite:
 
     def test_lock_held_str_owner(self):
         client = MagicMock()
-        client.setnx.return_value = False
+        client.set.return_value = None
         client.get.return_value = "owner_agent"
         r = resolve_first_write("me", client, "res", None)
         assert r.winner_agent_id == "owner_agent"
 
     def test_lock_held_missing_owner_defaults_unknown(self):
         client = MagicMock()
-        client.setnx.return_value = False
+        client.set.return_value = None
         client.get.return_value = None
         r = resolve_first_write("me", client, "res", None)
         assert r.winner_agent_id == "unknown"

--- a/tests/unit/memory/test_cross_session_coordinator.py
+++ b/tests/unit/memory/test_cross_session_coordinator.py
@@ -37,7 +37,7 @@ def _mock_memory() -> RedisShortTermMemory:
     """
     memory = RedisShortTermMemory(use_mock=True)
     mock_client = MagicMock()
-    mock_client.setnx.return_value = True
+    mock_client.set.return_value = True
     mock_client.get.return_value = None
     mock_client.hgetall.return_value = {}
     mock_client.hget.return_value = None
@@ -363,7 +363,7 @@ class TestCrossSessionCoordinatorConflictResolution:
         """FIRST_WRITE_WINS: current writer wins when lock is available."""
         memory = _mock_memory()
         memory._base._client.hget.return_value = None
-        memory._base._client.setnx.return_value = True  # lock available
+        memory._base._client.set.return_value = True  # lock available
 
         coord = CrossSessionCoordinator(
             memory=memory,
@@ -406,18 +406,20 @@ class TestCrossSessionCoordinatorLocking:
     """acquire_lock / release_lock / check_lock with mocked Redis client."""
 
     def test_acquire_lock_success(self):
-        """acquire_lock returns True when setnx succeeds."""
+        """acquire_lock returns True when the atomic SET nx+ex succeeds."""
         memory = _mock_memory()
-        memory._base._client.setnx.return_value = True
+        memory._base._client.set.return_value = True
 
         coord = CrossSessionCoordinator(memory=memory, auto_announce=False)
         assert coord.acquire_lock("resource_x") is True
-        memory._base._client.expire.assert_called()
+        # The TTL rides on the acquisition — a second EXPIRE is the H2
+        # crash window this fix closed.
+        memory._base._client.expire.assert_not_called()
 
     def test_acquire_lock_failure(self):
-        """acquire_lock returns False when setnx fails (lock held)."""
+        """acquire_lock returns False when the atomic SET nx+ex is refused (lock held)."""
         memory = _mock_memory()
-        memory._base._client.setnx.return_value = False
+        memory._base._client.set.return_value = None
 
         coord = CrossSessionCoordinator(memory=memory, auto_announce=False)
         assert coord.acquire_lock("resource_x") is False

--- a/tests/unit/memory/test_cross_session_service.py
+++ b/tests/unit/memory/test_cross_session_service.py
@@ -36,7 +36,7 @@ def _mock_memory() -> RedisShortTermMemory:
     """
     memory = RedisShortTermMemory(use_mock=True)
     mock_client = MagicMock()
-    mock_client.setnx.return_value = True
+    mock_client.set.return_value = True
     mock_client.get.return_value = None
     mock_client.hgetall.return_value = {}
     mock_client.hget.return_value = None
@@ -149,7 +149,7 @@ class TestBackgroundServiceStart:
     def test_start_fails_when_lock_not_acquired(self):
         """start() returns False when the service lock is already held."""
         memory = _mock_memory()
-        memory._base._client.setnx.return_value = False  # lock held
+        memory._base._client.set.return_value = None  # lock held
         service = BackgroundService(memory=memory)
         result = service.start()
         assert result is False
@@ -158,7 +158,7 @@ class TestBackgroundServiceStart:
     def test_start_succeeds_when_lock_acquired(self):
         """start() returns True and sets is_running when lock is free."""
         memory = _mock_memory()
-        memory._base._client.setnx.return_value = True
+        memory._base._client.set.return_value = True
 
         with patch.object(threading.Thread, "start"), patch.object(threading.Thread, "join"):
             service = BackgroundService(memory=memory)
@@ -170,7 +170,7 @@ class TestBackgroundServiceStart:
     def test_start_returns_false_when_already_running(self):
         """Calling start() twice returns False on the second call."""
         memory = _mock_memory()
-        memory._base._client.setnx.return_value = True
+        memory._base._client.set.return_value = True
 
         with patch.object(threading.Thread, "start"), patch.object(threading.Thread, "join"):
             service = BackgroundService(memory=memory)
@@ -224,7 +224,7 @@ class TestGetOrStartService:
     def test_returns_none_when_lock_held(self):
         """Returns None when service lock is already held by another process."""
         memory = _mock_memory()
-        memory._base._client.setnx.return_value = False  # lock held
+        memory._base._client.set.return_value = None  # lock held
 
         result = get_or_start_service(memory)
         assert result is None
@@ -232,7 +232,7 @@ class TestGetOrStartService:
     def test_returns_service_when_started(self):
         """Returns a BackgroundService when the lock is successfully acquired."""
         memory = _mock_memory()
-        memory._base._client.setnx.return_value = True
+        memory._base._client.set.return_value = True
 
         with patch.object(threading.Thread, "start"), patch.object(threading.Thread, "join"):
             result = get_or_start_service(memory)

--- a/tests/unit/memory/test_cross_session_service_internals.py
+++ b/tests/unit/memory/test_cross_session_service_internals.py
@@ -21,18 +21,17 @@ class _FakeClient:
     def __init__(self):
         self.calls: list = []
 
-    def setnx(self, key, value):
-        self.calls.append(("setnx", key))
-        return True
-
     def expire(self, key, ttl):
         self.calls.append(("expire", key, ttl))
 
     def delete(self, key):
         self.calls.append(("delete", key))
 
-    def set(self, key, value):
-        self.calls.append(("set", key))
+    def set(self, key, value, **kwargs):
+        # nx/ex ride along on the acquisition — library-review H2 removed
+        # the follow-up EXPIRE, so this fake must accept them.
+        self.calls.append(("set", key, kwargs))
+        return True
 
 
 class _FakeMemory:
@@ -108,7 +107,7 @@ def test_refresh_lock_extends_ttl_and_writes_heartbeat():
     names = [c[0] for c in client.calls]
     assert "expire" in names and "set" in names
     assert any(c == ("expire", KEY_SERVICE_LOCK, c[2]) for c in client.calls if c[0] == "expire")
-    assert ("set", KEY_SERVICE_HEARTBEAT) in client.calls
+    assert any(c[0] == "set" and c[1] == KEY_SERVICE_HEARTBEAT for c in client.calls)
 
 
 def test_refresh_lock_without_client_is_noop():

--- a/tests/unit/memory/test_lock_liveness.py
+++ b/tests/unit/memory/test_lock_liveness.py
@@ -23,7 +23,6 @@ Licensed under Apache 2.0
 
 from __future__ import annotations
 
-import contextlib
 import os
 import socket
 import time
@@ -57,28 +56,38 @@ class _MemoryStub:
         self._client = client
 
 
-def _command_count(client, command: str) -> int:
-    """How many times the SERVER has executed a command.
+class _Recording:
+    """A pass-through wrapper that records the commands it forwards.
 
-    Server-side truth about what the code actually sent. Asserting the
-    end state (a TTL is present) cannot tell the two implementations
-    apart — ``SETNX`` + ``EXPIRE`` leaves the same TTL when nothing
-    crashes, which is exactly why this class survived review. Asserting
-    that ZERO ``EXPIRE`` commands were sent while the key still came out
-    with a TTL proves the TTL arrived with the SET.
+    NOT a mock: every call reaches the real server and returns the real
+    reply — the wrapper only notes what went past. That distinction is
+    the point. Asserting the END STATE (a TTL is present) cannot tell
+    the two implementations apart, because ``SETNX`` + ``EXPIRE`` leaves
+    exactly the same TTL when nothing crashes, which is why this class
+    survived review in the first place. Asserting that no ``EXPIRE`` was
+    SENT while the key still came out with a TTL proves the TTL arrived
+    with the ``SET``.
+
+    An earlier version read the server's global ``commandstats``, which
+    any unrelated client or concurrent test could perturb into a false
+    failure (codex D11 lane, 2026-08-20). Per-client recording is
+    deterministic and needs no exclusive server.
     """
-    stats = client.info("commandstats") or {}
-    entry = stats.get(f"cmdstat_{command}") or {}
-    return int(entry.get("calls", 0))
 
+    def __init__(self, client):
+        self._client = client
+        self.commands: list[str] = []
 
-@contextlib.contextmanager
-def _expire_calls(client):
-    """Yield a one-element list that receives the EXPIRE delta."""
-    before = _command_count(client, "expire")
-    delta: list[int] = []
-    yield delta
-    delta.append(_command_count(client, "expire") - before)
+    def __getattr__(self, name):
+        attr = getattr(self._client, name)
+        if not callable(attr):
+            return attr
+
+        def _record(*args, **kwargs):
+            self.commands.append(name)
+            return attr(*args, **kwargs)
+
+        return _record
 
 
 def test_acquired_lock_carries_a_ttl_immediately(live_client):
@@ -90,18 +99,18 @@ def test_acquired_lock_carries_a_ttl_immediately(live_client):
     lock_key = f"empathy:lock:{resource}"
     keys.append(lock_key)
 
+    recorder = _Recording(client)
     coordinator = CrossSessionCoordinator.__new__(CrossSessionCoordinator)
-    coordinator._memory = _MemoryStub(client)
+    coordinator._memory = _MemoryStub(recorder)
     coordinator._agent_id = "agent-1"
 
-    with _expire_calls(client) as expires:
-        assert coordinator.acquire_lock(resource, timeout_seconds=30) is True
+    assert coordinator.acquire_lock(resource, timeout_seconds=30) is True
 
     ttl = client.ttl(lock_key)
     assert ttl > 0, f"lock is immortal (TTL={ttl})"
     assert ttl <= 30
     assert (
-        expires[0] == 0
+        "expire" not in recorder.commands
     ), "the TTL came from a SECOND command — crash in between and it is immortal"
 
 
@@ -133,15 +142,17 @@ def test_service_singleton_lock_carries_a_ttl_immediately(live_client):
     client.delete(KEY_SERVICE_LOCK)
     keys.append(KEY_SERVICE_LOCK)
 
+    recorder = _Recording(client)
     service = BackgroundService.__new__(BackgroundService)
-    service._memory = _MemoryStub(client)
+    service._memory = _MemoryStub(recorder)
 
-    with _expire_calls(client) as expires:
-        assert service._acquire_service_lock() is True
+    assert service._acquire_service_lock() is True
 
     ttl = client.ttl(KEY_SERVICE_LOCK)
     assert ttl > 0, f"service lock is immortal (TTL={ttl})"
-    assert expires[0] == 0, "a crash between SETNX and EXPIRE wedges the service permanently"
+    assert (
+        "expire" not in recorder.commands
+    ), "a crash between SETNX and EXPIRE wedges the service permanently"
 
 
 def test_conflict_lock_carries_a_ttl_immediately(live_client):
@@ -153,14 +164,14 @@ def test_conflict_lock_carries_a_ttl_immediately(live_client):
     lock_key = f"empathy:lock:{resource}"
     keys.append(lock_key)
 
-    with _expire_calls(client) as expires:
-        result = resolve_first_write(
-            agent_id="agent-1", client=client, resource_key=resource, other_session=None
-        )
+    recorder = _Recording(client)
+    result = resolve_first_write(
+        agent_id="agent-1", client=recorder, resource_key=resource, other_session=None
+    )
 
     assert result.winner_agent_id == "agent-1"
     assert client.ttl(lock_key) > 0
-    assert expires[0] == 0
+    assert "expire" not in recorder.commands
 
 
 # --------------------------------------------------------------------------
@@ -193,22 +204,33 @@ def test_a_caller_supplied_timeout_still_wins():
     assert kwargs["socket_connect_timeout"] == 0.25
 
 
-def test_connect_to_an_unresponsive_endpoint_gives_up_promptly():
-    """A real listening socket that never completes the handshake.
+def test_the_factory_defaults_bound_an_unresponsive_endpoint():
+    """A real hung endpoint, bounded by OUR defaults — not redis-py's.
 
-    Not a patched clock and not a closed port (which errors instantly):
-    a socket with a full backlog that accepts nothing is what a
-    blackholed endpoint actually looks like, and it is the only shape
-    that distinguishes "we set a timeout" from "we hope redis-py did".
+    The endpoint is a real listening socket with a filled backlog: a
+    blackholed host, not a closed port (which errors instantly and would
+    prove nothing).
+
+    No timeout is passed in, so what is under test is exactly the
+    factory's own defaults. The bound asserted is well under the ~75s an
+    unbounded client blocks for on the project's declared pin floor
+    (redis 5.0.1, which supplies no default at all) and comfortably above
+    the 2s connect + 5s read the factory sets — an earlier version passed
+    an explicit 1s connect timeout and asserted ``elapsed < 15``, which a
+    fallback to redis-py's own 5s read timeout would also satisfy, so it
+    could not tell the two apart (codex D11 lane, 2026-08-20).
     """
     redis = pytest.importorskip("redis")
-    from attune.memory.recall_redis import connect_recall_redis
+    from attune.memory.recall_redis import (
+        DEFAULT_CONNECT_TIMEOUT,
+        DEFAULT_SOCKET_TIMEOUT,
+        connect_recall_redis,
+    )
 
     listener = socket.socket()
     listener.bind(("127.0.0.1", 0))
     listener.listen(0)  # accept nothing; connections queue and stall
     port = listener.getsockname()[1]
-    # Fill the backlog so our own connect cannot be completed.
     fillers = []
     for _ in range(3):
         filler = socket.socket()
@@ -216,7 +238,7 @@ def test_connect_to_an_unresponsive_endpoint_gives_up_promptly():
         filler.connect_ex(("127.0.0.1", port))
         fillers.append(filler)
 
-    client = connect_recall_redis(f"redis://127.0.0.1:{port}/0", socket_connect_timeout=1.0)
+    client = connect_recall_redis(f"redis://127.0.0.1:{port}/0")
     started = time.monotonic()
     try:
         with pytest.raises(redis.RedisError):
@@ -227,4 +249,8 @@ def test_connect_to_an_unresponsive_endpoint_gives_up_promptly():
             filler.close()
         listener.close()
 
-    assert elapsed < 15, f"blocked {elapsed:.1f}s — the connect timeout did not apply"
+    ceiling = DEFAULT_CONNECT_TIMEOUT + DEFAULT_SOCKET_TIMEOUT + 3
+    assert elapsed < ceiling, (
+        f"blocked {elapsed:.1f}s, over the {ceiling:.0f}s the factory's own "
+        f"defaults allow — the never-block contract is not being set here"
+    )

--- a/tests/unit/memory/test_lock_liveness.py
+++ b/tests/unit/memory/test_lock_liveness.py
@@ -1,0 +1,230 @@
+"""Locks must carry their TTL atomically, and readers must be bounded.
+
+Library-review H2: every lock was taken with ``SETNX`` and then given a
+TTL by a SECOND ``EXPIRE`` command. A crash in the window leaves the key
+immortal with no reaper — for the background-service singleton that
+means the service can never start again. The comment at that site read
+"Use SETNX for atomic lock acquisition", which is the belief the class
+falsifies: SETNX is atomic, SETNX-then-EXPIRE is not.
+
+Library-review H5: recall readers on documented never-block paths built
+clients with no ``socket_connect_timeout``, delegating the contract to
+whichever redis-py is installed. On the declared pin floor (5.0.1) there
+is no default and a blackholed endpoint blocks ~75s.
+
+The lock tests run against a REAL Redis (skipped when none is reachable)
+and read the TTL back off the server, because the defect is in what the
+server ends up holding — a mock records the calls it was given, which is
+precisely the thing that was already fine.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under Apache 2.0
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+import socket
+import time
+import uuid
+
+import pytest
+
+#: The suite scrubs REDIS_URL for hermeticity; the live lane takes its
+#: endpoint from here.
+LIVE_REDIS_URL = os.environ.get("TEST_REDIS_URL", "redis://127.0.0.1:6379/0")
+
+
+@pytest.fixture()
+def live_client():
+    redis = pytest.importorskip("redis")
+    client = redis.Redis.from_url(LIVE_REDIS_URL, socket_connect_timeout=0.5)
+    try:
+        client.ping()
+    except Exception:  # noqa: BLE001 — any failure means "no server here"
+        pytest.skip(f"no reachable Redis at {LIVE_REDIS_URL}")
+    keys: list[str] = []
+    yield client, keys
+    for key in keys:
+        client.delete(key)
+
+
+class _MemoryStub:
+    """Only the attribute the lock helpers read — not the lock itself."""
+
+    def __init__(self, client):
+        self._client = client
+
+
+def _command_count(client, command: str) -> int:
+    """How many times the SERVER has executed a command.
+
+    Server-side truth about what the code actually sent. Asserting the
+    end state (a TTL is present) cannot tell the two implementations
+    apart — ``SETNX`` + ``EXPIRE`` leaves the same TTL when nothing
+    crashes, which is exactly why this class survived review. Asserting
+    that ZERO ``EXPIRE`` commands were sent while the key still came out
+    with a TTL proves the TTL arrived with the SET.
+    """
+    stats = client.info("commandstats") or {}
+    entry = stats.get(f"cmdstat_{command}") or {}
+    return int(entry.get("calls", 0))
+
+
+@contextlib.contextmanager
+def _expire_calls(client):
+    """Yield a one-element list that receives the EXPIRE delta."""
+    before = _command_count(client, "expire")
+    delta: list[int] = []
+    yield delta
+    delta.append(_command_count(client, "expire") - before)
+
+
+def test_acquired_lock_carries_a_ttl_immediately(live_client):
+    """Read the TTL off the SERVER — no second command may be required."""
+    from attune.memory.cross_session.coordinator import CrossSessionCoordinator
+
+    client, keys = live_client
+    resource = f"res-{uuid.uuid4().hex[:8]}"
+    lock_key = f"empathy:lock:{resource}"
+    keys.append(lock_key)
+
+    coordinator = CrossSessionCoordinator.__new__(CrossSessionCoordinator)
+    coordinator._memory = _MemoryStub(client)
+    coordinator._agent_id = "agent-1"
+
+    with _expire_calls(client) as expires:
+        assert coordinator.acquire_lock(resource, timeout_seconds=30) is True
+
+    ttl = client.ttl(lock_key)
+    assert ttl > 0, f"lock is immortal (TTL={ttl})"
+    assert ttl <= 30
+    assert (
+        expires[0] == 0
+    ), "the TTL came from a SECOND command — crash in between and it is immortal"
+
+
+def test_second_acquirer_is_refused_while_the_lock_is_held(live_client):
+    """Atomicity did not cost mutual exclusion."""
+    from attune.memory.cross_session.coordinator import CrossSessionCoordinator
+
+    client, keys = live_client
+    resource = f"res-{uuid.uuid4().hex[:8]}"
+    keys.append(f"empathy:lock:{resource}")
+
+    first = CrossSessionCoordinator.__new__(CrossSessionCoordinator)
+    first._memory = _MemoryStub(client)
+    first._agent_id = "agent-1"
+    second = CrossSessionCoordinator.__new__(CrossSessionCoordinator)
+    second._memory = _MemoryStub(client)
+    second._agent_id = "agent-2"
+
+    assert first.acquire_lock(resource, timeout_seconds=30) is True
+    assert second.acquire_lock(resource, timeout_seconds=30) is False
+
+
+def test_service_singleton_lock_carries_a_ttl_immediately(live_client):
+    """The highest-consequence instance: no TTL here wedges the service."""
+    from attune.memory.cross_session.models import KEY_SERVICE_LOCK
+    from attune.memory.cross_session.service import BackgroundService
+
+    client, keys = live_client
+    client.delete(KEY_SERVICE_LOCK)
+    keys.append(KEY_SERVICE_LOCK)
+
+    service = BackgroundService.__new__(BackgroundService)
+    service._memory = _MemoryStub(client)
+
+    with _expire_calls(client) as expires:
+        assert service._acquire_service_lock() is True
+
+    ttl = client.ttl(KEY_SERVICE_LOCK)
+    assert ttl > 0, f"service lock is immortal (TTL={ttl})"
+    assert expires[0] == 0, "a crash between SETNX and EXPIRE wedges the service permanently"
+
+
+def test_conflict_lock_carries_a_ttl_immediately(live_client):
+    """Third instance of the same class."""
+    from attune.memory.cross_session.conflicts import resolve_first_write
+
+    client, keys = live_client
+    resource = f"res-{uuid.uuid4().hex[:8]}"
+    lock_key = f"empathy:lock:{resource}"
+    keys.append(lock_key)
+
+    with _expire_calls(client) as expires:
+        result = resolve_first_write(
+            agent_id="agent-1", client=client, resource_key=resource, other_session=None
+        )
+
+    assert result.winner_agent_id == "agent-1"
+    assert client.ttl(lock_key) > 0
+    assert expires[0] == 0
+
+
+# --------------------------------------------------------------------------
+# H5 — the never-block contract, against a real unresponsive endpoint
+# --------------------------------------------------------------------------
+
+
+def test_recall_client_defaults_carry_explicit_timeouts():
+    """The contract is stated here, not inherited from the installed redis-py."""
+    pytest.importorskip("redis")
+    from attune.memory.recall_redis import (
+        DEFAULT_CONNECT_TIMEOUT,
+        DEFAULT_SOCKET_TIMEOUT,
+        connect_recall_redis,
+    )
+
+    kwargs = connect_recall_redis().connection_pool.connection_kwargs
+
+    assert kwargs["socket_connect_timeout"] == DEFAULT_CONNECT_TIMEOUT
+    assert kwargs["socket_timeout"] == DEFAULT_SOCKET_TIMEOUT
+
+
+def test_a_caller_supplied_timeout_still_wins():
+    """setdefault, not override — the tighter callers keep their bounds."""
+    pytest.importorskip("redis")
+    from attune.memory.recall_redis import connect_recall_redis
+
+    kwargs = connect_recall_redis(socket_connect_timeout=0.25).connection_pool.connection_kwargs
+
+    assert kwargs["socket_connect_timeout"] == 0.25
+
+
+def test_connect_to_an_unresponsive_endpoint_gives_up_promptly():
+    """A real listening socket that never completes the handshake.
+
+    Not a patched clock and not a closed port (which errors instantly):
+    a socket with a full backlog that accepts nothing is what a
+    blackholed endpoint actually looks like, and it is the only shape
+    that distinguishes "we set a timeout" from "we hope redis-py did".
+    """
+    redis = pytest.importorskip("redis")
+    from attune.memory.recall_redis import connect_recall_redis
+
+    listener = socket.socket()
+    listener.bind(("127.0.0.1", 0))
+    listener.listen(0)  # accept nothing; connections queue and stall
+    port = listener.getsockname()[1]
+    # Fill the backlog so our own connect cannot be completed.
+    fillers = []
+    for _ in range(3):
+        filler = socket.socket()
+        filler.setblocking(False)
+        filler.connect_ex(("127.0.0.1", port))
+        fillers.append(filler)
+
+    client = connect_recall_redis(f"redis://127.0.0.1:{port}/0", socket_connect_timeout=1.0)
+    started = time.monotonic()
+    try:
+        with pytest.raises(redis.RedisError):
+            client.ping()
+    finally:
+        elapsed = time.monotonic() - started
+        for filler in fillers:
+            filler.close()
+        listener.close()
+
+    assert elapsed < 15, f"blocked {elapsed:.1f}s — the connect timeout did not apply"


### PR DESCRIPTION
Tier 3 of the library review's batch 3 — the two liveness classes. Chair
said go without a further check-in.

## H2 — the TTL was a second command

All three distributed locks did `SETNX` and then `EXPIRE`. A crash in the
window leaves an immortal key with **no reaper**: `acquire_lock()`
returns False forever after. The worst instance is the background
service's singleton lock, where it means the service can never start
again — and the comment above it read *"Use SETNX for atomic lock
acquisition"*, which is exactly the belief the class falsifies. SETNX is
atomic; SETNX-then-EXPIRE is not.

| Site | |
|---|---|
| `cross_session/coordinator.py:367` | resource locks |
| `cross_session/conflicts.py:104` | first-write-wins conflict resolution |
| `cross_session/service.py:154` | the background-service singleton |

All three now use `set(key, value, nx=True, ex=timeout)` — one command.

## H5 — the never-block contract was delegated to redis-py

Recall readers on documented never-block paths built clients with no
`socket_connect_timeout`, so the contract was decided by whichever
redis-py happened to be installed. On the project's **declared pin floor
(redis 5.0.1) there is no default at all** and a blackholed endpoint
blocks ~75s; it passes today only because redis-py 8 supplies 5s.

`connect_recall_redis` now defaults both timeouts (2s connect, 5s read)
at the factory rather than in each caller, via `setdefault` so the
already-compliant callers keep their tighter bounds.
`attune_redis/signals.py`, which builds its own client, gets explicit
values too.

## Class M caught a weak test of mine, and that is worth reading

The first version of the lock tests asserted the **end state** — "a TTL
is present after acquire" — and **passed against the pre-fix code**,
because `SETNX` + `EXPIRE` leaves exactly the same TTL when nothing
crashes. That is precisely why this class survived review in the first
place.

They now read the server's own `commandstats` and assert that **zero
`EXPIRE` commands were sent while the key still came out with a TTL** —
which proves the TTL arrived with the `SET`. Server-side truth about what
the code actually sent, not a mock recording the calls it was handed.

Generalizable, and now in the register: **when a defect is about HOW a
result was reached, an end-state assertion cannot see it.** Find a real
observation of the mechanism.

The H5 timeout test connects to a real listening socket with a
deliberately filled backlog — a blackholed endpoint, not a closed port,
which errors instantly and would prove nothing.

## Receipts

- Full unit suite green.
- **Live-fire on a real `redis-server`**, hard-killing the process with
  `os._exit(9)` immediately after acquisition:

  ```
  old: exists=1 ttl= -1  -> IMMORTAL — lock never expires, no reaper
  new: exists=1 ttl= 30  -> bounded
  ```

- All three lock tests and the timeout-default test verified failing
  against pre-fix source.

Four existing mocked lock tests moved to the atomic call shape; the
coordinator's `expire.assert_called()` became `assert_not_called()` — the
second command is now the thing that must not happen.

Follows #2128 (tier 1) and #2129 (tier 2); independent of both, branched
from main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
