### PR TITLE
docs(changelog): note next release is 13.0.0 (major)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+_Next release: **13.0.0** (major). The breaking removal of the dormant
+in-package hook-execution engine below forces the major bump; the
+attune-forms 0.7.0 schema sync ships alongside it._
+
 ### Changed — attune-forms 0.7.0: elicitation schema sync (D3 mirror)
 
 - **Dependency floor raised to `attune-forms>=0.7.0,<1.0`** and the


### PR DESCRIPTION
The `[Unreleased]` section already carries a breaking removal (the dormant hook-execution engine, #2125), which forces the next release to be a **major bump → 13.0.0**. This adds a one-line note under the `[Unreleased]` header recording that, so the version is unambiguous whenever the release is cut. Header left as `[Unreleased]` so release tooling still keys off it.

Docs-only; no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)