### PR TITLE
fix(hooks): lessons_reminder survives an unwritable home

### DIFF
--- a/src/attune/hooks/scripts/lessons_reminder.py
+++ b/src/attune/hooks/scripts/lessons_reminder.py
@@ -31,9 +31,20 @@ def already_reminded() -> bool:
 
 
 def mark_reminded() -> None:
-    """Write the sentinel file to suppress repeat reminders."""
-    SENTINEL.parent.mkdir(parents=True, exist_ok=True)
-    SENTINEL.touch()
+    """Write the sentinel file to suppress repeat reminders.
+
+    Best-effort: on an unwritable home (read-only FS, a permissions
+    problem) the write is skipped rather than raised. The cost is a
+    repeat reminder on the next Stop — the fail-safe direction for a
+    nudge — never a crashed Stop hook that drops the reminder entirely.
+    """
+    try:
+        SENTINEL.parent.mkdir(parents=True, exist_ok=True)
+        SENTINEL.touch()
+    except OSError:
+        # INTENTIONAL: the sentinel is an optimization, not a correctness
+        # requirement — if it can't be written we simply remind again.
+        pass
 
 
 def has_session_work() -> bool:
@@ -85,4 +96,15 @@ if __name__ == "__main__":
     from _sdk_gate import exit_if_sdk_subprocess
 
     exit_if_sdk_subprocess()
-    sys.exit(main())
+    try:
+        sys.exit(main())
+    except Exception as exc:  # noqa: BLE001
+        # INTENTIONAL: a Stop hook must never crash the session with a
+        # traceback. main() returning 2 (remind) raises SystemExit, which
+        # passes through; only an unexpected error is caught, and it exits
+        # 0 (allow the stop) — the fail-safe direction for a nudge.
+        print(
+            f"[lessons-reminder] hook error (continuing): {type(exc).__name__}: {exc}",
+            file=sys.stderr,
+        )
+        sys.exit(0)

--- a/tests/unit/gates/test_broad_except_ratchet.py
+++ b/tests/unit/gates/test_broad_except_ratchet.py
@@ -146,7 +146,10 @@ _BASELINE: dict[str, int] = {
     # nested fields (tool_input/file_path), not only OSError.
     "src/attune/hooks/scripts/format_on_save.py": 1,
     "src/attune/hooks/scripts/help_freshness_nudge.py": 1,
-    "src/attune/hooks/scripts/lessons_reminder.py": 1,
+    # lessons_reminder raised 1 -> 2: the Stop-hook __main__ block now
+    # wraps main() to exit 0 on any unexpected error (it must never crash
+    # the session with a traceback), matching every sibling hook here.
+    "src/attune/hooks/scripts/lessons_reminder.py": 2,
     # security_guard added 1 for library-review L1 (PR #2117): a
     # blocking guard must fail OPEN on wrong-typed fields, so main()
     # is wrapped to exit 0 instead of crashing to a non-blocking 1.

--- a/tests/unit/hooks/test_hook_scripts.py
+++ b/tests/unit/hooks/test_hook_scripts.py
@@ -168,6 +168,25 @@ class TestMarkReminded:
         mock_parent.mkdir.assert_called_once_with(parents=True, exist_ok=True)
         mock_sentinel.touch.assert_called_once()
 
+    def test_swallows_oserror_on_unwritable_home(self) -> None:
+        """An unwritable home must not raise — the Stop hook stays alive."""
+        mock_sentinel = MagicMock(spec=Path)
+        mock_sentinel.parent.mkdir.side_effect = OSError("read-only file system")
+
+        with patch("attune.hooks.scripts.lessons_reminder.SENTINEL", mock_sentinel):
+            from attune.hooks.scripts.lessons_reminder import mark_reminded
+
+            mark_reminded()  # must not raise
+
+    def test_swallows_oserror_from_touch(self) -> None:
+        mock_sentinel = MagicMock(spec=Path)
+        mock_sentinel.touch.side_effect = OSError("permission denied")
+
+        with patch("attune.hooks.scripts.lessons_reminder.SENTINEL", mock_sentinel):
+            from attune.hooks.scripts.lessons_reminder import mark_reminded
+
+            mark_reminded()  # must not raise
+
 
 class TestHasSessionWork:
     """Tests for has_session_work() in lessons_reminder."""
@@ -299,6 +318,29 @@ class TestLessonsReminderMain:
 
         assert result == 2
         mock_mark.assert_called_once()
+
+    def test_reminds_even_when_sentinel_unwritable(self, capsys: pytest.CaptureFixture) -> None:
+        """With the REAL mark_reminded and an unwritable sentinel, the
+        reminder still fires (return 2) — the write failure is swallowed."""
+        mock_sentinel = MagicMock(spec=Path)
+        mock_sentinel.parent.mkdir.side_effect = OSError("read-only file system")
+        with (
+            patch(
+                "attune.hooks.scripts.lessons_reminder.already_reminded",
+                return_value=False,
+            ),
+            patch(
+                "attune.hooks.scripts.lessons_reminder.has_session_work",
+                return_value=True,
+            ),
+            patch("attune.hooks.scripts.lessons_reminder.SENTINEL", mock_sentinel),
+        ):
+            from attune.hooks.scripts.lessons_reminder import main
+
+            result = main()
+
+        assert result == 2
+        assert "attune.docs_outbox write" in capsys.readouterr().err
 
     def test_reminder_printed_to_stderr(self, capsys: pytest.CaptureFixture) -> None:
         with (


### PR DESCRIPTION
## What

Batch-1 ledger needs-a-look: **`lessons_reminder` mark_reminded
unwritable-home** (Stop hook).

`mark_reminded()` called `SENTINEL.parent.mkdir()` / `SENTINEL.touch()`
unguarded, and the `__main__` block ran `sys.exit(main())` without the
`try/except` that **every sibling hook** (starter_reconciler,
starter_prompt_nudge, format_on_save) has. On an unwritable home
(read-only FS, a permissions problem) the `OSError` propagated out of
the Stop hook as an uncaught traceback and the lessons-review reminder
was lost.

## Fix

- **Best-effort sentinel write**: `mark_reminded()` swallows `OSError`.
  The cost is a repeat reminder on the next Stop — the fail-safe
  direction for a nudge — never a crashed hook that drops the reminder.
- **Standard `__main__` guard**: exit 0 on any unexpected error (allow
  the stop). `main()` returning 2 raises `SystemExit`, which passes
  through the `except Exception`, so the block/remind path is preserved.

## Tests

- `mark_reminded()` swallows `OSError` from both `mkdir` and `touch`.
- `main()` still returns 2 and prints the reminder to stderr when the
  sentinel is unwritable (real `mark_reminded`, not mocked).

Thread `q-attune-ai-review-checkpoint1-001`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
