### PR TITLE
fix(tests): skip three POSIX-only memory tests on Windows (main hotfix)

### DIFF
--- a/tests/memory/test_long_term_classification.py
+++ b/tests/memory/test_long_term_classification.py
@@ -22,6 +22,8 @@ Design notes (why these assertions, not coverage padding):
   short-circuit mutants die.
 """
 
+import sys
+
 import pytest
 
 from attune.memory.long_term_classification import (
@@ -208,6 +210,12 @@ def test_internal_defaults_the_reader_workspace_to_the_running_process(tmp_path,
     )
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="POSIX-only: Windows forbids deleting the current working directory "
+    "(WinError 32), so a process can never be left with a deleted cwd — the "
+    "bypass this reproduces cannot occur on Windows.",
+)
 def test_a_deleted_working_directory_cannot_bypass_isolation(tmp_path, monkeypatch):
     """The bypass, reproduced against a really-deleted cwd.
 

--- a/tests/unit/memory/test_atomic_io.py
+++ b/tests/unit/memory/test_atomic_io.py
@@ -46,6 +46,12 @@ def test_lock_is_exclusive_between_processes(tmp_path):
     assert "REFUSED" in peer.stdout, peer.stdout + peer.stderr
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="POSIX-only: Windows can't unlink a lock file file_lock holds open "
+    "(WinError 32), so a peer can never break-and-retake it — the ABA race "
+    "this guards against cannot occur on Windows.",
+)
 def test_release_does_not_delete_a_lock_we_no_longer_own(tmp_path):
     """The ABA race: a broken-as-stale holder must not free the new owner.
 

--- a/tests/unit/memory/test_file_stash.py
+++ b/tests/unit/memory/test_file_stash.py
@@ -498,6 +498,7 @@ def test_remember_returns_false_when_write_denied(backend):
     assert backend.recent() == []  # nothing durable — and we said so
 
 
+@_needs_write_denial
 def test_eperm_through_public_stash_entry_returns_false(backend, monkeypatch):
     """R1 regression at the PUBLIC boundary: stash_entry propagates the
     backend's durable-write result and the failure reason is visible."""


### PR DESCRIPTION
## Hotfix: main is red on all 5 Windows lanes

The memory-durability wave (#2128/#2129/#2130) merged three tests that
assert **POSIX filesystem semantics Windows forbids**, so they fail in
setup on Windows — `main`'s latest CI is `failure` on every Windows lane,
and every in-flight PR inherits it through the merge ref (e.g. #2135).

None of the three is a Windows code bug — the scenarios they reproduce
**cannot occur on Windows**:

| Test | Why it can't run on Windows | Fix |
|---|---|---|
| `test_a_deleted_working_directory_cannot_bypass_isolation` | `os.chdir` + `shutil.rmtree` the cwd → WinError 32 (can't delete the cwd) | `skipif(win32)` |
| `test_release_does_not_delete_a_lock_we_no_longer_own` | unlinks a lock `file_lock` holds open → WinError 32 (can't unlink an open file), so the ABA race can't happen | `skipif(win32)` |
| `test_eperm_through_public_stash_entry_returns_false` | `_writes_denied` uses `chmod 0o400/0o500`, a no-op on Windows → write lands, `assert … is False` fails | add `@_needs_write_denial` (the marker its two sibling write-denial tests already carry) |

**Test-only, +15 lines, no source change.** The guarded behaviors and
their POSIX assertions are untouched — the tests still run and pass on
Linux/macOS. 115 tests pass locally across the three files.

Once merged, re-running #2135's CI will go green with no changes to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
