### PR TITLE
fix(hooks): plugin hook timeouts are seconds, not ms (were 1000x too large)

### DIFF
--- a/plugin/hooks/format_on_save.py
+++ b/plugin/hooks/format_on_save.py
@@ -24,8 +24,9 @@ from pathlib import Path
 logger = logging.getLogger(__name__)
 
 #: Total wall-clock budget SHARED across both formatters (black + ruff),
-#: seconds. The registered PostToolUse timeout is 10s (10000ms in
-#: ``plugin/hooks/hooks.json``); this sits below it so the two formatters
+#: seconds. The registered PostToolUse timeout is 10s (``timeout: 10`` in
+#: ``plugin/hooks/hooks.json`` — the field is SECONDS); this sits below it
+#: so the two formatters
 #: COMBINED — plus interpreter start-up — finish before the harness
 #: SIGKILLs the hook. Each formatter previously carried its own 10s
 #: ceiling, so a hung black + hung ruff could run ~20s (> the 10s

--- a/plugin/hooks/hooks.json
+++ b/plugin/hooks/hooks.json
@@ -6,7 +6,7 @@
           {
             "type": "command",
             "command": "PY=$(command -v python3 || command -v python) && \"$PY\" ${CLAUDE_PLUGIN_ROOT}/hooks/welcome.py",
-            "timeout": 3000
+            "timeout": 3
           }
         ]
       },
@@ -15,7 +15,7 @@
           {
             "type": "command",
             "command": "PY=$(command -v python3 || command -v python) && \"$PY\" ${CLAUDE_PLUGIN_ROOT}/hooks/usage_consent_notice.py",
-            "timeout": 2000
+            "timeout": 2
           }
         ]
       },
@@ -24,7 +24,7 @@
           {
             "type": "command",
             "command": "PY=$(command -v python3 || command -v python) && \"$PY\" ${CLAUDE_PLUGIN_ROOT}/hooks/spec_orient.py",
-            "timeout": 4000
+            "timeout": 4
           }
         ]
       },
@@ -33,7 +33,7 @@
           {
             "type": "command",
             "command": "PY=$(command -v python3 || command -v python) && \"$PY\" ${CLAUDE_PLUGIN_ROOT}/hooks/session_recall.py",
-            "timeout": 3000
+            "timeout": 3
           }
         ]
       }
@@ -44,7 +44,7 @@
           {
             "type": "command",
             "command": "PY=$(command -v python3 || command -v python) && \"$PY\" ${CLAUDE_PLUGIN_ROOT}/hooks/compact_warning.py",
-            "timeout": 4000
+            "timeout": 4
           }
         ]
       },
@@ -53,7 +53,7 @@
           {
             "type": "command",
             "command": "PY=$(command -v python3 || command -v python) && \"$PY\" ${CLAUDE_PLUGIN_ROOT}/hooks/session_stash.py",
-            "timeout": 15000
+            "timeout": 15
           }
         ]
       }
@@ -65,7 +65,7 @@
           {
             "type": "command",
             "command": "PY=$(command -v python3 || command -v python) && \"$PY\" ${CLAUDE_PLUGIN_ROOT}/hooks/jit_recall.py",
-            "timeout": 3000
+            "timeout": 3
           }
         ]
       },
@@ -75,7 +75,7 @@
           {
             "type": "command",
             "command": "PY=$(command -v python3 || command -v python) && \"$PY\" ${CLAUDE_PLUGIN_ROOT}/hooks/security_guard.py",
-            "timeout": 5000
+            "timeout": 5
           }
         ]
       },
@@ -85,7 +85,7 @@
           {
             "type": "command",
             "command": "PY=$(command -v python3 || command -v python) && \"$PY\" ${CLAUDE_PLUGIN_ROOT}/hooks/friction_gate.py",
-            "timeout": 4000
+            "timeout": 4
           }
         ]
       },
@@ -95,7 +95,7 @@
           {
             "type": "command",
             "command": "PY=$(command -v python3 || command -v python) && \"$PY\" ${CLAUDE_PLUGIN_ROOT}/hooks/security_guard.py",
-            "timeout": 5000
+            "timeout": 5
           }
         ]
       }
@@ -107,7 +107,7 @@
           {
             "type": "command",
             "command": "PY=$(command -v python3 || command -v python) && \"$PY\" ${CLAUDE_PLUGIN_ROOT}/hooks/format_on_save.py",
-            "timeout": 10000
+            "timeout": 10
           }
         ]
       },
@@ -117,7 +117,7 @@
           {
             "type": "command",
             "command": "PY=$(command -v python3 || command -v python) && \"$PY\" ${CLAUDE_PLUGIN_ROOT}/hooks/help_on_error.py",
-            "timeout": 3000
+            "timeout": 3
           }
         ]
       },
@@ -127,7 +127,7 @@
           {
             "type": "command",
             "command": "PY=$(command -v python3 || command -v python) && \"$PY\" ${CLAUDE_PLUGIN_ROOT}/hooks/help_post_commit.py",
-            "timeout": 5000
+            "timeout": 5
           }
         ]
       },
@@ -137,7 +137,7 @@
           {
             "type": "command",
             "command": "PY=$(command -v python3 || command -v python) && \"$PY\" ${CLAUDE_PLUGIN_ROOT}/hooks/trap_stash.py",
-            "timeout": 5000
+            "timeout": 5
           }
         ]
       }
@@ -148,7 +148,7 @@
           {
             "type": "command",
             "command": "PY=$(command -v python3 || command -v python) && \"$PY\" ${CLAUDE_PLUGIN_ROOT}/hooks/lesson_recall.py",
-            "timeout": 5000
+            "timeout": 5
           }
         ]
       }

--- a/scripts/session_hook_fleet.json
+++ b/scripts/session_hook_fleet.json
@@ -7,7 +7,7 @@
     "_sdk_gate.py"
   ],
   "settings_command": "python .claude/hooks/spec_orient.py",
-  "settings_timeout": 4000,
+  "settings_timeout": 4,
   "siblings": [
     "~/attune-help",
     "~/attune-author",

--- a/scripts/sync_session_hooks.py
+++ b/scripts/sync_session_hooks.py
@@ -155,7 +155,7 @@ def write_sibling(sibling: Path, registry: dict) -> list[str]:
         entry = {
             "type": "command",
             "command": registry["settings_command"],
-            "timeout": registry.get("settings_timeout", 4000),
+            "timeout": registry.get("settings_timeout", 4),
         }
         hooks = settings.setdefault("hooks", {})
         hooks.setdefault("SessionStart", []).append({"hooks": [entry]})

--- a/src/attune/hooks/scripts/format_on_save.py
+++ b/src/attune/hooks/scripts/format_on_save.py
@@ -24,8 +24,9 @@ from pathlib import Path
 logger = logging.getLogger(__name__)
 
 #: Total wall-clock budget SHARED across both formatters (black + ruff),
-#: seconds. The registered PostToolUse timeout is 10s (10000ms in
-#: ``plugin/hooks/hooks.json``, 10s in ``.claude/settings.json``); this
+#: seconds. The registered PostToolUse timeout is 10s (10 in both
+#: ``plugin/hooks/hooks.json`` and ``.claude/settings.json`` — the
+#: ``timeout`` field is SECONDS on both surfaces); this
 #: sits below it so the two formatters COMBINED — plus interpreter
 #: start-up and the src-path import — finish before the harness SIGKILLs
 #: the hook. Each formatter previously carried its own 10s ceiling, so a

--- a/tests/unit/hooks/test_hook_scripts.py
+++ b/tests/unit/hooks/test_hook_scripts.py
@@ -571,17 +571,27 @@ class TestFormatOnSaveSharedBudget:
     def test_wall_budget_under_registered_timeout(self) -> None:
         import attune.hooks.scripts.format_on_save as fos
 
-        # Guard against the surface where the timeout unit is certain:
-        # .claude/settings.json is in seconds (the dev-repo registration
-        # this hook runs under, where the 2x10s>10s overrun was measured).
-        # The plugin hooks.json value (10000) is deliberately NOT asserted
-        # here — its unit (seconds, vs the author's likely-intended ms) is
-        # unverified, so a divisor would encode a guess. Tracked separately.
+        # The ``timeout`` field is SECONDS on BOTH registration surfaces —
+        # ``.claude/settings.json`` and the plugin ``hooks/hooks.json``
+        # share the same hook schema and unit (Claude Code hooks guide:
+        # "Override per hook with the ``timeout`` field in seconds"). So
+        # WALL_BUDGET (seconds) must sit below BOTH registered timeouts,
+        # or the two black+ruff formatters combined can outrun the harness
+        # SIGKILL. Asserting both closes the surface the plugin value was
+        # once (pending unit verification) skipped on.
         repo = Path(__file__).resolve().parents[3]
+
         settings = json.loads((repo / ".claude" / "settings.json").read_text(encoding="utf-8"))
         settings_s = _find_hook_timeout(settings, "format_on_save.py")
         assert settings_s is not None
         assert fos.WALL_BUDGET < settings_s
+
+        plugin_hooks = json.loads(
+            (repo / "plugin" / "hooks" / "hooks.json").read_text(encoding="utf-8")
+        )
+        plugin_s = _find_hook_timeout(plugin_hooks, "format_on_save.py")
+        assert plugin_s is not None
+        assert fos.WALL_BUDGET < plugin_s
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/plugins/test_plugin_config_validation.py
+++ b/tests/unit/plugins/test_plugin_config_validation.py
@@ -147,15 +147,25 @@ class TestHooksJson:
                         )
 
     def test_timeouts_are_reasonable(self) -> None:
-        """Test that hook timeouts are between 1s and 60s."""
+        """Test that hook timeouts are between 1s and 60s.
+
+        The ``timeout`` field is in SECONDS — plugin ``hooks.json`` shares
+        the same hook schema (and unit) as ``.claude/settings.json``. See
+        the Claude Code hooks guide: "Override per hook with the ``timeout``
+        field in seconds." A value like ``10000`` would be read as 10000
+        SECONDS (~2.8 hours), so the plugin's hooks effectively never hit
+        the harness SIGKILL — the latent bug this guard now catches.
+        """
         path = PLUGIN_ROOT / "hooks" / "hooks.json"
         data = json.loads(path.read_text(encoding="utf-8"))
         for _event, entries in data["hooks"].items():
             for entry in entries:
                 for hook in entry["hooks"]:
                     if "timeout" in hook:
-                        assert 1000 <= hook["timeout"] <= 60000, (
-                            f"Timeout {hook['timeout']}ms outside " f"reasonable range (1-60s)"
+                        assert 1 <= hook["timeout"] <= 60, (
+                            f"Timeout {hook['timeout']}s outside reasonable "
+                            f"range (1-60s). The field is SECONDS, not ms — "
+                            f"a value like 10000 means ~2.8 hours."
                         )
 
 

--- a/tests/unit/scripts/test_sync_session_hooks.py
+++ b/tests/unit/scripts/test_sync_session_hooks.py
@@ -39,7 +39,7 @@ def fleet(tmp_path, projector, monkeypatch):
         "canonical_dir": "canon",
         "files": ["spec_orient.py", "_state.py"],
         "settings_command": "python .claude/hooks/spec_orient.py",
-        "settings_timeout": 4000,
+        "settings_timeout": 4,
         "siblings": ["~/sib"],
     }
     monkeypatch.setattr(projector, "REPO_ROOT", tmp_path)


### PR DESCRIPTION
## What

The hook `timeout` field is **seconds** on every registration surface — plugin `hooks.json` shares the same schema/unit as `.claude/settings.json` ([Claude Code hooks guide](https://code.claude.com/docs/en/hooks-guide.md): *"Override per hook with the `timeout` field in seconds"*). The plugin's values (`3000`–`15000`) were being read as **seconds**, giving 50 min – 4 hr timeouts — so the plugin's hooks effectively **never hit the harness SIGKILL**.

Divided every plugin value by 1000 to the intended seconds, matching `.claude/settings.json` (`security_guard=5`, `format_on_save=10`, …).

## Unit verification

Not a guess — confirmed against the official docs before changing anything. Three repo surfaces already *assumed* milliseconds (the config, a guard test, and a code comment), but all traced to the same author, so none was authoritative.

## Same defect found adjacent (also fixed)

The session-hook **fleet projector** re-seeds each sibling repo's SessionStart `settings.json` entry with the same 1000× value:
- `scripts/session_hook_fleet.json` — `settings_timeout: 4000 → 4`
- `scripts/sync_session_hooks.py` — default `4000 → 4`
- `tests/unit/scripts/test_sync_session_hooks.py` — fixture `4000 → 4`

## Guards corrected / added (so it can't recur)

- `test_plugin_config_validation::test_timeouts_are_reasonable` asserted the **ms** range `1000–60000` with an "ms" message — it encoded the same wrong guess. Now asserts seconds `1–60`.
- `test_hook_scripts::test_wall_budget_under_registered_timeout` had the plugin-side assertion **skipped** "pending unit verification". Unit now verified as seconds, so it asserts `WALL_BUDGET < ` **both** the `settings.json` and plugin `hooks.json` registered timeouts — tying the two configs together.
- Stale `10000ms` comments fixed in both `format_on_save.py` copies.

## Testing

- `tests/unit/{hooks,plugins,scripts}` — 1358 passed, 3 skipped
- black + ruff clean; both edited JSON configs parse

## Context

Surfaced while fixing the batch-1 "subprocess-timeout-sum > registered timeout" finding (#2127). The `format_on_save` `WALL_BUDGET=8` code fix is self-bounding and correct regardless of the registration unit; this PR is only about the plugin `hooks.json` timeout **values**.

## Not touched (flagging)

1. **Sibling repos already synced** still hold `timeout: 4000` in their `.claude/settings.json` — the projector only *appends* when no `spec_orient.py` entry exists, so it won't self-heal them.
2. **Spec docs cite the old ms values** — `docs/specs/claim-drift-gates/requirements.md` (rows 49–50, 176) and `docs/specs/self-healing-traps/design.md:56`. `claim-drift-gates` is active and this fix invalidates its premise; left the analytical record for that spec's owner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
