### PR TITLE
docs: 13.0.0 release framing — value-first changelog + upgrade guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,9 @@ killed mid-run. The major version marks two things to check before you
 upgrade — a dormant in-package hook-execution engine was removed (dead
 code, no live caller), and the memory durability & scoping changes alter
 observable behavior — both detailed under **Changed** and **Removed**
-below.
+below. Upgrading? The
+[13.0.0 upgrade guide](docs/migration/upgrading-to-13.0.0.md) has a
+one-glance "are you affected?" table.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,66 +10,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [13.0.0] - 2026-08-20
 
 **Correctness you can trust under failure.** A library-wide review
-hardened the paths that only matter when something goes wrong — memory
-writes that reported success but didn't land, telemetry and gate state
-that a malformed record could corrupt, external input that could crash
-a parse instead of degrading. The major bump is forced by removing the
-dormant in-package hook-execution engine (dead code, no live caller);
-the memory-durability and MCP-schema changes below alter observable
-behavior and are called out for migration.
-
-### Removed — BREAKING: dormant in-package hook-execution engine
-
-- **`attune.hooks.HookRegistry` / `HookExecutor` / `HookConfig`
-  (+ `HookDefinition` / `HookEvent` / `HookMatcher` / `HookRule` /
-  `HookType`) and `attune.commands.CommandContext` /
-  `CommandExecutor` / `create_command_context` deleted.** The
-  in-package hook-execution engine (`src/attune/hooks/executor.py`,
-  `registry.py`, `config.py`, `commands/context.py`) had **no live
-  caller** in attune — the hooks Claude Code actually runs are the
-  scripts under `attune/hooks/scripts/`, wired via the plugin's
-  `hooks.json`, which never touched this engine. Removed under the
-  removing-dead-code gate (5/5 removal signals: zero live usage,
-  fake-success stub tell, orphaned motivation — its originating
-  use-case was retired in 9.0.0 — never-worked with six ledgered
-  bugs, and a fix trip-wire). Chair-ruled DELETE.
-  Migrating? Use Claude Code's own hooks (plugin `hooks.json` +
-  scripts) — see `docs/hooks.md`. (#2125)
-
-### Changed — BREAKING-adjacent: memory durability & scoping semantics
-
-The library-review's memory tier changed behavior code may have relied
-on. Review any code that treats a memory write as fire-and-forget or
-assumed the old (permissive) INTERNAL scoping:
-
-- **The durability set (tier 1):** memory writes that reported success
-  without landing now actually persist or surface the failure — a store
-  write no longer silently drops (#2128).
-- **INTERNAL workspace scoping is now real (tier 2):** scoping that was
-  documented but not enforced is enforced; memory search is documented
-  as ungoverned (not scope-filtered) so callers don't assume isolation
-  it never provided (#2129).
-- **Atomic lock acquisition + bounded recall connects (tier 3):** lock
-  acquisition is atomic and recall connection attempts are bounded, so
-  a contended or unreachable store degrades instead of hanging (#2130).
-
-### Changed — attune-forms 0.7.0: elicitation schema sync (D3 mirror)
-
-- **Dependency floor raised to `attune-forms>=0.7.0,<1.0`** and the
-  hand-maintained MCP elicitation tool schema
-  (`attune.mcp.tool_schemas.get_elicitation_tools`) re-sourced from the
-  library. The v2 rich field/form schema now derives from
-  `attune_forms.mcp_server` instead of a hand-declared copy, so the MCP
-  server advertises 0.7.0's contract to end users: the full construct
-  vocabulary (adds `deliberation`, `triage`, `confirm`, `ranking`,
-  `assumption_review`), typed object-array extras (`progress_items`,
-  `triage_items`, `consequences`, `assumptions`), a multi-type
-  `default` (incl. object for triage rulings), `inferred_from`
-  provenance, and `additionalProperties: false` strictness on both the
-  form and field objects. The v1 AskUserQuestion surface stays a
-  deliberate 4-type schema (D10 enum-honesty). A drift test pins
-  attune-ai's v2 schema to the library's, retiring the recurring
-  hand-sync obligation. Closes the forms 0.7.0 D3 mirror gate. (#2131)
+hardened the paths that only matter when something goes wrong. What you
+get: memory writes that actually persist or tell you they didn't; a
+release Security gate a hallucinated LLM count can no longer slip past;
+malformed or hostile input that degrades instead of crashing a parse;
+and hooks that finish inside their timeout budget instead of being
+killed mid-run. The major version marks two things to check before you
+upgrade — a dormant in-package hook-execution engine was removed (dead
+code, no live caller), and the memory durability & scoping changes alter
+observable behavior — both detailed under **Changed** and **Removed**
+below.
 
 ### Added
 
@@ -130,6 +80,59 @@ MCP correctness:
 - `_check_ownership` reads the pattern owner at the correct nesting
   level (M4) (#2119); `help_init` names are validated before save
   (#2118).
+
+### Changed — BREAKING-adjacent: memory durability & scoping semantics
+
+The library-review's memory tier changed behavior code may have relied
+on. Review any code that treats a memory write as fire-and-forget or
+assumed the old (permissive) INTERNAL scoping:
+
+- **The durability set (tier 1):** memory writes that reported success
+  without landing now actually persist or surface the failure — a store
+  write no longer silently drops (#2128).
+- **INTERNAL workspace scoping is now real (tier 2):** scoping that was
+  documented but not enforced is enforced; memory search is documented
+  as ungoverned (not scope-filtered) so callers don't assume isolation
+  it never provided (#2129).
+- **Atomic lock acquisition + bounded recall connects (tier 3):** lock
+  acquisition is atomic and recall connection attempts are bounded, so
+  a contended or unreachable store degrades instead of hanging (#2130).
+
+### Changed — attune-forms 0.7.0: elicitation schema sync (D3 mirror)
+
+- **Dependency floor raised to `attune-forms>=0.7.0,<1.0`** and the
+  hand-maintained MCP elicitation tool schema
+  (`attune.mcp.tool_schemas.get_elicitation_tools`) re-sourced from the
+  library. The v2 rich field/form schema now derives from
+  `attune_forms.mcp_server` instead of a hand-declared copy, so the MCP
+  server advertises 0.7.0's contract to end users: the full construct
+  vocabulary (adds `deliberation`, `triage`, `confirm`, `ranking`,
+  `assumption_review`), typed object-array extras (`progress_items`,
+  `triage_items`, `consequences`, `assumptions`), a multi-type
+  `default` (incl. object for triage rulings), `inferred_from`
+  provenance, and `additionalProperties: false` strictness on both the
+  form and field objects. The v1 AskUserQuestion surface stays a
+  deliberate 4-type schema (D10 enum-honesty). A drift test pins
+  attune-ai's v2 schema to the library's, retiring the recurring
+  hand-sync obligation. Closes the forms 0.7.0 D3 mirror gate. (#2131)
+
+### Removed — BREAKING: dormant in-package hook-execution engine
+
+- **`attune.hooks.HookRegistry` / `HookExecutor` / `HookConfig`
+  (+ `HookDefinition` / `HookEvent` / `HookMatcher` / `HookRule` /
+  `HookType`) and `attune.commands.CommandContext` /
+  `CommandExecutor` / `create_command_context` deleted.** The
+  in-package hook-execution engine (`src/attune/hooks/executor.py`,
+  `registry.py`, `config.py`, `commands/context.py`) had **no live
+  caller** in attune — the hooks Claude Code actually runs are the
+  scripts under `attune/hooks/scripts/`, wired via the plugin's
+  `hooks.json`, which never touched this engine. Removed under the
+  removing-dead-code gate (5/5 removal signals: zero live usage,
+  fake-success stub tell, orphaned motivation — its originating
+  use-case was retired in 9.0.0 — never-worked with six ledgered
+  bugs, and a fix trip-wire). Chair-ruled DELETE.
+  Migrating? Use Claude Code's own hooks (plugin `hooks.json` +
+  scripts) — see `docs/hooks.md`. (#2125)
 
 ## [12.0.0] - 2026-08-18
 

--- a/docs/migration/upgrading-to-13.0.0.md
+++ b/docs/migration/upgrading-to-13.0.0.md
@@ -2,7 +2,7 @@
 
 13.0.0 mostly makes things you already rely on more dependable — the
 failure paths that only matter when something goes wrong now behave
-correctly (see the [changelog](../../CHANGELOG.md)). **Most projects
+correctly (see the [changelog](https://github.com/Smart-AI-Memory/attune-ai/blob/main/CHANGELOG.md)). **Most projects
 upgrade with no code changes.** A few items change observable behavior
 or a public surface; the table below is a 30-second check for whether
 any touch you.
@@ -134,5 +134,5 @@ nothing to preserve.
 
 ## See also
 
-- [CHANGELOG.md](../../CHANGELOG.md) — the full 13.0.0 entry
+- [CHANGELOG.md](https://github.com/Smart-AI-Memory/attune-ai/blob/main/CHANGELOG.md) — the full 13.0.0 entry
 - [docs/hooks.md](../hooks.md) — Claude Code hooks (the §4 replacement)

--- a/docs/migration/upgrading-to-13.0.0.md
+++ b/docs/migration/upgrading-to-13.0.0.md
@@ -1,22 +1,22 @@
 # Upgrading to 13.0.0
 
-13.0.0 is mostly a **hardening** release — failure paths that only
-matter when something goes wrong now behave correctly (see the
-[changelog](../../CHANGELOG.md)). Most projects upgrade with **no code
-changes**. The major version marks a handful of breaking or
-behavior-changing items; the table below tells you in one glance whether
-any apply to you.
+13.0.0 mostly makes things you already rely on more dependable — the
+failure paths that only matter when something goes wrong now behave
+correctly (see the [changelog](../../CHANGELOG.md)). **Most projects
+upgrade with no code changes.** A few items change observable behavior
+or a public surface; the table below is a 30-second check for whether
+any touch you.
 
-## Are you affected?
+## Do you need to change anything?
 
-| If you… | What changed | Action |
+| Situation | What's different in 13.0.0 | What to do |
 |---|---|---|
-| import `attune.hooks.HookRegistry` / `HookExecutor` / `HookConfig` (or `HookDefinition` / `HookEvent` / `HookMatcher` / `HookRule` / `HookType`), or `attune.commands.CommandContext` / `CommandExecutor` / `create_command_context` | **Removed** (§1) | switch to Claude Code's own hooks |
-| relied on a memory pattern staying visible **across projects** | INTERNAL scoping is now enforced (§2a) | expect cross-project reads to be denied |
-| treated a memory store as **fire-and-forget** (ignored its return value) | durability is now truthful (§2b) | check the return; a `False`/failure is now real |
-| assumed `memory_search` results were **scope-filtered** | search is documented as ungoverned (§2c) | don't rely on search for isolation |
-| pin `attune-forms` **below 0.7.0** | dependency floor raised (§3) | allow `attune-forms>=0.7.0,<1.0` |
-| call the `doc_gen` MCP tool with `doc_type`/`audience`, `attune_set_level` with a boolean, or `memory_store` with `classification` | MCP tool-schema tightening (§4) | drop the dropped params; pass an int level |
+| You import `attune.hooks.*` or `attune.commands.*` internals — `HookRegistry` / `HookExecutor` / `HookConfig` / `HookDefinition` / `HookEvent` / `HookMatcher` / `HookRule` / `HookType`, `CommandContext` / `CommandExecutor` / `create_command_context` (§1) | a dead engine was removed | use Claude Code's hooks |
+| You share `INTERNAL` memory across projects (§2a) | `INTERNAL` is now scoped to its workspace | classify shared patterns `PUBLIC` |
+| You ignore a memory store's return value (§2b) | writes now report failure truthfully | check the return value |
+| You treat `memory_search` as an access boundary (§2c) | search is (and always was) unscoped — now documented | use `memory_retrieve` for isolation |
+| You pin `attune-forms` below 0.7.0 (§3) | floor raised to `>=0.7.0,<1.0` | widen the pin |
+| You call `doc_gen` with `doc_type`/`audience`, `attune_set_level` with a boolean, or `memory_store` with `classification` (§4) | schemas dropped inputs that did nothing | drop the dropped params; pass an int level |
 
 **If none of these describe you, you're done — upgrade normally.** The
 common case (file-based memory, the plugin's hooks, `attune-forms`
@@ -24,119 +24,113 @@ unpinned or already ≥0.7.0) needs nothing.
 
 ---
 
-## 1. Removed: the dormant in-package hook-execution engine
+## 1. A dead in-package hook engine was removed
 
-**Affected if** your code imports any of: `attune.hooks.HookRegistry`,
-`HookExecutor`, `HookConfig`, `HookDefinition`, `HookEvent`,
-`HookMatcher`, `HookRule`, `HookType`, or `attune.commands.CommandContext`,
-`CommandExecutor`, `create_command_context`.
+**This touches you only if** your own code imports
+`attune.hooks.HookRegistry`, `HookExecutor`, `HookConfig`,
+`HookDefinition`, `HookEvent`, `HookMatcher`, `HookRule`, `HookType`, or
+`attune.commands.CommandContext`, `CommandExecutor`,
+`create_command_context`.
 
-This in-package engine (`attune/hooks/executor.py`, `registry.py`,
-`config.py`, `commands/context.py`) had **no live caller** inside attune
-— it never ran the hooks Claude Code actually executes. Those are the
+The reassuring part: this engine never actually ran anything. It had
+**no live caller** inside attune — the hooks Claude Code executes are the
 scripts under `attune/hooks/scripts/`, wired through the plugin's
-`hooks.json`. The engine was removed under the removing-dead-code gate
+`hooks.json`, which never touched it. It was removed as dead code
 (chair-ruled DELETE, #2125).
 
 **What to do:** use Claude Code's own hook system — the plugin
-`hooks.json` plus scripts under `attune/hooks/scripts/`. See
-[docs/hooks.md](../hooks.md). If you had built your own runner on top of
-the removed classes, it was running against dead code and produced no
-effect; there is nothing to preserve.
+`hooks.json` plus the scripts under `attune/hooks/scripts/`. See
+[docs/hooks.md](../hooks.md). If you had built a runner on the removed
+classes, it was running against dead code and had no effect, so there is
+nothing to preserve.
 
-## 2. Changed: memory durability & scoping
+## 2. Memory is more dependable — and a little stricter
 
-The library-review memory tier changed behavior code may have relied on.
-Review anything that assumed the old (permissive) scoping or treated a
-write as fire-and-forget.
+The library-review memory tier makes writes honest and scoping real.
+Both are improvements; each has one narrow case where you'd adjust.
 
-### 2a. INTERNAL workspace scoping is now enforced (#2129)
+### 2a. INTERNAL memory is now scoped to its workspace (#2129)
 
-**Affected if** you relied on an `INTERNAL`-classified pattern created in
-one project being visible from another.
+Scoping that was documented but never enforced is now real: an
+`INTERNAL`-classified pattern is visible only inside the project that
+created it, closing a quiet cross-project leak.
 
-Scoping that was *documented but not enforced* is now enforced: an
-`INTERNAL` pattern is visible only within the workspace that created it.
-Cross-workspace reads that previously succeeded will now be denied.
+**You only need to act if** you were relying on that cross-project
+visibility — classify patterns you mean to share as `PUBLIC` (visible
+everywhere). `SENSITIVE` stays creator-only; `PUBLIC` stays everyone.
 
-**What to do:** if you intentionally shared patterns across projects,
-classify them `PUBLIC` (visible everywhere) rather than relying on the
-old leak. `SENSITIVE` remains creator-only; `PUBLIC` remains everyone.
+### 2b. Memory writes are now honest about failure (#2128)
 
-### 2b. Memory writes are truthfully durable (#2128)
+Your writes now either land or tell you they didn't. A store that
+returns `False` (or raises) means the write did not persist — where
+before, that same call could silently drop and still look successful.
+Your data is safer, and failures are visible instead of hidden.
 
-**Affected if** you call a memory store and ignore its result.
+**You only need to act if** your code ignores store return values: start
+checking them and handle a failed write.
 
-A write that reported success without actually landing now either
-persists or surfaces the failure. A store that returns `False` (or
-raises) is telling you the write did **not** land — previously that same
-call could silently drop and still look successful.
+### 2c. `memory_search` is documented as an unscoped read (#2129)
 
-**What to do:** check the return value of store operations; handle a
-falsy/failed result instead of assuming success.
-
-### 2c. `memory_search` is documented as ungoverned (#2129)
-
-**Affected if** you used `memory_search` and assumed its results were
-access-scoped.
-
-Search is a raw read path: it is **not** classification- or
-workspace-filtered, so it can surface `SENSITIVE` or cross-workspace
-records that `memory_retrieve` would deny. This is now documented
-explicitly so callers don't assume isolation search never provided.
+One thing to know rather than a change: `memory_search` is a raw read —
+it is not classification- or workspace-filtered, so it can surface
+`SENSITIVE` or cross-workspace records that `memory_retrieve` would deny.
+It always worked this way; 13.0.0 documents it so no one assumes an
+isolation it never provided.
 
 **What to do:** don't use `memory_search` as an authorization boundary.
-Use `memory_retrieve` (which enforces ownership) when isolation matters.
+Reach for `memory_retrieve` (which enforces ownership) when isolation
+matters.
 
-### 2d. Contended/unreachable stores degrade instead of hanging (#2130)
+### 2d. Contended or unreachable stores degrade instead of hanging (#2130)
 
-**No action needed** — lock acquisition is now atomic and recall
-connection attempts are bounded, so a contended or unreachable store
-degrades gracefully rather than hanging. This only removes failure
-modes.
+**Nothing to do** — lock acquisition is now atomic and recall connection
+attempts are bounded, so a busy or unreachable store fails fast and
+degrades gracefully instead of hanging. This only removes failure modes.
 
-## 3. Dependency floor: `attune-forms >= 0.7.0`
+## 3. `attune-forms` now requires 0.7.0+
 
-**Affected if** you pin `attune-forms` below `0.7.0`.
+**This touches you only if** you pin `attune-forms` below `0.7.0`.
 
-The floor is raised to `attune-forms>=0.7.0,<1.0` (#2131). The MCP
-elicitation schema is now sourced from the library, so the server
+The floor is raised to `attune-forms>=0.7.0,<1.0` (#2131), and the MCP
+elicitation schema is now sourced from the library — so the server
 advertises 0.7.0's full construct vocabulary (adds `deliberation`,
-`triage`, `confirm`, `ranking`, `assumption_review`).
+`triage`, `confirm`, `ranking`, `assumption_review`) with no
+hand-maintained mirror to drift.
 
-**What to do:** allow `attune-forms>=0.7.0,<1.0` in your environment.
-A plain `pip install -U attune-ai` resolves it for you.
+**What to do:** allow `attune-forms>=0.7.0,<1.0`. A plain
+`pip install -U attune-ai` resolves it for you.
 
-## 4. MCP tool-schema tightening
+## 4. MCP tool schemas dropped inputs that never worked
 
-**Affected if** you call these MCP tools with the named inputs:
+**This touches you only if** you call these MCP tools with the named
+inputs:
 
-- **`doc_gen`** no longer accepts `doc_type` / `audience` — both were
+- **`doc_gen`** no longer accepts `doc_type` / `audience`. Both were
   dropped from the underlying workflow in the v4.2.0 SDK migration and
-  had been silently ignored. Remove them from your calls; the generated
-  shape is chosen from the source.
-- **`attune_set_level`** rejects a boolean `level`. `True`/`False`
+  had been silently ignored ever since — removing them just stops
+  advertising inputs that did nothing. The generated shape is chosen
+  from the source.
+- **`attune_set_level`** now rejects a boolean `level`. `True`/`False`
   previously slipped through as `1`/`0`; pass an integer `1`–`5`.
 - **`memory_store`** now honors an explicit `classification` on the
-  persisted long-term pattern (previously ignored). Omit it to keep
-  automatic classification — passing a value **overrides** auto-detection,
-  so don't send `PUBLIC` on content that should stay `SENSITIVE`.
+  persisted long-term pattern (it was ignored before). Omit it to keep
+  automatic classification — an explicit value **overrides**
+  auto-detection, so don't send `PUBLIC` on content that should stay
+  `SENSITIVE`.
 
 **What to do:** drop the removed `doc_gen` params, pass an integer level,
-and set `memory_store`'s `classification` only when you mean to override
-auto-classification.
+and set `memory_store`'s `classification` only when you deliberately want
+to override auto-classification.
 
 ---
 
-## Not sure whether you're affected?
+## Not sure whether anything applies?
 
-- Grep your code for the removed symbols in §1 — no hits means §1
-  doesn't apply.
+- Grep your code for the symbols in §1 — no hits means §1 is moot.
 - If you only use file-based memory through the CLI/plugin and never
   import `attune.memory` directly, §2 is transparent to you.
 - If you don't pin `attune-forms`, §3 is automatic.
-- If you don't call the MCP tools in §4 with those inputs, §4 doesn't
-  apply.
+- If you don't call the MCP tools in §4 with those inputs, §4 is moot.
 
 ## See also
 

--- a/docs/migration/upgrading-to-13.0.0.md
+++ b/docs/migration/upgrading-to-13.0.0.md
@@ -1,0 +1,144 @@
+# Upgrading to 13.0.0
+
+13.0.0 is mostly a **hardening** release — failure paths that only
+matter when something goes wrong now behave correctly (see the
+[changelog](../../CHANGELOG.md)). Most projects upgrade with **no code
+changes**. The major version marks a handful of breaking or
+behavior-changing items; the table below tells you in one glance whether
+any apply to you.
+
+## Are you affected?
+
+| If you… | What changed | Action |
+|---|---|---|
+| import `attune.hooks.HookRegistry` / `HookExecutor` / `HookConfig` (or `HookDefinition` / `HookEvent` / `HookMatcher` / `HookRule` / `HookType`), or `attune.commands.CommandContext` / `CommandExecutor` / `create_command_context` | **Removed** (§1) | switch to Claude Code's own hooks |
+| relied on a memory pattern staying visible **across projects** | INTERNAL scoping is now enforced (§2a) | expect cross-project reads to be denied |
+| treated a memory store as **fire-and-forget** (ignored its return value) | durability is now truthful (§2b) | check the return; a `False`/failure is now real |
+| assumed `memory_search` results were **scope-filtered** | search is documented as ungoverned (§2c) | don't rely on search for isolation |
+| pin `attune-forms` **below 0.7.0** | dependency floor raised (§3) | allow `attune-forms>=0.7.0,<1.0` |
+| call the `doc_gen` MCP tool with `doc_type`/`audience`, `attune_set_level` with a boolean, or `memory_store` with `classification` | MCP tool-schema tightening (§4) | drop the dropped params; pass an int level |
+
+**If none of these describe you, you're done — upgrade normally.** The
+common case (file-based memory, the plugin's hooks, `attune-forms`
+unpinned or already ≥0.7.0) needs nothing.
+
+---
+
+## 1. Removed: the dormant in-package hook-execution engine
+
+**Affected if** your code imports any of: `attune.hooks.HookRegistry`,
+`HookExecutor`, `HookConfig`, `HookDefinition`, `HookEvent`,
+`HookMatcher`, `HookRule`, `HookType`, or `attune.commands.CommandContext`,
+`CommandExecutor`, `create_command_context`.
+
+This in-package engine (`attune/hooks/executor.py`, `registry.py`,
+`config.py`, `commands/context.py`) had **no live caller** inside attune
+— it never ran the hooks Claude Code actually executes. Those are the
+scripts under `attune/hooks/scripts/`, wired through the plugin's
+`hooks.json`. The engine was removed under the removing-dead-code gate
+(chair-ruled DELETE, #2125).
+
+**What to do:** use Claude Code's own hook system — the plugin
+`hooks.json` plus scripts under `attune/hooks/scripts/`. See
+[docs/hooks.md](../hooks.md). If you had built your own runner on top of
+the removed classes, it was running against dead code and produced no
+effect; there is nothing to preserve.
+
+## 2. Changed: memory durability & scoping
+
+The library-review memory tier changed behavior code may have relied on.
+Review anything that assumed the old (permissive) scoping or treated a
+write as fire-and-forget.
+
+### 2a. INTERNAL workspace scoping is now enforced (#2129)
+
+**Affected if** you relied on an `INTERNAL`-classified pattern created in
+one project being visible from another.
+
+Scoping that was *documented but not enforced* is now enforced: an
+`INTERNAL` pattern is visible only within the workspace that created it.
+Cross-workspace reads that previously succeeded will now be denied.
+
+**What to do:** if you intentionally shared patterns across projects,
+classify them `PUBLIC` (visible everywhere) rather than relying on the
+old leak. `SENSITIVE` remains creator-only; `PUBLIC` remains everyone.
+
+### 2b. Memory writes are truthfully durable (#2128)
+
+**Affected if** you call a memory store and ignore its result.
+
+A write that reported success without actually landing now either
+persists or surfaces the failure. A store that returns `False` (or
+raises) is telling you the write did **not** land — previously that same
+call could silently drop and still look successful.
+
+**What to do:** check the return value of store operations; handle a
+falsy/failed result instead of assuming success.
+
+### 2c. `memory_search` is documented as ungoverned (#2129)
+
+**Affected if** you used `memory_search` and assumed its results were
+access-scoped.
+
+Search is a raw read path: it is **not** classification- or
+workspace-filtered, so it can surface `SENSITIVE` or cross-workspace
+records that `memory_retrieve` would deny. This is now documented
+explicitly so callers don't assume isolation search never provided.
+
+**What to do:** don't use `memory_search` as an authorization boundary.
+Use `memory_retrieve` (which enforces ownership) when isolation matters.
+
+### 2d. Contended/unreachable stores degrade instead of hanging (#2130)
+
+**No action needed** — lock acquisition is now atomic and recall
+connection attempts are bounded, so a contended or unreachable store
+degrades gracefully rather than hanging. This only removes failure
+modes.
+
+## 3. Dependency floor: `attune-forms >= 0.7.0`
+
+**Affected if** you pin `attune-forms` below `0.7.0`.
+
+The floor is raised to `attune-forms>=0.7.0,<1.0` (#2131). The MCP
+elicitation schema is now sourced from the library, so the server
+advertises 0.7.0's full construct vocabulary (adds `deliberation`,
+`triage`, `confirm`, `ranking`, `assumption_review`).
+
+**What to do:** allow `attune-forms>=0.7.0,<1.0` in your environment.
+A plain `pip install -U attune-ai` resolves it for you.
+
+## 4. MCP tool-schema tightening
+
+**Affected if** you call these MCP tools with the named inputs:
+
+- **`doc_gen`** no longer accepts `doc_type` / `audience` — both were
+  dropped from the underlying workflow in the v4.2.0 SDK migration and
+  had been silently ignored. Remove them from your calls; the generated
+  shape is chosen from the source.
+- **`attune_set_level`** rejects a boolean `level`. `True`/`False`
+  previously slipped through as `1`/`0`; pass an integer `1`–`5`.
+- **`memory_store`** now honors an explicit `classification` on the
+  persisted long-term pattern (previously ignored). Omit it to keep
+  automatic classification — passing a value **overrides** auto-detection,
+  so don't send `PUBLIC` on content that should stay `SENSITIVE`.
+
+**What to do:** drop the removed `doc_gen` params, pass an integer level,
+and set `memory_store`'s `classification` only when you mean to override
+auto-classification.
+
+---
+
+## Not sure whether you're affected?
+
+- Grep your code for the removed symbols in §1 — no hits means §1
+  doesn't apply.
+- If you only use file-based memory through the CLI/plugin and never
+  import `attune.memory` directly, §2 is transparent to you.
+- If you don't pin `attune-forms`, §3 is automatic.
+- If you don't call the MCP tools in §4 with those inputs, §4 doesn't
+  apply.
+
+## See also
+
+- [CHANGELOG.md](../../CHANGELOG.md) — the full 13.0.0 entry
+- [docs/hooks.md](../hooks.md) — Claude Code hooks (the §1 replacement)

--- a/docs/migration/upgrading-to-13.0.0.md
+++ b/docs/migration/upgrading-to-13.0.0.md
@@ -11,12 +11,12 @@ any touch you.
 
 | Situation | What's different in 13.0.0 | What to do |
 |---|---|---|
-| You import `attune.hooks.*` or `attune.commands.*` internals — `HookRegistry` / `HookExecutor` / `HookConfig` / `HookDefinition` / `HookEvent` / `HookMatcher` / `HookRule` / `HookType`, `CommandContext` / `CommandExecutor` / `create_command_context` (§1) | a dead engine was removed | use Claude Code's hooks |
-| You share `INTERNAL` memory across projects (§2a) | `INTERNAL` is now scoped to its workspace | classify shared patterns `PUBLIC` |
-| You ignore a memory store's return value (§2b) | writes now report failure truthfully | check the return value |
-| You treat `memory_search` as an access boundary (§2c) | search is (and always was) unscoped — now documented | use `memory_retrieve` for isolation |
-| You pin `attune-forms` below 0.7.0 (§3) | floor raised to `>=0.7.0,<1.0` | widen the pin |
-| You call `doc_gen` with `doc_type`/`audience`, `attune_set_level` with a boolean, or `memory_store` with `classification` (§4) | schemas dropped inputs that did nothing | drop the dropped params; pass an int level |
+| You share `INTERNAL` memory across projects (§1a) | `INTERNAL` is now scoped to its workspace | classify shared patterns `PUBLIC` |
+| You ignore a memory store's return value (§1b) | writes now report failure truthfully | check the return value |
+| You treat `memory_search` as an access boundary (§1c) | search is (and always was) unscoped — now documented | use `memory_retrieve` for isolation |
+| You pin `attune-forms` below 0.7.0 (§2) | floor raised to `>=0.7.0,<1.0` | widen the pin |
+| You call `doc_gen` with `doc_type`/`audience`, `attune_set_level` with a boolean, or `memory_store` with `classification` (§3) | schemas dropped inputs that did nothing | drop the dropped params; pass an int level |
+| You import `attune.hooks.*` or `attune.commands.*` internals (§4) | a dead engine was removed | use Claude Code's hooks |
 
 **If none of these describe you, you're done — upgrade normally.** The
 common case (file-based memory, the plugin's hooks, `attune-forms`
@@ -24,32 +24,12 @@ unpinned or already ≥0.7.0) needs nothing.
 
 ---
 
-## 1. A dead in-package hook engine was removed
-
-**This touches you only if** your own code imports
-`attune.hooks.HookRegistry`, `HookExecutor`, `HookConfig`,
-`HookDefinition`, `HookEvent`, `HookMatcher`, `HookRule`, `HookType`, or
-`attune.commands.CommandContext`, `CommandExecutor`,
-`create_command_context`.
-
-The reassuring part: this engine never actually ran anything. It had
-**no live caller** inside attune — the hooks Claude Code executes are the
-scripts under `attune/hooks/scripts/`, wired through the plugin's
-`hooks.json`, which never touched it. It was removed as dead code
-(chair-ruled DELETE, #2125).
-
-**What to do:** use Claude Code's own hook system — the plugin
-`hooks.json` plus the scripts under `attune/hooks/scripts/`. See
-[docs/hooks.md](../hooks.md). If you had built a runner on the removed
-classes, it was running against dead code and had no effect, so there is
-nothing to preserve.
-
-## 2. Memory is more dependable — and a little stricter
+## 1. Memory is more dependable — and a little stricter
 
 The library-review memory tier makes writes honest and scoping real.
 Both are improvements; each has one narrow case where you'd adjust.
 
-### 2a. INTERNAL memory is now scoped to its workspace (#2129)
+### 1a. INTERNAL memory is now scoped to its workspace (#2129)
 
 Scoping that was documented but never enforced is now real: an
 `INTERNAL`-classified pattern is visible only inside the project that
@@ -59,7 +39,7 @@ created it, closing a quiet cross-project leak.
 visibility — classify patterns you mean to share as `PUBLIC` (visible
 everywhere). `SENSITIVE` stays creator-only; `PUBLIC` stays everyone.
 
-### 2b. Memory writes are now honest about failure (#2128)
+### 1b. Memory writes are now honest about failure (#2128)
 
 Your writes now either land or tell you they didn't. A store that
 returns `False` (or raises) means the write did not persist — where
@@ -69,7 +49,7 @@ Your data is safer, and failures are visible instead of hidden.
 **You only need to act if** your code ignores store return values: start
 checking them and handle a failed write.
 
-### 2c. `memory_search` is documented as an unscoped read (#2129)
+### 1c. `memory_search` is documented as an unscoped read (#2129)
 
 One thing to know rather than a change: `memory_search` is a raw read —
 it is not classification- or workspace-filtered, so it can surface
@@ -81,13 +61,13 @@ isolation it never provided.
 Reach for `memory_retrieve` (which enforces ownership) when isolation
 matters.
 
-### 2d. Contended or unreachable stores degrade instead of hanging (#2130)
+### 1d. Contended or unreachable stores degrade instead of hanging (#2130)
 
 **Nothing to do** — lock acquisition is now atomic and recall connection
 attempts are bounded, so a busy or unreachable store fails fast and
 degrades gracefully instead of hanging. This only removes failure modes.
 
-## 3. `attune-forms` now requires 0.7.0+
+## 2. `attune-forms` now requires 0.7.0+
 
 **This touches you only if** you pin `attune-forms` below `0.7.0`.
 
@@ -100,7 +80,7 @@ hand-maintained mirror to drift.
 **What to do:** allow `attune-forms>=0.7.0,<1.0`. A plain
 `pip install -U attune-ai` resolves it for you.
 
-## 4. MCP tool schemas dropped inputs that never worked
+## 3. MCP tool schemas dropped inputs that never worked
 
 **This touches you only if** you call these MCP tools with the named
 inputs:
@@ -122,17 +102,37 @@ inputs:
 and set `memory_store`'s `classification` only when you deliberately want
 to override auto-classification.
 
+## 4. A dead in-package hook engine was removed
+
+**Almost certainly not you** — this touches only code that imports
+`attune.hooks.HookRegistry`, `HookExecutor`, `HookConfig`,
+`HookDefinition`, `HookEvent`, `HookMatcher`, `HookRule`, `HookType`, or
+`attune.commands.CommandContext`, `CommandExecutor`,
+`create_command_context`.
+
+The reassuring part: this engine never actually ran anything. It had
+**no live caller** inside attune — the hooks Claude Code executes are the
+scripts under `attune/hooks/scripts/`, wired through the plugin's
+`hooks.json`, which never touched it. It was removed as dead code
+(chair-ruled DELETE, #2125).
+
+**What to do:** use Claude Code's own hook system — the plugin
+`hooks.json` plus the scripts under `attune/hooks/scripts/`. See
+[docs/hooks.md](../hooks.md). If you had built a runner on the removed
+classes, it was running against dead code and had no effect, so there is
+nothing to preserve.
+
 ---
 
 ## Not sure whether anything applies?
 
-- Grep your code for the symbols in §1 — no hits means §1 is moot.
 - If you only use file-based memory through the CLI/plugin and never
-  import `attune.memory` directly, §2 is transparent to you.
-- If you don't pin `attune-forms`, §3 is automatic.
-- If you don't call the MCP tools in §4 with those inputs, §4 is moot.
+  import `attune.memory` directly, §1 is transparent to you.
+- If you don't pin `attune-forms`, §2 is automatic.
+- If you don't call the MCP tools in §3 with those inputs, §3 is moot.
+- Grep your code for the symbols in §4 — no hits means §4 is moot.
 
 ## See also
 
 - [CHANGELOG.md](../../CHANGELOG.md) — the full 13.0.0 entry
-- [docs/hooks.md](../hooks.md) — Claude Code hooks (the §1 replacement)
+- [docs/hooks.md](../hooks.md) — Claude Code hooks (the §4 replacement)


### PR DESCRIPTION
## What

Two pieces of 13.0.0 release polish.

### 1. Value-first changelog reorder
The 13.0.0 entry opened with `Removed — BREAKING: dormant engine` — an
inward-facing cleanup — before anything a user gains. Reordered
subsections **Added → Fixed → Changed → Removed** and rewrote the intro
to lead with *what you get* (memory that persists or says it didn't, a
Security gate a hallucinated count can't slip past, input that degrades
instead of crashing, hooks that finish in budget). Pure reorder + intro
rewrite — **15 bullets / 25 PR refs, identical before and after.**

### 2. "Are you affected?" upgrade guide
`docs/migration/upgrading-to-13.0.0.md`, led by a one-glance table.
The two *silent* behavior changes (INTERNAL scoping now enforced, memory
writes truthfully durable) don't error for affected code — it just
behaves differently — so a polished major needs an upgrade story, not
only changelog bullets. Per-change sections cover: the removed hook
engine, memory durability & scoping (incl. ungoverned search), the
`attune-forms>=0.7.0` floor, and the MCP tool-schema tightening (#2140),
each with an affected-if test and an action. Linked from the changelog
intro.

## Safety

- No changelog bullet content changed (reorder only).
- Removed symbols appear as inline code, never in import fences →
  doc-import-audit stays green (verified locally).
- `prepare_release.py` inserts new entries (order-independent);
  `website/app/changelog/page.tsx` reads `CHANGELOG.md` at build time, so
  both changes propagate to the site automatically.

Levers 1 and 3 of the three 13.0.0 "polish" moves. (Lever 2 — a
deliberate call on ungoverned search — is still open.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
