### PR TITLE
chore(release): bump version to 13.0.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "Persistent memory and receipt-verified workflows for Claude Code. Spec-driven development with an approval loop, plus 28 auto-triggering skills: security audits, code review, test generation, release prep.",
-    "version": "12.0.0"
+    "version": "13.0.0"
   },
   "plugins": [
     {
       "name": "attune-ai",
       "description": "Persistent memory and receipt-verified workflows for Claude Code. /spec carries an idea through brainstorm, requirements, design, and task execution with quality gates and your approval at each stage. Backed by 28 auto-triggering skills — security audits, code reviews, test generation, bug prediction, and release preparation. For help content tools, also install attune-help from this marketplace; authoring ships built in via the attune.authoring module.",
       "source": "./plugin",
-      "version": "12.0.0",
+      "version": "13.0.0",
       "author": {
         "name": "Smart AI Memory",
         "email": "patrick.roebuck@smartaimemory.com"

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,4 +1,4 @@
-# Attune AI Framework v12.0.0
+# Attune AI Framework v13.0.0
 
 AI-powered developer workflows with cost optimization and multi-agent orchestration.
 
@@ -556,7 +556,7 @@ attune_redis/          # Redis plugin — BUNDLED, ships in the attune-ai
 
 ---
 
-**Version:** 12.0.0 | **License:** Apache 2.0 | **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)
+**Version:** 13.0.0 | **License:** Apache 2.0 | **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)
 
 ## Lessons — core
 

--- a/docs/reference/API_REFERENCE.md
+++ b/docs/reference/API_REFERENCE.md
@@ -1,6 +1,6 @@
 # Attune AI API Reference
 
-**Version:** 12.0.0
+**Version:** 13.0.0
 **License:** Apache License 2.0
 **Copyright:** 2025-2026 Smart AI Memory, LLC
 
@@ -1152,5 +1152,5 @@ msg = format_error(
 
 ---
 
-**Version:** 12.0.0 | **License:** Apache 2.0
+**Version:** 13.0.0 | **License:** Apache 2.0
 **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)

--- a/plugin/.claude-plugin/marketplace.json
+++ b/plugin/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "Spec-driven development for Claude Code — /spec plans, reviews, and executes with quality gates; plus security audits, code reviews, test generation, and release prep from /attune.",
-    "version": "12.0.0"
+    "version": "13.0.0"
   },
   "plugins": [
     {
       "name": "attune-ai",
       "description": "Spec-driven development for Claude Code — /spec plans, reviews, and executes with quality gates; plus security audits, code reviews, test generation, and release prep from /attune.",
       "source": "./",
-      "version": "12.0.0",
+      "version": "13.0.0",
       "author": {
         "name": "Smart AI Memory",
         "email": "patrick.roebuck@smartaimemory.com"

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "attune-ai",
-  "version": "12.0.0",
+  "version": "13.0.0",
   "description": "Persistent memory and receipt-verified workflows for Claude Code — /spec plans, reviews, and executes with quality gates; plus security audits, code reviews, test generation, and release prep from /attune.",
   "author": {
     "name": "Smart AI Memory",

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -4,7 +4,7 @@ Spec-driven development for Claude Code — turn requirements
 into reliable software. <!-- cap:skill_count -->28 auto-triggering skills<!-- /cap -->, zero
 commands: say what you need and Claude picks the right skill.
 
-**Version:** 12.0.0 | **License:** Apache 2.0
+**Version:** 13.0.0 | **License:** Apache 2.0
 
 > **Fix Receipts** (`/fix`) — new in 11.2.0. Say `fix this and
 > prove it`.

--- a/plugin/core/__init__.py
+++ b/plugin/core/__init__.py
@@ -5,4 +5,4 @@ This module provides the core workflow functionality when the full
 attune-ai package is not installed via pip.
 """
 
-__version__ = "12.0.0"
+__version__ = "13.0.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "attune-ai"
-version = "12.0.0"
+version = "13.0.0"
 description = "Persistent memory and receipt-verified workflows for Claude Code — plugin, MCP server, and spec-driven dev framework."
 readme = {file = "README.md", content-type = "text/markdown"}
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -299,7 +299,7 @@ wheels = [
 
 [[package]]
 name = "attune-ai"
-version = "12.0.0"
+version = "13.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "agent-memory-client" },

--- a/website/app/page.tsx
+++ b/website/app/page.tsx
@@ -54,7 +54,7 @@ export default function Home() {
             <div className="grid lg:grid-cols-2 gap-16 items-center">
               <div className="z-10">
                 <div className="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-[var(--surface-container-high)] text-[var(--primary)] text-xs font-bold tracking-widest mb-6 uppercase">
-                  <span>v12.0.0</span>
+                  <span>v13.0.0</span>
                   <span className="w-1 h-1 rounded-full bg-[var(--primary)]"></span>
                   <span className="opacity-80">Memory &amp; receipts for Claude Code</span>
                 </div>

--- a/website/lib/features.ts
+++ b/website/lib/features.ts
@@ -34,7 +34,7 @@ export const PRODUCTS: Product[] = [
     id: "attune-ai",
     name: "Attune AI",
     pypiName: "attune-ai",
-    version: "12.0.0",
+    version: "13.0.0",
     tagline: "Generate, maintain, and serve help from your code",
     installCommand: "pip install attune-ai",
     marketplaceInstall:
@@ -78,7 +78,7 @@ export const PRODUCTS: Product[] = [
     id: "claude-code-plugin",
     name: "Claude Code Plugin",
     pypiName: "attune-ai",
-    version: "12.0.0",
+    version: "13.0.0",
     tagline: "Progressive help right in your terminal",
     installCommand:
       "claude plugin marketplace add Smart-AI-Memory/attune-ai",


### PR DESCRIPTION
## What

Version bump **12.0.0 → 13.0.0** — the last gate before tagging (the
pre-release check flagged this as the one blocker).

Applied via the canonical `scripts/bump_version.py` (not hand-edited, so
the website version sites aren't missed), plus `uv lock`:

- `pyproject.toml`, `uv.lock`
- `plugin/.claude-plugin/plugin.json`, both `marketplace.json` (root +
  plugin), `plugin/core/__init__.py`, `plugin/README.md`
- `docs/reference/API_REFERENCE.md`, `.claude/CLAUDE.md`
- `website/lib/features.ts`, `website/app/page.tsx` — bumped because the
  **required** `test_website_version_accuracy.py` couples website→pyproject
  during the release window

The 13.0.0 CHANGELOG entry already landed (value-first reorder + the
interactive-forms Added item + migration guide).

## Verified locally

- `test_website_version_accuracy` — 15 passed (website↔pyproject)
- `test_version_check` + `test_bump_version` — 21 passed
- No test hardcodes the old version

Once this merges green, re-running `attune-release-check 13.0.0` should
come back all-green and ready to `gh release create v13.0.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
