### PR TITLE
ci(release): make the GitHub Release step idempotent

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,15 +70,24 @@ jobs:
         echo "---" >> RELEASE_NOTES.md
         echo "**Full Changelog**: https://github.com/${{ github.repository }}/compare/$(git describe --tags --abbrev=0 HEAD^)...v${{ steps.version.outputs.version }}" >> RELEASE_NOTES.md
 
-    - name: Create GitHub Release
+    - name: Create or update GitHub Release
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        gh release create v${{ steps.version.outputs.version }} \
-          dist/* \
-          --title "v${{ steps.version.outputs.version }}" \
-          --notes-file RELEASE_NOTES.md \
-          --verify-tag
+        VER="v${{ steps.version.outputs.version }}"
+        if gh release view "$VER" >/dev/null 2>&1; then
+          # Release already exists (created manually, or a re-run) —
+          # attach the built artifacts to it instead of hard-failing on
+          # a duplicate. Leaves any hand-written notes untouched.
+          echo "Release $VER exists — uploading artifacts to it"
+          gh release upload "$VER" dist/* --clobber
+        else
+          gh release create "$VER" \
+            dist/* \
+            --title "$VER" \
+            --notes-file RELEASE_NOTES.md \
+            --verify-tag
+        fi
 
     # PyPI publishing is handled by publish-pypi.yml via OIDC trusted publishing
     # which triggers when this release is created


### PR DESCRIPTION
## What

Make `release.yml`'s "Create GitHub Release" step **idempotent** — so the
built wheels always get attached to the release, regardless of how the
release came to exist.

## Why

Today's 13.0.0 tag exposed it. The intended flow is: tag push →
`release.yml` runs `gh release create … dist/*` → that creates the
Release with wheels → which triggers `publish-pypi.yml`. But the 13.0.0
release was **created manually in the UI first**, so the workflow's
`gh release create` hit `"a release with the same tag name already
exists"` and **exited 1 before attaching the wheels** — the release page
had no artifacts until I uploaded them by hand. (The PyPI publish was
unaffected; it triggers on the release-created event either way.)

## Fix

```
if gh release view "$VER"; then
  gh release upload "$VER" dist/* --clobber   # attach to the existing release
else
  gh release create "$VER" dist/* --title … --notes-file … --verify-tag
fi
```

Wheels now land on the release whether it was created by the workflow,
manually, or on a re-run — and the step never hard-fails on a duplicate.
Hand-written notes on a pre-existing release are left untouched.

## Not doing

No backfill of GitHub Releases — the `gh` API shows a release already
exists for every version (v9.1.0 → v13.0.0), matching PyPI. There is no
gap; this only prevents the duplicate-collision failure from recurring.

## Verified

`yaml.safe_load` parses; `test_workflow_yaml` + `test_ci_spend_guard`
pass (330). No secret refs added.

Note: `.github/` diffs can't use the `auto-merge-when-green` label (the
when-green guard rules them out of class), so this needs a manual merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
