### PR TITLE
fix(memory): anchor default long-term storage to ~/.attune, not CWD

### DIFF
--- a/src/attune/memory/control_panel.py
+++ b/src/attune/memory/control_panel.py
@@ -36,7 +36,7 @@ from __future__ import annotations
 import json
 import time
 import warnings
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -74,6 +74,7 @@ from .redis_bootstrap import (
     stop_redis,
 )
 from .short_term import RedisShortTermMemory
+from .storage_backend import default_storage_dir
 from .types import AccessTier, AgentCredentials
 
 # Suppress noisy warnings in CLI mode
@@ -91,7 +92,7 @@ class ControlPanelConfig:
 
     redis_host: str = "127.0.0.1"
     redis_port: int = 6379
-    storage_dir: str = "./memdocs_storage"
+    storage_dir: str = field(default_factory=default_storage_dir)
     audit_dir: str = "./logs"
     auto_start_redis: bool = True
 

--- a/src/attune/memory/control_panel_display.py
+++ b/src/attune/memory/control_panel_display.py
@@ -17,6 +17,8 @@ from typing import TYPE_CHECKING, Any
 
 import structlog
 
+from .storage_backend import default_storage_dir
+
 if TYPE_CHECKING:
     from .control_panel import MemoryControlPanel
 
@@ -188,7 +190,7 @@ Quick Start:
     )
     parser.add_argument(
         "--storage",
-        default="./memdocs_storage",
+        default=default_storage_dir(),
         help="Long-term storage directory",
     )
     parser.add_argument(

--- a/src/attune/memory/long_term_integration.py
+++ b/src/attune/memory/long_term_integration.py
@@ -74,7 +74,7 @@ class SecureMemDocsIntegration(PatternPipelineMixin, PatternOperationsMixin):
     def __init__(
         self,
         claude_memory_config=None,
-        storage_dir: str = "./memdocs_storage",
+        storage_dir: str | None = None,
         audit_log_dir: str | None = None,
         classification_rules: dict[Classification, ClassificationRules] | None = None,
         enable_encryption: bool = True,
@@ -84,7 +84,8 @@ class SecureMemDocsIntegration(PatternPipelineMixin, PatternOperationsMixin):
 
         Args:
             claude_memory_config: Configuration for Claude memory
-            storage_dir: Directory for MemDocs storage
+            storage_dir: Directory for MemDocs storage. When None,
+                resolves to the home-anchored default store.
             audit_log_dir: Directory for audit logs
             classification_rules: Custom rules (defaults if None)
             enable_encryption: Enable encryption for SENSITIVE patterns
@@ -122,7 +123,7 @@ class SecureMemDocsIntegration(PatternPipelineMixin, PatternOperationsMixin):
         logger.info(
             "secure_memdocs_initialized",
             encryption_enabled=self.encryption_enabled,
-            storage_dir=storage_dir,
+            storage_dir=str(self.storage.storage_dir),
             audit_dir=audit_log_dir,
         )
 

--- a/src/attune/memory/storage_backend.py
+++ b/src/attune/memory/storage_backend.py
@@ -27,6 +27,29 @@ from attune.security.path_validation import _validate_file_path
 logger = structlog.get_logger(__name__)
 
 
+def default_storage_dir() -> str:
+    """Resolve the default long-term memory storage directory.
+
+    Anchors to ``~/.attune/memdocs_storage`` so long-term patterns do not
+    scatter across whatever directory a process happens to be launched
+    from — a CWD-relative default silently splits (and appears to lose)
+    memory when the same install is started from different projects.
+
+    For backward compatibility, an existing ``memdocs_storage`` directory
+    under the current working directory (the historical default location)
+    is preferred so already-stored data is never stranded; its absolute
+    path is returned so a later ``chdir`` cannot move the target.
+
+    Returns:
+        Absolute path string for the default storage directory.
+
+    """
+    legacy = Path.cwd() / "memdocs_storage"
+    if legacy.is_dir():
+        return str(legacy)
+    return str(Path.home() / ".attune" / "memdocs_storage")
+
+
 class MemDocsStorage:
     """Mock/Simple MemDocs storage backend.
 
@@ -34,14 +57,16 @@ class MemDocsStorage:
     For now, provides a simple file-based storage for testing.
     """
 
-    def __init__(self, storage_dir: str = "./memdocs_storage"):
+    def __init__(self, storage_dir: str | None = None):
         """Initialize storage backend.
 
         Args:
-            storage_dir: Directory for pattern storage
+            storage_dir: Directory for pattern storage. When ``None``,
+                resolves to :func:`default_storage_dir` (home-anchored,
+                with a legacy-CWD fallback).
 
         """
-        self.storage_dir = Path(storage_dir)
+        self.storage_dir = Path(storage_dir if storage_dir is not None else default_storage_dir())
         self.storage_dir.mkdir(parents=True, exist_ok=True)
         logger.info("memdocs_storage_initialized", storage_dir=str(self.storage_dir))
 

--- a/src/attune/memory/storage_backend.py
+++ b/src/attune/memory/storage_backend.py
@@ -47,7 +47,17 @@ def default_storage_dir() -> str:
     legacy = Path.cwd() / "memdocs_storage"
     if legacy.is_dir():
         return str(legacy)
-    return str(Path.home() / ".attune" / "memdocs_storage")
+    try:
+        home = Path.home()
+    except (RuntimeError, OSError):
+        # No resolvable home directory — e.g. a Windows account or CI env
+        # with USERPROFILE/HOMEDRIVE unset (POSIX falls back to pwd; Windows
+        # does not). Degrade to an absolute temp-based root so storage still
+        # works and never silently reverts to a CWD-relative path.
+        import tempfile
+
+        home = Path(tempfile.gettempdir())
+    return str(home / ".attune" / "memdocs_storage")
 
 
 class MemDocsStorage:

--- a/src/attune/memory/unified.py
+++ b/src/attune/memory/unified.py
@@ -48,6 +48,7 @@ from .short_term import (
     AccessTier,
     RedisShortTermMemory,
 )
+from .storage_backend import default_storage_dir
 
 logger = structlog.get_logger(__name__)
 
@@ -81,7 +82,7 @@ class MemoryConfig:
     default_ttl_seconds: int = 3600  # 1 hour
 
     # Long-term memory settings
-    storage_dir: str = "./memdocs_storage"
+    storage_dir: str = field(default_factory=default_storage_dir)
     encryption_enabled: bool = True
 
     # Claude memory settings
@@ -140,7 +141,7 @@ class MemoryConfig:
             == "true",
             redis_required=(get_attune_env("REDIS_REQUIRED", "false") or "false").lower() == "true",
             # Long-term storage
-            storage_dir=get_attune_env("STORAGE_DIR", "./memdocs_storage") or "./memdocs_storage",
+            storage_dir=get_attune_env("STORAGE_DIR", "") or default_storage_dir(),
             encryption_enabled=(get_attune_env("ENCRYPTION", "true") or "true").lower() == "true",
             claude_memory_enabled=(get_attune_env("CLAUDE_MEMORY", "true") or "true").lower()
             == "true",

--- a/tests/memory/test_control_panel.py
+++ b/tests/memory/test_control_panel.py
@@ -75,7 +75,7 @@ class TestControlPanelConfig:
         config = ControlPanelConfig()
         assert config.redis_host == "127.0.0.1"
         assert config.redis_port == 6379
-        assert config.storage_dir == "./memdocs_storage"
+        assert config.storage_dir.endswith("memdocs_storage")
         assert config.audit_dir == "./logs"
         assert config.auto_start_redis is True
 

--- a/tests/unit/memory/test_control_panel.py
+++ b/tests/unit/memory/test_control_panel.py
@@ -481,7 +481,7 @@ class TestControlPanelConfig:
         config = ControlPanelConfig()
         assert config.redis_host == "127.0.0.1"
         assert config.redis_port == 6379
-        assert config.storage_dir == "./memdocs_storage"
+        assert config.storage_dir.endswith("memdocs_storage")
         assert config.audit_dir == "./logs"
         assert config.auto_start_redis is True
 

--- a/tests/unit/memory/test_storage_dir_default.py
+++ b/tests/unit/memory/test_storage_dir_default.py
@@ -1,0 +1,74 @@
+"""Regression: the default long-term storage dir is home-anchored, not CWD.
+
+A CWD-relative default (``./memdocs_storage``) silently splits long-term
+memory across whatever directory the process was launched from, so patterns
+stored from one project look *gone* when the same install is started from
+another. These tests pin the home-anchored default and the backward-compat
+fallback that keeps using an existing ``./memdocs_storage`` if one is present.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from attune.memory.storage_backend import MemDocsStorage, default_storage_dir
+from attune.memory.unified import MemoryConfig
+
+
+@pytest.fixture
+def clean_env(monkeypatch, tmp_path):
+    """Isolate HOME/CWD and clear any storage-dir env override."""
+    home = tmp_path / "home"
+    home.mkdir()
+    work = tmp_path / "work"
+    work.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("USERPROFILE", str(home))  # Path.home() on Windows
+    for var in ("ATTUNE_STORAGE_DIR", "EMPATHY_STORAGE_DIR", "STORAGE_DIR"):
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.chdir(work)
+    return home, work
+
+
+def test_default_is_home_anchored_when_no_legacy_dir(clean_env):
+    home, _work = clean_env
+    expected = (home / ".attune" / "memdocs_storage").resolve()
+    assert Path(default_storage_dir()).resolve() == expected
+
+
+def test_default_prefers_existing_cwd_legacy_dir(clean_env):
+    _home, work = clean_env
+    legacy = work / "memdocs_storage"
+    legacy.mkdir()
+    # An existing CWD store is kept (as an absolute path) so data is not stranded.
+    got = Path(default_storage_dir())
+    assert got.is_absolute()
+    assert got.resolve() == legacy.resolve()
+
+
+def test_default_is_always_absolute(clean_env):
+    assert Path(default_storage_dir()).is_absolute()
+
+
+def test_backend_none_resolves_and_creates_dir(clean_env):
+    home, _work = clean_env
+    storage = MemDocsStorage()  # storage_dir=None -> default
+    assert storage.storage_dir.is_absolute()
+    assert storage.storage_dir.exists()
+    assert storage.storage_dir.resolve() == (home / ".attune" / "memdocs_storage").resolve()
+
+
+def test_config_from_environment_is_home_anchored(clean_env):
+    home, _work = clean_env
+    config = MemoryConfig.from_environment()
+    assert Path(config.storage_dir).is_absolute()
+    assert Path(config.storage_dir).resolve() == (home / ".attune" / "memdocs_storage").resolve()
+
+
+def test_env_override_wins(clean_env, monkeypatch, tmp_path):
+    override = tmp_path / "explicit-store"
+    monkeypatch.setenv("ATTUNE_STORAGE_DIR", str(override))
+    config = MemoryConfig.from_environment()
+    assert config.storage_dir == str(override)

--- a/tests/unit/memory/test_storage_dir_default.py
+++ b/tests/unit/memory/test_storage_dir_default.py
@@ -72,3 +72,21 @@ def test_env_override_wins(clean_env, monkeypatch, tmp_path):
     monkeypatch.setenv("ATTUNE_STORAGE_DIR", str(override))
     config = MemoryConfig.from_environment()
     assert config.storage_dir == str(override)
+
+
+def test_degrades_when_home_unresolvable(clean_env, monkeypatch):
+    """No resolvable home (Windows env cleared) must not crash resolution.
+
+    Mirrors the ``patch.dict(os.environ, {}, clear=True)`` env-parsing tests,
+    which strip USERPROFILE/HOMEDRIVE so ``Path.home()`` raises on Windows.
+    """
+
+    def _raise():
+        raise RuntimeError("Could not determine home directory.")
+
+    monkeypatch.setattr("attune.memory.storage_backend.Path.home", staticmethod(_raise))
+    got = Path(default_storage_dir())
+    assert got.is_absolute()
+    assert got.name == "memdocs_storage"
+    # from_environment (the live source) must also survive it.
+    assert Path(MemoryConfig.from_environment().storage_dir).is_absolute()

--- a/tests/unit/memory/test_unified.py
+++ b/tests/unit/memory/test_unified.py
@@ -61,7 +61,7 @@ class TestMemoryConfig:
         assert config.redis_mock is False
         assert config.redis_auto_start is False  # File-first: Redis is optional
         assert config.default_ttl_seconds == 3600
-        assert config.storage_dir == "./memdocs_storage"
+        assert config.storage_dir.endswith("memdocs_storage")
         assert config.encryption_enabled is True
         assert config.claude_memory_enabled is True
         # File-first architecture fields


### PR DESCRIPTION
## Batch-1 finding: `memdocs_storage` created relative to CWD

The last live item from the batch-1 library-review "needs-a-look" list. **Confirmed SEVERE-live**, not dormant:

| Link | Fact |
|---|---|
| `memory_handlers.py:54` | MCP builds `UnifiedMemory(user_id=…)` with **no `storage_dir`** |
| `unified.py` | `config` defaults to `from_environment()` → `storage_dir` defaults to CWD-relative `./memdocs_storage` |
| `backend_init_mixin.py:193/199/209` | `self.config.storage_dir` flows straight into the long-term backend |
| env + plugin | `ATTUNE_STORAGE_DIR`/`STORAGE_DIR` set **nowhere** — nothing masks it |
| disk | a `memdocs_storage/` dir already exists, created relative to a launch CWD |

So the live MCP server writes long-term patterns under whatever directory it was launched from. Start the same install from a different project → prior patterns look **gone**. Classic silent split/loss.

## Fix (Option A — home-anchored with legacy fallback)

New `default_storage_dir()` in `storage_backend.py`:
- anchors to `~/.attune/memdocs_storage`, so memory no longer scatters by launch dir;
- **but** returns an existing `./memdocs_storage` under the CWD if one is present (as an absolute path), so current users' data is never stranded;
- an explicit `ATTUNE_STORAGE_DIR` still wins.

Every `"./memdocs_storage"` literal default now routes through it — the authoritative `MemoryConfig` (dataclass default + `from_environment`), plus `MemDocsStorage`, `SecureMemDocsIntegration`, `ControlPanelConfig`, and the control-panel `--storage` arg. No CWD-relative literal remains as a live default.

## Receipts

- New `tests/unit/memory/test_storage_dir_default.py` (6 cases): home-anchored when no legacy dir, legacy-CWD fallback, always-absolute, backend `None`-resolution, `from_environment` resolution, env-override precedence.
- Full memory suites: **2769 passed**, 81 skipped. (5 failures are `test_ams_backend_integration.py` against a live Agent Memory Server returning HTTP 500 — 0 refs to `storage_dir`/`memdocs`, environmental, skipped in keyless CI.)
- Gates green: broad-except ratchet + path-validation (12 passed). Pinned black + ruff clean on all changed files.

## Scope note

`file_session_dir` defaults to `".attune"` (same CWD-relative shape, lower blast radius — session data is ephemeral and project-local by design). Left out of this PR deliberately; can follow up if we want it home-anchored too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
