### PR TITLE
chore(release): bump version to 13.0.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "Persistent memory and receipt-verified workflows for Claude Code. Spec-driven development with an approval loop, plus 28 auto-triggering skills: security audits, code review, test generation, release prep.",
-    "version": "13.0.0"
+    "version": "13.0.1"
   },
   "plugins": [
     {
       "name": "attune-ai",
       "description": "Persistent memory and receipt-verified workflows for Claude Code. /spec carries an idea through brainstorm, requirements, design, and task execution with quality gates and your approval at each stage. Backed by 28 auto-triggering skills — security audits, code reviews, test generation, bug prediction, and release preparation. For help content tools, also install attune-help from this marketplace; authoring ships built in via the attune.authoring module.",
       "source": "./plugin",
-      "version": "13.0.0",
+      "version": "13.0.1",
       "author": {
         "name": "Smart AI Memory",
         "email": "patrick.roebuck@smartaimemory.com"

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,4 +1,4 @@
-# Attune AI Framework v13.0.0
+# Attune AI Framework v13.0.1
 
 AI-powered developer workflows with cost optimization and multi-agent orchestration.
 
@@ -556,7 +556,7 @@ attune_redis/          # Redis plugin — BUNDLED, ships in the attune-ai
 
 ---
 
-**Version:** 13.0.0 | **License:** Apache 2.0 | **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)
+**Version:** 13.0.1 | **License:** Apache 2.0 | **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)
 
 ## Lessons — core
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [13.0.1] - 2026-08-21
+
+**A memory fix worth upgrading for.** Long-term memory storage resolved
+relative to the current working directory, so the MCP server wrote
+patterns under whatever directory it happened to be launched from —
+starting the same install from a different project made prior memory
+look gone. Storage is now anchored to your home directory, and existing
+data is never stranded.
+
+### Fixed
+
+- **Long-term memory no longer splits by launch directory.** The default
+  long-term storage dir was CWD-relative (`./memdocs_storage`), so
+  `UnifiedMemory` built without an explicit `storage_dir` — which is how
+  the MCP server builds it — wrote patterns wherever it was started.
+  Storage now resolves through a new `default_storage_dir()` to a
+  home-anchored `~/.attune/memdocs_storage`, routed through every default
+  site (the `MemoryConfig` dataclass and `from_environment`,
+  `MemDocsStorage`, `SecureMemDocsIntegration`, `ControlPanelConfig`, and
+  the control-panel `--storage` argument). **Already have data?** An
+  existing `./memdocs_storage` in the working directory is still honored
+  and returned as an absolute path, so nothing is stranded, and an
+  explicit `ATTUNE_STORAGE_DIR` still wins. Resolution also degrades to
+  an absolute temp-rooted path when the home directory is unresolvable
+  (minimal Windows accounts), instead of silently reverting to a
+  CWD-relative path. (#2145)
+
+### Changed
+
+- The release workflow's GitHub Release step is now idempotent, so a
+  re-run against an existing tag updates the release instead of
+  failing. (#2144)
+
+
 ## [13.0.0] - 2026-08-20
 
 **Correctness you can trust under failure.** A library-wide review

--- a/docs/reference/API_REFERENCE.md
+++ b/docs/reference/API_REFERENCE.md
@@ -1,6 +1,6 @@
 # Attune AI API Reference
 
-**Version:** 13.0.0
+**Version:** 13.0.1
 **License:** Apache License 2.0
 **Copyright:** 2025-2026 Smart AI Memory, LLC
 
@@ -1152,5 +1152,5 @@ msg = format_error(
 
 ---
 
-**Version:** 13.0.0 | **License:** Apache 2.0
+**Version:** 13.0.1 | **License:** Apache 2.0
 **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)

--- a/plugin/.claude-plugin/marketplace.json
+++ b/plugin/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "Spec-driven development for Claude Code — /spec plans, reviews, and executes with quality gates; plus security audits, code reviews, test generation, and release prep from /attune.",
-    "version": "13.0.0"
+    "version": "13.0.1"
   },
   "plugins": [
     {
       "name": "attune-ai",
       "description": "Spec-driven development for Claude Code — /spec plans, reviews, and executes with quality gates; plus security audits, code reviews, test generation, and release prep from /attune.",
       "source": "./",
-      "version": "13.0.0",
+      "version": "13.0.1",
       "author": {
         "name": "Smart AI Memory",
         "email": "patrick.roebuck@smartaimemory.com"

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "attune-ai",
-  "version": "13.0.0",
+  "version": "13.0.1",
   "description": "Persistent memory and receipt-verified workflows for Claude Code — /spec plans, reviews, and executes with quality gates; plus security audits, code reviews, test generation, and release prep from /attune.",
   "author": {
     "name": "Smart AI Memory",

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -4,7 +4,7 @@ Spec-driven development for Claude Code — turn requirements
 into reliable software. <!-- cap:skill_count -->28 auto-triggering skills<!-- /cap -->, zero
 commands: say what you need and Claude picks the right skill.
 
-**Version:** 13.0.0 | **License:** Apache 2.0
+**Version:** 13.0.1 | **License:** Apache 2.0
 
 > **Fix Receipts** (`/fix`) — new in 11.2.0. Say `fix this and
 > prove it`.

--- a/plugin/core/__init__.py
+++ b/plugin/core/__init__.py
@@ -5,4 +5,4 @@ This module provides the core workflow functionality when the full
 attune-ai package is not installed via pip.
 """
 
-__version__ = "13.0.0"
+__version__ = "13.0.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "attune-ai"
-version = "13.0.0"
+version = "13.0.1"
 description = "Persistent memory and receipt-verified workflows for Claude Code — plugin, MCP server, and spec-driven dev framework."
 readme = {file = "README.md", content-type = "text/markdown"}
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -299,7 +299,7 @@ wheels = [
 
 [[package]]
 name = "attune-ai"
-version = "13.0.0"
+version = "13.0.1"
 source = { editable = "." }
 dependencies = [
     { name = "agent-memory-client" },

--- a/website/app/page.tsx
+++ b/website/app/page.tsx
@@ -54,7 +54,7 @@ export default function Home() {
             <div className="grid lg:grid-cols-2 gap-16 items-center">
               <div className="z-10">
                 <div className="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-[var(--surface-container-high)] text-[var(--primary)] text-xs font-bold tracking-widest mb-6 uppercase">
-                  <span>v13.0.0</span>
+                  <span>v13.0.1</span>
                   <span className="w-1 h-1 rounded-full bg-[var(--primary)]"></span>
                   <span className="opacity-80">Memory &amp; receipts for Claude Code</span>
                 </div>

--- a/website/lib/features.ts
+++ b/website/lib/features.ts
@@ -34,7 +34,7 @@ export const PRODUCTS: Product[] = [
     id: "attune-ai",
     name: "Attune AI",
     pypiName: "attune-ai",
-    version: "13.0.0",
+    version: "13.0.1",
     tagline: "Generate, maintain, and serve help from your code",
     installCommand: "pip install attune-ai",
     marketplaceInstall:
@@ -78,7 +78,7 @@ export const PRODUCTS: Product[] = [
     id: "claude-code-plugin",
     name: "Claude Code Plugin",
     pypiName: "attune-ai",
-    version: "13.0.0",
+    version: "13.0.1",
     tagline: "Progressive help right in your terminal",
     installCommand:
       "claude plugin marketplace add Smart-AI-Memory/attune-ai",


### PR DESCRIPTION
## Why

[#2145](https://github.com/Smart-AI-Memory/attune-ai/pull/2145) merged **one commit after the `v13.0.0` tag**, so the shipped 13.0.0 does not carry it. It fixes a silent memory split: the default long-term storage dir was CWD-relative, so `UnifiedMemory` built without an explicit `storage_dir` — which is how the MCP server builds it — wrote patterns under whatever directory it was launched from. Starting the same install from a different project made prior memory look gone.

That is a data-integrity bug in a memory product. It should not wait for the next feature release.

## What's in 13.0.1

| PR | Change |
|---|---|
| #2145 | Long-term memory storage anchored to `~/.attune/memdocs_storage`, not CWD. Existing `./memdocs_storage` still honored (as an absolute path); `ATTUNE_STORAGE_DIR` still wins; resolution degrades to an absolute temp-rooted path when home is unresolvable. |
| #2144 | GitHub Release step is idempotent — a re-run against an existing tag updates rather than fails. |

Plus two `[skip ci]` framework-docs rebuilds.

## Prep receipts

- `scripts/bump_version.py 13.0.1` — 10 files, count-validated before write and verified after.
- `grep -rn "13.0.0"` leaves only CHANGELOG history, the README's "New in 13.0.0" feature framing (still true for a 13.0.x patch), the unrelated `rich>=13.0.0` dep, and generated/lockfile output.
- `tests/unit/plugins/test_plugin_config_validation.py` — 29 passed (carries `test_all_versions_match`).
- `uv lock` diff is the version line only.
- Pinned black + ruff preflighted on the touched Python file.
- Docs regen deliberately skipped — `check-docs-freshness` spikes on any version bump (version-hash noise). `SKIP=check-docs-freshness` on the prep commit; `/coach maintain` queued post-release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
