### PR TITLE
fix(gates): close class G1 — deterministic temp-file publish

### DIFF
--- a/src/attune/authoring/polish.py
+++ b/src/attune/authoring/polish.py
@@ -34,10 +34,12 @@ Opting out of strict mode is explicit and deliberate:
 
 from __future__ import annotations
 
+import contextlib
 import hashlib
 import logging
 import os
 import re
+import tempfile
 import time
 from dataclasses import dataclass
 from pathlib import Path
@@ -148,9 +150,21 @@ def _cache_get(key: str) -> str | None:
 def _cache_put(key: str, content: str) -> None:
     cache = _cache_dir()
     cache.mkdir(parents=True, exist_ok=True)
-    tmp = cache / f"{key}.tmp"
-    tmp.write_text(content, encoding="utf-8")
-    tmp.rename(cache / f"{key}.md")
+    # mkstemp names the temp file uniquely per call: deriving it from the
+    # key lets two processes pick the same path, so one truncates the
+    # other's partial write before the rename publishes it (class G1).
+    # replace() rather than rename() — rename fails on Windows when the
+    # destination already exists, which is the common case for a re-put.
+    fd, tmp_name = tempfile.mkstemp(prefix=f".{key}.", suffix=".tmp", dir=str(cache))
+    tmp = Path(tmp_name)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(content)
+        tmp.replace(cache / f"{key}.md")
+    finally:
+        if tmp.exists():
+            with contextlib.suppress(OSError):
+                tmp.unlink()
     # Lazy disk-space hygiene: piggyback the prune onto write
     # operations so we don't need a separate scheduler. Cost is
     # one stat per entry in the cache dir, which is negligible

--- a/src/attune/curator/cache.py
+++ b/src/attune/curator/cache.py
@@ -13,9 +13,12 @@ daily housekeeping the spec calls for.
 
 from __future__ import annotations
 
+import contextlib
 import hashlib
 import json
 import logging
+import os
+import tempfile
 import time
 from dataclasses import asdict
 from datetime import datetime, timedelta, timezone
@@ -113,13 +116,23 @@ class CuratorCache:
         stamp = result.cached_at or datetime.now(timezone.utc)
         snapshot = _serialise(result, cached_at=stamp)
         path = self._path_for(key)
-        tmp_path = path.with_suffix(path.suffix + ".tmp")
         try:
-            tmp_path.write_text(
-                json.dumps(snapshot, sort_keys=True),
-                encoding="utf-8",
+            # mkstemp names the temp file uniquely per call: deriving it
+            # from the target lets two processes pick the same path, so
+            # one truncates the other's partial write before the rename
+            # publishes it (class G1).
+            fd, tmp_name = tempfile.mkstemp(
+                prefix=f".{path.name}.", suffix=".tmp", dir=str(path.parent)
             )
-            tmp_path.replace(path)
+            tmp_path = Path(tmp_name)
+            try:
+                with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                    handle.write(json.dumps(snapshot, sort_keys=True))
+                tmp_path.replace(path)
+            finally:
+                if tmp_path.exists():
+                    with contextlib.suppress(OSError):
+                        tmp_path.unlink()
         except OSError as exc:
             logger.warning("curator-cache: write %s failed: %s", path, exc)
 

--- a/src/attune/gates/envelope.py
+++ b/src/attune/gates/envelope.py
@@ -17,8 +17,11 @@ Licensed under Apache 2.0
 
 from __future__ import annotations
 
+import contextlib
 import json
 import logging
+import os
+import tempfile
 from dataclasses import asdict, dataclass
 from pathlib import Path
 
@@ -153,12 +156,27 @@ def save_envelope(env: Envelope, path: Path | None = None) -> None:
     caller's load path. Uses ``Path.replace`` for a cross-platform
     atomic rename (Windows ``Path.rename`` fails when the target
     exists).
+
+    The temp file is named by :func:`tempfile.mkstemp` rather than
+    derived from the target: two processes saving the same envelope
+    would otherwise pick the same ``<name>.tmp`` and one would
+    truncate the other's partial write before the rename published
+    it (class G1).
     """
     path = path or _default_envelope_path()
     path.parent.mkdir(parents=True, exist_ok=True)
-    tmp = path.parent / (path.name + ".tmp")
-    tmp.write_text(json.dumps(asdict(env), indent=2) + "\n", encoding="utf-8")
-    tmp.replace(path)
+    fd, tmp_name = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".tmp", dir=str(path.parent))
+    tmp = Path(tmp_name)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(json.dumps(asdict(env), indent=2) + "\n")
+        tmp.replace(path)
+    finally:
+        # A successful replace consumes the temp file, so this only
+        # fires on the failure paths — no leftover .tmp either way.
+        if tmp.exists():
+            with contextlib.suppress(OSError):
+                tmp.unlink()
 
 
 def load_or_new(

--- a/src/attune/help/feedback.py
+++ b/src/attune/help/feedback.py
@@ -7,8 +7,11 @@ workflow chain prediction, and precursor warnings.
 
 from __future__ import annotations
 
+import contextlib
 import json
 import logging
+import os
+import tempfile
 from pathlib import Path
 
 from attune.help.templates import (
@@ -56,12 +59,20 @@ def _save_feedback(generated_dir: Path, data: dict) -> None:
         data: Feedback dict to save.
     """
     path = generated_dir / _FEEDBACK_FILE
-    tmp = path.with_suffix(".json.tmp")
-    tmp.write_text(
-        json.dumps(data, indent=2, ensure_ascii=False) + "\n",
-        encoding="utf-8",
-    )
-    tmp.replace(path)  # replace() is cross-platform; rename() fails on Windows
+    path.parent.mkdir(parents=True, exist_ok=True)
+    # mkstemp names the temp file uniquely per call: deriving it from the
+    # target lets two processes pick the same path, so one truncates the
+    # other's partial write before the rename publishes it (class G1).
+    fd, tmp_name = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".tmp", dir=str(path.parent))
+    tmp = Path(tmp_name)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(json.dumps(data, indent=2, ensure_ascii=False) + "\n")
+        tmp.replace(path)  # replace() is cross-platform; rename() fails on Windows
+    finally:
+        if tmp.exists():
+            with contextlib.suppress(OSError):
+                tmp.unlink()
 
 
 def record_template_feedback(

--- a/src/attune/help/session.py
+++ b/src/attune/help/session.py
@@ -7,8 +7,11 @@ with a 4-hour TTL. Thread-safe for concurrent sessions.
 
 from __future__ import annotations
 
+import contextlib
 import json
 import logging
+import os
+import tempfile
 import threading
 import time
 from pathlib import Path
@@ -72,19 +75,33 @@ def _persist_session(state: dict[str, Any]) -> None:
     with _SESSION_LOCK:
         try:
             _SESSION_FILE.parent.mkdir(parents=True, exist_ok=True)
-            tmp = _SESSION_FILE.with_suffix(".json.tmp")
-            tmp.write_text(
-                json.dumps(
-                    {
-                        "last_topic": state["last_topic"],
-                        "depth_level": state["depth_level"],
-                        "timestamp": time.time(),
-                    }
-                )
-                + "\n",
-                encoding="utf-8",
+            # mkstemp names the temp file uniquely per call: deriving it
+            # from the target lets two sessions pick the same path, so one
+            # truncates the other's partial write before the rename
+            # publishes it (class G1).
+            fd, tmp_name = tempfile.mkstemp(
+                prefix=f".{_SESSION_FILE.name}.",
+                suffix=".tmp",
+                dir=str(_SESSION_FILE.parent),
             )
-            tmp.replace(_SESSION_FILE)
+            tmp = Path(tmp_name)
+            try:
+                with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                    handle.write(
+                        json.dumps(
+                            {
+                                "last_topic": state["last_topic"],
+                                "depth_level": state["depth_level"],
+                                "timestamp": time.time(),
+                            }
+                        )
+                        + "\n"
+                    )
+                tmp.replace(_SESSION_FILE)
+            finally:
+                if tmp.exists():
+                    with contextlib.suppress(OSError):
+                        tmp.unlink()
         except OSError:
             pass  # Best-effort
 

--- a/src/attune/ops/routes/curator.py
+++ b/src/attune/ops/routes/curator.py
@@ -16,8 +16,11 @@ Three endpoints:
 
 from __future__ import annotations
 
+import contextlib
 import json
 import logging
+import os
+import tempfile
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
@@ -115,9 +118,22 @@ async def curator_dismiss(
     try:
         validated = _validate_file_path(str(path))
         validated.parent.mkdir(parents=True, exist_ok=True)
-        tmp = validated.with_suffix(validated.suffix + ".tmp")
-        tmp.write_text(json.dumps(dismissals, sort_keys=True), encoding="utf-8")
-        tmp.replace(validated)
+        # mkstemp names the temp file uniquely per call: deriving it from
+        # the target lets two requests pick the same path, so one truncates
+        # the other's partial write before the rename publishes it
+        # (class G1).
+        fd, tmp_name = tempfile.mkstemp(
+            prefix=f".{validated.name}.", suffix=".tmp", dir=str(validated.parent)
+        )
+        tmp = Path(tmp_name)
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                handle.write(json.dumps(dismissals, sort_keys=True))
+            tmp.replace(validated)
+        finally:
+            if tmp.exists():
+                with contextlib.suppress(OSError):
+                    tmp.unlink()
     except (OSError, ValueError) as exc:
         logger.warning("curator: dismiss write failed for %s: %s", path, exc)
         return JSONResponse({"ok": False, "error": "write failed"}, status_code=500)

--- a/src/attune/ops/runner.py
+++ b/src/attune/ops/runner.py
@@ -14,9 +14,11 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import os
 import re
 import shlex
 import sys
+import tempfile
 import time
 import uuid
 from collections import OrderedDict
@@ -931,15 +933,25 @@ def _persist_run(run: Run, runs_dir: Path) -> Path | None:
 
     workflow_dir = runs_dir / run.workflow
     dest = workflow_dir / f"{run.id}.json"
-    tmp = workflow_dir / f"{run.id}.json.tmp"
+    tmp: Path | None = None
     try:
         workflow_dir.mkdir(parents=True, exist_ok=True)
-        tmp.write_text(json.dumps(record, indent=2), encoding="utf-8")
+        # mkstemp names the temp file uniquely per call: deriving it from
+        # the run id lets two writers for the same run pick the same path,
+        # so one truncates the other's partial write before the rename
+        # publishes it (class G1).
+        fd, tmp_name = tempfile.mkstemp(
+            prefix=f".{run.id}.json.", suffix=".tmp", dir=str(workflow_dir)
+        )
+        tmp = Path(tmp_name)
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(json.dumps(record, indent=2))
         tmp.replace(dest)
     except OSError as exc:
         logger.warning("ops.persist: write failed for %s/%s: %s", run.workflow, run.id, exc)
-        with _suppress_oserror():
-            tmp.unlink()
+        if tmp is not None:
+            with _suppress_oserror():
+                tmp.unlink()
         return None
     return dest
 

--- a/src/attune/pipeline_learner/scaffold.py
+++ b/src/attune/pipeline_learner/scaffold.py
@@ -14,7 +14,9 @@ Licensed under the Apache License, Version 2.0
 from __future__ import annotations
 
 import json
+import os
 import re
+import tempfile
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -93,12 +95,24 @@ def scaffold_acceptance(
         "scaffolded_at": datetime.now(timezone.utc).isoformat(),
     }
 
-    yaml_tmp = pipelines_dir / f"{name}.yaml.tmp"
-    evidence_tmp = pipelines_dir / f"{name}.evidence.json.tmp"
+    # mkstemp names each temp file uniquely per call: deriving them from
+    # the pipeline name lets two concurrent scaffolds pick the same paths,
+    # so one truncates the other's partial write before the rename
+    # publishes it (class G1). Rollback below still covers both.
+    yaml_fd, yaml_tmp_name = tempfile.mkstemp(
+        prefix=f".{name}.yaml.", suffix=".tmp", dir=str(pipelines_dir)
+    )
+    evidence_fd, evidence_tmp_name = tempfile.mkstemp(
+        prefix=f".{name}.evidence.json.", suffix=".tmp", dir=str(pipelines_dir)
+    )
+    yaml_tmp = Path(yaml_tmp_name)
+    evidence_tmp = Path(evidence_tmp_name)
     written: list[Path] = []
     try:
-        yaml_tmp.write_text(_pipeline_yaml(name, candidate), encoding="utf-8")
-        evidence_tmp.write_text(json.dumps(evidence, indent=2) + "\n", encoding="utf-8")
+        with os.fdopen(yaml_fd, "w", encoding="utf-8") as handle:
+            handle.write(_pipeline_yaml(name, candidate))
+        with os.fdopen(evidence_fd, "w", encoding="utf-8") as handle:
+            handle.write(json.dumps(evidence, indent=2) + "\n")
         yaml_tmp.replace(yaml_dest)
         written.append(yaml_dest)
         evidence_tmp.replace(evidence_dest)

--- a/src/attune/telemetry/usage_tracker.py
+++ b/src/attune/telemetry/usage_tracker.py
@@ -8,12 +8,14 @@ Licensed under the Apache License, Version 2.0
 """
 
 import atexit
+import contextlib
 import hashlib
 import hmac
 import json
 import logging
 import os
 import secrets
+import tempfile
 import threading
 from collections.abc import Iterator
 from datetime import datetime, timedelta, timezone
@@ -386,10 +388,24 @@ class UsageTracker:
                 "source_sig": source_sig if source_sig is not None else self._source_signature(),
                 "days": self._daily_summary,
             }
-            tmp = self._summary_file.with_suffix(".tmp")
-            with open(tmp, "w", encoding="utf-8") as f:
-                json.dump(data, f, separators=(",", ":"))
-            tmp.replace(self._summary_file)
+            # mkstemp names the temp file uniquely per call: deriving it
+            # from the target lets two processes pick the same path, so one
+            # truncates the other's partial write before the rename
+            # publishes it (class G1).
+            fd, tmp_name = tempfile.mkstemp(
+                prefix=f".{self._summary_file.name}.",
+                suffix=".tmp",
+                dir=str(self._summary_file.parent),
+            )
+            tmp = Path(tmp_name)
+            try:
+                with os.fdopen(fd, "w", encoding="utf-8") as f:
+                    json.dump(data, f, separators=(",", ":"))
+                tmp.replace(self._summary_file)
+            finally:
+                if tmp.exists():
+                    with contextlib.suppress(OSError):
+                        tmp.unlink()
         except OSError:
             pass  # Best effort — stats still work via slow path
 

--- a/tests/unit/curator/test_cache.py
+++ b/tests/unit/curator/test_cache.py
@@ -208,8 +208,18 @@ def test_put_swallows_mkdir_failure(cache_root, monkeypatch):
     assert not any(cache_root.glob("*.json"))
 
 
-@pytest.mark.skipif(os.name == "nt", reason="POSIX mode bits; chmod is a no-op on Windows")
-@pytest.mark.skipif(os.geteuid() == 0, reason="root ignores the write bit")
+#: A chmod'd directory only refuses writes on POSIX as a non-root user.
+#: Computed eagerly here on purpose — ``skipif`` conditions are evaluated
+#: at COLLECTION time, so a bare ``os.geteuid()`` in the decorator raises
+#: AttributeError on Windows (no such attribute) and errors the whole
+#: module before any skip can apply. ``getattr`` keeps it safe there.
+_CANNOT_REFUSE_WRITES = os.name == "nt" or getattr(os, "geteuid", lambda: 1)() == 0
+
+
+@pytest.mark.skipif(
+    _CANNOT_REFUSE_WRITES,
+    reason="needs POSIX mode bits as a non-root user",
+)
 def test_put_swallows_write_failure(cache_root):
     """If the atomic write fails, put logs and returns cleanly.
 

--- a/tests/unit/curator/test_cache.py
+++ b/tests/unit/curator/test_cache.py
@@ -208,19 +208,30 @@ def test_put_swallows_mkdir_failure(cache_root, monkeypatch):
     assert not any(cache_root.glob("*.json"))
 
 
-def test_put_swallows_write_failure(cache_root, monkeypatch):
-    """If the atomic write fails partway, put logs and returns cleanly."""
+@pytest.mark.skipif(os.name == "nt", reason="POSIX mode bits; chmod is a no-op on Windows")
+@pytest.mark.skipif(os.geteuid() == 0, reason="root ignores the write bit")
+def test_put_swallows_write_failure(cache_root):
+    """If the atomic write fails, put logs and returns cleanly.
+
+    The refusal is a REAL one — the cache directory is chmod'd
+    unwritable — rather than a patched write method. An earlier version
+    of this test monkeypatched ``Path.write_text``; when the class-G1
+    fix moved the write to ``tempfile.mkstemp`` + ``os.fdopen`` the fake
+    stopped firing and the test passed while asserting nothing (the
+    "mock defined the contract" class). A real boundary cannot go stale
+    that way.
+    """
     cache_root.mkdir(parents=True, exist_ok=True)
     cache = CuratorCache(root=cache_root)
 
-    from pathlib import Path as _Path
+    cache_root.chmod(0o500)  # r-x: the dir cannot accept a new entry
+    try:
+        cache.put("abc", _make_result())  # must not raise
+    finally:
+        cache_root.chmod(0o700)
 
-    def boom(self, *a, **kw):  # noqa: ANN001
-        raise OSError("disk full")
-
-    monkeypatch.setattr(_Path, "write_text", boom)
-    cache.put("abc", _make_result())  # must not raise
     assert not (cache_root / "abc.json").is_file()
+    assert not any(cache_root.glob("*.tmp")), "left a temp file behind"
 
 
 def test_sweep_glob_oserror_returns_zero(cache_root, monkeypatch):

--- a/tests/unit/gates/test_deterministic_tmp_gate.py
+++ b/tests/unit/gates/test_deterministic_tmp_gate.py
@@ -1,0 +1,203 @@
+"""Gate: a temp file that is renamed onto a target must have a unique name.
+
+The durable shape for "replace this file atomically" is
+:func:`tempfile.mkstemp` in the target's own directory followed by
+``Path.replace``. The unsafe shape — and the one this gate scans for —
+derives the temp path *deterministically* from the target
+(``path.with_suffix(".tmp")``, ``dir / f"{name}.tmp"``,
+``path.parent / (path.name + ".tmp")``) and then renames it into place.
+
+Two processes writing the same target then pick the *same* temp path.
+One truncates the other's partial write and the rename publishes
+whichever half won. Confirmed in the library review under class G1:
+two OS processes x 20 ``remember()`` calls landed **22 of 40** records
+(45% silently lost), with the loser's run emitting a
+``findings.jsonl.tmp -> findings.jsonl`` ENOENT as the tell.
+
+The memory layer was fixed in the tier-1 PR. This gate is the mechanical
+guard so the class cannot reappear anywhere in the tree — it scans the
+shipped source rather than pinning a list of known sites, because a list
+cannot stop the class showing up in a module nobody has written yet.
+
+Reference implementation: :func:`attune.memory.atomic_io.atomic_write_text`.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under Apache 2.0
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+SRC_ROOT = Path(__file__).resolve().parents[3] / "src" / "attune"
+REPO_ROOT = SRC_ROOT.parent.parent
+
+#: Producing the temp name through one of these makes it unique per call,
+#: which is the whole point — such a function is never a G1 site.
+_UNIQUE_MAKERS = {"mkstemp", "mkdtemp", "NamedTemporaryFile", "TemporaryDirectory"}
+
+#: Publishing calls. A deterministic ``.tmp`` that is never renamed onto
+#: a target is scratch, not a publish step, and is out of scope.
+_PUBLISH = {"replace", "rename", "move"}
+
+
+def _ends_with_tmp(node: ast.AST) -> bool:
+    """True if the expression's literal tail is a ``.tmp`` suffix.
+
+    Covers a plain constant (``".tmp"``, ``".json.tmp"``), an f-string
+    whose final piece is a ``.tmp`` literal, and ``a + ".tmp"``.
+    """
+    if isinstance(node, ast.Constant):
+        return isinstance(node.value, str) and node.value.endswith(".tmp")
+    if isinstance(node, ast.JoinedStr):
+        tail = node.values[-1] if node.values else None
+        return isinstance(tail, ast.Constant) and str(tail.value).endswith(".tmp")
+    if isinstance(node, ast.BinOp) and isinstance(node.op, ast.Add):
+        return _ends_with_tmp(node.right)
+    return False
+
+
+def _builds_deterministic_tmp(node: ast.AST) -> bool:
+    """True if this expression builds a ``.tmp`` path from literal text."""
+    for sub in ast.walk(node):
+        # dir / f"{name}.tmp"   |   path.parent / (path.name + ".tmp")
+        if isinstance(sub, ast.BinOp) and isinstance(sub.op, ast.Div):
+            if _ends_with_tmp(sub.right):
+                return True
+        # path.with_suffix(".tmp") | .with_suffix(path.suffix + ".tmp")
+        if isinstance(sub, ast.Call) and isinstance(sub.func, ast.Attribute):
+            if sub.func.attr == "with_suffix" and sub.args:
+                if _ends_with_tmp(sub.args[0]):
+                    return True
+    return False
+
+
+def _uses_unique_maker(fn: ast.AST) -> bool:
+    for sub in ast.walk(fn):
+        if isinstance(sub, ast.Call):
+            func = sub.func
+            name = func.attr if isinstance(func, ast.Attribute) else getattr(func, "id", "")
+            if name in _UNIQUE_MAKERS:
+                return True
+    return False
+
+
+def _publishes(fn: ast.AST) -> bool:
+    for sub in ast.walk(fn):
+        if isinstance(sub, ast.Call) and isinstance(sub.func, ast.Attribute):
+            if sub.func.attr in _PUBLISH:
+                return True
+    return False
+
+
+def _offending_sites(path: Path) -> list[str]:
+    """Return ``file:line`` for each deterministic-tmp publish in ``path``."""
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8", errors="replace"))
+    except (SyntaxError, ValueError):
+        return []
+
+    hits: list[str] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+            continue
+        if _uses_unique_maker(node) or not _publishes(node):
+            continue
+        for stmt in ast.walk(node):
+            if not isinstance(stmt, ast.Assign | ast.AnnAssign) or stmt.value is None:
+                continue
+            if _builds_deterministic_tmp(stmt.value):
+                hits.append(f"{_label(path)}:{stmt.lineno}")
+    return hits
+
+
+def _label(path: Path) -> str:
+    """Repo-relative path when possible; the fixtures live outside it."""
+    try:
+        return str(path.relative_to(REPO_ROOT))
+    except ValueError:
+        return str(path)
+
+
+def _shipped_modules() -> list[Path]:
+    return sorted(p for p in SRC_ROOT.rglob("*.py") if "__pycache__" not in p.parts)
+
+
+def test_no_deterministic_tmp_publish() -> None:
+    """No shipped module may rename a deterministically-named temp file."""
+    offenders: list[str] = []
+    for module in _shipped_modules():
+        offenders.extend(_offending_sites(module))
+
+    assert not offenders, (
+        "Deterministic temp-file publish (class G1) found at:\n  "
+        + "\n  ".join(offenders)
+        + "\n\nTwo processes writing the same target pick the SAME temp path; "
+        "one truncates the other's partial write and the rename publishes "
+        "whichever half won.\nUse tempfile.mkstemp in the target's directory "
+        "then Path.replace — see attune.memory.atomic_io.atomic_write_text."
+    )
+
+
+def test_rule_flags_the_unsafe_shape(tmp_path: Path) -> None:
+    """The rule must fire on the shape the class is defined by."""
+    module = tmp_path / "offender.py"
+    module.write_text(
+        "from pathlib import Path\n"
+        "def save(path: Path, text: str) -> None:\n"
+        "    tmp = path.with_suffix('.tmp')\n"
+        "    tmp.write_text(text)\n"
+        "    tmp.replace(path)\n",
+        encoding="utf-8",
+    )
+    assert _offending_sites(module), "rule failed to flag a with_suffix('.tmp') publish"
+
+    joined = tmp_path / "offender_fstring.py"
+    joined.write_text(
+        "from pathlib import Path\n"
+        "def save(d: Path, name: str, text: str) -> None:\n"
+        "    tmp = d / f'{name}.json.tmp'\n"
+        "    tmp.write_text(text)\n"
+        "    tmp.replace(d / name)\n",
+        encoding="utf-8",
+    )
+    assert _offending_sites(joined), "rule failed to flag an f-string .tmp publish"
+
+
+def test_rule_clears_the_safe_shape(tmp_path: Path) -> None:
+    """The reference implementation must not be flagged."""
+    module = tmp_path / "safe.py"
+    module.write_text(
+        "import os, tempfile\n"
+        "from pathlib import Path\n"
+        "def save(path: Path, text: str) -> None:\n"
+        "    fd, name = tempfile.mkstemp(suffix='.tmp', dir=str(path.parent))\n"
+        "    tmp = Path(name)\n"
+        "    with os.fdopen(fd, 'w') as fh:\n"
+        "        fh.write(text)\n"
+        "    tmp.replace(path)\n",
+        encoding="utf-8",
+    )
+    assert not _offending_sites(module), "rule false-positived on mkstemp"
+
+
+def test_reference_implementation_is_clean() -> None:
+    """The real atomic writer this gate points offenders at must pass."""
+    assert not _offending_sites(SRC_ROOT / "memory" / "atomic_io.py")
+
+
+@pytest.mark.parametrize("scratch", [".tmp scratch never renamed"])
+def test_scratch_tmp_is_out_of_scope(tmp_path: Path, scratch: str) -> None:
+    """A deterministic .tmp that is never published is not this class."""
+    module = tmp_path / "scratch.py"
+    module.write_text(
+        "from pathlib import Path\n"
+        "def cache(path: Path, text: str) -> None:\n"
+        "    tmp = path.with_suffix('.tmp')\n"
+        "    tmp.write_text(text)\n",
+        encoding="utf-8",
+    )
+    assert not _offending_sites(module), scratch

--- a/tests/unit/gates/test_path_validation_gate.py
+++ b/tests/unit/gates/test_path_validation_gate.py
@@ -40,6 +40,13 @@ _WRITE_ATTRS = {"write_text", "write_bytes"}
 _SHUTIL_FUNCS = {"copy", "copy2", "copyfile", "copytree", "move", "rmtree"}
 #: os.<fn> calls that destroy or rename filesystem entries.
 _OS_FUNCS = {"remove", "unlink", "rename", "replace"}
+#: tempfile.<fn> calls that CREATE a filesystem entry in a caller-supplied
+#: ``dir=``. The atomic-write idiom (mkstemp + os.fdopen + Path.replace)
+#: writes real files without ever calling ``.write_text``, so a scanner
+#: that knows only the write-attr forms goes blind to those modules the
+#: moment they adopt it — which is exactly what happened when the class-G1
+#: sweep-fix landed. Detect the creation call itself.
+_TEMPFILE_FUNCS = {"mkstemp", "mkdtemp", "NamedTemporaryFile", "TemporaryFile"}
 #: Modules with file ops and no path-validation reference, vetted at
 #: seeding (2026-07-29): each writes only internal/derived paths
 #: (state stores, telemetry sinks, generated docs). Remove entries as
@@ -51,6 +58,10 @@ _OS_FUNCS = {"remove", "unlink", "rename", "replace"}
 ALLOWLIST = frozenset(
     {
         "src/attune/authoring/fact_check/__init__.py",
+        # Re-seeded 2026-08-21 with the atomic-write idiom. Reviewed:
+        # NamedTemporaryFile with no caller-supplied dir, so the path is
+        # entirely OS-chosen — nothing to validate.
+        "src/attune/authoring/fact_check/tutorial_static_check.py",
         "src/attune/authoring/faithfulness/__init__.py",
         "src/attune/authoring/generator.py",
         "src/attune/authoring/manifest.py",
@@ -77,6 +88,12 @@ ALLOWLIST = frozenset(
         "src/attune/ops/ops_config_store.py",
         "src/attune/ops/pending_writes.py",
         "src/attune/ops/routes/specs.py",
+        # Re-seeded 2026-08-21 when the scanner learned the atomic-write
+        # idiom (tempfile.mkstemp + os.fdopen), previously invisible.
+        # Reviewed: writes <attune_home>/ops/session_summaries/<id>.json.
+        # NOTE: the <id> component is interpolated unvalidated — tracked
+        # separately as a traversal question, not waved through here.
+        "src/attune/ops/session_summary_cache.py",
         "src/attune/ops/sweep_results.py",
         "src/attune/orchestration/ghosts/worktree.py",
         "src/attune/pipeline_learner/decisions.py",
@@ -153,6 +170,19 @@ def scan_source(source: str) -> tuple[list[str], bool]:
                     and func.attr in _OS_FUNCS
                 ):
                     ops.append(f"os.{func.attr}() at line {node.lineno}")
+                elif (
+                    isinstance(func.value, ast.Name)
+                    and func.value.id == "os"
+                    and func.attr == "fdopen"
+                    and _open_mode_is_write(node, mode_arg_index=1)
+                ):
+                    ops.append(f"os.fdopen()-for-write at line {node.lineno}")
+                elif (
+                    isinstance(func.value, ast.Name)
+                    and func.value.id == "tempfile"
+                    and func.attr in _TEMPFILE_FUNCS
+                ):
+                    ops.append(f"tempfile.{func.attr}() at line {node.lineno}")
     return ops, has_validation
 
 
@@ -228,6 +258,29 @@ def test_scanner_detects_write_text_shutil_and_os_ops() -> None:
         "shutil.rmtree() at line 2",
         "os.remove() at line 3",
     ]
+
+
+def test_scanner_detects_the_atomic_write_idiom() -> None:
+    """mkstemp + os.fdopen writes a real file and must stay visible.
+
+    The class-G1 sweep-fix replaced ``.write_text()`` with this idiom at
+    ten sites. A scanner blind to it would have silently dropped six
+    modules off the offender list while they still wrote files — the
+    ratchet would then have demanded their allowlist entries be removed,
+    making the gate assert something untrue.
+    """
+    source = 'fd, n = tempfile.mkstemp(dir=d)\nwith os.fdopen(fd, "w") as h:\n    h.write(x)\n'
+    ops, _ = scan_source(source)
+    assert ops == [
+        "tempfile.mkstemp() at line 1",
+        "os.fdopen()-for-write at line 2",
+    ]
+
+
+def test_scanner_ignores_fdopen_for_read() -> None:
+    """A read-mode fdopen is not a write op."""
+    ops, _ = scan_source('with os.fdopen(fd, "r") as h:\n    h.read()\n')
+    assert ops == []
 
 
 def test_scanner_validation_reference_clears_module() -> None:

--- a/tests/unit/pipeline_learner/test_learner.py
+++ b/tests/unit/pipeline_learner/test_learner.py
@@ -378,8 +378,12 @@ class TestScaffold:
         evidence_dest = pipelines_dir / "rollback-test.evidence.json"
         original_replace = Path.replace
 
+        # Keyed on the DESTINATION, not the temp file's name. The earlier
+        # version matched a deterministic "<dest>.tmp" source name; when
+        # the class-G1 fix moved temp naming to tempfile.mkstemp the fake
+        # stopped firing and the test passed while asserting nothing.
         def fake_replace(self, target):
-            if self.name == evidence_dest.name + ".tmp":
+            if Path(target) == evidence_dest:
                 raise OSError("simulated disk failure")
             return original_replace(self, target)
 
@@ -389,5 +393,5 @@ class TestScaffold:
 
         assert not (pipelines_dir / "rollback-test.yaml").exists()
         assert not evidence_dest.exists()
-        assert not (pipelines_dir / "rollback-test.yaml.tmp").exists()
-        assert not (pipelines_dir / "rollback-test.evidence.json.tmp").exists()
+        # No temp file of any name may survive the rollback.
+        assert not list(pipelines_dir.glob("*.tmp")), "rollback left a temp file"


### PR DESCRIPTION
Closes class **G1** from the library review — the first of the four fixed-but-ungated classes to get its gate.

## The class

The durable shape for "replace this file atomically" is `tempfile.mkstemp` in the target's own directory then `Path.replace`. The unsafe shape derives the temp path *from the target* — `with_suffix(".tmp")`, `dir / f"{name}.tmp"`, `parent / (name + ".tmp")` — and renames it into place. Two processes writing the same target then pick the **same** temp path: one truncates the other's partial write and the rename publishes whichever half won.

Measured at the memory layer during the review: two OS processes × 20 `remember()` landed **22 of 40** records. The memory layer was fixed in #2128, but the class had no gate, so it stayed live everywhere else.

## The gate

`tests/unit/gates/test_deterministic_tmp_gate.py` — an AST rule scanning the shipped tree, not a pinned list of known sites (a list cannot stop the class appearing in a module nobody has written yet).

**Calibration:** 10 hits across exactly the 9 modules the class register predicted independently, zero false positives on the shape fixtures or the reference implementation. Fails against pre-fix source, passes after.

## The sweep-fix — all 10 sites

Each keeps its existing error contract: `mkstemp` raises only `OSError`, which every guarded site already catches. Three needed more than a mechanical swap:

| Site | Why it wasn't mechanical |
|---|---|
| `gates/envelope.py` | Deliberately does **not** run `_validate_file_path` (it would resolve the macOS `/var` → `/private/var` symlink and desync from the caller's load path), so it uses `mkstemp` inline rather than the shared `atomic_write_text` helper, which validates |
| `telemetry/usage_tracker.py` | Catches only `OSError`; `atomic_write_text`'s `ValueError` would have escaped and crashed a best-effort write |
| `pipeline_learner/scaffold.py` | Publishes two files under both-or-neither rollback (RR-7); both temp names are now unique and the rollback still covers both |

`authoring/polish.py` also moves `rename()` → `replace()`: rename fails on Windows when the destination exists, which is the common case for a cache re-put.

## The part worth reading — the path-validation gate went blind

The scanner knew `.write_text` / `.open(mode=w)` / `shutil` / `os` ops. It did **not** know `mkstemp` + `os.fdopen`. So six modules dropped **off** the offender list the moment they adopted the safe idiom — still writing files, just invisible — and the shrink-only ratchet then demanded their allowlist entries be removed, which would have made the gate assert something untrue.

Taught the scanner `tempfile.{mkstemp,mkdtemp,NamedTemporaryFile,TemporaryFile}` and `os.fdopen`-for-write, with unit tests pinning both directions (write mode detected, read mode ignored).

That widening surfaced **two pre-existing writers that were never visible**:

- `authoring/fact_check/tutorial_static_check.py` — `NamedTemporaryFile` with no caller-supplied `dir`, so the path is entirely OS-chosen. Allowlisted; nothing to validate.
- `ops/session_summary_cache.py` — writes `<attune_home>/ops/session_summaries/<id>.json`. Allowlisted, **but** the `<id>` component is interpolated unvalidated, so a traversing id would write outside the cache dir. Recorded in the allowlist comment and chipped as its own task rather than waved through, or silently widened into this PR.

## Two tests rewritten under the class-M ruling

Both mocked the very mechanism this fix changed, so they stopped testing anything the moment it moved:

- `curator::test_put_swallows_write_failure` patched `Path.write_text`; it now `chmod`s the cache dir unwritable — a real refusal that cannot go stale (skipped on Windows and as root).
- `pipeline_learner` rollback test keyed its fake on the deterministic temp **name**; it now keys on the destination and asserts no temp file of any name survives.

## Receipts

| Test | Pre-fix | Post-fix |
|---|---|---|
| `test_no_deterministic_tmp_publish` | **fails** | passes |
| `test_put_swallows_write_failure` | passes | passes |
| `test_partial_write_failure_rolls_back_both_or_neither` | passes | passes |

The two rewritten tests passing both ways is correct — they cover contracts this fix did not change; the rewrite only made them mechanism-independent.

**Stated plainly:** the gate proves the *shape* across the tree, not that each of the 10 sites is concurrency-safe under load. The measured survival receipt exists for the memory layer only.

1532 passed / 2 skipped / 3 xfailed across the gates, help, curator, telemetry and pipeline_learner suites, run serially (`-p no:xdist`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
