### PR TITLE
docs(usage-signals): 2026-08-20 reach snapshot — the 12.0.0 AFTER pair

### DIFF
--- a/docs/specs/usage-signals/snapshots/2026-08-20.json
+++ b/docs/specs/usage-signals/snapshots/2026-08-20.json
@@ -1,0 +1,64 @@
+{
+  "attempts": [
+    {
+      "at": "2026-08-20T11:30:03.030180+00:00",
+      "captured": 5,
+      "outcome": "complete"
+    }
+  ],
+  "date": "2026-08-20",
+  "github": {
+    "clones_14d": 127943,
+    "forks": 0,
+    "stars": 10,
+    "views_14d": 553
+  },
+  "manifest": {
+    "captured": [
+      "attune-ai",
+      "attune-rag",
+      "attune-help",
+      "attune-author",
+      "attune-verify"
+    ],
+    "complete": true,
+    "expected": [
+      "attune-ai",
+      "attune-rag",
+      "attune-help",
+      "attune-author",
+      "attune-verify"
+    ],
+    "missing": [],
+    "observed_at": "2026-08-20T11:30:03.030914+00:00",
+    "source": "pypistats.org/api/recent"
+  },
+  "pypi_recent": {
+    "attune-ai": {
+      "last_day": 95,
+      "last_month": 2079,
+      "last_week": 150
+    },
+    "attune-author": {
+      "last_day": 0,
+      "last_month": 222,
+      "last_week": 34
+    },
+    "attune-help": {
+      "last_day": 433,
+      "last_month": 28609,
+      "last_week": 1032
+    },
+    "attune-rag": {
+      "last_day": 138,
+      "last_month": 50345,
+      "last_week": 302
+    },
+    "attune-verify": {
+      "last_day": 144,
+      "last_month": 2317,
+      "last_week": 478
+    }
+  },
+  "taken_at": "2026-08-20T11:30:03.030914+00:00"
+}


### PR DESCRIPTION
Captured 2026-08-20 11:30 UTC by the launchd job, complete at 5/5 packages, inside the 08-20 → 08-22 AFTER window US-5 pairs against the 12.0.0 tag.

This closes the open question from the 08-19 starter: whether the schedule actually **runs**, as opposed to merely being installed. It does — the snapshot landed on its own without anyone invoking it. An install receipt is not a running receipt, and this is the running one.

Signal in the numbers:

| Metric | 08-19 | 08-20 |
|---|---|---|
| attune-ai `last_day` | 20 | **95** |
| `clones_14d` | 101,713 | 127,943 |
| `views_14d` | 501 | 553 |

The file was written into the main checkout by the job and had been sitting untracked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)