### PR TITLE
fix(gates): close class H1 — split-brain reachability oracle

### DIFF
--- a/src/attune/agents/release/release_prep_team.py
+++ b/src/attune/agents/release/release_prep_team.py
@@ -122,11 +122,17 @@ class ReleasePrepTeam:
                 logger.info(f"Redis not available (non-fatal): {e}")
                 self.redis = None
         elif REDIS_AVAILABLE:
-            # Try default localhost Redis
+            # No URL passed: fall back to THE CONFIGURED endpoint, not a
+            # literal localhost:6379. A hardcoded pair ignores REDIS_URL
+            # entirely, so a team running against rediss://cache:6380/3
+            # would silently coordinate through a different server (or
+            # none) — class H1.
             try:
-                self.redis = redis_lib.Redis(host="localhost", port=6379, decode_responses=True)
+                from attune.memory.recall_redis import connect_recall_redis
+
+                self.redis = connect_recall_redis(decode_responses=True)
                 self.redis.ping()
-                logger.info("Release team connected to local Redis")
+                logger.info("Release team connected to configured Redis")
             except Exception:  # noqa: BLE001
                 # INTENTIONAL: Redis is optional
                 self.redis = None

--- a/src/attune/cli_commands/utility_commands.py
+++ b/src/attune/cli_commands/utility_commands.py
@@ -410,12 +410,21 @@ def cmd_doctor(args: Namespace) -> int:
             _warn(f"{pkg_name} not installed", "optional")
 
     # 5. Redis connectivity
+    #
+    # Probe THE CONFIGURED endpoint, via the canonical resolver. A bare
+    # ``redis.Redis(...)`` defaults to localhost:6379 no matter what
+    # REDIS_URL says, so `attune doctor` used to report reachability for
+    # a server the user does not run — the H1 split-brain oracle, in the
+    # one command whose entire job is telling the truth about the
+    # environment.
     try:
-        import redis as _redis_mod
+        from attune.memory.config import resolve_redis_connection
+        from attune.memory.recall_redis import connect_recall_redis
 
-        client = _redis_mod.Redis(socket_connect_timeout=2)
+        resolved = resolve_redis_connection()
+        client = connect_recall_redis(socket_connect_timeout=2, socket_timeout=2)
         client.ping()
-        _ok("Redis server reachable")
+        _ok(f"Redis server reachable ({resolved.redacted_url})")
     except ImportError:
         _warn("Redis connectivity", "redis package not installed")
     except Exception:  # noqa: BLE001

--- a/tests/unit/agents/test_release_prep_team_orchestration.py
+++ b/tests/unit/agents/test_release_prep_team_orchestration.py
@@ -178,18 +178,40 @@ class TestRedisOptionalInit:
         team = rpt.ReleasePrepTeam(redis_url="redis://example:6379/0")
         assert team.redis is None
 
-    def test_no_url_tries_localhost(self, monkeypatch):
-        client = FakeRedisClient()
-        fake_lib = type("L", (), {"Redis": staticmethod(lambda **kw: client)})
-        monkeypatch.setattr(rpt, "REDIS_AVAILABLE", True)
-        monkeypatch.setattr(rpt, "redis_lib", fake_lib)
-        team = rpt.ReleasePrepTeam()
-        assert team.redis is client
+    # The two no-URL cases below use a REAL listening socket rather than a
+    # patched ``redis_lib``. They previously asserted that a fake lib's
+    # ``Redis(**kw)`` was called and were named "tries_localhost" —
+    # pinning a literal endpoint, which is class H1: a team configured
+    # against rediss://cache:6380/3 would have coordinated through a
+    # different server, or none. Patching the lib also proved only that
+    # the test handed itself its own fake (class M), never which endpoint
+    # was dialled. The contract is now "no URL → the CONFIGURED endpoint".
 
-    def test_no_url_localhost_down_degrades_to_none(self, monkeypatch):
-        fake_lib = type("L", (), {"Redis": staticmethod(lambda **kw: FakeRedisClient(False))})
+    def test_no_url_uses_configured_endpoint(self, monkeypatch):
+        from tests.support.redis_stub import RespStub
+
+        stub = RespStub()
         monkeypatch.setattr(rpt, "REDIS_AVAILABLE", True)
-        monkeypatch.setattr(rpt, "redis_lib", fake_lib)
+        for name in ("ATTUNE_REDIS_URL", "REDIS_PASSWORD", "REDIS_HOST", "REDIS_PORT"):
+            monkeypatch.delenv(name, raising=False)
+        monkeypatch.setenv("REDIS_URL", f"redis://127.0.0.1:{stub.port}/0")
+        try:
+            team = rpt.ReleasePrepTeam()
+            assert team.redis is not None, (
+                "no-URL init did not reach the CONFIGURED endpoint, which a "
+                "real server was answering on"
+            )
+            assert all(agent.redis is team.redis for agent in team.agents)
+        finally:
+            stub.close()
+
+    def test_no_url_configured_endpoint_down_degrades_to_none(self, monkeypatch):
+        from tests.support.redis_stub import closed_port
+
+        monkeypatch.setattr(rpt, "REDIS_AVAILABLE", True)
+        for name in ("ATTUNE_REDIS_URL", "REDIS_PASSWORD", "REDIS_HOST", "REDIS_PORT"):
+            monkeypatch.delenv(name, raising=False)
+        monkeypatch.setenv("REDIS_URL", f"redis://127.0.0.1:{closed_port()}/0")
         team = rpt.ReleasePrepTeam()
         assert team.redis is None
 

--- a/tests/unit/cli/test_doctor_redis_endpoint.py
+++ b/tests/unit/cli/test_doctor_redis_endpoint.py
@@ -1,0 +1,129 @@
+"""``attune doctor`` must report on the CONFIGURED Redis, not localhost.
+
+Class H1 — the split-brain reachability oracle — in the one command whose
+whole job is telling the truth about the environment. ``redis.Redis()``
+with no host/port silently defaults to ``localhost:6379`` regardless of
+``REDIS_URL``, so doctor used to answer about a server the user does not
+run. Observed live on 2026-08-21: with ``REDIS_URL`` naming a reachable
+server, the old probe dialled 6379, hit an ``AuthenticationError`` there,
+and reported "Redis server not reachable" while the real client was
+connected and working.
+
+These tests use a REAL listening socket speaking REAL RESP
+(``tests/support/redis_stub.RespStub``), never a patched client — per the
+class-M ruling, a test that mocks the connection cannot see a defect
+about *which endpoint gets dialled*.
+
+**Why two directions.** Each is decisive in the environment the other is
+blind to, and together they cover both:
+
+- ``test_reports_reachable_for_configured_endpoint`` fails against
+  pre-fix source on any machine with nothing on 6379 (probe finds
+  nothing, reports unreachable, while the configured stub is up).
+- ``test_reports_unreachable_for_configured_dead_endpoint`` fails against
+  pre-fix source on any machine that DOES have Redis on 6379 (probe finds
+  it, reports reachable, while the configured endpoint is dead).
+
+Neither alone is a receipt; the pair is.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under Apache 2.0
+"""
+
+from __future__ import annotations
+
+import sys
+from argparse import Namespace
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+
+from attune.cli_commands.utility_commands import cmd_doctor  # noqa: E402
+from tests.support.redis_stub import RespStub, closed_port  # noqa: E402
+
+#: Every env var that can redirect the resolver, cleared so the test's own
+#: REDIS_URL is the only input. A stray ATTUNE_REDIS_URL on a developer
+#: machine would otherwise silently decide the outcome.
+_REDIS_ENV = (
+    "REDIS_URL",
+    "ATTUNE_REDIS_URL",
+    "REDIS_PASSWORD",
+    "ATTUNE_REDIS_PASSWORD",
+    "REDIS_HOST",
+    "REDIS_PORT",
+)
+
+
+def _run_doctor(monkeypatch: pytest.MonkeyPatch, url: str, capsys) -> str:
+    for name in _REDIS_ENV:
+        monkeypatch.delenv(name, raising=False)
+    monkeypatch.setenv("REDIS_URL", url)
+    cmd_doctor(Namespace())
+    return capsys.readouterr().out
+
+
+def _redis_line(output: str) -> str:
+    for line in output.splitlines():
+        if "Redis server" in line:
+            return line
+    return ""
+
+
+def test_reports_reachable_for_configured_endpoint(monkeypatch, capsys) -> None:
+    """A live server at the CONFIGURED endpoint must read as reachable."""
+    stub = RespStub()
+    try:
+        out = _run_doctor(monkeypatch, f"redis://127.0.0.1:{stub.port}/0", capsys)
+    finally:
+        stub.close()
+
+    line = _redis_line(out)
+    assert line, f"doctor printed no Redis line:\n{out}"
+    assert "not reachable" not in line, (
+        "doctor reported the CONFIGURED endpoint unreachable while a real "
+        f"server was answering PING on it (class H1):\n  {line}"
+    )
+
+
+def test_reports_unreachable_for_configured_dead_endpoint(monkeypatch, capsys) -> None:
+    """A dead CONFIGURED endpoint must not be masked by a live localhost."""
+    dead = closed_port()
+    out = _run_doctor(monkeypatch, f"redis://127.0.0.1:{dead}/0", capsys)
+
+    line = _redis_line(out)
+    assert line, f"doctor printed no Redis line:\n{out}"
+    assert "not reachable" in line, (
+        "doctor reported Redis reachable while the CONFIGURED endpoint had "
+        "nothing listening — it dialled some other server (class H1):\n"
+        f"  {line}"
+    )
+
+
+def test_reachable_line_names_the_endpoint_it_probed(monkeypatch, capsys) -> None:
+    """The success line must say WHICH endpoint answered.
+
+    A bare "Redis server reachable" is what let the split brain hide: the
+    user cannot tell which server the answer is about. The URL is printed
+    redacted, so a password in REDIS_URL never reaches the terminal.
+    """
+    stub = RespStub()
+    try:
+        out = _run_doctor(monkeypatch, f"redis://127.0.0.1:{stub.port}/0", capsys)
+    finally:
+        stub.close()
+
+    line = _redis_line(out)
+    assert str(stub.port) in line, f"success line does not name the probed endpoint:\n  {line}"
+
+
+def test_password_in_redis_url_is_not_printed(monkeypatch, capsys) -> None:
+    """Printing the endpoint must not leak the password with it."""
+    stub = RespStub()
+    try:
+        out = _run_doctor(monkeypatch, f"redis://user:sup3rsecret@127.0.0.1:{stub.port}/0", capsys)
+    finally:
+        stub.close()
+
+    assert "sup3rsecret" not in out, "doctor leaked the Redis password to stdout"

--- a/tests/unit/gates/test_reachability_oracle_gate.py
+++ b/tests/unit/gates/test_reachability_oracle_gate.py
@@ -1,0 +1,213 @@
+"""Gate: a Redis client must dial the RESOLVED endpoint, never a literal
+or implicit one (library-review class H1).
+
+H1 is the *split-brain reachability oracle*: a probe that answers about a
+different endpoint than the one real clients use. It has two shapes, and
+the second is subtle enough that it was reintroduced by H1's own fix:
+
+1. **Implicit or literal endpoint.** ``redis.Redis()`` with no host/port
+   silently defaults to ``localhost:6379``. A health command built that
+   way reports "Redis server reachable" about a server the user does not
+   use — found live in ``attune doctor`` (2026-08-21).
+2. **Decomposing a resolved URL into host+port.** host+port cannot carry
+   the scheme, db or username, so ``rediss://alice:pw@cache:6380/3`` gets
+   probed over a plain socket at db 0 with no user. Every TLS, ACL and
+   unix-socket deployment reads DOWN. Caught by the codex D11 lane on the
+   tier-1 fix branch — "H1, one layer up, introduced by the H1 fix."
+
+The rule therefore targets the *endpoint source*, not the call site: a
+client construction whose endpoint is implicit or literal cannot reflect
+a resolved URL, so it is a candidate second oracle. Constructions that
+splat a resolved config (``Redis(**cfg.to_redis_kwargs())``) or pass
+resolver-derived names are correct and must not trip.
+
+Canonical factories, which every caller should prefer:
+``attune.memory.config.redis_probe_client`` / ``ping_redis`` and
+``attune.memory.recall_redis.connect_recall_redis`` — all of which reach
+``redis.Redis.from_url(resolved_url)`` and preserve scheme, db and user.
+
+``from_url`` is never flagged: it takes the whole URL by construction.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under Apache 2.0
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SRC_ROOTS = (REPO_ROOT / "src" / "attune", REPO_ROOT / "attune_redis")
+
+#: Direct client constructors. ``from_url`` is deliberately absent — it
+#: consumes a full URL and is the shape this gate steers callers toward.
+_CLIENT_CTORS = {"Redis", "StrictRedis"}
+
+#: Keywords that name an endpoint. A literal here pins the probe to an
+#: address the resolver never saw.
+_ENDPOINT_KWARGS = {"host", "port", "unix_socket_path", "url"}
+
+#: Modules permitted to construct a client directly, each with its reason.
+#: Ratchets shrink-only, like the path-validation allowlist.
+#:
+#: EMPTY, and that is the finding. The class register carries a standing
+#: caution to "delete or allowlist the deprecated
+#: redis_memory_{coordination,storage}.py twins first — they trip any rule
+#: written for the live code." They do not trip THIS rule: they take host
+#: and port as function PARAMETERS, and a parameter is not a literal. Nor
+#: does the canonical resolver, whose host/port branch passes
+#: resolver-derived names. Keying the rule on where the endpoint COMES
+#: FROM, rather than on which call sites are allowed to construct clients,
+#: makes the exemption unnecessary — so the gate needs no escape hatch,
+#: and there is no allowlist entry to review later.
+ALLOWLIST: dict[str, str] = {}
+
+
+def _is_literal(node: ast.AST) -> bool:
+    return isinstance(node, ast.Constant) and isinstance(node.value, str | int)
+
+
+def _endpoint_is_resolved(call: ast.Call) -> bool:
+    """True if the endpoint plausibly comes from the resolver.
+
+    A ``**kwargs`` splat carries a resolved config wholesale; a non-literal
+    host/port is a name or call, i.e. computed rather than pinned.
+    """
+    if any(kw.arg is None for kw in call.keywords):  # **splat
+        return True
+    endpoint_kws = [kw for kw in call.keywords if kw.arg in _ENDPOINT_KWARGS]
+    if not endpoint_kws:
+        return False  # implicit endpoint -> localhost:6379
+    return all(not _is_literal(kw.value) for kw in endpoint_kws)
+
+
+def _offending_sites(path: Path) -> list[str]:
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8", errors="replace"))
+    except (SyntaxError, ValueError):
+        return []
+
+    hits: list[str] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        name = func.attr if isinstance(func, ast.Attribute) else getattr(func, "id", "")
+        if name not in _CLIENT_CTORS:
+            continue
+        if _endpoint_is_resolved(node):
+            continue
+        how = "implicit (defaults to localhost:6379)"
+        lits = [
+            f"{kw.arg}={kw.value.value!r}"
+            for kw in node.keywords
+            if kw.arg in _ENDPOINT_KWARGS and _is_literal(kw.value)
+        ]
+        if lits:
+            how = "literal " + ", ".join(lits)
+        hits.append(f"{_label(path)}:{node.lineno}  {name}(...) — {how}")
+    return hits
+
+
+def _label(path: Path) -> str:
+    try:
+        return str(path.relative_to(REPO_ROOT))
+    except ValueError:
+        return str(path)
+
+
+def _shipped_modules() -> list[Path]:
+    out: list[Path] = []
+    for root in SRC_ROOTS:
+        if root.exists():
+            out.extend(p for p in root.rglob("*.py") if "__pycache__" not in p.parts)
+    return sorted(out)
+
+
+def _current_offenders() -> dict[str, list[str]]:
+    found: dict[str, list[str]] = {}
+    for module in _shipped_modules():
+        hits = _offending_sites(module)
+        if hits:
+            found[_label(module)] = hits
+    return found
+
+
+def test_no_unresolved_redis_endpoint() -> None:
+    """No shipped module may dial a literal or implicit Redis endpoint."""
+    offenders = {k: v for k, v in _current_offenders().items() if k not in ALLOWLIST}
+    detail = "\n".join(f"  {line}" for lines in offenders.values() for line in lines)
+    assert not offenders, (
+        "Redis client dialing an unresolved endpoint (class H1 — split-brain "
+        f"reachability oracle):\n{detail}\n\n"
+        "A probe built this way answers about a different server than real "
+        "clients use: an implicit endpoint is localhost:6379 regardless of "
+        "REDIS_URL, and a literal one ignores scheme, db and username.\n"
+        "Use attune.memory.config.ping_redis / redis_probe_client, or "
+        "attune.memory.recall_redis.connect_recall_redis — all reach "
+        "redis.Redis.from_url(resolved_url)."
+    )
+
+
+def test_allowlist_entries_are_still_needed() -> None:
+    """The allowlist ratchets down: stale entries must be removed."""
+    offenders = _current_offenders()
+    missing = sorted(m for m in ALLOWLIST if not (REPO_ROOT / m).exists())
+    assert not missing, f"ALLOWLIST entries for deleted modules — remove them: {missing}"
+    stale = sorted(m for m in ALLOWLIST if m not in offenders)
+    assert not stale, (
+        "ALLOWLIST entries no longer needed (module now resolves its "
+        f"endpoint or dropped its client construction) — remove them: {stale}"
+    )
+
+
+def test_rule_flags_the_implicit_endpoint(tmp_path: Path) -> None:
+    """The zero-arg form is the shape that bit `attune doctor`."""
+    module = tmp_path / "implicit.py"
+    module.write_text(
+        "import redis\n"
+        "def check() -> bool:\n"
+        "    client = redis.Redis(socket_connect_timeout=2)\n"
+        "    return bool(client.ping())\n",
+        encoding="utf-8",
+    )
+    hits = _offending_sites(module)
+    assert hits and "implicit" in hits[0], hits
+
+
+def test_rule_flags_a_literal_endpoint(tmp_path: Path) -> None:
+    module = tmp_path / "literal.py"
+    module.write_text(
+        "import redis\n"
+        "def check() -> bool:\n"
+        "    client = redis.Redis(host='localhost', port=6379)\n"
+        "    return bool(client.ping())\n",
+        encoding="utf-8",
+    )
+    hits = _offending_sites(module)
+    assert hits and "literal" in hits[0], hits
+
+
+def test_rule_clears_resolved_shapes(tmp_path: Path) -> None:
+    """from_url, a config splat, and resolver-derived names all pass."""
+    module = tmp_path / "resolved.py"
+    module.write_text(
+        "import redis\n"
+        "def a(url):\n"
+        "    return redis.Redis.from_url(url)\n"
+        "def b(cfg):\n"
+        "    return redis.Redis(**cfg.to_redis_kwargs())\n"
+        "def c(env):\n"
+        "    h, p = resolved_redis_endpoint(env)\n"
+        "    return redis.Redis(host=h, port=p)\n",
+        encoding="utf-8",
+    )
+    assert not _offending_sites(module)
+
+
+def test_canonical_factories_are_clean() -> None:
+    """The factories this gate points callers at must not be offenders."""
+    recall = REPO_ROOT / "src/attune/memory/recall_redis.py"
+    if recall.exists():
+        assert not _offending_sites(recall)


### PR DESCRIPTION
Closes library-review class **H1** — second of the four fixed-but-ungated classes to get its gate (after G1 in #2147).

## The class

H1 is a probe that answers about a **different endpoint than real clients use**. Two shapes, and the second was reintroduced by H1's own fix:

1. **Implicit or literal endpoint.** `redis.Redis()` with no host/port silently defaults to `localhost:6379` regardless of `REDIS_URL`.
2. **Decomposing a resolved URL into host+port**, which cannot carry scheme, db or username — so `rediss://alice:pw@cache:6380/3` gets probed over a plain socket at db 0 with no user, and every TLS, ACL and unix-socket deployment reads DOWN. Caught by the codex D11 lane: *"H1, one layer up, introduced by the H1 fix."*

The gate targets the **endpoint source**, not the call site: a construction whose endpoint is implicit or literal cannot reflect a resolved URL. A `**kwargs` splat of a resolved config, resolver-derived names, and `from_url` all pass untouched.

## A live user-facing instance, found by calibration

`attune doctor` probed `redis.Redis(socket_connect_timeout=2)` — implicit, so `localhost:6379` — and printed **"Redis server reachable"**. In the one command whose entire job is telling the truth about the environment.

Demonstrated on real sockets, with `REDIS_URL` naming a reachable server on `:6399`:

| Oracle | Verdict |
|---|---|
| Ground truth (real client via resolver) | **True** |
| OLD — implicit endpoint | **False** (`AuthenticationError` — it dialled `:6379`) |
| NEW — resolver-backed | **True** |

So doctor told users their Redis was unreachable while it was running fine.

## Fixes

- **`cli_commands/utility_commands.py`** — doctor resolves and probes via `connect_recall_redis`, and now **names the endpoint it probed** (redacted, so a password in `REDIS_URL` never reaches the terminal). A bare "reachable" with no endpoint is what let the split brain hide.
- **`agents/release/release_prep_team.py`** — the no-URL branch was a literal `localhost:6379`; it now falls back to the configured endpoint, so a team running against `rediss://cache:6380/3` coordinates through the right server rather than silently through none.

## The allowlist is empty, and that is the finding

The class register carries a standing caution: *"delete or allowlist the deprecated `redis_memory_{coordination,storage}.py` twins first — they trip any rule written for the live code."*

They do not trip **this** rule. They take `host` and `port` as **parameters**, and a parameter is not a literal. Neither does the canonical resolver, whose host/port branch passes resolver-derived names. Keying on where the endpoint *comes from* — rather than on which call sites may construct clients — made the exemption unnecessary.

So this gate ships with **no escape hatch and nothing to review later**. Worth noting because the G1 gate in #2147 needed two allowlist entries; a rule shaped around data flow needed none.

## Two tests rewritten under the class-M ruling

`test_no_url_tries_localhost` pinned the literal endpoint **in its name** and asserted a patched `redis_lib` was called — proving only that the test handed itself its own fake, never which endpoint was dialled. That is exactly how H1 survived. Both no-URL cases now use a real listening socket speaking real RESP (`tests/support/redis_stub.RespStub`).

## Receipts

The doctor suite is deliberately **two-directional**, because each direction is decisive only where the other is blind:

- live-stub case → fails pre-fix on any machine with **nothing** on 6379
- dead-endpoint case → fails pre-fix on any machine that **does** have Redis on 6379

One of the two always fires. Measured here: **2 of 4 fail against pre-fix source** — `[--] Redis server not reachable (optional)` while the stub was answering PING.

**3379 passed** across `tests/unit/{cli,gates,agents,memory}` **and** `tests/memory` — both memory trees, per the register's own lesson that checking only `tests/unit` is what made #2128 ship green and fail every CI lane.

5 failures in `tests/memory/test_ams_backend_integration.py` are **pre-existing** — verified identical on a clean baseline with these changes stashed (local agent-memory-server returning HTTP 500).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
