### PR TITLE
fix(gates): close class G2 — per-record guard narrower than the work

### DIFF
--- a/src/attune/ops/data.py
+++ b/src/attune/ops/data.py
@@ -1043,7 +1043,7 @@ def read_memory_summary(path: Path | None = None) -> dict[str, Any]:
                     continue
 
                 name = str(event.get("event") or "unknown")
-                tokens = int(event.get("est_tokens", 0) or 0)
+                tokens = _as_int(event.get("est_tokens"))
                 # Memory events use the ``ts`` key (v1.0 schema in
                 # _memory_telemetry.log_memory_event); ``timestamp`` is a
                 # defensive fallback. Without it every event misses the
@@ -1316,11 +1316,11 @@ def estimate_feedback_signal(path: Path | None = None) -> dict[str, Any]:
                         continue
                     name = event.get("event")
                     if name == "memory_feedback":
-                        count = int(event.get("count", 0) or 0)
+                        count = _as_int(event.get("count"))
                         rejected += count
                         by_source[str(event.get("source") or "unknown")] += count
                     elif name == "session_stash":
-                        findings_written += int(event.get("written", 0) or 0)
+                        findings_written += _as_int(event.get("written"))
         except OSError:
             return {
                 "rejected": 0,
@@ -1602,7 +1602,7 @@ def read_daily_spend(
                 ordinal = _ordinal(day)
                 if ordinal is None or ordinal < cutoff:
                     continue
-                out[day] += float(event.get("total_cost", event.get("cost", 0.0)) or 0.0)
+                out[day] += _as_float(event.get("total_cost", event.get("cost")))
     except OSError:
         return {}
     return {d: round(c, 4) for d, c in out.items()}
@@ -1737,6 +1737,34 @@ def env_health(config: Config) -> dict[str, Any]:
         "project_root": str(config.project_root),
         "anthropic_api_key": bool(_env("ANTHROPIC_API_KEY")),
     }
+
+
+def _as_int(value: Any, default: int = 0) -> int:
+    """Coerce a record field to int, TOTALLY — never raises (class G2).
+
+    A reader loop that skips malformed JSON has declared per-record
+    tolerance; coercing a field with a bare ``int()`` right after breaks
+    that promise, because well-formed JSON can still carry
+    ``{"est_tokens": "abc"}`` and ``int()`` raises ``ValueError`` past
+    the loop's ``except json.JSONDecodeError``. One bad line then costs
+    every good record in the file, not just its own.
+    """
+    if value is None or value == "":
+        return default
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _as_float(value: Any, default: float = 0.0) -> float:
+    """Coerce a record field to float, TOTALLY — never raises. See _as_int."""
+    if value is None or value == "":
+        return default
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
 
 
 def _to_day(ts: str) -> str | None:

--- a/tests/unit/gates/test_per_record_guard_gate.py
+++ b/tests/unit/gates/test_per_record_guard_gate.py
@@ -1,0 +1,236 @@
+"""Gate: a loop that declares per-record tolerance must honour it
+(library-review class G2).
+
+The shape, from ``file_stash._load_records`` pre-fix:
+
+    for line in lines:
+        try:
+            rec = json.loads(line)
+        except json.JSONDecodeError:
+            continue                              # per-record SKIP guard
+        ts = datetime.fromisoformat(rec["ts"])    # raises, OUTSIDE the guard
+        records.append(rec)
+
+The ``except ... : continue`` is a promise: a bad record is skipped, the
+rest survive. A bare coercion right after breaks that promise, because
+**well-formed JSON can still carry a badly-typed field**. The guard
+catches ``JSONDecodeError``; ``int("abc")`` raises ``ValueError``, which
+sails past it and out of the function. One bad line then costs every
+good record in the file — silently, since the caller usually degrades.
+
+Confirmed by executed repro (2026-08-21), ``read_memory_summary`` over
+three records whose middle one carried ``{"est_tokens": "abc"}``::
+
+    pre-fix : ValueError: invalid literal for int() with base 10: 'abc'
+    post-fix: total_events 3, total_est_tokens 30   (10 + 0 + 20)
+
+The fix is NOT to widen the ``try``. It is to make the coercion TOTAL —
+``_as_int`` / ``_as_float`` / ``_to_day`` return a default instead of
+raising — so per-record tolerance is a property of the helper rather
+than of every call site remembering to wrap it.
+
+**Why the rule keys on record data.** It fires only when the coerced
+value comes out of a parsed record (a ``.get(...)`` or a subscript).
+That discriminator was derived empirically: the naive "any int()/float()
+after a skip guard" rule found 6 sites, of which 2 were lookalikes —
+``int(elapsed * 1000)`` on floats and ``int(m.group(1))`` on a ``(\\d+)``
+capture, neither of which can raise. Adding the discriminator took the
+rule to 4 hits, 4 real, zero false positives.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under Apache 2.0
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SRC_ROOTS = (REPO_ROOT / "src" / "attune", REPO_ROOT / "attune_redis")
+
+#: Coercions that raise on malformed input. Deliberately a short, known
+#: list — "anything that might raise" would be all false positives.
+_RAISERS = {
+    "fromisoformat",
+    "fromtimestamp",
+    "utcfromtimestamp",
+    "strptime",
+    "loads",
+    "int",
+    "float",
+}
+
+
+def _handler_continues(handler: ast.ExceptHandler) -> bool:
+    """A handler that SKIPS this record rather than aborting the loop."""
+    return any(isinstance(s, ast.Continue) for s in ast.walk(handler))
+
+
+def _reads_record_data(call: ast.Call) -> bool:
+    """True if the coercion's argument comes out of a parsed record."""
+    for sub in ast.walk(call):
+        if isinstance(sub, ast.Subscript):
+            return True
+        if isinstance(sub, ast.Call) and isinstance(sub.func, ast.Attribute):
+            if sub.func.attr == "get":
+                return True
+    return False
+
+
+def _inside_any_try_body(node: ast.AST, tries: list[ast.Try]) -> bool:
+    for t in tries:
+        for stmt in t.body:
+            for sub in ast.walk(stmt):
+                if sub is node:
+                    return True
+    return False
+
+
+def _call_name(call: ast.Call) -> str:
+    f = call.func
+    return f.attr if isinstance(f, ast.Attribute) else getattr(f, "id", "")
+
+
+def _offending_sites(path: Path) -> list[str]:
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8", errors="replace"))
+    except (SyntaxError, ValueError):
+        return []
+
+    hits: list[str] = []
+    for loop in ast.walk(tree):
+        if not isinstance(loop, ast.For | ast.AsyncFor):
+            continue
+        guards = [
+            s
+            for s in loop.body
+            if isinstance(s, ast.Try) and any(_handler_continues(h) for h in s.handlers)
+        ]
+        if not guards:
+            continue
+        all_tries = [s for s in ast.walk(loop) if isinstance(s, ast.Try)]
+        for stmt in loop.body:
+            if isinstance(stmt, ast.Try):
+                continue
+            for sub in ast.walk(stmt):
+                if not isinstance(sub, ast.Call) or _call_name(sub) not in _RAISERS:
+                    continue
+                if _inside_any_try_body(sub, all_tries) or not _reads_record_data(sub):
+                    continue
+                hits.append(
+                    f"{_label(path)}:{sub.lineno}  {_call_name(sub)}(...) on record data, "
+                    f"outside the per-record guard at line {guards[0].lineno}"
+                )
+    return hits
+
+
+def _label(path: Path) -> str:
+    try:
+        return str(path.relative_to(REPO_ROOT))
+    except ValueError:
+        return str(path)
+
+
+def _shipped_modules() -> list[Path]:
+    out: list[Path] = []
+    for root in SRC_ROOTS:
+        if root.exists():
+            out.extend(p for p in root.rglob("*.py") if "__pycache__" not in p.parts)
+    return sorted(out)
+
+
+def test_no_unguarded_per_record_coercion() -> None:
+    """A loop promising to skip bad records must not raise on one."""
+    offenders: list[str] = []
+    for module in _shipped_modules():
+        offenders.extend(_offending_sites(module))
+
+    assert not offenders, (
+        "Per-record coercion outside the per-record guard (class G2):\n  "
+        + "\n  ".join(offenders)
+        + "\n\nThe loop's `except ...: continue` promises a bad record is "
+        "skipped, but well-formed JSON can still carry a badly-typed field: "
+        "int('abc') raises ValueError past a JSONDecodeError handler and out "
+        "of the function, costing every good record in the file.\n"
+        "Do NOT widen the try — make the coercion total, as "
+        "attune.ops.data._as_int / _as_float / _to_day do."
+    )
+
+
+def test_rule_flags_the_class(tmp_path: Path) -> None:
+    """The canonical shape must fire."""
+    module = tmp_path / "offender.py"
+    module.write_text(
+        "import json\n"
+        "def load(lines):\n"
+        "    out = []\n"
+        "    for line in lines:\n"
+        "        try:\n"
+        "            rec = json.loads(line)\n"
+        "        except json.JSONDecodeError:\n"
+        "            continue\n"
+        "        n = int(rec.get('n'))\n"
+        "        out.append(n)\n"
+        "    return out\n",
+        encoding="utf-8",
+    )
+    assert _offending_sites(module), "rule missed the canonical G2 shape"
+
+
+def test_rule_clears_a_total_coercion(tmp_path: Path) -> None:
+    """Routing through a total helper is the fix, and must pass."""
+    module = tmp_path / "fixed.py"
+    module.write_text(
+        "import json\n"
+        "def load(lines):\n"
+        "    out = []\n"
+        "    for line in lines:\n"
+        "        try:\n"
+        "            rec = json.loads(line)\n"
+        "        except json.JSONDecodeError:\n"
+        "            continue\n"
+        "        out.append(_as_int(rec.get('n')))\n"
+        "    return out\n",
+        encoding="utf-8",
+    )
+    assert not _offending_sites(module)
+
+
+def test_rule_ignores_coercions_that_cannot_raise(tmp_path: Path) -> None:
+    """The two lookalikes that made the naive rule 67% precise.
+
+    ``int(elapsed * 1000)`` on floats and ``int(m.group(1))`` on a
+    digit-only capture cannot raise; neither reads a record field.
+    """
+    module = tmp_path / "lookalikes.py"
+    module.write_text(
+        "import json, time\n"
+        "def run(probes, matches):\n"
+        "    for probe in probes:\n"
+        "        start = time.monotonic()\n"
+        "        try:\n"
+        "            r = probe.run()\n"
+        "        except OSError:\n"
+        "            continue\n"
+        "        ms = int((time.monotonic() - start) * 1000)\n"
+        "        n = int(matches.group(1))\n"
+        "        print(r, ms, n)\n",
+        encoding="utf-8",
+    )
+    assert not _offending_sites(module)
+
+
+def test_rule_ignores_a_loop_with_no_skip_guard(tmp_path: Path) -> None:
+    """Without a per-record guard there is no promise to break.
+
+    A loop that lets everything propagate is a different (possibly fine)
+    contract; this class is specifically about declaring tolerance and
+    then not honouring it.
+    """
+    module = tmp_path / "nopromise.py"
+    module.write_text(
+        "def load(recs):\n    for rec in recs:\n        yield int(rec.get('n'))\n",
+        encoding="utf-8",
+    )
+    assert not _offending_sites(module)

--- a/tests/unit/ops/test_data_malformed_record_fields.py
+++ b/tests/unit/ops/test_data_malformed_record_fields.py
@@ -1,0 +1,100 @@
+"""One badly-typed field must not cost the whole file (class G2).
+
+These readers skip malformed JSON per record. That is a promise: a bad
+line is skipped, the rest survive. Well-formed JSON carrying a
+badly-typed field used to break the promise — the guard catches
+``JSONDecodeError`` while ``int("abc")`` raises ``ValueError``, which
+sails past it and out of the function, taking every good record with it.
+
+Real files on disk, real reads — no patched parsers. The defect is about
+what a coercion does to a value that actually came off disk, so a mocked
+loader could not see it (class-M ruling).
+
+Copyright 2026 Smart-AI-Memory
+Licensed under Apache 2.0
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from attune.ops.data import _as_float, _as_int, read_memory_summary
+
+
+def _write(path: Path, records: list[dict]) -> Path:
+    path.write_text(
+        "".join(json.dumps(r) + "\n" for r in records),
+        encoding="utf-8",
+    )
+    return path
+
+
+def test_bad_token_field_does_not_lose_the_good_records(tmp_path: Path) -> None:
+    """The middle record is poison; the outer two must still be counted."""
+    path = _write(
+        tmp_path / "memory_events.jsonl",
+        [
+            {"event": "recall", "est_tokens": 10, "ts": "2026-08-21T00:00:00Z"},
+            {"event": "recall", "est_tokens": "abc", "ts": "2026-08-21T00:00:00Z"},
+            {"event": "recall", "est_tokens": 20, "ts": "2026-08-21T00:00:00Z"},
+        ],
+    )
+
+    summary = read_memory_summary(path)
+
+    assert summary["total_events"] == 3, "a badly-typed field dropped whole records"
+    assert summary["total_est_tokens"] == 30, (
+        "the poison record must contribute 0, not corrupt the sum "
+        f"(got {summary['total_est_tokens']})"
+    )
+
+
+def test_malformed_json_line_is_still_skipped(tmp_path: Path) -> None:
+    """The original per-record promise still holds."""
+    path = tmp_path / "memory_events.jsonl"
+    path.write_text(
+        json.dumps({"event": "recall", "est_tokens": 5, "ts": "2026-08-21T00:00:00Z"})
+        + "\n{ this is not json\n"
+        + json.dumps({"event": "recall", "est_tokens": 7, "ts": "2026-08-21T00:00:00Z"})
+        + "\n",
+        encoding="utf-8",
+    )
+
+    summary = read_memory_summary(path)
+    assert summary["total_events"] == 2
+    assert summary["total_est_tokens"] == 12
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("abc", 0),
+        (None, 0),
+        ("", 0),
+        ([], 0),
+        ({}, 0),
+        ("12", 12),
+        (12, 12),
+        (12.9, 12),
+        (True, 1),
+    ],
+)
+def test_as_int_is_total(value: object, expected: int) -> None:
+    """_as_int must return for every input, never raise."""
+    assert _as_int(value) == expected
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [("abc", 0.0), (None, 0.0), ("", 0.0), ([], 0.0), ("1.5", 1.5), (2, 2.0)],
+)
+def test_as_float_is_total(value: object, expected: float) -> None:
+    assert _as_float(value) == pytest.approx(expected)
+
+
+def test_total_coercions_honour_an_explicit_default() -> None:
+    assert _as_int("abc", default=-1) == -1
+    assert _as_float("abc", default=-1.0) == pytest.approx(-1.0)


### PR DESCRIPTION
Closes library-review class **G2** — third of the four fixed-but-ungated classes to get its gate (after G1 in #2147 and H1 in #2150).

## The class

A loop that skips malformed records has made a **promise**: a bad record is skipped, the rest survive. G2 is breaking that promise one line later.

```python
for line in lines:
    try:
        rec = json.loads(line)
    except json.JSONDecodeError:
        continue                   # ← the promise
    n = int(rec.get("n"))          # ← breaks it
```

The guard catches `JSONDecodeError`. But **well-formed JSON can still carry `{"n": "abc"}`**, and `int()` raises `ValueError` — which sails straight past that handler and out of the function. One bad line then costs every good record in the file, silently, because the caller degrades.

## Four live sites, all telemetry readers behind the ops dashboard

Confirmed by executed repro over three records whose middle one carried `{"est_tokens": "abc"}`:

```
pre-fix : ValueError: invalid literal for int() with base 10: 'abc'
post-fix: total_events 3, total_est_tokens 30   (10 + 0 + 20)
```

The poison record degrades to zero rather than corrupting the sum or killing the read.

## Fixed by making the coercion total, not by widening the try

`_as_int` and `_as_float` join the `_to_day` / `_ordinal` idiom **already in this file**, so per-record tolerance becomes a property of the helper rather than of every call site remembering to wrap it.

Widening the `try` would have worked once and rotted at the next added line — the guard would drift narrower than the work again, which is the class itself.

## Calibration — why the rule reads the way it does

| Rule form | Hits | Real | False positives |
|---|---|---|---|
| naive: any `int()`/`float()` after a skip guard | 6 | 4 | 2 |
| **+ value must come from a parsed record** | **4** | **4** | **0** |

The two lookalikes were `int(elapsed * 1000)` on floats and `int(m.group(1))` on a `(\d+)` capture — neither can raise. Requiring the coerced value to come out of a `.get(...)` or a subscript separates them cleanly, and **both are pinned as fixtures** so the discriminator cannot be quietly lost later.

The rule also ignores loops with no skip guard: letting everything propagate is a different, possibly correct contract. This class is specifically about *declaring* tolerance and then not honouring it.

## Receipts

- Gate **fails against pre-fix source naming all four sites**, passes after.
- **1971 passed** across `tests/unit/{ops,gates}`.
- Behavioural suite pins `_as_int` / `_as_float` totality across `"abc"`, `None`, `""`, `[]`, `{}`, bools and floats, plus explicit-default handling.

**One honest limitation:** the behavioural suite cannot itself run pre-fix — it imports `_as_int`/`_as_float`, which don't exist there, so it errors at collection rather than failing. The executed repro above is the receipt for the behaviour change; the gate is the receipt for the class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
