### PR TITLE
fix(gates): close class I-4 — deserialize here, subscript there

### DIFF
--- a/src/attune/redis_memory_coordination.py
+++ b/src/attune/redis_memory_coordination.py
@@ -28,6 +28,7 @@ from .memory.types import (  # noqa: E402
     AgentCredentials,
     ConflictContext,
     TTLStrategy,
+    parse_stored_record,
 )
 
 
@@ -114,7 +115,11 @@ class ConflictNegotiationMixin:
         if raw is None:
             return None
 
-        return ConflictContext.from_dict(json.loads(raw))
+        # Deserialize-here / subscript-there (library-review I-4): a value
+        # that parses to a LIST makes from_dict raise TypeError from inside
+        # the call, past a caller whose except tuple lists only
+        # JSONDecodeError. parse_stored_record returns None instead.
+        return parse_stored_record(ConflictContext, raw, key=key)
 
     def resolve_conflict(
         self,

--- a/src/attune/redis_memory_patterns.py
+++ b/src/attune/redis_memory_patterns.py
@@ -24,7 +24,12 @@ warnings.warn(
 import json  # noqa: E402
 from typing import TYPE_CHECKING  # noqa: E402
 
-from .memory.types import AgentCredentials, StagedPattern, TTLStrategy  # noqa: E402
+from .memory.types import (  # noqa: E402
+    AgentCredentials,
+    StagedPattern,
+    TTLStrategy,
+    parse_stored_record,
+)
 
 
 class PatternStagingMixin:
@@ -97,7 +102,12 @@ class PatternStagingMixin:
         if raw is None:
             return None
 
-        return StagedPattern.from_dict(json.loads(raw))
+        # Deserialize-here / subscript-there (library-review I-4): a
+        # legacy or hand-edited value that parses to a LIST makes
+        # from_dict raise TypeError from inside the call, past a caller
+        # whose except tuple lists only JSONDecodeError. parse_stored_record
+        # collapses all three failure modes to None.
+        return parse_stored_record(StagedPattern, raw, key=key)
 
     def list_staged_patterns(
         self,
@@ -118,8 +128,14 @@ class PatternStagingMixin:
 
         for key in keys:
             raw = self._get(key)
-            if raw:
-                patterns.append(StagedPattern.from_dict(json.loads(raw)))
+            if not raw:
+                continue
+            # One unreadable key must not block the listing that backs
+            # every promotion (library-review I-4, P15: degrade, never
+            # block).
+            staged = parse_stored_record(StagedPattern, raw, key=key)
+            if staged is not None:
+                patterns.append(staged)
 
         return patterns
 

--- a/tests/unit/gates/test_deserialize_subscript_gate.py
+++ b/tests/unit/gates/test_deserialize_subscript_gate.py
@@ -1,0 +1,227 @@
+"""Gate: a parse result handed straight to a reconstructor must be
+guarded (library-review class I-4).
+
+I-4 is *deserialize here, subscript there*:
+
+    return StagedPattern.from_dict(json.loads(raw))
+
+The parse result is never bound to a name, so there is no local value to
+isinstance-check — which is precisely why **the C3 dict-guard gate
+cannot see this shape**. If the stored bytes hold a LIST, ``json.loads``
+succeeds and ``from_dict`` raises ``TypeError`` from *inside* the
+consumer, past a caller whose except tuple lists only
+``JSONDecodeError``. Since that read backs promotion, one legacy or
+hand-edited key blocked **every** promotion — a Principle-15 violation
+(the memory layer degrades, it never blocks).
+
+Confirmed by executed repro against the deprecated twin (2026-08-21),
+one good staged record beside one legacy list-shaped key::
+
+    pre-fix : TypeError: list indices must be integers or slices, not str
+    post-fix: RETURNED 1 record(s): ['p-good']
+
+Reference implementation: :func:`attune.memory.types.parse_stored_record`,
+which collapses all three failure modes — unparseable JSON, a parsed
+value that is not a mapping, and fields ``from_dict`` rejects — to None.
+
+**Scope, deliberately narrow.** The rule fires only on the RECONSTRUCTOR
+shape, where the consumer subscripts immediately. The looser
+``out.append(json.loads(line))`` shape defers the subscript to a caller;
+that is C3's territory (its row records 15 stored-data sites carried
+into batch 3), and re-flagging it here would re-litigate dispositions
+another gate already owns. Two classes, two gates, no overlap.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under Apache 2.0
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SRC_ROOTS = (REPO_ROOT / "src" / "attune", REPO_ROOT / "attune_redis")
+
+#: Deserialisers returning an object of unknown shape.
+_PARSERS = {"loads", "safe_load", "load"}
+
+#: Consumers that immediately subscript what they are handed.
+_RECONSTRUCTORS = {"from_dict", "from_json", "parse_obj", "model_validate", "from_record"}
+
+#: Catching any of these covers the TypeError a list-shaped record raises.
+_COVERS = {"TypeError", "Exception", "BaseException"}
+
+
+def _handler_names(handler: ast.ExceptHandler) -> set[str]:
+    node = handler.type
+    if node is None:
+        return {"BaseException"}
+    parts = node.elts if isinstance(node, ast.Tuple) else [node]
+    return {
+        p.id if isinstance(p, ast.Name) else p.attr
+        for p in parts
+        if isinstance(p, ast.Name | ast.Attribute)
+    }
+
+
+def _is_parse_call(node: ast.AST) -> bool:
+    if not isinstance(node, ast.Call):
+        return False
+    f = node.func
+    name = f.attr if isinstance(f, ast.Attribute) else getattr(f, "id", "")
+    return name in _PARSERS
+
+
+def _guarded_for_typeerror(node: ast.AST, tree: ast.AST) -> bool:
+    """True if node sits in a try body whose handlers cover TypeError."""
+    for t in ast.walk(tree):
+        if not isinstance(t, ast.Try):
+            continue
+        if not any(node is sub for stmt in t.body for sub in ast.walk(stmt)):
+            continue
+        caught: set[str] = set()
+        for h in t.handlers:
+            caught |= _handler_names(h)
+        if caught & _COVERS:
+            return True
+    return False
+
+
+def _offending_sites(path: Path) -> list[str]:
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8", errors="replace"))
+    except (SyntaxError, ValueError):
+        return []
+
+    hits: list[str] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        f = node.func
+        cname = f.attr if isinstance(f, ast.Attribute) else getattr(f, "id", "")
+        reconstructor = cname in _RECONSTRUCTORS and any(_is_parse_call(a) for a in node.args)
+        # Model(**json.loads(raw)) is the same hazard with a splat.
+        splat = any(k.arg is None and _is_parse_call(k.value) for k in node.keywords)
+        if not reconstructor and not splat:
+            continue
+        if _guarded_for_typeerror(node, tree):
+            continue
+        hits.append(f"{_label(path)}:{node.lineno}  {cname}(<parse>(...)) unguarded")
+    return hits
+
+
+def _label(path: Path) -> str:
+    try:
+        return str(path.relative_to(REPO_ROOT))
+    except ValueError:
+        return str(path)
+
+
+def _shipped_modules() -> list[Path]:
+    out: list[Path] = []
+    for root in SRC_ROOTS:
+        if root.exists():
+            out.extend(
+                p
+                for p in root.rglob("*.py")
+                if "__pycache__" not in p.parts and "tests" not in p.parts
+            )
+    return sorted(out)
+
+
+def test_no_unguarded_deserialize_into_reconstructor() -> None:
+    """No shipped module may hand a bare parse result to a reconstructor."""
+    offenders: list[str] = []
+    for module in _shipped_modules():
+        offenders.extend(_offending_sites(module))
+
+    assert not offenders, (
+        "Unguarded deserialize-into-reconstructor (class I-4):\n  "
+        + "\n  ".join(offenders)
+        + "\n\nThe parse result is never bound, so nothing can be "
+        "isinstance-checked and the C3 dict-guard cannot see it. A stored "
+        "LIST parses fine and makes the reconstructor raise TypeError from "
+        "inside the call — past an except tuple listing only "
+        "JSONDecodeError.\n"
+        "Use attune.memory.types.parse_stored_record, which returns None "
+        "for unparseable JSON, a non-mapping, or rejected fields."
+    )
+
+
+def test_rule_flags_the_class(tmp_path: Path) -> None:
+    module = tmp_path / "offender.py"
+    module.write_text(
+        "import json\n" "def load(raw):\n" "    return Model.from_dict(json.loads(raw))\n",
+        encoding="utf-8",
+    )
+    assert _offending_sites(module), "rule missed the canonical I-4 shape"
+
+
+def test_rule_flags_the_splat_form(tmp_path: Path) -> None:
+    """Model(**json.loads(raw)) is the same hazard."""
+    module = tmp_path / "splat.py"
+    module.write_text(
+        "import json\ndef load(raw):\n    return Model(**json.loads(raw))\n",
+        encoding="utf-8",
+    )
+    assert _offending_sites(module), "rule missed the **splat form"
+
+
+def test_rule_clears_a_typeerror_guarded_site(tmp_path: Path) -> None:
+    """The same shape inside a TypeError-covering try is DEFENDED.
+
+    This is not hypothetical: gates/lifecycle/ledger.py writes exactly
+    this, and its except tuple includes TypeError. Flagging it would have
+    made the gate demand a change to already-correct code.
+    """
+    module = tmp_path / "guarded.py"
+    module.write_text(
+        "import json\n"
+        "def load(lines):\n"
+        "    out = []\n"
+        "    for line in lines:\n"
+        "        try:\n"
+        "            out.append(Model.from_dict(json.loads(line)))\n"
+        "        except (json.JSONDecodeError, KeyError, TypeError, ValueError):\n"
+        "            pass\n"
+        "    return out\n",
+        encoding="utf-8",
+    )
+    assert not _offending_sites(module)
+
+
+def test_rule_clears_the_total_helper(tmp_path: Path) -> None:
+    """Routing through parse_stored_record is the fix, and must pass."""
+    module = tmp_path / "fixed.py"
+    module.write_text(
+        "def load(raw, key):\n    return parse_stored_record(Model, raw, key=key)\n",
+        encoding="utf-8",
+    )
+    assert not _offending_sites(module)
+
+
+def test_rule_ignores_deferred_subscript(tmp_path: Path) -> None:
+    """append(json.loads(x)) is C3's class, not this one.
+
+    The subscript happens in a caller, not inside the consumer. C3 owns
+    those sites; double-gating them would re-litigate its dispositions.
+    """
+    module = tmp_path / "deferred.py"
+    module.write_text(
+        "import json\n"
+        "def load(lines):\n"
+        "    out = []\n"
+        "    for line in lines:\n"
+        "        out.append(json.loads(line))\n"
+        "    return out\n",
+        encoding="utf-8",
+    )
+    assert not _offending_sites(module)
+
+
+def test_reference_implementation_is_clean() -> None:
+    """parse_stored_record itself must not be an offender."""
+    types_mod = REPO_ROOT / "src/attune/memory/types.py"
+    if types_mod.exists():
+        assert not _offending_sites(types_mod)

--- a/tests/unit/memory/test_legacy_staged_record_degrades.py
+++ b/tests/unit/memory/test_legacy_staged_record_degrades.py
@@ -1,0 +1,142 @@
+"""One legacy list-shaped key must not block every promotion (class I-4).
+
+``StagedPattern.from_dict(json.loads(raw))`` parses fine on a stored
+LIST and then raises ``TypeError`` from inside ``from_dict`` — past a
+caller whose except tuple lists only ``JSONDecodeError``. Because the
+listing backs promotion, one such key blocked ALL promotions, which is a
+Principle-15 violation: the memory layer degrades, it never blocks.
+
+Exercised through the real mixin against a store holding real JSON — the
+defect is about what a reconstructor does to bytes that actually came
+back from storage, so a mocked parser could not see it (class-M ruling).
+
+Copyright 2026 Smart-AI-Memory
+Licensed under Apache 2.0
+"""
+
+from __future__ import annotations
+
+import json
+import warnings
+
+import pytest
+
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore", DeprecationWarning)
+    from attune.redis_memory_coordination import ConflictNegotiationMixin
+    from attune.redis_memory_patterns import PatternStagingMixin
+
+from attune.memory.types import (
+    AccessTier,
+    AgentCredentials,
+    ConflictContext,
+    StagedPattern,
+)
+
+
+def _good_pattern() -> StagedPattern:
+    return StagedPattern(
+        pattern_id="p-good",
+        agent_id="agent-1",
+        pattern_type="insight",
+        name="good pattern",
+        description="a readable staged record",
+    )
+
+
+class _Staging(PatternStagingMixin):
+    PREFIX_STAGED = "staged:"
+
+    def __init__(self, store: dict[str, str]) -> None:
+        self._store = store
+
+    def _keys(self, pattern: str) -> list[str]:
+        return sorted(self._store)
+
+    def _get(self, key: str) -> str | None:
+        return self._store.get(key)
+
+    def _delete(self, key: str) -> bool:
+        return self._store.pop(key, None) is not None
+
+
+class _Conflicts(ConflictNegotiationMixin):
+    PREFIX_CONFLICT = "conflict:"
+
+    def __init__(self, store: dict[str, str]) -> None:
+        self._store = store
+
+    def _get(self, key: str) -> str | None:
+        return self._store.get(key)
+
+
+@pytest.fixture
+def creds() -> AgentCredentials:
+    return AgentCredentials(agent_id="a1", tier=AccessTier.VALIDATOR)
+
+
+def test_legacy_list_key_does_not_block_the_listing(creds) -> None:
+    """The good record must survive a list-shaped sibling."""
+    good = _good_pattern()
+    staging = _Staging(
+        {
+            "staged:p-good": json.dumps(good.to_dict()),
+            # The legacy shape: valid JSON, not a mapping.
+            "staged:p-legacy": json.dumps(["p-legacy", "old list form"]),
+        }
+    )
+
+    out = staging.list_staged_patterns(creds)
+
+    assert [p.pattern_id for p in out] == ["p-good"], (
+        "a legacy list-shaped key blocked the listing that backs every "
+        "promotion (P15: degrade, never block)"
+    )
+
+
+def test_single_legacy_record_reads_as_absent(creds) -> None:
+    """A single unreadable record is None, not an exception."""
+    staging = _Staging({"staged:p-legacy": json.dumps(["not", "a", "mapping"])})
+    assert staging.get_staged_pattern("p-legacy", creds) is None
+
+
+def test_unparseable_bytes_read_as_absent(creds) -> None:
+    """Not-JSON-at-all degrades the same way."""
+    staging = _Staging({"staged:p-broken": "{ this is not json"})
+    assert staging.get_staged_pattern("p-broken", creds) is None
+
+
+def test_promotion_of_a_legacy_record_degrades(creds) -> None:
+    """Promotion returns None rather than raising, and deletes nothing."""
+    store = {"staged:p-legacy": json.dumps(["not", "a", "mapping"])}
+    staging = _Staging(store)
+    assert staging.promote_pattern("p-legacy", creds) is None
+    assert "staged:p-legacy" in store, "unreadable record was deleted on a failed promote"
+
+
+def test_good_record_still_round_trips(creds) -> None:
+    """The guard must not break the normal path."""
+    good = _good_pattern()
+    staging = _Staging({"staged:p-good": json.dumps(good.to_dict())})
+    got = staging.get_staged_pattern("p-good", creds)
+    assert got is not None
+    assert got.pattern_id == "p-good"
+    assert got.name == "good pattern"
+
+
+def test_conflict_context_legacy_record_degrades(creds) -> None:
+    """The same class in the coordination twin."""
+    conflicts = _Conflicts({"conflict:c-legacy": json.dumps(["old", "form"])})
+    assert conflicts.get_conflict_context("c-legacy", creds) is None
+
+
+def test_conflict_context_good_record_round_trips(creds) -> None:
+    ctx = ConflictContext(
+        conflict_id="c1",
+        positions={"a": "x"},
+        interests={"a": ["y"]},
+    )
+    conflicts = _Conflicts({"conflict:c1": json.dumps(ctx.to_dict())})
+    got = conflicts.get_conflict_context("c1", creds)
+    assert got is not None
+    assert got.conflict_id == "c1"


### PR DESCRIPTION
Closes library-review class **I-4** — the last of the four fixed-but-ungated classes (after G1 #2147, H1 #2150, G2 #2151).

## The class

```python
return StagedPattern.from_dict(json.loads(raw))
```

The parse result is **never bound to a name**, so there is no local value to `isinstance`-check — which is exactly why **the C3 dict-guard gate cannot see this shape**, and why I-4 needed a gate of its own.

A stored LIST parses fine and makes `from_dict` raise `TypeError` from *inside* the consumer, past a caller whose `except` tuple lists only `JSONDecodeError`. Because that read backs promotion, one legacy or hand-edited key blocked **every** promotion — a Principle-15 violation: the memory layer degrades, it never blocks.

## Executed repro

Real mixin, one good staged record beside one legacy list-shaped key:

```
pre-fix : TypeError: list indices must be integers or slices, not str
          → one bad key blocked the whole listing
post-fix: RETURNED 1 record(s): ['p-good']
```

Matching the register's documented receipt exactly.

## Fixed, not allowlisted

Three sites, all in the deprecated `redis_memory_{patterns,coordination}` twins.

The register's standing caution is to *"delete or allowlist the twins first — they trip any rule written for the live code."* For **this** rule they genuinely do (unlike H1's, which they escaped by taking `host`/`port` as parameters). But both already import from `.memory.types`, so routing them through `parse_stored_record` was three one-liners with no import-cycle risk — and it leaves this gate with an **empty allowlist**, nothing to review later, and a better deprecated path for anyone still on it.

Worth noting they're production-dead: `attune.redis_memory` is imported only by tests.

## Scope — deliberately narrow, to avoid re-litigating C3

The rule fires only on the **reconstructor** shape, where the consumer subscripts immediately. The looser `out.append(json.loads(line))` shape defers the subscript to a caller — that's C3's territory (its register row records 15 stored-data sites carried into batch 3), and re-flagging it here would re-litigate dispositions another gate already owns.

Two classes, two gates, no overlap — pinned by `test_rule_ignores_deferred_subscript`.

Calibration also cleared `gates/lifecycle/ledger.py`, which writes this exact shape but wraps it in a `try` whose tuple includes `TypeError`. A rule without the guard check would have demanded a change to already-correct code; that site is pinned as a fixture too.

## Receipts

**Six failures against pre-fix source** — five behavioural plus the gate:

```
FAILED test_legacy_list_key_does_not_block_the_listing
FAILED test_single_legacy_record_reads_as_absent
FAILED test_unparseable_bytes_read_as_absent
FAILED test_promotion_of_a_legacy_record_degrades
FAILED test_conflict_context_legacy_record_degrades
FAILED test_no_unguarded_deserialize_into_reconstructor
```

The two that pass both ways are the good-record round-trips, which verify the fix didn't break the normal path.

- **2518 passed** across `tests/unit/{gates,memory}` plus `test_coverage_batch9.py` (the twins' own test consumer).
- **675 passed** in `tests/memory` — both trees, per the register's lesson.
- The 5 `test_ams_backend_integration.py` failures are **pre-existing**, baselined earlier today on a clean tree (local agent-memory-server returning HTTP 500).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
