### PR TITLE
fix(readme): bump the tests floor 20,000 → 25,000 (main is red)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 [![Downloads](https://static.pepy.tech/badge/attune-ai)](https://pepy.tech/projects/attune-ai)
 [![Downloads/month](https://static.pepy.tech/badge/attune-ai/month)](https://pepy.tech/projects/attune-ai)
 [![Downloads/week](https://static.pepy.tech/badge/attune-ai/week)](https://pepy.tech/projects/attune-ai)
-[![Tests](https://img.shields.io/badge/tests-20%2C000%2B%20passing-brightgreen)](https://github.com/Smart-AI-Memory/attune-ai/actions/workflows/tests.yml)
+[![Tests](https://img.shields.io/badge/tests-25%2C000%2B%20passing-brightgreen)](https://github.com/Smart-AI-Memory/attune-ai/actions/workflows/tests.yml)
 [![Coverage](https://img.shields.io/codecov/c/github/Smart-AI-Memory/attune-ai?branch=main)](https://codecov.io/gh/Smart-AI-Memory/attune-ai)
 [![Security](https://github.com/Smart-AI-Memory/attune-ai/actions/workflows/security.yml/badge.svg)](https://github.com/Smart-AI-Memory/attune-ai/actions/workflows/security.yml)
 [![Python](https://img.shields.io/badge/python-3.10--3.14-blue)](https://www.python.org)


### PR DESCRIPTION
**main has been failing its required `coverage` check since `ced39888a`.**

```
Badge freshness check FAILED:
  - tests badge STALE: actual 25,009 exceeds floor 20,000 by >5,000
    — bump the round floor.
```

Not a coverage regression. `scripts/check_badge_freshness.py` runs inside the coverage job and guards the README's manually-maintained round **floor**. `MARGIN` is 5,000, so it trips once actual exceeds floor + 5,000. The floor had already drifted ~4,970 stale; today's four library-review gate PRs ([#2147](https://github.com/Smart-AI-Memory/attune-ai/pull/2147), [#2150](https://github.com/Smart-AI-Memory/attune-ai/pull/2150), [#2151](https://github.com/Smart-AI-Memory/attune-ai/pull/2151), [#2152](https://github.com/Smart-AI-Memory/attune-ai/pull/2152)) added the tests that crossed it.

**25,000 is the documented next step**, not an invented number — the README's own maintenance comment says to bump *"once the suite clears 25,000"*.

## Verified pre/post with the real script

| Floor | Result |
|---|---|
| 20,000 (old) | `FAILED: actual 25,009 exceeds floor 20,000 by >5,000` |
| 25,000 (this PR) | `Badge freshness OK.` |

## A second, separate cause on the same main run — not fixed here

`test-matrix-complete` also failed, because `test (ubuntu-latest, 3.13)` was **cancelled**, not failed. Three PR merges landed within 15 minutes (17:44, 17:45, 17:59) and `cancel-in-progress` killed the earlier runs' lanes; cancelled-but-required blocks.

No code change can fix that one — it clears on the next full main run, which merging this triggers. Recorded so the next reader doesn't hunt for a second bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)