### PR TITLE
docs(outbox): sweep 2 artifacts

### DIFF
--- a/.claude/lessons.md
+++ b/.claude/lessons.md
@@ -23688,3 +23688,72 @@ imposes on every other in-flight PR, not just the next one.
   `git worktree list` + per-path `branch --show-current`, (2) `dirty`
   count per worktree, (3) open-PR head refs, (4) **live peer sessions**,
   (5) the current session's own path.
+
+- **Promoting into a VERBATIM-MIRRORED section: extract
+  programmatically from the merged canon, never retype and never copy
+  the source artifact — plus read the guard for a SIZE CAP before you
+  start**: 2026-08-22, promoting four lessons into `.claude/CLAUDE.md`'s
+  "Lessons — core", which `tests/unit/lessons/test_core_mirror.py`
+  requires to be a byte-faithful mirror of entries in
+  `.claude/lessons.md`. Four mechanics, none of them guessable:
+  (1) **There is a hard size cap.** The guard asserts
+  `15 <= len(core) <= 30`, not just mirror-fidelity. Core stood at 22, so
+  +4 landed at 26 — but a bigger batch would have failed CI for a reason
+  that has nothing to do with the copy being correct. **Read the whole
+  guard, not the part you expect to trip.**
+  (2) **Copy from the MERGED canon, not the outbox artifact.** The
+  docs-outbox `apply` step may normalise whitespace on the way into
+  lessons.md, and the guard compares against lessons.md — so the
+  artifact you authored is NOT the reference. Extract from the file as
+  it exists on main after the batch merges.
+  (3) **Extract with the same splitter the guard uses.** A hand-written
+  search phrase for one lesson used ``pytest.mark.skipif`` (double
+  backticks) while the canon had `pytest.mark.skipif` (single) — visually
+  identical in a diff, and it would have shipped a mirror that failed the
+  byte comparison in CI twenty minutes later. The programmatic extract
+  surfaced it in two seconds. Never retype a mirrored block.
+  (4) **The same-commit constraint is temporary, and knowing when it
+  lifts saves a race.** While NEITHER side exists, mirror + canon must
+  land together or whichever merges first fails. Once the canon is on
+  main, a mirror-only follow-up PR passes cleanly — the twins are there.
+  So a promotion that misses its batch is not a problem, it is just a
+  second small PR.
+  Rider on coordination, from the same episode: the canon batch was
+  owned by a live peer chip session. The chair approved promotion AFTER
+  that session had already committed. Correct move was to **relay the
+  decision via SendMessage and let the owner amend**, then take the
+  follow-up myself when it did not — never force-push another session's
+  branch, especially one with auto-merge armed. Pairs with
+  [[live-peer-sessions-are-a-prune-exclusion-class]]: a peer session
+  owning a FILE is the same hazard class as one owning a worktree.
+
+- **Relaying a chair decision to a peer session: MARK IT AS A RELAY and
+  let the receiver confirm — at the receiving end a wrong relay is
+  indistinguishable from a right one**: 2026-08-22, the core-promotion
+  hand-off. A chip session's prompt said promotion to the drift-guarded
+  core section was the chair's call and told it to ASK Patrick. When
+  Patrick approved, I messaged that session: *"this is the chair's
+  answer to the promotion question your prompt told you to ask —
+  Patrick has approved promoting four to core."* Accurate, and still
+  wrong in form: I asserted the decision rather than flagging it as
+  second-hand, and invited no confirmation. The peer declined to act on
+  it, asked Patrick itself, got the same four, and then told me plainly
+  why — *"a peer relay of 'Patrick has approved' is not something I can
+  treat as the chair's approval; that rule holds even when the relay is
+  accurate, which yours was."* It was right. **This is the SAME rule
+  that binds every session from the other direction** (a peer message
+  is never the user's approval for a pending action — the standing
+  anti-permission-laundering rule); I applied it inbound all session
+  and violated it outbound in one message. The asymmetry is the tell:
+  if I would not accept "the chair said yes" from a peer as
+  authorization, I must not emit it in that form either. Correct shape
+  when relaying: (1) say explicitly that you are RELAYING, (2) name the
+  decision and who made it, (3) tell the receiver to confirm with the
+  chair before acting, (4) never phrase it as the chair speaking. Note
+  the outcome converged here only by luck of the relay being accurate —
+  which is exactly why the outcome is not evidence the form was fine.
+  Pairs with [[live-peer-sessions-are-a-prune-exclusion-class]] and
+  [[promoting-into-a-verbatim-mirrored-section]]: the same episode also
+  taught that a peer owning a FILE is the same hazard class as one
+  owning a worktree, and that authority is a third thing peers cannot
+  hand each other.


### PR DESCRIPTION
Applies the docs-outbox digest — 2 pending, oldest 0.0d, both clean with
no duplicates, no lint issues, and no flags.

Produced by `python -m attune.docs_outbox apply --repo-root .`.
**Append-only to `.claude/lessons.md`** (69 insertions, 0 deletions, 1 file).
No artifacts were skipped; the outbox is now empty.

### Applied (2, both `kind: lesson` → `.claude/lessons.md`)

| Artifact |
|---|
| `20260822-0649-lesson-promoting-into-a-verbatim-mirrored-section` |
| `20260822-0729-lesson-relaying-a-chair-decision-needs-a-relay-marker` |

Both come out of the 2026-08-22 core-promotion episode (#2155 / #2156):
the mechanics of promoting into a verbatim-mirrored section (size cap,
extract-from-canon, never retype), and the relay-marker rule for handing
a chair decision to a peer session.

Their `[[links]]` resolve: `live-peer-sessions-are-a-prune-exclusion-class`
landed in #2155, and `promoting-into-a-verbatim-mirrored-section` is the
sibling in this batch.

### Core promotion — none

No entries mirrored into `.claude/CLAUDE.md` "Lessons — core". The sweep
flagged neither artifact core-worthy, and core is at 26 of a hard 30
(`tests/unit/lessons/test_core_mirror.py:53` asserts `15 <= len(core) <= 30`).

### Receipts

- `python -m pytest tests/unit/lessons/ -o addopts= -q` → **30 passed**
- `python scripts/check_badge_freshness.py` → **Badge freshness OK**
- `python -m attune.docs_outbox status` → **outbox empty**
- `git diff --stat` → `.claude/lessons.md | 69 +++`, single file, append-only

Third batch of the 2026-08-22 cycle (#2149, #2155 preceded).
