### PR TITLE
test(lessons): pin the always-loaded core to a byte budget

### DIFF
--- a/tests/unit/lessons/test_core_mirror.py
+++ b/tests/unit/lessons/test_core_mirror.py
@@ -24,6 +24,17 @@ LESSONS_MD = REPO_ROOT / ".claude" / "lessons.md"
 
 CORE_HEADING = "## Lessons — core"
 
+# Hard ceiling for the always-loaded core section, in bytes. Core is the
+# single largest eagerly-loaded block in the repo — it dwarfs the 20,000
+# byte budget that tests/unit/rules/test_rules_residency_budget.py pins on
+# eager rules, yet was governed only by an entry COUNT until 2026-08-22.
+# A count cap is a poor ceiling: at the observed ~1,690 B/entry mean, the
+# <= 30 cap silently authorises ~51 KB nobody ratified. This budget binds
+# BEFORE the count cap, so a promotion that costs real context trips here
+# and forces the eviction conversation. Seeded at 43,969 (26 entries,
+# 2026-08-22). SHRINK-ONLY: demote something rather than widening it.
+CORE_BUDGET_BYTES = 46_000
+
 
 def _core_section_text() -> str:
     text = CLAUDE_MD.read_text(encoding="utf-8")
@@ -60,6 +71,16 @@ def test_every_core_lesson_mirrors_lessons_md_verbatim() -> None:
             f"core lesson {title[:60]!r} DIVERGED from its lessons.md canon "
             "— re-sync both copies"
         )
+
+
+def test_core_section_within_byte_budget() -> None:
+    """The always-loaded core stays under its context budget."""
+    total = len(_core_section_text().encode("utf-8"))
+    assert total <= CORE_BUDGET_BYTES, (
+        f"core section is {total:,} bytes > {CORE_BUDGET_BYTES:,} budget — "
+        "demote a core lesson to the lessons.md tail rather than widening "
+        "the budget (it is shrink-only). Core is always-loaded context."
+    )
 
 
 def test_lessons_md_is_the_index_source() -> None:


### PR DESCRIPTION
## The gap

The core section of `.claude/CLAUDE.md` was governed **only by an entry
count** (`15 <= n <= 30`) while being the single largest eagerly-loaded
block in the repo.

| Always-loaded surface | Size | Governed by |
|---|---|---|
| Eager rules (4 files) | 15,440 B | hard byte budget, 20,000 |
| **Core lessons section** | **44,932 B** | count only |

Core is **2.9x the entire rules budget** and 62% of CLAUDE.md.
[rules-corpus-jit](docs/specs/rules-corpus-jit/) cut eager rules
116.6 KB -> 12.9 KB and pinned the result in bytes; the biggest
always-loaded block never got the same treatment.

A count cap is a poor ceiling. At the observed ~1,690 B/entry mean,
`<= 30` silently authorises **~51 KB nobody ratified**.

## Why now

```
2026-06-20   22 entries   35,928 B
2026-07-15   22 entries   36,066 B
2026-08-18   22 entries   36,406 B
2026-08-22   26 entries   44,951 B   <- +4 entries / +23% bytes, one batch
```

Core was flat at 22 for two months, then took four promotions in a
single action (#2156) with the byte cost invisible to everyone involved.
This is not creep — it is one unpriced batch, which is exactly the thing
a budget catches and a count cap does not.

## The change

One constant and one test in the guard that already exists:

```python
CORE_BUDGET_BYTES = 46_000  # seeded at 44,932 (26 entries, 2026-08-22)
```

It binds at ~27 entries — **before** the count cap — so the count stays
as a harmless backstop and the byte cost is what actually gates a
promotion. Shrink-only, matching the `EAGER_BUDGET_BYTES` precedent in
`tests/unit/rules/test_rules_residency_budget.py`.

**This is effectively a freeze**: ~1 KB headroom means the next
promotion must trade against a demotion. That is the intended stance
given core is already 2.9x the rules budget; a separate eviction pass is
what creates headroom, not widening the constant.

## Receipts

- `python -m pytest tests/unit/lessons/ -o addopts= -q` -> **31 passed**
  (was 30; +1 new test)
- Pinned `black` and `ruff check` on the touched file -> both pass
- Enforcer claims in the eviction analysis verified live:
  `tests/unit/help/test_maintenance.py` (dry_run guard) and
  `doc-import-audit` (required on every PR to main, no path filter)

No production code touched; test-only.
