### PR TITLE
chore(release): bump version to 13.0.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "Persistent memory and receipt-verified workflows for Claude Code. Spec-driven development with an approval loop, plus 28 auto-triggering skills: security audits, code review, test generation, release prep.",
-    "version": "13.0.1"
+    "version": "13.0.2"
   },
   "plugins": [
     {
       "name": "attune-ai",
       "description": "Persistent memory and receipt-verified workflows for Claude Code. /spec carries an idea through brainstorm, requirements, design, and task execution with quality gates and your approval at each stage. Backed by 28 auto-triggering skills — security audits, code reviews, test generation, bug prediction, and release preparation. For help content tools, also install attune-help from this marketplace; authoring ships built in via the attune.authoring module.",
       "source": "./plugin",
-      "version": "13.0.1",
+      "version": "13.0.2",
       "author": {
         "name": "Smart AI Memory",
         "email": "patrick.roebuck@smartaimemory.com"

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,4 +1,4 @@
-# Attune AI Framework v13.0.1
+# Attune AI Framework v13.0.2
 
 AI-powered developer workflows with cost optimization and multi-agent orchestration.
 
@@ -556,7 +556,7 @@ attune_redis/          # Redis plugin — BUNDLED, ships in the attune-ai
 
 ---
 
-**Version:** 13.0.1 | **License:** Apache 2.0 | **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)
+**Version:** 13.0.2 | **License:** Apache 2.0 | **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)
 
 ## Lessons — core
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,69 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [13.0.2] - 2026-08-22
+
+**Four correctness classes, closed at the gate.** The library review had
+already fixed these shapes where it found them; this release fixes the
+rest and adds an AST gate per class so none of them can come back in a
+module nobody has written yet. The one you can see from the outside:
+`attune doctor` was reporting on a Redis server you may not run.
+
+### Fixed
+
+- **`attune doctor` no longer lies about Redis.** The probe constructed
+  `redis.Redis(socket_connect_timeout=2)` — no host, no port — so it
+  dialled an implicit `localhost:6379` regardless of `REDIS_URL`, and
+  printed "Redis server reachable" for a server that was not the one
+  your clients use. With `REDIS_URL` naming a reachable server on
+  another port, the old probe hit the local socket, failed
+  authentication there, and reported NOT REACHABLE while the real client
+  was connected and working. `doctor` now resolves and probes the same
+  endpoint recall uses, and NAMES the endpoint it probed (password
+  redacted) — a bare "reachable" with no endpoint is what let the split
+  brain hide. The release-prep team's coordination fallback had the same
+  literal `localhost:6379` and now falls back to the configured
+  endpoint. (#2150)
+- **One malformed record no longer costs the whole file.** Four
+  telemetry readers behind the ops dashboard skipped records that failed
+  to parse, then coerced fields out of the records that did — so a
+  well-formed `{"est_tokens": "abc"}` raised `ValueError` past a handler
+  that only caught `JSONDecodeError`, and one bad line silently killed
+  every good record in the file. Coercion is now total: the poison
+  record degrades to zero and the rest survive. (#2151)
+- **Concurrent atomic writes no longer publish half a file.** Ten sites
+  derived their temp path from the target (`with_suffix(".tmp")` and
+  friends), so two processes writing the same file picked the *same*
+  temp path — one truncated the other's partial write, and the rename
+  published whichever half won. All ten now use `tempfile.mkstemp` in
+  the target's own directory, each keeping its existing error contract.
+  `authoring/polish.py` also moves `rename()` to `replace()`, which
+  fixes a Windows failure when the destination already exists — the
+  common case for a cache re-put. (#2147)
+- **One legacy-shaped key no longer blocks every memory promotion.** The
+  deprecated `redis_memory_{patterns,coordination}` readers passed
+  `json.loads(raw)` straight into a reconstructor, so a stored value of
+  the wrong shape raised `TypeError` from inside the consumer, past a
+  caller catching only `JSONDecodeError` — and a single hand-edited or
+  legacy key blocked the entire listing. These reads now degrade per
+  record, as the memory layer is meant to. (#2152)
+
+### Changed
+
+- Four new AST gates ship with the test suite — deterministic temp-file
+  publish, reachability-oracle endpoints, per-record guard scope, and
+  reconstructor deserialization. Three of the four carry an **empty**
+  allowlist. The path-validation gate's scanner also learned
+  `tempfile.mkstemp` and `os.fdopen`, which it did not know before: six
+  modules had dropped off its offender list purely by adopting the safer
+  idiom, and it surfaced two file writers it had never seen. (#2147,
+  #2150, #2151, #2152)
+- The always-loaded lessons core is now capped by a byte budget
+  (46,000 B), not just an entry count — a promotion that costs real
+  context now has to argue for it. (#2158)
+- README badge floor raised to 25,000 tests, the next step its own
+  maintenance note documents. (#2154)
+
 ## [13.0.1] - 2026-08-21
 
 **A memory fix worth upgrading for.** Long-term memory storage resolved

--- a/docs/reference/API_REFERENCE.md
+++ b/docs/reference/API_REFERENCE.md
@@ -1,6 +1,6 @@
 # Attune AI API Reference
 
-**Version:** 13.0.1
+**Version:** 13.0.2
 **License:** Apache License 2.0
 **Copyright:** 2025-2026 Smart AI Memory, LLC
 
@@ -1152,5 +1152,5 @@ msg = format_error(
 
 ---
 
-**Version:** 13.0.1 | **License:** Apache 2.0
+**Version:** 13.0.2 | **License:** Apache 2.0
 **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)

--- a/plugin/.claude-plugin/marketplace.json
+++ b/plugin/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "Spec-driven development for Claude Code — /spec plans, reviews, and executes with quality gates; plus security audits, code reviews, test generation, and release prep from /attune.",
-    "version": "13.0.1"
+    "version": "13.0.2"
   },
   "plugins": [
     {
       "name": "attune-ai",
       "description": "Spec-driven development for Claude Code — /spec plans, reviews, and executes with quality gates; plus security audits, code reviews, test generation, and release prep from /attune.",
       "source": "./",
-      "version": "13.0.1",
+      "version": "13.0.2",
       "author": {
         "name": "Smart AI Memory",
         "email": "patrick.roebuck@smartaimemory.com"

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "attune-ai",
-  "version": "13.0.1",
+  "version": "13.0.2",
   "description": "Persistent memory and receipt-verified workflows for Claude Code — /spec plans, reviews, and executes with quality gates; plus security audits, code reviews, test generation, and release prep from /attune.",
   "author": {
     "name": "Smart AI Memory",

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -4,7 +4,7 @@ Spec-driven development for Claude Code — turn requirements
 into reliable software. <!-- cap:skill_count -->28 auto-triggering skills<!-- /cap -->, zero
 commands: say what you need and Claude picks the right skill.
 
-**Version:** 13.0.1 | **License:** Apache 2.0
+**Version:** 13.0.2 | **License:** Apache 2.0
 
 > **Fix Receipts** (`/fix`) — new in 11.2.0. Say `fix this and
 > prove it`.

--- a/plugin/core/__init__.py
+++ b/plugin/core/__init__.py
@@ -5,4 +5,4 @@ This module provides the core workflow functionality when the full
 attune-ai package is not installed via pip.
 """
 
-__version__ = "13.0.1"
+__version__ = "13.0.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "attune-ai"
-version = "13.0.1"
+version = "13.0.2"
 description = "Persistent memory and receipt-verified workflows for Claude Code — plugin, MCP server, and spec-driven dev framework."
 readme = {file = "README.md", content-type = "text/markdown"}
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -299,7 +299,7 @@ wheels = [
 
 [[package]]
 name = "attune-ai"
-version = "13.0.1"
+version = "13.0.2"
 source = { editable = "." }
 dependencies = [
     { name = "agent-memory-client" },

--- a/website/app/page.tsx
+++ b/website/app/page.tsx
@@ -54,7 +54,7 @@ export default function Home() {
             <div className="grid lg:grid-cols-2 gap-16 items-center">
               <div className="z-10">
                 <div className="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-[var(--surface-container-high)] text-[var(--primary)] text-xs font-bold tracking-widest mb-6 uppercase">
-                  <span>v13.0.1</span>
+                  <span>v13.0.2</span>
                   <span className="w-1 h-1 rounded-full bg-[var(--primary)]"></span>
                   <span className="opacity-80">Memory &amp; receipts for Claude Code</span>
                 </div>

--- a/website/lib/features.ts
+++ b/website/lib/features.ts
@@ -34,7 +34,7 @@ export const PRODUCTS: Product[] = [
     id: "attune-ai",
     name: "Attune AI",
     pypiName: "attune-ai",
-    version: "13.0.1",
+    version: "13.0.2",
     tagline: "Generate, maintain, and serve help from your code",
     installCommand: "pip install attune-ai",
     marketplaceInstall:
@@ -78,7 +78,7 @@ export const PRODUCTS: Product[] = [
     id: "claude-code-plugin",
     name: "Claude Code Plugin",
     pypiName: "attune-ai",
-    version: "13.0.1",
+    version: "13.0.2",
     tagline: "Progressive help right in your terminal",
     installCommand:
       "claude plugin marketplace add Smart-AI-Memory/attune-ai",


### PR DESCRIPTION
Release prep for **13.0.2** — a patch release covering the 13 commits on
main since `v13.0.1`.

## What ships

Four library-review correctness classes, each fixed everywhere it
occurs and now held by an AST gate (three with an **empty** allowlist):

| Class | Shape | PR |
|---|---|---|
| H1 | reachability oracle probing a different endpoint than clients use | #2150 |
| G2 | per-record skip guard narrower than the work it guards | #2151 |
| G1 | temp path derived from the target — colliding atomic publishes | #2147 |
| I-4 | `from_dict(json.loads(raw))` with no local value to guard | #2152 |

The user-visible one is H1: `attune doctor` constructed
`redis.Redis(socket_connect_timeout=2)` — no host, no port — so it
probed an implicit `localhost:6379` regardless of `REDIS_URL` and
printed "Redis server reachable" for a server the user may not run.

Also in: the lessons-core byte budget (#2158) and the README tests-floor
bump to 25,000 (#2154).

## This PR

- `scripts/bump_version.py 13.0.2` — 10 files, count-validated before
  write and re-verified after
- CHANGELOG `[13.0.2]` section written from the merged commit bodies
  (the `[Unreleased]` section was empty — the gate PRs did not add
  entries)
- `uv lock` — one line, the self-version

## Receipts

- `tests/unit/test_website_version_accuracy.py`,
  `tests/unit/plugins/test_plugin_config_validation.py`,
  `tests/unit/gates/test_claim_drift.py`,
  `tests/unit/gates/test_brand_drift.py` — 68 passed
- `grep -rn "13\.0\.1"` finds only CHANGELOG history and lessons prose
- pinned black/ruff clean; commit GPG-signed (`%G?` = G)

Pre-tag gates (`/attune-release-check`, `scripts/release_recall_gate.py`)
run after merge, against the merge SHA — per the 13.0.1 lesson that the
recall gate builds its wheel from the checkout it runs in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
