### PR TITLE
perf(telemetry): batch scan-then-fetch Redis listings into one MGET

### DIFF
--- a/src/attune/telemetry/_redis_batch.py
+++ b/src/attune/telemetry/_redis_batch.py
@@ -1,0 +1,83 @@
+"""Batched Redis reads for scan-then-fetch listings.
+
+A listing that scans a key pattern and then calls ``client.get(key)`` per
+key pays one network round trip per record — the N+1 shape. ``mget_json``
+fetches every scanned record in a single ``MGET`` instead, so a listing
+costs one round trip regardless of how many keys the scan returned.
+
+Decoding is TOTAL, in the same spirit as ``attune.ops.data._as_int``: a
+record that is missing, undecodable, not JSON, or not a JSON object
+yields ``None`` for that key ONLY. One malformed record never costs the
+whole listing.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import Iterable
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Cap on keys per MGET. Redis serves one command at a time, so a single
+# unbounded MGET over a large scan would block the server for its whole
+# duration; chunking keeps each command short while still costing
+# ceil(N / _MGET_CHUNK) round trips instead of N.
+_MGET_CHUNK = 500
+
+
+def _decode_key(key: Any) -> str:
+    """Decode a scanned key to str (scan_iter yields bytes by default)."""
+    if isinstance(key, bytes):
+        return key.decode("utf-8", errors="replace")
+    return str(key)
+
+
+def decode_json_object(raw: Any) -> dict[str, Any] | None:
+    """Decode one raw Redis value to a dict, or None. Never raises."""
+    if not raw:
+        return None
+    if isinstance(raw, bytes):
+        try:
+            raw = raw.decode("utf-8")
+        except UnicodeDecodeError:
+            return None
+    try:
+        value = json.loads(raw)
+    except (TypeError, ValueError):  # JSONDecodeError subclasses ValueError
+        return None
+    return value if isinstance(value, dict) else None
+
+
+def mget_json(client: Any, keys: Iterable[Any]) -> list[tuple[str, dict[str, Any] | None]]:
+    """Fetch many JSON records in one round trip per chunk of keys.
+
+    Args:
+        client: Redis client (needs ``mget``).
+        keys: Keys as returned by ``scan_iter`` — bytes or str.
+
+    Returns:
+        ``(decoded_key, record_or_None)`` pairs in the order the keys were
+        given. A key whose value is absent or malformed carries ``None``;
+        callers skip those records individually.
+
+    Note:
+        Errors from ``mget`` itself are NOT swallowed — a broken client is
+        a listing-wide failure, exactly as a broken ``get`` was, and every
+        caller already handles it.
+
+    """
+    decoded_keys = [_decode_key(key) for key in keys]
+    records: list[tuple[str, dict[str, Any] | None]] = []
+
+    for start in range(0, len(decoded_keys), _MGET_CHUNK):
+        chunk = decoded_keys[start : start + _MGET_CHUNK]
+        values = client.mget(chunk)
+        for key, raw in zip(chunk, values, strict=False):
+            record = decode_json_object(raw)
+            if record is None and raw:
+                logger.debug("Skipping malformed record at %s", key)
+            records.append((key, record))
+
+    return records

--- a/src/attune/telemetry/agent_coordination.py
+++ b/src/attune/telemetry/agent_coordination.py
@@ -42,6 +42,8 @@ from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any
 from uuid import uuid4
 
+from attune.telemetry._redis_batch import mget_json
+
 if TYPE_CHECKING:
     from attune.memory.types import AgentCredentials
 
@@ -97,6 +99,19 @@ class CoordinationSignal:
             timestamp=timestamp,
             ttl_seconds=data.get("ttl_seconds", 60),
         )
+
+
+def _signal_from_record(key: str, data: dict[str, Any]) -> CoordinationSignal | None:
+    """Build a signal from one scanned record, or None if it is malformed.
+
+    Per-record tolerance (class G2): one unparseable record is skipped
+    alone rather than raising into the caller's listing-wide handler.
+    """
+    try:
+        return CoordinationSignal.from_dict(data)
+    except (KeyError, TypeError, ValueError):
+        logger.debug("Skipping malformed coordination signal %s", key, exc_info=True)
+        return None
 
 
 class CoordinationSignals:
@@ -360,16 +375,14 @@ class CoordinationSignals:
                 else:
                     continue
 
-                for key in keys:
-                    if isinstance(key, bytes):
-                        key = key.decode("utf-8")
-
-                    # Retrieve signal
-                    data = self._retrieve_signal(key)
+                # One MGET for the scanned keys, not one get() per key.
+                for key, data in mget_json(self.memory._client, keys):
                     if not data:
                         continue
 
-                    signal = CoordinationSignal.from_dict(data)
+                    signal = _signal_from_record(key, data)
+                    if signal is None:
+                        continue
 
                     # Filter by source if specified
                     if source_agent and signal.source_agent != source_agent:
@@ -413,15 +426,14 @@ class CoordinationSignals:
                 else:
                     continue
 
-                for key in keys:
-                    if isinstance(key, bytes):
-                        key = key.decode("utf-8")
-
-                    data = self._retrieve_signal(key)
+                # One MGET for the scanned keys, not one get() per key.
+                for key, data in mget_json(self.memory._client, keys):
                     if not data:
                         continue
 
-                    signal = CoordinationSignal.from_dict(data)
+                    signal = _signal_from_record(key, data)
+                    if signal is None:
+                        continue
 
                     # Filter by type if specified
                     if signal_type and signal.signal_type != signal_type:
@@ -458,26 +470,6 @@ class CoordinationSignals:
                 count += 1
 
         return count
-
-    def _retrieve_signal(self, key: str) -> dict[str, Any] | None:
-        """Retrieve signal data from memory."""
-        if not self.memory:
-            return None
-
-        try:
-            # Use direct Redis access (signal keys are stored without prefix)
-            if hasattr(self.memory, "_client"):
-                import json
-
-                data = self.memory._client.get(key)
-                if data:
-                    if isinstance(data, bytes):
-                        data = data.decode("utf-8")
-                    return json.loads(data)
-            return None
-        except Exception as e:  # noqa: BLE001
-            logger.debug(f"Failed to retrieve signal {key}: {e}")
-            return None
 
     def _delete_signal(self, key: str) -> bool:
         """Delete signal from memory."""

--- a/src/attune/telemetry/agent_tracking.py
+++ b/src/attune/telemetry/agent_tracking.py
@@ -37,6 +37,8 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Any
 
+from attune.telemetry._redis_batch import mget_json
+
 logger = logging.getLogger(__name__)
 
 
@@ -90,6 +92,19 @@ class AgentHeartbeat:
             metadata=data.get("metadata", {}),
             display_name=data.get("display_name"),
         )
+
+
+def _heartbeat_from_record(key: str, data: dict[str, Any]) -> AgentHeartbeat | None:
+    """Build a heartbeat from one scanned record, or None if it is malformed.
+
+    Per-record tolerance (class G2): one unparseable record is skipped
+    alone rather than raising into the caller's listing-wide handler.
+    """
+    try:
+        return AgentHeartbeat.from_dict(data)
+    except (KeyError, TypeError, ValueError):
+        logger.debug("Skipping malformed heartbeat %s", key, exc_info=True)
+        return None
 
 
 class HeartbeatCoordinator:
@@ -288,13 +303,14 @@ class HeartbeatCoordinator:
                 return []
 
             heartbeats = []
-            for key in keys:
-                if isinstance(key, bytes):
-                    key = key.decode("utf-8")
+            # One MGET for the scanned keys, not one get() per key.
+            for key, data in mget_json(self.memory._client, keys):
+                if not data:
+                    continue
 
-                data = self._retrieve_heartbeat(key)
-                if data:
-                    heartbeats.append(AgentHeartbeat.from_dict(data))
+                heartbeat = _heartbeat_from_record(key, data)
+                if heartbeat is not None:
+                    heartbeats.append(heartbeat)
 
             return heartbeats
         except Exception as e:  # noqa: BLE001

--- a/src/attune/telemetry/approval_gates.py
+++ b/src/attune/telemetry/approval_gates.py
@@ -46,6 +46,8 @@ from datetime import datetime, timezone
 from typing import Any
 from uuid import uuid4
 
+from attune.telemetry._redis_batch import mget_json
+
 logger = logging.getLogger(__name__)
 
 
@@ -151,6 +153,20 @@ class ApprovalResponse:
             reason=data.get("reason", ""),
             timestamp=timestamp,
         )
+
+
+def _request_from_record(key: str, data: dict[str, Any]) -> ApprovalRequest | None:
+    """Build a request from one scanned record, or None if it is malformed.
+
+    Per-record tolerance (class G2): a record missing a required field or
+    carrying an unparseable timestamp is skipped alone. Raising here would
+    hit the caller's listing-wide handler and cost every good record too.
+    """
+    try:
+        return ApprovalRequest.from_dict(data)
+    except (KeyError, TypeError, ValueError):
+        logger.debug("Skipping malformed approval request %s", key, exc_info=True)
+        return None
 
 
 class ApprovalGate:
@@ -480,29 +496,18 @@ class ApprovalGate:
             return []
 
         try:
-            # Scan for approval_request:* keys
+            # Scan for approval_request:* keys, then fetch every record in
+            # ONE round trip - a get() per key cost N of them.
             keys = list(self.memory._client.scan_iter(match="approval_request:*", count=100))
 
             requests = []
-            for key in keys:
-                if isinstance(key, bytes):
-                    key = key.decode("utf-8")
-
-                # Retrieve request - use direct Redis access (approval keys are stored without prefix)
-                import json
-
-                raw_data = self.memory._client.get(key)
-                if raw_data:
-                    if isinstance(raw_data, bytes):
-                        raw_data = raw_data.decode("utf-8")
-                    data = json.loads(raw_data)
-                else:
-                    data = None
-
+            for key, data in mget_json(self.memory._client, keys):
                 if not data:
                     continue
 
-                request = ApprovalRequest.from_dict(data)
+                request = _request_from_record(key, data)
+                if request is None:
+                    continue
 
                 # Filter by status (only pending)
                 if request.status != "pending":
@@ -537,25 +542,14 @@ class ApprovalGate:
             now = datetime.now(timezone.utc)
             cleared = 0
 
-            for key in keys:
-                if isinstance(key, bytes):
-                    key = key.decode("utf-8")
-
-                # Retrieve request - use direct Redis access (approval keys are stored without prefix)
-                import json
-
-                raw_data = self.memory._client.get(key)
-                if raw_data:
-                    if isinstance(raw_data, bytes):
-                        raw_data = raw_data.decode("utf-8")
-                    data = json.loads(raw_data)
-                else:
-                    data = None
-
+            # One MGET for the whole scan, not one get() per key.
+            for key, data in mget_json(self.memory._client, keys):
                 if not data:
                     continue
 
-                request = ApprovalRequest.from_dict(data)
+                request = _request_from_record(key, data)
+                if request is None:
+                    continue
 
                 # Check if expired
                 elapsed = (now - request.timestamp).total_seconds()

--- a/tests/unit/gates/test_broad_except_ratchet.py
+++ b/tests/unit/gates/test_broad_except_ratchet.py
@@ -279,7 +279,7 @@ _BASELINE: dict[str, int] = {
     "src/attune/roundtable/solutions.py": 1,
     "src/attune/roundtable/triage_appendix.py": 2,
     "src/attune/routing/classifier.py": 1,
-    "src/attune/telemetry/agent_coordination.py": 7,
+    "src/attune/telemetry/agent_coordination.py": 6,
     "src/attune/telemetry/agent_tracking.py": 5,
     "src/attune/telemetry/approval_gates.py": 8,
     "src/attune/telemetry/cli_analysis.py": 1,

--- a/tests/unit/telemetry/conftest.py
+++ b/tests/unit/telemetry/conftest.py
@@ -3,7 +3,22 @@
 Ensures Rich Console has adequate width during tests to prevent truncation.
 """
 
+from typing import Any
+
 import pytest
+
+
+def serve_mget_from_get(client: Any) -> Any:
+    """Let a ``Mock`` Redis client answer MGET from its per-key ``get``.
+
+    The scan-then-fetch listings read their records with one MGET instead
+    of a get() per key. These suites assert on the RECORDS, not on the
+    transport, so replaying the same per-key values through mget keeps
+    them focused; the round-trip count is pinned separately in
+    ``test_redis_batch_access.py``.
+    """
+    client.mget.side_effect = lambda keys: [client.get(key) for key in keys]
+    return client
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit/telemetry/test_agent_coordination.py
+++ b/tests/unit/telemetry/test_agent_coordination.py
@@ -13,6 +13,7 @@ import pytest
 
 from attune.memory.types import AccessTier, AgentCredentials
 from attune.telemetry.agent_coordination import CoordinationSignal, CoordinationSignals
+from tests.unit.telemetry.conftest import serve_mget_from_get
 
 
 class TestCoordinationSignal:
@@ -123,7 +124,7 @@ class TestCoordinationSignalsWithMemory:
         # Use spec to prevent Mock from having stash attribute
         # This makes hasattr(memory, "stash") return False
         memory = Mock(spec=["_client"])
-        memory._client = Mock()
+        memory._client = serve_mget_from_get(Mock())
         return memory
 
     @pytest.fixture

--- a/tests/unit/telemetry/test_agent_coordination_branches.py
+++ b/tests/unit/telemetry/test_agent_coordination_branches.py
@@ -10,7 +10,6 @@ Copyright 2025 Smart-AI-Memory
 Licensed under the Apache License, Version 2.0
 """
 
-import json
 from datetime import datetime, timezone
 from unittest.mock import Mock, patch
 
@@ -149,29 +148,6 @@ class TestClearSignalsGuard:
     def test_no_agent_id_returns_zero(self, mock_memory):
         coordinator = CoordinationSignals(memory=mock_memory, agent_id=None)
         assert coordinator.clear_signals() == 0
-
-
-class TestRetrieveSignalBranches:
-    def test_no_memory_returns_none(self, coordinator):
-        coordinator.memory = None
-        assert coordinator._retrieve_signal("key") is None
-
-    def test_memory_without_client_returns_none(self):
-        coordinator = CoordinationSignals(memory=Mock(spec=[]), agent_id="test-agent")
-        assert coordinator._retrieve_signal("key") is None
-
-    def test_invalid_json_returns_none(self, coordinator, mock_memory):
-        mock_memory._client.get.return_value = b"not json"
-        assert coordinator._retrieve_signal("key") is None
-
-    def test_bytes_payload_decodes(self, coordinator, mock_memory):
-        payload = {
-            "signal_id": "signal_1",
-            "signal_type": "ready",
-            "source_agent": "a",
-        }
-        mock_memory._client.get.return_value = json.dumps(payload).encode("utf-8")
-        assert coordinator._retrieve_signal("key") == payload
 
 
 class TestDeleteSignalBranches:

--- a/tests/unit/telemetry/test_agent_tracking.py
+++ b/tests/unit/telemetry/test_agent_tracking.py
@@ -10,6 +10,7 @@ from unittest.mock import Mock, patch
 import pytest
 
 from attune.telemetry.agent_tracking import AgentHeartbeat, HeartbeatCoordinator
+from tests.unit.telemetry.conftest import serve_mget_from_get
 
 
 class TestAgentHeartbeat:
@@ -122,7 +123,7 @@ class TestHeartbeatCoordinatorWithMemory:
         # Use spec to prevent Mock from having stash attribute
         # This makes hasattr(memory, "stash") return False
         memory = Mock(spec=["_client"])
-        memory._client = Mock()
+        memory._client = serve_mget_from_get(Mock())
         return memory
 
     @pytest.fixture

--- a/tests/unit/telemetry/test_approval_gates.py
+++ b/tests/unit/telemetry/test_approval_gates.py
@@ -9,6 +9,7 @@ from datetime import datetime, timezone
 from unittest.mock import MagicMock, Mock, patch
 
 from attune.telemetry.approval_gates import ApprovalGate, ApprovalRequest, ApprovalResponse
+from tests.unit.telemetry.conftest import serve_mget_from_get
 
 
 class TestApprovalRequest:
@@ -325,6 +326,7 @@ class TestApprovalGate:
             return None
 
         mock_client.get.side_effect = mock_get
+        serve_mget_from_get(mock_client)
 
         mock_memory = Mock(spec=["_client"])
         mock_memory._client = mock_client
@@ -378,6 +380,7 @@ class TestApprovalGate:
             return None
 
         mock_client.get.side_effect = mock_get
+        serve_mget_from_get(mock_client)
 
         mock_memory = Mock(spec=["_client"])
         mock_memory._client = mock_client
@@ -440,6 +443,7 @@ class TestApprovalGate:
         import json
 
         mock_client.get.return_value = json.dumps(request_data).encode()
+        serve_mget_from_get(mock_client)
 
         mock_memory = Mock(spec=["_client"])
         mock_memory._client = mock_client
@@ -472,6 +476,7 @@ class TestApprovalGateIntegration:
 
         mock_client.setex.side_effect = mock_setex
         mock_client.get.side_effect = mock_get
+        serve_mget_from_get(mock_client)
 
         # Pipeline mock: respond_to_approval() uses pipeline for batching
         mock_pipe = Mock()

--- a/tests/unit/telemetry/test_redis_batch_access.py
+++ b/tests/unit/telemetry/test_redis_batch_access.py
@@ -1,0 +1,297 @@
+"""Scan-then-fetch listings must cost ONE round trip, not N.
+
+Every listing below scans a key pattern and then reads the records. The
+regression this pins is a *round-trip count*: a refactor that swaps the
+batched read back for a per-key ``get()`` loop keeps every functional
+assertion green while restoring the N+1 pattern, so the transport itself
+is asserted here.
+
+The fake client counts calls and REFUSES ``get`` outright inside the
+listing paths, so the N+1 shape fails loudly rather than silently.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from attune.telemetry._redis_batch import decode_json_object, mget_json
+from attune.telemetry.agent_coordination import CoordinationSignals
+from attune.telemetry.agent_tracking import HeartbeatCoordinator
+from attune.telemetry.approval_gates import ApprovalGate
+
+
+class CountingClient:
+    """Redis stand-in that counts round trips and bans per-key get()."""
+
+    def __init__(self, records: dict[str, object], *, allow_get: bool = False):
+        # ``records`` values are pre-encoded payloads (bytes/str) or None.
+        self.records = records
+        self.allow_get = allow_get
+        self.mget_calls: list[list[str]] = []
+        self.get_calls: list[str] = []
+        self.setex_calls: list[tuple[str, int, str]] = []
+
+    def scan_iter(self, match: str = "*", count: int = 100):
+        # Returned as bytes, exactly as redis-py does by default.
+        yield from (key.encode() for key in self.records)
+
+    def mget(self, keys):
+        keys = list(keys)
+        self.mget_calls.append(keys)
+        return [self.records.get(key) for key in keys]
+
+    def get(self, key):
+        self.get_calls.append(key)
+        if not self.allow_get:
+            raise AssertionError(
+                f"per-key get({key!r}) in a listing path — the batched read regressed to N+1"
+            )
+        return self.records.get(key)
+
+    def setex(self, key, ttl, value):
+        self.setex_calls.append((key, ttl, value))
+        return True
+
+    def delete(self, key):
+        self.records.pop(key, None)
+        return 1
+
+
+class FakeMemory:
+    def __init__(self, client):
+        self._client = client
+
+
+def _approval(request_id: str, *, status: str = "pending", age_seconds: float = 0.0) -> bytes:
+    ts = datetime.now(timezone.utc) - timedelta(seconds=age_seconds)
+    return json.dumps(
+        {
+            "request_id": request_id,
+            "approval_type": "deploy",
+            "agent_id": "agent-1",
+            "context": {},
+            "timestamp": ts.isoformat(),
+            "timeout_seconds": 300.0,
+            "status": status,
+        }
+    ).encode()
+
+
+def _signal(signal_id: str, *, signal_type: str = "ready") -> bytes:
+    return json.dumps(
+        {
+            "signal_id": signal_id,
+            "signal_type": signal_type,
+            "source_agent": "agent-2",
+            "target_agent": "agent-1",
+            "payload": {},
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "ttl_seconds": 60,
+        }
+    ).encode()
+
+
+def _heartbeat(agent_id: str) -> bytes:
+    return json.dumps(
+        {
+            "agent_id": agent_id,
+            "status": "running",
+            "progress": 0.5,
+            "current_task": "work",
+            "last_beat": datetime.now(timezone.utc).isoformat(),
+            "metadata": {},
+        }
+    ).encode()
+
+
+class TestApprovalGateBatching:
+    def test_pending_approvals_uses_one_mget_for_many_keys(self):
+        records = {f"approval_request:approval_{i}": _approval(f"approval_{i}") for i in range(5)}
+        client = CountingClient(records)
+        gate = ApprovalGate(memory=FakeMemory(client))
+
+        pending = gate.get_pending_approvals()
+
+        assert len(pending) == 5
+        assert len(client.mget_calls) == 1
+        assert client.get_calls == []
+
+    def test_pending_approvals_skips_malformed_record_only(self):
+        records = {
+            "approval_request:good_1": _approval("good_1"),
+            "approval_request:not_json": b"{not json",
+            "approval_request:not_an_object": b"[1, 2, 3]",
+            "approval_request:missing_field": json.dumps({"approval_type": "deploy"}).encode(),
+            "approval_request:bad_timestamp": json.dumps(
+                {
+                    "request_id": "bad_ts",
+                    "approval_type": "deploy",
+                    "agent_id": "agent-1",
+                    "timestamp": "not-a-timestamp",
+                }
+            ).encode(),
+            "approval_request:absent": None,
+            "approval_request:good_2": _approval("good_2"),
+        }
+        client = CountingClient(records)
+        gate = ApprovalGate(memory=FakeMemory(client))
+
+        pending = gate.get_pending_approvals()
+
+        assert [r.request_id for r in pending] == ["good_1", "good_2"]
+        assert len(client.mget_calls) == 1
+
+    def test_clear_expired_requests_uses_one_mget(self):
+        records = {
+            "approval_request:fresh": _approval("fresh"),
+            "approval_request:stale": _approval("stale", age_seconds=1000),
+        }
+        client = CountingClient(records)
+        gate = ApprovalGate(memory=FakeMemory(client))
+
+        assert gate.clear_expired_requests() == 1
+        assert len(client.mget_calls) == 1
+        assert client.get_calls == []
+        assert [call[0] for call in client.setex_calls] == ["approval_request:stale"]
+
+    def test_clear_expired_requests_skips_malformed_record_only(self):
+        records = {
+            "approval_request:broken": b"{not json",
+            "approval_request:stale": _approval("stale", age_seconds=1000),
+        }
+        client = CountingClient(records)
+        gate = ApprovalGate(memory=FakeMemory(client))
+
+        assert gate.clear_expired_requests() == 1
+
+
+class TestCoordinationSignalBatching:
+    def test_pending_signals_uses_one_mget_per_scanned_pattern(self):
+        records = {f"signal:agent-1:ready:sig{i}": _signal(f"sig{i}") for i in range(4)}
+        client = CountingClient(records)
+        signals = CoordinationSignals(memory=FakeMemory(client), agent_id="agent-1")
+
+        pending = signals.get_pending_signals()
+
+        # Two scanned patterns (targeted + broadcast) => at most one MGET each.
+        assert len(pending) == 8  # same fake keys served for both patterns
+        assert len(client.mget_calls) == 2
+        assert client.get_calls == []
+
+    def test_check_signal_uses_one_mget(self):
+        records = {"signal:agent-1:ready:sig1": _signal("sig1")}
+        client = CountingClient(records)
+        signals = CoordinationSignals(memory=FakeMemory(client), agent_id="agent-1")
+
+        found = signals.check_signal("ready", consume=False)
+
+        assert found is not None
+        assert found.signal_id == "sig1"
+        assert len(client.mget_calls) == 1
+        assert client.get_calls == []
+
+    def test_pending_signals_skips_malformed_record_only(self):
+        records = {
+            "signal:agent-1:ready:good": _signal("good"),
+            "signal:agent-1:ready:broken": b"{not json",
+            "signal:agent-1:ready:incomplete": json.dumps({"signal_id": "x"}).encode(),
+        }
+        client = CountingClient(records)
+        signals = CoordinationSignals(memory=FakeMemory(client), agent_id="agent-1")
+
+        pending = signals.get_pending_signals()
+
+        assert {s.signal_id for s in pending} == {"good"}
+
+
+class TestHeartbeatBatching:
+    def test_active_agents_uses_one_mget_for_many_keys(self):
+        records = {f"empathy:heartbeat:agent-{i}": _heartbeat(f"agent-{i}") for i in range(6)}
+        client = CountingClient(records)
+        coordinator = HeartbeatCoordinator(memory=FakeMemory(client))
+
+        active = coordinator.get_active_agents()
+
+        assert len(active) == 6
+        assert len(client.mget_calls) == 1
+        assert client.get_calls == []
+
+    def test_active_agents_skips_malformed_record_only(self):
+        records = {
+            "empathy:heartbeat:good": _heartbeat("good"),
+            "empathy:heartbeat:broken": b"{not json",
+            "empathy:heartbeat:incomplete": json.dumps({"agent_id": "x"}).encode(),
+            "empathy:heartbeat:absent": None,
+        }
+        client = CountingClient(records)
+        coordinator = HeartbeatCoordinator(memory=FakeMemory(client))
+
+        active = coordinator.get_active_agents()
+
+        assert [h.agent_id for h in active] == ["good"]
+
+
+class TestMgetJsonHelper:
+    def test_decodes_bytes_keys_and_values_in_order(self):
+        client = CountingClient({"a": b'{"n": 1}', "b": '{"n": 2}'})
+
+        assert mget_json(client, [b"a", b"b"]) == [("a", {"n": 1}), ("b", {"n": 2})]
+
+    def test_empty_keys_makes_no_round_trip(self):
+        client = CountingClient({})
+
+        assert mget_json(client, []) == []
+        assert client.mget_calls == []
+
+    def test_chunks_large_key_sets(self):
+        from attune.telemetry import _redis_batch
+
+        keys = [f"k{i}" for i in range(_redis_batch._MGET_CHUNK + 1)]
+        client = CountingClient({k: b'{"n": 1}' for k in keys})
+
+        records = mget_json(client, keys)
+
+        assert len(records) == len(keys)
+        assert len(client.mget_calls) == 2
+
+    def test_mget_errors_are_not_swallowed(self):
+        class BrokenClient(CountingClient):
+            def mget(self, keys):
+                raise ConnectionError("redis down")
+
+        with pytest.raises(ConnectionError):
+            mget_json(BrokenClient({}), ["a"])
+
+    @pytest.mark.parametrize(
+        "raw",
+        [None, b"", "", b"{not json", b"[1,2]", b'"a string"', b"\xff\xfe", 12345],
+    )
+    def test_decode_json_object_is_total(self, raw):
+        assert decode_json_object(raw) is None
+
+
+class TestListingsDegradeWithoutRedis:
+    def test_listings_return_empty_when_mget_fails(self):
+        class BrokenClient(CountingClient):
+            def mget(self, keys):
+                raise ConnectionError("redis down")
+
+        records = {"approval_request:a": _approval("a")}
+        gate = ApprovalGate(memory=FakeMemory(BrokenClient(records)))
+        assert gate.get_pending_approvals() == []
+        assert gate.clear_expired_requests() == 0
+
+        signals = CoordinationSignals(
+            memory=FakeMemory(BrokenClient({"signal:agent-1:ready:s": _signal("s")})),
+            agent_id="agent-1",
+        )
+        assert signals.get_pending_signals() == []
+        assert signals.check_signal("ready") is None
+
+        coordinator = HeartbeatCoordinator(
+            memory=FakeMemory(BrokenClient({"empathy:heartbeat:a": _heartbeat("a")}))
+        )
+        assert coordinator.get_active_agents() == []


### PR DESCRIPTION
## What

Five telemetry listings scanned a Redis key pattern and then read each
record with its own `get()` — one network round trip per record. They now
fetch every scanned record in a single `MGET`.

Found in the 13.0.2 post-release self-review (code-review run
`4e9314b89990`). The review confirmed `approval_gates.py` by reading the
source and named two more sites unverified; both were checked here and the
pattern holds. A fourth site with the identical shape turned up adjacent to
the first.

| Site | Provenance |
|---|---|
| `approval_gates.get_pending_approvals` | named + confirmed in the review |
| `approval_gates.clear_expired_requests` | **same shape, not in the review** |
| `agent_coordination.check_signal` | named, pattern confirmed here |
| `agent_coordination.get_pending_signals` | same shape |
| `agent_tracking.get_active_agents` | named, pattern confirmed here (`get_stale_agents` inherits it) |

## How

New `attune.telemetry._redis_batch.mget_json(client, keys)` returns
`(key, record_or_None)` pairs from one `MGET`, chunked at 500 keys so a
large scan doesn't become a single server-blocking command.

Decoding is **total**, in the spirit of `ops.data._as_int` (class G2): a
missing, undecodable, non-JSON, or non-object value yields `None` for that
key alone. Errors from `MGET` itself are deliberately **not** swallowed — a
broken client was already a listing-wide failure through each caller's
existing handler, and preserving that avoids inventing a new degradation
mode.

### Per-record degradation is repaired in `approval_gates`

The old loop called `json.loads` and `ApprovalRequest.from_dict` bare inside
the function-wide `try`, so one malformed record raised past the per-key
logic into `except Exception` and returned an empty listing — one bad
record cost every good one. Each module now has a `_<thing>_from_record`
helper catching `KeyError/TypeError/ValueError`. The other two modules
already degraded per-record via their `_retrieve_*` helpers; that behavior
is preserved.

## Test

`tests/unit/telemetry/test_redis_batch_access.py` (22 tests) pins the
**round-trip count**, since that is the entire claim: the fake client
counts `mget` calls and **raises `AssertionError` on any `get()`** inside a
listing path, so a later refactor back to N+1 fails loudly rather than
passing every functional assertion. It also pins per-record skipping (bad
JSON, JSON arrays, missing fields, unparseable timestamps, absent keys),
the chunk boundary, and empty-on-Redis-down for all five listings.

## Two judgment calls worth a reviewer's eye

1. **`_retrieve_signal` deleted.** Moving both of its callers to `mget_json`
   left it with zero production callers and only four tests — a stale
   duplicate read path. Removed with those tests; its decoding branches are
   covered by the new parametrized `decode_json_object` test.
   `_retrieve_heartbeat` stays: `is_agent_alive` and `get_agent_status` do
   genuine single-key reads.
2. **Existing suites mocked the transport.** 13 tests set
   `_client.get.side_effect`. They assert on *records*, not round trips, so
   `conftest.serve_mget_from_get` replays the same per-key values through
   `mget`. The round-trip contract lives in the new file alone.

Broad-except ratchet baseline for `agent_coordination.py` drops 7 → 6 (the
deleted helper carried one) — the ratchet's staleness half caught this and
demanded it.

## Receipts

- Full unit suite: **20,937 passed / 108 skipped / 6 xfailed**. The one
  failure on the way there was the ratchet catching the stale baseline
  above; gates + telemetry re-run clean after the edit (972 passed).
- Pinned `black`, `ruff`, and `ruff-bare-exception-check` pass on every
  touched file.
- **No live-Redis timing number** — local Redis returns `NOAUTH` in this
  environment. The claim is a call count, so the counting-fake assertion is
  direct evidence rather than a proxy; a wall-clock figure against a real
  instance would need credentials.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
