### PR TITLE
docs(outbox): sweep 3 artifacts + fix stale core budget seed figure

### DIFF
--- a/.claude/lessons.md
+++ b/.claude/lessons.md
@@ -23966,3 +23966,91 @@ imposes on every other in-flight PR, not just the next one.
   standing on the right branch can host the step instead. The shared
   checkout is shared state, and release steps should not be the thing that
   perturbs it.
+
+- **Parsing `gh pr checks` TABULAR output with positional `awk` fields
+  silently misreads the bucket — check NAMES contain spaces, so `$2` is a
+  name fragment, not the status; use `--json name,bucket`**: 2026-08-22,
+  watching two PRs to green with a standing "admin-merge if auto-merge
+  stalls" authorization. The watcher counted pending work with
+  `awk '$2=="pending"'`. On the row `test (windows-latest, 3.12)  pending`
+  field 2 is `(windows-latest,` — so a RUNNING Windows lane counted as
+  zero-pending. The watcher printed `pend=0 fail=[]` while the PR sat
+  `OPEN/BLOCKED`, which its own stall detector read as "all checks
+  terminal, still open" = auto-merge stalled. Acting on that would have
+  admin-merged a PR whose Windows lane had not yet reported — precisely
+  the failure the existing "admin-merging a PR before Windows lanes
+  complete buries a real bug on main" lesson warns about, reached through
+  a parsing bug rather than impatience. The same break hides bad news:
+  `fail=[]` is indistinguishable from "I could not see the failures," so
+  the watcher's clean bill of health carried no information at all.
+  Fix: `gh pr checks <n> --json name,bucket` piped through `jq`, never
+  positional `awk` — EVERY multi-word check name breaks column
+  assumptions and `gh` does not quote them (`test (ubuntu-latest, 3.12)`,
+  `Analyze (python)`, `clock-tz (America/Anchorage)`, `Vercel – website`).
+  Diagnostic tell, and it is free: a bucket tally that CONTRADICTS the
+  PR's own `mergeStateStatus`. `BLOCKED` with zero pending and zero fails
+  is not a stall, it is an impossibility — and the impossible half is
+  your parser, not GitHub. Extends "CI watchers report ABSENCE as
+  success" one layer down (mis-parse rendering as absence, absence
+  rendering as success) and pairs with "`gh pr checks --json` field is
+  `bucket`, NOT `conclusion`" — same command, and the JSON path avoids
+  both traps at once.
+
+- **The docs-outbox is a DOCS queue, not a work queue — `report`/`draft`/
+  `plan` kinds CREATE a new `.md` target and cannot carry an edit to a
+  `.py`; queue non-doc follow-ups somewhere else**: 2026-08-22, asked to
+  "batch this one-line comment fix with the next PR." The outbox looked
+  like the obvious home — it is the repo's own mechanism for pending
+  small work, and it surfaces automatically in the next digest. Reading
+  `routing.py` and `sweep.py` first showed why it does not fit:
+  `OUTBOX_TARGETS` maps `lesson -> .claude/lessons.md` and
+  `report`/`draft`/`plan -> None`, but a `None` default does NOT mean
+  "queued and inert" — it means the artifact must name its OWN target,
+  which is then validated as repo-relative, `.md`-suffixed, and
+  **non-existent** ("refusing overwrite"), and `apply` CREATES that file.
+  So routing a `.py` one-liner through a `draft` would have produced a
+  stray markdown file, not the fix. General shape: a queue's ROUTING
+  TABLE is its type signature — read it before adopting the queue,
+  because a mechanism that accepts your artifact is not the same as a
+  mechanism that will DO the right thing with it. What worked instead:
+  a ready-to-apply patch file under `~/.attune/queued-edits/` carrying
+  the verification command, the exact `sed`, the post-apply gate check,
+  AND the decision that produced it (here: do NOT raise
+  `CORE_BUDGET_BYTES`, it is shrink-only) — machine-local, survives
+  sessions, and reusable by whoever picks it up. Dry-run the queued patch
+  against a scratch copy before filing it: a `sed` that matches nothing
+  files as a confident no-op and is discovered only much later.
+
+- **A squash-merge REBASES the sibling PR's base, so a clean
+  `git merge-tree` between branch TIPS does not predict post-merge
+  mergeability — and GitHub's `CONFLICTING` right after that merge can
+  itself be stale; rebase and LOOK before believing either**: 2026-08-22,
+  two same-day PRs both appending to the tail of `.claude/lessons.md`.
+  Before either landed I ran `git merge-tree --write-tree <A> <B>`, got a
+  clean tree and exit 0, and told the chair no rebase would be needed.
+  When #2160 squash-merged, #2161 immediately read
+  `mergeStateStatus=DIRTY mergeable=CONFLICTING`. BOTH readings were
+  wrong, in opposite directions: the merge-tree probe compared two tips
+  against their shared base, which is not the situation after a squash
+  rewrites main's tail into one new commit; and the `CONFLICTING` was
+  stale — `git rebase origin/main` then replayed the branch with ZERO
+  conflicts. Practices: (1) treat a clean tip-to-tip merge-tree as
+  evidence about the CURRENT bases only, never as a forecast across a
+  sibling merge — squash AND rebase merge strategies both invalidate it,
+  and squash is the repo default; (2) when GitHub reports CONFLICTING,
+  run the rebase before reporting a conflict to anyone — the field is
+  computed asynchronously and lags the true state by minutes; (3) verify
+  `%G?` after the rebase (the existing rebase-drops-GPG-signature
+  lesson) — here it survived as `G`, but the check is one command and the
+  failure is silent.
+  Companion technique worth keeping: to learn whether two in-flight PRs
+  are JOINTLY safe before either lands — the state neither PR's own CI
+  ever exercises, and the gap behind "a drift guard merged in one PR
+  won't catch drift from a sibling content-PR" — materialize the combined
+  tree and run the gates on it. `git merge-tree --write-tree A B` prints
+  a TREE oid, and `git worktree add` rejects it (`is a tree, not a
+  commit`); the working move is
+  `git archive <oid> <paths> | tar -x -C <scratch>`, then copy those
+  files over a scratch worktree and run the suite there. It found nothing
+  this time — the honest outcome most of the time — but it is the only
+  probe that answers the both-merged question BEFORE it is irreversible.

--- a/tests/unit/lessons/test_core_mirror.py
+++ b/tests/unit/lessons/test_core_mirror.py
@@ -31,7 +31,7 @@ CORE_HEADING = "## Lessons — core"
 # A count cap is a poor ceiling: at the observed ~1,690 B/entry mean, the
 # <= 30 cap silently authorises ~51 KB nobody ratified. This budget binds
 # BEFORE the count cap, so a promotion that costs real context trips here
-# and forces the eviction conversation. Seeded at 43,969 (26 entries,
+# and forces the eviction conversation. Seeded at 44,951 (26 entries,
 # 2026-08-22). SHRINK-ONLY: demote something rather than widening it.
 CORE_BUDGET_BYTES = 46_000
 


### PR DESCRIPTION
Two things, batched per chair instruction ("batch it with the next PR").

## 1. Outbox sweep — 3 lessons (+88/-0)

All three append to `.claude/lessons.md`; no other doc changes.

| Lesson | Gist |
|---|---|
| `gh-pr-checks-awk-field-splitting` | Positional `awk` over `gh pr checks` misreads the bucket — check names contain spaces, so `$2` on `test (windows-latest, 3.12)` is `(windows-latest,`. A **running** Windows lane counted as zero-pending and nearly tripped an admin-merge on a PR whose Windows lane had not reported. Use `--json name,bucket`. |
| `squash-merge-invalidates-tip-merge-tree` | A clean tip-to-tip `git merge-tree` does not survive a sibling **squash**-merge, and GitHub's `CONFLICTING` immediately after can itself be stale. Rebase and look before believing either. Carries the technique for pre-testing the both-merged tree. |
| `docs-outbox-is-a-docs-queue` | `draft`/`report`/`plan` kinds **create** a `.md` target and cannot carry a non-doc edit — read a queue's routing table before adopting it. |

All three are live findings from the #2160/#2161 merge session, not
theory. The first two are diagnostic recipes; deliberately NOT promoted
to core (see below).

## 2. Stale seed figure in the core byte budget (+1/-1, comment only)

`tests/unit/lessons/test_core_mirror.py` cited
`Seeded at 43,969 (26 entries, 2026-08-22)`. Core actually measured
**44,951 B** at the seeding commit `38086773c` (#2158):

```
git show 38086773c:.claude/CLAUDE.md | python3 -c "
import sys; t=sys.stdin.read()
c='## Lessons - core'+t.split('## Lessons - core',1)[1]
print(len(c.encode()))"
# -> 44951
```

That number is the baseline for reasoning about core growth, so the
error is not cosmetic: 43,969 overstates growth-since-seeding as
+1,299 B when the true figure is **+317 B**.

`CORE_BUDGET_BYTES` is unchanged at `46_000` and stays **shrink-only**.
No promotion in this PR — core sits at 45,268 B with 732 B headroom,
under half a mean entry, so any promotion must name an eviction first.

## Receipts

```
python scripts/check_lessons_corpus.py                              -> exit 0
pytest tests/unit/lessons/ tests/unit/rules/...residency_budget.py  -> 35 passed
pytest tests/unit/gates/ tests/unit/quality/                        -> 331 passed
pre-commit run --files <both changed files>                         -> all Passed
```

Ratchet-gate sweep run because this diff touches `tests/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
