### PR TITLE
test(telemetry): fix 5 vacuous listing tests and gate the class

### DIFF
--- a/tests/unit/gates/test_listing_mock_transport_gate.py
+++ b/tests/unit/gates/test_listing_mock_transport_gate.py
@@ -87,14 +87,22 @@ def _fixture_sources(scope: ast.AST, source: str) -> dict[str, str]:
     return out
 
 
-def _violations() -> list[str]:
-    conftest = _TELEMETRY_TESTS / "conftest.py"
+def _violations(root: Path | None = None) -> list[str]:
+    """Scan ``root`` (default: the telemetry tests) for the vacuity shape.
+
+    ``root`` is a parameter so the self-check below can scan a throwaway
+    directory. A test that wrote its fixture INTO the scanned tree would
+    be mutating a directory pytest is collecting from — a race under
+    xdist and a stray file if the run is killed mid-test.
+    """
+    root = root or _TELEMETRY_TESTS
+    conftest = root / "conftest.py"
     conftest_src = conftest.read_text(encoding="utf-8") if conftest.exists() else ""
     conftest_tree = ast.parse(conftest_src) if conftest_src else ast.parse("")
     conftest_fixtures = _fixture_sources(conftest_tree, conftest_src)
 
     found: list[str] = []
-    for path in sorted(_TELEMETRY_TESTS.glob("test_*.py")):
+    for path in sorted(root.glob("test_*.py")):
         source = path.read_text(encoding="utf-8")
         tree = ast.parse(source)
         # Module-level fixtures only; class fixtures are added per class
@@ -156,10 +164,9 @@ def test_listing_tests_serve_the_batched_transport():
     )
 
 
-def test_gate_detects_a_planted_violation():
+def test_gate_detects_a_planted_violation(tmp_path):
     """The gate must actually fire — a green run should mean a clean tree."""
-    planted = _TELEMETRY_TESTS / "test_gate_selfcheck_tmp.py"
-    planted.write_text(
+    (tmp_path / "test_planted_vacuous.py").write_text(
         "from unittest.mock import Mock\n\n\n"
         "def test_planted():\n"
         "    c = Mock()\n"
@@ -167,7 +174,21 @@ def test_gate_detects_a_planted_violation():
         "    c.get.return_value = None\n",
         encoding="utf-8",
     )
-    try:
-        assert any("test_gate_selfcheck_tmp.py" in v for v in _violations())
-    finally:
-        planted.unlink()
+
+    assert any("test_planted_vacuous.py" in v for v in _violations(tmp_path))
+
+
+def test_gate_accepts_a_wired_test(tmp_path):
+    """The counterpart: serving the transport clears the violation."""
+    (tmp_path / "test_planted_wired.py").write_text(
+        "from unittest.mock import Mock\n\n"
+        "from tests.unit.telemetry.conftest import serve_mget_from_get\n\n\n"
+        "def test_planted():\n"
+        "    c = Mock()\n"
+        '    c.scan_iter.return_value = [b"k:1"]\n'
+        "    c.get.return_value = None\n"
+        "    serve_mget_from_get(c)\n",
+        encoding="utf-8",
+    )
+
+    assert _violations(tmp_path) == []

--- a/tests/unit/gates/test_listing_mock_transport_gate.py
+++ b/tests/unit/gates/test_listing_mock_transport_gate.py
@@ -1,0 +1,173 @@
+"""A listing test that stubs only ``get`` asserts nothing.
+
+The telemetry listings read their records with one ``MGET`` instead of a
+``get()`` per key. A test that stubs only ``get`` therefore hands the
+listing a bare ``Mock`` for ``mget``, which is not iterable — the
+resulting ``TypeError`` is swallowed by each listing's function-wide
+``except Exception`` and the call returns ``[]`` / ``0`` / ``None``.
+
+Any assertion expecting an empty result then passes **for the wrong
+reason**: the payload the test set up is never read, and the logic the
+test names never runs. This is not hypothetical — five tests were
+silently vacuous this way after the MGET migration, including the only
+test guarding ``get_pending_approvals``' "only pending" status filter.
+
+The failure is invisible by construction: tests with POSITIVE assertions
+(``assert len(x) == 1``) go red immediately and get fixed, while tests
+asserting emptiness are satisfied by the very failure they should catch.
+So the suite cannot self-report this class — hence a gate.
+
+Fix a violation by wiring the transport, not by loosening this rule::
+
+    mock_client.get.return_value = ...
+    serve_mget_from_get(mock_client)      # replay get() through mget()
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_TELEMETRY_TESTS = _REPO_ROOT / "tests" / "unit" / "telemetry"
+
+#: Any of these in a test body (or in a fixture it requests) means the
+#: batched transport is served, so the listing reads real records.
+_WIRED_MARKERS = ("serve_mget_from_get", "mget", "CountingClient")
+
+
+def _stubs_nonempty_scan(node: ast.AST) -> bool:
+    """True if this function stubs ``scan_iter`` so a listing reaches MGET.
+
+    An empty ``return_value`` cannot reach MGET (the helper short-circuits)
+    and a raising ``side_effect`` fails before it, so neither can be
+    vacuous — only a scan that actually yields keys qualifies.
+    """
+    for sub in ast.walk(node):
+        if not isinstance(sub, ast.Assign):
+            continue
+        for target in sub.targets:
+            if not isinstance(target, ast.Attribute):
+                continue
+            if target.attr not in ("return_value", "side_effect"):
+                continue
+            owner = target.value
+            if not (isinstance(owner, ast.Attribute) and owner.attr == "scan_iter"):
+                continue
+
+            value = sub.value
+            if isinstance(value, ast.List | ast.Tuple):
+                return bool(value.elts)  # empty scan short-circuits
+            if target.attr == "side_effect":
+                # A raising side_effect fails before MGET; anything else
+                # (a list, a generator) still feeds the listing.
+                if isinstance(value, ast.Call) and isinstance(value.func, ast.Name):
+                    if value.func.id.endswith(("Error", "Exception")):
+                        return False
+                if isinstance(value, ast.Name) and value.id.endswith(("Error", "Exception")):
+                    return False
+            return True
+    return False
+
+
+def _fixture_sources(scope: ast.AST, source: str) -> dict[str, str]:
+    """Map fixture name -> source text for fixtures defined DIRECTLY in ``scope``.
+
+    Deliberately NOT recursive: one file often defines the same fixture name
+    in several classes — one wiring the transport, one not — so module and
+    class scopes must stay separate or the wrong definition wins and the
+    gate reports a false positive.
+    """
+    out: dict[str, str] = {}
+    for node in getattr(scope, "body", []):
+        if not isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+            continue
+        if any("fixture" in ast.dump(dec) for dec in node.decorator_list):
+            out[node.name] = ast.get_source_segment(source, node) or ""
+    return out
+
+
+def _violations() -> list[str]:
+    conftest = _TELEMETRY_TESTS / "conftest.py"
+    conftest_src = conftest.read_text(encoding="utf-8") if conftest.exists() else ""
+    conftest_tree = ast.parse(conftest_src) if conftest_src else ast.parse("")
+    conftest_fixtures = _fixture_sources(conftest_tree, conftest_src)
+
+    found: list[str] = []
+    for path in sorted(_TELEMETRY_TESTS.glob("test_*.py")):
+        source = path.read_text(encoding="utf-8")
+        tree = ast.parse(source)
+        # Module-level fixtures only; class fixtures are added per class
+        # below. A name may be defined in several classes (one wiring the
+        # transport, one not), so a flat map would resolve to the wrong one.
+        module_fixtures = {
+            **conftest_fixtures,
+            **_fixture_sources(tree, source),
+        }
+
+        # (test node, fixtures visible to it) — class scope shadows module.
+        scoped: list[tuple[ast.AST, dict[str, str]]] = []
+        for node in tree.body:
+            if isinstance(node, ast.ClassDef):
+                visible = {**module_fixtures, **_fixture_sources(node, source)}
+                for item in ast.walk(node):
+                    if isinstance(item, ast.FunctionDef | ast.AsyncFunctionDef):
+                        scoped.append((item, visible))
+            elif isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+                scoped.append((node, module_fixtures))
+
+        for node, fixtures in scoped:
+            if not node.name.startswith("test_"):
+                continue
+            if not _stubs_nonempty_scan(node):
+                continue
+
+            body = ast.get_source_segment(source, node) or ""
+            # The transport may be served in the test itself, or by any
+            # fixture the test requests (possibly via a fixture chain).
+            scopes = [body]
+            pending = [a.arg for a in node.args.args if a.arg != "self"]
+            seen: set[str] = set()
+            while pending:
+                name = pending.pop()
+                if name in seen or name not in fixtures:
+                    continue
+                seen.add(name)
+                scopes.append(fixtures[name])
+                fixture_node = ast.parse(fixtures[name]).body[0]
+                if isinstance(fixture_node, ast.FunctionDef | ast.AsyncFunctionDef):
+                    pending.extend(a.arg for a in fixture_node.args.args if a.arg != "self")
+
+            if not any(marker in scope for scope in scopes for marker in _WIRED_MARKERS):
+                found.append(f"{path.name}::{node.name} (line {node.lineno})")
+    return found
+
+
+def test_listing_tests_serve_the_batched_transport():
+    """A telemetry test feeding a non-empty scan must also serve MGET."""
+    violations = _violations()
+    assert not violations, (
+        "These tests stub a non-empty scan_iter but never serve mget, so the "
+        "listing raises 'Mock object is not iterable' into its own except "
+        "handler and returns empty — any emptiness assertion passes "
+        "vacuously.\n  " + "\n  ".join(violations) + "\n\n"
+        "Fix: call serve_mget_from_get(mock_client) after setting up get(), "
+        "or use CountingClient. Do not relax this gate."
+    )
+
+
+def test_gate_detects_a_planted_violation():
+    """The gate must actually fire — a green run should mean a clean tree."""
+    planted = _TELEMETRY_TESTS / "test_gate_selfcheck_tmp.py"
+    planted.write_text(
+        "from unittest.mock import Mock\n\n\n"
+        "def test_planted():\n"
+        "    c = Mock()\n"
+        '    c.scan_iter.return_value = [b"k:1"]\n'
+        "    c.get.return_value = None\n",
+        encoding="utf-8",
+    )
+    try:
+        assert any("test_gate_selfcheck_tmp.py" in v for v in _violations())
+    finally:
+        planted.unlink()

--- a/tests/unit/telemetry/test_agent_coordination_branches.py
+++ b/tests/unit/telemetry/test_agent_coordination_branches.py
@@ -16,13 +16,14 @@ from unittest.mock import Mock, patch
 import pytest
 
 from attune.telemetry.agent_coordination import CoordinationSignal, CoordinationSignals
+from tests.unit.telemetry.conftest import serve_mget_from_get
 
 
 @pytest.fixture
 def mock_memory():
     """Memory backend double exposing only _client."""
     memory = Mock(spec=["_client"])
-    memory._client = Mock()
+    memory._client = serve_mget_from_get(Mock())
     return memory
 
 

--- a/tests/unit/telemetry/test_agent_tracking_branches.py
+++ b/tests/unit/telemetry/test_agent_tracking_branches.py
@@ -17,13 +17,14 @@ from unittest.mock import Mock, patch
 import pytest
 
 from attune.telemetry.agent_tracking import AgentHeartbeat, HeartbeatCoordinator
+from tests.unit.telemetry.conftest import serve_mget_from_get
 
 
 @pytest.fixture
 def mock_memory():
     """Memory backend double exposing only _client."""
     memory = Mock(spec=["_client"])
-    memory._client = Mock()
+    memory._client = serve_mget_from_get(Mock())
     return memory
 
 

--- a/tests/unit/telemetry/test_approval_gates.py
+++ b/tests/unit/telemetry/test_approval_gates.py
@@ -412,6 +412,7 @@ class TestApprovalGate:
         import json
 
         mock_client.get.return_value = json.dumps(request_data).encode()
+        serve_mget_from_get(mock_client)
 
         mock_memory = Mock()
         mock_memory._client = mock_client
@@ -872,6 +873,7 @@ class TestGetPendingApprovalsBranches:
         mock_client = Mock()
         mock_client.scan_iter.return_value = [b"approval_request:r_gone"]
         mock_client.get.return_value = None
+        serve_mget_from_get(mock_client)
 
         mock_memory = Mock(spec=["_client"])
         mock_memory._client = mock_client
@@ -914,6 +916,7 @@ class TestClearExpiredRequestsBranches:
         mock_client = Mock()
         mock_client.scan_iter.return_value = [b"approval_request:r_gone"]
         mock_client.get.return_value = None
+        serve_mget_from_get(mock_client)
 
         mock_memory = Mock(spec=["_client"])
         mock_memory._client = mock_client


### PR DESCRIPTION
## What

Five telemetry tests passed without asserting anything, and this adds a gate so the class can't recur silently.

The MGET migration (#2162) left them stubbing only `get`. Each listing then received a bare `Mock` for `mget` — not iterable — and the resulting `TypeError` was swallowed by the listing's own `except Exception`, returning `[]` / `0` / `None`. **Every assertion expecting emptiness was satisfied by the failure it was supposed to catch.**

## The cost, measured

Disabling `get_pending_approvals`' "only pending" status filter entirely on `d9ceca32e`:

```
646 passed
```

Zero tests caught it. That filter had **no effective coverage** — its only guard was one of the vacuous tests. As a control, disabling the sibling `approval_type` filter *does* fail a test, so the suite isn't broadly blind, just to this class.

## Fixed

| Test | File |
|---|---|
| `test_get_pending_approvals_excludes_non_pending` | `test_approval_gates.py` |
| `test_key_with_no_data_is_skipped` (approvals) | `test_approval_gates.py` |
| `test_key_with_no_data_is_skipped` (clear_expired) | `test_approval_gates.py` |
| `test_unretrievable_signal_is_skipped` ×2 | `test_agent_coordination_branches.py` |

The last two came from a shared fixture that was a plain `Mock()`, unlike its siblings in `test_agent_coordination.py`. `test_agent_tracking_branches`' fixture is wired the same way as a prophylactic — nothing there feeds a non-empty scan today, so it wasn't vacuous, but the trap was one test away.

**Receipt that the fixes are real, not just green:** with the status filter disabled, `test_get_pending_approvals_excludes_non_pending` now *fails*. For the skip tests, `get()` call count goes `0 -> 2` and the swallowed `"Mock object is not iterable"` disappears — the skip path genuinely runs.

## Why a gate

This class is **invisible by construction**. Tests with positive assertions (`assert len(x) == 1`) go red instantly and get fixed; tests asserting emptiness are satisfied by the very failure they should catch. The split was perfectly clean across the 13 tests touching these listings:

| Assertion style | transport wired |
|---|---|
| positive (`assert len == 1`) | **3 / 3** |
| expects empty (`assert == []`) | **0 / 10** |

Not carelessness — the suite gave no signal. So it needs a gate rather than vigilance.

`tests/unit/gates/test_listing_mock_transport_gate.py` fails any telemetry test that stubs a non-empty `scan_iter` without serving `mget`.

### Calibration

**5 hits, 5 real, 0 false positives** against the pre-fix tree — exactly the five found by hand. Two false-positive classes were eliminated during calibration; both are load-bearing and worth a reviewer's eye:

1. A **raising** `scan_iter` side_effect fails *before* MGET — 4 would-be hits.
2. Fixtures are **class-scoped**. `test_agent_coordination.py` defines `mock_memory` twice — one wiring the transport, one not — so a flat name→fixture map resolves to the wrong one. 8 would-be hits.

The gate carries a self-check that plants a violation and asserts it fires, so a green run means a clean tree rather than a broken scanner.

## Verification

- `tests/unit/telemetry/` + `tests/unit/gates/`: **974 passed**
- Full `tests/` collection: **25,295**, zero import errors
- `scripts/check_badge_freshness.py`: OK
- **Pinned** `black`, `ruff`, `ruff-bare-exception-check` on every touched file

## Provenance

Found in the 13.0.2 post-release self-review follow-up, while checking whether a vacuous test spotted pre-#2162 had survived the merge. It had — plus four more.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
