### PR TITLE
docs(lessons): fold the Edit-surface remedies into the Bash entry, evict the standalone

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1187,28 +1187,17 @@ this section only if core-worthy (and then keep both copies in sync).
   — authoritative and immune to the local stale-object trap that
   muddied diagnosis; (4) when archaeology spirals, stop theorizing and
   fact-check trees directly (`git diff <ref-a> <ref-b> --stat` — an
-  empty diff settles arguments instantly). Pairs with the "harness
+  empty diff settles arguments instantly); (5) the SAME reconciliation
+  applies to a rejected or interrupted **Edit** — `grep` the exact
+  target line before re-applying, because the rejection message is not
+  proof that nothing was written (an append that reported "NOT
+  written" was already on disk, and re-applying duplicated the
+  suffix); (6) prefer an `old_string` that is NOT a strict prefix of
+  the intended `new_string`, so an accidental double-apply fails
+  loudly instead of silently duplicating. Pairs with the "harness
   safety classifier blocks bundled-destructive scripts" lesson — same
   root cause family (compound commands + interruption), this one is
   the state-reconciliation half.
-
-- **A user-rejected Edit tool call may have PARTIALLY landed —
-  grep the target region before re-applying after any
-  interruption/rejection**: 2026-06-11, an Edit appending
-  `, score` to a return statement was interrupted ("user doesn't
-  want to proceed… new_string was NOT written"), yet the change
-  WAS on disk; re-applying the same Edit on resume then matched
-  `return findings, suggestions, summary` as a PREFIX of the
-  already-updated line and produced `..., score, score` (caught
-  by a `ValueError: too many values to unpack` test failure, not
-  by the edit itself). Two rules: (1) after ANY
-  rejected/interrupted Edit, `grep` the exact target line before
-  re-applying — the rejection message is not proof nothing was
-  written; (2) prefer old_strings that are not a strict prefix
-  of the intended new_string (include trailing context), so an
-  accidental double-apply fails loudly instead of duplicating
-  the suffix. Extends the "interrupted compound Bash command may
-  have partially executed" lesson to the Edit-tool surface.
 
 - **Teaching a scanner a new safe idiom can make its gate go BLIND —
   and a shrink-only allowlist ratchet then demands you delete the

--- a/.claude/lessons.md
+++ b/.claude/lessons.md
@@ -7769,7 +7769,14 @@ files.
   — authoritative and immune to the local stale-object trap that
   muddied diagnosis; (4) when archaeology spirals, stop theorizing and
   fact-check trees directly (`git diff <ref-a> <ref-b> --stat` — an
-  empty diff settles arguments instantly). Pairs with the "harness
+  empty diff settles arguments instantly); (5) the SAME reconciliation
+  applies to a rejected or interrupted **Edit** — `grep` the exact
+  target line before re-applying, because the rejection message is not
+  proof that nothing was written (an append that reported "NOT
+  written" was already on disk, and re-applying duplicated the
+  suffix); (6) prefer an `old_string` that is NOT a strict prefix of
+  the intended `new_string`, so an accidental double-apply fails
+  loudly instead of silently duplicating. Pairs with the "harness
   safety classifier blocks bundled-destructive scripts" lesson — same
   root cause family (compound commands + interruption), this one is
   the state-reconciliation half.


### PR DESCRIPTION
Follow-up to #2164, which landed the awk promotion at **exactly
46,000 / 46,000 bytes**. The gate passes on `<=`, but the next
character added to ANY core entry would fail CI — including a typo
fix. This restores headroom without losing coverage.

## Two halves, landing together

**1. Evicts** "A user-rejected Edit tool call may have PARTIALLY
landed" (1,053 B) from core to the `lessons.md` tail. It stays in the
corpus and remains `/recall`-able — demotion, not deletion.

**2. Folds** its two operative remedies into "An interrupted/rejected
compound Bash command may have PARTIALLY executed" — which sits
directly above it and stays in core — as new rules (5) and (6):

- `grep` the exact target line before re-applying, because the
  rejection message is not proof nothing was written
- prefer an `old_string` that is NOT a strict prefix of the intended
  `new_string`, so a double-apply fails loudly instead of silently
  duplicating the suffix

## Why fold rather than simply evict

A pure eviction frees more (1,054 B vs 584 B) but drops both remedies
out of always-loaded context. The evicted entry's own text describes
itself as extending the Bash lesson *to the Edit-tool surface*, and
the Bash entry did not carry the Edit specifics — verified by probe,
not assumed. Folding keeps the guidance resident for ~470 B instead of
the ~1,053 B the standalone entry occupied, and consolidates one
failure class into one entry rather than splitting it across two tool
surfaces.

| | Pure eviction | This PR |
|---|---|---|
| Core bytes | 44,946 | **45,416** |
| Headroom | 1,054 B | **584 B** |
| Edit remedies resident | ABSENT | **PRESENT** |

## Both files edited identically

Core entries are verbatim mirrors, so folding into the core copy alone
would fail the mirror guard. `.claude/lessons.md` carries the same new
text; `test_core_mirror.py` passing is the receipt that they are in
sync.

## Receipts (on the rebased tree, against merged main)

```
pytest tests/unit/lessons/ tests/unit/rules/   -> 35 passed
python scripts/check_lessons_corpus.py         -> exit 0
uvx pre-commit run --files <both>              -> all Passed
```

Core: 25 entries, 45,416 B, 584 B headroom.
Probes: Edit remedies PRESENT · standalone entry ABSENT · #2164's awk
entry PRESENT.

`CORE_BUDGET_BYTES` unchanged at `46_000` and still shrink-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
