### PR TITLE
test(authoring): close the polish-cache prune TTL race

### DIFF
--- a/tests/unit/authoring/test_polish_cache.py
+++ b/tests/unit/authoring/test_polish_cache.py
@@ -119,15 +119,20 @@ class TestCachePrune:
     ) -> None:
         from attune.authoring.polish import _cache_prune, _cache_put
 
-        monkeypatch.setenv("ATTUNE_AUTHOR_POLISH_CACHE_TTL_SECONDS", "1")
+        # The TTL must be comfortably LONGER than this test's own wall
+        # clock: the surviving entry is written here and must still be
+        # fresh at prune time. A 1s TTL raced on loaded runners — any
+        # pause over a second between _cache_put and _cache_prune aged
+        # BOTH entries out and the prune deleted 2, not 1 (seen on
+        # windows-latest mid-suite, "assert 2 == 1"). One hour is far
+        # beyond any plausible scheduling gap while staying well under
+        # the 10,000s backdate below, so exactly one entry is stale.
+        monkeypatch.setenv("ATTUNE_AUTHOR_POLISH_CACHE_TTL_SECONDS", "3600")
         _cache_put("a", "alpha")
         _cache_put("b", "beta")
-        # Backdate one entry past the TTL.
-        for path in cache_dir.glob("*.md"):
-            if "a" in path.name:
-                continue  # leave 'a' fresh — file name is the sha256, so this
-                # branch never matches; we instead pick the first entry below
-        # Pick the first .md and backdate it.
+        # Backdate exactly one entry past the TTL. Entries are named by
+        # sha256 of the key, so pick deterministically by sort order
+        # rather than by matching the key text in the filename.
         targets = sorted(cache_dir.glob("*.md"))
         old_path = targets[0]
         ancient = time.time() - 10_000


### PR DESCRIPTION
`test_prune_deletes_stale_entries` set the cache TTL to **1 second**,
wrote two entries, backdated one, and asserted the prune deleted
exactly 1. The surviving entry is written *by the test itself*, so any
pause longer than the TTL between `_cache_put` and `_cache_prune` ages
BOTH entries out and the prune deletes 2.

Not hypothetical — it failed on `windows-latest` mid-suite with
`assert 2 == 1`, on an unrelated **docs-only** PR (#2167) where 24,670
other tests passed. A loaded xdist worker pausing over a second between
two statements is routine.

## Fix

Raise the TTL to `3600`. It stays far below the 10,000s backdate, so
exactly one entry is stale; and far above any plausible scheduling gap,
so the survivor cannot age out.

## Receipt — the race reproduced, then closed

Injecting a 2s stall before the prune:

```
ttl=1    -> deleted 2   (reproduces the CI failure exactly)
ttl=3600 -> deleted 1
```

That is the point of the receipt: not "the test passes" (it passed
before too, most of the time), but that the failure mode is
demonstrably gone under the condition that triggered it.

## Also: a dead loop removed

```python
for path in cache_dir.glob("*.md"):
    if "a" in path.name:
        continue  # leave 'a' fresh — file name is the sha256, so this
        # branch never matches; we instead pick the first entry below
```

The loop body is a bare `continue` guarded by a condition its own
comment says never fires — entries are named by sha256 of the key, so
`"a" in path.name` is incidental at best. The code below already picked
the target by sort order. Removing it makes the selection explicit
rather than apparently-conditional.

## Siblings checked, unaffected

`test_prune_with_ttl_zero_disables` (TTL=0 disables pruning outright)
and `test_invalid_ttl_falls_back_to_default` (TTL="garbage" -> 30-day
default, 1-hour-old entry) neither depend on elapsed wall clock.

## Gates

```
pytest tests/unit/authoring/test_polish_cache.py  -> 14 passed
pytest tests/unit/gates/ tests/unit/quality/      -> 334 passed
uvx pre-commit run --files <the test>             -> all Passed
```

Ratchet sweep run because this touches `tests/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
