### PR TITLE
fix(monitoring): anchor the alert database so a chdir cannot strand it

### DIFF
--- a/src/attune/monitoring/engine.py
+++ b/src/attune/monitoring/engine.py
@@ -62,7 +62,19 @@ class AlertEngine:
             telemetry_dir: Path to telemetry directory (default: ~/.attune/telemetry)
 
         """
-        self.db_path = Path(db_path)
+        # Resolved to an ABSOLUTE path so a later ``chdir`` cannot move the
+        # target. The default is CWD-relative (".attune/alerts.db"), and
+        # ``alerts watch --daemon`` calls ``os.chdir("/")`` while
+        # daemonizing — every query after that point would otherwise look
+        # for "/.attune/alerts.db" and fail with "unable to open database
+        # file". Same anchoring rule as
+        # ``attune.memory.storage_backend.default_storage_dir``, which
+        # likewise anchors via ``Path.cwd()`` rather than ``resolve()``:
+        # making the path absolute is what the fix needs, and resolving
+        # symlinks on top would silently rewrite a caller's own absolute
+        # path (a caller passing /var/... on macOS would read back
+        # /private/var/...).
+        self.db_path = Path(db_path).expanduser().absolute()
         self.db_path.parent.mkdir(parents=True, exist_ok=True)
 
         self.telemetry_dir = (

--- a/tests/unit/monitoring/test_engine_db_path_anchoring.py
+++ b/tests/unit/monitoring/test_engine_db_path_anchoring.py
@@ -1,0 +1,79 @@
+"""AlertEngine's database must survive a later chdir.
+
+``alerts watch --daemon`` calls ``os.chdir("/")`` inside ``_daemonize``
+while the default ``db_path`` is CWD-relative (``.attune/alerts.db``).
+An unanchored path therefore resolves to ``/.attune/alerts.db`` for
+every query issued after the fork, and ``sqlite3.connect`` fails with
+"unable to open database file" for a non-root user — daemon mode could
+not reach the database it had just created.
+
+The same anchoring rule is documented in
+``attune.memory.storage_backend.default_storage_dir``: return an
+absolute path so a later chdir cannot move the target.
+
+Copyright 2025 Smart-AI-Memory
+Licensed under Apache 2.0
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from attune.monitoring.engine import AlertEngine
+
+
+@pytest.fixture()
+def workdir(tmp_path, monkeypatch):
+    """A directory to construct the engine from, then leave."""
+    monkeypatch.chdir(tmp_path)
+    return tmp_path
+
+
+class TestPathIsAnchored:
+    def test_relative_db_path_becomes_absolute(self, workdir):
+        engine = AlertEngine(db_path=".attune/alerts.db")
+
+        assert engine.db_path.is_absolute()
+        # Compared through resolve() on BOTH sides so the assertion is
+        # symlink-agnostic (/var -> /private/var on macOS).
+        assert engine.db_path.resolve() == (workdir / ".attune" / "alerts.db").resolve()
+
+    def test_absolute_db_path_is_preserved(self, tmp_path):
+        target = tmp_path / "nested" / "alerts.db"
+
+        engine = AlertEngine(db_path=target)
+
+        assert engine.db_path == target, "an absolute path must be preserved as given"
+
+
+class TestSurvivesChdir:
+    def test_engine_still_reads_its_own_database_after_chdir(self, workdir, tmp_path):
+        """The daemon case: construct here, chdir away, keep querying."""
+        engine = AlertEngine(db_path=".attune/alerts.db")
+        created = engine.db_path
+        assert created.exists(), "engine did not create its database"
+
+        # _daemonize does exactly this.
+        elsewhere = tmp_path / "elsewhere"
+        elsewhere.mkdir()
+        os.chdir(elsewhere)
+
+        # Would raise sqlite3.OperationalError("unable to open database
+        # file") against an unanchored relative path.
+        engine.list_alerts()
+
+        assert engine.db_path == created
+        assert not (elsewhere / ".attune").exists(), "engine created a second database"
+
+    def test_chdir_to_root_does_not_strand_the_database(self, workdir):
+        """The literal daemon path: os.chdir("/"), which is unwritable."""
+        engine = AlertEngine(db_path=".attune/alerts.db")
+
+        os.chdir("/")
+
+        engine.list_alerts()
+        assert engine.db_path.exists()
+        assert not Path("/.attune").exists(), "engine reached for a root-level database"


### PR DESCRIPTION
## What

`attune alerts watch --daemon` could not reach the database it had just created.

`_daemonize()` calls `os.chdir("/")`, while `AlertEngine`'s `db_path` defaults to the CWD-relative `.attune/alerts.db` and was stored unresolved. So every query issued after the fork looked for `/.attune/alerts.db` and raised `sqlite3.OperationalError: unable to open database file` for any non-root user.

The engine created its database correctly *before* daemonizing, then lost it.

## Reproduction

Construct an engine, then do exactly what `_daemonize` does:

```
db: /private/tmp/dr2/.attune/alerts.db
os.chdir("/"); os.umask(0o077)
e.list_alerts()
```

| | result |
|---|---|
| before | `sqlite3.OperationalError: unable to open database file` |
| after | OK, against the original file |

## `.absolute()`, not `.resolve()` — deliberately

Making the path absolute is the whole fix. Resolving symlinks on top would silently rewrite a caller's own absolute path — pass `/var/...` on macOS, read back `/private/var/...`.

I tried `.resolve()` first and **two existing tests caught it immediately** by asserting the path they had passed in. Those assertions were correct, so the fix moved rather than the tests.

This also matches the in-repo precedent: `attune.memory.storage_backend.default_storage_dir` anchors via `Path.cwd()` for the same stated reason — *"a later chdir cannot move the target"* — and likewise does not resolve symlinks.

## Tests

Four regression tests:

- the relative default becomes absolute
- an absolute path is **preserved as given**
- the engine still reads its own database after a chdir elsewhere — and asserts it does **not** create a second one
- the literal `chdir("/")` case, asserting nothing reaches for `/.attune`

Mutation-checked: reverting the anchoring fails three of them with the real `OperationalError`.

## Verification

- `tests/unit/monitoring/` + `tests/unit/gates/`: **501 passed, 1 skipped**
- Full `tests/` collection: **25,300**, zero import errors
- End-to-end daemon repro passes
- Pinned `black` + `ruff` clean; `check_badge_freshness` OK

## Provenance

Found while verifying the daemon umask finding for #2168, and deliberately kept out of that PR — this is a correctness bug, not a security finding, and a security PR is the wrong place to bury one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
