### PR TITLE
docs(specs): release-audit-stage — roundtable-authored pre-release audit spec

### DIFF
--- a/docs/handoffs/claude-roundtable-audit-workflow-b99ec3.md
+++ b/docs/handoffs/claude-roundtable-audit-workflow-b99ec3.md
@@ -1,0 +1,41 @@
+# Handoff — release-audit-stage spec shipped; build work queued
+
+**Branch:** `claude/roundtable-audit-workflow-b99ec3` · **PR:**
+https://github.com/Smart-AI-Memory/attune-ai/pull/2171 · 2026-08-22
+
+## Verified state (commands actually run)
+
+- Spec + decisions + curated stub committed (`fca6bbf4f`), pushed,
+  PR #2171 open against main. Docs-only.
+- Board thread `q-release-audit-roundtable-stage-001` (13 msgs,
+  TTL ~7 days from 2026-08-22): everything durable is promoted;
+  full transcript at `~/.attune/reports/roundtable/<slug>.md`.
+- Memory corpus lint: 0 violations (fixed a wrong `[[global:]]`
+  prefix in `project_exceptions_removal_held_for_major`).
+- Two lessons in the docs outbox
+  (`roundtable-board-draft-kind`, `macos-timeout-127-seat-invocation`)
+  awaiting the next outbox sweep digest.
+
+## Next actions (chair-ratified order, D8 + feedback picks)
+
+1. **Phase X — class-M receipt check** (independent, ships first):
+   PR metadata + commit-trailer check per R6 of
+   `docs/specs/release-audit-stage/requirements.md`. Structured
+   one-shot; no Phase 0 dependency.
+2. **Phase 0 — rule pack + derived register** (R1+R2, blocking for
+   the stage): promote `~/.attune/reports/attune-ai-review/
+   sweep_suite_v2_r7.py` into `src/attune/classes/`; derive status,
+   never author it. Multi-PR.
+3. **Calibration on attune-forms pre-fix commit** (with or right
+   after Phase 0): the forms-23 defects are pinned ground truth;
+   record recall/precision honestly per R1 (no 1.0 bar — declined,
+   see dissent register).
+
+## Risks / open
+
+- OQ3's rule→gate-test identity mapping needs its own drift guard
+  (R2) — the seat flagged it as unpriced scope; price it in Phase 0.
+- Teeth (Phase 2) arm ONLY on a chair-recorded promotion naming the
+  rule-pack version (R5) — do not wire the hard-block early.
+
+Delete this file when the branch merges.

--- a/docs/handoffs/claude-roundtable-audit-workflow-b99ec3.md
+++ b/docs/handoffs/claude-roundtable-audit-workflow-b99ec3.md
@@ -3,39 +3,61 @@
 **Branch:** `claude/roundtable-audit-workflow-b99ec3` · **PR:**
 https://github.com/Smart-AI-Memory/attune-ai/pull/2171 · 2026-08-22
 
-## Verified state (commands actually run)
+## Goal
 
-- Spec + decisions + curated stub committed (`fca6bbf4f`), pushed,
-  PR #2171 open against main. Docs-only.
-- Board thread `q-release-audit-roundtable-stage-001` (13 msgs,
-  TTL ~7 days from 2026-08-22): everything durable is promoted;
-  full transcript at `~/.attune/reports/roundtable/<slug>.md`.
-- Memory corpus lint: 0 violations (fixed a wrong `[[global:]]`
-  prefix in `project_exceptions_removal_held_for_major`).
-- Two lessons in the docs outbox
-  (`roundtable-board-draft-kind`, `macos-timeout-127-seat-invocation`)
-  awaiting the next outbox sweep digest.
+Ship the release-audit-stage spec (roundtable-authored) and queue its
+build phases in the chair-ratified order.
 
-## Next actions (chair-ratified order, D8 + feedback picks)
+## Acceptance criteria
 
-1. **Phase X — class-M receipt check** (independent, ships first):
-   PR metadata + commit-trailer check per R6 of
-   `docs/specs/release-audit-stage/requirements.md`. Structured
-   one-shot; no Phase 0 dependency.
-2. **Phase 0 — rule pack + derived register** (R1+R2, blocking for
-   the stage): promote `~/.attune/reports/attune-ai-review/
-   sweep_suite_v2_r7.py` into `src/attune/classes/`; derive status,
-   never author it. Multi-PR.
-3. **Calibration on attune-forms pre-fix commit** (with or right
-   after Phase 0): the forms-23 defects are pinned ground truth;
-   record recall/precision honestly per R1 (no 1.0 bar — declined,
-   see dissent register).
+- Spec (`requirements.md` R1–R7, `decisions.md` D1–D9) + curated
+  roundtable stub merged to main via PR #2171, CI green.
+- Build order recorded: Phase X first, then Phase 0, then
+  calibration; teeth (Phase 2) unarmed until chair promotion.
 
-## Risks / open
+## Scope and assumptions
 
-- OQ3's rule→gate-test identity mapping needs its own drift guard
-  (R2) — the seat flagged it as unpriced scope; price it in Phase 0.
-- Teeth (Phase 2) arm ONLY on a chair-recorded promotion naming the
-  rule-pack version (R5) — do not wire the hard-block early.
+Docs-only on this branch. Code work (Phase X onward) happens on its
+own branches — Phase X is already up as PR #2172
+(`claude/class-m-receipt-check`). Assumes the class register and
+sweep suite remain machine-local until Phase 0 promotes them.
+
+## Current state
+
+- Spec + decisions + curated stub committed and pushed; PR #2171
+  open against main.
+- Board thread `q-release-audit-roundtable-stage-001` (13 msgs, TTL
+  ~7 days from 2026-08-22): all durable content promoted; full
+  transcript at `~/.attune/reports/roundtable/<slug>.md`.
+- Phase X implemented and shipped separately: PR #2172
+  (`attune.classes.class_m` + `mock_worklist`, 29 tests, calibration
+  receipt in the PR body).
+- Two lessons in the docs outbox (`roundtable-board-draft-kind`,
+  `macos-timeout-127-seat-invocation`) awaiting the next sweep.
+- Memory: `feedback_governance_spec_drafter_critics` written; corpus
+  lint 0 violations.
+
+## Verification
+
+- Spec lint: round-2 draft passed `compiler.lint_draft`; both
+  critiques passed `compiler.lint_critique` (receipts in the curated
+  stub's provenance section).
+- Phase X: 29 tests green locally (incl. real-git `check_range`
+  round trip); coverage 85% measured via the /tmp worktree recipe.
+- This handoff: sections conform to `templates/agent-handoff.md`
+  (the corpus lint failed PR #2171's first CI run on exactly that —
+  fixed here).
+
+## Next action
+
+1. **Merge PR #2171** (spec) and **PR #2172** (Phase X) when green —
+   each needs its own chair merge word bound to its head SHA.
+2. **Phase 0** — rule pack + derived register (R1+R2): promote
+   `~/.attune/reports/attune-ai-review/sweep_suite_v2_r7.py` into
+   `src/attune/classes/`; derive status, never author. Multi-PR;
+   price OQ3's rule→gate-test drift guard here.
+3. **Calibration on attune-forms pre-fix commit** (forms-23 ground
+   truth) — record recall/precision honestly per R1; no 1.0 bar
+   (declined, dissent register).
 
 Delete this file when the branch merges.

--- a/docs/reports/roundtable/q-release-audit-roundtable-stage-001.md
+++ b/docs/reports/roundtable/q-release-audit-roundtable-stage-001.md
@@ -1,0 +1,169 @@
+# Round table — the round table as a pre-release audit stage (ratified)
+
+**Thread:** `q-release-audit-roundtable-stage-001` · 2026-08-22 ·
+3/3 seats (Claude, Antigravity, Codex), 1 round, halted on
+convergence. Chair-promoted sections only; full transcript is
+machine-local (`~/.attune/reports/roundtable/`).
+
+Adapts the class-first review model
+(`~/.attune/reports/attune-ai-review/CLASS-REGISTER.md`) into a
+per-release stage. The register's central measured finding is the
+premise the whole design rests on:
+
+> Review is the right tool for FINDING A CLASS and the wrong tool for
+> ENUMERATING ITS INSTANCES. Only the gate is permanent.
+
+Two measurements behind it: the attune-forms review, where a 3-seat
+table designed the funnel and a SINGLE reviewer found all 23 confirmed
+defects; and attune-ai batch 2, where 3 reviewers and ~450k tokens
+yielded 8 instances of one class, while mechanizing that class took
+~20 minutes and found 84 more at zero false positives.
+
+## Chair rulings
+
+- **RULED A** — the audit is a stage inside `/release`, not a separate
+  command or a headless routine.
+- **RULED B** — the table sits on EVERY release, not gated on residual
+  size. (The register makes an empty residual nearly impossible: 15 of
+  26 classes are ungated or open.)
+- **RULED C, seat roles** — (a) advise ship/hold per residual item and
+  (c) rank which ungated/open classes need a gate before this release
+  are IN. (d) detect defects in the diff is OUT; the two measurements
+  above settle it.
+- **RULED D, teeth** — `gate-before-ship` HAS TEETH. The stage may hold
+  a release until a fixed-but-ungated class re-exposed by the diff gets
+  its gate. Advisory-only rejected: with 7 classes already
+  fixed-but-ungated, an advisory stage reports a growing set every
+  release while nothing forces it to shrink.
+- **RULED E, trigger** — a calibrated rule HIT blocks; surface EXPOSURE
+  warns. Exposure remains the §3 boolean matrix (below), not a
+  warning-severity row competing with hits for the packet's cap.
+- **RULED F, escape** — `DEFER` with owner and expiry. An accepted
+  release risk is recorded and cannot quietly become permanent.
+  (The moderator recommended a lighter one-line record and was
+  overruled toward more rigor.)
+
+## The stage
+
+```text
+0  baseline    git diff <last-tag>..HEAD --name-only
+1  reconcile   every CLOSED class's gate green in CI (receipt: run id)
+2  diff sweep  mechanized rules over CHANGED FILES ONLY, weighted
+               toward the 7 fixed-but-ungated classes
+3  residual    sweep hits + ungated exposure + new-boundary inventory
+4  sitting     one round, three seats, no rebuttal loop
+5  chair       rules per item; manifest row per changed package
+```
+
+**Early aborts, no sitting:** reconcile red at step 1 stops the stage —
+never sit on a red baseline. A packet over caps means the chair splits
+the release, not that the packet is reformatted.
+
+**Explicit non-stop:** an empty residual does NOT skip the sitting. It
+produces a one-page packet and three one-line ships in minutes. The
+near-zero cost floor is what makes RULED B payable.
+
+## The residual packet (3/3 convergent; caps are Claude's)
+
+Hard budget: ≤1500 words, ≤12 residual items, ≤20 sweep rows, zero diff
+hunks, no file contents. All three seats independently demanded a
+structured manifest and forbade a raw diff.
+
+| § | Content |
+|---|---|
+| 0 | Header: tag range, files changed, packages touched, public symbols added/removed |
+| 1 | Reconcile receipt: CI run id, closed-class gates green |
+| 2 | Sweep hits: class id, `file:line`, one-line excerpt, **and the rule's recall/precision** so seats can weight it |
+| 3 | **Ungated exposure** — per fixed-but-ungated class, a boolean over the changed surface, plus the file |
+| 4 | New-boundary inventory, two program points each |
+| 5 | Open-class exposure of the changed surface |
+| 6 | Explicit NULL section — what the diff does NOT introduce |
+| 7 | **A pre-filled default disposition per item** |
+
+§3 is the reason the stage exists: nothing prevents a fixed-but-ungated
+class from walking back in on a new diff, and that risk is both certain
+and invisible.
+
+§7 is the anti-mush mechanism. A seat asked to COMPOSE from a dump
+produces prose; a seat asked to AMEND a pre-filled disposition produces
+a delta. Seats reply per item number, one closing paragraph maximum.
+
+## Class M — not a table question (unanimous)
+
+All three seats routed class M ("the mock defined the contract")
+mechanical-detector → single reviewer with tree access → table only on
+the unresolved residue, and all three independently reached the same
+zero-cost enforcement:
+
+> A fix for a boundary class whose DECLARED receipt type is `suite`
+> rather than `live-fire`/`behavioral` is class M **by declaration**.
+
+That is a PR metadata check against the repo's existing
+receipt-declared delegation rule. No AST required, and it catches the
+case the AST rules will miss. Codex adds that the reviewer attestation
+must carry an evidence pointer and receipt type, never a bare "yes",
+or it becomes checkbox theater.
+
+Three AST shapes seed the detector's worklist (a worklist, never a
+verdict): a patched call site whose only assertions are on the mock; a
+test-local literal passed to a deserializer whose paired writer exists
+in the package (I-4 mirrored into tests); a "cannot write" test that
+induces failure by patching `open`/`write_text` rather than by a real
+chmod or read-only directory.
+
+## The status column should not exist (unanimous)
+
+All three seats concluded the register's hand-maintained status column
+is the wrong artifact, and refused to let a fresh repo inherit `CLOSED`
+without a local scan receipt. It is a cache of a value that is
+mechanically derivable per repo:
+
+| gate test present? | current sweep hits | derived status |
+|---|---|---|
+| yes | 0 | CLOSED |
+| no | 0 | FIXED BUT UNGATED |
+| no | >0 | OPEN |
+| yes | >0 | **broken gate — loud** |
+
+The fourth quadrant is the one a hand-maintained column cannot report
+at all.
+
+Portability follows from this: what the three-day review bought was the
+**class vocabulary**, and vocabulary is the portable artifact. Rules
+port; status is derived per repo; calibration is per-corpus and a rule
+runs advisory and labeled `uncalibrated-here` in a new repo until that
+repo has its own calibration receipt (~20 min/rule of hand triage,
+versus three days of review).
+
+## Held, not promoted
+
+**Role (b) — name a new class from a diff summary.** 2 NO, 1 qualified
+yes, and the split is narrower than the vote: Codex's NO already
+contains the fallback "candidate hypotheses labeled unconfirmed leads,
+with no hold or register effect", which is nearly verbatim the
+re-scoped (b) Claude defended. Antigravity is the only unqualified no,
+on the sharpest argument in the thread — asked to invent classes from
+static summaries, models predictably emit generic anti-patterns that
+pollute the residual.
+
+Not promoted this session. If it returns, the only defensible form is
+the instrumented one: a candidate carries its confirm recipe, never
+blocks, and the manifest tallies candidates-named against
+candidates-later-confirmed so the role retires itself by evidence.
+
+## Prerequisite (why this is not yet buildable)
+
+The sweep suite (`sweep_suite_v2_r7.py`, 157 lines) and the class
+register are machine-local scratch artifacts under
+`~/.attune/reports/attune-ai-review/`. Steps 1–3 read both. Promoting
+them into tracked code — a rule pack under `src/attune/classes/` with
+`{id, invariant, calibration, fixtures}` per rule, a `scan` verb over
+changed paths, and a `register` verb that DERIVES the table above — is
+Phase 0 of the build, not a follow-on.
+
+## Provenance
+
+Board thread `q-release-audit-roundtable-stage-001`, messages 2, 3, 4
+(positions), 7 (synthesis), 8 (chair ruling) promoted 2026-08-22.
+Seat receipts: Codex ~39s (gpt-5.6-sol); Antigravity ~63s (plan mode);
+Claude 87,126 tokens (~135s, agent seat).

--- a/docs/specs/release-audit-stage/decisions.md
+++ b/docs/specs/release-audit-stage/decisions.md
@@ -1,0 +1,82 @@
+# Release Audit Stage — Decisions
+
+Append-only. Chair rules; the lead records.
+
+## D1 — Stage inside /release (RATIFIED chair 2026-08-22)
+
+Not a separate command, not a headless routine. One surface; the
+audit runs where the release already runs. (Roundtable
+`q-release-audit-roundtable-stage-001` intake form.)
+
+## D2 — The table sits every release (RATIFIED chair 2026-08-22)
+
+Not gated on residual size. The register makes an empty residual
+nearly impossible (15/26 classes ungated or open), and the moderator's
+"only when non-empty" gate would have fired every release anyway —
+same rule, less machinery. Payability comes from the near-zero cost
+floor of an empty-residual sitting (R3), not from skipping.
+
+## D3 — Seat roles (RATIFIED chair 2026-08-22)
+
+(a) advise ship/hold per residual item: IN. (c) rank which
+ungated/open classes need a gate before this release: IN. (d) detect
+defects in the diff: OUT — settled by measurement (attune-forms: the
+single reviewer found all 23 defects; batch 2: 450k tokens for 8
+instances of one class). (b) name a NEW class from a diff summary:
+HELD, not promoted — 2 seats no, 1 qualified yes; may return only in
+the instrumented form (candidate + confirm recipe, never blocking,
+tallied candidates-named vs candidates-confirmed so the role retires
+itself by evidence).
+
+## D4 — Teeth (RATIFIED chair 2026-08-22)
+
+`gate-before-ship` HAS TEETH: the stage may hold a release until a
+fixed-but-ungated class re-exposed by the diff gets its gate.
+Advisory-only rejected — an advisory stage reports a growing set
+while nothing forces it to shrink. (Both external seats independently
+asked this exact question, blind to each other — msgs 5 and 6.)
+
+## D5 — Trigger: hit blocks, exposure warns (RATIFIED chair 2026-08-22)
+
+A calibrated rule HIT blocks. Surface EXPOSURE warns via the packet's
+§3 boolean matrix only — never warning-severity rows competing with
+hits for the packet's cap (a noisy gate gets allowlisted into
+uselessness). Chair confirmed the moderator's narrowing with the
+round-2 triage batch (former OQ2).
+
+## D6 — Escape: DEFER with owner and expiry (RATIFIED chair 2026-08-22)
+
+Chair overruled the moderator's lighter one-line record toward more
+rigor. The expiry is not a reminder — at expiry the block RESUMES,
+which is the convergence mechanism D4 reaches for. Schema and
+tracked-file location in R5 (round-2 convergent critique, Codex#11 +
+Agy#5).
+
+## D7 — Round-2 critique triage (RATIFIED chair 2026-08-22, batch)
+
+Claude drafted; Codex and Antigravity critiqued (both lint-clean;
+Codex `needs-revision` with 16 items, Antigravity `ready-with-edits`
+with 8). Triage: 21 ACCEPTED (6 convergent-pair defects among them),
+2 ACCEPTED-MODIFIED (Codex#9 split semantics — partition re-runs
+accepted, auto-partition proposer declined; Codex#2 path semantics —
+folded into R1 acceptance), 1 DECLINED with reason (Agy#1 perfect-
+recall calibration bar — see the dissent register in
+requirements.md). OQ1 resolved to release-count expiry on convergent
+critic recommendation.
+
+## D8 — Phase order (RATIFIED chair 2026-08-22)
+
+Item 1 (the stage) carries item 4 (derived status column) as its
+Phase 0 — the stage's steps 1–3 read artifacts that are machine-local
+scratch today, so the rule-pack promotion is the critical path, not a
+side finding. Item 3 (class M by receipt declaration) is Phase X:
+independent, may ship first.
+
+## D9 — The sitting instruments itself (RATIFIED chair 2026-08-22)
+
+From the post-spec feedback review: roles (a)/(c) had no instrument
+while role (b) did. The manifest's `sitting_delta` field records, per
+release, whether the sitting changed any disposition from the §7
+pre-filled defaults. Zero deltas across ~6 releases puts D2 (the
+every-release sitting) up for review by measurement rather than
+argument — the same retire-by-evidence mechanism ruled for role (b).

--- a/docs/specs/release-audit-stage/requirements.md
+++ b/docs/specs/release-audit-stage/requirements.md
@@ -1,0 +1,295 @@
+# Release Audit Stage — Requirements
+
+**Status:** approved (chair, 2026-08-22) — triage of 24 critique
+items ratified in session; D1–D6 ratified; OQ1 resolved (releases);
+OQ2–OQ3 folded into R2/R5.
+**Slug:** `release-audit-stage`
+**Provenance:** roundtable `q-release-audit-roundtable-stage-001`
+(2026-08-22, 3/3 seats, round-1 convergence halt; round-2
+draft+critique loop: Claude drafter, Codex + Antigravity critics,
+both lint-clean, 24 items triaged — 21 accepted, 2
+accepted-modified, 1 declined-with-reason). Curated stub:
+[docs/reports/roundtable/q-release-audit-roundtable-stage-001.md](../../reports/roundtable/q-release-audit-roundtable-stage-001.md).
+Full transcript machine-local at `~/.attune/reports/roundtable/`.
+
+## Problem
+
+Three release surfaces exist and none of them looks at the diff:
+
+| Surface | Covers |
+|---|---|
+| `attune workflow run release-gate` | bandit / ruff / pytest vs hard thresholds — hygiene |
+| `attune-release-check` skill | version not on PyPI, clean tree, CI green, changelog — hygiene |
+| `release-execute` skill | publish mechanics with per-step postconditions |
+| `release_notes` MCP tool | advisory go/no-go with no evidence about this diff |
+
+Nothing asks **what class of defect this release could have
+introduced.** The library review answered that for the tree as of
+2026-08-20 and produced a 26-class register — but a register is a
+snapshot, and 15 of its 26 classes have no tree-scanning gate:
+
+- **7 fixed-but-ungated** (H1, G1, G2, I-4, I-3, H2, H5) — confirmed
+  and fixed with executed receipts; nothing prevents the same shape
+  re-entering on a new diff.
+- **8 open** — confirmed, unmechanized.
+
+That certain-and-invisible risk is what this spec catches. The
+register's measured premise governs the design:
+
+> Review is the right tool for FINDING A CLASS and the wrong tool for
+> ENUMERATING ITS INSTANCES. Only the gate is permanent.
+
+Evidence: the attune-forms review (3-seat table designed the funnel;
+a SINGLE reviewer found all 23 confirmed defects) and attune-ai batch
+2 (3 reviewers, ~450k tokens, 8 instances of one class; mechanizing
+that class took ~20 minutes and found 84 more at zero false
+positives).
+
+## Goal
+
+Every release carries a receipt about its own diff's class exposure,
+produced mostly mechanically, with a bounded deliberative sitting on
+the residual — and the fixed-but-ungated set **shrinks** over
+releases rather than accumulating.
+
+## Blocking prerequisite
+
+`sweep_suite_v2_r7.py` (157 lines) and `CLASS-REGISTER.md` are
+machine-local scratch under `~/.attune/reports/attune-ai-review/`.
+Stage steps 1–3 read both. Phase 0 is not a follow-on — nothing else
+here is buildable until it lands.
+
+## Requirements
+
+### R1 — The rule pack is tracked code
+
+A rule pack under `src/attune/classes/`; each rule a callable plus
+metadata `{id, invariant, calibration, fixtures}`.
+
+- **Calibration receipt schema** (Codex#1 + Agy#1, convergent):
+  `{repo, recall, precision, date, fixture_hash}`. A rule is
+  `calibrated-here` only when its repo field matches the current
+  repo's canonical identity (normalized `origin` slug, directory-name
+  fallback — the session-start-integrity D1 convention) AND its
+  pinned fixtures pass. Corpus recall/precision are **recorded
+  honestly, not thresholded** — the register's own shipped standard
+  is 8/11 recall, and pretending to 1.0 would be fiction (Agy#1
+  declined on this point, ledgered).
+- Any populated-but-non-matching calibration object is
+  `uncalibrated-here`: advisory, never blocks, never clears.
+- **Scan path semantics** (Codex#2, accepted-modified into
+  acceptance): `attune classes scan --paths <changed>` takes
+  normalized repo-relative paths; deleted files are skipped, renames
+  scan the new path, binary/generated files are excluded by the same
+  filters the sweep suite used.
+- **Fail closed** (Agy#7): a rule callable crash or timeout marks the
+  class `SCAN-ERROR`, lands in packet §2, and aborts the stage unless
+  the chair explicitly waives — a failed gatekeeper fails the gate
+  (contract §7).
+- Acceptance: scan runs in CI on this repo; the 2026-08-20
+  calibration fixtures pass as pinned tests; a deliberately-crashing
+  fixture rule produces `SCAN-ERROR` and a non-zero exit.
+
+### R2 — The status column is DERIVED, never authored
+
+`attune classes register` computes each class's status:
+
+| gate present + passing? | full-repo hits | active DEFER? | derived status |
+|---|---|---|---|
+| yes | 0 | — | CLOSED |
+| no | 0 | no | FIXED BUT UNGATED |
+| no | >0 | no | OPEN |
+| no | any | yes, unexpired | DEFERRED |
+| yes | >0 | — | **BROKEN GATE — loud** |
+
+- **Full-repo hits, never the changed-file sweep** (Codex#4): status
+  derives from a whole-tree scan; changed-file hits are reserved for
+  release exposure analysis. Deriving from a partial scan would
+  falsely report CLOSED.
+- **Gate mapping is identity, not existence** (Codex#3): the mapping
+  references stable test node IDs plus the asserted class id, and the
+  drift guard checks both existence and identity — a renamed or
+  reassigned gate must not preserve CLOSED.
+- **CLOSED requires the gate PASSING** (Agy#2), confirmed at
+  reconcile time — presence on disk is not a gate.
+- **DEFERRED state** (Agy#2): an unexpired DEFER record renders as
+  its own status, so the register and the stage evaluator agree.
+- Acceptance: derived output matches the 2026-08-20 hand-maintained
+  register on hand-check; a renamed gate test in a fixture repo trips
+  the drift guard; a fixture DEFER renders DEFERRED and flips back at
+  expiry.
+
+### R3 — The six-step stage inside /release
+
+```text
+0  baseline    merge-base diff vs last release tag
+1  reconcile   CLOSED gates green in CI (bound receipt)
+2  diff sweep  rules over changed files, weighted to fixed-but-ungated
+3  residual    hits + ungated exposure + new-boundary inventory
+4  sitting     one round, three seats, no rebuttal loop
+5  chair       rules per item; manifest written
+```
+
+- **Baseline definition** (Codex#5 + Agy#3, convergent):
+  `git diff $(git merge-base <last-release-tag> HEAD)..HEAD`, with a
+  `--baseline <ref>` override. The resolved baseline SHA is recorded
+  in the manifest. No valid baseline (no tag, shallow clone) fails
+  closed with a preflight error — never a guessed range.
+- **Reconcile receipt binding** (Codex#6): the receipt names an
+  allowlisted workflow, the repository, the HEAD SHA, and a
+  successful conclusion. A green run for an earlier commit does not
+  authorize.
+- **Disposition vocabulary + completion invariant** (Codex#7): chair
+  dispositions are exactly `SHIP | HOLD | GATE-FIRST | DEFER`; the
+  stage is complete only when every residual item id carries exactly
+  one ruling — missing or duplicate rulings reject the manifest.
+- Reconcile red at step 1 aborts before any sitting. An empty
+  residual still sits (one-page packet, minutes) — the near-zero cost
+  floor is what makes the every-release ruling payable.
+- Acceptance: one full dry run on a real release diff produces a
+  valid manifest; a no-tag fixture repo fails preflight closed.
+
+### R4 — The residual packet (versioned schema v1)
+
+Hard caps: ≤1500 words, ≤12 residual items, ≤20 sweep rows, zero diff
+hunks, no file contents. The schema below is normative (Codex#8 +
+Agy#4, convergent — no reference-only sections):
+
+| § | Content | Required fields |
+|---|---|---|
+| 0 | Header | tag range, baseline SHA, files changed, packages touched, public symbols added/removed |
+| 1 | Reconcile receipt | CI run id, workflow name, HEAD SHA, conclusion |
+| 2 | Sweep hits | class id, `file:line`, one-line excerpt, rule recall/precision, any `SCAN-ERROR` |
+| 3 | Ungated exposure | per fixed-but-ungated class: boolean over changed surface + file (matrix only — never warning-severity rows competing with hits; OQ2 resolved) |
+| 4 | New-boundary inventory | boundary kind + two program points each |
+| 5 | Open-class exposure | class id + file |
+| 6 | Explicit NULL section | what the diff does NOT introduce |
+| 7 | Default dispositions | one pre-filled disposition per item |
+
+- **Over-cap refusal** (Agy#4): exit code 2 with structured JSON
+  diagnostics — the chair splits the release; the builder never
+  truncates.
+- **Split semantics** (Codex#9, accepted-modified): each chair-chosen
+  partition re-runs baseline → sweep → exposure independently; the
+  auto-partition proposer is declined — the chair splits, the tool
+  re-runs.
+- §7 is the anti-mush mechanism: seats AMEND pre-filled dispositions
+  per item number, one closing paragraph maximum — they never compose
+  from a dump.
+- Acceptance: builder emits all 8 sections from a real diff; an
+  over-cap diff exits 2 with the split diagnostic, untruncated.
+
+### R5 — Teeth
+
+- A calibrated rule HIT on a fixed-but-ungated class **re-exposed by
+  the diff** blocks the release until the class gets its gate.
+  Exposure warns via §3 only.
+- **Re-exposure operationally defined** (Codex#10): a finding present
+  at HEAD and absent at baseline, compared by stable finding identity
+  (class id + normalized path + structural anchor, rename-tracked).
+  Pre-existing findings are register debt, not release blocks.
+- **DEFER record** (Codex#11 + Agy#5, convergent): tracked YAML at
+  `.attune/defers/<class_id>.yaml` —
+  `{class_id, finding_identity, owner, reason, approved_at,
+  created_sha, expires_after_releases, chair_receipt}`. Validated by
+  `attune classes register`; a record missing chair_receipt or scoped
+  wider than one class is rejected.
+- **Expiry unit: releases** (OQ1 RESOLVED — both critics converged on
+  release count): at expiry the block resumes automatically. The
+  block resuming IS the convergence mechanism.
+- **Arming gate** (Codex#16): Phase 2 arms only on a chair-recorded
+  promotion naming the validated rule-pack version, after Phase 1 has
+  produced at least one clean dry-run manifest.
+- Acceptance: a deliberately re-exposed fixture class blocks; an
+  expired DEFER re-blocks; boundary tests pin the exact expiration
+  transition.
+
+### R6 — Class M by receipt-type declaration
+
+- **Receipt-type enum** (Codex#14): `suite | behavioral | live-fire |
+  metric | evidence-chain` — the decision-routine taxonomy verbatim.
+  Admissibility: a boundary-class fix requires `behavioral` or
+  `live-fire`.
+- **Metadata schema, fail closed** (Codex#13): the check reads a
+  validated declaration naming the class id; a changed fix touching a
+  boundary class with no declaration fails the check — absence is not
+  a pass.
+- **Survives squash** (Agy#6): enforcement is at PR CI, and the
+  release-stage sweep re-verifies commit trailers
+  (`Receipt-Type:`, `Evidence:`) across the release baseline for all
+  commits touching boundary classes — PR metadata detaches on squash;
+  trailers do not.
+- Attestations carry an evidence pointer and receipt type, never a
+  bare yes.
+- Three AST shapes seed a detector **worklist, never a verdict**:
+  mock-only-assertion patched call sites; test-local literals fed to
+  a deserializer whose paired writer exists (I-4 mirrored into
+  tests); "cannot write" tests that patch instead of chmod.
+- Independent of R1–R5; may ship first.
+- Acceptance: metadata check fires on a fixture PR declaring `suite`
+  for a boundary-class fix; trailer re-verification catches a
+  squashed fixture commit; worklist detector emits its three shapes
+  on pinned fixtures.
+
+### R7 — The chair manifest (Codex#15 + Agy#8, convergent)
+
+`.attune/release-manifests/<tag>.json`, schema-versioned:
+`{tag, head_sha, baseline_sha, packet_hash, reconcile_receipt,
+per_item_dispositions, defer_refs, sitting_delta, chair_receipt}`.
+
+- Immutable once written; a re-run writes a new manifest.
+- **`sitting_delta` — the sitting instruments itself** (D9): a
+  boolean per residual item recording whether any seat amendment
+  changed the chair's final disposition from the packet's §7
+  pre-filled default, plus the release-over-release tally. The same
+  retire-by-evidence instrument ruled for role (b): if the sitting
+  changes no disposition across ~6 releases, the every-release
+  ruling (D2) has earned its own review — by measurement, not
+  argument.
+- **Required input to `release-execute`** — the publish path verifies
+  a valid manifest exists for the tag being cut, connecting the stage
+  to deployment instead of leaving it advisory-by-accident.
+- Acceptance: `release-execute` refuses a tag with no manifest;
+  manifest validation rejects missing/duplicate item rulings (R3);
+  `sitting_delta` is required — a manifest without it is invalid.
+
+## Phases
+
+| Phase | Scope | Gate |
+|---|---|---|
+| **0** | R1 + R2 | scan + register in CI; derived status matches 2026-08-20 register; SCAN-ERROR fixture fails closed |
+| **1** | R3 + R4 + R7 | one clean dry-run manifest on a real release diff |
+| **2** | R5 armed | chair-recorded promotion naming rule-pack version (Codex#16) |
+| **X** | R6 | independent; may ship first |
+
+## Non-goals
+
+- Seats do not detect defects in the diff (ruled out on measured
+  evidence: 450k tokens → 8 instances of one class).
+- Seats do not name new defect classes this cycle (held; only the
+  instrumented candidate form may return — see the curated stub).
+- The stage does not replace `release-gate`, `attune-release-check`,
+  or `release-execute`; it covers the diff-risk gap they leave.
+- No auto-partition proposer for over-cap releases (declined,
+  Codex#9-as-filed): the chair splits, the tool re-runs.
+
+## Dissent register
+
+- **Agy#1 (calibration bar `recall == 1.0`): DECLINED.** Seat's
+  claim: calibrated status should require perfect recall on
+  repo-pinned positive fixtures. Lead's reason: conflates
+  fixture-pinning (which must pass) with corpus recall (which is
+  recorded, not thresholded) — the register's own shipped calibration
+  standard is 8/11 recall, honestly stated; a 1.0 bar would either
+  block every real rule or invite fixture-shrinking to meet it.
+  Fixture passage is required; corpus metrics are receipts, not
+  gates.
+
+## Resolved questions
+
+- **OQ1 — expiry unit: RELEASES** (both critics convergent; ratified
+  with the triage).
+- **OQ2 — exposure rendering: §3 boolean matrix only** (folded into
+  R4; ratified with the triage batch).
+- **OQ3 — rule→gate mapping drift: folded into R2** (identity-checked
+  mapping + drift guard; Codex#3).


### PR DESCRIPTION
## Summary
- New spec `docs/specs/release-audit-stage/` (requirements R1–R7, decisions D1–D9): a class-register-driven audit stage inside `/release` — mechanical reconcile + diff sweep, one bounded three-seat sitting on the residual, chair manifest gating `release-execute`.
- Authored via the roundtable drafter+critics loop (thread `q-release-audit-roundtable-stage-001`, 3/3 seats, 2 rounds): Claude drafted, Codex + Antigravity critiqued lint-clean (24 items — 21 accepted, 2 accepted-modified, 1 declined with ledgered reason in the dissent register).
- Curated stub in `docs/reports/roundtable/`; full transcript machine-local per local-first reports.

## Key rulings carried
- Teeth: a calibrated rule hit on a re-exposed fixed-but-ungated class blocks until gated; DEFER escape is tracked YAML with owner + release-count expiry.
- Status column is derived, never authored (BROKEN-GATE quadrant included).
- `sitting_delta` (D9): the sitting instruments itself so the every-release ruling can retire by evidence.

Docs-only; no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)