### PR TITLE
feat(classes): Phase X — class-M receipt checks + AST worklist detector

### DIFF
--- a/src/attune/classes/__init__.py
+++ b/src/attune/classes/__init__.py
@@ -1,0 +1,23 @@
+"""Class register tooling (release-audit-stage spec).
+
+Phase X ships :mod:`attune.classes.class_m` (receipt-type
+declaration checks) and :mod:`attune.classes.mock_worklist` (the
+class-M AST worklist detector). Phase 0 adds the rule pack and the
+derived register.
+"""
+
+from attune.classes.class_m import (
+    BOUNDARY_CLASS_IDS,
+    RECEIPT_TYPES,
+    ReceiptProblem,
+    check_commit,
+    check_range,
+)
+
+__all__ = [
+    "BOUNDARY_CLASS_IDS",
+    "RECEIPT_TYPES",
+    "ReceiptProblem",
+    "check_commit",
+    "check_range",
+]

--- a/src/attune/classes/class_m.py
+++ b/src/attune/classes/class_m.py
@@ -1,0 +1,217 @@
+"""Class M — "the mock defined the contract" — receipt-type checks.
+
+Release-audit-stage R6 (Phase X, independent of the stage): a fix
+for a boundary class must declare a receipt type that actually
+exercises the boundary. Enforcement reads **commit trailers**, which
+survive squash merges where PR metadata detaches (Agy#6):
+
+    Class-Fix: G1
+    Receipt-Type: live-fire
+    Evidence: tests/unit/memory/test_file_stash.py::test_two_process
+
+Rules (fail closed — Codex#13/#14):
+
+- ``Receipt-Type`` must be one of :data:`RECEIPT_TYPES` (the
+  decision-routine taxonomy verbatim).
+- A boundary-class fix (``Class-Fix`` naming an id in
+  :data:`BOUNDARY_CLASS_IDS`) requires ``behavioral`` or
+  ``live-fire`` — ``suite`` is class M by declaration.
+- Every ``Class-Fix`` requires an ``Evidence`` pointer; a bare
+  declaration is checkbox theater.
+- A commit whose subject names a known class id without a
+  ``Class-Fix`` trailer is an UNDECLARED fix and fails — absence is
+  not a pass.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from dataclasses import dataclass
+
+#: The receipt taxonomy, verbatim from the decision-routine rule.
+RECEIPT_TYPES = frozenset({"suite", "behavioral", "live-fire", "metric", "evidence-chain"})
+
+#: Receipt types that exercise a real boundary (R6 admissibility).
+BOUNDARY_ADMISSIBLE = frozenset({"behavioral", "live-fire"})
+
+#: Register class ids whose defect crosses a real boundary. Seeded
+#: from the 2026-08-20 register; Phase 0's rule pack takes over
+#: ownership of this set when it lands.
+BOUNDARY_CLASS_IDS = frozenset(
+    {
+        "C1",
+        "C2",
+        "C3",
+        "C4a",
+        "C4b",
+        "C5",
+        "C6",
+        "C8",
+        "H1",
+        "H2",
+        "H3",
+        "H4",
+        "H5",
+        "G1",
+        "G2",
+        "G3",
+        "G5",
+        "I-1",
+        "I-2",
+        "I-3",
+        "I-4",
+        "I-5",
+        "I-6",
+    }
+)
+
+_TRAILER_RE = re.compile(
+    r"^(?P<key>Class-Fix|Receipt-Type|Evidence):\s*(?P<value>.+?)\s*$",
+    re.MULTILINE,
+)
+# A class id mentioned as its own token in a subject line, e.g.
+# "fix(G1): ..." or "close I-4 escape". Sorted longest-first so
+# "C4a" wins over a hypothetical "C4".
+_ID_TOKEN_RE = re.compile(
+    r"\b("
+    + "|".join(sorted((re.escape(c) for c in BOUNDARY_CLASS_IDS), key=len, reverse=True))
+    + r")\b"
+)
+
+
+@dataclass
+class ReceiptProblem:
+    """One violation found on one commit."""
+
+    sha: str
+    problem: str
+
+    def __str__(self) -> str:
+        return f"{self.sha[:12]}: {self.problem}"
+
+
+def _trailers(message: str) -> dict[str, list[str]]:
+    found: dict[str, list[str]] = {}
+    for m in _TRAILER_RE.finditer(message):
+        found.setdefault(m.group("key"), []).append(m.group("value"))
+    return found
+
+
+def check_commit(sha: str, message: str) -> list[ReceiptProblem]:
+    """Validate one commit message against the R6 trailer schema.
+
+    Args:
+        sha: The commit SHA (used only for reporting).
+        message: The full commit message, subject included.
+
+    Returns:
+        Every violation found; empty means the commit passes.
+    """
+    problems: list[ReceiptProblem] = []
+    trailers = _trailers(message)
+    class_fixes = trailers.get("Class-Fix", [])
+    receipt_types = trailers.get("Receipt-Type", [])
+    evidence = trailers.get("Evidence", [])
+    subject = message.splitlines()[0] if message else ""
+
+    if not class_fixes:
+        mentioned = _ID_TOKEN_RE.search(subject)
+        if mentioned:
+            problems.append(
+                ReceiptProblem(
+                    sha,
+                    f"subject names class {mentioned.group(1)} but carries no "
+                    "Class-Fix trailer (undeclared fix fails closed)",
+                )
+            )
+        return problems
+
+    for value in receipt_types:
+        if value not in RECEIPT_TYPES:
+            problems.append(
+                ReceiptProblem(
+                    sha,
+                    f"Receipt-Type {value!r} not in " f"{sorted(RECEIPT_TYPES)}",
+                )
+            )
+
+    if not receipt_types:
+        problems.append(ReceiptProblem(sha, "Class-Fix declared without a Receipt-Type"))
+    if not evidence:
+        problems.append(ReceiptProblem(sha, "Class-Fix declared without an Evidence pointer"))
+
+    for class_id in class_fixes:
+        if class_id not in BOUNDARY_CLASS_IDS:
+            problems.append(
+                ReceiptProblem(
+                    sha,
+                    f"Class-Fix {class_id!r} is not a known class id",
+                )
+            )
+            continue
+        admissible = [t for t in receipt_types if t in BOUNDARY_ADMISSIBLE]
+        if receipt_types and not admissible:
+            problems.append(
+                ReceiptProblem(
+                    sha,
+                    f"boundary class {class_id} declared with "
+                    f"{sorted(set(receipt_types))} — requires one of "
+                    f"{sorted(BOUNDARY_ADMISSIBLE)} (class M by declaration)",
+                )
+            )
+    return problems
+
+
+def check_range(base: str, head: str = "HEAD", *, cwd: str | None = None) -> list[ReceiptProblem]:
+    """Validate every commit in ``base..head`` (the release baseline).
+
+    Args:
+        base: Baseline ref (e.g. the merge-base with the last tag).
+        head: Head ref, default ``HEAD``.
+        cwd: Repository directory; default the process cwd.
+
+    Returns:
+        All violations across the range, oldest commit first.
+
+    Raises:
+        subprocess.CalledProcessError: If git cannot resolve the range.
+    """
+    raw = subprocess.run(
+        ["git", "log", "--reverse", "--format=%H%x00%B%x01", f"{base}..{head}"],
+        capture_output=True,
+        text=True,
+        check=True,
+        timeout=60,
+        cwd=cwd,
+    ).stdout
+    problems: list[ReceiptProblem] = []
+    for record in raw.split("\x01"):
+        record = record.strip("\n")
+        if not record:
+            continue
+        sha, _, message = record.partition("\x00")
+        problems.extend(check_commit(sha.strip(), message))
+    return problems
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI: ``python -m attune.classes.class_m --base <ref> [--head <ref>]``."""
+    import argparse
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base", required=True, help="baseline ref")
+    parser.add_argument("--head", default="HEAD")
+    args = parser.parse_args(argv)
+    problems = check_range(args.base, args.head)
+    for p in problems:
+        print(p)
+    if problems:
+        print(f"{len(problems)} receipt problem(s)")
+        return 1
+    print("receipt check clean")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/src/attune/classes/mock_worklist.py
+++ b/src/attune/classes/mock_worklist.py
@@ -1,0 +1,210 @@
+"""Class-M AST worklist detector — three shapes, never a verdict.
+
+Release-audit-stage R6: the detector flags test functions whose
+shape SUGGESTS the mock defined the contract. Every hit is a
+worklist item for a tree-holding reviewer; the detector itself
+renders no verdict (adjudicating a mock against the code under test
+is defect-reading, which seats and scanners don't do).
+
+Shapes (each earned from a live instance, register ruling M):
+
+1. ``patched-call-site`` — a test that patches something and whose
+   only assertions are mock assertions (``assert_called*``,
+   ``call_count``): the patched call site stops testing anything
+   the moment the code moves.
+2. ``literal-fixture`` — a dict literal passed straight to a
+   reader/deserializer: a record fixture must come from the
+   writer's own serializer, or the shape drifts from the writer's.
+3. ``patched-refusal`` — a "cannot write" test that induces failure
+   by patching a write call with an OSError side effect instead of
+   making the filesystem actually refuse (chmod / read-only dir).
+"""
+
+from __future__ import annotations
+
+import ast
+from dataclasses import dataclass
+from pathlib import Path
+
+_MOCK_ASSERT_PREFIXES = ("assert_called", "assert_not_called", "assert_any_call", "assert_awaited")
+_READER_NAMES = frozenset(
+    {"from_dict", "load", "loads", "deserialize", "parse_obj", "model_validate", "read_record"}
+)
+#: Final attribute segment of a patch target that names a FILE write
+#: op. Matched exactly on the last dotted segment — substring matching
+#: falsely flagged ``urllib.request.urlopen`` and ``subprocess.Popen``
+#: (network/subprocess error tests are not filesystem-refusal
+#: candidates; calibration probe 2026-08-22).
+_WRITE_TARGET_SEGMENTS = frozenset(
+    {"write_text", "write_bytes", "open", "replace", "rename", "mkdir", "unlink"}
+)
+_ERROR_NAMES = frozenset({"OSError", "PermissionError", "IOError"})
+
+
+@dataclass
+class WorklistItem:
+    """One flagged test-shape occurrence."""
+
+    path: str
+    line: int
+    shape: str
+    detail: str
+
+    def __str__(self) -> str:
+        return f"{self.path}:{self.line} [{self.shape}] {self.detail}"
+
+
+def _is_patch_call(node: ast.Call) -> str | None:
+    """Return the patch target string if ``node`` is ``patch("...")``."""
+    func = node.func
+    name = None
+    if isinstance(func, ast.Name):
+        name = func.id
+    elif isinstance(func, ast.Attribute):
+        name = func.attr
+    if name not in {"patch", "object"}:
+        return None
+    if node.args and isinstance(node.args[0], ast.Constant) and isinstance(node.args[0].value, str):
+        return node.args[0].value
+    if name == "object" and len(node.args) >= 2:
+        attr = node.args[1]
+        if isinstance(attr, ast.Constant) and isinstance(attr.value, str):
+            return attr.value
+    return None
+
+
+def _mock_asserts_only(func: ast.FunctionDef | ast.AsyncFunctionDef) -> bool:
+    """True when the function asserts ONLY through mock assertions."""
+    saw_mock_assert = False
+    for node in ast.walk(func):
+        if isinstance(node, ast.Assert):
+            return False
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute):
+            if node.func.attr.startswith(_MOCK_ASSERT_PREFIXES):
+                saw_mock_assert = True
+    return saw_mock_assert
+
+
+def _patch_targets(func: ast.FunctionDef | ast.AsyncFunctionDef) -> list[tuple[int, str]]:
+    targets: list[tuple[int, str]] = []
+    for node in ast.walk(func):
+        if isinstance(node, ast.Call):
+            target = _is_patch_call(node)
+            if target:
+                targets.append((node.lineno, target))
+    for decorator in func.decorator_list:
+        if isinstance(decorator, ast.Call):
+            target = _is_patch_call(decorator)
+            if target:
+                targets.append((decorator.lineno, target))
+    return targets
+
+
+def _has_error_side_effect(func: ast.FunctionDef | ast.AsyncFunctionDef) -> bool:
+    for node in ast.walk(func):
+        if isinstance(node, ast.keyword) and node.arg == "side_effect":
+            for inner in ast.walk(node.value):
+                if isinstance(inner, ast.Name) and inner.id in _ERROR_NAMES:
+                    return True
+    return False
+
+
+def _literal_fixture_hits(func: ast.FunctionDef | ast.AsyncFunctionDef) -> list[tuple[int, str]]:
+    hits: list[tuple[int, str]] = []
+    for node in ast.walk(func):
+        if not isinstance(node, ast.Call):
+            continue
+        name = None
+        if isinstance(node.func, ast.Attribute):
+            name = node.func.attr
+        elif isinstance(node.func, ast.Name):
+            name = node.func.id
+        if name in _READER_NAMES and any(isinstance(a, ast.Dict) for a in node.args):
+            hits.append((node.lineno, name))
+    return hits
+
+
+def scan_file(path: Path) -> list[WorklistItem]:
+    """Scan one test file for the three class-M shapes.
+
+    Args:
+        path: A Python test file.
+
+    Returns:
+        Worklist items; empty when no shape matches. Unparseable
+        files return empty (the sweep's job is shapes, not syntax).
+    """
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+    except (SyntaxError, ValueError, OSError):
+        return []
+    items: list[WorklistItem] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+            continue
+        if not node.name.startswith("test"):
+            continue
+        targets = _patch_targets(node)
+        if targets and _mock_asserts_only(node):
+            line, target = targets[0]
+            items.append(
+                WorklistItem(
+                    str(path),
+                    node.lineno,
+                    "patched-call-site",
+                    f"{node.name} patches {target!r} and asserts only on the mock",
+                )
+            )
+        for line, name in _literal_fixture_hits(node):
+            items.append(
+                WorklistItem(
+                    str(path),
+                    line,
+                    "literal-fixture",
+                    f"{node.name} feeds a dict literal to {name}()",
+                )
+            )
+        if _has_error_side_effect(node):
+            write_targets = [
+                (line, t) for line, t in targets if t.rsplit(".", 1)[-1] in _WRITE_TARGET_SEGMENTS
+            ]
+            if write_targets:
+                line, target = write_targets[0]
+                items.append(
+                    WorklistItem(
+                        str(path),
+                        line,
+                        "patched-refusal",
+                        f"{node.name} patches {target!r} with an error side_effect "
+                        "instead of a real filesystem refusal",
+                    )
+                )
+    return items
+
+
+def scan_paths(paths: list[Path]) -> list[WorklistItem]:
+    """Scan test files under the given paths (files or directories)."""
+    items: list[WorklistItem] = []
+    for root in paths:
+        files = [root] if root.is_file() else sorted(root.rglob("test_*.py"))
+        for f in files:
+            items.extend(scan_file(f))
+    return items
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI: ``python -m attune.classes.mock_worklist <paths...>``."""
+    import argparse
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("paths", nargs="+", type=Path)
+    args = parser.parse_args(argv)
+    items = scan_paths(args.paths)
+    for item in items:
+        print(item)
+    print(f"{len(items)} worklist item(s) — worklist, not verdicts")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tests/unit/classes/test_class_m.py
+++ b/tests/unit/classes/test_class_m.py
@@ -1,0 +1,135 @@
+"""Class-M receipt checks (release-audit-stage R6, Phase X)."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from attune.classes.class_m import (
+    BOUNDARY_CLASS_IDS,
+    RECEIPT_TYPES,
+    check_commit,
+    check_range,
+)
+
+
+class TestCheckCommit:
+    def test_suite_receipt_on_boundary_class_is_class_m(self):
+        msg = "fix memory store\n\nClass-Fix: G1\nReceipt-Type: suite\nEvidence: tests/x.py\n"
+        problems = check_commit("a" * 40, msg)
+        assert len(problems) == 1
+        assert "class M by declaration" in problems[0].problem
+
+    @pytest.mark.parametrize("receipt", ["behavioral", "live-fire"])
+    def test_admissible_receipt_passes(self, receipt):
+        msg = f"fix\n\nClass-Fix: G1\nReceipt-Type: {receipt}\nEvidence: tests/x.py\n"
+        assert check_commit("a" * 40, msg) == []
+
+    def test_unknown_receipt_type_fails(self):
+        msg = "fix\n\nClass-Fix: G1\nReceipt-Type: vibes\nEvidence: e\n"
+        problems = check_commit("a" * 40, msg)
+        assert any("not in" in p.problem for p in problems)
+
+    def test_missing_receipt_type_fails(self):
+        msg = "fix\n\nClass-Fix: G1\nEvidence: e\n"
+        problems = check_commit("a" * 40, msg)
+        assert any("without a Receipt-Type" in p.problem for p in problems)
+
+    def test_missing_evidence_fails(self):
+        msg = "fix\n\nClass-Fix: G1\nReceipt-Type: live-fire\n"
+        problems = check_commit("a" * 40, msg)
+        assert any("without an Evidence pointer" in p.problem for p in problems)
+
+    def test_unknown_class_id_fails(self):
+        msg = "fix\n\nClass-Fix: Z9\nReceipt-Type: live-fire\nEvidence: e\n"
+        problems = check_commit("a" * 40, msg)
+        assert any("not a known class id" in p.problem for p in problems)
+
+    def test_subject_naming_class_without_trailer_fails_closed(self):
+        problems = check_commit("a" * 40, "fix(G1): stop losing records\n\nbody\n")
+        assert len(problems) == 1
+        assert "undeclared fix fails closed" in problems[0].problem
+
+    def test_longest_id_wins_c4a_over_prefix(self):
+        problems = check_commit("a" * 40, "close C4a null-byte escape\n")
+        assert "C4a" in problems[0].problem
+
+    def test_ordinary_commit_passes(self):
+        assert check_commit("a" * 40, "docs: fix typo in README\n") == []
+
+    def test_class_id_inside_word_does_not_fire(self):
+        assert check_commit("a" * 40, "feat: add G1000 telemetry panel\n") == []
+
+    def test_problem_str_carries_short_sha(self):
+        problems = check_commit(
+            "abcdef123456" + "0" * 28,
+            "fix\n\nClass-Fix: Z9\nReceipt-Type: live-fire\nEvidence: e\n",
+        )
+        assert str(problems[0]).startswith("abcdef123456:")
+
+    def test_enum_matches_decision_routine_taxonomy(self):
+        assert RECEIPT_TYPES == {"suite", "behavioral", "live-fire", "metric", "evidence-chain"}
+        assert "G1" in BOUNDARY_CLASS_IDS
+
+
+class TestCheckRangeRealGit:
+    """Non-mocked round trip through the real git boundary (class M
+
+    binds this module's own tests: the boundary here IS git log
+    formatting, so a real repository exercises it).
+    """
+
+    @pytest.fixture()
+    def repo(self, tmp_path: Path) -> Path:
+        subprocess.run(["git", "init", "-q", str(tmp_path)], check=True, timeout=30)
+        for k, v in (("user.email", "t@t"), ("user.name", "t"), ("commit.gpgsign", "false")):
+            subprocess.run(["git", "-C", str(tmp_path), "config", k, v], check=True, timeout=30)
+        (tmp_path / "f.txt").write_text("base\n")
+        subprocess.run(["git", "-C", str(tmp_path), "add", "."], check=True, timeout=30)
+        subprocess.run(
+            ["git", "-C", str(tmp_path), "commit", "-q", "-m", "base"], check=True, timeout=30
+        )
+        return tmp_path
+
+    def _commit(self, repo: Path, message: str) -> None:
+        f = repo / "f.txt"
+        f.write_text(f.read_text() + "x\n")
+        subprocess.run(["git", "-C", str(repo), "add", "."], check=True, timeout=30)
+        subprocess.run(
+            ["git", "-C", str(repo), "commit", "-q", "-F", "-"],
+            input=message,
+            text=True,
+            check=True,
+            timeout=30,
+        )
+
+    def test_squashed_style_commit_with_suite_receipt_is_caught(self, repo):
+        self._commit(
+            repo,
+            "fix G1 store race (#999)\n\nClass-Fix: G1\nReceipt-Type: suite\nEvidence: tests/x.py\n",
+        )
+        problems = check_range("HEAD~1", "HEAD", cwd=str(repo))
+        assert len(problems) == 1
+        assert "class M by declaration" in problems[0].problem
+
+    def test_clean_range_passes(self, repo):
+        self._commit(
+            repo,
+            "fix\n\nClass-Fix: H1\nReceipt-Type: live-fire\nEvidence: tests/t.py::test_real_port\n",
+        )
+        self._commit(repo, "docs: unrelated\n")
+        assert check_range("HEAD~2", "HEAD", cwd=str(repo)) == []
+
+    def test_problems_reported_oldest_first(self, repo):
+        self._commit(repo, "close I-4 escape\n")
+        self._commit(repo, "fix\n\nClass-Fix: H2\nEvidence: e\n")
+        problems = check_range("HEAD~2", "HEAD", cwd=str(repo))
+        assert len(problems) == 2
+        assert "undeclared" in problems[0].problem
+        assert "Receipt-Type" in problems[1].problem
+
+    def test_bad_ref_raises(self, repo):
+        with pytest.raises(subprocess.CalledProcessError):
+            check_range("no-such-ref", "HEAD", cwd=str(repo))

--- a/tests/unit/classes/test_mock_worklist.py
+++ b/tests/unit/classes/test_mock_worklist.py
@@ -1,0 +1,176 @@
+"""Class-M AST worklist detector — three shapes on pinned fixtures."""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+from attune.classes.mock_worklist import scan_file, scan_paths
+
+
+def _write(tmp_path: Path, body: str) -> Path:
+    f = tmp_path / "test_fixture.py"
+    f.write_text(textwrap.dedent(body))
+    return f
+
+
+class TestPatchedCallSite:
+    def test_mock_only_assertions_flag(self, tmp_path):
+        f = _write(
+            tmp_path,
+            """
+            from unittest.mock import patch
+
+            def test_calls_store():
+                with patch("pkg.mod.get_store") as m:
+                    run()
+                    m.assert_called_once_with("x")
+        """,
+        )
+        items = scan_file(f)
+        assert [i.shape for i in items] == ["patched-call-site"]
+        assert "pkg.mod.get_store" in items[0].detail
+
+    def test_real_assert_alongside_mock_does_not_flag(self, tmp_path):
+        f = _write(
+            tmp_path,
+            """
+            from unittest.mock import patch
+
+            def test_calls_store():
+                with patch("pkg.mod.get_store") as m:
+                    result = run()
+                    m.assert_called_once()
+                    assert result == 3
+        """,
+        )
+        assert scan_file(f) == []
+
+    def test_decorator_patch_detected(self, tmp_path):
+        f = _write(
+            tmp_path,
+            """
+            from unittest.mock import patch
+
+            @patch("pkg.mod.helper")
+            def test_uses_helper(m):
+                go()
+                m.assert_called_once()
+        """,
+        )
+        items = scan_file(f)
+        assert items and items[0].shape == "patched-call-site"
+
+    def test_non_test_function_ignored(self, tmp_path):
+        f = _write(
+            tmp_path,
+            """
+            from unittest.mock import patch
+
+            def helper():
+                with patch("pkg.mod.x") as m:
+                    m.assert_called_once()
+        """,
+        )
+        assert scan_file(f) == []
+
+
+class TestLiteralFixture:
+    def test_dict_literal_to_from_dict_flags(self, tmp_path):
+        f = _write(
+            tmp_path,
+            """
+            def test_reads_record():
+                rec = Store.from_dict({"ts": 1, "body": "x"})
+                assert rec.ts == 1
+        """,
+        )
+        items = scan_file(f)
+        assert [i.shape for i in items] == ["literal-fixture"]
+        assert "from_dict" in items[0].detail
+
+    def test_serializer_built_record_does_not_flag(self, tmp_path):
+        f = _write(
+            tmp_path,
+            """
+            def test_reads_record():
+                rec = Store.from_dict(make_record().to_dict())
+                assert rec.ts == 1
+        """,
+        )
+        assert scan_file(f) == []
+
+
+class TestPatchedRefusal:
+    def test_patched_write_with_oserror_flags(self, tmp_path):
+        f = _write(
+            tmp_path,
+            """
+            from unittest.mock import patch
+
+            def test_cannot_write():
+                with patch("pathlib.Path.write_text", side_effect=OSError("denied")):
+                    assert save() is False
+        """,
+        )
+        items = scan_file(f)
+        assert [i.shape for i in items] == ["patched-refusal"]
+
+    def test_urlopen_error_is_not_a_refusal_candidate(self, tmp_path):
+        # Calibration FP pin (2026-08-22): substring "open" matched
+        # urlopen; network error tests are legitimate patches.
+        f = _write(
+            tmp_path,
+            """
+            from unittest.mock import patch
+
+            def test_network_down():
+                with patch("urllib.request.urlopen", side_effect=OSError("net")):
+                    assert fetch() is None
+        """,
+        )
+        assert [i.shape for i in scan_file(f)] == []
+
+    def test_popen_error_is_not_a_refusal_candidate(self, tmp_path):
+        # Calibration FP pin (2026-08-22): "Popen" substring-matched "open".
+        f = _write(
+            tmp_path,
+            """
+            from unittest.mock import patch
+
+            def test_subprocess_fails():
+                with patch("subprocess.Popen", side_effect=OSError("boom")):
+                    assert launch() is None
+        """,
+        )
+        assert [i.shape for i in scan_file(f)] == []
+
+    def test_real_chmod_refusal_does_not_flag(self, tmp_path):
+        f = _write(
+            tmp_path,
+            """
+            def test_cannot_write(tmp_path):
+                tmp_path.chmod(0o500)
+                assert save(tmp_path) is False
+        """,
+        )
+        assert scan_file(f) == []
+
+
+class TestScanPlumbing:
+    def test_unparseable_file_returns_empty(self, tmp_path):
+        f = tmp_path / "test_bad.py"
+        f.write_text("def broken(:\n")
+        assert scan_file(f) == []
+
+    def test_scan_paths_walks_directories(self, tmp_path):
+        _write(
+            tmp_path,
+            """
+            def test_x():
+                rec = load({"a": 1})
+                assert rec
+        """,
+        )
+        items = scan_paths([tmp_path])
+        assert len(items) == 1


### PR DESCRIPTION
## Summary
- `attune.classes.class_m` — commit-trailer receipt validation per release-audit-stage R6: `Class-Fix` / `Receipt-Type` / `Evidence`. A boundary-class fix declaring `suite` is class M by declaration; undeclared fixes, unknown receipt types, and missing evidence all fail closed. Trailer-based so the check survives squash merges; `check_range` walks a release baseline through real git.
- `attune.classes.mock_worklist` — the three chair-ruled class-M shapes as an AST **worklist, never a verdict**: mock-only-assertion patched call sites, dict-literal fixtures fed to deserializers, patched-refusal write tests.

## Calibration (probe-first rule)
132 → 130 hits on `tests/unit` after fixing a substring FP (`"open"` matched `urlopen`/`Popen`). Final distribution: 90 patched-call-site / 22 patched-refusal (all genuine file ops on inspection) / 18 literal-fixture. Both eliminated FPs pinned as passing fixtures. R6's operating point is the per-diff intersection, not tree-wide volume.

## Tests
29 tests, 85% coverage. `check_range` is tested through a **real temp git repo** — class M's own rule applied to its own checker.

Spec: `docs/specs/release-audit-stage` (#2171). Phase X ships first per D8; Phase 0 (rule pack + derived register) follows separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)