### PR TITLE
fix(tests): deflake cross-drive relpath test — patch module alias, not global os.path

### DIFF
--- a/src/attune/orchestration/friction/blast_radius.py
+++ b/src/attune/orchestration/friction/blast_radius.py
@@ -13,6 +13,11 @@ the same file scores identically on Windows and POSIX.
 import os
 import re
 
+# Module-level alias so tests can monkeypatch this module's relpath
+# without mutating the process-global ``os.path`` (which races other
+# tests under xdist).
+_relpath = os.path.relpath
+
 # Path patterns are anchored to a path segment boundary so that e.g.
 # ``docs/oauth/notes.md`` does NOT match the ``auth/`` rule.
 _CRITICAL_PATH_PATTERNS: tuple[re.Pattern[str], ...] = tuple(
@@ -135,7 +140,7 @@ class BlastRadiusClassifier:
         """Normalizes a path relative to workspace root with '/' separators."""
         abs_path = os.path.abspath(raw_path)
         try:
-            rel = os.path.relpath(abs_path, self.workspace_root)
+            rel = _relpath(abs_path, self.workspace_root)
         except ValueError:
             rel = raw_path
         return rel.replace("\\", "/")

--- a/tests/unit/orchestration/test_friction_matrix.py
+++ b/tests/unit/orchestration/test_friction_matrix.py
@@ -83,9 +83,9 @@ class TestBlastRadiusClassifier:
         def cross_drive(path, start):
             raise ValueError("path is on mount 'D:', start on mount 'C:'")
 
-        monkeypatch.setattr(
-            "attune.orchestration.friction.blast_radius.os.path.relpath", cross_drive
-        )
+        # Patch the module-level alias, NOT os.path.relpath — patching
+        # the global os.path races other xdist tests in this process.
+        monkeypatch.setattr("attune.orchestration.friction.blast_radius._relpath", cross_drive)
         assert classifier.evaluate_file_path("src/attune/auth/login.py") >= 4
 
     def test_normal_file_edit(self) -> None:


### PR DESCRIPTION
## What

Fixes the xdist flake in
`tests/unit/orchestration/test_friction_matrix.py::TestBlastRadiusClassifier::test_cross_drive_relpath_falls_back_to_raw_path`
(`KeyError: 139661737532288` on PR #2172, ubuntu-latest 3.10, run 32585674547).

## Why

The test monkeypatched
`attune.orchestration.friction.blast_radius.os.path.relpath` — that target
resolves to the **process-global** `os.path` module, so the patch (and its
teardown bookkeeping) races every other test running in the same xdist
worker. The `KeyError`-on-`id()` shape is the known signature of patch
bookkeeping racing teardown under parallel execution.

## How

- `blast_radius.py` now holds a module-level alias `_relpath = os.path.relpath`
  and `_sanitize_and_relativize` calls it.
- The test patches `blast_radius._relpath`, scoping the patch to the module —
  `os.path` is never mutated.
- The Windows cross-drive `ValueError` → raw-path fallback behavior is
  unchanged and still pinned by the test.

## Receipts

- `tests/unit/orchestration` run 5× with `-n auto`: **612 passed, 2 skipped**
  every run.
- Pinned black/ruff pre-flighted clean; all pre-commit hooks passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
