### PR TITLE
chore(release): bump version to 14.0.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "Persistent memory and receipt-verified workflows for Claude Code. Spec-driven development with an approval loop, plus 28 auto-triggering skills: security audits, code review, test generation, release prep.",
-    "version": "13.0.2"
+    "version": "14.0.0"
   },
   "plugins": [
     {
       "name": "attune-ai",
       "description": "Persistent memory and receipt-verified workflows for Claude Code. /spec carries an idea through brainstorm, requirements, design, and task execution with quality gates and your approval at each stage. Backed by 28 auto-triggering skills — security audits, code reviews, test generation, bug prediction, and release preparation. For help content tools, also install attune-help from this marketplace; authoring ships built in via the attune.authoring module.",
       "source": "./plugin",
-      "version": "13.0.2",
+      "version": "14.0.0",
       "author": {
         "name": "Smart AI Memory",
         "email": "patrick.roebuck@smartaimemory.com"

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,4 +1,4 @@
-# Attune AI Framework v13.0.2
+# Attune AI Framework v14.0.0
 
 AI-powered developer workflows with cost optimization and multi-agent orchestration.
 
@@ -556,7 +556,7 @@ attune_redis/          # Redis plugin — BUNDLED, ships in the attune-ai
 
 ---
 
-**Version:** 13.0.2 | **License:** Apache 2.0 | **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)
+**Version:** 14.0.0 | **License:** Apache 2.0 | **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)
 
 ## Lessons — core
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,15 +9,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [14.0.0] - 2026-08-22
 
-**A cleanup major.** The breaking change is the removal of dead API —
-`attune.exceptions`, the last unremoved surface of the "Empathy"
-framework retired in 9.0.0. Nothing in the library raised those
-exceptions, so the migration is to delete the handler rather than
-repoint the import. Alongside it: three security findings closed, a
-daemon that could not reach its own database fixed, an N+1 against Redis
-batched away, and a tracked rule pack behind the class register.
+**The release checks its own diff.** `/release audit` asks a question
+the other release surfaces do not: what class of defect could *this*
+release have introduced? It resolves the range from the last release
+tag, proves the previously-green gates are still green on this exact
+commit, sweeps the changed package surface with a calibrated rule pack,
+and produces a capped one-page residual for a three-model sitting.
+`/release publish` then refuses to tag until every residual item carries
+a chair ruling. The major version is a removal — `attune.exceptions`,
+the last surface of the "Empathy" framework retired in 9.0.0 — and the
+migration is to delete the handler rather than repoint the import.
 
 ### Added
+
+- **The release-audit stage (`/release audit`).** Six steps: baseline
+  (merge-base vs the last release tag, failing closed rather than
+  guessing a range), reconcile (an allowlisted CI workflow green on
+  THIS head SHA — a green run for an earlier commit does not
+  authorize), sweep, residual packet, sitting, chair ruling. The packet
+  is capped at 1500 words / 12 items / 20 sweep rows and carries no diff
+  hunks; exceeding a cap is a **refusal with exit code 2**, never a
+  truncation, because a packet that quietly dropped an item would let a
+  chair rule on a subset believing they ruled on the whole. It reports
+  how many files were swept against how many changed, so an empty
+  residual can never be mistaken for a clean one. The sitting is one
+  round of three seats that amend pre-filled dispositions per item —
+  an absent or malformed seat is recorded as such, never read as
+  agreement. Rulings are written to an immutable, SHA-bound manifest at
+  `.attune/release-manifests/<tag>.json`, and `publish` verifies one
+  exists for the tag being cut. (#2180)
 
 - **Class register — tracked rule pack with a derived status column.**
   The register's status is computed, never authored: a class derives
@@ -32,6 +52,14 @@ batched away, and a tracked rule pack behind the class register.
 
 ### Fixed
 
+- **Whole-tree scanners survive a null byte.** `ast.parse` raises
+  `ValueError`, not `SyntaxError`, on a source string containing a null
+  byte. Fourteen sites across the repo's gates and CI scripts caught
+  only `SyntaxError`, so a single such file would abort an entire scan
+  instead of skipping that file — including the gate that exists to
+  enforce this rule, which had been scoped to `src/attune` and so never
+  examined itself. Widening that scope surfaced all fourteen; twelve
+  were long-standing. (#2179)
 - **`attune alerts watch --daemon` could not reach its own database.**
   `_daemonize()` calls `os.chdir("/")` while the alert engine held a
   CWD-relative default (`.attune/alerts.db`), so every query issued

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,58 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [14.0.0] - 2026-08-22
+
+**A cleanup major.** The breaking change is the removal of dead API —
+`attune.exceptions`, the last unremoved surface of the "Empathy"
+framework retired in 9.0.0. Nothing in the library raised those
+exceptions, so the migration is to delete the handler rather than
+repoint the import. Alongside it: three security findings closed, a
+daemon that could not reach its own database fixed, an N+1 against Redis
+batched away, and a tracked rule pack behind the class register.
+
+### Added
+
+- **Class register — tracked rule pack with a derived status column.**
+  The register's status is computed, never authored: a class derives
+  CLOSED / BROKEN-GATE / FIXED-BUT-UNGATED / OPEN / DEFERRED from
+  whether its gate resolves, how many calibrated hits remain, and
+  whether an active DEFER covers it. Gate mapping is checked by
+  IDENTITY, not existence — a gate file must exist, define the named
+  test, AND carry a matching `Register-Class:` tag, so a renamed or
+  reassigned gate goes loud instead of silently preserving CLOSED. A
+  class with no calibrated rule derives UNMECHANIZED rather than
+  fabricating a status. (#2173, #2172)
+
+### Fixed
+
+- **`attune alerts watch --daemon` could not reach its own database.**
+  `_daemonize()` calls `os.chdir("/")` while the alert engine held a
+  CWD-relative default (`.attune/alerts.db`), so every query issued
+  after the fork looked for `/.attune/alerts.db` and raised
+  `unable to open database file` for any non-root user. The engine
+  created its database correctly, then lost it. The path is now
+  anchored absolute at construction, so a later chdir cannot move the
+  target. (#2170)
+- **Three security findings from the 13.0.2 post-release review.** The
+  ops client-token check compared with `!=`, which short-circuits on
+  the first differing byte and leaks a matching prefix through response
+  latency — it now uses `secrets.compare_digest` over bytes, so a
+  hostile header returns 403 rather than crashing the comparison. A git
+  ref beginning with `-` was passed straight to `git log`, where it
+  parses as an OPTION rather than a revision, and is now refused before
+  git runs. The alert daemon ran with `umask(0)`, which left a created
+  directory world-writable; it now uses `0o077`. (#2168)
+
+### Performance
+
+- **Five telemetry listings no longer pay a round trip per record.**
+  Each scanned a Redis key pattern and then read every record with its
+  own `get()` — the N+1 shape. They now fetch the whole scan in one
+  `MGET`, chunked so a large scan does not become a single
+  server-blocking command, with per-record decoding kept total so one
+  malformed value cannot cost the whole listing. (#2162)
+
 ### Removed
 
 - **The legacy `attune.exceptions` hierarchy.** The nine-class tree

--- a/README.md
+++ b/README.md
@@ -135,24 +135,39 @@ memory storage and recall, and every local transform.
      release with the headline feature; the displaced content moves to
      a permanent section below. Don't stack a second "New in" here. -->
 
-## New in 13.0.0 — correctness you can trust under failure
+## New in 14.0.0 — a status column that can't lie to you
 
-The code paths that only matter when something goes wrong got a
-library-wide review. Memory writes that reported success without
-landing now actually persist or surface the failure; telemetry and
-security-gate state a single malformed record could corrupt are
-locked down; external input that could crash a parse now degrades
-instead. Shared stores (`AgentStateStore`, `ComplianceDatabase`) write
-atomically under a lock. And agents gain **interactive forms** — richer
-than yes/no: a decision card with per-option tradeoffs, a pushback card
-for disagreement, progress reports, plus ranking, triage, and more, each
-rendered to whatever surface your client supports — a native dialog, an
-HTML widget, or multiple-choice (via `attune-forms` 0.7.0). The major
-bump is the removal of
-the dormant in-package hook-execution engine — dead code with no live
-caller (the hooks Claude Code runs are unchanged); the
-memory-durability and schema changes alter observable behavior, so
-check the CHANGELOG's migration notes if you depend on them.
+The class register now **derives** its status instead of carrying one
+someone typed. Each class resolves to CLOSED, BROKEN-GATE,
+FIXED-BUT-UNGATED, OPEN, or DEFERRED from three facts: whether its gate
+actually resolves, how many calibrated hits remain, and whether an
+active deferral covers it. The payoff is that the register cannot drift
+into a comfortable lie — the usual failure of a hand-maintained status
+table is that a gate gets renamed or repointed and the row keeps
+reading CLOSED. Mapping is checked by **identity**, not existence: the
+gate file must exist, define the named test, *and* carry a matching
+`Register-Class:` tag, so a reassigned gate goes loud. And a class with
+no calibrated rule derives UNMECHANIZED rather than inventing a verdict
+it has no evidence for.
+
+Background alerting got solid in the same pass: `attune alerts watch
+--daemon` keeps a firm hold on its database across the fork, and writes
+owner-only files while it runs. The ops client token is compared in
+constant time, git refs are validated before they reach the command
+line, and telemetry listings are markedly lighter on Redis — a scan and
+its records now cost a single round trip instead of one per record,
+chunked so a big scan stays responsive.
+
+The major bump is a removal: `attune.exceptions` — the nine-class tree
+rooted at `EmpathyFrameworkError` — was the final unremoved surface of
+the "Empathy" framework retired in 9.0.0, and nothing in the library
+raised any of them once their throwers were deleted. **The migration is
+to delete the handler, not repoint the import**: a `try/except` naming
+one of these was already dead code, and there is deliberately no shim
+for an exception that can never be caught. One trap worth naming —
+`attune.config.validation.ValidationError` is a *different, live* class
+(a dataclass describing a config problem, not an exception), so
+repointing there gets you something you cannot catch.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -135,28 +135,33 @@ memory storage and recall, and every local transform.
      release with the headline feature; the displaced content moves to
      a permanent section below. Don't stack a second "New in" here. -->
 
-## New in 14.0.0 — a status column that can't lie to you
+## New in 14.0.0 — the release checks its own diff
 
-The class register now **derives** its status instead of carrying one
-someone typed. Each class resolves to CLOSED, BROKEN-GATE,
-FIXED-BUT-UNGATED, OPEN, or DEFERRED from three facts: whether its gate
-actually resolves, how many calibrated hits remain, and whether an
-active deferral covers it. The payoff is that the register cannot drift
-into a comfortable lie — the usual failure of a hand-maintained status
-table is that a gate gets renamed or repointed and the row keeps
-reading CLOSED. Mapping is checked by **identity**, not existence: the
-gate file must exist, define the named test, *and* carry a matching
-`Register-Class:` tag, so a reassigned gate goes loud. And a class with
-no calibrated rule derives UNMECHANIZED rather than inventing a verdict
-it has no evidence for.
+`/release audit` answers a question the other release checks don't ask:
+**what class of defect could *this* release have introduced?** It
+resolves the range from your last release tag, proves the gates that
+were green are still green *on this exact commit*, sweeps the changed
+package surface with a calibrated rule pack, and hands you a capped
+one-page residual — never a diff dump. Three models then sit on it for
+a single round and either accept or amend a pre-filled disposition per
+item. You rule; `/release publish` refuses to tag until every item
+carries a ruling, and records that ruling next to the commit it was
+made about.
 
-Background alerting got solid in the same pass: `attune alerts watch
---daemon` keeps a firm hold on its database across the fork, and writes
-owner-only files while it runs. The ops client token is compared in
-constant time, git refs are validated before they reach the command
-line, and telemetry listings are markedly lighter on Redis — a scan and
-its records now cost a single round trip instead of one per record,
-chunked so a big scan stays responsive.
+It also knows what it didn't look at. The packet states how many files
+were swept against how many changed, so an empty result can never be
+mistaken for a clean one. And the class register behind it **derives**
+each status from evidence — whether the gate resolves, what it still
+finds, whether a deferral covers it — so a gate that gets renamed goes
+loud instead of quietly reading CLOSED.
+
+The rest you can see from the outside. Background alerting is solid:
+`attune alerts watch --daemon` keeps a firm hold on its database across
+the fork and writes owner-only files. The ops client token is compared
+in constant time, git refs are validated before they reach the command
+line, and telemetry listings cost a single Redis round trip instead of
+one per record. The repo's own whole-tree scanners now survive a file
+with a null byte in it rather than stopping at the first one.
 
 The major bump is a removal: `attune.exceptions` — the nine-class tree
 rooted at `EmpathyFrameworkError` — was the final unremoved surface of

--- a/docs/reference/API_REFERENCE.md
+++ b/docs/reference/API_REFERENCE.md
@@ -1,6 +1,6 @@
 # Attune AI API Reference
 
-**Version:** 13.0.2
+**Version:** 14.0.0
 **License:** Apache License 2.0
 **Copyright:** 2025-2026 Smart AI Memory, LLC
 
@@ -1133,5 +1133,5 @@ msg = format_error(
 
 ---
 
-**Version:** 13.0.2 | **License:** Apache 2.0
+**Version:** 14.0.0 | **License:** Apache 2.0
 **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)

--- a/plugin/.claude-plugin/marketplace.json
+++ b/plugin/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "Spec-driven development for Claude Code — /spec plans, reviews, and executes with quality gates; plus security audits, code reviews, test generation, and release prep from /attune.",
-    "version": "13.0.2"
+    "version": "14.0.0"
   },
   "plugins": [
     {
       "name": "attune-ai",
       "description": "Spec-driven development for Claude Code — /spec plans, reviews, and executes with quality gates; plus security audits, code reviews, test generation, and release prep from /attune.",
       "source": "./",
-      "version": "13.0.2",
+      "version": "14.0.0",
       "author": {
         "name": "Smart AI Memory",
         "email": "patrick.roebuck@smartaimemory.com"

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "attune-ai",
-  "version": "13.0.2",
+  "version": "14.0.0",
   "description": "Persistent memory and receipt-verified workflows for Claude Code — /spec plans, reviews, and executes with quality gates; plus security audits, code reviews, test generation, and release prep from /attune.",
   "author": {
     "name": "Smart AI Memory",

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -4,7 +4,7 @@ Spec-driven development for Claude Code — turn requirements
 into reliable software. <!-- cap:skill_count -->28 auto-triggering skills<!-- /cap -->, zero
 commands: say what you need and Claude picks the right skill.
 
-**Version:** 13.0.2 | **License:** Apache 2.0
+**Version:** 14.0.0 | **License:** Apache 2.0
 
 > **Fix Receipts** (`/fix`) — new in 11.2.0. Say `fix this and
 > prove it`.

--- a/plugin/core/__init__.py
+++ b/plugin/core/__init__.py
@@ -5,4 +5,4 @@ This module provides the core workflow functionality when the full
 attune-ai package is not installed via pip.
 """
 
-__version__ = "13.0.2"
+__version__ = "14.0.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "attune-ai"
-version = "13.0.2"
+version = "14.0.0"
 description = "Persistent memory and receipt-verified workflows for Claude Code — plugin, MCP server, and spec-driven dev framework."
 readme = {file = "README.md", content-type = "text/markdown"}
 requires-python = ">=3.10"

--- a/src/attune/__init__.py
+++ b/src/attune/__init__.py
@@ -39,8 +39,7 @@ REMOVED in 9.0.0 — legacy "Empathy" framework (see CHANGELOG):
     is the Claude Code workflow plugin. StateManager is now deprecated and
     will be removed in a future release.
 
-REMOVED, pending release — the `attune.exceptions` hierarchy. Breaking,
-so it rides the next MAJOR; see CHANGELOG [Unreleased]:
+REMOVED in 14.0.0 — the `attune.exceptions` hierarchy (see CHANGELOG):
     EmpathyFrameworkError and its eight subclasses. They were the last
     unremoved surface of the 9.0.0 retirement — nothing raised them once
     their throwers were deleted. Note ValidationError went with them;

--- a/uv.lock
+++ b/uv.lock
@@ -299,7 +299,7 @@ wheels = [
 
 [[package]]
 name = "attune-ai"
-version = "13.0.2"
+version = "14.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "agent-memory-client" },

--- a/website/app/page.tsx
+++ b/website/app/page.tsx
@@ -54,7 +54,7 @@ export default function Home() {
             <div className="grid lg:grid-cols-2 gap-16 items-center">
               <div className="z-10">
                 <div className="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-[var(--surface-container-high)] text-[var(--primary)] text-xs font-bold tracking-widest mb-6 uppercase">
-                  <span>v13.0.2</span>
+                  <span>v14.0.0</span>
                   <span className="w-1 h-1 rounded-full bg-[var(--primary)]"></span>
                   <span className="opacity-80">Memory &amp; receipts for Claude Code</span>
                 </div>

--- a/website/lib/features.ts
+++ b/website/lib/features.ts
@@ -34,7 +34,7 @@ export const PRODUCTS: Product[] = [
     id: "attune-ai",
     name: "Attune AI",
     pypiName: "attune-ai",
-    version: "13.0.2",
+    version: "14.0.0",
     tagline: "Generate, maintain, and serve help from your code",
     installCommand: "pip install attune-ai",
     marketplaceInstall:
@@ -78,7 +78,7 @@ export const PRODUCTS: Product[] = [
     id: "claude-code-plugin",
     name: "Claude Code Plugin",
     pypiName: "attune-ai",
-    version: "13.0.2",
+    version: "14.0.0",
     tagline: "Progressive help right in your terminal",
     installCommand:
       "claude plugin marketplace add Smart-AI-Memory/attune-ai",


### PR DESCRIPTION
## 14.0.0 — the release checks its own diff

`/release audit` answers a question the other release surfaces don't ask: **what class of defect could *this* release have introduced?** It resolves the range from the last release tag, proves the previously-green gates are still green on **this exact commit**, sweeps the changed package surface, and produces a capped one-page residual for a three-model sitting. `/release publish` then refuses to tag until every residual item carries a chair ruling.

The major version is justified by a removal — `attune.exceptions`, the last surface of the "Empathy" framework retired in 9.0.0. attune-ai has no scheduled majors; this is the genuine breaking change.

## Version sites

`bump_version.py` wrote its **10 owned sites**. Three it does **not** own, handled by hand:

| Site | Action |
|---|---|
| `README.md` rotating "New in" slot | **replaced** per the file's own inline instruction, not stacked |
| `README.md` historical "new in 13.0.0" | **left alone** — a fact about when attune-forms 0.7.0 landed; a blind find-replace would falsify it |
| `src/attune/__init__.py` docstring | "REMOVED, pending release" → "REMOVED in 14.0.0" |
| `uv.lock` | `uv lock` — one line |

## Both docs surfaces were rewritten once, at the end

They originally framed 14.0.0 as *"a cleanup major"* — describing the release by what it removes. That was written before the audit stage existed. Rewriting **after** A and B landed meant writing it once, against what actually shipped, rather than three times against a moving target.

Order on both surfaces is now **feature → improvements → breaking change**, with fixes written as capabilities gained rather than defects suffered.

Also added the missing #2179 entry: fourteen `ValueError`-blind `ast.parse` sites across the repo's gates and CI scripts — including the gate that exists to enforce that rule, which had been scoped to `src/attune` and so never examined itself.

## Post-rebase verification

Rebased onto main after [#2179](https://github.com/Smart-AI-Memory/attune-ai/pull/2179) and [#2180](https://github.com/Smart-AI-Memory/attune-ai/pull/2180) landed. A clean rebase is exactly when a shared counter silently keeps the stale side, so each was re-checked rather than assumed:

- Badge floor **matches main's 25,000** (an earlier rebase in this session *did* silently revert it — not this time)
- Version sites still `14.0.0`; `test_all_versions_match` + website accuracy: **16 passed**
- `check_badge_freshness`: OK
- One `## New in` section; the historical attune-forms mention intact
- 0 commits behind main; commits GPG-signed

## Still owed before publish

Per `release-execute`: `/attune-release-check`, `scripts/release_recall_gate.py`, verifying version + changelog are present **in the merge SHA**, and — new this release — an audit manifest for the tag being cut. The dogfood manifest is bound to `093cd7acd`, so by design it cannot authorize the real tag.

The `pypi` environment gate remains a manual click.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
