### PR TITLE
fix(gates): widen the ast.parse null-byte gate past its own blind spot

### DIFF
--- a/scripts/ast_api_extractor.py
+++ b/scripts/ast_api_extractor.py
@@ -189,7 +189,7 @@ def extract_api_signatures(
         extractor = APIExtractor()
         extractor.visit(tree)
         return extractor.classes, extractor.functions
-    except SyntaxError as e:
+    except (SyntaxError, ValueError) as e:
         raise ValueError(f"Invalid Python syntax: {e}") from e
 
 

--- a/scripts/audit_doc_imports.py
+++ b/scripts/audit_doc_imports.py
@@ -163,7 +163,7 @@ def _import_statements(body: str) -> list[tuple[int, str]]:
     out: list[tuple[int, str]] = []
     try:
         tree = ast.parse(body)
-    except SyntaxError:
+    except (SyntaxError, ValueError):
         for idx, ln in enumerate(body.splitlines()):
             if _IMPORT_LINE_RE.match(ln) and "(" not in ln:
                 out.append((idx, ln.strip()))
@@ -302,7 +302,7 @@ def _deep_check_python(body: str) -> list[tuple[int, str, str]]:
     out: list[tuple[int, str, str]] = []
     try:
         tree = ast.parse(body)
-    except SyntaxError:
+    except (SyntaxError, ValueError):
         return out
     objects = _fence_objects(tree)
     if not objects:

--- a/scripts/auto_implement_all_todos.py
+++ b/scripts/auto_implement_all_todos.py
@@ -136,7 +136,7 @@ def get_function_signature(source_file: Path, func_name: str) -> dict | None:
                     "has_return": has_return,
                     "docstring": docstring,
                 }
-    except (SyntaxError, OSError) as e:
+    except (SyntaxError, OSError, ValueError) as e:
         console.print(f"[dim]Could not parse function {func_name}: {e}[/dim]")
 
     return None
@@ -155,7 +155,7 @@ def get_class_methods(source_file: Path, class_name: str) -> list[str]:
                     if isinstance(item, ast.FunctionDef) and not item.name.startswith("_"):
                         methods.append(item.name)
                 return methods
-    except (SyntaxError, OSError) as e:
+    except (SyntaxError, OSError, ValueError) as e:
         console.print(f"[dim]Could not get methods for {class_name}: {e}[/dim]")
 
     return []

--- a/scripts/check_doc_examples.py
+++ b/scripts/check_doc_examples.py
@@ -81,12 +81,12 @@ def _check_block(src: str, funcs: set[str], methods: set[str]) -> list[str]:
     problems: list[str] = []
     try:
         tree = ast.parse(src)
-    except SyntaxError:
+    except (SyntaxError, ValueError):
         # Tolerate top-level-await fragments: retry wrapped in async def.
         indented = "\n".join("    " + line for line in src.splitlines())
         try:
             tree = ast.parse("async def __frag__():\n" + indented)
-        except SyntaxError as exc:
+        except (SyntaxError, ValueError) as exc:
             return [f"does not compile: {exc.msg} (line {exc.lineno})"]
     awaited = _awaited_or_scheduled(tree)
     for node in ast.walk(tree):

--- a/scripts/check_test_quality.py
+++ b/scripts/check_test_quality.py
@@ -67,7 +67,7 @@ class TestQualityChecker:
         try:
             content = file_path.read_text()
             tree = ast.parse(content)
-        except (SyntaxError, UnicodeDecodeError):
+        except (SyntaxError, UnicodeDecodeError, ValueError):
             return
 
         for node in ast.walk(tree):

--- a/scripts/find_dead_defensive_code.py
+++ b/scripts/find_dead_defensive_code.py
@@ -44,7 +44,7 @@ def _enum_value_names(repo_root: Path) -> dict[str, set[str]]:
     for py in repo_root.rglob("*.py"):
         try:
             tree = ast.parse(py.read_text(encoding="utf-8"))
-        except (SyntaxError, UnicodeDecodeError):
+        except (SyntaxError, UnicodeDecodeError, ValueError):
             continue
         for node in ast.walk(tree):
             if not isinstance(node, ast.ClassDef):
@@ -257,7 +257,7 @@ def main() -> int:
             continue
         try:
             tree = ast.parse(py.read_text(encoding="utf-8"))
-        except (SyntaxError, UnicodeDecodeError):
+        except (SyntaxError, UnicodeDecodeError, ValueError):
             continue
         rel = py.relative_to(repo_root)
         hits: list[tuple[int, str]] = []

--- a/tests/unit/gates/test_ast_parse_null_byte_guard.py
+++ b/tests/unit/gates/test_ast_parse_null_byte_guard.py
@@ -32,7 +32,22 @@ from pathlib import Path
 
 import pytest
 
-SRC_ROOT = Path(__file__).resolve().parents[3] / "src" / "attune"
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+#: Every root that runs ``ast.parse`` over a tree of files. Scoping this
+#: to ``src/attune`` (as it was until 2026-08-22) left the gate blind to
+#: ITSELF and to every other whole-tree scanner: widening it surfaced 14
+#: ValueError-blind sites, four of them in gates or CI scripts, including
+#: this file. A gate that crashes on the input it exists to guard against
+#: is a failed gatekeeper, and absence is not a pass (contract §7).
+SCAN_ROOTS = (
+    REPO_ROOT / "src" / "attune",
+    REPO_ROOT / "scripts",
+    REPO_ROOT / "tests",
+    REPO_ROOT / "plugin",
+)
+
+SRC_ROOT = REPO_ROOT / "src" / "attune"
 
 #: Catching either of these subsumes ``ValueError``.
 _CATCH_ALL = {"Exception", "BaseException"}
@@ -72,7 +87,7 @@ def _unguarded_sites(path: Path) -> list[str]:
     """Return ``file:line`` for each ast.parse under a ValueError-blind try."""
     try:
         tree = ast.parse(path.read_text(encoding="utf-8", errors="replace"))
-    except SyntaxError:
+    except (SyntaxError, ValueError):
         return []
 
     hits: list[str] = []
@@ -86,17 +101,20 @@ def _unguarded_sites(path: Path) -> list[str]:
             caught |= _handler_names(handler)
         if "ValueError" in caught or caught & _CATCH_ALL:
             continue
-        hits.append(f"{path.relative_to(SRC_ROOT.parent.parent)}:{node.lineno}")
+        hits.append(f"{path.relative_to(REPO_ROOT)}:{node.lineno}")
     return hits
 
 
 def test_guarded_ast_parse_also_catches_value_error() -> None:
     """A try/except around ast.parse must cover the null-byte ValueError."""
     offenders: list[str] = []
-    for path in sorted(SRC_ROOT.rglob("*.py")):
-        if "__pycache__" in str(path):
+    for root in SCAN_ROOTS:
+        if not root.exists():
             continue
-        offenders.extend(_unguarded_sites(path))
+        for path in sorted(root.rglob("*.py")):
+            if "__pycache__" in str(path):
+                continue
+            offenders.extend(_unguarded_sites(path))
 
     assert not offenders, (
         "ast.parse guarded by a handler set that misses ValueError — a "

--- a/tests/unit/gates/test_broad_except_ratchet.py
+++ b/tests/unit/gates/test_broad_except_ratchet.py
@@ -388,7 +388,7 @@ def _handler_is_broad(handler: ast.ExceptHandler) -> bool:
 def _count_in_file(path: Path) -> int:
     try:
         tree = ast.parse(path.read_text(encoding="utf-8", errors="replace"))
-    except (OSError, SyntaxError):
+    except (OSError, SyntaxError, ValueError):
         # Unparseable/unreadable files cannot be audited; skip rather than
         # fail the gate on something that is not a broad-except problem.
         return 0

--- a/tests/unit/security/test_security_remediation.py
+++ b/tests/unit/security/test_security_remediation.py
@@ -143,7 +143,7 @@ class TestNoActualVulnerabilities:
                         if isinstance(node.func, ast.Name):
                             if node.func.id in ("eval", "exec"):
                                 eval_exec_found.append((py_file, node.lineno, node.func.id))
-            except SyntaxError:
+            except (SyntaxError, ValueError):
                 # Skip files that can't be parsed
                 pass
 

--- a/tests/unit/test_env_isolation_guard.py
+++ b/tests/unit/test_env_isolation_guard.py
@@ -71,7 +71,7 @@ def test_no_module_level_binding_freezes_a_resolver_result():
     for path in (repo_root / "src" / "attune").rglob("*.py"):
         try:
             tree = ast.parse(path.read_text(encoding="utf-8", errors="ignore"))
-        except SyntaxError:  # pragma: no cover - unparseable file
+        except (SyntaxError, ValueError):  # pragma: no cover - unparseable file
             continue
         for node in tree.body:  # module level only
             if isinstance(node, ast.Assign | ast.AnnAssign):


### PR DESCRIPTION
## What

The gate that exists to catch `ValueError`-blind `ast.parse` calls scanned only `src/attune` — so **it never saw itself**, or any other whole-tree scanner. Widening it to `src + scripts + tests + plugin` surfaced **14** sites, four of them in gates or CI scripts.

`ast.parse` raises `ValueError`, not `SyntaxError`, on a null byte:

```
ValueError: source code string cannot contain null bytes
```

Every site caught only `SyntaxError` (or `+ OSError` / `+ UnicodeDecodeError`), so **one null-byte .py file anywhere aborts the entire scan** instead of skipping that file. Demonstrated before fixing — both gate helpers crash on such a file. These are whole-tree scanners, so the blast radius is the repo. A failed gatekeeper fails the gate; absence is not a pass (contract §7).

## The 14

| File | Sites |
|---|---|
| `tests/unit/gates/test_ast_parse_null_byte_guard.py` | 1 — **the gate itself** |
| `tests/unit/gates/test_broad_except_ratchet.py` | 1 |
| `tests/unit/security/test_security_remediation.py` | 1 |
| `tests/unit/test_env_isolation_guard.py` | 1 |
| `scripts/audit_doc_imports.py` | 2 — the CI doc-import gate |
| `scripts/check_doc_examples.py` | 2 |
| `scripts/find_dead_defensive_code.py` | 2 |
| `scripts/auto_implement_all_todos.py` | 2 |
| `scripts/ast_api_extractor.py` | 1 |
| `scripts/check_test_quality.py` | 1 |

## Red-first

The widened gate was landed against the current tree **first** and its failure captured (14 offenders), then every site fixed in the same commit until green — the repo's ratified pattern for new gate scope. Mutation-checked: reverting any single site fails the gate again.

The fix is one handler each — `ValueError` appended to the existing tuple. `# pragma: no cover` comments and `as e` bindings are preserved, and the patcher **re-parsed every file before writing** (an earlier attempt of mine collapsed line endings and left two files unparseable; the gate passed anyway, because `_unguarded_sites` skips files it cannot parse — that near-miss is why the parse check is now part of the write).

## Provenance, and why the scope matters

Found by the release-audit stage's sweep over the 14.0.0 release diff (`docs/specs/release-audit-stage`). **Two** of the 14 were in that diff; the other **12** were already present, invisible behind the gate's own `src/attune` scope.

That is the concrete argument against narrowing a sweep by path: a scope exclusion makes a gate blind in a way that looks like health — it passes green while never looking at the code that would fail it.

## Verification

- `tests/unit/gates/`: **330 passed** with the widened gate
- security-remediation + env-isolation + classes suites: **115 passed, 5 skipped**
- `scripts/audit_doc_imports.py` still runs clean on `docs/reference`
- Every touched file re-parses; the diff is **handler lines only**
- Pinned `black`, `ruff`, `ruff-bare-exception-check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)