### PR TITLE
feat(classes): release-audit stage Phase 1 — packet, sitting, manifest, /release gate

### DIFF
--- a/.agents/skills/release/SKILL.md
+++ b/.agents/skills/release/SKILL.md
@@ -13,6 +13,7 @@ Release preparation, validation, and publishing.
 | `prep` | Release readiness checks |
 | `security` | Pre-release security audit |
 | `health` | Code health check |
+| `audit` | Release-audit stage — what class of defect could this release introduce? |
 | `publish` | Version bump and publish |
 
 ## Usage
@@ -22,6 +23,7 @@ Release preparation, validation, and publishing.
 /release prep           # Release prep checks
 /release security       # Security audit
 /release health         # Health check
+/release audit          # Release-audit stage (packet + sitting)
 /release publish        # Publish release
 ```
 
@@ -59,9 +61,57 @@ Run code health checks:
 - Type check status
 - Dependency audit
 
+### audit
+
+The release-audit stage (`docs/specs/release-audit-stage/`). The other
+release surfaces check hygiene; this one asks what class of defect THIS
+diff could have introduced. It sits every release (D2) — an empty
+residual still sits, which is cheap by design.
+
+```bash
+python -m attune.classes.stage --repo <owner/name>
+```
+
+Six steps: baseline (merge-base vs the last release tag) -> reconcile
+(CLOSED gates green in CI, bound to this head SHA) -> sweep (rules over
+the changed `src/` surface, D10) -> residual packet -> sitting (three
+seats, one round) -> chair rules.
+
+Exit codes are the contract:
+
+| Code | Meaning | What to do |
+| ---- | ------- | ---------- |
+| 0 | Ready for the chair | Rule each residual item |
+| 1 | Aborted | Read `aborted_at` — a red reconcile means fix CI first; seats never sit on a broken baseline |
+| 2 | Residual exceeds schema v1 | **Split the release.** The chair splits; the tool re-runs each partition. Never truncate. |
+
+Then the chair rules every item exactly once
+(`SHIP` / `HOLD` / `GATE-FIRST` / `DEFER`) and a manifest is written to
+`.attune/release-manifests/<tag>.json`. A manifest is immutable; a
+re-run writes a new one.
+
 ### publish
 
-Use `AskUserQuestion` to confirm:
+**Gate first — a tag needs a cleared audit manifest (R7):**
+
+```bash
+python -c "
+from pathlib import Path
+from attune.classes.manifest import require_manifest, ManifestError
+try:
+    m = require_manifest(Path('.'), '<tag>', '<full-40-char-head-sha>')
+    print('audit manifest OK:', m.chair_receipt)
+except ManifestError as e:
+    raise SystemExit(f'REFUSED [{e.reason}] {e.detail}')
+"
+```
+
+This refuses a tag with no manifest, a manifest recorded against a
+DIFFERENT commit (a ruling on an earlier SHA does not authorize this
+tag), or one whose chair left items at `HOLD`/`GATE-FIRST` — D4's teeth:
+the stage may hold a release until a re-exposed class gets its gate.
+
+Then use `AskUserQuestion` to confirm:
 
 - Version bump type? (patch, minor, major)
 - Changelog reviewed?

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -31,6 +31,7 @@ Release preparation, validation, and publishing.
 | `prep` | Release readiness checks |
 | `security` | Pre-release security audit |
 | `health` | Code health check |
+| `audit` | Release-audit stage — what class of defect could this release introduce? |
 | `publish` | Version bump and publish |
 
 ## Usage
@@ -40,6 +41,7 @@ Release preparation, validation, and publishing.
 /release prep           # Release prep checks
 /release security       # Security audit
 /release health         # Health check
+/release audit          # Release-audit stage (packet + sitting)
 /release publish        # Publish release
 ```
 
@@ -77,9 +79,57 @@ Run code health checks:
 - Type check status
 - Dependency audit
 
+### audit
+
+The release-audit stage (`docs/specs/release-audit-stage/`). The other
+release surfaces check hygiene; this one asks what class of defect THIS
+diff could have introduced. It sits every release (D2) — an empty
+residual still sits, which is cheap by design.
+
+```bash
+python -m attune.classes.stage --repo <owner/name>
+```
+
+Six steps: baseline (merge-base vs the last release tag) -> reconcile
+(CLOSED gates green in CI, bound to this head SHA) -> sweep (rules over
+the changed `src/` surface, D10) -> residual packet -> sitting (three
+seats, one round) -> chair rules.
+
+Exit codes are the contract:
+
+| Code | Meaning | What to do |
+| ---- | ------- | ---------- |
+| 0 | Ready for the chair | Rule each residual item |
+| 1 | Aborted | Read `aborted_at` — a red reconcile means fix CI first; seats never sit on a broken baseline |
+| 2 | Residual exceeds schema v1 | **Split the release.** The chair splits; the tool re-runs each partition. Never truncate. |
+
+Then the chair rules every item exactly once
+(`SHIP` / `HOLD` / `GATE-FIRST` / `DEFER`) and a manifest is written to
+`.attune/release-manifests/<tag>.json`. A manifest is immutable; a
+re-run writes a new one.
+
 ### publish
 
-Use `AskUserQuestion` to confirm:
+**Gate first — a tag needs a cleared audit manifest (R7):**
+
+```bash
+python -c "
+from pathlib import Path
+from attune.classes.manifest import require_manifest, ManifestError
+try:
+    m = require_manifest(Path('.'), '<tag>', '<full-40-char-head-sha>')
+    print('audit manifest OK:', m.chair_receipt)
+except ManifestError as e:
+    raise SystemExit(f'REFUSED [{e.reason}] {e.detail}')
+"
+```
+
+This refuses a tag with no manifest, a manifest recorded against a
+DIFFERENT commit (a ruling on an earlier SHA does not authorize this
+tag), or one whose chair left items at `HOLD`/`GATE-FIRST` — D4's teeth:
+the stage may hold a release until a re-exposed class gets its gate.
+
+Then use `AskUserQuestion` to confirm:
 
 - Version bump type? (patch, minor, major)
 - Changelog reviewed?

--- a/docs/specs/release-audit-stage/decisions.md
+++ b/docs/specs/release-audit-stage/decisions.md
@@ -80,3 +80,44 @@ release, whether the sitting changed any disposition from the §7
 pre-filled defaults. Zero deltas across ~6 releases puts D2 (the
 every-release sitting) up for review by measurement rather than
 argument — the same retire-by-evidence mechanism ruled for role (b).
+
+## D10 — The sweep is package-scoped (RATIFIED chair 2026-08-22)
+
+The per-release sweep scans `src/` only. Amends R1's scan-path
+semantics, which named no root.
+
+**Why.** The rule pack's calibration receipts were measured against
+PACKAGE sites — the R7 receipt is "11 confirmed sites fixed in PR #2121"
+in `src/attune`. Running those rules over `tests/` is
+out-of-distribution: the recorded recall/precision does not transfer,
+and a test that does `data = json.loads(fixture); data["k"]` is
+controlled input, not the malformed-input class the rule targets.
+
+**The measurement that forced it.** The stage's first live run, on the
+real `v13.0.2..HEAD` release diff, produced **8/8 blocking hits, all in
+test files**. Under D5 that would have held 14.0.0 on eight false
+positives — precisely the failure D5 names, "a noisy gate gets
+allowlisted into uselessness". Rescanning scoped: 53 changed files, 20
+swept, **0 blocking**, and §0 still names all nine removed public
+symbols. The breaking change stays visible; the noise goes.
+
+**Scope of this ruling — narrow, deliberately.** It governs the
+per-release SWEEP only. Continuous gates keep scanning the whole tree,
+and narrowing THEM is the opposite call. Evidence from the same
+session: the `ast.parse` null-byte gate was scoped to `src/attune` and
+therefore never saw ITSELF; widening it surfaced 14 ValueError-blind
+sites, 12 of them long-standing, four in gates or CI scripts. A
+scope exclusion makes a gate blind in a way that looks like health.
+
+**The counter-position, recorded.** The lead argued against scoping by
+path at all, proposing instead that a hit BLOCKS only where the rule's
+calibration matches the surface it was measured on, while everything
+scanned stays visible as an advisory §2 row — same clearing of 14.0.0,
+without buying it by not looking. The chair chose the simpler path
+scope. Consequence accepted: defect shapes in `tests/` and `scripts/`
+are outside the per-release audit and rely on continuous gates instead.
+
+**Anti-blindness requirement.** Because a narrowed sweep must not read
+like a clean one, the packet's §0 reports `files_changed`,
+`files_swept`, `files_not_swept`, and `sweep_scope`. An empty residual
+is never ambiguous between "no defects here" and "did not look here".

--- a/docs/specs/release-audit-stage/requirements.md
+++ b/docs/specs/release-audit-stage/requirements.md
@@ -82,6 +82,14 @@ metadata `{id, invariant, calibration, fixtures}`.
   normalized repo-relative paths; deleted files are skipped, renames
   scan the new path, binary/generated files are excluded by the same
   filters the sweep suite used.
+- **Sweep scope** (D10, chair-ruled 2026-08-22): the per-release sweep
+  scans `src/` only, because the calibration receipts were measured
+  against package sites. Deleted paths are still tracked separately —
+  the sweep skips them, but the packet's §0 symbol delta must not, since
+  a deleted module is the clearest public-surface removal there is.
+  The packet reports `files_swept` and `files_not_swept` so a narrowed
+  sweep cannot read as a clean one. This governs the SWEEP only;
+  continuous gates keep scanning the whole tree.
 - **Fail closed** (Agy#7): a rule callable crash or timeout marks the
   class `SCAN-ERROR`, lands in packet §2, and aborts the stage unless
   the chair explicitly waives — a failed gatekeeper fails the gate

--- a/src/attune/classes/baseline.py
+++ b/src/attune/classes/baseline.py
@@ -32,6 +32,18 @@ __all__ = ["Baseline", "BaselineError", "resolve_baseline", "changed_files", "de
 #: become one.
 _RELEASE_TAG = re.compile(r"^v\d+\.\d+\.\d+$")
 
+#: Roots the release-audit sweep looks at. Chair-ruled 2026-08-22 (D10):
+#: the rules' calibration receipts were measured against PACKAGE sites,
+#: so running them over tests/ is out-of-distribution — the recorded
+#: recall/precision does not transfer, and the first live run produced
+#: 8/8 blocking hits that were all controlled-input test fixtures.
+#:
+#: This scopes the per-release SWEEP only. Continuous gates deliberately
+#: scan the whole tree: narrowing THEM is how a gate goes blind (the
+#: null-byte gate was scoped to src/attune and so never saw itself —
+#: widening it found 14 sites, 12 of them long-standing).
+SWEEP_ROOTS = ("src/",)
+
 #: Extensions the rule pack cannot parse. Kept in step with the sweep's
 #: own filters (R1: "binary/generated files are excluded by the same
 #: filters the sweep suite used") — the sweep only parses Python.
@@ -70,6 +82,21 @@ class Baseline:
     #: symbol delta — a deleted module is the clearest surface removal
     #: there is, and 14.0.0's own breaking change lives in one.
     deleted: tuple[str, ...] = field(default=())
+
+    @property
+    def to_sweep(self) -> tuple[str, ...]:
+        """Changed paths the release-audit sweep actually scans (D10).
+
+        A subset of :attr:`changed`. The packet reports both counts so a
+        reader can see what was NOT looked at — a narrowed sweep that
+        hides its own narrowing is how a gate goes quietly blind.
+        """
+        return tuple(p for p in self.changed if p.startswith(SWEEP_ROOTS))
+
+    @property
+    def not_swept(self) -> tuple[str, ...]:
+        """Changed paths deliberately outside the sweep (D10)."""
+        return tuple(p for p in self.changed if not p.startswith(SWEEP_ROOTS))
 
     @property
     def tag_range(self) -> str:

--- a/src/attune/classes/baseline.py
+++ b/src/attune/classes/baseline.py
@@ -1,0 +1,215 @@
+"""Release-audit baseline resolution (release-audit-stage R3 step 0).
+
+The stage asks what class of defect *this release* could have
+introduced, so every later step is relative to one resolved point:
+
+    git diff $(git merge-base <last-release-tag> HEAD)..HEAD
+
+with a ``--baseline <ref>`` override. The resolved SHA is recorded in
+the manifest (R7) so a reader can reproduce exactly what was swept.
+
+**Fails closed, never guesses** (R3): no release tag, a shallow clone,
+or an unresolvable override raises :class:`BaselineError` rather than
+falling back to a default range. A guessed range would make the whole
+audit assert something untrue — an empty sweep reads identically
+whether the diff is clean or the range was wrong.
+
+Copyright 2025 Smart AI Memory, LLC
+Licensed under the Apache License, Version 2.0
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from dataclasses import dataclass, field
+from pathlib import Path
+
+__all__ = ["Baseline", "BaselineError", "resolve_baseline", "changed_files", "deleted_files"]
+
+#: Release tags look like ``v1.2.3``. Anything else (a moved pointer, a
+#: dated snapshot tag) is not a release boundary and must not silently
+#: become one.
+_RELEASE_TAG = re.compile(r"^v\d+\.\d+\.\d+$")
+
+#: Extensions the rule pack cannot parse. Kept in step with the sweep's
+#: own filters (R1: "binary/generated files are excluded by the same
+#: filters the sweep suite used") — the sweep only parses Python.
+_SCANNABLE_SUFFIXES = frozenset({".py"})
+
+
+class BaselineError(RuntimeError):
+    """Preflight failure — the audit has no valid range to work from.
+
+    Carries ``reason`` so a caller can render a structured diagnostic
+    instead of a bare string.
+    """
+
+    def __init__(self, reason: str, detail: str = "") -> None:
+        self.reason = reason
+        self.detail = detail
+        super().__init__(f"{reason}: {detail}" if detail else reason)
+
+
+@dataclass(frozen=True)
+class Baseline:
+    """One resolved audit range."""
+
+    #: The tag the range starts from, or None when explicitly overridden.
+    tag: str | None
+    #: The merge-base SHA the sweep is relative to (full 40 chars).
+    baseline_sha: str
+    #: The commit being audited (full 40 chars).
+    head_sha: str
+    #: How the range was chosen — "last-release-tag" or "override".
+    source: str
+    #: Repo-relative paths added or modified in the range, scannable only.
+    changed: tuple[str, ...] = field(default=())
+    #: Scannable paths DELETED in the range. Skipped by the sweep (there
+    #: is nothing left to scan) but load-bearing for the packet's public
+    #: symbol delta — a deleted module is the clearest surface removal
+    #: there is, and 14.0.0's own breaking change lives in one.
+    deleted: tuple[str, ...] = field(default=())
+
+    @property
+    def tag_range(self) -> str:
+        """Human-readable range for the packet header (R4 §0)."""
+        return f"{self.tag or self.baseline_sha[:9]}..{self.head_sha[:9]}"
+
+
+def _git(repo_root: Path, *args: str, check: bool = True) -> str:
+    """Run one git command in ``repo_root`` and return stripped stdout."""
+    try:
+        result = subprocess.run(  # noqa: S603 — fixed argv, no shell
+            ["git", "-C", str(repo_root), *args],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        raise BaselineError("git-unavailable", f"{args[0]}: {exc}") from exc
+    if check and result.returncode != 0:
+        raise BaselineError(
+            "git-failed", f"{' '.join(args)}: {result.stderr.strip() or result.returncode}"
+        )
+    return result.stdout.strip()
+
+
+def _assert_full_clone(repo_root: Path) -> None:
+    """A shallow clone cannot resolve a merge-base — fail closed (R3)."""
+    if _git(repo_root, "rev-parse", "--is-shallow-repository") == "true":
+        raise BaselineError(
+            "shallow-clone",
+            "merge-base against a release tag needs full history; "
+            "fetch with --unshallow before auditing",
+        )
+
+
+def last_release_tag(repo_root: Path) -> str:
+    """Newest ``vX.Y.Z`` tag by version order.
+
+    Sorted by ``version:refname`` rather than commit date so a tag
+    pushed late for an older release cannot masquerade as the latest.
+    """
+    raw = _git(repo_root, "tag", "--list", "v*", "--sort=-version:refname")
+    for line in raw.splitlines():
+        candidate = line.strip()
+        if _RELEASE_TAG.match(candidate):
+            return candidate
+    raise BaselineError(
+        "no-release-tag",
+        "no vX.Y.Z tag found; pass --baseline <ref> to audit an explicit range",
+    )
+
+
+def changed_files(repo_root: Path, baseline_sha: str, head: str = "HEAD") -> tuple[str, ...]:
+    """Scannable repo-relative paths added or modified in the range.
+
+    R1 scan-path semantics: deleted files are skipped (nothing left to
+    scan), a rename scans the NEW path, and files the rule pack cannot
+    parse are excluded by the same filter the sweep uses.
+    """
+    raw = _git(repo_root, "diff", "--name-status", "-M", f"{baseline_sha}..{head}")
+    paths: list[str] = []
+    for line in raw.splitlines():
+        parts = line.split("\t")
+        if len(parts) < 2:
+            continue
+        status = parts[0]
+        if status.startswith("D"):
+            continue  # deleted — nothing to scan
+        # A rename/copy row is "R100\told\tnew"; scan the new path.
+        path = parts[-1]
+        if Path(path).suffix in _SCANNABLE_SUFFIXES:
+            paths.append(path)
+    # Deterministic order so a packet hash is stable across runs.
+    return tuple(sorted(dict.fromkeys(paths)))
+
+
+def deleted_files(repo_root: Path, baseline_sha: str, head: str = "HEAD") -> tuple[str, ...]:
+    """Scannable repo-relative paths DELETED in the range.
+
+    The sweep skips these, but the packet's §0 symbol delta must not:
+    removing a module removes every public name it exported.
+    """
+    raw = _git(repo_root, "diff", "--name-status", "-M", f"{baseline_sha}..{head}")
+    paths = [
+        parts[1]
+        for line in raw.splitlines()
+        if (parts := line.split("\t")) and len(parts) >= 2 and parts[0].startswith("D")
+        if Path(parts[1]).suffix in _SCANNABLE_SUFFIXES
+    ]
+    return tuple(sorted(dict.fromkeys(paths)))
+
+
+def resolve_baseline(
+    repo_root: Path | None = None,
+    *,
+    override: str | None = None,
+    head: str = "HEAD",
+) -> Baseline:
+    """Resolve the audit range, or raise :class:`BaselineError`.
+
+    Args:
+        repo_root: Repository to audit; defaults to the current directory.
+        override: An explicit ref to diff from (``--baseline``). When
+            given, no tag lookup happens — the caller has named the range.
+        head: The commit being audited.
+
+    Returns:
+        A :class:`Baseline` with both SHAs resolved to full 40 characters
+        and the scannable changed-file list attached.
+
+    Raises:
+        BaselineError: No release tag, a shallow clone, or a ref that
+            does not resolve. Never returns a guessed range.
+
+    """
+    root = Path(repo_root) if repo_root is not None else Path.cwd()
+    _assert_full_clone(root)
+
+    head_sha = _git(root, "rev-parse", head)
+
+    if override is not None:
+        try:
+            start = _git(root, "rev-parse", override)
+        except BaselineError as exc:
+            raise BaselineError("bad-baseline-ref", f"{override!r} does not resolve") from exc
+        tag: str | None = None
+        source = "override"
+    else:
+        tag = last_release_tag(root)
+        start = _git(root, "rev-parse", tag)
+        source = "last-release-tag"
+
+    merge_base = _git(root, "merge-base", start, head_sha)
+
+    return Baseline(
+        tag=tag,
+        baseline_sha=merge_base,
+        head_sha=head_sha,
+        source=source,
+        changed=changed_files(root, merge_base, head_sha),
+        deleted=deleted_files(root, merge_base, head_sha),
+    )

--- a/src/attune/classes/manifest.py
+++ b/src/attune/classes/manifest.py
@@ -1,0 +1,327 @@
+"""The chair manifest — release-audit-stage R7.
+
+What connects the audit to deployment. Without it the stage is
+advisory-by-accident: a chair could sit, rule, and then tag something
+else entirely. ``release-execute`` verifies a valid manifest exists for
+the tag being cut, so a ruling is bound to a release rather than to a
+conversation.
+
+Two invariants do the work:
+
+**Completion (R3).** The stage is complete only when EVERY residual item
+id carries EXACTLY ONE ruling. A missing ruling means the chair did not
+see an item; a duplicate means two rulings disagree. Both reject the
+manifest rather than picking a winner.
+
+**Immutability (R7).** A manifest is written once. A re-run writes a new
+one — amending in place would let a recorded decision change after the
+fact, which is the whole thing the receipt exists to prevent.
+
+``sitting_delta`` (D9) is REQUIRED, not optional: per item, did any seat
+amendment change the chair's disposition away from the packet's §7
+default? Its release-over-release tally is how the every-release sitting
+earns — or loses — its own justification, by measurement rather than
+argument.
+
+Copyright 2025 Smart AI Memory, LLC
+Licensed under the Apache License, Version 2.0
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from attune.classes.packet import DISPOSITIONS, Packet
+from attune.security.path_validation import _validate_file_path
+
+__all__ = [
+    "MANIFEST_SCHEMA_VERSION",
+    "ManifestError",
+    "Manifest",
+    "manifest_path",
+    "build_manifest",
+    "write_manifest",
+    "load_manifest",
+    "validate_manifest",
+    "require_manifest",
+]
+
+MANIFEST_SCHEMA_VERSION = 1
+
+_REQUIRED_KEYS = (
+    "schema_version",
+    "tag",
+    "head_sha",
+    "baseline_sha",
+    "packet_hash",
+    "reconcile_receipt",
+    "per_item_dispositions",
+    "defer_refs",
+    "sitting_delta",
+    "chair_receipt",
+)
+
+
+class ManifestError(ValueError):
+    """A manifest is missing, malformed, or does not rule on the packet."""
+
+    def __init__(self, reason: str, detail: str = "") -> None:
+        self.reason = reason
+        self.detail = detail
+        super().__init__(f"{reason}: {detail}" if detail else reason)
+
+
+@dataclass(frozen=True)
+class Manifest:
+    """One chair ruling, bound to one tag and one packet."""
+
+    tag: str
+    head_sha: str
+    baseline_sha: str
+    packet_hash: str
+    reconcile_receipt: dict[str, Any]
+    per_item_dispositions: dict[str, str]
+    defer_refs: tuple[str, ...]
+    sitting_delta: dict[str, bool]
+    chair_receipt: str
+    schema_version: int = MANIFEST_SCHEMA_VERSION
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "tag": self.tag,
+            "head_sha": self.head_sha,
+            "baseline_sha": self.baseline_sha,
+            "packet_hash": self.packet_hash,
+            "reconcile_receipt": self.reconcile_receipt,
+            "per_item_dispositions": dict(self.per_item_dispositions),
+            "defer_refs": list(self.defer_refs),
+            "sitting_delta": dict(self.sitting_delta),
+            "chair_receipt": self.chair_receipt,
+        }
+
+    @property
+    def blocked(self) -> tuple[str, ...]:
+        """Items the chair did NOT clear — the release stops for these (D4)."""
+        return tuple(
+            sorted(
+                item_id
+                for item_id, ruling in self.per_item_dispositions.items()
+                if ruling in ("HOLD", "GATE-FIRST")
+            )
+        )
+
+    @property
+    def sitting_changed_anything(self) -> bool:
+        """D9: did the sitting move a single disposition this release?"""
+        return any(self.sitting_delta.values())
+
+
+#: A release tag is caller-supplied and lands in a filesystem path, so it
+#: is constrained to the characters a tag can legitimately hold. Without
+#: this, a "tag" of ``../../../etc/cron.d/x`` would write outside the
+#: manifest directory — the path-validation gate flagged exactly this.
+_SAFE_TAG = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$")
+
+
+def manifest_path(repo_root: Path, tag: str) -> Path:
+    """Where a tag's manifest lives.
+
+    The tag is validated and the resolved path is confined to the
+    manifest directory: a manifest is a release receipt, so an
+    attacker-influenced tag must not be able to place a file anywhere
+    else, nor read one from anywhere else.
+
+    Raises:
+        ManifestError: The tag is not a plausible tag name, or the
+            resolved path escapes ``.attune/release-manifests``.
+
+    """
+    if not isinstance(tag, str) or not _SAFE_TAG.match(tag):
+        raise ManifestError("bad-tag", f"{tag!r} is not a valid release tag name")
+
+    root = Path(repo_root) / ".attune" / "release-manifests"
+    candidate = root / f"{tag}.json"
+    try:
+        validated = _validate_file_path(str(candidate), allowed_dir=str(root.resolve().parent))
+    except ValueError as exc:
+        raise ManifestError("unsafe-path", str(exc)) from exc
+
+    if validated.parent.resolve() != root.resolve():
+        raise ManifestError("unsafe-path", f"{tag!r} escapes the manifest directory")
+    return validated
+
+
+def build_manifest(
+    packet: Packet,
+    *,
+    tag: str,
+    head_sha: str,
+    baseline_sha: str,
+    rulings: dict[str, str],
+    chair_receipt: str,
+    reconcile_receipt: dict[str, Any] | None = None,
+    defer_refs: tuple[str, ...] = (),
+    sitting_delta: dict[str, bool] | None = None,
+) -> Manifest:
+    """Assemble a manifest and validate it against the packet it rules on.
+
+    Raises:
+        ManifestError: A ruling is missing, unknown, or names an item the
+            packet does not contain. Rather than silently accepting a
+            partial ruling set, which would let the stage report complete.
+
+    """
+    item_ids = {item.item_id for item in packet.items}
+    ruled = set(rulings)
+
+    missing = sorted(item_ids - ruled)
+    if missing:
+        raise ManifestError("missing-rulings", f"{len(missing)} unruled item(s): {missing[:5]}")
+
+    unknown = sorted(ruled - item_ids)
+    if unknown:
+        raise ManifestError("unknown-items", f"rulings for items not in the packet: {unknown[:5]}")
+
+    bad = sorted({r for r in rulings.values() if r not in DISPOSITIONS})
+    if bad:
+        raise ManifestError("bad-disposition", f"{bad} not in {list(DISPOSITIONS)}")
+
+    delta = sitting_delta if sitting_delta is not None else {}
+    missing_delta = sorted(item_ids - set(delta))
+    if missing_delta:
+        raise ManifestError(
+            "missing-sitting-delta",
+            f"D9 requires a per-item delta; {len(missing_delta)} missing",
+        )
+
+    return Manifest(
+        tag=tag,
+        head_sha=head_sha,
+        baseline_sha=baseline_sha,
+        packet_hash=packet.packet_hash,
+        reconcile_receipt=reconcile_receipt or {},
+        per_item_dispositions=dict(rulings),
+        defer_refs=tuple(defer_refs),
+        sitting_delta=dict(delta),
+        chair_receipt=chair_receipt,
+    )
+
+
+def write_manifest(manifest: Manifest, repo_root: Path) -> Path:
+    """Write a manifest atomically. Refuses to overwrite (R7 immutability).
+
+    Raises:
+        ManifestError: A manifest already exists for this tag. A re-run
+            writes a NEW manifest under a new tag; amending in place would
+            let a recorded decision change after it was relied on.
+
+    """
+    target = manifest_path(repo_root, manifest.tag)
+    if target.exists():
+        raise ManifestError(
+            "already-exists",
+            f"{target} — manifests are immutable; a re-run writes a new tag",
+        )
+    target.parent.mkdir(parents=True, exist_ok=True)
+
+    payload = json.dumps(manifest.as_dict(), indent=2, sort_keys=True) + "\n"
+    handle, tmp = tempfile.mkstemp(dir=str(target.parent), suffix=".tmp")
+    try:
+        with os.fdopen(handle, "w", encoding="utf-8") as stream:
+            stream.write(payload)
+        os.replace(tmp, target)
+    except OSError:
+        Path(tmp).unlink(missing_ok=True)
+        raise
+    return target
+
+
+def validate_manifest(data: dict[str, Any]) -> Manifest:
+    """Parse and validate a manifest mapping.
+
+    Raises:
+        ManifestError: Missing keys, wrong schema version, an unknown
+            disposition, or an empty ``sitting_delta`` — D9 makes the
+            delta required, so a manifest without it is invalid.
+
+    """
+    if not isinstance(data, dict):
+        raise ManifestError("not-a-mapping", type(data).__name__)
+
+    missing = [k for k in _REQUIRED_KEYS if k not in data]
+    if missing:
+        raise ManifestError("missing-keys", str(missing))
+
+    if data["schema_version"] != MANIFEST_SCHEMA_VERSION:
+        raise ManifestError(
+            "schema-version", f"expected {MANIFEST_SCHEMA_VERSION}, got {data['schema_version']!r}"
+        )
+
+    rulings = data["per_item_dispositions"]
+    if not isinstance(rulings, dict):
+        raise ManifestError("bad-dispositions", "per_item_dispositions must be a mapping")
+
+    bad = sorted({r for r in rulings.values() if r not in DISPOSITIONS})
+    if bad:
+        raise ManifestError("bad-disposition", f"{bad} not in {list(DISPOSITIONS)}")
+
+    delta = data["sitting_delta"]
+    if not isinstance(delta, dict) or (rulings and not delta):
+        raise ManifestError("missing-sitting-delta", "D9 requires a per-item sitting delta")
+
+    return Manifest(
+        tag=data["tag"],
+        head_sha=data["head_sha"],
+        baseline_sha=data["baseline_sha"],
+        packet_hash=data["packet_hash"],
+        reconcile_receipt=data["reconcile_receipt"],
+        per_item_dispositions=rulings,
+        defer_refs=tuple(data["defer_refs"]),
+        sitting_delta=delta,
+        chair_receipt=data["chair_receipt"],
+    )
+
+
+def load_manifest(repo_root: Path, tag: str) -> Manifest:
+    """Read and validate the manifest for ``tag``."""
+    target = manifest_path(repo_root, tag)
+    if not target.is_file():
+        raise ManifestError("no-manifest", f"no audit manifest for {tag} at {target}")
+    try:
+        data = json.loads(target.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as exc:
+        raise ManifestError("unreadable", f"{target}: {exc}") from exc
+    return validate_manifest(data)
+
+
+def require_manifest(repo_root: Path, tag: str, head_sha: str) -> Manifest:
+    """Gate for ``release-execute``: refuse a tag with no valid manifest.
+
+    Also refuses a manifest recorded against a DIFFERENT commit — a
+    ruling on an earlier SHA does not authorize the tag you are cutting
+    now, which is the same binding rule the reconcile receipt uses.
+
+    Raises:
+        ManifestError: No manifest, an invalid one, one bound to another
+            commit, or one whose chair left items blocked.
+
+    """
+    manifest = load_manifest(repo_root, tag)
+    if manifest.head_sha != head_sha:
+        raise ManifestError(
+            "sha-mismatch",
+            f"manifest rules on {manifest.head_sha[:9]}, tagging {head_sha[:9]}",
+        )
+    if manifest.blocked:
+        raise ManifestError(
+            "blocked-items",
+            f"chair did not clear {len(manifest.blocked)}: {list(manifest.blocked)[:5]}",
+        )
+    return manifest

--- a/src/attune/classes/packet.py
+++ b/src/attune/classes/packet.py
@@ -1,0 +1,383 @@
+"""The residual packet — release-audit-stage R4, schema v1.
+
+What the seats sit on. The packet is a small, normative artifact: eight
+sections, hard caps, and **no diff hunks or file contents**. Its job is
+to make an every-release sitting payable (D2) by keeping the reading
+cost near zero when the residual is empty, and bounded when it is not.
+
+**Over-cap is a refusal, never a truncation** (R4/Agy#4). A packet that
+silently dropped its 13th item would let the chair rule on a subset
+while believing they ruled on the whole — so :func:`build_packet`
+raises :class:`PacketOverCap` carrying structured diagnostics, and the
+chair splits the release (R4 split semantics: the chair splits, the
+tool re-runs).
+
+Section map::
+
+    §0 header        tag range, baseline SHA, files, packages, symbol delta
+    §1 reconcile     CI run id, workflow, HEAD SHA, conclusion
+    §2 sweep hits    class, file:line, excerpt, recall/precision, SCAN-ERROR
+    §3 exposure      fixed-but-ungated classes x changed surface (matrix)
+    §4 boundaries    new boundary kind + two program points each
+    §5 open classes  open class x file
+    §6 NULL          what this diff does NOT introduce
+    §7 dispositions  one pre-filled default per residual item
+
+Copyright 2025 Smart AI Memory, LLC
+Licensed under the Apache License, Version 2.0
+"""
+
+from __future__ import annotations
+
+import ast
+import hashlib
+import json
+import subprocess
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from attune.classes.baseline import Baseline
+
+__all__ = [
+    "DISPOSITIONS",
+    "PacketOverCap",
+    "Packet",
+    "ResidualItem",
+    "build_packet",
+]
+
+#: R3 disposition vocabulary — exactly these, no synonyms.
+DISPOSITIONS = ("SHIP", "HOLD", "GATE-FIRST", "DEFER")
+
+#: R4 hard caps. Exceeding any of them is a refusal, not a trim.
+MAX_WORDS = 1500
+MAX_ITEMS = 12
+MAX_SWEEP_ROWS = 20
+
+#: D5 — a calibrated HIT blocks, surface EXPOSURE only warns. These are
+#: PRE-FILLED defaults the seats amend and the chair rules on (R4 §7);
+#: they are never the final word.
+_DEFAULT_DISPOSITION = {
+    "hit": "GATE-FIRST",
+    "advisory-hit": "SHIP",
+    "exposure": "SHIP",
+    "open-class": "SHIP",
+    "boundary": "SHIP",
+}
+
+
+class PacketOverCap(RuntimeError):
+    """The residual does not fit schema v1 — the chair splits the release."""
+
+    def __init__(self, diagnostics: dict[str, Any]) -> None:
+        self.diagnostics = diagnostics
+        super().__init__(json.dumps(diagnostics, indent=2, sort_keys=True))
+
+    #: Process exit code reserved for an over-cap refusal (R4).
+    exit_code = 2
+
+
+@dataclass(frozen=True)
+class ResidualItem:
+    """One thing the chair must rule on.
+
+    ``item_id`` is stable for a given (kind, class, locus) so a manifest
+    ruling can be matched back to what it ruled on.
+    """
+
+    item_id: str
+    kind: str
+    class_id: str
+    locus: str
+    detail: str
+    default_disposition: str
+
+    def as_dict(self) -> dict[str, str]:
+        return {
+            "item_id": self.item_id,
+            "kind": self.kind,
+            "class_id": self.class_id,
+            "locus": self.locus,
+            "detail": self.detail,
+            "default_disposition": self.default_disposition,
+        }
+
+
+@dataclass(frozen=True)
+class Packet:
+    """A schema-v1 residual packet."""
+
+    sections: dict[str, Any]
+    items: tuple[ResidualItem, ...] = field(default=())
+    schema_version: int = 1
+
+    @property
+    def packet_hash(self) -> str:
+        """Content hash the manifest binds to (R7 ``packet_hash``)."""
+        payload = json.dumps(self.as_dict(), sort_keys=True, ensure_ascii=False)
+        return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+    @property
+    def blocking(self) -> tuple[ResidualItem, ...]:
+        """Items whose default is to stop the release (D4/D5 teeth)."""
+        return tuple(i for i in self.items if i.default_disposition in ("HOLD", "GATE-FIRST"))
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "sections": self.sections,
+            "items": [i.as_dict() for i in self.items],
+        }
+
+    def word_count(self) -> int:
+        return len(json.dumps(self.as_dict(), ensure_ascii=False).split())
+
+
+def _public_symbols(source: str) -> set[str]:
+    """Top-level public names a module exports."""
+    try:
+        tree = ast.parse(source)
+    except (SyntaxError, ValueError):
+        return set()
+    names: set[str] = set()
+    for node in tree.body:
+        if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef | ast.ClassDef):
+            if not node.name.startswith("_"):
+                names.add(node.name)
+        elif isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Name) and not target.id.startswith("_"):
+                    names.add(target.id)
+    return names
+
+
+def _show(repo_root: Path, ref: str, path: str) -> str:
+    """File contents at a ref, or "" when absent there."""
+    result = subprocess.run(  # noqa: S603 — fixed argv, no shell
+        ["git", "-C", str(repo_root), "show", f"{ref}:{path}"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    return result.stdout if result.returncode == 0 else ""
+
+
+#: Only these paths carry the PACKAGE's public surface. A test class
+#: named ``TestValidationError`` disappearing is not an API removal, and
+#: letting it into §0 buries the removals that actually break a caller.
+_PACKAGE_ROOTS = ("src/",)
+
+
+def _is_package_surface(path: str) -> bool:
+    return path.startswith(_PACKAGE_ROOTS)
+
+
+def _symbol_delta(repo_root: Path, baseline: Baseline) -> dict[str, list[str]]:
+    """Public symbols added/removed across the range (R4 §0).
+
+    A public-surface change is what makes a release breaking, so the
+    header states it rather than leaving the chair to infer it.
+
+    DELETED modules are included deliberately. The sweep skips them —
+    there is nothing left to scan — but every public name a deleted
+    module exported is removed, and that is the clearest breaking change
+    a release can contain. Reading only the changed set would have made
+    14.0.0's own breaking removal invisible here.
+    """
+    added: set[str] = set()
+    removed: set[str] = set()
+
+    for path in baseline.changed:
+        if not _is_package_surface(path):
+            continue
+        before = _public_symbols(_show(repo_root, baseline.baseline_sha, path))
+        after = _public_symbols(_show(repo_root, baseline.head_sha, path))
+        added |= after - before
+        removed |= before - after
+
+    for path in baseline.deleted:
+        if not _is_package_surface(path):
+            continue
+        removed |= _public_symbols(_show(repo_root, baseline.baseline_sha, path))
+
+    return {"added": sorted(added), "removed": sorted(removed)}
+
+
+def _packages_touched(changed: tuple[str, ...]) -> list[str]:
+    """Distinct top-level package paths in the changed set (R4 §0)."""
+    packages = set()
+    for path in changed:
+        parts = Path(path).parts
+        packages.add("/".join(parts[:2]) if len(parts) > 1 else parts[0])
+    return sorted(packages)
+
+
+def build_packet(
+    baseline: Baseline,
+    sweep: dict[str, Any],
+    register: dict[str, Any],
+    *,
+    repo_root: Path | None = None,
+    reconcile: dict[str, Any] | None = None,
+    boundaries: tuple[dict[str, Any], ...] = (),
+) -> Packet:
+    """Assemble the schema-v1 residual packet.
+
+    Args:
+        baseline: The resolved audit range (R3 step 0).
+        sweep: :func:`attune.classes.scan.scan_paths` output over
+            ``baseline.changed`` (R3 step 2).
+        register: :func:`attune.classes.register.derive_register` output.
+        repo_root: Repo to read file contents from for the §0 symbol delta.
+        reconcile: The §1 receipt, or None when reconcile has not run.
+        boundaries: §4 new-boundary inventory entries.
+
+    Returns:
+        A :class:`Packet` whose items each carry a pre-filled disposition.
+
+    Raises:
+        PacketOverCap: Any R4 cap exceeded. Carries diagnostics naming
+            which cap and by how much; the caller exits 2 and the chair
+            splits the release. Nothing is truncated.
+
+    """
+    root = Path(repo_root) if repo_root is not None else Path.cwd()
+    rows = register.get("rows", [])
+    by_status: dict[str, list[dict]] = {}
+    for row in rows:
+        by_status.setdefault(row["status"], []).append(row)
+
+    rule_meta = sweep.get("rules", {})
+    items: list[ResidualItem] = []
+
+    # -- §2 sweep hits ----------------------------------------------------
+    sweep_rows: list[dict[str, Any]] = []
+    for hit in sweep.get("hits", []):
+        meta = rule_meta.get(hit["rule_id"], {})
+        calibration = meta.get("calibration") or {}
+        calibrated = bool(meta.get("calibrated_here"))
+        locus = f"{hit['path']}:{hit['line']}"
+        sweep_rows.append(
+            {
+                "class_ids": meta.get("class_ids", []),
+                "rule_id": hit["rule_id"],
+                "locus": locus,
+                "excerpt": str(hit.get("detail", ""))[:120],
+                "recall": calibration.get("recall"),
+                "precision": calibration.get("precision"),
+                "calibrated_here": calibrated,
+            }
+        )
+        # Only a CALIBRATED hit becomes a residual item. An uncalibrated
+        # rule is advisory here (R1: "never blocks, never clears"), so it
+        # is reported as a sweep row and NOT given a chair ruling — it
+        # would consume the item cap with something unrulable.
+        if not calibrated:
+            continue
+        class_id = (meta.get("class_ids") or ["?"])[0]
+        items.append(
+            ResidualItem(
+                item_id=f"hit:{hit['rule_id']}:{locus}",
+                kind="hit",
+                class_id=class_id,
+                locus=locus,
+                detail=str(hit.get("detail", ""))[:120],
+                default_disposition=_DEFAULT_DISPOSITION["hit"],
+            )
+        )
+
+    # -- §3 ungated exposure: a MATRIX, never severity rows (D5) ----------
+    ungated = [r["class_id"] for r in by_status.get("FIXED-BUT-UNGATED", [])]
+    exposure_matrix = [
+        {"class_id": class_id, "changed_surface": bool(baseline.changed)} for class_id in ungated
+    ]
+    # D5: exposure WARNS through this matrix and nothing else. Minting a
+    # residual item per ungated class would put warning-severity rows in
+    # competition with hits for the item cap — the precise thing D5
+    # forbids, because a noisy gate gets allowlisted into uselessness.
+
+    # -- §5 open-class exposure -------------------------------------------
+    open_rows = []
+    for row in by_status.get("OPEN", []):
+        open_rows.append({"class_id": row["class_id"], "hits": row.get("calibrated_hits", 0)})
+        items.append(
+            ResidualItem(
+                item_id=f"open-class:{row['class_id']}",
+                kind="open-class",
+                class_id=row["class_id"],
+                locus="register",
+                detail="confirmed class with no gate",
+                default_disposition=_DEFAULT_DISPOSITION["open-class"],
+            )
+        )
+
+    # -- §4 new boundaries -------------------------------------------------
+    for boundary in boundaries:
+        items.append(
+            ResidualItem(
+                item_id=f"boundary:{boundary.get('kind')}:{boundary.get('locus')}",
+                kind="boundary",
+                class_id=str(boundary.get("class_id", "-")),
+                locus=str(boundary.get("locus", "")),
+                detail=str(boundary.get("kind", "")),
+                default_disposition=_DEFAULT_DISPOSITION["boundary"],
+            )
+        )
+
+    # -- §6 explicit NULL: stating what is ABSENT is the point -------------
+    null_section = {
+        "no_calibrated_hits": not any(i.kind == "hit" for i in items),
+        "no_scan_errors": not sweep.get("scan_errors"),
+        "no_public_symbols_removed": True,  # replaced below once computed
+        "no_new_boundaries": not boundaries,
+    }
+
+    symbol_delta = _symbol_delta(root, baseline)
+    null_section["no_public_symbols_removed"] = not symbol_delta["removed"]
+
+    sections = {
+        "0_header": {
+            "tag_range": baseline.tag_range,
+            "baseline_sha": baseline.baseline_sha,
+            "head_sha": baseline.head_sha,
+            "baseline_source": baseline.source,
+            "files_changed": len(baseline.changed),
+            "packages_touched": _packages_touched(baseline.changed),
+            "public_symbols": symbol_delta,
+        },
+        "1_reconcile": reconcile,
+        "2_sweep_hits": sweep_rows,
+        "3_ungated_exposure": exposure_matrix,
+        "4_new_boundaries": list(boundaries),
+        "5_open_class_exposure": open_rows,
+        "6_null": null_section,
+        "7_default_dispositions": [
+            {"item_id": i.item_id, "disposition": i.default_disposition} for i in items
+        ],
+        "scan_errors": sweep.get("scan_errors", []),
+    }
+
+    packet = Packet(sections=sections, items=tuple(items))
+
+    breaches = []
+    if len(items) > MAX_ITEMS:
+        breaches.append({"cap": "items", "limit": MAX_ITEMS, "actual": len(items)})
+    if len(sweep_rows) > MAX_SWEEP_ROWS:
+        breaches.append({"cap": "sweep_rows", "limit": MAX_SWEEP_ROWS, "actual": len(sweep_rows)})
+    words = packet.word_count()
+    if words > MAX_WORDS:
+        breaches.append({"cap": "words", "limit": MAX_WORDS, "actual": words})
+
+    if breaches:
+        raise PacketOverCap(
+            {
+                "error": "residual-over-cap",
+                "remedy": "split the release; each partition re-runs baseline -> sweep -> exposure",
+                "tag_range": baseline.tag_range,
+                "breaches": breaches,
+            }
+        )
+
+    return packet

--- a/src/attune/classes/packet.py
+++ b/src/attune/classes/packet.py
@@ -37,7 +37,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
-from attune.classes.baseline import Baseline
+from attune.classes.baseline import SWEEP_ROOTS, Baseline
 
 __all__ = [
     "DISPOSITIONS",
@@ -344,6 +344,13 @@ def build_packet(
             "head_sha": baseline.head_sha,
             "baseline_source": baseline.source,
             "files_changed": len(baseline.changed),
+            # D10: the sweep is package-scoped. Stating what was NOT
+            # looked at keeps a narrowed sweep from reading like a clean
+            # one — an empty residual must never be ambiguous between
+            # "no defects here" and "did not look here".
+            "files_swept": len(baseline.to_sweep),
+            "files_not_swept": len(baseline.not_swept),
+            "sweep_scope": list(SWEEP_ROOTS),
             "packages_touched": _packages_touched(baseline.changed),
             "public_symbols": symbol_delta,
         },

--- a/src/attune/classes/reconcile.py
+++ b/src/attune/classes/reconcile.py
@@ -1,0 +1,194 @@
+"""Reconcile receipt — release-audit-stage R3 step 1.
+
+Before anyone sits, the stage proves the classes already marked CLOSED
+are still green **on the commit being released**. That proof is a bound
+receipt, not a glance at a dashboard.
+
+The binding is the whole point (Codex#6): the receipt names an
+**allowlisted workflow**, the **repository**, the **HEAD SHA**, and a
+**successful conclusion**. A green run for an earlier commit does not
+authorize — that is exactly how a regression introduced in the last
+push slips through a reconcile that "looked green".
+
+Reconcile red aborts the stage before any sitting (R3): seats should
+never deliberate on a residual whose baseline is already broken.
+
+Network access is injected, never assumed. ``runs_provider`` lets the
+caller supply runs from anywhere; the default shells out to ``gh``.
+That keeps the binding logic — the part with the security-relevant
+refusals — testable without a network at all.
+
+Copyright 2025 Smart AI Memory, LLC
+Licensed under the Apache License, Version 2.0
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+__all__ = [
+    "ALLOWED_WORKFLOWS",
+    "ReconcileError",
+    "ReconcileReceipt",
+    "gh_runs_provider",
+    "reconcile",
+]
+
+#: Workflows whose success means "the gate suite ran". ``Tests`` carries
+#: ``tests/unit/gates`` on this repo. Kept explicit rather than accepting
+#: any green run: a docs-only workflow going green says nothing about a
+#: CLOSED class still being closed.
+ALLOWED_WORKFLOWS = ("Tests",)
+
+#: The only conclusion that authorizes. ``skipped``/``cancelled`` are
+#: NOT success — a cancelled required lane is the documented way a gate
+#: silently stops guarding.
+_GREEN = "success"
+
+
+class ReconcileError(RuntimeError):
+    """Reconcile failed — the stage aborts before the sitting (R3)."""
+
+    def __init__(self, reason: str, detail: str = "") -> None:
+        self.reason = reason
+        self.detail = detail
+        super().__init__(f"{reason}: {detail}" if detail else reason)
+
+
+@dataclass(frozen=True)
+class ReconcileReceipt:
+    """One CI run, bound to one commit — the packet's §1."""
+
+    run_id: str
+    workflow: str
+    repo: str
+    head_sha: str
+    conclusion: str
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "run_id": self.run_id,
+            "workflow": self.workflow,
+            "repo": self.repo,
+            "head_sha": self.head_sha,
+            "conclusion": self.conclusion,
+        }
+
+
+def gh_runs_provider(repo: str, head_sha: str) -> list[dict[str, Any]]:
+    """Default provider: workflow runs for ``head_sha`` via the ``gh`` CLI.
+
+    Returns an empty list when ``gh`` is unavailable or errors — the
+    caller then fails closed with ``no-run`` rather than this function
+    inventing a green result.
+    """
+    try:
+        result = subprocess.run(  # noqa: S603 — fixed argv, no shell
+            [
+                "gh",
+                "run",
+                "list",
+                "--repo",
+                repo,
+                "--commit",
+                head_sha,
+                "--json",
+                "databaseId,name,conclusion,status,headSha",
+                "--limit",
+                "50",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=60,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return []
+    if result.returncode != 0:
+        return []
+    try:
+        data = json.loads(result.stdout or "[]")
+    except ValueError:
+        return []
+    return data if isinstance(data, list) else []
+
+
+def reconcile(
+    repo: str,
+    head_sha: str,
+    *,
+    runs_provider: Callable[[str, str], list[dict[str, Any]]] | None = None,
+    allowed_workflows: tuple[str, ...] = ALLOWED_WORKFLOWS,
+) -> ReconcileReceipt:
+    """Prove an allowlisted workflow succeeded for exactly ``head_sha``.
+
+    Args:
+        repo: ``owner/name`` of the repository being released.
+        head_sha: The full commit SHA being audited.
+        runs_provider: Returns candidate runs; defaults to :func:`gh_runs_provider`.
+        allowed_workflows: Workflow names whose success counts.
+
+    Returns:
+        A :class:`ReconcileReceipt` naming the run that authorizes.
+
+    Raises:
+        ReconcileError: No run, none from an allowlisted workflow, none
+            still in flight resolved, a run for a different commit, or
+            no successful conclusion. Every path fails CLOSED — an
+            unprovable reconcile is never treated as green.
+
+    """
+    if not head_sha or len(head_sha) < 40:
+        raise ReconcileError("bad-head-sha", f"{head_sha!r} is not a full 40-char SHA")
+
+    provider = runs_provider or gh_runs_provider
+    runs = provider(repo, head_sha)
+    if not runs:
+        raise ReconcileError("no-run", f"no workflow run found for {head_sha[:9]} in {repo}")
+
+    # A provider may return runs for other commits; the binding is ours
+    # to enforce, not the provider's to promise.
+    for_this_sha = [r for r in runs if str(r.get("headSha", head_sha)) == head_sha]
+    if not for_this_sha:
+        others = sorted({str(r.get("headSha", ""))[:9] for r in runs if r.get("headSha")})
+        raise ReconcileError(
+            "sha-mismatch",
+            f"runs exist for {others} but none for {head_sha[:9]} — "
+            "a green run for an earlier commit does not authorize",
+        )
+
+    allowed = [r for r in for_this_sha if str(r.get("name", "")) in allowed_workflows]
+    if not allowed:
+        seen = sorted({str(r.get("name", "?")) for r in for_this_sha})
+        raise ReconcileError(
+            "workflow-not-allowlisted",
+            f"no run from {list(allowed_workflows)}; saw {seen}",
+        )
+
+    in_flight = [r for r in allowed if str(r.get("status", "")) != "completed"]
+    green = [r for r in allowed if str(r.get("conclusion", "")) == _GREEN]
+
+    if not green:
+        if in_flight:
+            raise ReconcileError(
+                "still-running",
+                f"{len(in_flight)} allowlisted run(s) not yet complete for {head_sha[:9]}",
+            )
+        conclusions = sorted({str(r.get("conclusion", "?")) for r in allowed})
+        raise ReconcileError(
+            "not-green",
+            f"allowlisted run(s) concluded {conclusions}; only {_GREEN!r} authorizes",
+        )
+
+    run = green[0]
+    return ReconcileReceipt(
+        run_id=str(run.get("databaseId", "")),
+        workflow=str(run.get("name", "")),
+        repo=repo,
+        head_sha=head_sha,
+        conclusion=_GREEN,
+    )

--- a/src/attune/classes/reconcile.py
+++ b/src/attune/classes/reconcile.py
@@ -117,6 +117,51 @@ def gh_runs_provider(repo: str, head_sha: str) -> list[dict[str, Any]]:
     return data if isinstance(data, list) else []
 
 
+def _runs_for_sha(runs: list[dict[str, Any]], head_sha: str) -> list[dict[str, Any]]:
+    """Keep only runs for ``head_sha``. The binding is ours to enforce."""
+    for_this_sha = [r for r in runs if str(r.get("headSha", head_sha)) == head_sha]
+    if for_this_sha:
+        return for_this_sha
+    others = sorted({str(r.get("headSha", ""))[:9] for r in runs if r.get("headSha")})
+    raise ReconcileError(
+        "sha-mismatch",
+        f"runs exist for {others} but none for {head_sha[:9]} — "
+        "a green run for an earlier commit does not authorize",
+    )
+
+
+def _allowlisted_runs(
+    runs: list[dict[str, Any]], allowed_workflows: tuple[str, ...]
+) -> list[dict[str, Any]]:
+    """Keep only runs whose success means the gate suite actually ran."""
+    allowed = [r for r in runs if str(r.get("name", "")) in allowed_workflows]
+    if allowed:
+        return allowed
+    seen = sorted({str(r.get("name", "?")) for r in runs})
+    raise ReconcileError(
+        "workflow-not-allowlisted",
+        f"no run from {list(allowed_workflows)}; saw {seen}",
+    )
+
+
+def _first_green(runs: list[dict[str, Any]], head_sha: str) -> dict[str, Any]:
+    """The authorizing run, or a refusal naming why none qualifies."""
+    green = [r for r in runs if str(r.get("conclusion", "")) == _GREEN]
+    if green:
+        return green[0]
+    in_flight = [r for r in runs if str(r.get("status", "")) != "completed"]
+    if in_flight:
+        raise ReconcileError(
+            "still-running",
+            f"{len(in_flight)} allowlisted run(s) not yet complete for {head_sha[:9]}",
+        )
+    conclusions = sorted({str(r.get("conclusion", "?")) for r in runs})
+    raise ReconcileError(
+        "not-green",
+        f"allowlisted run(s) concluded {conclusions}; only {_GREEN!r} authorizes",
+    )
+
+
 def reconcile(
     repo: str,
     head_sha: str,
@@ -125,6 +170,10 @@ def reconcile(
     allowed_workflows: tuple[str, ...] = ALLOWED_WORKFLOWS,
 ) -> ReconcileReceipt:
     """Prove an allowlisted workflow succeeded for exactly ``head_sha``.
+
+    A short pipeline of refusals: each helper either narrows the candidate
+    runs or raises with the reason. Every path fails CLOSED — an
+    unprovable reconcile is never treated as green.
 
     Args:
         repo: ``owner/name`` of the repository being released.
@@ -136,55 +185,21 @@ def reconcile(
         A :class:`ReconcileReceipt` naming the run that authorizes.
 
     Raises:
-        ReconcileError: No run, none from an allowlisted workflow, none
-            still in flight resolved, a run for a different commit, or
-            no successful conclusion. Every path fails CLOSED — an
-            unprovable reconcile is never treated as green.
+        ReconcileError: Bad SHA, no run, a run only for another commit,
+            none from an allowlisted workflow, none complete, or none
+            successful.
 
     """
     if not head_sha or len(head_sha) < 40:
         raise ReconcileError("bad-head-sha", f"{head_sha!r} is not a full 40-char SHA")
 
-    provider = runs_provider or gh_runs_provider
-    runs = provider(repo, head_sha)
+    runs = (runs_provider or gh_runs_provider)(repo, head_sha)
     if not runs:
         raise ReconcileError("no-run", f"no workflow run found for {head_sha[:9]} in {repo}")
 
-    # A provider may return runs for other commits; the binding is ours
-    # to enforce, not the provider's to promise.
-    for_this_sha = [r for r in runs if str(r.get("headSha", head_sha)) == head_sha]
-    if not for_this_sha:
-        others = sorted({str(r.get("headSha", ""))[:9] for r in runs if r.get("headSha")})
-        raise ReconcileError(
-            "sha-mismatch",
-            f"runs exist for {others} but none for {head_sha[:9]} — "
-            "a green run for an earlier commit does not authorize",
-        )
+    candidates = _allowlisted_runs(_runs_for_sha(runs, head_sha), allowed_workflows)
+    run = _first_green(candidates, head_sha)
 
-    allowed = [r for r in for_this_sha if str(r.get("name", "")) in allowed_workflows]
-    if not allowed:
-        seen = sorted({str(r.get("name", "?")) for r in for_this_sha})
-        raise ReconcileError(
-            "workflow-not-allowlisted",
-            f"no run from {list(allowed_workflows)}; saw {seen}",
-        )
-
-    in_flight = [r for r in allowed if str(r.get("status", "")) != "completed"]
-    green = [r for r in allowed if str(r.get("conclusion", "")) == _GREEN]
-
-    if not green:
-        if in_flight:
-            raise ReconcileError(
-                "still-running",
-                f"{len(in_flight)} allowlisted run(s) not yet complete for {head_sha[:9]}",
-            )
-        conclusions = sorted({str(r.get("conclusion", "?")) for r in allowed})
-        raise ReconcileError(
-            "not-green",
-            f"allowlisted run(s) concluded {conclusions}; only {_GREEN!r} authorizes",
-        )
-
-    run = green[0]
     return ReconcileReceipt(
         run_id=str(run.get("databaseId", "")),
         workflow=str(run.get("name", "")),

--- a/src/attune/classes/sitting.py
+++ b/src/attune/classes/sitting.py
@@ -1,0 +1,270 @@
+"""The sitting — release-audit-stage R3 step 4.
+
+One round, three seats, no rebuttal loop. The seats do NOT re-review the
+diff: D3 settled that by measurement (450k tokens produced 8 instances
+of a single class), so role (d) "detect defects" is OUT. What they do is
+narrow and cheap:
+
+* **(a)** advise SHIP/HOLD per residual item, by amending the packet's
+  §7 pre-filled defaults **per item id**
+* **(c)** rank which ungated/open classes most need a gate before this
+  release
+
+That is why the sitting is payable every release (D2): the seats read a
+capped packet and amend a list, rather than composing an opinion from a
+dump. R4 §7 is explicit — seats AMEND pre-filled dispositions, one
+closing paragraph maximum.
+
+An ABSENT seat is a valid outcome, never a fabricated one. A seat whose
+reply does not parse is recorded as ``format_noncompliant`` with its raw
+text preserved; the stage does not invent amendments on its behalf.
+
+Copyright 2025 Smart AI Memory, LLC
+Licensed under the Apache License, Version 2.0
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass, field
+from typing import Any
+
+from attune.classes.packet import DISPOSITIONS, Packet
+
+__all__ = [
+    "SEATS",
+    "SeatAmendment",
+    "SeatReply",
+    "Sitting",
+    "build_sitting_brief",
+    "compute_sitting_delta",
+    "hold_sitting",
+    "parse_seat_reply",
+]
+
+#: Three seats, one round (R3 step 4). Order is stable so a manifest's
+#: recorded replies are comparable release over release.
+SEATS: tuple[str, ...] = ("claude", "codex", "antigravity")
+
+#: Reply budget. The packet is already capped; a seat that needs more
+#: than this is composing rather than amending.
+SEAT_REPLY_CHARS = 4000
+
+_AMEND = re.compile(
+    r"^\s*AMEND\s+(?P<item>\S+)\s*->\s*(?P<disp>[A-Z-]+)\s*:\s*(?P<reason>.+?)\s*$",
+    re.MULTILINE,
+)
+_RANK = re.compile(r"^\s*GATE-RANK\s*:\s*(?P<ranking>.+?)\s*$", re.MULTILINE)
+_CLOSING = re.compile(r"^\s*CLOSING\s*:\s*(?P<text>.+?)\s*$", re.MULTILINE | re.DOTALL)
+_NO_AMENDMENTS = re.compile(r"^\s*NO AMENDMENTS\s*$", re.MULTILINE)
+
+
+@dataclass(frozen=True)
+class SeatAmendment:
+    """One seat's proposed disposition for one residual item."""
+
+    item_id: str
+    disposition: str
+    reason: str
+
+    def as_dict(self) -> dict[str, str]:
+        return {"item_id": self.item_id, "disposition": self.disposition, "reason": self.reason}
+
+
+@dataclass(frozen=True)
+class SeatReply:
+    """What one seat said. ``status`` is never inferred as agreement."""
+
+    seat: str
+    status: str  # "replied" | "absent" | "format_noncompliant"
+    amendments: tuple[SeatAmendment, ...] = field(default=())
+    gate_ranking: tuple[str, ...] = field(default=())
+    closing: str = ""
+    raw: str = ""
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "seat": self.seat,
+            "status": self.status,
+            "amendments": [a.as_dict() for a in self.amendments],
+            "gate_ranking": list(self.gate_ranking),
+            "closing": self.closing,
+        }
+
+
+@dataclass(frozen=True)
+class Sitting:
+    """One round of three seats over one packet."""
+
+    packet_hash: str
+    replies: tuple[SeatReply, ...]
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "packet_hash": self.packet_hash,
+            "replies": [r.as_dict() for r in self.replies],
+        }
+
+    @property
+    def seats_present(self) -> tuple[str, ...]:
+        return tuple(r.seat for r in self.replies if r.status == "replied")
+
+    def amendments_for(self, item_id: str) -> tuple[SeatAmendment, ...]:
+        """Every seat amendment naming ``item_id``."""
+        return tuple(a for r in self.replies for a in r.amendments if a.item_id == item_id)
+
+    def proposed_dispositions(self, item_id: str) -> set[str]:
+        """The distinct dispositions seats proposed for one item."""
+        return {a.disposition for a in self.amendments_for(item_id)}
+
+
+def build_sitting_brief(packet: Packet) -> str:
+    """The brief. Its constraints ARE the D3 role limits, stated to the seat."""
+    lines = [
+        "You are one seat at a release-audit sitting. ONE round, no rebuttal.",
+        "",
+        "You are NOT reviewing a diff and you are NOT looking for defects.",
+        "That role was measured and ruled out. Do not ask for the diff.",
+        "",
+        "You have exactly two jobs:",
+        "  (a) For each residual item below, either accept its pre-filled",
+        "      disposition or AMEND it. Amend BY ITEM ID.",
+        "  (c) Rank which classes most need a gate before this release.",
+        "",
+        f"Dispositions are exactly: {', '.join(DISPOSITIONS)}.",
+        "",
+        "Reply in EXACTLY this format, nothing else:",
+        "  AMEND <item_id> -> <DISPOSITION>: <one line why>",
+        "  (repeat per amended item; write NO AMENDMENTS if you accept all)",
+        "  GATE-RANK: <class_id>, <class_id>, ...",
+        "  CLOSING: <one paragraph maximum>",
+        "",
+        "--- PACKET ---",
+        f"range: {packet.sections.get('0_header', {}).get('tag_range', '?')}",
+        f"swept: {packet.sections.get('0_header', {}).get('files_swept', '?')} of "
+        f"{packet.sections.get('0_header', {}).get('files_changed', '?')} changed files",
+        "",
+        "RESIDUAL ITEMS (id | class | locus | pre-filled disposition):",
+    ]
+    if not packet.items:
+        lines.append("  (none — an empty residual still sits)")
+    for item in packet.items:
+        lines.append(
+            f"  {item.item_id} | {item.class_id} | {item.locus} | {item.default_disposition}"
+        )
+    exposure = packet.sections.get("3_ungated_exposure", [])
+    if exposure:
+        lines += ["", "UNGATED CLASSES over the changed surface (for GATE-RANK):"]
+        lines += [f"  {row.get('class_id')}" for row in exposure]
+    return "\n".join(lines)
+
+
+def parse_seat_reply(seat: str, exit_code: int, text: str) -> SeatReply:
+    """Parse one seat's reply. Never fabricates content on its behalf."""
+    body = (text or "").strip()
+    if exit_code != 0 or not body:
+        return SeatReply(seat=seat, status="absent", raw=body)
+
+    amendments = tuple(
+        SeatAmendment(
+            item_id=m.group("item"),
+            disposition=m.group("disp").strip(),
+            reason=m.group("reason").strip(),
+        )
+        for m in _AMEND.finditer(body)
+    )
+    ranking_match = _RANK.search(body)
+    ranking = ()
+    if ranking_match:
+        ranking = tuple(
+            part.strip() for part in ranking_match.group("ranking").split(",") if part.strip()
+        )
+    closing_match = _CLOSING.search(body)
+    closing = closing_match.group("text").strip() if closing_match else ""
+
+    # A reply that neither amends, nor says NO AMENDMENTS, nor ranks has
+    # not answered the brief — recorded as-is rather than read as assent.
+    answered = bool(amendments) or bool(_NO_AMENDMENTS.search(body)) or bool(ranking)
+    if not answered:
+        return SeatReply(seat=seat, status="format_noncompliant", closing=closing, raw=body)
+
+    bad = [a for a in amendments if a.disposition not in DISPOSITIONS]
+    if bad:
+        return SeatReply(seat=seat, status="format_noncompliant", closing=closing, raw=body)
+
+    return SeatReply(
+        seat=seat,
+        status="replied",
+        amendments=amendments,
+        gate_ranking=ranking,
+        closing=closing,
+        raw=body,
+    )
+
+
+def hold_sitting(
+    packet: Packet,
+    *,
+    invoke: Callable[[Sequence[str], str], tuple[int, str]] | None = None,
+    seats: tuple[str, ...] = SEATS,
+) -> Sitting:
+    """Run one round over ``packet`` and collect the replies.
+
+    Args:
+        packet: The residual packet the seats rule on.
+        invoke: ``(recipe, brief) -> (exit_code, text)``. Defaults to the
+            round table's seat runner. Injected so the sitting is testable
+            without spending a single model call.
+        seats: Seat names, in stable order.
+
+    Returns:
+        A :class:`Sitting`. Seats that fail or say nothing are ABSENT —
+        absence is recorded, never read as agreement.
+
+    """
+    from attune.roundtable.routine import SEAT_RECIPES, default_invoke_seat
+
+    recipes = dict(SEAT_RECIPES)
+    runner = invoke or (
+        lambda recipe, brief: default_invoke_seat(recipe, brief, reply_chars=SEAT_REPLY_CHARS)
+    )
+    brief = build_sitting_brief(packet)
+
+    replies: list[SeatReply] = []
+    for seat in seats:
+        recipe = recipes.get(seat)
+        if recipe is None:
+            replies.append(SeatReply(seat=seat, status="absent", raw="no recipe"))
+            continue
+        try:
+            exit_code, text = runner(recipe, brief)
+        except (OSError, ValueError) as exc:  # a seat CLI that is not installed
+            replies.append(SeatReply(seat=seat, status="absent", raw=str(exc)))
+            continue
+        replies.append(parse_seat_reply(seat, exit_code, text))
+
+    return Sitting(packet_hash=packet.packet_hash, replies=tuple(replies))
+
+
+def compute_sitting_delta(
+    packet: Packet,
+    rulings: dict[str, str],
+    sitting: Sitting | None = None,
+) -> dict[str, bool]:
+    """D9 — per item, did the SITTING move the chair off the §7 default?
+
+    True only when the final ruling differs from the pre-filled default
+    AND some seat proposed that ruling. A chair who moves an item with no
+    seat suggesting it did so on their own; crediting the sitting for
+    that would inflate the very tally that decides whether the sitting
+    keeps earning its place (D2/D9).
+    """
+    defaults = {item.item_id: item.default_disposition for item in packet.items}
+    delta: dict[str, bool] = {}
+    for item_id, default in defaults.items():
+        final = rulings.get(item_id)
+        moved = final is not None and final != default
+        seat_backed = bool(sitting and final in sitting.proposed_dispositions(item_id))
+        delta[item_id] = bool(moved and seat_backed)
+    return delta

--- a/src/attune/classes/stage.py
+++ b/src/attune/classes/stage.py
@@ -1,0 +1,182 @@
+"""The release-audit stage — release-audit-stage R3, steps 0-5.
+
+Six steps, in order, inside the release path (D1)::
+
+    0  baseline    merge-base diff vs the last release tag
+    1  reconcile   CLOSED gates green in CI, bound to THIS head SHA
+    2  diff sweep  rules over the changed package surface (D10)
+    3  residual    the schema-v1 packet
+    4  sitting     one round, three seats, no rebuttal
+    5  chair       rules per item; manifest written
+
+Two orderings are load-bearing rather than incidental:
+
+* **Reconcile red aborts before any sitting** (R3). Seats must never
+  deliberate on a residual whose baseline is already broken — the
+  deliberation would be about the wrong tree.
+* **The packet is built before the sitting and hashed**, so the manifest
+  records which residual was actually sat on. A packet rebuilt after the
+  fact would not hash the same.
+
+``run_stage`` stops at step 4 and hands back everything the chair needs.
+It does NOT rule: dispositions are the chair's, and a tool that picked
+them would make the manifest a record of itself.
+
+Copyright 2025 Smart AI Memory, LLC
+Licensed under the Apache License, Version 2.0
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from attune.classes.baseline import Baseline, BaselineError, resolve_baseline
+from attune.classes.packet import Packet, PacketOverCap, build_packet
+from attune.classes.reconcile import ReconcileError, ReconcileReceipt, reconcile
+from attune.classes.register import derive_register
+from attune.classes.scan import scan_paths
+from attune.classes.sitting import Sitting, hold_sitting
+
+__all__ = ["StageAborted", "StageResult", "run_stage", "main"]
+
+
+class StageAborted(RuntimeError):
+    """The stage stopped before completing. Carries the step and reason."""
+
+    def __init__(self, step: str, reason: str, detail: str = "") -> None:
+        self.step = step
+        self.reason = reason
+        self.detail = detail
+        super().__init__(f"step {step}: {reason}{f' — {detail}' if detail else ''}")
+
+
+@dataclass(frozen=True)
+class StageResult:
+    """Everything the chair needs to rule, and nothing pre-ruled."""
+
+    baseline: Baseline
+    reconcile_receipt: ReconcileReceipt | None
+    packet: Packet
+    sitting: Sitting | None
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "baseline": {
+                "tag_range": self.baseline.tag_range,
+                "baseline_sha": self.baseline.baseline_sha,
+                "head_sha": self.baseline.head_sha,
+                "source": self.baseline.source,
+            },
+            "reconcile": self.reconcile_receipt.as_dict() if self.reconcile_receipt else None,
+            "packet": self.packet.as_dict(),
+            "packet_hash": self.packet.packet_hash,
+            "sitting": self.sitting.as_dict() if self.sitting else None,
+            "blocking_by_default": [i.item_id for i in self.packet.blocking],
+        }
+
+
+def run_stage(
+    repo_root: Path,
+    repo_slug: str,
+    *,
+    baseline_override: str | None = None,
+    skip_reconcile: bool = False,
+    hold: bool = True,
+    invoke_seat: Callable[[Sequence[str], str], tuple[int, str]] | None = None,
+    runs_provider: Callable[[str, str], list[dict[str, Any]]] | None = None,
+) -> StageResult:
+    """Run steps 0-4 and return the chair's inputs.
+
+    Args:
+        repo_root: Repository being released.
+        repo_slug: ``owner/name`` for the reconcile receipt.
+        baseline_override: ``--baseline`` ref; skips the tag lookup.
+        skip_reconcile: Dry-run escape for a commit with no CI run. The
+            resulting packet records ``1_reconcile: null`` so the gap is
+            visible rather than implied-green.
+        hold: Run the sitting. False builds the packet and stops.
+        invoke_seat: Injected seat runner (testing / offline).
+        runs_provider: Injected CI reader (testing / offline).
+
+    Returns:
+        A :class:`StageResult`. Dispositions are NOT chosen here.
+
+    Raises:
+        StageAborted: A step failed in a way that must stop the release —
+            an unresolvable baseline, a red or absent reconcile, or a
+            residual that exceeds schema v1 and needs the chair to split.
+
+    """
+    try:
+        baseline = resolve_baseline(repo_root, override=baseline_override)
+    except BaselineError as exc:
+        raise StageAborted("0-baseline", exc.reason, exc.detail) from exc
+
+    receipt: ReconcileReceipt | None = None
+    if not skip_reconcile:
+        try:
+            receipt = reconcile(repo_slug, baseline.head_sha, runs_provider=runs_provider)
+        except ReconcileError as exc:
+            # R3: red at step 1 aborts BEFORE any sitting.
+            raise StageAborted("1-reconcile", exc.reason, exc.detail) from exc
+
+    # D10: the sweep is package-scoped; the packet reports what it skipped.
+    sweep = scan_paths([Path(p) for p in baseline.to_sweep], repo_root=repo_root)
+    register = derive_register(repo_root=repo_root)
+
+    try:
+        packet = build_packet(
+            baseline,
+            sweep,
+            register,
+            repo_root=repo_root,
+            reconcile=receipt.as_dict() if receipt else None,
+        )
+    except PacketOverCap as exc:
+        raise StageAborted(
+            "3-residual", "over-cap", json.dumps(exc.diagnostics["breaches"])
+        ) from exc
+
+    sitting = hold_sitting(packet, invoke=invoke_seat) if hold else None
+    return StageResult(baseline=baseline, reconcile_receipt=receipt, packet=packet, sitting=sitting)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI: ``python -m attune.classes.stage``.
+
+    Exit codes are the contract: 0 ready for the chair, 1 aborted, and
+    2 reserved for an over-cap residual (R4) so a caller can tell "split
+    the release" apart from every other failure.
+    """
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-root", type=Path, default=Path("."))
+    parser.add_argument("--repo", default="Smart-AI-Memory/attune-ai")
+    parser.add_argument("--baseline", default=None, help="explicit ref to diff from")
+    parser.add_argument("--skip-reconcile", action="store_true")
+    parser.add_argument("--no-sitting", action="store_true", help="build the packet only")
+    args = parser.parse_args(argv)
+
+    try:
+        result = run_stage(
+            args.repo_root,
+            args.repo,
+            baseline_override=args.baseline,
+            skip_reconcile=args.skip_reconcile,
+            hold=not args.no_sitting,
+        )
+    except StageAborted as exc:
+        print(json.dumps({"aborted_at": exc.step, "reason": exc.reason, "detail": exc.detail}))
+        return 2 if exc.reason == "over-cap" else 1
+
+    print(json.dumps(result.as_dict(), indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/tests/unit/classes/test_baseline.py
+++ b/tests/unit/classes/test_baseline.py
@@ -213,3 +213,45 @@ class TestBaselineShape:
 
         with pytest.raises(AttributeError):
             baseline.baseline_sha = "c" * 40  # type: ignore[misc]
+
+
+class TestSweepScopeD10:
+    """D10: the sweep is package-scoped, and says what it did not look at."""
+
+    def test_only_package_paths_are_swept(self, tmp_path):
+        repo = _repo(tmp_path)
+        _commit(repo, "src/attune/mod.py")
+        _git(repo, "tag", "v1.0.0")
+        _commit(repo, "src/attune/other.py")
+        _commit(repo, "tests/unit/test_thing.py")
+        _commit(repo, "scripts/tool.py")
+
+        baseline = resolve_baseline(repo)
+
+        assert baseline.to_sweep == ("src/attune/other.py",)
+        assert set(baseline.not_swept) == {"tests/unit/test_thing.py", "scripts/tool.py"}
+
+    def test_changed_still_reports_everything(self, tmp_path):
+        """The narrowing must be visible, not silent."""
+        repo = _repo(tmp_path)
+        _commit(repo, "src/attune/mod.py")
+        _git(repo, "tag", "v1.0.0")
+        _commit(repo, "tests/unit/test_thing.py")
+
+        baseline = resolve_baseline(repo)
+
+        assert baseline.changed == ("tests/unit/test_thing.py",)
+        assert baseline.to_sweep == ()
+        assert baseline.not_swept == ("tests/unit/test_thing.py",)
+
+    def test_the_two_partition_changed_exactly(self, tmp_path):
+        repo = _repo(tmp_path)
+        _commit(repo, "src/attune/a.py")
+        _git(repo, "tag", "v1.0.0")
+        for name in ("src/attune/b.py", "tests/t.py", "scripts/s.py", "plugin/p.py"):
+            _commit(repo, name)
+
+        baseline = resolve_baseline(repo)
+
+        assert set(baseline.to_sweep) | set(baseline.not_swept) == set(baseline.changed)
+        assert not (set(baseline.to_sweep) & set(baseline.not_swept))

--- a/tests/unit/classes/test_baseline.py
+++ b/tests/unit/classes/test_baseline.py
@@ -1,0 +1,215 @@
+"""Baseline resolution for the release-audit stage (R3 step 0).
+
+The property under test is FAIL-CLOSED. An audit whose range is wrong
+reports an empty sweep, which reads exactly like a clean diff — so
+every unresolvable input must raise rather than fall back to a default
+range.
+
+Copyright 2025 Smart-AI-Memory
+Licensed under Apache 2.0
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from attune.classes.baseline import (
+    Baseline,
+    BaselineError,
+    changed_files,
+    last_release_tag,
+    resolve_baseline,
+)
+
+
+def _git(repo: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", "-C", str(repo), *args],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=True,
+    )
+    return result.stdout.strip()
+
+
+def _repo(tmp_path: Path) -> Path:
+    subprocess.run(["git", "init", "-q", str(tmp_path)], check=True, timeout=30)
+    for key, value in (
+        ("user.email", "t@t"),
+        ("user.name", "t"),
+        ("commit.gpgsign", "false"),
+        ("tag.gpgsign", "false"),
+    ):
+        _git(tmp_path, "config", key, value)
+    return tmp_path
+
+
+def _commit(repo: Path, name: str, body: str = "x = 1\n") -> str:
+    target = repo / name
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(body, encoding="utf-8")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-q", "-m", f"add {name}")
+    return _git(repo, "rev-parse", "HEAD")
+
+
+class TestResolvesTheRange:
+    def test_uses_the_last_release_tag(self, tmp_path):
+        repo = _repo(tmp_path)
+        _commit(repo, "a.py")
+        _git(repo, "tag", "v1.0.0")
+        head = _commit(repo, "b.py")
+
+        baseline = resolve_baseline(repo)
+
+        assert baseline.tag == "v1.0.0"
+        assert baseline.source == "last-release-tag"
+        assert baseline.head_sha == head
+        assert len(baseline.baseline_sha) == 40, "SHAs are recorded full-length for the manifest"
+        assert baseline.changed == ("b.py",)
+
+    def test_override_skips_tag_lookup_entirely(self, tmp_path):
+        """--baseline names the range; an untagged repo must still work."""
+        repo = _repo(tmp_path)
+        first = _commit(repo, "a.py")
+        _commit(repo, "b.py")
+
+        baseline = resolve_baseline(repo, override=first)
+
+        assert baseline.source == "override"
+        assert baseline.tag is None
+        assert baseline.baseline_sha == first
+        assert baseline.changed == ("b.py",)
+
+    def test_tag_is_picked_by_VERSION_not_commit_date(self, tmp_path):
+        """A tag pushed late for an older release must not win."""
+        repo = _repo(tmp_path)
+        _commit(repo, "a.py")
+        _git(repo, "tag", "v2.0.0")
+        _commit(repo, "b.py")
+        # v1.9.0 is created LAST, so a date-ordered lookup would pick it.
+        _git(repo, "tag", "v1.9.0")
+
+        assert last_release_tag(repo) == "v2.0.0"
+
+    def test_non_release_tags_are_ignored(self, tmp_path):
+        repo = _repo(tmp_path)
+        _commit(repo, "a.py")
+        _git(repo, "tag", "nightly-2026-08-22")
+        _git(repo, "tag", "v0.1.0")
+        _git(repo, "tag", "v1.0.0-rc1")
+
+        assert last_release_tag(repo) == "v0.1.0"
+
+    def test_tag_range_is_readable(self, tmp_path):
+        repo = _repo(tmp_path)
+        _commit(repo, "a.py")
+        _git(repo, "tag", "v1.0.0")
+        _commit(repo, "b.py")
+
+        assert resolve_baseline(repo).tag_range.startswith("v1.0.0..")
+
+
+class TestFailsClosed:
+    """Never guess a range — an empty sweep must mean a clean diff."""
+
+    def test_no_release_tag_raises(self, tmp_path):
+        repo = _repo(tmp_path)
+        _commit(repo, "a.py")
+
+        with pytest.raises(BaselineError) as exc:
+            resolve_baseline(repo)
+
+        assert exc.value.reason == "no-release-tag"
+        assert "--baseline" in str(exc.value), "the error must name the way forward"
+
+    def test_unresolvable_override_raises(self, tmp_path):
+        repo = _repo(tmp_path)
+        _commit(repo, "a.py")
+
+        with pytest.raises(BaselineError) as exc:
+            resolve_baseline(repo, override="no-such-ref")
+
+        assert exc.value.reason == "bad-baseline-ref"
+
+    def test_shallow_clone_raises(self, tmp_path):
+        origin = _repo(tmp_path / "origin")
+        _commit(origin, "a.py")
+        _git(origin, "tag", "v1.0.0")
+        _commit(origin, "b.py")
+
+        shallow = tmp_path / "shallow"
+        subprocess.run(
+            ["git", "clone", "-q", "--depth", "1", f"file://{origin}", str(shallow)],
+            check=True,
+            timeout=60,
+        )
+
+        with pytest.raises(BaselineError) as exc:
+            resolve_baseline(shallow)
+
+        assert exc.value.reason == "shallow-clone"
+
+    def test_not_a_repo_raises_rather_than_returning_empty(self, tmp_path):
+        with pytest.raises(BaselineError):
+            resolve_baseline(tmp_path)
+
+
+class TestChangedFileSemantics:
+    """R1: deleted skipped, rename scans the NEW path, unscannable filtered."""
+
+    def test_deleted_file_is_skipped(self, tmp_path):
+        repo = _repo(tmp_path)
+        _commit(repo, "gone.py")
+        base = _git(repo, "rev-parse", "HEAD")
+        (repo / "gone.py").unlink()
+        _git(repo, "add", "-A")
+        _git(repo, "commit", "-q", "-m", "delete")
+
+        assert changed_files(repo, base) == ()
+
+    def test_rename_scans_the_new_path(self, tmp_path):
+        repo = _repo(tmp_path)
+        _commit(repo, "old.py", "x = 1\n" * 20)
+        base = _git(repo, "rev-parse", "HEAD")
+        _git(repo, "mv", "old.py", "new.py")
+        _git(repo, "commit", "-q", "-m", "rename")
+
+        assert changed_files(repo, base) == ("new.py",)
+
+    def test_unscannable_files_are_filtered(self, tmp_path):
+        repo = _repo(tmp_path)
+        _commit(repo, "a.py")
+        base = _git(repo, "rev-parse", "HEAD")
+        _commit(repo, "notes.md", "# notes\n")
+        (repo / "data.json").write_text("{}", encoding="utf-8")
+        _git(repo, "add", "-A")
+        _git(repo, "commit", "-q", "-m", "non-python")
+
+        assert changed_files(repo, base) == ()
+
+    def test_order_is_deterministic_and_deduped(self, tmp_path):
+        """A packet hash must be stable across runs of the same range."""
+        repo = _repo(tmp_path)
+        _commit(repo, "a.py")
+        base = _git(repo, "rev-parse", "HEAD")
+        _commit(repo, "z.py")
+        _commit(repo, "m.py")
+        _commit(repo, "z.py", "x = 2\n")  # touched twice
+
+        result = changed_files(repo, base)
+
+        assert result == ("m.py", "z.py")
+        assert result == changed_files(repo, base), "repeated calls must agree"
+
+
+class TestBaselineShape:
+    def test_is_frozen_so_a_recorded_range_cannot_drift(self):
+        baseline = Baseline(tag="v1.0.0", baseline_sha="a" * 40, head_sha="b" * 40, source="t")
+
+        with pytest.raises(AttributeError):
+            baseline.baseline_sha = "c" * 40  # type: ignore[misc]

--- a/tests/unit/classes/test_manifest.py
+++ b/tests/unit/classes/test_manifest.py
@@ -1,0 +1,240 @@
+"""The chair manifest (release-audit-stage R7).
+
+The manifest is what stops the stage being advisory-by-accident, so the
+tests are about its REFUSALS: a partial ruling set, a ruling bound to a
+different commit, an in-place amendment, and a missing sitting delta
+must all reject rather than degrade.
+
+Copyright 2025 Smart-AI-Memory
+Licensed under Apache 2.0
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from attune.classes.manifest import (
+    MANIFEST_SCHEMA_VERSION,
+    ManifestError,
+    build_manifest,
+    load_manifest,
+    manifest_path,
+    require_manifest,
+    validate_manifest,
+    write_manifest,
+)
+from attune.classes.packet import Packet, ResidualItem
+
+_SHA = "a" * 40
+
+
+def _item(n: int, disposition: str = "GATE-FIRST") -> ResidualItem:
+    return ResidualItem(
+        item_id=f"hit:R7b:src/mod.py:{n}",
+        kind="hit",
+        class_id="C3",
+        locus=f"src/mod.py:{n}",
+        detail="parsed then used unguarded",
+        default_disposition=disposition,
+    )
+
+
+def _packet(count: int = 2) -> Packet:
+    return Packet(sections={"0_header": {}}, items=tuple(_item(i) for i in range(count)))
+
+
+def _kw(packet: Packet, **over):
+    rulings = over.pop("rulings", {i.item_id: "SHIP" for i in packet.items})
+    delta = over.pop("sitting_delta", {i.item_id: False for i in packet.items})
+    base = {
+        "tag": "v14.0.0",
+        "head_sha": _SHA,
+        "baseline_sha": "b" * 40,
+        "rulings": rulings,
+        "chair_receipt": "ruled 2026-08-22",
+        "sitting_delta": delta,
+    }
+    base.update(over)
+    return base
+
+
+class TestCompletionInvariant:
+    """R3: every residual item id carries EXACTLY ONE ruling."""
+
+    def test_missing_ruling_is_refused(self):
+        packet = _packet(3)
+        partial = {packet.items[0].item_id: "SHIP"}
+
+        with pytest.raises(ManifestError) as exc:
+            build_manifest(packet, **_kw(packet, rulings=partial))
+
+        assert exc.value.reason == "missing-rulings"
+
+    def test_ruling_for_an_item_not_in_the_packet_is_refused(self):
+        packet = _packet(1)
+        rulings = {packet.items[0].item_id: "SHIP", "hit:ghost:x.py:1": "SHIP"}
+
+        with pytest.raises(ManifestError) as exc:
+            build_manifest(packet, **_kw(packet, rulings=rulings))
+
+        assert exc.value.reason == "unknown-items"
+
+    def test_unknown_disposition_is_refused(self):
+        packet = _packet(1)
+        rulings = {packet.items[0].item_id: "LGTM"}
+
+        with pytest.raises(ManifestError) as exc:
+            build_manifest(packet, **_kw(packet, rulings=rulings))
+
+        assert exc.value.reason == "bad-disposition"
+
+    def test_complete_ruling_set_builds(self):
+        packet = _packet(2)
+
+        manifest = build_manifest(packet, **_kw(packet))
+
+        assert manifest.packet_hash == packet.packet_hash
+        assert len(manifest.per_item_dispositions) == 2
+
+
+class TestSittingDeltaIsRequired:
+    """D9 — a manifest without it is invalid, not merely incomplete."""
+
+    def test_absent_delta_is_refused_at_build(self):
+        packet = _packet(2)
+
+        with pytest.raises(ManifestError) as exc:
+            build_manifest(packet, **_kw(packet, sitting_delta={}))
+
+        assert exc.value.reason == "missing-sitting-delta"
+
+    def test_absent_delta_is_refused_at_validate(self):
+        packet = _packet(1)
+        data = build_manifest(packet, **_kw(packet)).as_dict()
+        data["sitting_delta"] = {}
+
+        with pytest.raises(ManifestError) as exc:
+            validate_manifest(data)
+
+        assert exc.value.reason == "missing-sitting-delta"
+
+    def test_delta_reports_whether_the_sitting_moved_anything(self):
+        packet = _packet(2)
+        ids = [i.item_id for i in packet.items]
+
+        quiet = build_manifest(packet, **_kw(packet))
+        moved = build_manifest(packet, **_kw(packet, sitting_delta={ids[0]: True, ids[1]: False}))
+
+        assert quiet.sitting_changed_anything is False
+        assert moved.sitting_changed_anything is True
+
+
+class TestImmutability:
+    def test_writing_twice_is_refused(self, tmp_path):
+        packet = _packet(1)
+        manifest = build_manifest(packet, **_kw(packet))
+        write_manifest(manifest, tmp_path)
+
+        with pytest.raises(ManifestError) as exc:
+            write_manifest(manifest, tmp_path)
+
+        assert exc.value.reason == "already-exists"
+
+    def test_written_manifest_round_trips(self, tmp_path):
+        packet = _packet(2)
+        manifest = build_manifest(packet, **_kw(packet))
+
+        path = write_manifest(manifest, tmp_path)
+        loaded = load_manifest(tmp_path, "v14.0.0")
+
+        assert path == manifest_path(tmp_path, "v14.0.0")
+        assert loaded.as_dict() == manifest.as_dict()
+        assert json.loads(path.read_text())["schema_version"] == MANIFEST_SCHEMA_VERSION
+
+
+class TestReleaseExecuteGate:
+    """require_manifest is what stops the stage being advisory."""
+
+    def test_no_manifest_refuses_the_tag(self, tmp_path):
+        with pytest.raises(ManifestError) as exc:
+            require_manifest(tmp_path, "v14.0.0", _SHA)
+
+        assert exc.value.reason == "no-manifest"
+
+    def test_manifest_for_a_different_commit_refuses(self, tmp_path):
+        """A ruling on an earlier SHA does not authorize this tag."""
+        packet = _packet(1)
+        write_manifest(build_manifest(packet, **_kw(packet)), tmp_path)
+
+        with pytest.raises(ManifestError) as exc:
+            require_manifest(tmp_path, "v14.0.0", "c" * 40)
+
+        assert exc.value.reason == "sha-mismatch"
+
+    def test_blocked_items_refuse_the_tag(self, tmp_path):
+        """D4 teeth: the stage may hold a release."""
+        packet = _packet(2)
+        rulings = {packet.items[0].item_id: "SHIP", packet.items[1].item_id: "GATE-FIRST"}
+        write_manifest(build_manifest(packet, **_kw(packet, rulings=rulings)), tmp_path)
+
+        with pytest.raises(ManifestError) as exc:
+            require_manifest(tmp_path, "v14.0.0", _SHA)
+
+        assert exc.value.reason == "blocked-items"
+
+    def test_cleared_manifest_authorizes_the_tag(self, tmp_path):
+        packet = _packet(2)
+        write_manifest(build_manifest(packet, **_kw(packet)), tmp_path)
+
+        manifest = require_manifest(tmp_path, "v14.0.0", _SHA)
+
+        assert manifest.blocked == ()
+
+    def test_corrupt_manifest_refuses_rather_than_degrading(self, tmp_path):
+        target = manifest_path(tmp_path, "v14.0.0")
+        target.parent.mkdir(parents=True)
+        target.write_text("{not json", encoding="utf-8")
+
+        with pytest.raises(ManifestError) as exc:
+            require_manifest(tmp_path, "v14.0.0", _SHA)
+
+        assert exc.value.reason == "unreadable"
+
+
+class TestTagCannotEscapeTheManifestDirectory:
+    """A tag is caller-supplied and lands in a path (path-validation gate)."""
+
+    @pytest.mark.parametrize(
+        "tag",
+        [
+            "../../../etc/cron.d/x",
+            "../outside",
+            "v1.0.0/../../escape",
+            "/absolute/elsewhere",
+            "with\x00null",
+            "",
+            "." * 200,
+        ],
+    )
+    def test_hostile_tag_is_refused(self, tmp_path, tag):
+        with pytest.raises(ManifestError) as exc:
+            manifest_path(tmp_path, tag)
+
+        assert exc.value.reason in ("bad-tag", "unsafe-path")
+
+    @pytest.mark.parametrize("tag", ["v14.0.0", "v1.2.3-rc1", "v0.1.0"])
+    def test_real_tags_are_accepted(self, tmp_path, tag):
+        path = manifest_path(tmp_path, tag)
+
+        assert path.name == f"{tag}.json"
+        assert path.parent.name == "release-manifests"
+
+    def test_escape_is_refused_at_write_time_too(self, tmp_path):
+        """The guard sits in the path builder, so writers inherit it."""
+        packet = _packet(1)
+        manifest = build_manifest(packet, **_kw(packet, tag="../escape"))
+
+        with pytest.raises(ManifestError):
+            write_manifest(manifest, tmp_path)

--- a/tests/unit/classes/test_packet.py
+++ b/tests/unit/classes/test_packet.py
@@ -1,0 +1,173 @@
+"""Residual packet, schema v1 (release-audit-stage R4).
+
+The properties that matter are the REFUSALS and the SCOPE rules, not
+the happy path: a packet that quietly truncated, or that let warnings
+crowd out hits, would let a chair rule on a subset while believing they
+ruled on the whole.
+
+Copyright 2025 Smart-AI-Memory
+Licensed under Apache 2.0
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from attune.classes.baseline import Baseline
+from attune.classes.packet import (
+    DISPOSITIONS,
+    MAX_ITEMS,
+    PacketOverCap,
+    build_packet,
+)
+
+_CALIBRATED = {
+    "invariant": "parsed then used unguarded",
+    "class_ids": ["C3"],
+    "calibrated_here": True,
+    "calibration": {"repo": "r", "recall": 0.72, "precision": 1.0},
+}
+_ADVISORY = {
+    "invariant": "same shape, uncalibrated here",
+    "class_ids": ["C9"],
+    "calibrated_here": False,
+    "calibration": {"repo": "other/repo", "recall": 0.1, "precision": 0.0},
+}
+
+
+def _baseline(**kw) -> Baseline:
+    return Baseline(
+        tag=kw.pop("tag", "v1.0.0"),
+        baseline_sha="a" * 40,
+        head_sha="b" * 40,
+        source="last-release-tag",
+        changed=kw.pop("changed", ("src/attune/mod.py",)),
+        deleted=kw.pop("deleted", ()),
+    )
+
+
+def _sweep(hits, rules=None):
+    return {"hits": hits, "rules": rules or {"R1": _CALIBRATED}, "scan_errors": []}
+
+
+def _hit(line, rule_id="R1"):
+    return {"rule_id": rule_id, "path": "src/attune/mod.py", "line": line, "detail": "d"}
+
+
+def _register(rows=()):
+    return {"rows": list(rows), "scan_errors": [], "defer_problems": []}
+
+
+class TestOverCapIsARefusal:
+    def test_too_many_items_raises_rather_than_truncating(self, tmp_path):
+        hits = [_hit(i) for i in range(MAX_ITEMS + 3)]
+
+        with pytest.raises(PacketOverCap) as exc:
+            build_packet(_baseline(), _sweep(hits), _register(), repo_root=tmp_path)
+
+        breach = exc.value.diagnostics["breaches"][0]
+        assert breach["cap"] == "items"
+        assert breach["actual"] == MAX_ITEMS + 3, "the diagnostic reports the REAL count"
+        assert "split" in exc.value.diagnostics["remedy"]
+
+    def test_refusal_carries_the_reserved_exit_code(self):
+        assert PacketOverCap.exit_code == 2
+
+    def test_under_cap_builds(self, tmp_path):
+        packet = build_packet(
+            _baseline(), _sweep([_hit(1), _hit(2)]), _register(), repo_root=tmp_path
+        )
+
+        assert len(packet.items) == 2
+
+
+class TestD5ExposureNeverCompetesWithHits:
+    """Exposure warns through the §3 matrix ONLY — never as an item."""
+
+    def test_ungated_classes_produce_a_matrix_not_items(self, tmp_path):
+        register = _register(
+            [{"class_id": f"C{i}", "status": "FIXED-BUT-UNGATED"} for i in range(9)]
+        )
+
+        packet = build_packet(_baseline(), _sweep([]), register, repo_root=tmp_path)
+
+        assert packet.items == (), "exposure must not mint residual items"
+        assert len(packet.sections["3_ungated_exposure"]) == 9
+        assert all("changed_surface" in row for row in packet.sections["3_ungated_exposure"])
+
+    def test_many_ungated_classes_cannot_push_a_packet_over_cap(self, tmp_path):
+        """The D5 failure mode: warnings crowding hits out of the cap."""
+        register = _register(
+            [{"class_id": f"C{i}", "status": "FIXED-BUT-UNGATED"} for i in range(40)]
+        )
+
+        packet = build_packet(_baseline(), _sweep([_hit(1)]), register, repo_root=tmp_path)
+
+        assert len(packet.items) == 1
+
+
+class TestAdvisoryHitsAreReportedNotRuled:
+    """R1: uncalibrated is advisory — never blocks, never clears."""
+
+    def test_advisory_hit_is_a_sweep_row_but_not_an_item(self, tmp_path):
+        sweep = _sweep([_hit(1, "ADV")], rules={"ADV": _ADVISORY})
+
+        packet = build_packet(_baseline(), sweep, _register(), repo_root=tmp_path)
+
+        assert len(packet.sections["2_sweep_hits"]) == 1
+        assert packet.items == (), "nothing for the chair to rule on"
+
+    def test_calibrated_hit_defaults_to_blocking(self, tmp_path):
+        packet = build_packet(_baseline(), _sweep([_hit(1)]), _register(), repo_root=tmp_path)
+
+        assert packet.items[0].default_disposition == "GATE-FIRST"
+        assert packet.blocking == packet.items
+
+
+class TestSectionsAndDispositions:
+    def test_every_item_carries_exactly_one_default(self, tmp_path):
+        register = _register([{"class_id": "C7", "status": "OPEN", "calibrated_hits": 2}])
+
+        packet = build_packet(_baseline(), _sweep([_hit(1)]), register, repo_root=tmp_path)
+
+        defaults = packet.sections["7_default_dispositions"]
+        assert len(defaults) == len(packet.items)
+        assert {d["item_id"] for d in defaults} == {i.item_id for i in packet.items}
+        assert all(d["disposition"] in DISPOSITIONS for d in defaults)
+
+    def test_item_ids_are_unique_so_rulings_map_one_to_one(self, tmp_path):
+        packet = build_packet(
+            _baseline(), _sweep([_hit(1), _hit(2), _hit(3)]), _register(), repo_root=tmp_path
+        )
+
+        ids = [i.item_id for i in packet.items]
+        assert len(ids) == len(set(ids))
+
+    def test_all_eight_sections_are_present(self, tmp_path):
+        packet = build_packet(_baseline(), _sweep([]), _register(), repo_root=tmp_path)
+
+        for section in range(8):
+            assert any(k.startswith(f"{section}_") for k in packet.sections), f"missing §{section}"
+
+    def test_null_section_states_absence_explicitly(self, tmp_path):
+        packet = build_packet(_baseline(), _sweep([]), _register(), repo_root=tmp_path)
+
+        null = packet.sections["6_null"]
+        assert null["no_calibrated_hits"] is True
+        assert null["no_new_boundaries"] is True
+
+    def test_packet_hash_is_stable_and_content_bound(self, tmp_path):
+        a = build_packet(_baseline(), _sweep([_hit(1)]), _register(), repo_root=tmp_path)
+        b = build_packet(_baseline(), _sweep([_hit(1)]), _register(), repo_root=tmp_path)
+        c = build_packet(_baseline(), _sweep([_hit(2)]), _register(), repo_root=tmp_path)
+
+        assert a.packet_hash == b.packet_hash, "same input must hash the same"
+        assert a.packet_hash != c.packet_hash, "different residual must hash differently"
+
+    def test_no_file_contents_or_diff_hunks_leak_in(self, tmp_path):
+        """R4: zero diff hunks, no file contents — the excerpt is capped."""
+        long_detail = {"rule_id": "R1", "path": "p.py", "line": 1, "detail": "x" * 5000}
+
+        packet = build_packet(_baseline(), _sweep([long_detail]), _register(), repo_root=tmp_path)
+
+        assert len(packet.sections["2_sweep_hits"][0]["excerpt"]) <= 120

--- a/tests/unit/classes/test_reconcile.py
+++ b/tests/unit/classes/test_reconcile.py
@@ -1,0 +1,138 @@
+"""Reconcile receipt (release-audit-stage R3 step 1).
+
+The binding is the security property: a green run for an EARLIER commit
+must not authorize the release. Every refusal below is a way that could
+otherwise happen, so each one is pinned.
+
+No network: the runs provider is injected.
+
+Copyright 2025 Smart-AI-Memory
+Licensed under Apache 2.0
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from attune.classes.reconcile import (
+    ReconcileError,
+    ReconcileReceipt,
+    reconcile,
+)
+
+_SHA = "a" * 40
+_OTHER = "b" * 40
+_REPO = "Smart-AI-Memory/attune-ai"
+
+
+def _run(**over):
+    run = {
+        "databaseId": 123,
+        "name": "Tests",
+        "conclusion": "success",
+        "status": "completed",
+        "headSha": _SHA,
+    }
+    run.update(over)
+    return run
+
+
+def _provider(*runs):
+    return lambda repo, sha: list(runs)
+
+
+class TestAuthorizes:
+    def test_green_allowlisted_run_for_this_sha(self):
+        receipt = reconcile(_REPO, _SHA, runs_provider=_provider(_run()))
+
+        assert isinstance(receipt, ReconcileReceipt)
+        assert receipt.conclusion == "success"
+        assert receipt.head_sha == _SHA
+        assert receipt.workflow == "Tests"
+        assert receipt.run_id == "123"
+
+    def test_receipt_serialises_for_packet_section_1(self):
+        receipt = reconcile(_REPO, _SHA, runs_provider=_provider(_run()))
+
+        assert set(receipt.as_dict()) == {
+            "run_id",
+            "workflow",
+            "repo",
+            "head_sha",
+            "conclusion",
+        }
+
+    def test_picks_the_allowlisted_run_among_others(self):
+        runs = [_run(name="Documentation", conclusion="success"), _run(name="Tests")]
+
+        assert reconcile(_REPO, _SHA, runs_provider=_provider(*runs)).workflow == "Tests"
+
+
+class TestBindingRefusals:
+    """A green run elsewhere must never authorize this commit."""
+
+    def test_green_run_for_an_earlier_commit_does_not_authorize(self):
+        stale = _run(headSha=_OTHER)
+
+        with pytest.raises(ReconcileError) as exc:
+            reconcile(_REPO, _SHA, runs_provider=_provider(stale))
+
+        assert exc.value.reason == "sha-mismatch"
+        assert "does not authorize" in str(exc.value)
+
+    def test_no_run_at_all_fails_closed(self):
+        with pytest.raises(ReconcileError) as exc:
+            reconcile(_REPO, _SHA, runs_provider=_provider())
+
+        assert exc.value.reason == "no-run"
+
+    def test_non_allowlisted_workflow_does_not_authorize(self):
+        """A docs workflow going green says nothing about the gates."""
+        with pytest.raises(ReconcileError) as exc:
+            reconcile(_REPO, _SHA, runs_provider=_provider(_run(name="Documentation")))
+
+        assert exc.value.reason == "workflow-not-allowlisted"
+
+    @pytest.mark.parametrize("conclusion", ["failure", "cancelled", "skipped", "timed_out", None])
+    def test_only_success_authorizes(self, conclusion):
+        """cancelled/skipped are how a required lane silently stops guarding."""
+        with pytest.raises(ReconcileError) as exc:
+            reconcile(_REPO, _SHA, runs_provider=_provider(_run(conclusion=conclusion)))
+
+        assert exc.value.reason == "not-green"
+
+    def test_still_running_is_not_green(self):
+        in_flight = _run(status="in_progress", conclusion=None)
+
+        with pytest.raises(ReconcileError) as exc:
+            reconcile(_REPO, _SHA, runs_provider=_provider(in_flight))
+
+        assert exc.value.reason == "still-running"
+
+    def test_short_sha_is_refused(self):
+        """Binding to an abbreviated SHA is not binding."""
+        with pytest.raises(ReconcileError) as exc:
+            reconcile(_REPO, "abc1234", runs_provider=_provider(_run()))
+
+        assert exc.value.reason == "bad-head-sha"
+
+    def test_a_failing_provider_fails_closed_not_open(self):
+        def broken(repo, sha):
+            return []
+
+        with pytest.raises(ReconcileError) as exc:
+            reconcile(_REPO, _SHA, runs_provider=broken)
+
+        assert exc.value.reason == "no-run"
+
+
+class TestAllowlistIsConfigurable:
+    def test_caller_can_name_its_own_workflows(self):
+        receipt = reconcile(
+            _REPO,
+            _SHA,
+            runs_provider=_provider(_run(name="CI")),
+            allowed_workflows=("CI",),
+        )
+
+        assert receipt.workflow == "CI"

--- a/tests/unit/classes/test_sitting.py
+++ b/tests/unit/classes/test_sitting.py
@@ -1,0 +1,225 @@
+"""The sitting (release-audit-stage R3 step 4).
+
+Two properties carry the design and both are about NOT inventing things:
+an absent or malformed seat is never read as agreement, and the D9
+delta credits the sitting only for changes a seat actually proposed.
+
+No model calls: the seat runner is injected.
+
+Copyright 2025 Smart-AI-Memory
+Licensed under Apache 2.0
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from attune.classes.packet import Packet, ResidualItem
+from attune.classes.sitting import (
+    SEATS,
+    Sitting,
+    build_sitting_brief,
+    compute_sitting_delta,
+    hold_sitting,
+    parse_seat_reply,
+)
+
+
+def _item(n: int, default: str = "GATE-FIRST") -> ResidualItem:
+    return ResidualItem(
+        item_id=f"hit:R7b:src/mod.py:{n}",
+        kind="hit",
+        class_id="C3",
+        locus=f"src/mod.py:{n}",
+        detail="parsed then used unguarded",
+        default_disposition=default,
+    )
+
+
+def _packet(count: int = 2, **sections) -> Packet:
+    base = {"0_header": {"tag_range": "v1..v2", "files_swept": 3, "files_changed": 9}}
+    base.update(sections)
+    return Packet(sections=base, items=tuple(_item(i) for i in range(count)))
+
+
+def _reply(text: str, code: int = 0):
+    return lambda recipe, brief: (code, text)
+
+
+class TestBriefEncodesTheRoleLimits:
+    """D3: seats advise and rank; they do NOT hunt defects."""
+
+    def test_brief_forbids_defect_hunting(self):
+        brief = build_sitting_brief(_packet())
+
+        assert "NOT reviewing a diff" in brief
+        assert "Do not ask for the diff" in brief
+
+    def test_brief_lists_items_with_their_prefilled_defaults(self):
+        packet = _packet(2)
+
+        brief = build_sitting_brief(packet)
+
+        for item in packet.items:
+            assert item.item_id in brief
+            assert item.default_disposition in brief
+
+    def test_empty_residual_still_produces_a_brief(self):
+        """D2 — the table sits every release, empty or not."""
+        brief = build_sitting_brief(_packet(0))
+
+        assert "empty residual still sits" in brief
+
+    def test_ungated_classes_are_offered_for_gate_rank(self):
+        packet = _packet(1, **{"3_ungated_exposure": [{"class_id": "H1"}, {"class_id": "G2"}]})
+
+        brief = build_sitting_brief(packet)
+
+        assert "GATE-RANK" in brief
+        assert "H1" in brief and "G2" in brief
+
+
+class TestAbsenceIsNeverAgreement:
+    def test_nonzero_exit_is_absent(self):
+        reply = parse_seat_reply("codex", 1, "boom")
+
+        assert reply.status == "absent"
+        assert reply.amendments == ()
+
+    def test_empty_output_is_absent(self):
+        assert parse_seat_reply("codex", 0, "   ").status == "absent"
+
+    def test_unparseable_reply_is_flagged_not_assumed(self):
+        reply = parse_seat_reply("claude", 0, "Looks fine to me, ship it!")
+
+        assert reply.status == "format_noncompliant"
+        assert reply.amendments == ()
+        assert reply.raw, "the raw text is preserved for the chair"
+
+    def test_invalid_disposition_is_noncompliant(self):
+        reply = parse_seat_reply("codex", 0, "AMEND hit:x -> LGTM: seems ok")
+
+        assert reply.status == "format_noncompliant"
+
+    def test_a_missing_seat_binary_is_absent_not_fatal(self):
+        def explode(recipe, brief):
+            raise OSError("codex: command not found")
+
+        sitting = hold_sitting(_packet(1), invoke=explode)
+
+        assert {r.status for r in sitting.replies} == {"absent"}
+        assert sitting.seats_present == ()
+
+
+class TestParsingAReply:
+    def test_amendments_and_ranking_and_closing(self):
+        text = (
+            "AMEND hit:R7b:src/mod.py:0 -> SHIP: fixture input, not external\n"
+            "AMEND hit:R7b:src/mod.py:1 -> DEFER: gate lands next release\n"
+            "GATE-RANK: H1, G2, C3\n"
+            "CLOSING: Nothing here blocks the release.\n"
+        )
+
+        reply = parse_seat_reply("codex", 0, text)
+
+        assert reply.status == "replied"
+        assert [a.disposition for a in reply.amendments] == ["SHIP", "DEFER"]
+        assert reply.gate_ranking == ("H1", "G2", "C3")
+        assert "blocks the release" in reply.closing
+
+    def test_no_amendments_is_a_valid_answer(self):
+        reply = parse_seat_reply("claude", 0, "NO AMENDMENTS\nGATE-RANK: H1\n")
+
+        assert reply.status == "replied"
+        assert reply.amendments == ()
+
+    def test_ranking_alone_counts_as_answering(self):
+        assert parse_seat_reply("claude", 0, "GATE-RANK: H1, G2").status == "replied"
+
+
+class TestHoldSitting:
+    def test_runs_every_seat_once_no_rebuttal(self):
+        calls = []
+
+        def spy(recipe, brief):
+            calls.append(recipe[0])
+            return 0, "NO AMENDMENTS\nGATE-RANK: H1\n"
+
+        sitting = hold_sitting(_packet(1), invoke=spy)
+
+        assert len(calls) == len(SEATS), "one round, one call per seat"
+        assert len(sitting.replies) == len(SEATS)
+
+    def test_binds_to_the_packet_it_sat_on(self):
+        packet = _packet(1)
+
+        sitting = hold_sitting(packet, invoke=_reply("NO AMENDMENTS"))
+
+        assert sitting.packet_hash == packet.packet_hash
+
+    def test_collects_amendments_across_seats(self):
+        packet = _packet(1)
+        text = f"AMEND {packet.items[0].item_id} -> SHIP: controlled input\n"
+
+        sitting = hold_sitting(packet, invoke=_reply(text))
+
+        assert len(sitting.amendments_for(packet.items[0].item_id)) == len(SEATS)
+        assert sitting.proposed_dispositions(packet.items[0].item_id) == {"SHIP"}
+
+
+class TestD9DeltaCreditsOnlyTheSitting:
+    """The tally decides whether the sitting keeps earning its place."""
+
+    def test_change_a_seat_proposed_counts(self):
+        packet = _packet(1)
+        item = packet.items[0].item_id
+        sitting = hold_sitting(packet, invoke=_reply(f"AMEND {item} -> SHIP: fixture\n"))
+
+        delta = compute_sitting_delta(packet, {item: "SHIP"}, sitting)
+
+        assert delta[item] is True
+
+    def test_chair_moving_it_alone_does_NOT_count(self):
+        """Crediting the sitting for a solo chair move would inflate D9."""
+        packet = _packet(1)
+        item = packet.items[0].item_id
+        sitting = hold_sitting(packet, invoke=_reply("NO AMENDMENTS\nGATE-RANK: H1\n"))
+
+        delta = compute_sitting_delta(packet, {item: "SHIP"}, sitting)
+
+        assert delta[item] is False
+
+    def test_accepting_the_default_is_not_a_delta(self):
+        packet = _packet(1)
+        item = packet.items[0].item_id
+        sitting = hold_sitting(packet, invoke=_reply("NO AMENDMENTS\n"))
+
+        delta = compute_sitting_delta(packet, {item: "GATE-FIRST"}, sitting)
+
+        assert delta[item] is False
+
+    def test_delta_covers_every_item_so_the_manifest_validates(self):
+        packet = _packet(3)
+        rulings = {i.item_id: i.default_disposition for i in packet.items}
+
+        delta = compute_sitting_delta(packet, rulings, None)
+
+        assert set(delta) == {i.item_id for i in packet.items}
+        assert not any(delta.values())
+
+
+class TestSittingShape:
+    def test_serialises_for_the_record(self):
+        packet = _packet(1)
+        sitting = hold_sitting(packet, invoke=_reply("NO AMENDMENTS\nGATE-RANK: H1\n"))
+
+        data = sitting.as_dict()
+
+        assert data["packet_hash"] == packet.packet_hash
+        assert {r["seat"] for r in data["replies"]} == set(SEATS)
+
+    def test_is_frozen(self):
+        sitting = Sitting(packet_hash="h", replies=())
+
+        with pytest.raises(AttributeError):
+            sitting.packet_hash = "other"  # type: ignore[misc]

--- a/tests/unit/classes/test_stage.py
+++ b/tests/unit/classes/test_stage.py
@@ -1,0 +1,165 @@
+"""Stage orchestration (release-audit-stage R3, steps 0-5).
+
+The orderings are the contract: reconcile red must abort BEFORE any
+sitting, and the stage must never choose a disposition on the chair's
+behalf. Both are pinned here, with every external call injected.
+
+Copyright 2025 Smart-AI-Memory
+Licensed under Apache 2.0
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from attune.classes.stage import StageAborted, run_stage
+
+_REPO = "Smart-AI-Memory/attune-ai"
+
+
+def _git(repo: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", "-C", str(repo), *args], capture_output=True, text=True, timeout=30, check=True
+    ).stdout.strip()
+
+
+def _repo(tmp_path: Path) -> Path:
+    subprocess.run(["git", "init", "-q", str(tmp_path)], check=True, timeout=30)
+    for key, value in (
+        ("user.email", "t@t"),
+        ("user.name", "t"),
+        ("commit.gpgsign", "false"),
+        ("tag.gpgsign", "false"),
+    ):
+        _git(tmp_path, "config", key, value)
+    src = tmp_path / "src" / "attune"
+    src.mkdir(parents=True)
+    (src / "mod.py").write_text("x = 1\n", encoding="utf-8")
+    _git(tmp_path, "add", "-A")
+    _git(tmp_path, "commit", "-q", "-m", "base")
+    _git(tmp_path, "tag", "v1.0.0")
+    (src / "mod.py").write_text("x = 2\n", encoding="utf-8")
+    _git(tmp_path, "add", "-A")
+    _git(tmp_path, "commit", "-q", "-m", "change")
+    return tmp_path
+
+
+def _green_ci(repo, sha):
+    return [
+        {
+            "databaseId": 1,
+            "name": "Tests",
+            "conclusion": "success",
+            "status": "completed",
+            "headSha": sha,
+        }
+    ]
+
+
+def _no_ci(repo, sha):
+    return []
+
+
+def _seat(text="NO AMENDMENTS\nGATE-RANK: C3\n"):
+    return lambda recipe, brief: (0, text)
+
+
+class TestOrderingIsTheContract:
+    def test_reconcile_red_aborts_BEFORE_any_sitting(self, tmp_path):
+        """R3 — seats never deliberate on a broken baseline."""
+        repo = _repo(tmp_path)
+        seat_calls = []
+
+        def spy(recipe, brief):
+            seat_calls.append(recipe)
+            return 0, "NO AMENDMENTS"
+
+        with pytest.raises(StageAborted) as exc:
+            run_stage(repo, _REPO, runs_provider=_no_ci, invoke_seat=spy)
+
+        assert exc.value.step == "1-reconcile"
+        assert seat_calls == [], "no seat may be invoked after a red reconcile"
+
+    def test_baseline_failure_aborts_at_step_0(self, tmp_path):
+        bare = tmp_path / "untagged"
+        subprocess.run(["git", "init", "-q", str(bare)], check=True, timeout=30)
+
+        with pytest.raises(StageAborted) as exc:
+            run_stage(bare, _REPO, runs_provider=_green_ci)
+
+        assert exc.value.step == "0-baseline"
+
+    def test_packet_is_hashed_before_the_sitting_sees_it(self, tmp_path):
+        repo = _repo(tmp_path)
+
+        result = run_stage(repo, _REPO, runs_provider=_green_ci, invoke_seat=_seat())
+
+        assert result.sitting is not None
+        assert result.sitting.packet_hash == result.packet.packet_hash
+
+
+class TestTheStageDoesNotRule:
+    def test_no_dispositions_are_chosen(self, tmp_path):
+        """A tool that picked dispositions would make the manifest a
+        record of itself rather than of the chair."""
+        repo = _repo(tmp_path)
+
+        result = run_stage(repo, _REPO, runs_provider=_green_ci, invoke_seat=_seat())
+
+        assert not hasattr(result, "rulings")
+        # every item still carries only its PRE-FILLED default
+        for item in result.packet.items:
+            assert item.default_disposition in ("SHIP", "HOLD", "GATE-FIRST", "DEFER")
+
+    def test_result_exposes_what_would_block(self, tmp_path):
+        repo = _repo(tmp_path)
+
+        result = run_stage(repo, _REPO, runs_provider=_green_ci, invoke_seat=_seat())
+
+        assert "blocking_by_default" in result.as_dict()
+
+
+class TestEscapesAreVisible:
+    def test_skip_reconcile_records_a_null_receipt_not_a_green_one(self, tmp_path):
+        """The gap must be visible, never implied-green."""
+        repo = _repo(tmp_path)
+
+        result = run_stage(repo, _REPO, skip_reconcile=True, invoke_seat=_seat())
+
+        assert result.reconcile_receipt is None
+        assert result.packet.sections["1_reconcile"] is None
+
+    def test_no_sitting_flag_builds_the_packet_only(self, tmp_path):
+        repo = _repo(tmp_path)
+
+        result = run_stage(repo, _REPO, runs_provider=_green_ci, hold=False)
+
+        assert result.sitting is None
+        assert result.packet is not None
+
+    def test_sweep_is_package_scoped(self, tmp_path):
+        """D10 — and the packet says what it did not look at."""
+        repo = _repo(tmp_path)
+        (repo / "tests").mkdir()
+        (repo / "tests" / "t.py").write_text("y = 1\n", encoding="utf-8")
+        _git(repo, "add", "-A")
+        _git(repo, "commit", "-q", "-m", "add test")
+
+        result = run_stage(repo, _REPO, runs_provider=_green_ci, hold=False)
+
+        header = result.packet.sections["0_header"]
+        assert header["files_not_swept"] >= 1
+        assert header["sweep_scope"] == ["src/"]
+
+
+class TestExitCodes:
+    def test_stage_result_serialises(self, tmp_path):
+        repo = _repo(tmp_path)
+
+        data = run_stage(repo, _REPO, runs_provider=_green_ci, invoke_seat=_seat()).as_dict()
+
+        assert set(data) >= {"baseline", "reconcile", "packet", "packet_hash", "sitting"}
+        assert data["reconcile"]["conclusion"] == "success"

--- a/tests/unit/classes/test_stage_cli_and_providers.py
+++ b/tests/unit/classes/test_stage_cli_and_providers.py
@@ -1,0 +1,329 @@
+"""The seams the injected-dependency design left uncovered.
+
+Everything in the stage takes its network and its seats as parameters,
+which is what keeps the logic testable — but it also means the DEFAULT
+implementations (the `gh` reader, the CLI entry point) never run in the
+suite. Those defaults are what actually execute in production, so their
+failure modes are pinned here.
+
+The property throughout is the same one the stage is built on: an
+unprovable result fails CLOSED. A `gh` that is missing, errors, or
+returns junk must yield "no runs" — never a fabricated green.
+
+Copyright 2025 Smart-AI-Memory
+Licensed under Apache 2.0
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+
+import pytest
+
+from attune.classes import reconcile as reconcile_mod
+from attune.classes import stage as stage_mod
+from attune.classes.manifest import (
+    ManifestError,
+    build_manifest,
+    manifest_path,
+    validate_manifest,
+    write_manifest,
+)
+from attune.classes.packet import Packet, ResidualItem, _public_symbols, _show
+from attune.classes.reconcile import gh_runs_provider
+
+_SHA = "a" * 40
+
+
+def _completed(stdout: str, returncode: int = 0):
+    return subprocess.CompletedProcess(args=["gh"], returncode=returncode, stdout=stdout, stderr="")
+
+
+class TestGhRunsProviderFailsClosed:
+    """The default CI reader. Every failure yields [] -> caller says no-run."""
+
+    def test_parses_a_normal_reply(self, monkeypatch):
+        payload = json.dumps([{"databaseId": 7, "name": "Tests", "headSha": _SHA}])
+        monkeypatch.setattr(subprocess, "run", lambda *a, **k: _completed(payload))
+
+        runs = gh_runs_provider("o/r", _SHA)
+
+        assert runs[0]["databaseId"] == 7
+
+    def test_nonzero_exit_yields_no_runs(self, monkeypatch):
+        monkeypatch.setattr(subprocess, "run", lambda *a, **k: _completed("", returncode=1))
+
+        assert gh_runs_provider("o/r", _SHA) == []
+
+    def test_unparseable_json_yields_no_runs(self, monkeypatch):
+        monkeypatch.setattr(subprocess, "run", lambda *a, **k: _completed("{not json"))
+
+        assert gh_runs_provider("o/r", _SHA) == []
+
+    def test_non_list_json_yields_no_runs(self, monkeypatch):
+        """A dict where a list was expected must not be iterated as runs."""
+        monkeypatch.setattr(subprocess, "run", lambda *a, **k: _completed('{"a": 1}'))
+
+        assert gh_runs_provider("o/r", _SHA) == []
+
+    @pytest.mark.parametrize("exc", [OSError("gh: not found"), subprocess.TimeoutExpired("gh", 60)])
+    def test_a_missing_or_hanging_gh_yields_no_runs(self, monkeypatch, exc):
+        def boom(*a, **k):
+            raise exc
+
+        monkeypatch.setattr(subprocess, "run", boom)
+
+        assert gh_runs_provider("o/r", _SHA) == []
+
+    def test_the_query_binds_repo_and_commit(self, monkeypatch):
+        seen = {}
+
+        def capture(argv, **k):
+            seen["argv"] = argv
+            return _completed("[]")
+
+        monkeypatch.setattr(subprocess, "run", capture)
+        gh_runs_provider("owner/name", _SHA)
+
+        assert "--repo" in seen["argv"] and "owner/name" in seen["argv"]
+        assert "--commit" in seen["argv"] and _SHA in seen["argv"]
+
+
+class TestStageCliExitCodes:
+    """Exit codes are the contract the /release skill documents."""
+
+    def test_ready_for_the_chair_is_zero(self, monkeypatch, capsys):
+        monkeypatch.setattr(
+            stage_mod,
+            "run_stage",
+            lambda *a, **k: stage_mod.StageResult(
+                baseline=_fake_baseline(),
+                reconcile_receipt=None,
+                packet=Packet(sections={"0_header": {}}, items=()),
+                sitting=None,
+            ),
+        )
+
+        assert stage_mod.main(["--no-sitting"]) == 0
+        assert json.loads(capsys.readouterr().out)["packet_hash"]
+
+    def test_abort_is_one(self, monkeypatch, capsys):
+        def abort(*a, **k):
+            raise stage_mod.StageAborted("1-reconcile", "no-run", "nothing for this sha")
+
+        monkeypatch.setattr(stage_mod, "run_stage", abort)
+
+        assert stage_mod.main([]) == 1
+        out = json.loads(capsys.readouterr().out)
+        assert out["aborted_at"] == "1-reconcile" and out["reason"] == "no-run"
+
+    def test_over_cap_is_two_so_split_is_distinguishable(self, monkeypatch, capsys):
+        """R4 reserves 2 so a caller can tell 'split the release' apart."""
+
+        def over(*a, **k):
+            raise stage_mod.StageAborted("3-residual", "over-cap", "[]")
+
+        monkeypatch.setattr(stage_mod, "run_stage", over)
+
+        assert stage_mod.main([]) == 2
+        assert json.loads(capsys.readouterr().out)["reason"] == "over-cap"
+
+
+def _fake_baseline():
+    from attune.classes.baseline import Baseline
+
+    return Baseline(tag="v1.0.0", baseline_sha="b" * 40, head_sha=_SHA, source="last-release-tag")
+
+
+class TestPacketHelpersDegrade:
+    def test_unparseable_source_yields_no_symbols(self):
+        """A corrupt module must not abort the whole symbol delta."""
+        assert _public_symbols("def (((") == set()
+
+    def test_null_byte_source_yields_no_symbols(self):
+        """ast.parse raises ValueError, not SyntaxError, on a null byte."""
+        assert _public_symbols("x = 1\x00\n") == set()
+
+    def test_private_names_are_not_public_surface(self):
+        source = "def _hidden(): pass\ndef shown(): pass\n_X = 1\nY = 2\n"
+
+        assert _public_symbols(source) == {"shown", "Y"}
+
+    def test_show_returns_empty_for_a_path_absent_at_that_ref(self, tmp_path):
+        subprocess.run(["git", "init", "-q", str(tmp_path)], check=True, timeout=30)
+
+        assert _show(tmp_path, "HEAD", "nope.py") == ""
+
+
+class TestManifestValidationBranches:
+    def _valid(self):
+        packet = Packet(
+            sections={},
+            items=(
+                ResidualItem(
+                    item_id="i1",
+                    kind="hit",
+                    class_id="C3",
+                    locus="src/m.py:1",
+                    detail="d",
+                    default_disposition="SHIP",
+                ),
+            ),
+        )
+        return build_manifest(
+            packet,
+            tag="v1.0.0",
+            head_sha=_SHA,
+            baseline_sha="b" * 40,
+            rulings={"i1": "SHIP"},
+            sitting_delta={"i1": False},
+            chair_receipt="ok",
+        ).as_dict()
+
+    def test_non_mapping_is_refused(self):
+        with pytest.raises(ManifestError) as exc:
+            validate_manifest(["not", "a", "mapping"])  # type: ignore[arg-type]
+
+        assert exc.value.reason == "not-a-mapping"
+
+    def test_wrong_schema_version_is_refused(self):
+        data = self._valid()
+        data["schema_version"] = 99
+
+        with pytest.raises(ManifestError) as exc:
+            validate_manifest(data)
+
+        assert exc.value.reason == "schema-version"
+
+    def test_dispositions_must_be_a_mapping(self):
+        data = self._valid()
+        data["per_item_dispositions"] = ["i1"]
+
+        with pytest.raises(ManifestError) as exc:
+            validate_manifest(data)
+
+        assert exc.value.reason == "bad-dispositions"
+
+    def test_unknown_disposition_is_refused_on_read(self):
+        data = self._valid()
+        data["per_item_dispositions"] = {"i1": "MAYBE"}
+
+        with pytest.raises(ManifestError) as exc:
+            validate_manifest(data)
+
+        assert exc.value.reason == "bad-disposition"
+
+    def test_missing_key_is_refused(self):
+        data = self._valid()
+        del data["chair_receipt"]
+
+        with pytest.raises(ManifestError) as exc:
+            validate_manifest(data)
+
+        assert exc.value.reason == "missing-keys"
+
+    def test_a_valid_manifest_round_trips_through_validate(self):
+        assert validate_manifest(self._valid()).tag == "v1.0.0"
+
+    def test_write_cleans_up_its_temp_file_on_failure(self, tmp_path, monkeypatch):
+        """An interrupted write must not leave a .tmp beside the manifest."""
+        packet = Packet(sections={}, items=())
+        manifest = build_manifest(
+            packet,
+            tag="v1.0.0",
+            head_sha=_SHA,
+            baseline_sha="b" * 40,
+            rulings={},
+            sitting_delta={},
+            chair_receipt="ok",
+        )
+        target = manifest_path(tmp_path, "v1.0.0")
+        target.parent.mkdir(parents=True, exist_ok=True)
+
+        def fail_replace(*a, **k):
+            raise OSError("disk full")
+
+        monkeypatch.setattr("attune.classes.manifest.os.replace", fail_replace)
+
+        with pytest.raises(OSError):
+            write_manifest(manifest, tmp_path)
+
+        assert list(target.parent.glob("*.tmp")) == [], "temp file must be cleaned up"
+
+
+class TestReconcileModuleSurface:
+    def test_allowlist_names_the_gate_carrying_workflow(self):
+        assert "Tests" in reconcile_mod.ALLOWED_WORKFLOWS
+
+    def test_only_success_is_treated_as_green(self):
+        assert reconcile_mod._GREEN == "success"
+
+
+class TestTheLastRefusalBranches:
+    """Defence-in-depth paths that the primary guards normally shadow."""
+
+    def test_git_unavailable_is_a_baseline_error_not_a_crash(self, tmp_path, monkeypatch):
+        from attune.classes import baseline as baseline_mod
+
+        def boom(*a, **k):
+            raise OSError("git: command not found")
+
+        monkeypatch.setattr(baseline_mod.subprocess, "run", boom)
+
+        with pytest.raises(baseline_mod.BaselineError) as exc:
+            baseline_mod.resolve_baseline(tmp_path)
+
+        assert exc.value.reason == "git-unavailable"
+
+    def test_manifest_path_parent_check_catches_what_the_tag_regex_misses(
+        self, tmp_path, monkeypatch
+    ):
+        """The regex normally shadows this; it is the belt to its braces."""
+        import re as _re
+
+        import attune.classes.manifest as manifest_mod
+
+        # Relax the shape guard so the resolved-parent assertion is the
+        # thing actually under test.
+        monkeypatch.setattr(manifest_mod, "_SAFE_TAG", _re.compile(r"^.*$"))
+
+        with pytest.raises(ManifestError) as exc:
+            manifest_mod.manifest_path(tmp_path, "../../escape")
+
+        assert exc.value.reason == "unsafe-path"
+
+    def test_a_seat_with_no_recipe_is_absent(self):
+        from attune.classes.sitting import hold_sitting
+
+        packet = Packet(sections={"0_header": {}}, items=())
+        sitting = hold_sitting(packet, seats=("nonexistent-seat",))
+
+        assert sitting.replies[0].status == "absent"
+        assert sitting.seats_present == ()
+
+    def test_amendment_serialises(self):
+        from attune.classes.sitting import SeatAmendment
+
+        data = SeatAmendment(item_id="i1", disposition="SHIP", reason="why").as_dict()
+
+        assert data == {"item_id": "i1", "disposition": "SHIP", "reason": "why"}
+
+    def test_over_cap_residual_aborts_the_stage_at_step_3(self, tmp_path, monkeypatch):
+        """The stage must translate a packet refusal into an abort, not crash."""
+        from attune.classes import stage as st
+        from attune.classes.packet import PacketOverCap
+
+        monkeypatch.setattr(st, "resolve_baseline", lambda *a, **k: _fake_baseline())
+        monkeypatch.setattr(st, "scan_paths", lambda *a, **k: {"hits": [], "rules": {}})
+        monkeypatch.setattr(st, "derive_register", lambda **k: {"rows": []})
+
+        def over(*a, **k):
+            raise PacketOverCap({"breaches": [{"cap": "items", "limit": 12, "actual": 20}]})
+
+        monkeypatch.setattr(st, "build_packet", over)
+
+        with pytest.raises(st.StageAborted) as exc:
+            st.run_stage(tmp_path, "o/r", skip_reconcile=True)
+
+        assert exc.value.step == "3-residual" and exc.value.reason == "over-cap"


### PR DESCRIPTION
## What

**Phase 1 of the release-audit stage** (`docs/specs/release-audit-stage/`, chair-approved 2026-08-22, roundtable-authored). R3 + R4 + R7.

The problem the spec names: three release surfaces exist and **none of them looks at the diff**. `release-gate` checks hygiene, `attune-release-check` checks hygiene, `release-execute` checks publish mechanics. Nothing asks *what class of defect this release could have introduced.*

Per **D1**, this runs where the release already runs — `/release audit`, not a separate command.

## The six steps

```
0  baseline    merge-base vs the last release tag   (fails closed, never guesses)
1  reconcile   CLOSED gates green in CI             (bound to THIS head SHA)
2  sweep       rules over the changed src/ surface  (D10)
3  residual    schema-v1 packet, hard caps          (over-cap REFUSES, exit 2)
4  sitting     three seats, one round, no rebuttal  (D3 roles a + c only)
5  chair       rules per item; manifest written     (R7)
```

`publish` is now **gated**: it calls `require_manifest` before tagging, refusing a tag with no manifest, one recorded against a **different commit**, or one whose chair left items at `HOLD`/`GATE-FIRST`. That's D4's teeth reaching the real publish path instead of staying advisory-by-accident.

## Two orderings are the contract

- **Reconcile red aborts BEFORE any sitting** (R3) — pinned with a spy asserting *zero* seat invocations after a red reconcile. Seats deliberating on a broken baseline deliberate about the wrong tree.
- **The packet is hashed before the sitting sees it**, so the manifest records which residual was actually sat on.

The stage **never rules**. Dispositions are the chair's; a tool that picked them would make the manifest a record of itself.

## Live-fire found three spec violations in my own code

The packet builder was run on the **real `v13.0.2..HEAD` diff before any tests were written**, and refused at 17 items. Chasing that number surfaced:

1. **D5 violation** — I minted a residual item per ungated-exposure class. D5 says exposure warns through the §3 matrix *only*, "never warning-severity rows competing with hits for the packet's cap". Now matrix-only; pinned that 40 ungated classes can't push a packet over cap.
2. **R1 violation** — uncalibrated hits consumed the item cap, though advisory findings "never block, never clear" and so are unrulable.
3. **§0 missed deleted modules** — so 14.0.0's *entire breaking change* was invisible in the section whose job is naming the breaking surface. It reported removed `Test*` classes instead. Now package-scoped and deletion-aware; it names all nine removed exception classes.

All three would have shipped behind green unit tests, because tests written after an implementation are written to match it.

## D10 — sweep scoped to `src/`, chair-ruled in-session

First live run produced **8/8 blocking hits, all in test files** — D5's exact stated fear. Scoped: **53 changed, 20 swept, 0 blocking**, breaking change still visible.

Because a narrowed sweep must not read like a clean one, §0 reports `files_changed`, `files_swept`, **`files_not_swept`**, and `sweep_scope`. An empty residual is never ambiguous between "no defects" and "did not look". `decisions.md` records D10 **including the counter-position I argued and the consequence the chair accepted**.

## Security

The path-validation gate flagged `manifest.py` and was **right**: `manifest_path()` interpolated a caller-supplied tag into a filesystem path, so `../../../etc/cron.d/x` would escape. Fixed rather than allowlisted — shape-validated tag, routed through `_validate_file_path`, resolved parent asserted. Seven hostile tags pinned.

## Verification

- **662 passed** across `classes` + `gates` + `plugins` (incl. the skills-mirror drift guard after re-projection)
- Full tree collection: **25,401**, zero import errors
- Live-fire: aborts `1-reconcile/no-run` (exit 1) on a headless branch; `--skip-reconcile` completes (exit 0), swept 20/53, zero blocking
- Every external call injected — **no model calls and no network in the test suite**
- Pinned `black`, `ruff`, `ruff-bare-exception-check`

## Not included

Phase 2 (R5 teeth armed) and role (b). `release-execute`'s own skill file is user-level, outside this repo — the gate is wired into the repo's `/release` skill here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
