### PR TITLE
chore(ci): raise the codecov floor from 80% to 85%

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -78,8 +78,9 @@ as pickable work.
    2026-07-29 with 35 vetted modules, ratchets shrink-only).*
 
 5. **Coverage is a floor, not a goal.** Changed code carries
-   ≥80% coverage; the local bar is 85%.
-   *Enforcers: `codecov.yml` project+patch gates (80%),
+   ≥85% coverage — CI and the local bar are the same number
+   (chair-ruled 2026-08-22, superseding the earlier 80/85 split).
+   *Enforcers: `codecov.yml` project+patch gates (85%),
    `tests/unit/ci/test_workflow_yaml.py::
    test_coverage_threshold_is_at_least_80` (the threshold itself
    is drift-guarded).*
@@ -328,7 +329,7 @@ as pickable work.
   required for file-op code.
 - NEVER use bare `except:` — catch specific exceptions and log them
   before handling.
-- Type hints and docstrings on all public APIs; minimum 80% test
+- Type hints and docstrings on all public APIs; minimum 85% test
   coverage on changed code.
 - Simpler is better: flatten nested conditionals, inline one-use
   helpers, prefer stdlib over custom abstractions.

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -71,8 +71,9 @@ as pickable work.
    2026-07-29 with 35 vetted modules, ratchets shrink-only).*
 
 5. **Coverage is a floor, not a goal.** Changed code carries
-   ≥80% coverage; the local bar is 85%.
-   *Enforcers: `codecov.yml` project+patch gates (80%),
+   ≥85% coverage — CI and the local bar are the same number
+   (chair-ruled 2026-08-22, superseding the earlier 80/85 split).
+   *Enforcers: `codecov.yml` project+patch gates (85%),
    `tests/unit/ci/test_workflow_yaml.py::
    test_coverage_threshold_is_at_least_80` (the threshold itself
    is drift-guarded).*
@@ -321,7 +322,7 @@ as pickable work.
   required for file-op code.
 - NEVER use bare `except:` — catch specific exceptions and log them
   before handling.
-- Type hints and docstrings on all public APIs; minimum 80% test
+- Type hints and docstrings on all public APIs; minimum 85% test
   coverage on changed code.
 - Simpler is better: flatten nested conditionals, inline one-use
   helpers, prefer stdlib over custom abstractions.
@@ -428,7 +429,7 @@ abstraction.
 - NEVER use bare except: - catch specific exceptions
 - ALWAYS log exceptions before handling
 - Type hints and docstrings required on all public APIs
-- Minimum 80% test coverage
+- Minimum 85% test coverage
 - Security tests required for file operations
 - When creating a detailed plan with 3+ tasks or touching
   3+ files, use XML-enhanced prompt format (see

--- a/.claude/python-standards.md
+++ b/.claude/python-standards.md
@@ -3,5 +3,5 @@
 - Use type hints
 - Follow PEP 8
 - Write docstrings
-- Test coverage: 80% enforced floor (codecov project + patch);
-  target 85%+ (the local `fail_under` bar)
+- Test coverage: 85% enforced floor (codecov project + patch),
+  matching the local `fail_under` bar — one number, not two

--- a/.claude/rules-tail/attune/coding-standards-index.md
+++ b/.claude/rules-tail/attune/coding-standards-index.md
@@ -438,7 +438,7 @@ def process_data(input_file: str, output_file: str, transform: Callable[[dict], 
 
 ## Testing Requirements
 
-### Minimum 80% Test Coverage
+### Minimum 85% Test Coverage
 
 ```bash
 # Check coverage
@@ -1036,7 +1036,7 @@ class TestPathTraversalProtection:
 
 ### Testing
 
-- [ ] Test coverage ≥80%
+- [ ] Test coverage ≥85%
 - [ ] Security tests for file operations
 - [ ] Edge case tests
 - [ ] Error handling tests
@@ -1076,7 +1076,7 @@ class TestPathTraversalProtection:
 - Bare `except:` clauses
 - Unjustified `except Exception:`
 - Missing type hints on public APIs
-- Test coverage <80%
+- Test coverage <85%
 - Missing security tests for file operations
 
 **Fix within:** Same PR/commit

--- a/.github/ISSUE_TEMPLATE/track1-batch-api.md
+++ b/.github/ISSUE_TEMPLATE/track1-batch-api.md
@@ -13,7 +13,7 @@ Enable Anthropic's Batch API for non-urgent tasks to achieve 50% cost reduction.
 - [ ] Batch API client implemented and tested
 - [ ] Successfully process 100+ task batch
 - [ ] Verify 50% cost reduction via telemetry
-- [ ] 85%+ test coverage
+- [ ] 80%+ test coverage
 
 ## Expected Impact
 - **Cost Reduction:** 50% for batch-eligible tasks

--- a/.github/ISSUE_TEMPLATE/track1-batch-api.md
+++ b/.github/ISSUE_TEMPLATE/track1-batch-api.md
@@ -13,7 +13,7 @@ Enable Anthropic's Batch API for non-urgent tasks to achieve 50% cost reduction.
 - [ ] Batch API client implemented and tested
 - [ ] Successfully process 100+ task batch
 - [ ] Verify 50% cost reduction via telemetry
-- [ ] 80%+ test coverage
+- [ ] 85%+ test coverage
 
 ## Expected Impact
 - **Cost Reduction:** 50% for batch-eligible tasks

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,8 +78,9 @@ as pickable work.
    2026-07-29 with 35 vetted modules, ratchets shrink-only).*
 
 5. **Coverage is a floor, not a goal.** Changed code carries
-   ≥80% coverage; the local bar is 85%.
-   *Enforcers: `codecov.yml` project+patch gates (80%),
+   ≥85% coverage — CI and the local bar are the same number
+   (chair-ruled 2026-08-22, superseding the earlier 80/85 split).
+   *Enforcers: `codecov.yml` project+patch gates (85%),
    `tests/unit/ci/test_workflow_yaml.py::
    test_coverage_threshold_is_at_least_80` (the threshold itself
    is drift-guarded).*
@@ -328,7 +329,7 @@ as pickable work.
   required for file-op code.
 - NEVER use bare `except:` — catch specific exceptions and log them
   before handling.
-- Type hints and docstrings on all public APIs; minimum 80% test
+- Type hints and docstrings on all public APIs; minimum 85% test
   coverage on changed code.
 - Simpler is better: flatten nested conditionals, inline one-use
   helpers, prefer stdlib over custom abstractions.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -217,7 +217,7 @@ evolved. xdist is now the standard.)
 
 ### Coverage Requirements
 
-- Minimum **80% overall coverage**
+- Minimum **85% overall coverage**
 - New modules should have **90%+ coverage**
 - Critical modules (core, workflows, security) should have **95%+ coverage**
 
@@ -451,7 +451,7 @@ if __name__ == "__main__":
 ### Before Submitting
 
 1. **Run all tests**: `pytest tests/ --cov=src/attune`
-2. **Check coverage**: Ensure 80%+ coverage
+2. **Check coverage**: Ensure 85%+ coverage
 3. **Update documentation**: Add/update relevant docs
 4. **Add examples**: If adding features, add example
 5. **Self-review**: Read through your changes
@@ -459,7 +459,7 @@ if __name__ == "__main__":
 ### PR Checklist
 
 - [ ] Tests pass locally
-- [ ] Coverage is 80%+ overall
+- [ ] Coverage is 85%+ overall
 - [ ] New code has tests (90%+ coverage for new modules)
 - [ ] Documentation updated
 - [ ] Examples added/updated if relevant

--- a/TESTING_QUICK_START.md
+++ b/TESTING_QUICK_START.md
@@ -51,12 +51,12 @@ pytest tests/behavioral/ -v -m "not slow"
 6. [ ] Test error paths (invalid input, edge cases)
 7. [ ] Run tests locally: `pytest <file> -v`
 8. [ ] Check coverage: `pytest <file> --cov=<module> --cov-report=term-missing`
-9. [ ] Aim for 80%+ coverage
+9. [ ] Aim for 85%+ coverage
 10. [ ] Commit with clear message
 
 ### After Implementation
 - [ ] All tests pass (100% pass rate)
-- [ ] Coverage ≥80%
+- [ ] Coverage ≥85%
 - [ ] Clear test names
 - [ ] Good docstrings
 - [ ] No skipped tests (unless documented)
@@ -638,7 +638,7 @@ Copy this for each module you implement:
 
 ### Validation
 - [ ] All tests pass
-- [ ] Coverage ≥80%
+- [ ] Coverage ≥85%
 - [ ] Clear test names
 - [ ] Good docstrings
 - [ ] No skipped tests

--- a/codecov.yml
+++ b/codecov.yml
@@ -2,13 +2,18 @@ coverage:
   status:
     project:
       default:
-        target: 80%
+        target: 85%
         threshold: 2%
     patch:
       default:
-        # Chair-ruled 2026-07-20 ("floor 80, local 85" story): the
-        # patch gate enforces the documented 80% changed-code floor.
-        target: 80%
+        # Chair-ruled 2026-08-22, superseding the 2026-07-20 "floor 80,
+        # local 85" split: CI now enforces the same 85 the local
+        # `fail_under` already required, so there is one number rather
+        # than two. Thresholds are KEPT deliberately — they absorb
+        # measurement noise, not intent; zeroing them would fail a PR at
+        # 84.97% on rounding, which is how a gate earns a reputation for
+        # crying wolf. Effective floors: 83% project, 80% patch.
+        target: 85%
         threshold: 5%
 
 ignore:

--- a/content/collaboration/contract.md
+++ b/content/collaboration/contract.md
@@ -50,8 +50,9 @@ as pickable work.
    2026-07-29 with 35 vetted modules, ratchets shrink-only).*
 
 5. **Coverage is a floor, not a goal.** Changed code carries
-   ≥80% coverage; the local bar is 85%.
-   *Enforcers: `codecov.yml` project+patch gates (80%),
+   ≥85% coverage — CI and the local bar are the same number
+   (chair-ruled 2026-08-22, superseding the earlier 80/85 split).
+   *Enforcers: `codecov.yml` project+patch gates (85%),
    `tests/unit/ci/test_workflow_yaml.py::
    test_coverage_threshold_is_at_least_80` (the threshold itself
    is drift-guarded).*
@@ -300,7 +301,7 @@ as pickable work.
   required for file-op code.
 - NEVER use bare `except:` — catch specific exceptions and log them
   before handling.
-- Type hints and docstrings on all public APIs; minimum 80% test
+- Type hints and docstrings on all public APIs; minimum 85% test
   coverage on changed code.
 - Simpler is better: flatten nested conditionals, inline one-use
   helpers, prefer stdlib over custom abstractions.

--- a/docs/CODING_STANDARDS.md
+++ b/docs/CODING_STANDARDS.md
@@ -346,10 +346,10 @@ if age > SENIOR_AGE_THRESHOLD:
 
 ## Testing Requirements
 
-### 1. Test Coverage: Minimum 80%
+### 1. Test Coverage: Minimum 85%
 
 **All new features must include:**
-- ✅ Unit tests (80%+ coverage)
+- ✅ Unit tests (85%+ coverage)
 - ✅ Edge case tests
 - ✅ Error handling tests
 
@@ -478,7 +478,7 @@ pre-commit install
 - [ ] All file paths validated with `_validate_file_path()`
 - [ ] Type hints on all functions
 - [ ] Docstrings on public APIs
-- [ ] Test coverage ≥80%
+- [ ] Test coverage ≥85%
 - [ ] Security tests for file operations
 - [ ] CHANGELOG.md updated
 - [ ] Pre-commit hooks passing
@@ -512,7 +512,7 @@ pre-commit install
 **HIGH** (Must fix before merge):
 - Bare `except:` clauses
 - Missing type hints on public APIs
-- Test coverage <80%
+- Test coverage <85%
 
 **MEDIUM** (Should fix):
 - Missing docstrings

--- a/plugin/help/generated/notes/critical-rules.md
+++ b/plugin/help/generated/notes/critical-rules.md
@@ -18,7 +18,7 @@ Non-negotiable security and quality rules for the attune-ai codebase.
 - NEVER use bare except: - catch specific exceptions
 - ALWAYS log exceptions before handling
 - Type hints and docstrings required on all public APIs
-- Minimum 80% test coverage
+- Minimum 85% test coverage
 - Security tests required for file operations
 - When creating a detailed plan with 3+ tasks or touching
   3+ files, use XML-enhanced prompt format (see


### PR DESCRIPTION
## What

Raises both codecov targets from 80% to 85%, superseding the 2026-07-20 *"floor 80, local 85"* split. `pyproject.toml`'s `fail_under` has been **85 all along** — so CI and local now enforce one number instead of two that had to be remembered separately.

| Gate | target | threshold | effective floor |
|---|---|---|---|
| project | 80% → **85%** | 2% (kept) | 78% → **83%** |
| patch | 80% → **85%** | 5% (kept) | 75% → **80%** |

**Thresholds kept deliberately.** Zeroing them was considered and rejected: they absorb measurement *noise*, not intent. A PR failing at 84.97% on rounding is exactly how a gate earns a reputation for crying wolf and gets allowlisted into uselessness.

## ⚠️ One consequence worth naming

[#2182](https://github.com/Smart-AI-Memory/attune-ai/pull/2182) currently **passes** at 76.19% patch coverage against the old 75% effective floor. Under the new **80% patch floor it would fail.** Anything in flight below 80% changed-code coverage needs tests before it can merge.

That's the point of the change, but it shouldn't be a surprise.

## Docs, so nothing cites the superseded number

Principle 8 — docs may not cite fiction. The collaboration contract is a **projection**, so principle 5 and the critical-rules line were edited in the master (`content/collaboration/contract.md`) and **re-projected** to `AGENTS.md`, `.claude/CLAUDE.md`, `.agents/AGENTS.md` — not hand-edited as twins (the drift guard fails on that).

Also updated: `python-standards`, `CODING_STANDARDS`, the coding-standards-index tail rule, `CONTRIBUTING`, `TESTING_QUICK_START`, one issue template, and the generated critical-rules help note.

**Deliberately not touched:** `content/blog/**` (published prose about a generic "30% to 80%" scenario — not a statement of this repo's policy) and `agents_md/quality-validator.md` (a *type*-coverage example table, a different metric).

## Verification

- **1,129 passed** across `ci`, `gates`, contract-projection and `help` suites — including the contract drift guard and claim-drift
- `check-yaml` + `end-of-file-fixer` pass
- No living surface still claims the 80% floor (archive, specs, changelog and lessons excluded as historical)

🤖 Generated with [Claude Code](https://claude.com/claude-code)