### PR TITLE
docs(changelog): record teeth and the 85% floor in 14.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,18 @@ migration is to delete the handler rather than repoint the import.
   `.attune/release-manifests/<tag>.json`, and `publish` verifies one
   exists for the tag being cut. (#2180)
 
+- **The blocking decision, computed but NOT armed (Phase 2, R5).**
+  Given a baseline and HEAD, the stage now decides which findings
+  BLOCK, WARN, or ride an active DEFER — and deliberately stops there.
+  It does not enforce: the CLI reports and exits 0 unless `--armed`,
+  and arming requires a chair-recorded promotion naming the validated
+  rule-pack version. Re-exposure is judged by IDENTITY, not line
+  numbers — (rule id, rename-tracked posix path, nearest enclosing
+  symbol) — so reformatting a file cannot re-block a release, and a
+  pre-existing finding stays register debt rather than becoming a
+  release block. An expired DEFER stops suppressing; the block
+  resuming is the convergence mechanism, not a reminder. (#2182)
+
 - **Class register — tracked rule pack with a derived status column.**
   The register's status is computed, never authored: a class derives
   CLOSED / BROKEN-GATE / FIXED-BUT-UNGATED / OPEN / DEFERRED from
@@ -49,6 +61,16 @@ migration is to delete the handler rather than repoint the import.
   reassigned gate goes loud instead of silently preserving CLOSED. A
   class with no calibrated rule derives UNMECHANIZED rather than
   fabricating a status. (#2173, #2172)
+
+### Changed
+
+- **Changed-code coverage floor raised from 80% to 85%.** Both codecov
+  targets move; the thresholds are kept, so the effective floors are
+  83% (project) and 80% (patch). This replaces the earlier "floor 80,
+  local 85" split — `pyproject.toml`'s `fail_under` had been 85 all
+  along, so CI and local now enforce one number instead of two that had
+  to be remembered separately. Contributors will see PRs below 80%
+  changed-code coverage fail the patch gate. (#2183)
 
 ### Fixed
 


### PR DESCRIPTION
## Why

[#2182](https://github.com/Smart-AI-Memory/attune-ai/pull/2182) (Phase 2 teeth) and [#2183](https://github.com/Smart-AI-Memory/attune-ai/pull/2183) (85% coverage floor) both landed **after** the release-prep commit `44b2aa9f9`. The tag will therefore be cut from a SHA that contains them — so without these entries, 14.0.0 ships describing **less than it contains**.

## Two entries

**Added — the blocking decision, computed but NOT armed.** Described as what it is: the CLI reports and exits 0 unless `--armed`, and arming requires a chair-recorded promotion naming the validated rule-pack version. The entry does **not** claim the stage can hold releases — it can't yet, and overclaiming that is precisely what the register's derived status column exists to prevent.

The re-exposure rule is called out because it's the non-obvious part: identity is *(rule id, rename-tracked path, nearest enclosing symbol)*, **not line numbers** — so reformatting a file can't re-block a release, and a pre-existing finding stays register debt rather than becoming a release block.

**Changed — coverage floor 80% → 85%**, with effective floors spelled out (83% project, 80% patch). "85%" alone would mislead anyone reading it as the number their PR must clear.

## Not touched

The README. Its "New in" slot is user-facing; an unarmed internal mechanism and a contributor coverage policy aren't user features. The audit stage stays the headline.

## Next

This becomes the tag target — the audit runs against **this** SHA, not `44b2aa9f9`. The dogfood manifest is bound to `093cd7acd` and by design cannot authorize it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)