### PR TITLE
perf(classes): walk each file twice, not once per rule

### DIFF
--- a/src/attune/classes/rules.py
+++ b/src/attune/classes/rules.py
@@ -259,13 +259,39 @@ class _V1Sweep(ast.NodeVisitor):
             self._hit("R6-redis-fstring-key", node, f"{f.value.id}.{f.attr}(f'...')")
 
 
-def _v1_only(rule_id: str) -> Callable[[ast.AST, str], list[Hit]]:
-    def check(tree: ast.AST, path: str) -> list[Hit]:
-        sweep = _V1Sweep(path)
-        sweep.visit(tree)
-        return [h for h in sweep.hits if h.rule_id == rule_id]
+@dataclass(frozen=True)
+class _SweepCheck:
+    """One rule's slice of a SHARED sweep.
 
-    return check
+    Every rule in a sweep family sees the same traversal, so running
+    the visitor per rule walked each file once per rule (8 walks for
+    the 8-rule pack) to keep one rule's hits and discard the rest.
+    Carrying the visitor class here lets :func:`scan_source` run each
+    distinct sweep once per file and slice it per rule.
+
+    Calling it directly still walks the tree on its own, so a caller
+    holding a single ``Rule`` keeps the old standalone behavior.
+    """
+
+    visitor: type[ast.NodeVisitor]
+    rule_id: str
+
+    def __call__(self, tree: ast.AST, path: str) -> list[Hit]:
+        return self.slice(self.sweep(tree, path))
+
+    def sweep(self, tree: ast.AST, path: str) -> list[Hit]:
+        """Run the whole family sweep once and return ALL its hits."""
+        visitor = self.visitor(path)
+        visitor.visit(tree)
+        return list(getattr(visitor, "hits", []))
+
+    def slice(self, swept: list[Hit]) -> list[Hit]:
+        """Keep only this rule's hits, in traversal order."""
+        return [h for h in swept if h.rule_id == self.rule_id]
+
+
+def _v1_only(rule_id: str) -> Callable[[ast.AST, str], list[Hit]]:
+    return _SweepCheck(_V1Sweep, rule_id)
 
 
 # --------------------------------------------------------------------------
@@ -401,12 +427,7 @@ class _R7Visitor(ast.NodeVisitor):
 
 
 def _r7_only(rule_id: str) -> Callable[[ast.AST, str], list[Hit]]:
-    def check(tree: ast.AST, path: str) -> list[Hit]:
-        visitor = _R7Visitor(path)
-        visitor.visit(tree)
-        return [h for h in visitor.hits if h.rule_id == rule_id]
-
-    return check
+    return _SweepCheck(_R7Visitor, rule_id)
 
 
 #: The pack. Class ids map to the 2026-08-20 register; a rule with no
@@ -490,7 +511,20 @@ def scan_source(source: str, path: str, rules: tuple[Rule, ...] = RULES) -> list
     except (SyntaxError, ValueError) as exc:
         lineno = getattr(exc, "lineno", 0) or 0
         return [Hit("PARSE-ERROR", path, lineno, str(exc))]
+    # One traversal per distinct sweep, not one per rule. Rules that
+    # share a visitor (all of RULES does) would otherwise walk the
+    # file once each -- 8 walks where 2 suffice, on every scanned file
+    # in every CI run.
+    swept: dict[type[ast.NodeVisitor], list[Hit]] = {}
     hits: list[Hit] = []
     for rule in rules:
-        hits.extend(rule.check(tree, path))
+        check = rule.check
+        if not isinstance(check, _SweepCheck):
+            hits.extend(check(tree, path))  # custom rule: unchanged
+            continue
+        family = swept.get(check.visitor)
+        if family is None:
+            family = check.sweep(tree, path)
+            swept[check.visitor] = family
+        hits.extend(check.slice(family))
     return hits

--- a/tests/unit/classes/test_rules.py
+++ b/tests/unit/classes/test_rules.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+import ast
 import subprocess
 import textwrap
 from pathlib import Path
 
+from attune.classes import rules as rules_mod
 from attune.classes.rules import (
     RULES,
     Calibration,
@@ -207,3 +209,98 @@ class TestCanonicalRepoId:
         d = tmp_path / "Plain"
         d.mkdir()
         assert canonical_repo_id(d) == "plain"
+
+
+class TestOneTraversalPerSweepFamily:
+    """The pack shares two visitors; a file must be walked twice, not 8x.
+
+    Running the visitor per rule is the obvious implementation and it
+    is what shipped in 14.0.0: each rule built its own visitor, walked
+    the whole file, then discarded every hit but its own. That is 8
+    full AST traversals per file for an 8-rule pack, on every scanned
+    file of every CI run. These tests pin the collapse so a later
+    refactor cannot quietly reintroduce it -- the output is identical
+    either way, so nothing else would notice.
+    """
+
+    def _count_constructions(self, source: str) -> list[str]:
+        """Return the visitor class names constructed during one scan."""
+        built: list[str] = []
+        originals = {}
+        for cls in (rules_mod._V1Sweep, rules_mod._R7Visitor):
+            originals[cls] = cls.__init__
+
+            def make(orig, name):
+                def __init__(self, path, *a, **k):
+                    built.append(name)
+                    orig(self, path, *a, **k)
+
+                return __init__
+
+            cls.__init__ = make(originals[cls], cls.__name__)
+        try:
+            rules_mod.scan_source(source, "sample.py")
+        finally:
+            for cls, orig in originals.items():
+                cls.__init__ = orig
+        return built
+
+    def test_each_sweep_family_is_walked_exactly_once(self):
+        source = (
+            "import subprocess\n"
+            "def f(data):\n"
+            "    subprocess.run(['x'])\n"
+            "    return data.get('k')\n"
+        )
+
+        built = self._count_constructions(source)
+
+        assert len(built) == 2, f"expected one walk per family, got {built}"
+        assert sorted(built) == ["_R7Visitor", "_V1Sweep"]
+
+    def test_walk_count_does_not_grow_with_the_rule_count(self):
+        """The whole point: adding rules must not add traversals."""
+        source = "def f(d):\n    return d.get('k')\n"
+
+        assert len(rules_mod.RULES) > 2, "pack should be bigger than its family count"
+        assert len(self._count_constructions(source)) == 2
+
+    def test_a_rule_outside_the_shared_sweeps_still_runs(self):
+        """Custom checks keep working -- the fast path is not the only path."""
+        seen: list[str] = []
+
+        def custom(tree, path):
+            seen.append(path)
+            return [rules_mod.Hit("CUSTOM", path, 1, "fired")]
+
+        rule = rules_mod.Rule("CUSTOM", "custom", (), custom, ())
+
+        hits = rules_mod.scan_source("x = 1\n", "sample.py", rules=(rule,))
+
+        assert seen == ["sample.py"]
+        assert [h.rule_id for h in hits] == ["CUSTOM"]
+
+    def test_calling_a_single_rule_directly_still_scans_standalone(self):
+        """A caller holding one Rule keeps the old self-contained behavior."""
+        source = "import subprocess\nsubprocess.run(['x'])\n"
+        rule = next(r for r in rules_mod.RULES if r.id == "R4-subprocess-no-timeout")
+
+        direct = rule.check(ast.parse(source), "sample.py")
+
+        assert [h.rule_id for h in direct] == ["R4-subprocess-no-timeout"]
+
+    def test_shared_sweep_output_matches_per_rule_scanning(self):
+        """Equivalence, not just speed: same hits, same order."""
+        source = (
+            "import subprocess\n"
+            "def f(data):\n"
+            "    subprocess.run(['a'])\n"
+            "    subprocess.run(['b'])\n"
+            "    return data.get('k')\n"
+        )
+        tree = ast.parse(source)
+
+        collapsed = rules_mod.scan_source(source, "sample.py")
+        per_rule = [h for rule in rules_mod.RULES for h in rule.check(tree, "sample.py")]
+
+        assert collapsed == per_rule


### PR DESCRIPTION
## What

The release-audit rule pack has 8 rules but exactly **two** visitors
(`_V1Sweep`, `_R7Visitor`). `_v1_only` / `_r7_only` each built a fresh
visitor, walked the entire file, then kept one rule's hits and threw the
rest away — so every scanned file got **8 full AST traversals where 2
suffice**. This drives both the per-release sweep and the continuous
gates, so it is ~4x wasted CPU on every CI push.

`scan_source` now runs each distinct sweep once per file and slices it
per rule.

## Receipt

Measured over the real tree, 751 files:

| | before | after |
|---|---|---|
| hits | 121 | 121 (**0 mismatches**) |
| visitor constructions / file | 8 | **2** |

Output is byte-identical. That is precisely why it needs a guard —
a regression here changes nothing observable.

`tests/unit/classes/test_rules.py::TestOneTraversalPerSweepFamily`
counts visitor constructions and fails if the per-rule form returns.
**Mutation-checked:** reverting `scan_source` to the old loop fails 2 of
the 5 new tests. The other 3 are equivalence/compat and pass either way
by design.

557 passed serially across `tests/unit/classes/`, `tests/unit/quality/`
(complexity ratchet), `tests/unit/gates/`.

## Compatibility

- A rule whose `check` is not one of the shared sweeps still runs
  normally — the fast path is not the only path.
- Calling a single `Rule.check(tree, path)` directly keeps the old
  self-contained behavior; `rule.check` had exactly one caller in-tree
  (`rules.py:495`), so blast radius is contained.

## Provenance

Found by the **14.0.0 post-release self-review** (release-execute step
16) run against the shipped tree — the release-audit stage's own scanner
was the top finding of its own release's review.

Not armed for auto-merge: this is gate-enforcement machinery, so per
D11 CHAIR-ARMS the chair arms it, after a different-model review lane.
