### PR TITLE
docs(contract): principle 16 — claims carry their basis

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -163,6 +163,26 @@ as pickable work.
     script where `~/.attune/memory/` exists and skips elsewhere,
     including CI).*
 
+16. **Claims carry their basis.** A load-bearing claim states how it
+    is known — "verified by <probe>" or, plainly, "inferred, not
+    checked". Verify whenever the probe is cheap; when you do not,
+    SAY SO IN THE CLAIM. The bug is never the inference, it is the
+    inference wearing the grammar of a verified fact, because the
+    reader cannot tell them apart and acts on both alike. Before
+    asserting, name the property your check actually establishes and
+    ask whether it is the property the next action depends on — a ref
+    comparison answers "what does the remote know", never "what is on
+    this disk"; a clean `git status` means "matches its own HEAD", not
+    "is current".
+    *Enforcer: **aspirational** (no gate detects an inference stated
+    as fact — it is a property of prose. Reviewed periodically via
+    the `/retro` close-out, which asks which claims carried no stated
+    basis. Ratified 2026-08-22 after a release session in which four
+    such claims — one relayed to a peer as the chair's authorization
+    — each had a one-line verifying command available and unrun, and
+    in which two existing detection mechanisms had already reported
+    the problem and were read as ambient noise.)*
+
 ### Shared truth
 
 - Treat the current worktree, Git state, and relevant test results as

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -156,6 +156,26 @@ as pickable work.
     script where `~/.attune/memory/` exists and skips elsewhere,
     including CI).*
 
+16. **Claims carry their basis.** A load-bearing claim states how it
+    is known — "verified by <probe>" or, plainly, "inferred, not
+    checked". Verify whenever the probe is cheap; when you do not,
+    SAY SO IN THE CLAIM. The bug is never the inference, it is the
+    inference wearing the grammar of a verified fact, because the
+    reader cannot tell them apart and acts on both alike. Before
+    asserting, name the property your check actually establishes and
+    ask whether it is the property the next action depends on — a ref
+    comparison answers "what does the remote know", never "what is on
+    this disk"; a clean `git status` means "matches its own HEAD", not
+    "is current".
+    *Enforcer: **aspirational** (no gate detects an inference stated
+    as fact — it is a property of prose. Reviewed periodically via
+    the `/retro` close-out, which asks which claims carried no stated
+    basis. Ratified 2026-08-22 after a release session in which four
+    such claims — one relayed to a peer as the chair's authorization
+    — each had a one-line verifying command available and unrun, and
+    in which two existing detection mechanisms had already reported
+    the problem and were read as ambient noise.)*
+
 ### Shared truth
 
 - Treat the current worktree, Git state, and relevant test results as
@@ -572,63 +592,6 @@ Query the tail with `/recall <topic>`; relevant lessons also surface
 automatically at prompt time and at tool-call decision points.
 APPEND NEW LESSONS to `.claude/lessons.md`, not here — mirror into
 this section only if core-worthy (and then keep both copies in sync).
-
-- **Pre-commit black/ruff/detect-secrets auto-fix vs staging —
-  the dance, one root cause and several symptoms**: the
-  auto-fix hooks modify staged files during `git commit`,
-  which interacts badly with staging. Core rule: **pre-flight
-  the PINNED hooks before `git add`** so they see already-clean
-  files. The symptoms and remedies:
-  - **Pre-flight the pinned tool** — run `uv run --with
-    pre-commit pre-commit run black --files <f>` (and `ruff`)
-    before staging. Use the PINNED version, not `.venv`'s —
-    they can format differently (saw py3.10 venv black leave a
-    triple-quoted layout that pinned black reformatted). Also
-    pre-flight `uv run ruff check <f>` for the non-autofixable
-    lint (F841, E402) that the format hooks don't catch. This
-    avoids the stash/restore dance entirely. **CI black runs on
-    the WHOLE file your PR touches, not just your diff** — so a
-    pre-existing pinned-black discrepancy on lines you never
-    edited fails your PR's `lint`/`pre-commit` (PR #689: CI black
-    wanted a `print(f"""…""")` wrapped at line 640, nowhere near
-    the change; local `.venv` black left it alone). Especially
-    likely after a **hand-resolved rebase conflict** (the resolved
-    region is only formatted by your LOCAL edit-formatter, which
-    differs from pinned) or when touching a file not pinned-black-
-    checked in a while. Diagnostic for "black fails on lines I
-    didn't write": run `uv run --with pre-commit pre-commit run
-    black --files <f>` and commit whatever it reformats.
-  - **Stash conflict** — if a hook auto-fixed staged files AND
-    any tracked file is unstaged (even unrelated — `uv.lock`, a
-    fixture), pre-commit's stash/restore cycle conflicts and
-    the commit fails (silently or in a loop). Quarantine:
-    `git add` the related files OR `git stash push <unrelated>`,
-    commit, then pop.
-  - **Re-stage after auto-fix** — when a hook reformats staged
-    files, the commit fails but the fixes land in the working
-    tree UNSTAGED; `git add <files>` again and retry. Distinct
-    from the stash conflict: here the hook ran fine and there
-    are no unstaged siblings — the commit just needs repeating.
-  - **`git commit -q` can exit 0 yet SKIP the commit** — when
-    end-of-file-fixer / trailing-whitespace modify files, the
-    tail shows "Passed" with no "Aborted" line, but the commit
-    is skipped and the files left re-staged. ALWAYS verify with
-    `git log --oneline -1` / `git status --short` after
-    committing — no error message ≠ commit landed.
-  - **detect-secrets** — (a) it flags obvious placeholders like
-    `"fake"` in `{"ANTHROPIC_API_KEY": "fake"}` via the
-    Secret-Keyword heuristic (even a 4-char string fires); add
-    `# pragma: allowlist secret` on the line. (b) when the hook
-    bumps `.secrets.baseline`'s schema (e.g. 1.4.0→1.5.0), a
-    previously-stashed `.secrets.baseline` reverts the bump on
-    `git stash pop` — after popping, `git diff .secrets.baseline`
-    then `git checkout .secrets.baseline` to discard the revert.
-  - **`SKIP=hookname` ≠ `--no-verify`** — `SKIP=check-docs-
-    freshness git commit …` runs every OTHER hook and skips
-    only the named one (surgical; defensible when one hook
-    fails on state orthogonal to the commit). `--no-verify`
-    skips ALL hooks and is forbidden by the rules; `SKIP=` is
-    the allowed alternative.
 
 - **Diagnosing "this branch cannot be merged", and "the command
   errored but the merge actually succeeded"**:
@@ -1203,6 +1166,39 @@ this section only if core-worthy (and then keep both copies in sync).
   migration is a silent recall regression for every gate that scans for
   the old one.** Pairs with the existing "reviewing gate allowlist
   entries — the escape hatch is the actual attack surface" prior.
+- **State the BASIS with every load-bearing claim — an inference in
+  the grammar of a verified fact is the bug, and the verifying command
+  is usually one line you already have**: ratified 2026-08-22 after a
+  release session where four such claims each had a cheap probe
+  available and unrun. **The rule: verify when the probe is cheap; when
+  you do not, SAY SO IN THE CLAIM** ("verified by X" / "inferred, not
+  checked"). An unmarked confident assertion is indistinguishable from
+  a checked one, so the reader acts on both alike — and Patrick's
+  framing is that guessing without flagging it is itself the issue, the
+  same posture that produces sloppy code. **The diagnostic: name the
+  property your check actually establishes, then ask whether it is the
+  property your next action depends on.** `git rev-parse origin/main:src`
+  matching a tag establishes something about a REMOTE-TRACKING REF; a
+  scan that reads the WORKING TREE is unaffected by it (that checkout
+  was 17 commits behind, and the review would have been filed as the
+  release receipt). `git status --porcelain` clean means "matches its
+  own HEAD", NOT "is current" — pair it with
+  `git rev-list --count HEAD..origin/main`. "The runner spawns a
+  subprocess" establishes a code path, not process independence — read
+  `ps -o ppid=,command=`. Which code will execute is answered by the
+  filesystem that will be read (`pyproject.toml` on disk, an imported
+  `__version__`, `__file__`), never by a ref. Relaying a third party's
+  approval ("X approved this") is the same error in social form: the
+  recipient cannot verify it through you. **Why this sits in core
+  rather than the tail: recall cannot save you from it.** The corpus
+  already held adjacent lessons and none fired, because the failure
+  happens when a CONCLUSION IS FORMED — earlier than any tool call that
+  would trigger retrieval — and on that session the SessionStart hook
+  had already printed `STALE SOURCE … 17 commits behind` and it was
+  read as ambient noise. Verification also keeps OLD lessons honest:
+  the same session found a core lesson's premise ("Windows lanes are
+  NOT required") had gone stale, so acting on it unverified would have
+  added pointless friction.
 - **`os.geteuid()` inside a `pytest.mark.skipif` condition errors the
   WHOLE MODULE at collection time on Windows — skipif conditions are
   evaluated eagerly, so a second `skipif(os.name == "nt")` above it

--- a/.claude/lessons.md
+++ b/.claude/lessons.md
@@ -24673,3 +24673,37 @@ launched in parallel.
   see it. Pairs with the existing worktree-vs-main PYTHONPATH/Write-path
   lessons: same family (locating the right tree), this one is the
   VERIFICATION surface rather than the execute or write surface.
+
+- **State the BASIS with every load-bearing claim — an inference in
+  the grammar of a verified fact is the bug, and the verifying command
+  is usually one line you already have**: ratified 2026-08-22 after a
+  release session where four such claims each had a cheap probe
+  available and unrun. **The rule: verify when the probe is cheap; when
+  you do not, SAY SO IN THE CLAIM** ("verified by X" / "inferred, not
+  checked"). An unmarked confident assertion is indistinguishable from
+  a checked one, so the reader acts on both alike — and Patrick's
+  framing is that guessing without flagging it is itself the issue, the
+  same posture that produces sloppy code. **The diagnostic: name the
+  property your check actually establishes, then ask whether it is the
+  property your next action depends on.** `git rev-parse origin/main:src`
+  matching a tag establishes something about a REMOTE-TRACKING REF; a
+  scan that reads the WORKING TREE is unaffected by it (that checkout
+  was 17 commits behind, and the review would have been filed as the
+  release receipt). `git status --porcelain` clean means "matches its
+  own HEAD", NOT "is current" — pair it with
+  `git rev-list --count HEAD..origin/main`. "The runner spawns a
+  subprocess" establishes a code path, not process independence — read
+  `ps -o ppid=,command=`. Which code will execute is answered by the
+  filesystem that will be read (`pyproject.toml` on disk, an imported
+  `__version__`, `__file__`), never by a ref. Relaying a third party's
+  approval ("X approved this") is the same error in social form: the
+  recipient cannot verify it through you. **Why this sits in core
+  rather than the tail: recall cannot save you from it.** The corpus
+  already held adjacent lessons and none fired, because the failure
+  happens when a CONCLUSION IS FORMED — earlier than any tool call that
+  would trigger retrieval — and on that session the SessionStart hook
+  had already printed `STALE SOURCE … 17 commits behind` and it was
+  read as ambient noise. Verification also keeps OLD lessons honest:
+  the same session found a core lesson's premise ("Windows lanes are
+  NOT required") had gone stale, so acting on it unverified would have
+  added pointless friction.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -163,6 +163,26 @@ as pickable work.
     script where `~/.attune/memory/` exists and skips elsewhere,
     including CI).*
 
+16. **Claims carry their basis.** A load-bearing claim states how it
+    is known — "verified by <probe>" or, plainly, "inferred, not
+    checked". Verify whenever the probe is cheap; when you do not,
+    SAY SO IN THE CLAIM. The bug is never the inference, it is the
+    inference wearing the grammar of a verified fact, because the
+    reader cannot tell them apart and acts on both alike. Before
+    asserting, name the property your check actually establishes and
+    ask whether it is the property the next action depends on — a ref
+    comparison answers "what does the remote know", never "what is on
+    this disk"; a clean `git status` means "matches its own HEAD", not
+    "is current".
+    *Enforcer: **aspirational** (no gate detects an inference stated
+    as fact — it is a property of prose. Reviewed periodically via
+    the `/retro` close-out, which asks which claims carried no stated
+    basis. Ratified 2026-08-22 after a release session in which four
+    such claims — one relayed to a peer as the chair's authorization
+    — each had a one-line verifying command available and unrun, and
+    in which two existing detection mechanisms had already reported
+    the problem and were read as ambient noise.)*
+
 ### Shared truth
 
 - Treat the current worktree, Git state, and relevant test results as

--- a/content/collaboration/contract.md
+++ b/content/collaboration/contract.md
@@ -135,6 +135,26 @@ as pickable work.
     script where `~/.attune/memory/` exists and skips elsewhere,
     including CI).*
 
+16. **Claims carry their basis.** A load-bearing claim states how it
+    is known — "verified by <probe>" or, plainly, "inferred, not
+    checked". Verify whenever the probe is cheap; when you do not,
+    SAY SO IN THE CLAIM. The bug is never the inference, it is the
+    inference wearing the grammar of a verified fact, because the
+    reader cannot tell them apart and acts on both alike. Before
+    asserting, name the property your check actually establishes and
+    ask whether it is the property the next action depends on — a ref
+    comparison answers "what does the remote know", never "what is on
+    this disk"; a clean `git status` means "matches its own HEAD", not
+    "is current".
+    *Enforcer: **aspirational** (no gate detects an inference stated
+    as fact — it is a property of prose. Reviewed periodically via
+    the `/retro` close-out, which asks which claims carried no stated
+    basis. Ratified 2026-08-22 after a release session in which four
+    such claims — one relayed to a peer as the chair's authorization
+    — each had a one-line verifying command available and unrun, and
+    in which two existing detection mechanisms had already reported
+    the problem and were read as ambient noise.)*
+
 ### Shared truth
 
 - Treat the current worktree, Git state, and relevant test results as

--- a/tests/unit/lessons/test_core_mirror.py
+++ b/tests/unit/lessons/test_core_mirror.py
@@ -33,6 +33,35 @@ CORE_HEADING = "## Lessons — core"
 # BEFORE the count cap, so a promotion that costs real context trips here
 # and forces the eviction conversation. Seeded at 44,951 (26 entries,
 # 2026-08-22). SHRINK-ONLY: demote something rather than widening it.
+#
+# WHICH lesson to demote, when this budget refuses a promotion
+# (criterion ratified 2026-08-22, in the retro that followed the first
+# eviction this budget forced):
+#
+#   Core residency is for failures that DON'T ANNOUNCE THEMSELVES.
+#
+# If the failure produces a loud, searchable symptom, the lesson belongs
+# in the lessons.md tail no matter how useful it is — JIT recall reaches
+# it, because the operator holds a term to retrieve on. A pre-commit
+# failure is loud: the commit fails, a hook prints its own name, files
+# show modified. An inference stated as a verified fact produces NO
+# symptom, so there is nothing to retrieve on and residency is the only
+# mechanism left; that asymmetry is why "claims carry their basis"
+# (contract principle 16) was promoted and the pre-commit auto-fix
+# lesson was demoted to pay for it.
+#
+# Two riders from the same trade. (1) Keep PREVENTION resident and let
+# DIAGNOSIS be retrievable: the demoted lesson's five operative rules
+# were already resident in CLAUDE.md's "Git and pre-commit" section, so
+# only the diagnosis of an already-visible incident moved to recall.
+# (2) The cost is easy to forget — core is context EVERY session pays
+# for whether or not the lesson fires, so a lesson that only earns its
+# keep during a recognizable incident should not be charged to every
+# session.
+#
+# Do not compare candidates on how much unique content each carries.
+# That was the losing argument in the ratifying discussion; the
+# deciding question is whether recall can reach it when it matters.
 CORE_BUDGET_BYTES = 46_000
 
 


### PR DESCRIPTION
## Principle 16 — Claims carry their basis

> A load-bearing claim states how it is known — "verified by \<probe\>"
> or, plainly, "inferred, not checked."

The bug is never the inference. It's the inference wearing the grammar
of a verified fact, because the reader can't tell the two apart and acts
on both alike.

**Ratified 2026-08-22**, after a release session where four such claims
each had a one-line verifying command available and unrun — one of them
relayed to a peer session as the chair's authorization, which that
session correctly refused.

## Why this is a claim-time discipline, not another warning

Two detection mechanisms **already existed and already fired**:
`collaboration_preflight.py` computes checkout staleness, and the
SessionStart hook printed `STALE SOURCE … 17 commits behind` before any
of it. Both were read as ambient noise. A third signal at the same layer
buys nothing — the gap isn't detection, it's that a conclusion got
formed without consulting what was already on screen.

Marked **aspirational**, per this contract's own convention: no gate
detects an inference stated as fact, because it's a property of prose.
Faking an enforcer would be worse than naming the gap. Reviewed
periodically instead — `/retro` grows an **UNBACKED CLAIMS** section
(user-level skill, edited outside this repo).

## The core mirror, and the eviction the budget forced

Promoted to the always-loaded core because **recall cannot catch this
class**: the corpus already held adjacent lessons and none fired, since
the failure happens when a conclusion is *formed* — earlier than any
tool call that would trigger retrieval.

The core budget is shrink-only and had **270 B** of headroom, so this
forced the eviction conversation it was designed to force. Demoted: the
pre-commit auto-fix lesson. Rationale, verified rather than asserted —
all five of its operative rules are **already duplicated in this same
file's resident "Git and pre-commit" section**:

| Rule | Resident already? |
|---|---|
| pre-flight the pinned tools before `git add` | yes |
| verify the commit landed (hooks skip at exit 0) | yes |
| re-stage after an auto-fix | yes |
| `--no-verify` forbidden; use `SKIP=<hook-id>` | yes |
| detect-secrets `# pragma: allowlist secret` | yes |

Only its diagnostic color moves to JIT recall. **Nothing left the
canon** — `lessons.md` keeps the full entry.

| | before | after |
|---|---|---|
| core section | 45,730 B | **44,563 B** |
| budget | 46,000 | 46,000 |

Net reduction. The contract was edited at the master
(`content/collaboration/contract.md`) and re-projected to all three
provider surfaces; the projection drift guard passes.

## Verification

`tests/unit/lessons/` + contract projection: 48 passed.
`tests/unit/rules/test_rules_residency_budget.py` + `tests/unit/gates/`:
334 passed.

## Not armed

Governance/enforcement text — CHAIR-ARMS reserves this one for the
chair.
