### PR TITLE
feat(elicitation): apply the AskUserQuestion conventions by construction

### DIFF
--- a/src/attune/elicitation/__init__.py
+++ b/src/attune/elicitation/__init__.py
@@ -124,6 +124,8 @@ from attune_forms.reference_form import EXAMPLE_ANSWERS, REFERENCE_FORM  # noqa:
 from attune_forms.template_store import form_from_template, list_templates  # noqa: E402
 from attune_forms.widget import WIDGET_RESPONSE_MARKER, form_to_widget_html  # noqa: E402
 
+from attune.elicitation.ask_payload import form_to_ask_payload  # noqa: E402
+
 __all__ = [
     "EXAMPLE_ANSWERS",
     "REFERENCE_FORM",
@@ -133,6 +135,7 @@ __all__ = [
     "form_from_dict",
     "form_from_template",
     "form_response_summary",
+    "form_to_ask_payload",
     "form_to_askuserquestion",
     "form_to_elicitation_schema",
     "form_to_widget_html",

--- a/src/attune/elicitation/ask_payload.py
+++ b/src/attune/elicitation/ask_payload.py
@@ -1,0 +1,142 @@
+"""Tool-ready ``AskUserQuestion`` payloads with this repo's conventions applied.
+
+``attune_forms.form_to_askuserquestion`` renders a :class:`FormSchema` to
+BATCHES of question dicts. Turning a batch into an actual tool call still
+takes two local conventions, both enforced by the user-level
+``ask_question_format_guard`` hook and neither expressible in the shared
+package:
+
+1. a batch of more than one question must opt in via ``metadata.source``
+   containing ``"form"``; and
+2. the FIRST option must be the recommended one and its label must end
+   with ``"(Recommended)"``.
+
+Those are host policy, not form semantics — baking them into
+``attune-forms`` would impose one consumer's hook on every consumer. So
+they live here, in the layer that already registers the host seams.
+
+The point is that a caller cannot forget them. Both rules cost a
+round-trip each when missed (observed 2026-08-22: two consecutive guard
+rejections on one form), and a convention that holds only when
+remembered is a habit, not a convention.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under Apache 2.0
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+RECOMMENDED_SUFFIX = "(Recommended)"
+
+#: Marks a payload as a deliberate multi-question form. The guard looks
+#: for "form" as a substring, so this value opts in by construction.
+DEFAULT_SOURCE = "elicit-form"
+
+#: AskUserQuestion renders this as a short chip; longer values are
+#: rejected, so derived headers are truncated to fit.
+MAX_HEADER_CHARS = 12
+
+_MULTI_TYPES = frozenset({"multi_select"})
+
+
+def _header_for(question: dict[str, Any]) -> str:
+    """Derive the short chip label from a question's text.
+
+    Prefers the question's own words over its id — ``"Binding"`` reads
+    better than ``"binding_surface"`` — and truncates rather than
+    raising, because a too-long header is a rejected tool call.
+    """
+    label = str(question.get("question") or question.get("question_id") or "Choose")
+    label = label.strip().rstrip("?:").strip()
+    if len(label) <= MAX_HEADER_CHARS:
+        return label
+    # Keep whole words where one fits; a hard slice is the fallback.
+    words = label.split()
+    if words and len(words[0]) <= MAX_HEADER_CHARS:
+        out = words[0]
+        for word in words[1:]:
+            if len(out) + 1 + len(word) > MAX_HEADER_CHARS:
+                break
+            out = f"{out} {word}"
+        return out
+    return label[:MAX_HEADER_CHARS]
+
+
+def mark_recommended(label: str) -> str:
+    """Return ``label`` carrying the recommendation marker exactly once."""
+    label = label.strip()
+    if label.endswith(RECOMMENDED_SUFFIX):
+        return label
+    return f"{label} {RECOMMENDED_SUFFIX}"
+
+
+def _options_for(
+    question: dict[str, Any],
+    descriptions: dict[str, str] | None,
+) -> list[dict[str, str]]:
+    """Build the option objects, marking the FIRST as recommended.
+
+    First-is-recommended is the guard's rule, so the ordering the caller
+    chose IS the recommendation — this never reorders, it only labels.
+    """
+    out: list[dict[str, str]] = []
+    for index, raw in enumerate(question.get("options") or []):
+        label = str(raw)
+        description = (descriptions or {}).get(label, "")
+        out.append(
+            {
+                "label": mark_recommended(label) if index == 0 else label,
+                "description": description,
+            }
+        )
+    return out
+
+
+def form_to_ask_payload(
+    form: Any,
+    *,
+    source: str = DEFAULT_SOURCE,
+    descriptions: dict[str, str] | None = None,
+) -> list[dict[str, Any]]:
+    """Render ``form`` to tool-ready ``AskUserQuestion`` payloads.
+
+    Args:
+        form: The :class:`FormSchema` to render.
+        source: Value for ``metadata.source``. Must contain ``"form"`` or
+            the guard rejects any batch of more than one question.
+        descriptions: Optional ``option label -> description`` map. Select
+            options are plain strings in the schema, so per-option prose
+            has nowhere else to live; unmapped options get ``""`` rather
+            than invented text.
+
+    Returns:
+        One payload dict per batch, each ready to pass straight to the
+        tool.
+
+    Raises:
+        ValueError: If ``source`` could not opt a batch in — failing here
+            beats a guard rejection at call time, which costs a turn.
+    """
+    if "form" not in source:
+        raise ValueError(
+            f"source={source!r} does not contain 'form'; a batch of more than "
+            "one question would be rejected by the format guard"
+        )
+
+    from attune.elicitation import form_to_askuserquestion
+
+    payloads: list[dict[str, Any]] = []
+    for batch in form_to_askuserquestion(form):
+        questions = [
+            {
+                "question": str(q.get("question") or ""),
+                "header": _header_for(q),
+                "multiSelect": q.get("type") in _MULTI_TYPES,
+                "options": _options_for(q, descriptions),
+            }
+            for q in batch
+        ]
+        payloads.append({"questions": questions, "metadata": {"source": source}})
+    return payloads

--- a/tests/unit/elicitation/test_ask_payload.py
+++ b/tests/unit/elicitation/test_ask_payload.py
@@ -1,0 +1,160 @@
+"""Host-local AskUserQuestion conventions, applied by construction.
+
+The two rules under test are enforced by a user-level hook
+(``ask_question_format_guard``), not by ``attune-forms`` — so nothing in
+the shared package can apply them and every caller had to remember both.
+On 2026-08-22 a single form cost two consecutive guard rejections, which
+is the friction this adapter removes.
+
+The receipt that matters is :class:`TestAgainstTheRealGuard`: the
+adapter's output is fed to the ACTUAL hook. Unit tests prove the shape;
+only the real script proves the shape is the one the guard wants.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under Apache 2.0
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from attune.elicitation import form_from_dict
+from attune.elicitation.ask_payload import (
+    RECOMMENDED_SUFFIX,
+    form_to_ask_payload,
+    mark_recommended,
+)
+
+GUARD = Path.home() / ".claude" / "hooks" / "ask_question_format_guard.py"
+
+
+def _form(n_questions: int = 2, n_options: int = 3):
+    return form_from_dict(
+        {
+            "title": "t",
+            "fields": [
+                {
+                    "id": f"q{i}",
+                    "type": "single_select" if i else "multi_select",
+                    "label": f"Question {i} text?",
+                    "options": [f"opt{i}-{j}" for j in range(n_options)],
+                }
+                for i in range(n_questions)
+            ],
+        }
+    )
+
+
+class TestTheTwoGuardRules:
+    def test_multi_question_batch_opts_in_via_metadata_source(self):
+        payload = form_to_ask_payload(_form(2))[0]
+
+        assert (
+            "form" in payload["metadata"]["source"]
+        ), "a batch of >1 question is blocked by default without this"
+        assert len(payload["questions"]) == 2
+
+    def test_first_option_carries_the_recommendation_marker(self):
+        payload = form_to_ask_payload(_form(1))[0]
+        labels = [o["label"] for o in payload["questions"][0]["options"]]
+
+        assert labels[0].endswith(RECOMMENDED_SUFFIX)
+        assert not any(
+            x.endswith(RECOMMENDED_SUFFIX) for x in labels[1:]
+        ), "exactly one option may claim the recommendation"
+
+    def test_ordering_is_never_changed_only_labelled(self):
+        """First-is-recommended means the CALLER's order is the answer."""
+        form = _form(1, n_options=3)
+        payload = form_to_ask_payload(form)[0]
+        labels = [o["label"] for o in payload["questions"][0]["options"]]
+
+        assert labels[0].startswith("opt0-0")
+        assert labels[1] == "opt0-1" and labels[2] == "opt0-2"
+
+    def test_a_source_that_would_be_rejected_fails_here_instead(self):
+        """Fail at build time, not at a wasted tool call."""
+        with pytest.raises(ValueError, match="does not contain 'form'"):
+            form_to_ask_payload(_form(2), source="manual")
+
+    def test_marker_is_not_doubled_when_already_present(self):
+        assert mark_recommended(f"x {RECOMMENDED_SUFFIX}") == f"x {RECOMMENDED_SUFFIX}"
+        assert mark_recommended("x") == f"x {RECOMMENDED_SUFFIX}"
+
+
+class TestPayloadShape:
+    def test_multi_select_flag_tracks_the_field_type(self):
+        payload = form_to_ask_payload(_form(2))[0]
+        by_header = {q["question"]: q["multiSelect"] for q in payload["questions"]}
+
+        assert by_header["Question 0 text?"] is True  # multi_select
+        assert by_header["Question 1 text?"] is False  # single_select
+
+    def test_header_fits_the_chip_budget(self):
+        payload = form_to_ask_payload(_form(2))[0]
+
+        for q in payload["questions"]:
+            assert 0 < len(q["header"]) <= 12, q["header"]
+
+    def test_descriptions_are_passed_through_never_invented(self):
+        payload = form_to_ask_payload(_form(1), descriptions={"opt0-1": "why"})[0]
+        options = {
+            o["label"].replace(f" {RECOMMENDED_SUFFIX}", ""): o["description"]
+            for o in payload["questions"][0]["options"]
+        }
+
+        assert options["opt0-1"] == "why"
+        assert options["opt0-2"] == "", "unmapped options must not get invented prose"
+
+
+@pytest.mark.skipif(not GUARD.exists(), reason="user-level hook not on this machine")
+class TestAgainstTheRealGuard:
+    """The receipt: the actual hook accepts what the adapter emits.
+
+    Machine-local by design — the guard is personal infra outside this
+    repo, so this class runs where it exists and skips elsewhere (CI
+    included), matching the session-hydrate fail-open test's pattern.
+    """
+
+    def _run(self, tool_input: dict) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            ["python3", str(GUARD)],
+            input=json.dumps({"tool_name": "AskUserQuestion", "tool_input": tool_input}),
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+
+    def test_adapter_output_passes_the_guard_first_try(self):
+        payload = form_to_ask_payload(_form(2))[0]
+
+        result = self._run(payload)
+
+        assert result.returncode == 0, result.stderr
+
+    def test_the_guard_still_rejects_a_hand_written_batch(self):
+        """Proves the test above is not vacuous — the guard does bite."""
+        hand_written = {
+            "questions": [
+                {
+                    "question": "a?",
+                    "header": "a",
+                    "multiSelect": False,
+                    "options": [{"label": "one", "description": ""}],
+                },
+                {
+                    "question": "b?",
+                    "header": "b",
+                    "multiSelect": False,
+                    "options": [{"label": "two", "description": ""}],
+                },
+            ]
+        }
+
+        result = self._run(hand_written)
+
+        assert result.returncode == 2, "guard should block an un-opted-in batch"


### PR DESCRIPTION
## What

Two host-local rules gate every `AskUserQuestion` call in this repo:

1. a batch of more than one question must opt in via `metadata.source`;
2. the first option must be the recommended one and its label must say so.

Both are enforced by a **user-level hook** (`ask_question_format_guard`),
and neither is expressible in `attune-forms` — so every caller had to
remember them. One form on 2026-08-22 cost two consecutive guard
rejections. A convention that holds only when remembered is a habit, not
a convention.

`form_to_ask_payload` renders a `FormSchema` straight to tool-ready
payloads with both applied.

## Why not fix it in attune-forms

That package is **published** and these are one consumer's hook
conventions — baking them in would impose this machine's policy on every
attune-forms user. `attune.elicitation` already exists to "register the
host seams", which is the correct layer for host policy.

## Design choices worth reviewing

- **Never reorders.** First-is-recommended means the caller's order IS
  the recommendation, so the adapter only labels.
- **Never invents prose.** An unmapped option description stays `""`
  rather than being filled in.
- **Fails at build time**, with a named error, rather than at a wasted
  tool call.

## Receipt

`TestAgainstTheRealGuard` feeds the adapter's output to the **actual
hook** and asserts exit 0 — plus a companion test proving the guard
still rejects a hand-written batch, so the first cannot pass vacuously.
Machine-local by design (the guard is personal infra outside this repo),
so it runs here and skips in CI, matching the session-hydrate fail-open
pattern.

465 passed across `tests/unit/elicitation/`.

Ratified as retro item 3.2.
