### PR TITLE
feat(workflows): say so when a scored report has no structured findings

### DIFF
--- a/src/attune/workflows/agent_sdk_adapter.py
+++ b/src/attune/workflows/agent_sdk_adapter.py
@@ -29,6 +29,7 @@ from attune.ops.session_redaction import redact
 from .base import ModelTier
 from .data_classes import CostReport, NextAction, WorkflowResult, WorkflowStage
 from .output import (
+    CalloutSection,
     Finding,
     FindingsSection,
     ListSection,
@@ -1709,6 +1710,38 @@ class AgentSDKResultAdapter:
         next_steps = next_steps_section_from_suggestions(suggestions)
         if next_steps is not None:
             sections.append(next_steps)
+
+        # A SCORED report with no sections analysed the code, graded it,
+        # and then handed back nothing structured. That renders as a blank
+        # panel and reports completed/exit 0, so it looks healthy from
+        # every angle — bug-predict did exactly this in 6 of 6 recorded
+        # runs across three weeks and nobody noticed. Say so in the report
+        # rather than rendering blank; the run still records, and the
+        # prose summary is still there to read.
+        #
+        # The scored-vs-unscored split is the discriminator, measured over
+        # the recorded run corpus (2026-08-22): an ABORTED run is also
+        # section-less but carries no score, and flagging those would make
+        # the marker noise. Do not widen this to "any empty report".
+        if score is not None and not sections:
+            logger.warning(
+                "%s produced a scored report with no structured sections; "
+                "findings exist only in the summary prose",
+                title,
+            )
+            sections.append(
+                CalloutSection(
+                    title="No structured findings",
+                    tier="essential",
+                    emphasis="warn",
+                    text=(
+                        "This workflow returned a score but no structured "
+                        "findings, so there is nothing to list here. Any "
+                        "findings are in the summary above. This is a "
+                        "reporting defect, not a clean result."
+                    ),
+                )
+            )
 
         report_metadata: dict[str, object] = {"duration_s": duration_ms / 1000}
         if total_cost is not None:

--- a/tests/unit/workflows/test_empty_report_guard.py
+++ b/tests/unit/workflows/test_empty_report_guard.py
@@ -1,0 +1,106 @@
+"""A scored report with no sections must say so, not render blank.
+
+The failure this guards is invisible from every angle that normally
+signals trouble: the run exits 0, records `completed`, and carries a
+score — it simply hands back nothing structured. `bug-predict` did
+exactly that in 6 of 6 recorded runs over three weeks (census taken
+2026-08-22 across `~/.attune/ops/runs/`), and the only reason it
+surfaced was someone reading a report expecting findings.
+
+Same shape as the vacuous-test class already in the corpus: a thing
+that satisfies its check BY being empty.
+
+The scored-vs-unscored split is the calibrated discriminator, not a
+guess. In the same census `deep-review` had a section-less run too —
+but with NO score, the signature of an aborted run, which is
+legitimately empty. Flagging those would make the marker noise and get
+it ignored, so both directions are pinned below.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under Apache 2.0
+"""
+
+from __future__ import annotations
+
+import logging
+
+from attune.workflows.agent_sdk_adapter import AgentSDKResultAdapter
+
+
+def _report(*, score, findings=None, suggestions=None):
+    return AgentSDKResultAdapter._to_workflow_report(
+        title="wf",
+        summary="prose summary",
+        score=score,
+        findings=findings or {},
+        suggestions=suggestions or [],
+        total_cost=None,
+        duration_ms=1000,
+    )
+
+
+def _callouts(report):
+    return [s for s in report.sections if getattr(s, "kind", None) == "callout"]
+
+
+class TestScoredButEmptyIsMarked:
+    def test_a_scored_report_with_no_sections_gets_a_loud_marker(self):
+        report = _report(score=60)
+
+        callouts = _callouts(report)
+
+        assert len(callouts) == 1, "the blank report must not render blank"
+        assert callouts[0].emphasis == "warn"
+        assert "reporting defect" in callouts[0].text
+
+    def test_the_marker_says_the_findings_are_in_the_prose(self):
+        """Readers must know where to look, not just that it is broken."""
+        report = _report(score=60)
+
+        assert "summary" in _callouts(report)[0].text.lower()
+
+    def test_the_score_and_summary_survive(self):
+        """The marker adds; it must not swallow what the run did produce."""
+        report = _report(score=60)
+
+        assert report.score == 60
+        assert report.summary == "prose summary"
+
+    def test_it_logs_so_the_defect_is_visible_outside_the_report(self, caplog):
+        with caplog.at_level(logging.WARNING):
+            _report(score=60)
+
+        assert any("no structured sections" in r.message for r in caplog.records)
+
+
+class TestTheDiscriminatorHolds:
+    """Calibration: only SCORED-and-empty is a defect."""
+
+    def test_an_unscored_empty_report_is_left_alone(self):
+        """An aborted run is legitimately section-less — do not flag it."""
+        report = _report(score=None)
+
+        assert _callouts(report) == []
+
+    def test_a_report_with_findings_is_left_alone(self):
+        report = _report(score=60, findings={"Security": [{"description": "x"}]})
+
+        assert _callouts(report) == []
+        assert report.sections, "the real sections must still be built"
+
+    def test_sections_from_suggestions_alone_count_as_output(self):
+        """Next-steps are structured output too — not a blank panel."""
+        from attune.workflows.data_classes import NextAction
+
+        report = _report(
+            score=60,
+            suggestions=[
+                NextAction(
+                    workflow_name="wf",
+                    description="do a thing",
+                    reasoning="because",
+                )
+            ],
+        )
+
+        assert _callouts(report) == [], "a next-steps section is real output"


### PR DESCRIPTION
## The failure

A report carrying a **score but zero sections** analysed the code, graded
it, and handed back nothing structured. It renders as a blank panel while
the run reports `completed` / exit 0 — healthy from every angle that
normally signals trouble.

`bug-predict` did exactly this in **6 of 6 recorded runs over three
weeks**. It surfaced only because someone read a report expecting
findings. Same shape as the vacuous-test class already in the corpus: a
thing that satisfies its check *by* being empty.

## The fix

The adapter appends a `warn` callout naming it a reporting defect and
pointing at the prose summary, and logs a warning so the defect is
visible outside the report. The run still records; the summary is
untouched. This makes the failure **legible**, it does not throw
anything away.

## Calibration — measured, not guessed

The scored-vs-unscored split is the discriminator, taken from the
recorded run corpus in `~/.attune/ops/runs/` (2026-08-22). An **aborted**
run is also section-less, but carries no score.

Replaying every recorded section-less run through the guard:

| workflow | score | result |
|---|---|---|
| `bug-predict` ×6 | 62, 42, 60, 40, 34, 47 | **FLAGGED** |
| `deep-review` ×1 | `None` (aborted) | quiet |

**6 hits / 6 real / 0 false positives.**

Widening this to "any empty report" would flag the aborted class and get
the marker allowlisted into uselessness — the standing lesson that
uncalibrated rules don't gate anything. Both directions are pinned as
tests so a later simplification can't drop the discriminator.

## Scope

Does **not** fix `bug-predict`'s missing sections — that's the underlying
bug and a separate change. This stops the class from being *silent*.

2,885 passed across `tests/unit/workflows/`.

Ratified as retro item 1.1.
