### PR TITLE
fix(patterns): refuse option-like git values at every boundary, not one

### DIFF
--- a/src/attune/patterns/git_extractor.py
+++ b/src/attune/patterns/git_extractor.py
@@ -30,6 +30,17 @@ from typing import Any
 logger = logging.getLogger(__name__)
 
 
+def _is_option_like(value: str) -> bool:
+    """True when git would parse ``value`` as an OPTION rather than data.
+
+    ``git log -1 --format=X --help`` prints usage instead of a commit, and
+    the same holds for any ref or config key a caller can shape. The rule
+    lived inline in one method and every sibling call site therefore had
+    to remember it; two did not. One definition, applied at each boundary.
+    """
+    return value.startswith("-")
+
+
 class GitPatternExtractor:
     """Extracts bug fix patterns from git commits.
 
@@ -210,7 +221,7 @@ class GitPatternExtractor:
         # "--" pins the remainder as "no pathspec follows" so a ref that
         # also names a file cannot be read as a path. Checked here (not
         # only at the call sites) so a future caller inherits it.
-        if ref.startswith("-"):
+        if _is_option_like(ref):
             logger.warning("Refusing option-like git ref: %r", ref)
             return None
 
@@ -240,10 +251,19 @@ class GitPatternExtractor:
             return None
 
     def _get_commit_diff(self, ref1: str, ref2: str) -> str:
-        """Get diff between two commits."""
+        """Get diff between two commits.
+
+        Mirrors :meth:`_get_commit_info`'s guard: option-like refs are
+        refused and ``--`` pins the remainder as "no pathspec follows",
+        so a ref that also names a file cannot be read as a path.
+        """
+        if _is_option_like(ref1) or _is_option_like(ref2):
+            logger.warning("Refusing option-like git ref: %r, %r", ref1, ref2)
+            return ""
+
         try:
             result = subprocess.run(
-                ["git", "diff", ref1, ref2],
+                ["git", "diff", ref1, ref2, "--"],
                 check=False,
                 capture_output=True,
                 text=True,
@@ -270,7 +290,17 @@ class GitPatternExtractor:
             return ""
 
     def _get_git_config(self, key: str) -> str | None:
-        """Get a git config value."""
+        """Get a git config value.
+
+        Only called with a literal today, so this is a latent gap rather
+        than a live one — but the key is a parameter, and the sibling
+        method's guard was written precisely so a future caller would
+        inherit it.
+        """
+        if _is_option_like(key):
+            logger.warning("Refusing option-like git config key: %r", key)
+            return None
+
         try:
             result = subprocess.run(
                 ["git", "config", key],

--- a/tests/unit/patterns/test_git_ref_validation.py
+++ b/tests/unit/patterns/test_git_ref_validation.py
@@ -1,0 +1,133 @@
+"""Option-like git refs and config keys are refused at every boundary.
+
+``git`` parses a leading ``-`` as an OPTION, not as data: a ref of
+``--help`` makes ``git log`` print usage instead of a commit, and the
+same holds for any value a caller can shape.
+
+``_get_commit_info`` carried this guard inline, with a comment saying it
+lived there "so a future caller inherits it" — but the rule was not
+shared, so ``_get_commit_diff`` (flagged by the 14.0.0 post-release
+review) and ``_get_git_config`` (found by sweeping the file rather than
+fixing only what was reported) both went without it. One definition now,
+applied at each boundary; these tests pin all three.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under Apache 2.0
+"""
+
+from __future__ import annotations
+
+import subprocess
+
+import pytest
+
+from attune.patterns.git_extractor import GitPatternExtractor, _is_option_like
+
+
+@pytest.fixture
+def extractor(tmp_path):
+    return GitPatternExtractor(patterns_dir=str(tmp_path))
+
+
+@pytest.fixture
+def argv_spy(monkeypatch):
+    """Capture argv and prove git is never actually invoked when refused."""
+    seen: list[list[str]] = []
+
+    def fake_run(argv, *a, **k):
+        seen.append(list(argv))
+        return subprocess.CompletedProcess(args=argv, returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    return seen
+
+
+class TestTheRuleItself:
+    @pytest.mark.parametrize("value", ["-x", "--help", "--upload-pack=evil", "-"])
+    def test_leading_dash_is_option_like(self, value):
+        assert _is_option_like(value)
+
+    @pytest.mark.parametrize("value", ["HEAD", "main", "v14.0.0", "abc123", "user.name"])
+    def test_ordinary_values_are_not(self, value):
+        assert not _is_option_like(value)
+
+
+class TestEveryBoundaryRefuses:
+    """Refused means git is NOT invoked — not merely that output is dropped."""
+
+    def test_commit_info_refuses_and_does_not_run_git(self, extractor, argv_spy):
+        assert extractor._get_commit_info("--help") is None
+        assert argv_spy == [], "git must not be invoked with an option-like ref"
+
+    @pytest.mark.parametrize("bad", [("--help", "HEAD"), ("HEAD", "--upload-pack=x")])
+    def test_commit_diff_refuses_either_ref(self, extractor, argv_spy, bad):
+        assert extractor._get_commit_diff(*bad) == ""
+        assert argv_spy == [], "either position must refuse"
+
+    def test_git_config_refuses_an_option_like_key(self, extractor, argv_spy):
+        assert extractor._get_git_config("--global") is None
+        assert argv_spy == []
+
+
+class TestOrdinaryInputStillWorks:
+    """A guard that breaks the happy path gets reverted, so pin it."""
+
+    def test_commit_diff_runs_for_real_refs(self, extractor, argv_spy):
+        extractor._get_commit_diff("HEAD~1", "HEAD")
+
+        assert len(argv_spy) == 1
+        assert argv_spy[0][:2] == ["git", "diff"]
+
+    def test_commit_diff_pins_the_argument_list_with_a_terminator(self, extractor, argv_spy):
+        """`--` stops a ref that also names a file being read as a path."""
+        extractor._get_commit_diff("HEAD~1", "HEAD")
+
+        assert argv_spy[0][-1] == "--"
+
+    def test_commit_info_still_carries_its_terminator(self, extractor, argv_spy):
+        extractor._get_commit_info("HEAD")
+
+        assert argv_spy[0][-1] == "--"
+
+    def test_git_config_runs_for_a_real_key(self, extractor, argv_spy):
+        extractor._get_git_config("user.name")
+
+        assert argv_spy[0] == ["git", "config", "user.name"]
+
+
+class TestNoBoundaryWasMissed:
+    """Sweep the module, not just the sites someone reported.
+
+    The reported finding was _get_commit_diff alone; _get_git_config came
+    out of walking every subprocess call in the file. This keeps that
+    sweep honest as the module grows.
+    """
+
+    def test_every_dynamic_git_argv_is_guarded(self):
+        import ast
+        import inspect
+
+        import attune.patterns.git_extractor as mod
+
+        tree = ast.parse(inspect.getsource(mod))
+        guarded = {"_get_commit_info", "_get_commit_diff", "_get_git_config"}
+        offenders = []
+        for fn in ast.walk(tree):
+            if not isinstance(fn, ast.FunctionDef) or fn.name in guarded:
+                continue
+            for node in ast.walk(fn):
+                if not (
+                    isinstance(node, ast.Call)
+                    and isinstance(node.func, ast.Attribute)
+                    and node.func.attr == "run"
+                    and node.args
+                    and isinstance(node.args[0], ast.List | ast.Tuple)
+                ):
+                    continue
+                if any(not isinstance(e, ast.Constant) for e in node.args[0].elts):
+                    offenders.append(f"{fn.name}:{node.lineno}")
+
+        assert not offenders, (
+            f"unguarded dynamic git argv: {offenders} — route the value through "
+            "_is_option_like or add the function to the guarded set"
+        )


### PR DESCRIPTION
## What

`git` parses a leading `-` as an **option**, not data — a ref of
`--help` makes `git log` print usage instead of a commit. The guard for
this existed in exactly one method, `_get_commit_info`, whose comment
says it lives there *"so a future caller inherits it."* Nothing
inherited anything: the rule was inline, not shared.

The 14.0.0 post-release review flagged `_get_commit_diff` (both refs
unguarded, no `--` terminator). Sweeping **every** subprocess call in
the file — rather than fixing only the reported site — found a third
boundary: `_get_git_config` interpolates a caller-supplied key. It's
called only with a literal today, so latent rather than live; recorded
as such and guarded anyway.

One module-level `_is_option_like` now, applied at all three
boundaries. `_get_commit_diff` also gains the `--` terminator its
sibling had.

## Receipts

- **Refused means git is not invoked** — the tests assert the
  subprocess never runs, not merely that output is dropped.
- **Mutation-checked**: neutering `_is_option_like` fails 8 of 18.
- **Happy paths pinned** so the guard cannot break real refs.
- **AST sweep test** fails if a future function adds a dynamic git argv
  without routing it through the rule — the third boundary was found by
  that sweep, so the sweep is now a test.
- 345 passed across `tests/unit/patterns/`.

## For the reviewer, honestly

The first attempt inserted the helper *inside* the class body, silently
terminating `GitPatternExtractor` after 4 of its 12 methods —
`ast.parse` accepted it because that's syntactically valid. The tests
caught it (`AttributeError`), and the redo asserts the class's method
list is byte-identical before writing. Worth knowing when reading the
diff.

Closes the second finding of the 14.0.0 post-release self-review
(retro item 1.4).
