### PR TITLE
fix(bug-predict): return structured findings instead of a scored, sectionless report

### DIFF
--- a/src/attune/workflows/agent_sdk_adapter.py
+++ b/src/attune/workflows/agent_sdk_adapter.py
@@ -1570,9 +1570,16 @@ class AgentSDKResultAdapter:
             if matched_category:
                 continue
 
-            # Any other h2/h3 header ends the current category
-            if stripped.startswith("##"):
+            # Any other h2 header ends the current category. Deeper
+            # headers (``### HIGH`` severity groups under ``## Bugs``)
+            # stay INSIDE it — treating them as terminators dropped
+            # every bullet beneath them and yielded ``{"bugs": []}``:
+            # a truthy findings dict that built a scored report with
+            # zero sections (bug-predict, 6/6 runs, 2026-08-22).
+            if stripped.startswith("##") and not stripped.startswith("###"):
                 current_category = None
+                continue
+            if stripped.startswith("###"):
                 continue
 
             # Collect bullet points under the current category

--- a/src/attune/workflows/bug_predict.py
+++ b/src/attune/workflows/bug_predict.py
@@ -47,6 +47,7 @@ from .bug_predict_patterns import (
     _should_exclude_file,  # noqa: F401 — re-exported
 )
 from .data_classes import WorkflowResult
+from .output_schemas import WORKFLOW_OUTPUT_SCHEMA
 from .step_config import WorkflowStepConfig
 from .validation import InputSchema
 
@@ -96,7 +97,9 @@ predicted bug hotspots.
 
 ## Bugs
 Predicted bugs organized by severity (HIGH, MEDIUM, LOW). Each entry \
-should include file path, line number, pattern type, and description.
+should include file path, line number, pattern type, and description. \
+In the structured output, key the findings as ``bugs`` and put the \
+severity on each entry's ``severity`` field.
 
 ## Suggestions
 Actionable prevention strategies ordered by priority. Include specific \
@@ -264,6 +267,13 @@ class BugPredictionWorkflow(BaseWorkflow):
                     allowed_tools=["Read", "Glob", "Grep", "Agent"],
                     permission_mode="default",
                     max_turns=max_turns,
+                    # Structured output, same as code-review and
+                    # security-audit. Without it the adapter falls back
+                    # to parsing ``## Bugs`` bullets out of markdown, and
+                    # the severity sub-headers this prompt asks for
+                    # (``### HIGH``) produced scored reports with ZERO
+                    # sections for 6/6 recorded runs (2026-08-22).
+                    output_format=WORKFLOW_OUTPUT_SCHEMA,
                     agents={
                         "pattern-scanner": claude_agent_sdk.AgentDefinition(
                             description=("Pattern scanner that finds common " "bug patterns."),

--- a/tests/unit/workflows/test_bug_predict_structured_sections.py
+++ b/tests/unit/workflows/test_bug_predict_structured_sections.py
@@ -1,0 +1,153 @@
+"""bug-predict must hand the adapter findings it can turn into sections.
+
+Root cause of the 6/6 scored-but-sectionless runs (census 2026-08-22,
+marked by the #2191 callout): bug-predict was the only subagent
+workflow NOT passing ``output_format=WORKFLOW_OUTPUT_SCHEMA``, so the
+adapter parsed its markdown — and its prompt asks for ``## Bugs``
+"organized by severity", which the agent renders as ``### HIGH`` /
+``### MEDIUM`` sub-headers. The parser treated every ``##``-prefixed
+line as a category terminator, so ``## Bugs`` opened the category,
+``### HIGH`` closed it, and every bullet beneath was dropped:
+``{"bugs": []}`` — truthy enough to build a report, empty enough to
+have no sections, scored because ``## Summary`` parsed fine.
+
+Two layers are pinned here, because either alone leaves the class
+open: the workflow requests structured output (the path code-review
+already used), and the text parser keeps sub-headers inside their
+category for any workflow still on the markdown path.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under Apache 2.0
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timedelta
+from unittest.mock import patch
+
+import claude_agent_sdk
+
+from attune.workflows.agent_sdk_adapter import AgentRunResult, AgentSDKResultAdapter
+from attune.workflows.bug_predict import BugPredictionWorkflow
+from attune.workflows.output_schemas import WORKFLOW_OUTPUT_SCHEMA
+
+# The markdown shape a live bug-predict agent emits for its prompt.
+_SEVERITY_GROUPED_REPORT = """\
+## Summary
+**Overall Risk Score: 60 / 100 (Moderate)**
+
+Risk is concentrated in a few I/O hubs.
+
+## Bugs
+### HIGH
+- `src/attune/ops/data.py:42` — resource leak: file handle never closed
+### MEDIUM
+- `src/attune/cli.py:88` — unchecked `int()` on user input
+
+## Suggestions
+- Add a context manager around the handle in ops/data.py
+"""
+
+
+def _callouts(report):
+    return [s for s in report["sections"] if s.get("kind") == "callout"]
+
+
+class TestTextParserKeepsSubHeadersInsideCategory:
+    def test_severity_sub_headers_do_not_drop_the_bullets(self) -> None:
+        findings = AgentSDKResultAdapter._parse_findings(_SEVERITY_GROUPED_REPORT)
+
+        assert len(findings["bugs"]) == 2
+        assert "resource leak" in findings["bugs"][0]
+        assert "int()" in findings["bugs"][1]
+
+    def test_h2_header_still_ends_the_category(self) -> None:
+        """Only h3+ nests; the next ``##`` still closes the category."""
+        findings = AgentSDKResultAdapter._parse_findings(_SEVERITY_GROUPED_REPORT)
+
+        # The "Add a context manager" bullet lives under ## Suggestions,
+        # which is not a findings category — it must not leak into bugs.
+        assert not any("context manager" in item for item in findings["bugs"])
+
+    def test_the_recorded_defect_shape_no_longer_reproduces(self) -> None:
+        """Scored + empty-sections was the census signature; it must be gone."""
+        started = datetime(2026, 8, 22, 12, 0, 0)
+        result = AgentSDKResultAdapter.from_agent_output(
+            report_title="Bug prediction",
+            result_text=_SEVERITY_GROUPED_REPORT,
+            subagent_names=["pattern-scanner"],
+            started_at=started,
+            completed_at=started + timedelta(seconds=5),
+        )
+
+        report = result.final_output
+        assert isinstance(report, dict), "findings parsed → report dict"
+        assert report["score"] == 60
+        assert report["sections"], "a scored report must carry sections"
+        assert not _callouts(report), "the #2191 defect marker must not fire"
+
+
+class TestBugPredictRequestsStructuredOutput:
+    @patch("attune.workflows.bug_predict.claude_agent_sdk.query")
+    def test_output_format_is_the_shared_workflow_schema(self, mock_query) -> None:
+        """Same structured path code-review and security-audit already use."""
+        captured: dict = {}
+
+        async def capturing_query(*args, **kwargs):
+            captured["options"] = kwargs.get("options")
+            result = claude_agent_sdk.ResultMessage(
+                subtype="success",
+                duration_ms=1,
+                duration_api_ms=1,
+                is_error=False,
+                num_turns=1,
+                session_id="s",
+                total_cost_usd=0.0,
+                usage={},
+                result="done",
+                structured_output=None,
+            )
+            yield result
+
+        mock_query.side_effect = capturing_query
+        asyncio.run(BugPredictionWorkflow()._run_agent_predict("/tmp/proj", 20, "standard"))
+
+        assert captured["options"].output_format is WORKFLOW_OUTPUT_SCHEMA
+
+    def test_structured_bugs_become_a_findings_section(self) -> None:
+        """The shape the schema yields renders as a FindingsSection."""
+        started = datetime(2026, 8, 22, 12, 0, 0)
+        run = AgentRunResult(
+            result_text="ignored when structured output is present",
+            structured_output={
+                "summary": {"score": 60, "text": "Risk is concentrated."},
+                "findings": {
+                    "bugs": [
+                        {
+                            "file": "src/attune/ops/data.py",
+                            "line": 42,
+                            "severity": "HIGH",
+                            "description": "resource leak",
+                        }
+                    ]
+                },
+                "suggestions": [{"description": "close the handle", "priority": "high"}],
+            },
+        )
+        result = AgentSDKResultAdapter.from_agent_output(
+            report_title="Bug prediction",
+            result_text=run.result_text,
+            subagent_names=["pattern-scanner"],
+            started_at=started,
+            completed_at=started + timedelta(seconds=5),
+            agent_run_result=run,
+        )
+
+        report = result.final_output
+        assert isinstance(report, dict)
+        assert report["score"] == 60
+        kinds = [s.get("kind") for s in report["sections"]]
+        assert "findings" in kinds
+        assert not _callouts(report)
+        assert result.suggestions and "close the handle" in result.suggestions[0].description


### PR DESCRIPTION
## What

Fixes the defect that made `bug-predict` produce reports with a score but **zero structured sections** — 6/6 recorded runs in `~/.attune/ops/runs/bug-predict/`, marked since #2191 by the "No structured findings" callout. This PR removes the cause; the callout stays as the tripwire.

## Root cause (verified by reproducing the parse in a REPL, then pinned in tests)

Two facts combine:

1. `bug-predict` was the only subagent workflow **not** passing `output_format=WORKFLOW_OUTPUT_SCHEMA` — `code-review` and `security-audit` do, which is why the same adapter gives them populated sections (6/6). Bug-predict fell back to the markdown text parser.
2. The text parser treated every `##`-prefixed line — **including `###`** — as ending the current category. Bug-predict's prompt asks for `## Bugs … organized by severity (HIGH, MEDIUM, LOW)`, so the agent emits `### HIGH` sub-headers. `## Bugs` opened the category, `### HIGH` closed it, every bullet beneath was dropped → `{"bugs": []}`: truthy enough to build a report, empty enough to have no sections, scored because `## Summary` parsed fine.

Repro: `_parse_findings("## Summary\n…60 / 100…\n## Bugs\n### HIGH\n- …")` → `{'bugs': []}`, score `60`.

## Fix (both layers, so the class is closed, not just the instance)

- `bug_predict.py`: adopt `output_format=WORKFLOW_OUTPUT_SCHEMA` (same path as code-review/security-audit; security-audit already proves it coexists with discovery-sweep's `STRUCTURED_EMIT_FOOTER`). Prompt tells the agent to key findings as `bugs` with per-entry `severity`.
- `agent_sdk_adapter.py`: `###`+ headers stay inside their category; `##` still terminates. Guards any workflow still on the text path.

## Tests — `tests/unit/workflows/test_bug_predict_structured_sections.py`

- Severity sub-headers no longer drop bullets; `##` still ends the category.
- The exact recorded defect shape through `from_agent_output` → score 60 **with** sections and **no** #2191 callout.
- `bug-predict` passes the shared schema object (captured `ClaudeAgentOptions`).
- Structured `bugs` render as a `FindingsSection`.

`test_empty_report_guard.py` untouched and green (discriminator survives). `tests/unit/workflows`: 2890 passed. `bug_predict.py` coverage 100%.

## Live receipt (ops-runner-launched, this branch's code)

Run `410497bd6f90` in `~/.attune/ops/runs/bug-predict/` — spend go from Patrick; subprocess python is this worktree's venv with `PYTHONPATH` pinned to its `src` (asserted `bug_predict.__file__` before launch).

- status `completed`, exit 0, score **74**, 279.8 s, **$2.91** (estimate was ~$2; over by $0.91)
- sections: `findings` "Bugs" with **18** findings (`severity`/`file`/`line`/`message` populated) + `next-steps` with 8 items
- callouts: **none** — the #2191 "No structured findings" marker did not fire

Previous 6/6 runs: `sections == []`. Opened **unarmed** (src/ change); the chair arms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

