### PR TITLE
fix(agents): the Security gate no longer passes on bandit output it could not read

### DIFF
--- a/src/attune/agents/release/security_agent.py
+++ b/src/attune/agents/release/security_agent.py
@@ -87,6 +87,10 @@ class SecurityAuditorAgent(ReleaseAgent):
                     "json",
                     "--severity-level",
                     "medium",
+                    # bandit >= 1.9 writes a rich "Working... 100%" progress
+                    # line to STDOUT ahead of the JSON document; -q
+                    # suppresses it so stdout is the document alone.
+                    "-q",
                 ],
                 cwd=codebase_path,
             )
@@ -141,10 +145,14 @@ class SecurityAuditorAgent(ReleaseAgent):
             Dict with classified findings
 
         """
+        # Both degrade paths below carry the -1 sentinel: an auditor that
+        # did not run, or whose output could not be read, has produced NO
+        # count, and the Security gate treats no count as a failure
+        # (contract principle 7 — absence is not a pass).
         if returncode == -1:
             # bandit not installed -- report as unknown
             return {
-                "critical_issues": 0,
+                "critical_issues": -1,
                 "high_issues": 0,
                 "medium_issues": 0,
                 "low_issues": 0,
@@ -162,7 +170,7 @@ class SecurityAuditorAgent(ReleaseAgent):
                 raise ValueError("bandit output was not a JSON object")
         except ValueError:  # includes json.JSONDecodeError
             return {
-                "critical_issues": 0,
+                "critical_issues": -1,
                 "high_issues": 0,
                 "medium_issues": 0,
                 "low_issues": 0,

--- a/tests/unit/agents/release/test_specialized_agents.py
+++ b/tests/unit/agents/release/test_specialized_agents.py
@@ -625,21 +625,58 @@ class TestSecurityAuditorAgent:
         assert result["score"] == pytest.approx(95.0)
 
     def test_parse_bandit_output_command_not_found(self):
-        """returncode=-1 → bandit not available, score=50, critical=0."""
+        """returncode=-1 → bandit not available, score=50, critical=-1 (fail-closed)."""
         agent = self._make_agent()
         result = agent._parse_bandit_output("", returncode=-1)
 
-        assert result["critical_issues"] == 0
+        assert result["critical_issues"] == -1
         assert result["score"] == pytest.approx(50.0)
         assert "bandit not available" in result.get("note", "")
 
     def test_parse_bandit_output_invalid_json_returns_defaults(self):
-        """Invalid JSON stdout returns safe defaults."""
+        """Invalid JSON stdout returns the fail-closed sentinel, never a clean count."""
         agent = self._make_agent()
         result = agent._parse_bandit_output("not json at all", returncode=0)
 
-        assert result["critical_issues"] == 0
+        assert result["critical_issues"] == -1
         assert "note" in result
+
+    def test_progress_bar_prefixed_stdout_fails_closed(self, monkeypatch):
+        """bandit >= 1.9 prefixes stdout with a progress line when not quieted.
+
+        Regression for the Security gate passing blind: the prefixed document
+        failed json.loads, the parser degraded to critical_issues=0, and the
+        gate read that as clean. Unreadable output must make the tier FAIL.
+        """
+        from attune.agents.release import security_agent as sec_mod
+        from attune.agents.release.release_models import Tier
+
+        agent = self._make_agent()
+        stdout = 'Working... \u2501\u2501\u2501 100% 0:00:04\n{"results": [], "errors": []}'
+        monkeypatch.setattr(sec_mod, "_run_command", lambda *a, **k: (0, stdout, ""))
+        success, findings = agent._execute_tier(".", Tier.CHEAP)
+
+        assert success is False
+        assert findings["critical_issues"] == -1
+        assert findings["note"] == "Could not parse bandit output"
+
+    def test_bandit_invocation_is_quiet(self, monkeypatch):
+        """The command passes -q so the JSON document is the whole of stdout."""
+        from attune.agents.release import security_agent as sec_mod
+        from attune.agents.release.release_models import Tier
+
+        seen: list[list[str]] = []
+
+        def fake_run(cmd, cwd=None):
+            seen.append(list(cmd))
+            return 0, '{"results": [], "errors": []}', ""
+
+        monkeypatch.setattr(sec_mod, "_run_command", fake_run)
+        agent = self._make_agent()
+        success, _ = agent._execute_tier(".", Tier.CHEAP)
+
+        assert success is True
+        assert seen and "-q" in seen[0] and "-f" in seen[0] and "json" in seen[0]
 
     def test_parse_bandit_output_top_findings_limited_to_five(self):
         """top_findings is capped at 5 entries."""


### PR DESCRIPTION
## What

The Security gate in `ReleasePrepTeam` had been **passing blind**. bandit ≥ 1.9 writes a rich `Working... 100%` progress line to **stdout** ahead of its JSON document; `json.loads` failed, `_parse_bandit_output` degraded to `critical_issues=0 / score=50 / note="Could not parse bandit output"`, and the gate read the zero as clean.

Found while running `/agents:release-prep` on `origin/main` (9e8068cea): the gate reported PASS while the agent's findings carried the parse note.

## Fix

- `-q` on the bandit invocation so stdout is the document alone — **verified live**: stdout now begins with `{`; the real medium+ finding count on this tree is 0, so the verdict was right by luck, not measurement.
- Both degrade paths (bandit not installed / output unreadable) now carry the `-1` sentinel, so `_execute_tier` reports failure and the gate **fails closed** — contract principle 7, absence is not a pass. The team's gate evaluation already handled the sentinel (pinned by `test_release_prep_team_orchestration.py`); only the agent was lenient.

## Receipts

- **suite**: 98 passed serially (`-n 0`) across `test_specialized_agents`, `test_release_agent_analysis_branches`, `test_external_input_dict_guard`, `test_release_prep_team`, `test_release_prep_team_orchestration`.
- **live-fire**: full `ReleasePrepTeam.assess_readiness(".")` run keyless and with `RELEASE_LLM_MODE=real` ($0.0044) — Security agent now `confidence 0.95`, no parse note. Remaining blocker is the known coverage-agent measurement fiction (40.0 from a worktree vs Codecov 95.95% on the same commit; chip `task_bc331bf3`), unchanged by this PR.

## Governance

This touches a security/enforcement surface (D11 risk class) → a different-model review lane is owed before the chair reads this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
