### PR TITLE
fix(memory): redis_health_check names the one endpoint the selected backend writes to

### DIFF
--- a/attune_redis/mcp_tools.py
+++ b/attune_redis/mcp_tools.py
@@ -539,8 +539,9 @@ def _write_target(backend: Any, stats: dict[str, Any], effective: dict[str, Any]
     read as healthy). Derive the target from ``backend_selected`` and
     label the other endpoint as not governing writes.
     """
-    name = type(backend).__name__
-    if name == "AMSMemoryBackend":
+    from attune_redis.memory import AMSMemoryBackend
+
+    if isinstance(backend, AMSMemoryBackend):
         effective["applies_to"] = (
             "direct Redis clients (recall index, telemetry) — does NOT govern "
             "the selected AMS write path"

--- a/attune_redis/mcp_tools.py
+++ b/attune_redis/mcp_tools.py
@@ -527,6 +527,32 @@ def _effective_config_report() -> dict[str, Any]:
     return report
 
 
+def _write_target(backend: Any, stats: dict[str, Any], effective: dict[str, Any]) -> dict[str, Any]:
+    """The ONE endpoint the selected backend writes to (principle 16).
+
+    A health answer that names two Redis endpoints — the AMS base URL
+    in ``stats`` and the direct-Redis resolver's ``redacted_url`` in
+    ``effective_config`` — cannot tell the reader which one their
+    stash depends on (round table q-post-redis-repair-broken-features-001,
+    2026-08-23: the resolver pointed at Redis Cloud while writes went
+    through a local AMS whose own Redis was auth-dead, and the answer
+    read as healthy). Derive the target from ``backend_selected`` and
+    label the other endpoint as not governing writes.
+    """
+    name = type(backend).__name__
+    if name == "AMSMemoryBackend":
+        effective["applies_to"] = (
+            "direct Redis clients (recall index, telemetry) — does NOT govern "
+            "the selected AMS write path"
+        )
+        return {
+            "kind": "ams",
+            "url": stats.get("base_url"),
+            "note": "AMS persists to its OWN configured Redis; see the AMS server log",
+        }
+    return {"kind": "direct-redis", "url": effective.get("redacted_url")}
+
+
 async def handle_redis_health_check(server: Any, args: dict[str, Any]) -> dict[str, Any]:
     """Check AMS health, connection status, and effective Redis config.
 
@@ -546,13 +572,15 @@ async def handle_redis_health_check(server: Any, args: dict[str, Any]) -> dict[s
         backend = _get_backend(server)
         connected = backend.is_connected()
         stats = backend.get_stats()
+        effective = _effective_config_report()
         return {
             "success": True,
             "connected": connected,
             "stats": stats,
             "source": "redis-ams",
             "backend_selected": type(backend).__name__,
-            "effective_config": _effective_config_report(),
+            "write_target": _write_target(backend, stats, effective),
+            "effective_config": effective,
         }
     except ImportError:
         return {

--- a/tests/unit/memory/test_redis_doctor_diagnostic.py
+++ b/tests/unit/memory/test_redis_doctor_diagnostic.py
@@ -140,6 +140,47 @@ class TestHandlerIntegration:
     def test_handler_registered(self):
         assert TOOL_HANDLERS["redis_health_check"] is handle_redis_health_check
 
+    def _run_with_backend_named(self, name: str, stats: dict) -> dict:
+        server = MagicMock()
+        backend = MagicMock()
+        backend.is_connected.return_value = True
+        backend.get_stats.return_value = stats
+        type(backend).__name__ = name
+        with (
+            patch("attune_redis.mcp_tools._get_backend", return_value=backend),
+            patch(
+                "attune_redis.mcp_tools._effective_config_report",
+                return_value={
+                    "available": True,
+                    "health": "healthy",
+                    "redacted_url": "redis://:***@cloud.example:15667/0",
+                },
+            ),
+        ):
+            return asyncio.run(handle_redis_health_check(server, {}))
+
+    def test_ams_backend_names_one_write_target_and_labels_the_resolver(self):
+        """Round table 2026-08-23: two endpoints in one answer hid a dead AMS."""
+        result = self._run_with_backend_named(
+            "AMSMemoryBackend", {"base_url": "http://localhost:8000"}
+        )
+        assert result["write_target"] == {
+            "kind": "ams",
+            "url": "http://localhost:8000",
+            "note": "AMS persists to its OWN configured Redis; see the AMS server log",
+        }
+        assert "does NOT govern the selected AMS write path" in (
+            result["effective_config"]["applies_to"]
+        )
+
+    def test_direct_backend_write_target_is_the_resolved_redis(self):
+        result = self._run_with_backend_named("RedisMemoryBackend", {"total_keys": 1})
+        assert result["write_target"] == {
+            "kind": "direct-redis",
+            "url": "redis://:***@cloud.example:15667/0",
+        }
+        assert "applies_to" not in result["effective_config"]
+
     def test_handler_failure_path_still_degrades(self):
         server = MagicMock()
         with patch("attune_redis.mcp_tools._get_backend", side_effect=RuntimeError("boom")):

--- a/tests/unit/memory/test_redis_doctor_diagnostic.py
+++ b/tests/unit/memory/test_redis_doctor_diagnostic.py
@@ -141,11 +141,17 @@ class TestHandlerIntegration:
         assert TOOL_HANDLERS["redis_health_check"] is handle_redis_health_check
 
     def _run_with_backend_named(self, name: str, stats: dict) -> dict:
+        from attune_redis.memory import AMSMemoryBackend
+
         server = MagicMock()
-        backend = MagicMock()
+        # An AMS SUBCLASS: the write target must follow isinstance, not the
+        # class name (cross-review finding, 2026-08-23).
+        spec = type("TracedAMS", (AMSMemoryBackend,), {}) if name == "AMSMemoryBackend" else None
+        backend = MagicMock(spec=spec) if spec else MagicMock()
         backend.is_connected.return_value = True
         backend.get_stats.return_value = stats
-        type(backend).__name__ = name
+        if not spec:
+            type(backend).__name__ = name
         with (
             patch("attune_redis.mcp_tools._get_backend", return_value=backend),
             patch(


### PR DESCRIPTION
## What

`redis_health_check` named **two** Redis endpoints in one answer — the AMS base URL in `stats` and the direct-Redis resolver's `redacted_url` in `effective_config` — so a reader could not tell which one their stash depended on. On 2026-08-23 the resolver pointed at Redis Cloud, writes went through a local AMS whose own Redis was auth-dead, and the answer read as healthy. Principle 16: a claim must carry what it actually establishes.

Ruled at round table `q-post-redis-repair-broken-features-001` (3/3 seats; chair-promoted C2).

## Fix

- New `write_target` derived from `backend_selected`: AMS → its base URL (noting AMS persists to its *own* Redis); direct backend → the resolver's redacted URL.
- When AMS is selected, `effective_config.applies_to` states the resolver section governs direct clients (recall index, telemetry), **not** the selected write path.

## Receipts

- **suite**: 12 passed in `test_redis_doctor_diagnostic` (2 new).
- **live-fire**: handler called against the real `AMSMemoryBackend` returns `write_target.kind == "ams"`, `url == http://localhost:8000`, with the `applies_to` label.

Companion to #2195 (the stash receipt) — independent files, no stacking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
