### PR TITLE
fix(agents): the LLM ratchet can no longer lift the Security gate's -1 sentinel

### DIFF
--- a/src/attune/agents/release/security_agent.py
+++ b/src/attune/agents/release/security_agent.py
@@ -113,12 +113,18 @@ class SecurityAuditorAgent(ReleaseAgent):
                             }
                         )
                         # Fail-closed ratchet: a stricter LLM severity
-                        # count may raise the bandit value, never lower it.
+                        # count may raise the bandit value, never lower it
+                        # — and never REPLACE the -1 did-not-run sentinel:
+                        # 0 > -1, so without the guard an LLM reporting
+                        # "no issues" turned an unreadable bandit run back
+                        # into a clean gate (found by bug-predict dogfood,
+                        # round table q-bug-predict-health-001).
                         for key in _SEVERITY_COUNT_KEYS:
                             llm_count = llm_findings.get(key)
                             if (
                                 isinstance(llm_count, int)
                                 and not isinstance(llm_count, bool)
+                                and findings[key] >= 0
                                 and llm_count > findings[key]
                             ):
                                 findings[key] = llm_count

--- a/tests/unit/agents/test_release_agent_analysis_branches.py
+++ b/tests/unit/agents/test_release_agent_analysis_branches.py
@@ -119,3 +119,32 @@ class TestDocumentationDefensivePaths:
         assert success is False
         assert findings["error"] == "fs exploded"
         assert findings["coverage_percent"] == 0.0
+
+
+def test_llm_ratchet_never_lifts_the_did_not_run_sentinel(monkeypatch):
+    """bug-predict dogfood 2026-08-23: bandit output unreadable -> -1; the LLM
+    says 0; 0 > -1 lifted the sentinel and the gate passed blind again."""
+    agent = sec_mod.SecurityAuditorAgent(redis_client=None)
+    monkeypatch.setattr(sec_mod, "_run_command", lambda *a, **k: (0, "Working... 100%\n{}", ""))
+    monkeypatch.setattr(sec_mod, "LLM_MODE", "real")
+    agent.llm_client = object()
+    monkeypatch.setattr(
+        agent,
+        "_call_llm",
+        lambda *a, **k: ('{"critical_issues": 0, "high_issues": 0, "score": 95}', {}),
+    )
+    success, findings = agent._execute_tier(".", Tier.CHEAP)
+    assert success is False
+    assert findings["critical_issues"] == -1
+    assert findings["note"] == "Could not parse bandit output"
+
+
+def test_llm_ratchet_still_raises_a_real_count(monkeypatch):
+    agent = sec_mod.SecurityAuditorAgent(redis_client=None)
+    monkeypatch.setattr(sec_mod, "_run_command", lambda *a, **k: (0, '{"results": []}', ""))
+    monkeypatch.setattr(sec_mod, "LLM_MODE", "real")
+    agent.llm_client = object()
+    monkeypatch.setattr(agent, "_call_llm", lambda *a, **k: ('{"critical_issues": 2}', {}))
+    success, findings = agent._execute_tier(".", Tier.CHEAP)
+    assert success is False
+    assert findings["critical_issues"] == 2


### PR DESCRIPTION
## What

#2194 made an unreadable bandit run return `critical_issues=-1` so the gate fails closed — but in `RELEASE_LLM_MODE=real` the severity ratchet (`if llm_count > findings[key]`) lifted `-1` to the LLM's `0`, and `success = critical == 0` passed the gate blind again. Reproduced: `success=True, critical_issues=0, note="Could not parse bandit output"`.

**Found by bug-predict** — a dogfood run on `security_agent.py` ranked this its top HIGH at the right line. Round table `q-bug-predict-health-001` (3/3 seats; chair-promoted C1).

## Fix

One extra condition in the ratchet: it applies only to a non-negative count, so the did-not-run sentinel is absorbing. The LLM can still raise a real count.

## Receipts

- **suite**: 72 passed serially across `test_release_agent_analysis_branches` (2 new), `test_specialized_agents`, `test_release_prep_team_orchestration`.
- **live-fire**: the exact reproduction probe now yields `success=False, critical_issues=-1`.

## Governance

Security/enforcement surface → D11 lane owed before the chair reads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)