### PR TITLE
fix(gates): the spend gate reports the billing the run will actually use, with its basis

### DIFF
--- a/src/attune/gates/meter.py
+++ b/src/attune/gates/meter.py
@@ -14,6 +14,7 @@ Licensed under Apache 2.0
 
 from __future__ import annotations
 
+import os
 from dataclasses import dataclass
 
 from attune.models.auth_strategy import AuthMode, AuthStrategy
@@ -28,6 +29,9 @@ class Meter:
     """The user's active billing meter and how to frame a spend."""
 
     mode: str  # "api" | "subscription"
+    #: How the mode was established — shown with the framing so the
+    #: reader can tell a measured fact from a configured preference.
+    basis: str = ""
 
     @property
     def is_dollars(self) -> bool:
@@ -49,14 +53,16 @@ class Meter:
             A one-line framing string for the confirm surface.
         """
         if self.is_dollars:
-            return (
+            text = (
                 f"≈ up to ${estimate_usd:.2f} this session window "
                 "— counts against your Anthropic API spend."
             )
-        return (
-            "uses your subscription quota (no per-call charge) "
-            "— counts against your Anthropic usage window."
-        )
+        else:
+            text = (
+                "uses your subscription quota (no per-call charge) "
+                "— counts against your Anthropic usage window."
+            )
+        return f"{text} [basis: {self.basis}]" if self.basis else text
 
 
 def resolve(
@@ -79,8 +85,19 @@ def resolve(
     Returns:
         The active :class:`Meter`.
     """
+    # The RUNTIME fact comes first: when ANTHROPIC_API_KEY is set, the
+    # Claude Code runtime bills that key over any claude.ai login
+    # ("ANTHROPIC_API_KEY … takes precedence over your claude.ai login"),
+    # whatever the strategy prefers. On 2026-08-23 this gate told a user
+    # "subscription quota (no per-call charge)" and the run billed $1.17
+    # to the key (round table q-bug-predict-health-001, principle 16).
+    if os.environ.get("ANTHROPIC_API_KEY"):
+        return Meter(
+            mode=METER_API,
+            basis="ANTHROPIC_API_KEY is set — the runtime bills the key over a claude.ai login",
+        )
     strategy = strategy or AuthStrategy.load()
     mode = strategy.get_recommended_mode(module_lines)
     if mode == AuthMode.SUBSCRIPTION:
-        return Meter(mode=METER_SUBSCRIPTION)
-    return Meter(mode=METER_API)
+        return Meter(mode=METER_SUBSCRIPTION, basis="auth-strategy preference; no API key in env")
+    return Meter(mode=METER_API, basis="auth-strategy preference")

--- a/tests/unit/gates/test_meter.py
+++ b/tests/unit/gates/test_meter.py
@@ -6,6 +6,8 @@ auth state) so the tests are deterministic across environments.
 
 from __future__ import annotations
 
+import pytest
+
 from attune.gates.meter import (
     METER_API,
     METER_SUBSCRIPTION,
@@ -13,6 +15,15 @@ from attune.gates.meter import (
     resolve,
 )
 from attune.models.auth_strategy import AuthMode, AuthStrategy, SubscriptionTier
+
+
+@pytest.fixture(autouse=True)
+def _no_ambient_api_key(monkeypatch):
+    """Meter resolution reads the RUNTIME key first (2026-08-23); these
+    tests exercise the preference path, so a developer's ambient key must
+    not leak in — keyless CI sets the var to "" and so do we."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "")
+
 
 # --- framing -------------------------------------------------------------
 
@@ -101,3 +112,34 @@ def test_resolve_defaults_to_loaded_strategy(monkeypatch) -> None:
         classmethod(lambda cls, path=None: sentinel),
     )
     assert resolve().mode == METER_SUBSCRIPTION
+
+
+# --- runtime basis beats preference (2026-08-23) --------------------------
+
+
+def test_api_key_in_env_forces_api_meter_over_subscription_preference(monkeypatch) -> None:
+    """The gate said "subscription quota" while the run billed the key."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")  # pragma: allowlist secret
+    strategy = AuthStrategy(default_mode=AuthMode.SUBSCRIPTION)
+    meter = resolve(strategy)
+    assert meter.mode == METER_API
+    assert "ANTHROPIC_API_KEY" in meter.basis
+    framing = meter.framing(1.0)
+    assert "Anthropic API spend" in framing
+    assert "subscription quota" not in framing
+    assert "[basis:" in framing
+
+
+def test_empty_api_key_falls_back_to_preference(monkeypatch) -> None:
+    """Keyless CI sets the var to "" — that is NOT a key."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "")
+    strategy = AuthStrategy(default_mode=AuthMode.SUBSCRIPTION)
+    meter = resolve(strategy)
+    assert meter.mode == METER_SUBSCRIPTION
+    assert "no API key in env" in meter.basis
+
+
+def test_framing_states_its_basis(monkeypatch) -> None:
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    meter = resolve(AuthStrategy(default_mode=AuthMode.API))
+    assert meter.framing(0.5).endswith("[basis: auth-strategy preference]")

--- a/tests/unit/gates/test_spend_gate.py
+++ b/tests/unit/gates/test_spend_gate.py
@@ -24,6 +24,15 @@ from attune.gates.spend_gate import (
 )
 from attune.models.auth_strategy import AuthMode, AuthStrategy, SubscriptionTier
 
+
+@pytest.fixture(autouse=True)
+def _no_ambient_api_key(monkeypatch):
+    """Meter resolution reads the RUNTIME key first (2026-08-23); these
+    tests exercise the preference path, so a developer's ambient key must
+    not leak in — keyless CI sets the var to "" and so do we."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "")
+
+
 # Pinned clock — deterministic window math.
 NOW = 1_700_000_000.0
 


### PR DESCRIPTION
## What

`meter.resolve()` read the user's `AuthStrategy` **preference**, while the Claude Code runtime bills `ANTHROPIC_API_KEY` whenever it is set ("takes precedence over your claude.ai login"). On 2026-08-23 the gate told a non-interactive bug-predict run *"uses your subscription quota (no per-call charge)"* and telemetry recorded **$1.17 to the key**. The one sentence whose job is to say what the user is about to spend was an inference dressed as a fact (principle 16).

Round table `q-bug-predict-health-001` (3/3 seats; chair-promoted C2).

## Fix

- `resolve()` checks the runtime fact first: a non-empty `ANTHROPIC_API_KEY` → API meter; `""` (keyless CI) is not a key.
- `Meter.basis` + framing suffix `[basis: …]` — a measured fact and a configured preference no longer read identically.
- Meter/spend-gate tests pin `ANTHROPIC_API_KEY=""` (autouse): the preference-path tests were silently environment-dependent — green keyless, red on any keyed dev box.

## Receipts

- **suite**: 333 passed serially across `tests/unit/gates` (3 new).
- **live-fire**: CLI refusal on this keyed machine now reads `counts against your Anthropic API spend [basis: ANTHROPIC_API_KEY is set — the runtime bills the key over a claude.ai login]`, matching this morning's telemetry.

## Open (chair)

Claude seat's follow-up: should the gate *refuse* (not warn) when the derived billing contradicts a subscription-first preference? Not implemented here — warn-with-basis only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)