### PR TITLE
feat(ops): reliability badges for secure-release and health-check (fleet-health containment)

### DIFF
--- a/docs/reports/roundtable/q-workflow-fleet-health-001.md
+++ b/docs/reports/roundtable/q-workflow-fleet-health-001.md
@@ -1,0 +1,44 @@
+# Round table — workflow fleet health (2026-08-23)
+
+Thread: `q-workflow-fleet-health-001` (Redis board, TTL 7d). Full
+transcript (moderator development data, untracked):
+`~/.attune/reports/roundtable/q-workflow-fleet-health-001.md`.
+
+All 20 dashboard workflows (bug-predict excluded — fixed that morning)
+were probed with real dashboard-shaped runs (`attune workflow run
+<name> [--path]`, LLM-real, ~$18 API). Seats: claude, codex,
+antigravity — one round, converged.
+
+## Chair-promoted findings (2026-08-23)
+
+1. **secure-release fails open** (Sev1, unanimous): both sub-workflows
+   died (SDK subprocess), zero checks executed, yet the pipeline
+   returned `success=True, go_no_go='GO', "All checks passed"`.
+   Violates contract P7 (a failed gatekeeper fails the gate).
+   → chip `task_df481436` (fail-closed sentinel, mirroring
+   #2204/#2205).
+2. **health-check fabricates perfection / doc-orchestrator reports "no
+   gaps" when its scout never loaded** (Sev2/5): 100/100 grade A in
+   9s/$0 with `coverage_percent=100.0` on an ~85-90% repo. Fix per the
+   table's bifurcation: gates fail closed; advisory surfaces show
+   DEGRADED / N-A, never fabricated numbers.
+   → chip `task_ca1c3c49`.
+3. **Trust probes for "working" verdicts**: on a clean small target,
+   "found nothing" cannot distinguish clean from blind — planted-defect
+   fixtures promoted into the test-quality program.
+   → chip `task_a37e52f7`.
+4. **Containment now**: dashboard reliability badges on secure-release
+   and health-check until the fixes land (this PR;
+   `RELIABILITY_NOTICES` in `src/attune/ops/data.py` — the fixing PR
+   removes the entry).
+
+## Recorded, not promoted
+
+- doc-gen + research-synthesis fail deterministically (same
+  `claude_agent_sdk.query()` transport as 12 working workflows — the
+  discriminator is per-call options, not transport; SDK env drift
+  0.2.116 vs lockfile 0.2.105 is real but explains neither break).
+- fix / rag-code-gen are dashboard-unrunnable (required `goal`/`query`
+  the Run button cannot supply).
+- release-prep's $0 rule-based degrade is the fleet's counterexample:
+  it degraded, said so, and still produced a real FAIL verdict.

--- a/src/attune/ops/data.py
+++ b/src/attune/ops/data.py
@@ -39,6 +39,7 @@ class WorkflowEntry:
     description: str
     stages: int
     tier_map: dict[str, str]
+    notice: str = ""
 
 
 @dataclass(frozen=True)
@@ -1688,6 +1689,24 @@ def read_sweep_chip_counts(scope_path: str, config: Config) -> SweepChipCounts:
     )
 
 
+#: Chair-ruled reliability notices (roundtable q-workflow-fleet-health-001,
+#: 2026-08-23): these workflows currently report success their execution
+#: does not support. Shown as a warning badge on the dashboard until the
+#: fail-closed fixes land; remove the entry in the fixing PR.
+RELIABILITY_NOTICES: dict[str, str] = {
+    "secure-release": (
+        "Known issue: can report GO even when its security-audit and "
+        "release-prep sub-workflows fail to execute. Do not trust a GO "
+        "from this workflow until the fail-closed fix lands."
+    ),
+    "health-check": (
+        "Known issue: reports perfect scores (100/100, grade A) when its "
+        "measurement agents do not run. Treat perfect scores from fast, "
+        "zero-cost runs as unmeasured, not healthy."
+    ),
+}
+
+
 def list_workflows() -> list[WorkflowEntry]:
     """Return the registered workflow catalog. Empty if the registry is unavailable."""
     try:
@@ -1706,6 +1725,7 @@ def list_workflows() -> list[WorkflowEntry]:
                     description=str(entry.get("description", "")),
                     stages=len(stages) if isinstance(stages, list) else 0,
                     tier_map={str(k): str(v) for k, v in tier_map.items()},
+                    notice=RELIABILITY_NOTICES.get(str(entry.get("name", "")), ""),
                 )
             )
     except Exception:  # noqa: BLE001

--- a/src/attune/ops/static/css/main.css
+++ b/src/attune/ops/static/css/main.css
@@ -3239,3 +3239,13 @@ a.kpi:hover {
 .memory-table .col-kind .chip {
   text-decoration: none;
 }
+
+/* Chair-ruled reliability notices (roundtable q-workflow-fleet-health-001) */
+.workflow-notice {
+  margin-top: 0.35rem;
+  padding: 0.3rem 0.55rem;
+  border-radius: 6px;
+  background: rgba(180, 83, 9, 0.12);
+  border: 1px solid rgba(180, 83, 9, 0.45);
+  font-size: 0.82rem;
+}

--- a/src/attune/ops/templates/workflows.html
+++ b/src/attune/ops/templates/workflows.html
@@ -110,6 +110,9 @@
           </td>
           <td>
             {{ w.description }}
+            {% if w.notice %}
+              <div class="workflow-notice" role="note">⚠ {{ w.notice }}</div>
+            {% endif %}
             <div class="run-status"><span data-status></span></div>
             {% if w.name == "discovery-sweep" %}
               {# Phase 3 chips. Server-rendered for first paint; runner.js

--- a/tests/unit/ops/test_workflow_reliability_notices.py
+++ b/tests/unit/ops/test_workflow_reliability_notices.py
@@ -1,0 +1,34 @@
+"""Chair-ruled reliability badges (roundtable q-workflow-fleet-health-001).
+
+Containment until the fail-closed fixes land: the dashboard must warn
+on workflows known to report success their execution does not support.
+The fixing PR removes the workflow's ``RELIABILITY_NOTICES`` entry and
+updates this test.
+"""
+
+from __future__ import annotations
+
+from attune.ops.data import RELIABILITY_NOTICES, WorkflowEntry, list_workflows
+
+
+def test_noticed_workflows_are_flagged():
+    assert set(RELIABILITY_NOTICES) == {"secure-release", "health-check"}
+    for name, text in RELIABILITY_NOTICES.items():
+        assert "Known issue" in text, name
+
+
+def test_list_workflows_carries_the_notice():
+    entries = {w.name: w for w in list_workflows()}
+    if not entries:  # registry unavailable in this environment
+        return
+    for name in RELIABILITY_NOTICES:
+        assert name in entries, f"{name} missing from the registry"
+        assert entries[name].notice == RELIABILITY_NOTICES[name]
+    # And un-noticed workflows carry an empty notice.
+    clean = next(n for n in entries if n not in RELIABILITY_NOTICES)
+    assert entries[clean].notice == ""
+
+
+def test_workflow_entry_notice_defaults_empty():
+    e = WorkflowEntry(name="x", description="d", stages=0, tier_map={})
+    assert e.notice == ""


### PR DESCRIPTION
## Summary

Chair-ruled containment from **roundtable `q-workflow-fleet-health-001`** (2026-08-23): all 20 dashboard workflows probed with real dashboard-shaped runs (LLM-real, ~$18 API). Two workflows currently report success their execution does not support:

- **secure-release** returned `success=True, go_no_go='GO', "All checks passed - ready for release"` while BOTH sub-workflows (security-audit, release-prep) failed to execute — a fail-open release gate (contract P7).
- **health-check** reported 100/100 grade A in 9s/$0 with `coverage_percent=100.0` on an ~85-90% repo — degrade-to-defaults rendered as measurement.

Until the fail-closed fixes land (chips `task_df481436`, `task_ca1c3c49`), the dashboard shows a warning badge on both:

- `RELIABILITY_NOTICES` map + `WorkflowEntry.notice` field in `src/attune/ops/data.py`
- badge rendering in `templates/workflows.html` + `.workflow-notice` style
- guard test `tests/unit/ops/test_workflow_reliability_notices.py` (the fixing PR removes the map entry and updates the pin)
- curated stub `docs/reports/roundtable/q-workflow-fleet-health-001.md` (promoted findings + thread id; full transcript stays machine-local per local-first policy)

## Receipts

- `uv run pytest tests/unit/ops/test_workflow_reliability_notices.py tests/unit/ops/test_data_characterization.py tests/unit/ops/test_workflow_list_chips.py tests/unit/ops/test_workflows_route_concerns.py -n 0` → **42 passed**.
- black/ruff pre-flighted; commit landed GPG-signed (`%G?` = G).

Advisory-only roundtable output; the badges are chair-promoted containment, not a gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
