### PR TITLE
fix(workflows): unmeasured metrics are N/A, never numbers — DEGRADED status for health check and doc orchestrator (Sev2/Sev5, roundtable q-workflow-fleet-health-001)

### DIFF
--- a/src/attune/mcp/workflow_handlers.py
+++ b/src/attune/mcp/workflow_handlers.py
@@ -298,6 +298,7 @@ class WorkflowHandlersMixin:
         return {
             "success": getattr(result, "phase", "") == "complete",
             "phase": getattr(result, "phase", "unknown"),
+            "degraded": getattr(result, "degraded", False),
             "items_found": getattr(result, "items_found", 0),
             "docs_generated": getattr(result, "docs_generated", []),
             "docs_updated": getattr(result, "docs_updated", []),
@@ -500,6 +501,7 @@ class WorkflowHandlersMixin:
             "success": getattr(result, "success", False),
             "health_score": getattr(result, "overall_health_score", 0),
             "grade": getattr(result, "grade", "unknown"),
+            "degraded": getattr(result, "degraded", False),
             "issues": getattr(result, "issues", []),
             "recommendations": getattr(result, "recommendations", []),
         }

--- a/src/attune/workflows/doc_orch_report.py
+++ b/src/attune/workflows/doc_orch_report.py
@@ -147,7 +147,12 @@ class DocOrchReportMixin:
             "=" * 60,
             "",
             f"Project: {self.project_root}",
-            f"Status: {'SUCCESS' if result.success else 'PARTIAL'}",
+            "Status: "
+            + (
+                "DEGRADED (scan did not run — gaps not assessed)"
+                if result.degraded
+                else ("SUCCESS" if result.success else "PARTIAL")
+            ),
             "",
             "-" * 60,
             "SCOUT PHASE",

--- a/src/attune/workflows/doc_orch_scout.py
+++ b/src/attune/workflows/doc_orch_scout.py
@@ -42,9 +42,15 @@ class DocOrchScoutMixin:
     include_missing: bool = True
     max_items: int = 5
     project_root: Path = Path()
+    # True only after a scan (scout or ProjectIndex fallback) actually
+    # ran — zero items with no scan is "not assessed", never "no gaps".
+    _scan_performed: bool = False
 
     async def _run_scout_phase(self) -> tuple[list, float]:
         """Run the scout phase to identify documentation gaps.
+
+        Sets ``self._scan_performed`` so the caller can distinguish an
+        empty result from a scan that never happened.
 
         Returns:
             Tuple of (items found, cost)
@@ -54,12 +60,14 @@ class DocOrchScoutMixin:
 
         items: list[DocumentationItem] = []
         cost = 0.0
+        self._scan_performed = False
 
         if self._scout is None:
             logger.warning("Scout (ManageDocumentationCrew) not available")
             # Fall back to ProjectIndex if available
             if self._project_index is not None:
                 items = self._items_from_index()
+                self._scan_performed = True
             return items, cost
 
         logger.info("Starting scout phase...")
@@ -71,6 +79,7 @@ class DocOrchScoutMixin:
         if not result.success:
             logger.error("Scout phase failed")
             return items, cost
+        self._scan_performed = True
 
         # Parse scout findings into DocumentationItems
         items = self._parse_scout_findings(result)

--- a/src/attune/workflows/documentation_orchestrator.py
+++ b/src/attune/workflows/documentation_orchestrator.py
@@ -108,6 +108,9 @@ class OrchestratorResult:
     errors: list[str] = field(default_factory=list)
     warnings: list[str] = field(default_factory=list)
     summary: str = ""
+    # True when no scan ran (no scout, no ProjectIndex) — gap data was
+    # never collected, so items_found=0 means "not assessed", not "no gaps".
+    degraded: bool = False
 
     def to_dict(self) -> dict:
         """Convert to dictionary for serialization."""
@@ -128,6 +131,7 @@ class OrchestratorResult:
             "errors": self.errors,
             "warnings": self.warnings,
             "summary": self.summary,
+            "degraded": self.degraded,
         }
 
 
@@ -460,8 +464,24 @@ class DocumentationOrchestrator(
         result.phase = "prioritize"
 
         if not items:
+            if not self._scan_performed:
+                # No scout and no ProjectIndex: nothing was scanned, so
+                # zero items is "not assessed" — never "no gaps found".
+                result.degraded = True
+                result.errors = errors + [
+                    "Documentation scan did not run (no scout or "
+                    "ProjectIndex available) — gaps were NOT assessed"
+                ]
+                result.warnings = warning_msgs
+                result.duration_ms = int((datetime.now() - started_at).total_seconds() * 1000)
+                result.total_cost = self._total_cost
+                result.summary = self._generate_summary(result, items)
+                print("\n[!] DEGRADED: documentation scan did not run — gaps were not assessed")
+                return result
             print("\n[✓] No documentation gaps found!")
-            return self._finalize_result(result, started_at, "complete", items)
+            return self._finalize_result(
+                result, started_at, "complete", items, warning_msgs=warning_msgs
+            )
 
         # Phase 2: Prioritize
         print(f"\n[PRIORITIZE] Found {len(items)} items, selecting top {self.max_items}...")
@@ -551,6 +571,7 @@ class DocumentationOrchestrator(
 
         return {
             "success": result.success,
+            "degraded": result.degraded,
             "stats": {
                 "items_found": result.items_found,
                 "stale_docs": result.stale_docs,

--- a/src/attune/workflows/health_check_models.py
+++ b/src/attune/workflows/health_check_models.py
@@ -19,11 +19,15 @@ class CategoryScore:
 
     Attributes:
         name: Category name (e.g., "Security")
-        score: Score 0-100
+        score: Score 0-100 (meaningless when measured is False)
         weight: Weight in overall score (0-1)
         raw_metrics: Raw metrics from agent
         issues: Issues found
         passed: Whether category passed threshold
+        measured: Whether the agent actually produced a measurement.
+            Unmeasured categories are excluded from the weighted
+            overall score and rendered as N/A — a metric that was
+            not measured must not be a number.
 
     """
 
@@ -33,6 +37,7 @@ class CategoryScore:
     raw_metrics: dict[str, Any] = field(default_factory=dict)
     issues: list[str] = field(default_factory=list)
     passed: bool = True
+    measured: bool = True
 
 
 @dataclass
@@ -51,6 +56,9 @@ class HealthCheckReport:
         timestamp: Report generation time
         agents_executed: Number of agents executed
         success: Whether check completed successfully
+        degraded: True when one or more categories were not measured
+            (agent missing or failed) — the score covers only the
+            measured categories and the report is INCOMPLETE DATA
 
     """
 
@@ -65,6 +73,7 @@ class HealthCheckReport:
     timestamp: str = field(default_factory=lambda: datetime.now().isoformat())
     agents_executed: int = 0
     success: bool = True
+    degraded: bool = False
 
     def to_dict(self) -> dict[str, Any]:
         """Convert report to dictionary for JSON serialization.
@@ -84,6 +93,7 @@ class HealthCheckReport:
                     "raw_metrics": cat.raw_metrics,
                     "issues": cat.issues,
                     "passed": cat.passed,
+                    "measured": cat.measured,
                 }
                 for cat in self.category_scores
             ],
@@ -95,6 +105,7 @@ class HealthCheckReport:
             "timestamp": self.timestamp,
             "agents_executed": self.agents_executed,
             "success": self.success,
+            "degraded": self.degraded,
         }
 
     def format_console_output(self) -> str:
@@ -122,11 +133,19 @@ class HealthCheckReport:
         }
         emoji = grade_emoji.get(self.grade, "")
 
-        lines.append(
-            f"Overall Health: {emoji} "
-            f"{self.overall_health_score:.1f}/100 "
-            f"(Grade {self.grade})",
-        )
+        if self.grade == "N/A":
+            lines.append("Overall Health: ❓ N/A — no categories were measured")
+        else:
+            lines.append(
+                f"Overall Health: {emoji} "
+                f"{self.overall_health_score:.1f}/100 "
+                f"(Grade {self.grade})",
+            )
+        if self.degraded:
+            lines.append(
+                "⚠️  DEGRADED — INCOMPLETE DATA: unmeasured categories "
+                "are shown as N/A and excluded from the score",
+            )
         lines.append(f"Mode: {self.mode.upper()}")
         lines.append(f"Agents Executed: {self.agents_executed}")
         lines.append(f"Generated: {self.timestamp}")
@@ -142,7 +161,14 @@ class HealthCheckReport:
         lines.append("CATEGORY BREAKDOWN")
         lines.append("-" * 70)
 
-        for category in sorted(self.category_scores, key=lambda x: x.score, reverse=True):
+        for category in sorted(
+            self.category_scores,
+            key=lambda x: (x.measured, x.score),
+            reverse=True,
+        ):
+            if not category.measured:
+                lines.append(f"❓ {category.name:15}   N/A (not measured)")
+                continue
             status = "✅" if category.passed else "❌"
             bar_length = int(category.score / 5)  # 0-20 chars
             bar = "█" * bar_length

--- a/src/attune/workflows/health_check_scoring.py
+++ b/src/attune/workflows/health_check_scoring.py
@@ -33,11 +33,33 @@ GRADE_THRESHOLDS: dict[str, float] = {
 }
 
 
+def _unmeasured_category(name: str, weight: float, agent_id: str) -> CategoryScore:
+    """Build the explicit N/A score for a category whose agent produced no data.
+
+    A metric that was not measured must not be a number: the category is
+    marked measured=False, carries an issue naming the missing agent, and
+    is excluded from the weighted overall score.
+    """
+    return CategoryScore(
+        name=name,
+        score=0.0,
+        weight=weight,
+        raw_metrics={},
+        issues=[f"{name} not measured — {agent_id} produced no measurement"],
+        passed=False,
+        measured=False,
+    )
+
+
 def calculate_category_scores(
     agent_results: dict[str, dict[str, Any]],
     category_weights: dict[str, float] | None = None,
 ) -> list[CategoryScore]:
     """Calculate health scores for each category.
+
+    A category is only scored when its agent actually produced the
+    metric it is scored on; a missing or failed agent yields an
+    unmeasured (N/A) category, never a defaulted number.
 
     Args:
         agent_results: Results from all agents
@@ -53,122 +75,145 @@ def calculate_category_scores(
 
     # Security score (from security_auditor)
     security_result = agent_results.get("security_auditor", {}).get("output", {})
-    critical_issues = security_result.get("critical_issues", 0)
-    high_issues = security_result.get("high_issues", 0)
-    medium_issues = security_result.get("medium_issues", 0)
+    if "critical_issues" not in security_result:
+        scores.append(_unmeasured_category("Security", weights["Security"], "security_auditor"))
+    else:
+        critical_issues = security_result.get("critical_issues", 0)
+        high_issues = security_result.get("high_issues", 0)
+        medium_issues = security_result.get("medium_issues", 0)
 
-    security_score = 100.0
-    security_issues: list[str] = []
+        security_score = 100.0
+        security_issues: list[str] = []
 
-    if critical_issues > 0:
-        security_score -= critical_issues * 20  # -20 per critical
-        security_issues.append(f"{critical_issues} critical security issue(s)")
-    if high_issues > 0:
-        security_score -= high_issues * 10  # -10 per high
-        security_issues.append(f"{high_issues} high severity issue(s)")
-    if medium_issues > 0:
-        security_score -= medium_issues * 5  # -5 per medium
-        security_issues.append(f"{medium_issues} medium severity issue(s)")
+        if critical_issues > 0:
+            security_score -= critical_issues * 20  # -20 per critical
+            security_issues.append(f"{critical_issues} critical security issue(s)")
+        if high_issues > 0:
+            security_score -= high_issues * 10  # -10 per high
+            security_issues.append(f"{high_issues} high severity issue(s)")
+        if medium_issues > 0:
+            security_score -= medium_issues * 5  # -5 per medium
+            security_issues.append(f"{medium_issues} medium severity issue(s)")
 
-    security_score = max(0.0, security_score)
+        security_score = max(0.0, security_score)
 
-    scores.append(
-        CategoryScore(
-            name="Security",
-            score=security_score,
-            weight=weights["Security"],
-            raw_metrics={
-                "critical": critical_issues,
-                "high": high_issues,
-                "medium": medium_issues,
-            },
-            issues=security_issues,
-            passed=critical_issues == 0 and high_issues == 0,
-        ),
-    )
+        scores.append(
+            CategoryScore(
+                name="Security",
+                score=security_score,
+                weight=weights["Security"],
+                raw_metrics={
+                    "critical": critical_issues,
+                    "high": high_issues,
+                    "medium": medium_issues,
+                },
+                issues=security_issues,
+                passed=critical_issues == 0 and high_issues == 0,
+            ),
+        )
 
     # Coverage score (from test_coverage_analyzer)
     coverage_result = agent_results.get("test_coverage_analyzer", {}).get("output", {})
-    coverage_percent = coverage_result.get("coverage_percent", 0.0)
+    if "coverage_percent" not in coverage_result:
+        scores.append(
+            _unmeasured_category("Coverage", weights["Coverage"], "test_coverage_analyzer")
+        )
+    else:
+        coverage_percent = coverage_result["coverage_percent"]
 
-    coverage_issues: list[str] = []
-    if coverage_percent < 80.0:
-        coverage_issues.append(f"Coverage below 80% ({coverage_percent:.1f}%)")
+        coverage_issues: list[str] = []
+        if coverage_percent < 80.0:
+            coverage_issues.append(f"Coverage below 80% ({coverage_percent:.1f}%)")
 
-    scores.append(
-        CategoryScore(
-            name="Coverage",
-            score=coverage_percent,
-            weight=weights["Coverage"],
-            raw_metrics={"coverage_percent": coverage_percent},
-            issues=coverage_issues,
-            passed=coverage_percent >= 80.0,
-        ),
-    )
+        scores.append(
+            CategoryScore(
+                name="Coverage",
+                score=coverage_percent,
+                weight=weights["Coverage"],
+                raw_metrics={"coverage_percent": coverage_percent},
+                issues=coverage_issues,
+                passed=coverage_percent >= 80.0,
+            ),
+        )
 
     # Quality score (from code_reviewer)
     quality_result = agent_results.get("code_reviewer", {}).get("output", {})
-    quality_score = quality_result.get("quality_score", 0.0)
-    # Convert 0-10 scale to 0-100
-    quality_score_100 = quality_score * 10
+    if "quality_score" not in quality_result:
+        scores.append(_unmeasured_category("Quality", weights["Quality"], "code_reviewer"))
+    else:
+        quality_score = quality_result["quality_score"]
+        # Convert 0-10 scale to 0-100
+        quality_score_100 = quality_score * 10
 
-    quality_issues: list[str] = []
-    if quality_score < 7.0:
-        quality_issues.append(f"Quality score below 7 ({quality_score:.1f}/10)")
+        quality_issues: list[str] = []
+        if quality_score < 7.0:
+            quality_issues.append(f"Quality score below 7 ({quality_score:.1f}/10)")
 
-    scores.append(
-        CategoryScore(
-            name="Quality",
-            score=quality_score_100,
-            weight=weights["Quality"],
-            raw_metrics={"quality_score": quality_score},
-            issues=quality_issues,
-            passed=quality_score >= 7.0,
-        ),
-    )
+        scores.append(
+            CategoryScore(
+                name="Quality",
+                score=quality_score_100,
+                weight=weights["Quality"],
+                raw_metrics={"quality_score": quality_score},
+                issues=quality_issues,
+                passed=quality_score >= 7.0,
+            ),
+        )
 
     # Performance score (from performance_optimizer, if available)
     if "performance_optimizer" in agent_results:
         perf_result = agent_results.get("performance_optimizer", {}).get("output", {})
-        bottleneck_count = perf_result.get("bottleneck_count", 0)
+        if "bottleneck_count" not in perf_result:
+            scores.append(
+                _unmeasured_category("Performance", weights["Performance"], "performance_optimizer")
+            )
+        else:
+            bottleneck_count = perf_result["bottleneck_count"]
 
-        perf_score = 100.0 - (bottleneck_count * 10)
-        perf_score = max(0.0, perf_score)
+            perf_score = 100.0 - (bottleneck_count * 10)
+            perf_score = max(0.0, perf_score)
 
-        perf_issues: list[str] = []
-        if bottleneck_count > 0:
-            perf_issues.append(f"{bottleneck_count} performance bottleneck(s)")
+            perf_issues: list[str] = []
+            if bottleneck_count > 0:
+                perf_issues.append(f"{bottleneck_count} performance bottleneck(s)")
 
-        scores.append(
-            CategoryScore(
-                name="Performance",
-                score=perf_score,
-                weight=weights["Performance"],
-                raw_metrics={"bottleneck_count": bottleneck_count},
-                issues=perf_issues,
-                passed=bottleneck_count <= 2,
-            ),
-        )
+            scores.append(
+                CategoryScore(
+                    name="Performance",
+                    score=perf_score,
+                    weight=weights["Performance"],
+                    raw_metrics={"bottleneck_count": bottleneck_count},
+                    issues=perf_issues,
+                    passed=bottleneck_count <= 2,
+                ),
+            )
 
     # Documentation score (from documentation_writer, if available)
     if "documentation_writer" in agent_results:
         docs_result = agent_results.get("documentation_writer", {}).get("output", {})
-        doc_coverage = docs_result.get("coverage_percent", 0.0)
+        if "coverage_percent" not in docs_result:
+            scores.append(
+                _unmeasured_category(
+                    "Documentation", weights["Documentation"], "documentation_writer"
+                )
+            )
+        else:
+            doc_coverage = docs_result["coverage_percent"]
 
-        doc_issues: list[str] = []
-        if doc_coverage < 100.0:
-            doc_issues.append(f"Documentation incomplete ({doc_coverage:.1f}%)")
+            doc_issues: list[str] = []
+            if doc_coverage < 100.0:
+                doc_issues.append(f"Documentation incomplete ({doc_coverage:.1f}%)")
 
-        scores.append(
-            CategoryScore(
-                name="Documentation",
-                score=doc_coverage,
-                weight=weights["Documentation"],
-                raw_metrics={"coverage_percent": doc_coverage},
-                issues=doc_issues,
-                passed=doc_coverage >= 90.0,
-            ),
-        )
+            scores.append(
+                CategoryScore(
+                    name="Documentation",
+                    score=doc_coverage,
+                    weight=weights["Documentation"],
+                    raw_metrics={"coverage_percent": doc_coverage},
+                    issues=doc_issues,
+                    passed=doc_coverage >= 90.0,
+                ),
+            )
 
     return scores
 
@@ -178,17 +223,23 @@ def calculate_overall_score(
 ) -> float:
     """Calculate weighted overall health score.
 
+    Unmeasured categories (measured=False) are excluded entirely —
+    their weight does not dilute the score and their placeholder 0.0
+    is never averaged in.
+
     Args:
         category_scores: Category scores
 
     Returns:
-        Overall score 0-100
+        Overall score 0-100 (0.0 when no category was measured)
 
     """
     total_score = 0.0
     total_weight = 0.0
 
     for category in category_scores:
+        if not category.measured:
+            continue
         total_score += category.score * category.weight
         total_weight += category.weight
 
@@ -265,9 +316,12 @@ def generate_recommendations(
     recommendations: list[str] = []
 
     sorted_categories = sorted(category_scores, key=lambda x: x.score)
+    unmeasured = [c.name for c in category_scores if not c.measured]
 
     for category in sorted_categories:
-        if category.passed:
+        # Unmeasured categories have no numbers to recommend against —
+        # they are reported as missing data below, not as failures.
+        if not category.measured or category.passed:
             continue
         template = _CATEGORY_RECOMMENDATIONS.get(category.name)
         if not template:
@@ -281,6 +335,13 @@ def generate_recommendations(
         }
         recommendations.append(heading_fmt.format(**fmt_vars))
         recommendations.extend(commands)
+
+    if unmeasured:
+        recommendations.append(
+            "⚠️ Not measured: "
+            + ", ".join(unmeasured)
+            + " — no data produced; excluded from the score",
+        )
 
     # Add general recommendations
     if len(recommendations) == 0:

--- a/src/attune/workflows/orchestrated_health_check.py
+++ b/src/attune/workflows/orchestrated_health_check.py
@@ -323,11 +323,16 @@ class OrchestratedHealthCheckWorkflow(BaseWorkflow):
         # Calculate category scores
         category_scores = self._calculate_category_scores(agent_results)
 
-        # Calculate overall health score
+        # A category whose agent produced no measurement is N/A: it is
+        # excluded from the weighted score and the report is DEGRADED.
+        measured_any = any(c.measured for c in category_scores)
+        degraded = any(not c.measured for c in category_scores)
+
+        # Calculate overall health score (measured categories only)
         overall_score = self._calculate_overall_score(category_scores)
 
-        # Assign grade
-        grade = self._assign_grade(overall_score)
+        # Assign grade — a grade needs at least one real measurement
+        grade = self._assign_grade(overall_score) if measured_any else "N/A"
 
         # Collect all issues
         issues: list[str] = []
@@ -350,6 +355,7 @@ class OrchestratedHealthCheckWorkflow(BaseWorkflow):
             mode=self.mode,
             agents_executed=len(agents),
             success=strategy_result.success,
+            degraded=degraded,
         )
 
     def _calculate_category_scores(

--- a/tests/unit/workflows/test_documentation_orchestrator.py
+++ b/tests/unit/workflows/test_documentation_orchestrator.py
@@ -1785,6 +1785,7 @@ class TestExecutePathKwarg:
         target = tmp_path / "scoped"
         target.mkdir()
         orchestrator._run_scout_phase = AsyncMock(return_value=([], 0.0))
+        orchestrator._scan_performed = True  # stub bypasses the real scan
         result = await orchestrator.execute(path=str(target))
         assert result.success is True
         assert orchestrator.project_root == target.resolve()
@@ -1793,6 +1794,7 @@ class TestExecutePathKwarg:
         target = tmp_path / "legacy"
         target.mkdir()
         orchestrator._run_scout_phase = AsyncMock(return_value=([], 0.0))
+        orchestrator._scan_performed = True  # stub bypasses the real scan
         with pytest.warns(DeprecationWarning, match="project_root"):
             result = await orchestrator.execute(project_root=str(target))
         assert result.success is True
@@ -1804,6 +1806,7 @@ class TestExecutePathKwarg:
         lose = tmp_path / "lose"
         lose.mkdir()
         orchestrator._run_scout_phase = AsyncMock(return_value=([], 0.0))
+        orchestrator._scan_performed = True  # stub bypasses the real scan
         with pytest.warns(DeprecationWarning, match="precedence"):
             result = await orchestrator.execute(path=str(win), project_root=str(lose))
         assert result.success is True
@@ -1813,6 +1816,7 @@ class TestExecutePathKwarg:
         target = tmp_path / "scoped2"
         target.mkdir()
         orchestrator._run_scout_phase = AsyncMock(return_value=([], 0.0))
+        orchestrator._scan_performed = True  # stub bypasses the real scan
         await orchestrator.execute(path=str(target))
         assert orchestrator.export_path == target.resolve() / "docs" / "generated"
 
@@ -1824,6 +1828,82 @@ class TestExecutePathKwarg:
         target = tmp_path / "scoped3"
         target.mkdir()
         orchestrator._run_scout_phase = AsyncMock(return_value=([], 0.0))
+        orchestrator._scan_performed = True  # stub bypasses the real scan
         await orchestrator.execute(path=str(target))
         # An explicitly-set export_path must NOT be re-derived on re-scope.
         assert orchestrator.export_path == export
+
+
+@pytest.mark.asyncio
+class TestDegradedScanStatus:
+    """Regression pins for roundtable q-workflow-fleet-health-001 (Sev5).
+
+    "No documentation gaps found!" may only be claimed after something
+    actually scanned. No scout AND no ProjectIndex means gaps were never
+    assessed — that is an explicit DEGRADED failure, not a success.
+    """
+
+    async def test_no_scout_no_index_is_degraded_not_no_gaps(self, tmp_path):
+        """Nothing scanned → success=False, degraded=True, no 'no gaps' claim."""
+        orchestrator = DocumentationOrchestrator(project_root=str(tmp_path), dry_run=True)
+        orchestrator._scout = None
+        orchestrator._project_index = None
+
+        result = await orchestrator.execute()
+
+        assert result.success is False
+        assert result.degraded is True
+        assert result.items_found == 0
+        assert any("NOT assessed" in error for error in result.errors)
+        assert "No documentation gaps found" not in result.summary
+        assert "DEGRADED" in result.summary
+
+    async def test_index_fallback_scan_counts_as_a_scan(self, tmp_path):
+        """A ProjectIndex fallback scan that finds nothing IS a clean result."""
+        orchestrator = DocumentationOrchestrator(project_root=str(tmp_path), dry_run=True)
+        orchestrator._scout = None
+        mock_index = MagicMock()
+        mock_index.get_context_for_workflow.return_value = {
+            "files_without_docstrings": [],
+            "docs_needing_review": [],
+        }
+        orchestrator._project_index = mock_index
+
+        result = await orchestrator.execute()
+
+        assert result.success is True
+        assert result.degraded is False
+        assert result.phase == "complete"
+
+    async def test_scout_failure_with_no_items_is_degraded(self, tmp_path):
+        """A scout that errored did not assess gaps — zero items is not 'no gaps'."""
+        orchestrator = DocumentationOrchestrator(project_root=str(tmp_path), dry_run=True)
+        mock_scout = MagicMock()
+        mock_result = MagicMock()
+        mock_result.success = False
+        mock_result.cost = 0.1
+        mock_result.findings = []
+        mock_scout.execute = AsyncMock(return_value=mock_result)
+        orchestrator._scout = mock_scout
+        orchestrator._project_index = None
+
+        result = await orchestrator.execute()
+
+        assert result.success is False
+        assert result.degraded is True
+
+    async def test_scout_as_json_surfaces_degraded(self, tmp_path):
+        """The VSCode JSON surface carries the degraded flag."""
+        orchestrator = DocumentationOrchestrator(project_root=str(tmp_path))
+        orchestrator._scout = None
+        orchestrator._project_index = None
+
+        payload = await orchestrator.scout_as_json()
+
+        assert payload["success"] is False
+        assert payload["degraded"] is True
+
+    def test_result_to_dict_includes_degraded(self):
+        """OrchestratorResult serialization exposes the degraded flag."""
+        result = OrchestratorResult(success=False, phase="scout", degraded=True)
+        assert result.to_dict()["degraded"] is True

--- a/tests/unit/workflows/test_orchestrated_health_check.py
+++ b/tests/unit/workflows/test_orchestrated_health_check.py
@@ -19,6 +19,11 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from attune.orchestration.execution_strategies import AgentResult, StrategyResult
+from attune.workflows.health_check_scoring import (
+    calculate_category_scores,
+    calculate_overall_score,
+    generate_recommendations,
+)
 from attune.workflows.orchestrated_health_check import (
     CategoryScore,
     HealthCheckReport,
@@ -802,6 +807,199 @@ class TestExecutePathKwarg:
         await workflow.execute(target=str(other_root))
 
         assert workflow.project_root == other_root.resolve()
+
+
+class TestUnmeasuredCategories:
+    """Regression pins for roundtable q-workflow-fleet-health-001 (Sev2).
+
+    A metric that was not measured must not be a number: categories whose
+    agent produced no measurement are N/A (measured=False), excluded from
+    the weighted score, and the report says so — never default-to-perfect.
+    """
+
+    def test_missing_agents_yield_unmeasured_categories(self):
+        """No agent results → every category is unmeasured, none perfect."""
+        scores = calculate_category_scores({})
+
+        assert len(scores) == 3  # Security, Coverage, Quality
+        assert all(s.measured is False for s in scores)
+        assert all(s.passed is False for s in scores)
+        security = next(s for s in scores if s.name == "Security")
+        assert security.score != 100.0
+        assert any("not measured" in issue for issue in security.issues)
+
+    def test_failed_agent_error_output_is_unmeasured(self):
+        """The error-shaped output a crashed agent emits is not a measurement."""
+        agent_results = {
+            "security_auditor": {
+                "success": False,
+                "output": {"agent_role": "sec", "error_details": "boom"},
+            },
+            "test_coverage_analyzer": {
+                "success": False,
+                "output": {"agent_role": "cov", "error_details": "no coverage.json"},
+            },
+            "code_reviewer": {"success": False, "output": {}},
+        }
+
+        scores = calculate_category_scores(agent_results)
+
+        assert all(s.measured is False for s in scores)
+
+    def test_unmeasured_categories_excluded_from_overall_score(self):
+        """The weighted score covers measured categories only — no dilution."""
+        agent_results = {
+            "security_auditor": {
+                "output": {"critical_issues": 1, "high_issues": 0, "medium_issues": 0},
+            },
+        }
+
+        scores = calculate_category_scores(agent_results)
+        security = next(s for s in scores if s.name == "Security")
+        assert security.measured is True
+        assert security.score == 80.0
+
+        # Coverage and Quality are unmeasured; only Security's 80 counts
+        assert calculate_overall_score(scores) == 80.0
+
+    def test_overall_score_zero_when_nothing_measured(self):
+        """With no measurements at all the score is 0.0, never a fabricated value."""
+        assert calculate_overall_score(calculate_category_scores({})) == 0.0
+
+    def test_recommendations_report_missing_data_not_fake_failures(self):
+        """Unmeasured categories surface as missing data, not 0.0% failures."""
+        recommendations = generate_recommendations(calculate_category_scores({}))
+        joined = "\n".join(recommendations)
+
+        assert "Not measured" in joined
+        assert "Security" in joined
+        # No fabricated numbers and no all-clear on zero data
+        assert "currently 0.0" not in joined
+        assert "health looks good" not in joined
+
+    def test_report_renders_na_and_degraded(self):
+        """Console output shows N/A rows and the DEGRADED banner."""
+        report = HealthCheckReport(
+            overall_health_score=85.0,
+            grade="B",
+            category_scores=[
+                CategoryScore(name="Coverage", score=85.0, weight=0.25),
+                CategoryScore(
+                    name="Security",
+                    score=0.0,
+                    weight=0.30,
+                    passed=False,
+                    measured=False,
+                    issues=["Security not measured — security_auditor produced no measurement"],
+                ),
+            ],
+            degraded=True,
+        )
+
+        output = report.format_console_output()
+
+        assert "DEGRADED" in output
+        assert "N/A (not measured)" in output
+        assert "85.0/100" in output  # the measured part still renders
+
+    def test_report_all_unmeasured_renders_na_not_a_number(self):
+        """Grade N/A: the header never prints a numeric overall score."""
+        report = HealthCheckReport(
+            overall_health_score=0.0,
+            grade="N/A",
+            category_scores=[
+                CategoryScore(
+                    name="Security", score=0.0, weight=0.30, passed=False, measured=False
+                ),
+            ],
+            degraded=True,
+        )
+
+        output = report.format_console_output()
+
+        assert "N/A — no categories were measured" in output
+        assert "0.0/100" not in output
+
+    def test_to_dict_carries_measured_and_degraded(self):
+        """Serialized reports expose the degraded flag and per-category measured."""
+        report = HealthCheckReport(
+            overall_health_score=0.0,
+            grade="N/A",
+            category_scores=[
+                CategoryScore(
+                    name="Security", score=0.0, weight=0.30, passed=False, measured=False
+                ),
+            ],
+            degraded=True,
+        )
+
+        data = report.to_dict()
+
+        assert data["degraded"] is True
+        assert data["category_scores"][0]["measured"] is False
+
+    @pytest.mark.asyncio
+    async def test_execute_all_agents_failed_reports_degraded_na(self, tmp_path):
+        """End-to-end: an all-agents-failed run is DEGRADED grade N/A, not 100/A."""
+        workflow = OrchestratedHealthCheckWorkflow(mode="daily", project_root=str(tmp_path))
+
+        with patch("attune.workflows.orchestrated_health_check.ParallelStrategy") as mock_strategy:
+            mock_results = [
+                AgentResult(
+                    agent_id=agent_id,
+                    success=False,
+                    output={"agent_role": agent_id, "error_details": "crashed"},
+                    error="crashed",
+                    confidence=0.0,
+                    duration_seconds=0.1,
+                )
+                for agent_id in ("security_auditor", "test_coverage_analyzer", "code_reviewer")
+            ]
+            mock_strategy_result = StrategyResult(
+                success=False,
+                outputs=mock_results,
+                aggregated_output={},
+                total_duration=0.3,
+            )
+            mock_strategy.return_value.execute = AsyncMock(return_value=mock_strategy_result)
+
+            report = await workflow.execute()
+
+        assert report.degraded is True
+        assert report.grade == "N/A"
+        assert report.overall_health_score == 0.0
+        output = report.format_console_output()
+        assert "DEGRADED" in output
+        assert "100.0/100" not in output
+
+    @pytest.mark.asyncio
+    async def test_execute_partial_measurement_is_degraded_but_scored(self, tmp_path):
+        """One measured category scores; the missing ones mark the run degraded."""
+        workflow = OrchestratedHealthCheckWorkflow(mode="daily", project_root=str(tmp_path))
+
+        with patch("attune.workflows.orchestrated_health_check.ParallelStrategy") as mock_strategy:
+            mock_results = [
+                AgentResult(
+                    agent_id="test_coverage_analyzer",
+                    success=True,
+                    output={"coverage_percent": 85.0},
+                    confidence=0.85,
+                    duration_seconds=1.0,
+                ),
+            ]
+            mock_strategy_result = StrategyResult(
+                success=True,
+                outputs=mock_results,
+                aggregated_output={},
+                total_duration=1.0,
+            )
+            mock_strategy.return_value.execute = AsyncMock(return_value=mock_strategy_result)
+
+            report = await workflow.execute()
+
+        assert report.degraded is True
+        assert report.overall_health_score == 85.0  # coverage only, undiluted
+        assert report.grade == "B"
 
 
 if __name__ == "__main__":

--- a/tests/unit/workflows/test_orchestrated_health_check_comprehensive.py
+++ b/tests/unit/workflows/test_orchestrated_health_check_comprehensive.py
@@ -328,20 +328,25 @@ class TestCategoryScoreCalculations:
     """Tests for category score calculation edge cases."""
 
     def test_calculate_category_scores_empty_results(self):
-        """Test category score calculation with empty agent results."""
+        """Empty agent results yield unmeasured (N/A) categories, never defaults.
+
+        Regression pin (roundtable q-workflow-fleet-health-001): a missing
+        security agent used to fabricate a perfect 100 — a metric that was
+        not measured must not be a number.
+        """
         workflow = OrchestratedHealthCheckWorkflow(mode="daily")
 
         scores = workflow._calculate_category_scores({})
 
-        # Should still create default scores even with empty results
-        # (Security, Coverage, Quality are always created)
+        # Security, Coverage, Quality entries still exist, but as N/A
         assert len(scores) >= 3
-        # Verify they use defaults when no data
         security = next(s for s in scores if s.name == "Security")
-        assert security.score == 100.0  # No issues = perfect score
+        assert security.measured is False
+        assert security.passed is False
+        assert any("not measured" in issue for issue in security.issues)
 
     def test_calculate_category_scores_missing_output(self):
-        """Test category score calculation with missing output."""
+        """An agent entry with no output produces an unmeasured category."""
         workflow = OrchestratedHealthCheckWorkflow(mode="daily")
 
         agent_results = {
@@ -350,10 +355,10 @@ class TestCategoryScoreCalculations:
 
         scores = workflow._calculate_category_scores(agent_results)
 
-        # Should handle missing output gracefully
         security_score = next((s for s in scores if s.name == "Security"), None)
         assert security_score is not None
-        assert security_score.score == 100.0  # Default when no issues found
+        assert security_score.measured is False
+        assert security_score.score != 100.0  # never default-to-perfect
 
     def test_calculate_category_scores_security_caps_at_zero(self):
         """Test security score can't go below 0."""


### PR DESCRIPTION
## Summary

Implements the chair-promoted Sev2/Sev5 fix from roundtable **q-workflow-fleet-health-001** (2026-08-23, unanimous across seats): advisory workflows must degrade to an explicit DEGRADED / INCOMPLETE_DATA status — **a metric that was not measured must not be a number.**

Sibling PRs from the same roundtable (no file overlap): #2208 (Sev1 secure-release gatekeeper), #2207 (ops reliability badges).

### Sev2 — OrchestratedHealthCheckWorkflow reported fiction as measurement

A category whose agent crashed or never ran was scored from dict defaults: a missing `security_auditor` fabricated a **perfect 100**, and an all-agents-failed run rendered as **100/100 grade A** (probe: 9s/$0 with `coverage_percent=100.0` on an ~85–90% repo).

Now:

- `CategoryScore.measured` — a category is only scored when its agent actually produced the metric it is scored on (key-presence discriminator: a crashed agent's `error_details`-only output is not a measurement). Missing data → `measured=False`, `passed=False`, an issue naming the missing agent.
- `calculate_overall_score` excludes unmeasured categories entirely — no dilution, no placeholder 0.0 averaged in.
- `HealthCheckReport.degraded` + console rendering: unmeasured rows show `N/A (not measured)`, the header carries a `⚠️ DEGRADED — INCOMPLETE DATA` banner, and a run with **zero** measured categories grades **N/A** with no numeric overall score printed.
- Recommendations report "Not measured: …" instead of fake `currently 0.0%` failures, and never emit the all-clear on zero data.

### Sev5 — DocumentationOrchestrator claimed "no gaps" when nothing scanned

The scout crew was removed in v5.3.0 (`HAS_SCOUT=False`); with no ProjectIndex either, `_run_scout_phase` returned `([], 0.0)` having scanned nothing, and `execute()` reported `success=True` + "SUCCESS: No documentation gaps found!".

Now:

- `_scan_performed` tracks whether a scan (scout or ProjectIndex fallback) actually ran; the ProjectIndex fallback still counts as a real scan.
- Zero items with no scan → `success=False`, `degraded=True`, phase stays `scout`, error "gaps were NOT assessed", summary status `DEGRADED (scan did not run — gaps not assessed)` — never "no gaps". A scout that errored with no fallback is likewise degraded.
- The no-items success path no longer drops the accumulated warnings.
- `to_dict`, `scout_as_json`, and both MCP handlers carry the `degraded` flag.

### Tests (roundtable pins)

- missing agent / failed-agent error output → unmeasured, never default-to-perfect (two stale pins asserting the old fictitious 100 were flipped)
- unmeasured weight excluded from the overall score; all-unmeasured → 0.0 + grade N/A
- console renders N/A + DEGRADED; grade-N/A header prints no number
- scout-unavailable+no-index → degraded failure, not "no gaps"; index fallback with zero items stays a clean success
- end-to-end: all-agents-failed run is DEGRADED grade N/A; partial measurement scores the measured category undiluted and flags degraded

## Verification

`tests/unit/workflows/` + `tests/unit/orchestration/` + MCP handler suite: **3544 passed, 2 skipped**; ops/gates/help referencing suites: 376 passed. Black pre-flighted on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
