### PR TITLE
fix(workflows): probe counts findings across all severity buckets, not one category key

### DIFF
--- a/scripts/workflow_probe_runner.py
+++ b/scripts/workflow_probe_runner.py
@@ -162,6 +162,20 @@ def _findings_for(result: Any, category: str) -> list[str]:
     return list(findings.get(category, []))
 
 
+def _total_findings(result: Any) -> int:
+    """Count findings across EVERY bucket of ``metadata["findings"]``.
+
+    Different workflows key the findings dict differently — security-audit
+    keys by SEVERITY (CRITICAL/HIGH/MEDIUM/LOW), others by category
+    (security/dependencies/...). Asserting on one hard-coded key silently
+    reads empty when the workflow used a different key, turning the probe
+    vacuous. Summing every bucket is key-agnostic.
+    """
+    meta = getattr(result, "metadata", None) or {}
+    findings = meta.get("findings") or {}
+    return sum(len(v) for v in findings.values() if isinstance(v, list))
+
+
 def _raw_text(result: Any) -> str:
     meta = getattr(result, "metadata", None) or {}
     text = meta.get("raw_result_text") or ""
@@ -265,16 +279,16 @@ async def probe_security_audit(budget: float) -> ProbeResult:
             cost_usd=_cost_of(result),
             duration_s=dur,
         )
-    findings = _findings_for(result, "security")
+    num_findings = _total_findings(result)
     text = _raw_text(result)
     score = _score_of(result)
     names_eval = _mentions(text, "eval", "cwe-95", "code injection")
     names_key = _mentions(text, "hardcoded", "secret", "credential", "api key", "cwe-798")
     non_perfect = score is None or score < 100
 
-    passed = bool(findings) and names_eval and names_key and non_perfect
+    passed = num_findings > 0 and names_eval and names_key and non_perfect
     reasons = []
-    if not findings:
+    if num_findings == 0:
         reasons.append("no security findings returned")
     if not names_eval:
         reasons.append("did not name the eval() defect")
@@ -290,7 +304,7 @@ async def probe_security_audit(budget: float) -> ProbeResult:
         reason=reason,
         cost_usd=_cost_of(result),
         duration_s=dur,
-        evidence={"score": score, "num_findings": len(findings)},
+        evidence={"score": score, "num_findings": num_findings},
     )
 
 
@@ -314,7 +328,7 @@ async def probe_dependency_check(budget: float) -> ProbeResult:
             cost_usd=_cost_of(result),
             duration_s=dur,
         )
-    findings = _findings_for(result, "dependencies")
+    num_findings = _total_findings(result)
     text = _raw_text(result)
     names_pkg = _mentions(
         text,
@@ -325,9 +339,9 @@ async def probe_dependency_check(budget: float) -> ProbeResult:
         "2.19.1",
         "5.3.1",
     )
-    passed = bool(findings) and names_pkg
+    passed = num_findings > 0 and names_pkg
     reasons = []
-    if not findings:
+    if num_findings == 0:
         reasons.append("no dependency findings returned")
     if not names_pkg:
         reasons.append("did not name a planted vulnerable package/CVE")
@@ -339,7 +353,7 @@ async def probe_dependency_check(budget: float) -> ProbeResult:
         reason=reason,
         cost_usd=_cost_of(result),
         duration_s=dur,
-        evidence={"num_findings": len(findings)},
+        evidence={"num_findings": num_findings},
     )
 
 

--- a/tests/unit/scripts/test_workflow_probe_runner.py
+++ b/tests/unit/scripts/test_workflow_probe_runner.py
@@ -118,6 +118,28 @@ def test_score_of_reads_report_dict(score, expected) -> None:
     assert runner._score_of(_R()) == expected
 
 
+def test_total_findings_is_key_agnostic() -> None:
+    # security-audit keys findings by SEVERITY, not category "security".
+    # Counting one hard-coded key would read 0 here and go vacuous.
+    class _R:
+        metadata = {"findings": {"CRITICAL": ["a"], "HIGH": ["b", "c"], "LOW": []}}
+
+    assert runner._total_findings(_R()) == 3
+    # And the category-keyed shape still counts.
+
+    class _R2:
+        metadata = {"findings": {"dependencies": ["x", "y"]}}
+
+    assert runner._total_findings(_R2()) == 2
+
+
+def test_total_findings_zero_when_absent() -> None:
+    class _R:
+        metadata: dict = {}
+
+    assert runner._total_findings(_R()) == 0
+
+
 def test_crash_reason_none_on_success() -> None:
     class _R:
         success = True


### PR DESCRIPTION
## What

Follow-up to #2210 (merged). The first **live** run of the
security-audit probe — after the API usage limit was raised — caught a
vacuous-assertion bug in the probe itself.

## The bug the live run exposed

The probe read `metadata["findings"]["security"]`, but security-audit
keys its findings by **severity** (`CRITICAL`/`HIGH`/`MEDIUM`/`LOW`),
not by the category `"security"`. So the probe saw **0 findings** and
reported `FAIL — "no security findings returned"` while the workflow had
actually done its job: score **28/100**, **3 findings** (1 CRITICAL + 2
HIGH) naming the hardcoded key (CWE-798), the `eval()` call, and the
path traversal, in a 19KB report. The workflow was right; the probe read
the wrong field — the classic wrong-key vacuous assertion this whole
harness exists to catch, turned on itself.

## Fix

- `_total_findings(result)` sums **every** bucket of the findings dict
  (key-agnostic), so a probe never goes vacuous because a workflow used
  severity keys instead of category keys.
- security-audit and dependency-check probes switched to it.
- Two unit tests pin the count for both the severity-keyed and
  category-keyed shapes.

## Live receipt (after the fix)

```
[PASS] security-audit: found the eval() and the key; score not perfect
  score=15/100, findings=3, $0.3983, 107s
```

security-audit's fleet "working" verdict is now **validated against a
planted defect**, not just "exited 0".

## Verification

- `pytest tests/unit/scripts/test_workflow_probe_runner.py` → 17 passed
- live probe run → PASS (receipt above)
- black + ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
