### PR TITLE
fix(workflows): doc-orchestrator index fallback — produce doc-coverage data, honest assessed flag

### DIFF
--- a/src/attune/project_index/index.py
+++ b/src/attune/project_index/index.py
@@ -673,6 +673,22 @@ class ProjectIndex:
                 "summary": self._summary.to_dict(),
             }
 
+        if workflow_type == "documentation":
+            # Doc-coverage view (#2220). The doc-orchestrator's index
+            # fallback consumed this key for years while NO branch
+            # produced it — every read defaulted empty and zero items
+            # rendered as "no gaps found". The presence of
+            # ``files_without_docstrings`` is also the scout's
+            # scan-was-performed marker, so only emit it from this
+            # branch, where it is genuinely computed.
+            undocumented = [f for f in self.get_files_by_category("source") if not f.has_docstrings]
+            return {
+                "files_without_docstrings": [
+                    {"path": f.path, "loc": f.lines_of_code} for f in undocumented[:50]
+                ],
+                "summary": self._summary.to_dict(),
+            }
+
         return {
             "summary": self._summary.to_dict(),
             "files_needing_attention": [

--- a/src/attune/workflows/doc_orch_scout.py
+++ b/src/attune/workflows/doc_orch_scout.py
@@ -64,10 +64,13 @@ class DocOrchScoutMixin:
 
         if self._scout is None:
             logger.warning("Scout (ManageDocumentationCrew) not available")
-            # Fall back to ProjectIndex if available
+            # Fall back to ProjectIndex if available. The index read
+            # counts as a performed scan ONLY when it actually carried
+            # doc-coverage data (#2220) — an empty/errored/capability-
+            # less read is "not assessed", never "no gaps found".
             if self._project_index is not None:
-                items = self._items_from_index()
-                self._scan_performed = True
+                items, assessed = self._items_from_index()
+                self._scan_performed = assessed
             return items, cost
 
         logger.info("Starting scout phase...")
@@ -86,7 +89,7 @@ class DocOrchScoutMixin:
 
         # Supplement with ProjectIndex data if available
         if self._project_index is not None:
-            index_items = self._items_from_index()
+            index_items, _ = self._items_from_index()
             # Merge, preferring scout items but adding unique index items
             existing_paths = {item.file_path for item in items}
             for idx_item in index_items:
@@ -96,17 +99,28 @@ class DocOrchScoutMixin:
         logger.info("Scout phase found %s items (cost: $%.4f)", len(items), cost)
         return items, cost
 
-    def _items_from_index(self) -> list:
-        """Extract documentation items from ProjectIndex."""
+    def _items_from_index(self) -> tuple[list, bool]:
+        """Extract documentation items from ProjectIndex.
+
+        Returns:
+            Tuple of (items, assessed). ``assessed`` is True only when
+            the index context actually carried doc-coverage data
+            (``files_without_docstrings``) — for years no index branch
+            produced that key, every read defaulted empty, and zero
+            items rendered as "no documentation gaps found" (#2220).
+            A capability-less or errored read is NOT an assessment.
+        """
         from .documentation_orchestrator import DocumentationItem
 
         items: list[DocumentationItem] = []
 
         if self._project_index is None:
-            return items
+            return items, False
 
         try:
             context = self._project_index.get_context_for_workflow("documentation")
+            if "files_without_docstrings" not in context:
+                return items, False
 
             # Get files without docstrings
             if self.include_missing:
@@ -147,8 +161,9 @@ class DocOrchScoutMixin:
                         )
         except Exception as e:  # noqa: BLE001
             logger.warning("Error extracting items from index: %s", e)
+            return items, False
 
-        return items
+        return items, True
 
     def _parse_scout_findings(self, result: Any) -> list:
         """Parse scout result into DocumentationItems."""

--- a/tests/unit/project_index/test_index_core.py
+++ b/tests/unit/project_index/test_index_core.py
@@ -262,6 +262,21 @@ class TestWorkflowContext:
         ctx = _populated(tmp_path).get_context_for_workflow("unknown")
         assert "files_needing_attention" in ctx
 
+    def test_documentation(self, tmp_path):
+        # #2220 — this branch did not exist: the doc-orchestrator read
+        # files_without_docstrings for years while nothing produced it,
+        # so every scan "found no gaps". Undocumented source files must
+        # be listed; documented ones must not.
+        idx = _populated(tmp_path)
+        for record in idx._records.values():
+            record.has_docstrings = record.path != "src/a.py"
+        ctx = idx.get_context_for_workflow("documentation")
+        assert "files_without_docstrings" in ctx
+        listed = [f["path"] for f in ctx["files_without_docstrings"]]
+        assert "src/a.py" in listed
+        assert "src/b.py" not in listed
+        assert all("loc" in f for f in ctx["files_without_docstrings"])
+
 
 class TestRefresh:
     def test_refresh_parallel(self, tmp_path):

--- a/tests/unit/workflows/test_documentation_orchestrator.py
+++ b/tests/unit/workflows/test_documentation_orchestrator.py
@@ -664,7 +664,7 @@ class TestItemsFromIndex:
     def test_items_from_index_no_index(self, orchestrator):
         """Test items extraction when ProjectIndex is not available."""
         orchestrator._project_index = None
-        items = orchestrator._items_from_index()
+        items, _ = orchestrator._items_from_index()
         assert items == []
 
     @patch("attune.workflows.documentation_orchestrator.HAS_PROJECT_INDEX", True)
@@ -680,7 +680,7 @@ class TestItemsFromIndex:
         }
         orchestrator._project_index = mock_index
 
-        items = orchestrator._items_from_index()
+        items, _ = orchestrator._items_from_index()
         assert len(items) == 2
         assert items[0].file_path == "src/main.py"
         assert items[0].issue_type == "missing_docstring"
@@ -704,7 +704,7 @@ class TestItemsFromIndex:
         }
         orchestrator._project_index = mock_index
 
-        items = orchestrator._items_from_index()
+        items, _ = orchestrator._items_from_index()
         assert len(items) == 1
         assert items[0].file_path == "docs/api.md"
         assert items[0].issue_type == "stale_doc"
@@ -734,7 +734,7 @@ class TestItemsFromIndex:
         }
         orchestrator._project_index = mock_index
 
-        items = orchestrator._items_from_index()
+        items, _ = orchestrator._items_from_index()
         # Should only have missing_docstring items
         assert len(items) == 1
         assert items[0].issue_type == "missing_docstring"
@@ -752,7 +752,7 @@ class TestItemsFromIndex:
         }
         orchestrator._project_index = mock_index
 
-        items = orchestrator._items_from_index()
+        items, _ = orchestrator._items_from_index()
         # Should only have main.py, not requirements.txt
         assert len(items) == 1
         assert items[0].file_path == "src/main.py"
@@ -780,7 +780,7 @@ class TestItemsFromIndex:
         }
         orchestrator._project_index = mock_index
 
-        items = orchestrator._items_from_index()
+        items, _ = orchestrator._items_from_index()
         # Only docs/api.md should survive - requirements.txt is excluded
         assert len(items) == 1
         assert items[0].file_path == "docs/api.md"
@@ -791,8 +791,46 @@ class TestItemsFromIndex:
         mock_index.get_context_for_workflow.side_effect = RuntimeError("index unavailable")
         orchestrator._project_index = mock_index
 
-        items = orchestrator._items_from_index()
+        items, assessed = orchestrator._items_from_index()
         assert items == []
+        # An errored read is NOT an assessment (#2220).
+        assert assessed is False
+
+    def test_capabilityless_context_is_not_an_assessment(self, orchestrator):
+        """#2220 — a context WITHOUT doc-coverage data must not count
+        as a performed scan. For years no index branch produced
+        `files_without_docstrings`; every read defaulted empty and
+        zero items rendered as 'no documentation gaps found'."""
+        mock_index = MagicMock()
+        mock_index.get_context_for_workflow.return_value = {
+            "summary": {},
+            "files_needing_attention": [],
+        }
+        orchestrator._project_index = mock_index
+
+        items, assessed = orchestrator._items_from_index()
+        assert items == []
+        assert assessed is False
+
+    def test_context_with_doc_data_is_an_assessment(self, orchestrator):
+        """The produced-key marker flips assessed True — including the
+        genuinely-clean case (key present, empty list)."""
+        mock_index = MagicMock()
+        mock_index.get_context_for_workflow.return_value = {
+            "files_without_docstrings": [],
+            "summary": {},
+        }
+        orchestrator._project_index = mock_index
+
+        items, assessed = orchestrator._items_from_index()
+        assert items == []
+        assert assessed is True
+
+    def test_no_index_is_not_an_assessment(self, orchestrator):
+        orchestrator._project_index = None
+        items, assessed = orchestrator._items_from_index()
+        assert items == []
+        assert assessed is False
 
 
 class TestGenerateSummary:
@@ -1762,7 +1800,7 @@ class TestProjectIndexEdgeCases:
         mock_index.records = mock_records
         orchestrator._index = mock_index
 
-        items = orchestrator._items_from_index()
+        items, _ = orchestrator._items_from_index()
 
         # Should only include source file, not requirements.txt
         assert len(items) <= 1


### PR DESCRIPTION
## What

Fixes #2220 — `doc-orchestrator` printed **'No documentation gaps found!'** on a fixture with a module carrying no docstrings at all. Root cause: `get_context_for_workflow` had **no `documentation` branch** — the keys the scout read (`files_without_docstrings`, `docs_needing_review`) were never produced by anything, so every index-fallback scan found zero items. Third instance of the phantom-key class (#2219, #2211).

## Fix (capability + honesty)

- **Real `documentation` context branch** in ProjectIndex: lists source files with `has_docstrings=False` (the index already computes this via AST) — the scan actually works now.
- **Honest assessed flag**: `_items_from_index` returns `(items, assessed)`; `assessed` only when the context actually carried doc-coverage data. Capability-less or errored reads set the #2209 DEGRADED path ('gaps were NOT assessed'), never 'no gaps'.

## Receipts

- **Live**: scout on a docstring-less fixture module now finds it (`items=1, scan_performed=True`, $0) — was 0 items / 'no gaps' on the same fixture.
- **Tests**: 21 targeted pass locally (4 new pins: capability-less ≠ assessment, errored ≠ assessment, produced-key+empty = honest clean, no-index ≠ assessment; + an index-side test for the new branch). 8 existing call sites updated to the tuple return.

Closes #2220.

🤖 Generated with [Claude Code](https://claude.com/claude-code)