### PR TITLE
fix(workflows): sweep lanes get measured budget floors — no more $0 abort lanes

### DIFF
--- a/src/attune/workflows/discovery_sweep/sources/bug_predict.py
+++ b/src/attune/workflows/discovery_sweep/sources/bug_predict.py
@@ -53,6 +53,12 @@ class BugPredictSource(LLMSource):
     name: str = "bug-predict"
     depth: str = "standard"
 
+    #: Below this per-call share the source SKIPS with an honest
+    #: info finding instead of launching a run that predictably
+    #: aborts at its budget cap while burning billed tokens into
+    #: a $0 failure marker (#2214; measured 2026-08-23).
+    min_useful_usd: float = 0.5
+
     async def discover(self, paths: list[str], budget_usd: float) -> list[Finding]:
         """Run BugPredictionWorkflow on each path and parse findings.
 
@@ -72,7 +78,8 @@ class BugPredictSource(LLMSource):
         # across paths. Single-path sweeps (the common case) get the
         # whole allocation. Below the floor, skip rather than truncate.
         share = budget_usd / len(paths)
-        if share < MIN_PER_CALL_BUDGET_USD:
+        floor = max(MIN_PER_CALL_BUDGET_USD, self.min_useful_usd)
+        if share < floor:
             return [budget_too_small_finding(self.name, len(paths), share, budget_usd)]
 
         # Late import keeps ``claude_agent_sdk`` out of this module's

--- a/src/attune/workflows/discovery_sweep/sources/dependency_check.py
+++ b/src/attune/workflows/discovery_sweep/sources/dependency_check.py
@@ -7,12 +7,16 @@ call with :data:`STRUCTURED_EMIT_FOOTER` passed via
 Phase 1.5 ``design.md``), invokes ``execute()`` once per path, and
 parses each result via :func:`findings_from_workflow_result`.
 
-``budget_multiplier = 0.5`` reflects the dependency-check
-workflow's narrower spend profile — two subagents
-(inventory-assessor + update-advisor) doing CVE-feed-heavy work
-that's mostly Bash/Read and not deep code analysis. Phase 1.5 set
-the default ratios as ``security=4`` / ``deps=0.5`` /
-``default=1`` so the engine allocates proportionally.
+``budget_multiplier = 1.0`` (raised from 0.5 in #2214): the
+original "narrower spend profile" premise was refuted by
+measurement — a quick-depth run costs ~$0.45, comparable to the
+other lanes, and the 0.5 multiplier allocated ~$0.29 at a $5
+sweep, so EVERY sweep aborted this lane at its budget cap while
+recording $0 (the probe registry's reproducible "$0 lane"). The
+source also defaults to ``depth="quick"`` — the sweep is a
+breadth pass, and quick depth demonstrably finds planted CVEs —
+and skips honestly below ``min_useful_usd`` instead of launching
+a run that is guaranteed to abort.
 
 The ``claude_agent_sdk`` import lives inside :meth:`discover` so
 this module is mock-friendly and doesn't drag the SDK into the
@@ -48,18 +52,28 @@ class DependencyCheckSource(LLMSource):
     Three structural attributes (``name``, ``is_llm``,
     ``budget_multiplier``) satisfy the :class:`FindingSource`
     Protocol; ``LLMSource`` is inherited for the ``--no-llm``
-    filter marker. The 0.5 multiplier overrides LLMSource's
-    default of 1.0 to reflect the workflow's lower per-call spend.
+    filter marker. The multiplier is 1.0 (#2214 — the old 0.5
+    under-allocated below the workflow's measured cost, so the
+    lane aborted at its cap on every sweep).
 
     ``depth`` is configurable per-instance and defaults to
-    ``"standard"`` — same default as standalone
-    ``attune workflow run dependency-check``. Sweep callers that
-    want a cheaper pass can construct with ``depth="quick"``.
+    ``"quick"`` — the sweep is a breadth pass and quick depth
+    demonstrably surfaces planted CVEs (~$0.45 measured). Callers
+    wanting the deeper standalone behavior construct with
+    ``depth="standard"``.
     """
 
     name: str = "dependency-check"
-    budget_multiplier: float = 0.5
-    depth: str = "standard"
+    budget_multiplier: float = 1.0
+    depth: str = "quick"
+
+    #: Below this per-call share the source SKIPS with an honest info
+    #: finding instead of launching a run that is guaranteed to abort
+    #: at its budget cap (#2214). Measured (2026-08-23 probe registry):
+    #: a quick-depth run costs ~$0.45; the old 0.5 multiplier allocated
+    #: ~$0.29 at a $5 sweep, so every sweep aborted this lane with
+    #: "Reached maximum budget" while recording $0.
+    min_useful_usd: float = 0.40
 
     async def discover(self, paths: list[str], budget_usd: float) -> list[Finding]:
         """Run DependencyCheckWorkflow on each path and parse findings.
@@ -80,7 +94,8 @@ class DependencyCheckSource(LLMSource):
         # across paths. Single-path sweeps (the common case) get the
         # whole allocation. Below the floor, skip rather than truncate.
         share = budget_usd / len(paths)
-        if share < MIN_PER_CALL_BUDGET_USD:
+        floor = max(MIN_PER_CALL_BUDGET_USD, self.min_useful_usd)
+        if share < floor:
             return [budget_too_small_finding(self.name, len(paths), share, budget_usd)]
 
         # Late import keeps ``claude_agent_sdk`` out of this

--- a/src/attune/workflows/discovery_sweep/sources/doc_audit.py
+++ b/src/attune/workflows/discovery_sweep/sources/doc_audit.py
@@ -60,6 +60,12 @@ class DocAuditSource(LLMSource):
     name: str = "doc-audit"
     depth: str = "standard"
 
+    #: Below this per-call share the source SKIPS with an honest
+    #: info finding instead of launching a run that predictably
+    #: aborts at its budget cap while burning billed tokens into
+    #: a $0 failure marker (#2214; measured 2026-08-23).
+    min_useful_usd: float = 0.45
+
     async def discover(self, paths: list[str], budget_usd: float) -> list[Finding]:
         """Run DocAuditWorkflow on each path and parse findings.
 
@@ -79,7 +85,8 @@ class DocAuditSource(LLMSource):
         # across paths. Single-path sweeps (the common case) get the
         # whole allocation. Below the floor, skip rather than truncate.
         share = budget_usd / len(paths)
-        if share < MIN_PER_CALL_BUDGET_USD:
+        floor = max(MIN_PER_CALL_BUDGET_USD, self.min_useful_usd)
+        if share < floor:
             return [budget_too_small_finding(self.name, len(paths), share, budget_usd)]
 
         # Late import keeps ``claude_agent_sdk`` out of this

--- a/src/attune/workflows/discovery_sweep/sources/perf_audit.py
+++ b/src/attune/workflows/discovery_sweep/sources/perf_audit.py
@@ -59,6 +59,12 @@ class PerfAuditSource(LLMSource):
     name: str = "perf-audit"
     depth: str = "standard"
 
+    #: Below this per-call share the source SKIPS with an honest
+    #: info finding instead of launching a run that predictably
+    #: aborts at its budget cap while burning billed tokens into
+    #: a $0 failure marker (#2214; measured 2026-08-23).
+    min_useful_usd: float = 0.25
+
     async def discover(self, paths: list[str], budget_usd: float) -> list[Finding]:
         """Run PerformanceAuditWorkflow on each path and parse findings.
 
@@ -78,7 +84,8 @@ class PerfAuditSource(LLMSource):
         # across paths. Single-path sweeps (the common case) get the
         # whole allocation. Below the floor, skip rather than truncate.
         share = budget_usd / len(paths)
-        if share < MIN_PER_CALL_BUDGET_USD:
+        floor = max(MIN_PER_CALL_BUDGET_USD, self.min_useful_usd)
+        if share < floor:
             return [budget_too_small_finding(self.name, len(paths), share, budget_usd)]
 
         # Late import keeps ``claude_agent_sdk`` out of this

--- a/src/attune/workflows/discovery_sweep/sources/security_audit.py
+++ b/src/attune/workflows/discovery_sweep/sources/security_audit.py
@@ -61,6 +61,12 @@ class SecurityAuditSource(LLMSource):
     budget_multiplier: float = 4.0
     depth: str = "standard"
 
+    #: Below this per-call share the source SKIPS with an honest
+    #: info finding instead of launching a run that predictably
+    #: aborts at its budget cap while burning billed tokens into
+    #: a $0 failure marker (#2214; measured 2026-08-23).
+    min_useful_usd: float = 0.5
+
     async def discover(self, paths: list[str], budget_usd: float) -> list[Finding]:
         """Run SecurityAuditWorkflow on each path and parse findings.
 
@@ -80,7 +86,8 @@ class SecurityAuditSource(LLMSource):
         # across paths. Single-path sweeps (the common case) get the
         # whole allocation. Below the floor, skip rather than truncate.
         share = budget_usd / len(paths)
-        if share < MIN_PER_CALL_BUDGET_USD:
+        floor = max(MIN_PER_CALL_BUDGET_USD, self.min_useful_usd)
+        if share < floor:
             return [budget_too_small_finding(self.name, len(paths), share, budget_usd)]
 
         # Late import keeps ``claude_agent_sdk`` out of this

--- a/src/attune/workflows/discovery_sweep/sources/test_audit.py
+++ b/src/attune/workflows/discovery_sweep/sources/test_audit.py
@@ -61,6 +61,12 @@ class TestAuditSource(LLMSource):
     name: str = "test-audit"
     depth: str = "standard"
 
+    #: Below this per-call share the source SKIPS with an honest
+    #: info finding instead of launching a run that predictably
+    #: aborts at its budget cap while burning billed tokens into
+    #: a $0 failure marker (#2214; measured 2026-08-23).
+    min_useful_usd: float = 0.45
+
     async def discover(self, paths: list[str], budget_usd: float) -> list[Finding]:
         """Run TestAuditWorkflow on each path and parse findings.
 
@@ -80,7 +86,8 @@ class TestAuditSource(LLMSource):
         # across paths. Single-path sweeps (the common case) get the
         # whole allocation. Below the floor, skip rather than truncate.
         share = budget_usd / len(paths)
-        if share < MIN_PER_CALL_BUDGET_USD:
+        floor = max(MIN_PER_CALL_BUDGET_USD, self.min_useful_usd)
+        if share < floor:
             return [budget_too_small_finding(self.name, len(paths), share, budget_usd)]
 
         # Late import keeps ``claude_agent_sdk`` out of this

--- a/tests/unit/workflows/discovery_sweep/test_budget_enforcement.py
+++ b/tests/unit/workflows/discovery_sweep/test_budget_enforcement.py
@@ -31,7 +31,6 @@ import pytest
 
 from attune.workflows.agent_sdk_adapter import get_max_budget_usd
 from attune.workflows.discovery_sweep.llm_source_base import (
-    MIN_PER_CALL_BUDGET_USD,
     budget_too_small_finding,
     cap_hit_finding_if_bound,
 )
@@ -187,12 +186,15 @@ async def test_floor_boundary_share_at_min_runs() -> None:
     factory = _FakeWorkflowFactory(
         results=[_FakeResult(final_output=_empty_findings_output())],
     )
+    source = SecurityAuditSource()
     with patch(_WF_PATH, new=factory):
-        # single path, allocation == floor → share == floor → not below → runs.
-        await SecurityAuditSource().discover(["src/"], budget_usd=MIN_PER_CALL_BUDGET_USD)
+        # single path, allocation == the source's own floor (#2214:
+        # per-source min_useful_usd, above the generic MIN) → share ==
+        # floor → not below → runs.
+        await source.discover(["src/"], budget_usd=source.min_useful_usd)
 
     assert len(factory.calls) == 1
-    assert factory.calls[0].execute_kwargs["max_budget_usd"] == MIN_PER_CALL_BUDGET_USD
+    assert factory.calls[0].execute_kwargs["max_budget_usd"] == source.min_useful_usd
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/workflows/discovery_sweep/test_dependency_check_source.py
+++ b/tests/unit/workflows/discovery_sweep/test_dependency_check_source.py
@@ -105,12 +105,17 @@ def _wellformed_payload() -> dict:
 
 
 def test_source_defaults() -> None:
-    """Defaults conform to LLMSource marker + 0.5 budget multiplier."""
+    """Defaults: 1.0 multiplier + quick depth + honest floor (#2214).
+
+    The old 0.5 multiplier under-allocated below the workflow's
+    measured cost, so the lane aborted at its cap on every sweep.
+    """
     source = DependencyCheckSource()
     assert source.name == SOURCE
     assert source.is_llm is True
-    assert source.budget_multiplier == 0.5
-    assert source.depth == "standard"
+    assert source.budget_multiplier == 1.0
+    assert source.depth == "quick"
+    assert source.min_useful_usd == 0.40
 
 
 def test_source_appears_in_default_sources() -> None:
@@ -155,7 +160,7 @@ async def test_single_path_returns_parsed_findings() -> None:
     assert len(factory.calls) == 1
     assert factory.calls[0].execute_kwargs == {
         "path": "./",
-        "depth": "standard",
+        "depth": "quick",
         "max_budget_usd": 0.5,
     }
 
@@ -180,7 +185,7 @@ async def test_constructor_receives_structured_emit_footer() -> None:
 
 @pytest.mark.asyncio
 async def test_custom_depth_is_passed_to_execute() -> None:
-    """``depth="quick"`` reaches the wrapped workflow's execute() call."""
+    """``depth="standard"`` override reaches the wrapped execute() call."""
     factory = _FakeWorkflowFactory(
         results=[_FakeResult(success=True, final_output=_wrap_json({"findings": []}))],
     )
@@ -189,11 +194,11 @@ async def test_custom_depth_is_passed_to_execute() -> None:
         "attune.workflows.dependency_check.DependencyCheckWorkflow",
         new=factory,
     ):
-        await DependencyCheckSource(depth="quick").discover(["./"], budget_usd=0.5)
+        await DependencyCheckSource(depth="standard").discover(["./"], budget_usd=0.5)
 
     assert factory.calls[0].execute_kwargs == {
         "path": "./",
-        "depth": "quick",
+        "depth": "standard",
         "max_budget_usd": 0.5,
     }
 
@@ -240,7 +245,7 @@ async def test_multiple_paths_yield_per_path_calls_and_concat_findings() -> None
         "attune.workflows.dependency_check.DependencyCheckWorkflow",
         new=factory,
     ):
-        findings = await DependencyCheckSource().discover(["./pkg-a/", "./pkg-b/"], budget_usd=0.5)
+        findings = await DependencyCheckSource().discover(["./pkg-a/", "./pkg-b/"], budget_usd=1.0)
 
     assert len(factory.calls) == 2
     assert [f.title for f in findings] == ["first", "second"]
@@ -299,7 +304,7 @@ async def test_wrapped_workflow_raise_does_not_abort_other_paths() -> None:
         "attune.workflows.dependency_check.DependencyCheckWorkflow",
         new=factory,
     ):
-        findings = await DependencyCheckSource().discover(["./bad/", "./good/"], budget_usd=0.5)
+        findings = await DependencyCheckSource().discover(["./bad/", "./good/"], budget_usd=1.0)
 
     assert len(findings) == 2
     assert findings[0].tags == ("source-failure",)
@@ -395,6 +400,26 @@ async def test_budget_below_floor_skips_runs_and_emits_finding() -> None:
     assert only.severity == "info"
     assert only.tags == ("budget-cap",)
     assert only.file is None
+
+
+@pytest.mark.asyncio
+async def test_share_below_min_useful_skips_instead_of_aborting() -> None:
+    """#2214 — a share above the generic floor but below this source's
+    measured minimum (~$0.45 quick run) skips honestly rather than
+    launching a run guaranteed to die at its budget cap ($0, failure
+    marker — the probe registry's reproducible '$0 lane')."""
+    factory = _FakeWorkflowFactory()
+
+    with patch(
+        "attune.workflows.dependency_check.DependencyCheckWorkflow",
+        new=factory,
+    ):
+        findings = await DependencyCheckSource().discover(["./"], budget_usd=0.29)
+
+    assert factory.calls == []  # no doomed run launched
+    assert len(findings) == 1
+    assert findings[0].severity == "info"
+    assert findings[0].tags == ("budget-cap",)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What

Fixes #2214 — the discovery-sweep dependency-check lane failed on **every** sweep with a "$0 / failure markers" result while the standalone workflow passed.

## Root cause (measured, two layers)

1. **deps under-allocation**: `budget_multiplier=0.5` rested on a 'narrower spend profile' premise that measurement refuted (quick ~$0.45, standard ~$1.87 — comparable to other lanes). Its ~$0.29 share at a $5 sweep guaranteed an SDK 'Reached maximum budget' abort — with **$0 recorded** (error results carry no cost_report; tokens were billed anyway).
2. **The deeper class** (exposed by the first fix attempt's honest receipt): lanes' natural appetite is ~$0.55, so static shares near that line abort **stochastically** — at $5, raising deps to share $0.556 flipped bug-predict and doc-audit into aborting too.

## Fix (fleet-wide)

- deps lane: multiplier **1.0**, `depth="quick"` (breadth pass; quick demonstrably finds planted CVEs), `min_useful_usd=0.40`
- **every LLM lane** gets a measured `min_useful_usd` floor (security/bug 0.50, doc/test 0.45, perf 0.25): a share below the measured minimum **skips with an honest info-finding** instead of launching a run guaranteed to die at its cap

## Receipts

- **Live, default $10 sweep**: all 7 lanes spend and find — deps **7 findings, $0.58** (was $0/markers every run); `failures: []`
- **Tests**: 239 sweep tests pass; floor-boundary tests re-pinned to per-source floors; new pin: a share above the generic floor but below the measured minimum skips without launching

Follow-up (queued on the gate-group branch, which owns the probe runner): probe sweep budgets scale with lane count instead of a flat cap.

Closes #2214.

🤖 Generated with [Claude Code](https://claude.com/claude-code)