### PR TITLE
feat(ops): hide known-broken workflows from user catalogs until they work

### DIFF
--- a/src/attune/cli_commands/workflow_commands.py
+++ b/src/attune/cli_commands/workflow_commands.py
@@ -23,8 +23,9 @@ logger = logging.getLogger(__name__)
 def cmd_workflow_list(args: Namespace) -> int:
     """List available workflows."""
     from attune.workflows import list_workflows
+    from attune.workflows.visibility import HIDDEN_WORKFLOWS, visible_entries
 
-    workflows = list_workflows()
+    workflows = visible_entries(list_workflows())
 
     print("\n📋 Available Workflows\n")
     print("-" * 60)
@@ -46,6 +47,12 @@ def cmd_workflow_list(args: Namespace) -> int:
 
     print("-" * 60)
     print(f"\nTotal: {len(workflows)} workflows")
+    if HIDDEN_WORKFLOWS:
+        print(
+            f"Hidden (known-broken or unrunnable here, {len(HIDDEN_WORKFLOWS)}): "
+            + ", ".join(sorted(HIDDEN_WORKFLOWS))
+        )
+        print("  see docs/specs/workflow-behavioral-validation/registry.md")
     print("\nRun a workflow: attune workflow run <name>")
     return 0
 

--- a/src/attune/mcp/server.py
+++ b/src/attune/mcp/server.py
@@ -644,10 +644,11 @@ class EmpathyMCPServer(MemoryHandlersMixin, WorkflowHandlersMixin, HandoffHandle
 
         """
         from attune.workflows import list_workflows
+        from attune.workflows.visibility import visible_entries
 
         workflows = [
             {"name": w.get("name", ""), "description": w.get("description", "")}
-            for w in list_workflows()
+            for w in visible_entries(list_workflows())
         ]
 
         wizards: list[dict[str, str]] = []

--- a/src/attune/ops/data.py
+++ b/src/attune/ops/data.py
@@ -950,7 +950,8 @@ def read_telemetry_summary(
     # is either a removed workflow or a stub from local development.
     # (P2-8 in the 2026-05-14 QA punch list.)
     try:
-        canonical_names = {w.name for w in list_workflows()}
+        # include_hidden: hidden workflows' historical telemetry is real.
+        canonical_names = {w.name for w in list_workflows(include_hidden=True)}
     except Exception:  # noqa: BLE001
         # INTENTIONAL: if the registry introspection fails, fall back
         # to showing everything rather than hiding all data.
@@ -1693,39 +1694,55 @@ def read_sweep_chip_counts(scope_path: str, config: Config) -> SweepChipCounts:
 #: 2026-08-23): these workflows currently report success their execution
 #: does not support. Shown as a warning badge on the dashboard until the
 #: fail-closed fixes land; remove the entry in the fixing PR.
-RELIABILITY_NOTICES: dict[str, str] = {
-    "secure-release": (
-        "Known issue: can report GO even when its security-audit and "
-        "release-prep sub-workflows fail to execute. Do not trust a GO "
-        "from this workflow until the fail-closed fix lands."
-    ),
-    "health-check": (
-        "Known issue: reports perfect scores (100/100, grade A) when its "
-        "measurement agents do not run. Treat perfect scores from fast, "
-        "zero-cost runs as unmeasured, not healthy."
-    ),
-}
+#: (secure-release and health-check entries removed 2026-08-24: the
+#: fail-closed fixes landed in #2222 / #2209 with live probe receipts —
+#: see docs/specs/workflow-behavioral-validation/registry.md.)
+RELIABILITY_NOTICES: dict[str, str] = {}
 
 
-def list_workflows() -> list[WorkflowEntry]:
-    """Return the registered workflow catalog. Empty if the registry is unavailable."""
+#: Workflows HIDDEN from the dashboard Workflows page (chair-directed
+#: 2026-08-24) until they demonstrably work — the probe registry
+#: (docs/specs/workflow-behavioral-validation/registry.md) is the
+#: evidence surface; remove an entry when its probe passes. Hidden from
+#: the PAGE only: the ops runner still accepts launches (probes/API),
+#: and telemetry keeps counting their historical runs.
+# Hidden-ness is owned by attune.workflows.visibility (single source of
+# truth for every catalog surface); imported LATE inside list_workflows()
+# to preserve this module's no-top-level-attune.workflows convention.
+
+
+def list_workflows(include_hidden: bool = False) -> list[WorkflowEntry]:
+    """Return the registered workflow catalog. Empty if the registry is unavailable.
+
+    Args:
+        include_hidden: When False (the dashboard default), workflows hidden for the
+            dashboard surface (attune.workflows.visibility) are omitted — known-broken or
+            dashboard-unrunnable entries stay off the Workflows page
+            until their probes pass. Validation and telemetry callers
+            pass True: hiding is a presentation concern, never a
+            data-integrity one.
+    """
     try:
         from attune.workflows import list_workflows as registry_list
+        from attune.workflows.visibility import is_hidden
     except ImportError:
         return []
 
     out: list[WorkflowEntry] = []
     try:
         for entry in registry_list():
+            name = str(entry.get("name", ""))
+            if not include_hidden and is_hidden(name, surface="dashboard"):
+                continue
             stages = entry.get("stages") or []
             tier_map = entry.get("tier_map") or {}
             out.append(
                 WorkflowEntry(
-                    name=str(entry.get("name", "")),
+                    name=name,
                     description=str(entry.get("description", "")),
                     stages=len(stages) if isinstance(stages, list) else 0,
                     tier_map={str(k): str(v) for k, v in tier_map.items()},
-                    notice=RELIABILITY_NOTICES.get(str(entry.get("name", "")), ""),
+                    notice=RELIABILITY_NOTICES.get(name, ""),
                 )
             )
     except Exception:  # noqa: BLE001

--- a/src/attune/ops/runner.py
+++ b/src/attune/ops/runner.py
@@ -473,7 +473,9 @@ class RunnerService:
         # Verify against the live registry. Cheap: ~25 entries, no I/O.
         from attune.ops import data as _data
 
-        valid_names = {w.name for w in _data.list_workflows()}
+        # include_hidden: hiding is presentation-only — API/probe launches
+        # of hidden workflows remain valid.
+        valid_names = {w.name for w in _data.list_workflows(include_hidden=True)}
         if name not in valid_names:
             logger.warning("recommendation rejected: unknown workflow %r", name)
             return None

--- a/src/attune/ops/static/js/runner.js
+++ b/src/attune/ops/static/js/runner.js
@@ -19,11 +19,10 @@
   // Regenerate: python scripts/sync_runner_workflow_names.py
   var WORKFLOW_NAMES = [
     "bug-predict", "code-review", "deep-review", "dependency-check",
-    "discovery-sweep", "doc-audit", "doc-gen", "doc-orchestrator",
-    "fix", "health-check", "orchestrated-health-check", "perf-audit",
-    "rag-code-gen", "refactor-plan", "release-gate", "release-notes",
-    "release-prep", "research-synthesis", "secure-release", "security-audit",
-    "simplify-code", "test-audit", "test-gen"
+    "discovery-sweep", "doc-audit", "doc-orchestrator", "health-check",
+    "orchestrated-health-check", "perf-audit", "refactor-plan", "release-gate",
+    "release-notes", "release-prep", "secure-release", "security-audit",
+    "simplify-code", "test-audit"
   ];
   // <<< AUTO-GENERATED: WORKFLOW_NAMES
 

--- a/src/attune/workflows/__init__.py
+++ b/src/attune/workflows/__init__.py
@@ -133,6 +133,9 @@ from .routing import (
 )
 from .step_config import WorkflowStepConfig, steps_from_tier_map, validate_step_config
 
+# Catalog visibility (hidden-from-users set; presentation only)
+from .visibility import HIDDEN_WORKFLOWS, is_hidden
+
 logger = logging.getLogger(__name__)
 
 # Lazy import mapping for workflow classes
@@ -672,6 +675,8 @@ __all__ = [
     "get_model",
     "get_workflow",
     "get_workflow_stats",
+    "HIDDEN_WORKFLOWS",
+    "is_hidden",
     "list_workflows",
     "refresh_workflow_registry",
     "steps_from_tier_map",

--- a/src/attune/workflows/visibility.py
+++ b/src/attune/workflows/visibility.py
@@ -1,0 +1,64 @@
+"""Workflow catalog visibility — the hidden-from-users sets.
+
+Chair-directed 2026-08-24: workflows that demonstrably do not work
+(probe registry: docs/specs/workflow-behavioral-validation/registry.md)
+are HIDDEN from user-facing catalogs until they work; workflows that
+only fail on surfaces unable to supply their required arguments are
+hidden from THOSE surfaces alone. Remove an entry when its probe
+passes.
+
+Two tiers:
+
+- :data:`HIDDEN_WORKFLOWS` — broken everywhere (deterministic failure
+  or no usable output on any surface). Hidden from every catalog: the
+  ops dashboard, ``attune workflow list``, the MCP
+  ``list_capabilities`` catalog.
+- :data:`DASHBOARD_HIDDEN_WORKFLOWS` — work when a caller supplies
+  their required arguments (CLI ``--input`` JSON, MCP tool params) but
+  are guaranteed error cards from the dashboard's argument-less Run
+  button. Hidden from the dashboard only.
+
+Hiding is a PRESENTATION concern only. The registry itself is
+untouched: ``get_workflow()`` resolves every name (probes, API
+launches, and the ops runner keep working), telemetry keeps counting
+historical runs, and the claim-drift count gates read the registry,
+not these catalogs.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Any
+
+#: Broken on every surface — name -> one-line reason (with tracking ref).
+HIDDEN_WORKFLOWS: dict[str, str] = {
+    "test-gen": "emits no runnable test files (no Write tool wired) — #2213",
+    "doc-gen": "deterministic SDK failure (fleet roundtable Sev3) — fix pending",
+    "research-synthesis": ("deterministic SDK failure (fleet roundtable Sev6) — fix pending"),
+}
+
+#: Unrunnable only from the dashboard's argument-less Run button.
+DASHBOARD_HIDDEN_WORKFLOWS: dict[str, str] = {
+    "fix": "requires a goal argument the dashboard Run button cannot supply",
+    "rag-code-gen": ("requires a query argument the dashboard Run button cannot supply"),
+}
+
+
+def is_hidden(name: str, *, surface: str = "catalog") -> bool:
+    """True when ``name`` is hidden on the given surface.
+
+    Args:
+        name: Registry workflow name.
+        surface: ``"catalog"`` (CLI/MCP — broken-everywhere set only)
+            or ``"dashboard"`` (also hides the argument-requiring set).
+    """
+    if name in HIDDEN_WORKFLOWS:
+        return True
+    return surface == "dashboard" and name in DASHBOARD_HIDDEN_WORKFLOWS
+
+
+def visible_entries(
+    entries: Iterable[dict[str, Any]], *, surface: str = "catalog"
+) -> list[dict[str, Any]]:
+    """Filter registry-shaped entry dicts (``{"name": ...}``) to visible ones."""
+    return [e for e in entries if not is_hidden(str(e.get("name", "")), surface=surface)]

--- a/tests/unit/ops/test_data_characterization.py
+++ b/tests/unit/ops/test_data_characterization.py
@@ -85,7 +85,7 @@ def test_read_telemetry_summary_happy_path_full_shape(tmp_path, monkeypatch):
         WorkflowEntry(name="security-audit", description="", stages=1, tier_map={}),
     ]
 
-    def _fake_list_workflows() -> list[WorkflowEntry]:
+    def _fake_list_workflows(include_hidden=False) -> list[WorkflowEntry]:
         return canonical
 
     monkeypatch.setattr(_data_mod, "list_workflows", _fake_list_workflows)
@@ -199,7 +199,7 @@ def test_read_telemetry_summary_workflow_field_fallback_chain(tmp_path, monkeypa
     # Force the "show everything" fallback by making the registry lookup
     # raise, so this test isolates the workflow-name resolution logic from
     # the canonical-filter logic (covered separately below).
-    def _raise():
+    def _raise(include_hidden=False):
         raise RuntimeError("registry unavailable")
 
     monkeypatch.setattr(_data_mod, "list_workflows", _raise)
@@ -308,7 +308,7 @@ def test_read_telemetry_summary_canonical_filter_excludes_unregistered_workflows
     import attune.ops.data as _data_mod
     from attune.ops.data import WorkflowEntry
 
-    def _fake_list_workflows():
+    def _fake_list_workflows(include_hidden=False):
         return [WorkflowEntry(name="code-review", description="", stages=1, tier_map={})]
 
     monkeypatch.setattr(_data_mod, "list_workflows", _fake_list_workflows)
@@ -343,7 +343,7 @@ def test_read_telemetry_summary_registry_failure_falls_back_to_show_everything(
     cfg = _config(tmp_path)
     import attune.ops.data as _data_mod
 
-    def _raise():
+    def _raise(include_hidden=False):
         raise RuntimeError("registry unavailable")
 
     monkeypatch.setattr(_data_mod, "list_workflows", _raise)
@@ -369,7 +369,7 @@ def test_read_telemetry_summary_by_workflow_caps_at_top_20(tmp_path, monkeypatch
     cfg = _config(tmp_path)
     import attune.ops.data as _data_mod
 
-    def _raise():
+    def _raise(include_hidden=False):
         raise RuntimeError("registry unavailable")  # show-everything fallback
 
     monkeypatch.setattr(_data_mod, "list_workflows", _raise)

--- a/tests/unit/ops/test_workflow_reliability_notices.py
+++ b/tests/unit/ops/test_workflow_reliability_notices.py
@@ -12,7 +12,12 @@ from attune.ops.data import RELIABILITY_NOTICES, WorkflowEntry, list_workflows
 
 
 def test_noticed_workflows_are_flagged():
-    assert set(RELIABILITY_NOTICES) == {"secure-release", "health-check"}
+    # 2026-08-24: the fail-closed fixes landed (#2222 secure-release,
+    # #2209 health-check) with live probe receipts, so their containment
+    # notices were removed per this file's own docstring contract. The
+    # dict stays as the mechanism for future containment entries; any
+    # entry present must carry the warning shape.
+    assert set(RELIABILITY_NOTICES) == set()
     for name, text in RELIABILITY_NOTICES.items():
         assert "Known issue" in text, name
 

--- a/tests/unit/ops/test_workflows_route_concerns.py
+++ b/tests/unit/ops/test_workflows_route_concerns.py
@@ -88,7 +88,14 @@ class TestConcernDerivation:
         assert derived["doc-orchestrator"] == "docs"  # not "meta"
         assert derived["perf-audit"] == "audit"
         assert derived["release-prep"] == "meta"
-        assert derived["rag-code-gen"] == "other"
+        # rag-code-gen is dashboard-hidden (visibility, 2026-08-24) so it
+        # no longer appears in the page's derivation; its concern class is
+        # still derivable from the full catalog.
+        full = {
+            w.name: workflow_concern.derive_concern(w.name)
+            for w in data.list_workflows(include_hidden=True)
+        }
+        assert full["rag-code-gen"] == "other"
 
     def test_concern_counts_sums_to_workflow_total(self) -> None:
         """concern_counts populates all 7 buckets; sum equals workflow total."""

--- a/tests/unit/plugins/test_registry_coverage.py
+++ b/tests/unit/plugins/test_registry_coverage.py
@@ -268,8 +268,13 @@ def _catalog_payload() -> dict:
 def _live_registry_counts() -> dict[str, int]:
     counts: dict[str, int] = {}
     from attune.workflows import list_workflows
+    from attune.workflows.visibility import visible_entries
 
-    counts["workflows"] = len(list_workflows())
+    # The catalog deliberately lists the VISIBLE set (known-broken
+    # workflows are hidden until their probes pass — 2026-08-24); the
+    # gate pins catalog == registry-minus-hidden so both silent drift
+    # AND an over-eager filter still fail here.
+    counts["workflows"] = len(visible_entries(list_workflows()))
     try:
         from attune.wizards.registry import list_wizards
 

--- a/tests/unit/workflows/test_visibility.py
+++ b/tests/unit/workflows/test_visibility.py
@@ -1,0 +1,60 @@
+"""Pins for workflow catalog visibility (chair-directed 2026-08-24).
+
+Known-broken workflows are hidden from user-facing catalogs until
+their probes pass; argument-requiring workflows are hidden from the
+dashboard only. Hiding is presentation-only — the registry resolves
+every name.
+"""
+
+from __future__ import annotations
+
+from attune.workflows import get_workflow
+from attune.workflows.visibility import (
+    DASHBOARD_HIDDEN_WORKFLOWS,
+    HIDDEN_WORKFLOWS,
+    is_hidden,
+    visible_entries,
+)
+
+
+def test_hidden_sets_carry_reasons() -> None:
+    for name, reason in {**HIDDEN_WORKFLOWS, **DASHBOARD_HIDDEN_WORKFLOWS}.items():
+        assert reason.strip(), name
+
+
+def test_hidden_names_still_resolve_in_registry() -> None:
+    # Hiding is presentation-only: probes, API launches, and the ops
+    # runner must keep working.
+    for name in {**HIDDEN_WORKFLOWS, **DASHBOARD_HIDDEN_WORKFLOWS}:
+        assert get_workflow(name) is not None
+
+
+def test_catalog_surface_hides_broken_only() -> None:
+    assert is_hidden("test-gen")
+    assert is_hidden("doc-gen")
+    assert not is_hidden("fix")  # arg-requiring: fine on CLI/MCP
+    assert not is_hidden("security-audit")
+
+
+def test_dashboard_surface_hides_both_tiers() -> None:
+    assert is_hidden("test-gen", surface="dashboard")
+    assert is_hidden("fix", surface="dashboard")
+    assert is_hidden("rag-code-gen", surface="dashboard")
+    assert not is_hidden("security-audit", surface="dashboard")
+
+
+def test_visible_entries_filters_by_surface() -> None:
+    entries = [{"name": n} for n in ("security-audit", "test-gen", "fix")]
+    assert [e["name"] for e in visible_entries(entries)] == ["security-audit", "fix"]
+    assert [e["name"] for e in visible_entries(entries, surface="dashboard")] == ["security-audit"]
+
+
+def test_ops_dashboard_list_respects_dashboard_tier() -> None:
+    from attune.ops import data
+
+    visible = {w.name for w in data.list_workflows()}
+    everything = {w.name for w in data.list_workflows(include_hidden=True)}
+    if not everything:  # registry unavailable in this environment
+        return
+    hidden = everything - visible
+    assert hidden == set(HIDDEN_WORKFLOWS) | set(DASHBOARD_HIDDEN_WORKFLOWS)


### PR DESCRIPTION
## What

Chair-directed: workflows the probe registry shows **don't work** stay off user-facing catalogs until their probes pass. Single source of truth: `attune.workflows.visibility`, two tiers:

| Tier | Workflows | Hidden from |
|------|-----------|-------------|
| Broken everywhere | test-gen (#2213), doc-gen, research-synthesis | ops Workflows page, `attune workflow list`, MCP `list_capabilities` |
| Dashboard-only (need args the Run button can't supply) | fix, rag-code-gen | ops dashboard only — CLI `--input` JSON and MCP tool params run them fine |

## Presentation-only, by design

`get_workflow()` resolves every name (ops runner launches with `include_hidden=True`; probes/API unaffected), telemetry keeps counting their history, and the claim-drift count gates read the registry — not these catalogs. The CLI prints the hidden set + probe-registry pointer instead of silently shrinking.

Also removes the secure-release / health-check `RELIABILITY_NOTICES` per their own remove-in-the-fixing-PR contract — #2222 and #2209 landed with live probe receipts.

## Tests

6 new visibility pins (hidden names still resolve; per-surface tiers; dashboard set = both tiers) + 3 consumer tests updated. 155 pass across the touched surfaces.

Re-show a workflow by deleting its entry when its probe passes — the registry (docs/specs/workflow-behavioral-validation/registry.md) is the evidence surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)