### PR TITLE
fix(workflows): surface the SDK child's real error text on the runner path

### DIFF
--- a/src/attune/workflows/agent_sdk_adapter.py
+++ b/src/attune/workflows/agent_sdk_adapter.py
@@ -192,6 +192,17 @@ async def iter_agent_messages(query: AsyncIterator[Any]) -> AsyncIterator[Any]:
     yielded, the iteration stops cleanly so the caller returns its
     already-captured result instead of discarding it.
 
+    When the stream raises AFTER an ``is_error`` ``ResultMessage`` was
+    seen, the raise is upgraded to a classified
+    :class:`SdkSubprocessError` built from that result's own error text.
+    The SDK's replacement exception names only the result *subtype*
+    (``"Claude Code returned an error result: success"``) and drops the
+    ``result`` body — which is where the CLI put the actual cause (e.g.
+    ``API Error: 400 ... specified API usage limits ...``). Re-probing
+    from the parent instead runs in a DIFFERENT env than the SDK child
+    and can report an unrelated auth condition (#2227), so the captured
+    in-stream text is the highest-fidelity source available.
+
     Any other exception — or one raised before a successful result — is
     re-raised unchanged, preserving fail-closed semantics: a genuine
     auth/quota/startup/runtime failure never becomes a false pass. The
@@ -208,6 +219,7 @@ async def iter_agent_messages(query: AsyncIterator[Any]) -> AsyncIterator[Any]:
         Each message from the underlying stream, unchanged.
     """
     saw_success = False
+    last_error_result_text: str | None = None
     iterator = query.__aiter__()
     while True:
         try:
@@ -227,12 +239,24 @@ async def iter_agent_messages(query: AsyncIterator[Any]) -> AsyncIterator[Any]:
                     exc,
                 )
                 return
+            if last_error_result_text is not None:
+                kind, summary = classify_subprocess_failure(last_error_result_text)
+                raise SdkSubprocessError(
+                    message=summary,
+                    stderr=last_error_result_text,
+                    kind=kind,
+                    original_exc=exc,
+                ) from exc
             raise
-        if (
-            isinstance(message, claude_agent_sdk.ResultMessage)
-            and getattr(message, "subtype", None) == "success"
-        ):
-            saw_success = True
+        if isinstance(message, claude_agent_sdk.ResultMessage):
+            if getattr(message, "subtype", None) == "success":
+                saw_success = True
+            if getattr(message, "is_error", False):
+                error_bits = [str(e) for e in (getattr(message, "errors", None) or [])]
+                result_text = getattr(message, "result", None)
+                if result_text:
+                    error_bits.append(str(result_text))
+                last_error_result_text = "\n".join(error_bits) or None
         yield message
 
 
@@ -795,6 +819,12 @@ _CLASSIFIERS: list[tuple[re.Pattern[str], SdkErrorKind, str]] = [
         "Anthropic API quota reached for this account.",
     ),
     (
+        re.compile(r"disabled Claude subscription access", re.I),
+        "auth",
+        "Claude subscription access is disabled for this organization; "
+        "set ANTHROPIC_API_KEY so workflow subprocesses bill the API key.",
+    ),
+    (
         re.compile(r"\b(401|invalid[_\s-]?api[_\s-]?key|unauthorized)\b", re.I),
         "auth",
         "Anthropic auth invalid or missing.",
@@ -834,6 +864,36 @@ def classify_subprocess_failure(stderr: str) -> tuple[SdkErrorKind, str]:
         if pattern.search(stderr):
             return kind, message
     return "unknown", "The claude CLI subprocess failed; see raw stderr below."
+
+
+def sdk_error_from_exception(exc: Exception) -> SdkSubprocessError:
+    """Return a classified :class:`SdkSubprocessError` for an SDK failure.
+
+    Fast-path: :func:`iter_agent_messages` already raises a fully
+    classified ``SdkSubprocessError`` when the CLI's own error-result
+    text was captured from the stream — reuse it as-is. A re-probe would
+    run outside the SDK child's env and can report a DIFFERENT auth
+    condition than the one the child actually hit (#2227).
+
+    Fallback: recover the failing argv from the exception, re-run/probe
+    the CLI, and classify the captured stderr (the Phase-2 path).
+
+    Args:
+        exc: The exception caught around an SDK ``query()`` call.
+
+    Returns:
+        A classified ``SdkSubprocessError`` (never raises).
+    """
+    if isinstance(exc, SdkSubprocessError):
+        return exc
+    stderr = capture_subprocess_failure(_last_subprocess_argv(exc))
+    kind, summary = classify_subprocess_failure(stderr)
+    return SdkSubprocessError(
+        message=summary,
+        stderr=stderr,
+        kind=kind,
+        original_exc=exc,
+    )
 
 
 def _sdk_error_probe_enabled() -> bool:
@@ -922,6 +982,16 @@ def capture_subprocess_failure(
             "(could not recover the exact failing command from the SDK; "
             "ran a minimal `claude` health probe instead)\n"
         )
+    if env is None:
+        # Mirror the SDK's child env (subprocess_cli strips CLAUDECODE and
+        # forces the sdk-py entrypoint) so the probe reproduces the
+        # condition the SDK child actually hit. Inheriting a desktop
+        # session's CLAUDE_CODE_ENTRYPOINT flips the CLI to host/
+        # subscription auth and reports an unrelated error (#2227,
+        # verified live 2026-08-24: probe said "subscription disabled"
+        # while the child's real failure was an API usage-limit 400).
+        env = {k: v for k, v in os.environ.items() if k != "CLAUDECODE"}
+        env["CLAUDE_CODE_ENTRYPOINT"] = "sdk-py"
     try:
         result = subprocess.run(  # noqa: S603
             args,

--- a/src/attune/workflows/bug_predict.py
+++ b/src/attune/workflows/bug_predict.py
@@ -24,16 +24,13 @@ import claude_agent_sdk
 from .agent_sdk_adapter import (
     AgentRunResult,
     AgentSDKResultAdapter,
-    SdkSubprocessError,
-    _last_subprocess_argv,
     build_result_text,
-    capture_subprocess_failure,
-    classify_subprocess_failure,
     collect_agent_output,
     get_max_budget_usd,
     get_subagent_model,
     iter_agent_messages,
     resolve_cwd_for_path,
+    sdk_error_from_exception,
     sdk_isolation_kwargs,
 )
 from .base import BaseWorkflow, ModelTier
@@ -218,18 +215,11 @@ class BugPredictionWorkflow(BaseWorkflow):
                 "Agent SDK bug prediction failed: %s",
                 type(exc).__name__,
             )
-            stderr = capture_subprocess_failure(_last_subprocess_argv(exc))
-            kind, summary = classify_subprocess_failure(stderr)
-            sdk_err = SdkSubprocessError(
-                message=summary,
-                stderr=stderr,
-                kind=kind,
-                original_exc=exc,
-            )
+            sdk_err = sdk_error_from_exception(exc)
             return self._error_result(
                 sdk_err.format_user_message(),
-                sdk_stderr=stderr,
-                sdk_error_kind=kind,
+                sdk_stderr=sdk_err.stderr,
+                sdk_error_kind=sdk_err.kind,
             )
 
     async def _run_agent_predict(

--- a/src/attune/workflows/code_review.py
+++ b/src/attune/workflows/code_review.py
@@ -27,11 +27,7 @@ import claude_agent_sdk
 from .agent_sdk_adapter import (
     AgentRunResult,
     AgentSDKResultAdapter,
-    SdkSubprocessError,
-    _last_subprocess_argv,
     build_result_text,
-    capture_subprocess_failure,
-    classify_subprocess_failure,
     collect_agent_output,
     collect_subagent_transcripts,
     format_subagent_transcripts_markdown,
@@ -41,6 +37,7 @@ from .agent_sdk_adapter import (
     get_thinking_config,
     iter_agent_messages,
     resolve_cwd_for_path,
+    sdk_error_from_exception,
     sdk_isolation_kwargs,
 )
 from .base import BaseWorkflow, ModelTier
@@ -292,18 +289,11 @@ class CodeReviewWorkflow(BaseWorkflow):
                 "Agent SDK code review failed: %s",
                 type(exc).__name__,
             )
-            stderr = capture_subprocess_failure(_last_subprocess_argv(exc))
-            kind, summary = classify_subprocess_failure(stderr)
-            sdk_err = SdkSubprocessError(
-                message=summary,
-                stderr=stderr,
-                kind=kind,
-                original_exc=exc,
-            )
+            sdk_err = sdk_error_from_exception(exc)
             return self._error_result(
                 sdk_err.format_user_message(),
-                sdk_stderr=stderr,
-                sdk_error_kind=kind,
+                sdk_stderr=sdk_err.stderr,
+                sdk_error_kind=sdk_err.kind,
             )
 
     async def _run_agent_review(

--- a/src/attune/workflows/deep_review.py
+++ b/src/attune/workflows/deep_review.py
@@ -30,16 +30,13 @@ import claude_agent_sdk
 from .agent_sdk_adapter import (
     AgentRunResult,
     AgentSDKResultAdapter,
-    SdkSubprocessError,
-    _last_subprocess_argv,
     build_result_text,
-    capture_subprocess_failure,
-    classify_subprocess_failure,
     collect_agent_output,
     get_max_budget_usd,
     get_subagent_model,
     iter_agent_messages,
     resolve_cwd_for_path,
+    sdk_error_from_exception,
     sdk_isolation_kwargs,
 )
 from .base import BaseWorkflow, ModelTier
@@ -259,15 +256,11 @@ class DeepReviewAgentSDKWorkflow(BaseWorkflow):
             # workflow Patrick hit 2026-06-01 with a 401 auth failure
             # that the legacy three-cause menu mis-attributed.
             logger.exception("Deep review failed: %s", type(exc).__name__)
-            stderr = capture_subprocess_failure(_last_subprocess_argv(exc))
-            kind, summary = classify_subprocess_failure(stderr)
-            sdk_err = SdkSubprocessError(
-                message=summary, stderr=stderr, kind=kind, original_exc=exc
-            )
+            sdk_err = sdk_error_from_exception(exc)
             return self._error_result(
                 sdk_err.format_user_message(),
-                sdk_stderr=stderr,
-                sdk_error_kind=kind,
+                sdk_stderr=sdk_err.stderr,
+                sdk_error_kind=sdk_err.kind,
             )
 
     async def _run_deep_review(

--- a/src/attune/workflows/dependency_check.py
+++ b/src/attune/workflows/dependency_check.py
@@ -20,16 +20,13 @@ import claude_agent_sdk
 from .agent_sdk_adapter import (
     AgentRunResult,
     AgentSDKResultAdapter,
-    SdkSubprocessError,
-    _last_subprocess_argv,
     build_result_text,
-    capture_subprocess_failure,
-    classify_subprocess_failure,
     collect_agent_output,
     get_max_budget_usd,
     get_subagent_model,
     iter_agent_messages,
     resolve_cwd_for_path,
+    sdk_error_from_exception,
     sdk_isolation_kwargs,
 )
 from .base import BaseWorkflow, ModelTier
@@ -204,18 +201,11 @@ class DependencyCheckWorkflow(BaseWorkflow):
             # WorkflowResult.metadata for the dashboard to render the
             # truth instead of regex-guessing.
             logger.exception("Agent SDK dependency check failed: %s", type(exc).__name__)
-            stderr = capture_subprocess_failure(_last_subprocess_argv(exc))
-            kind, summary = classify_subprocess_failure(stderr)
-            sdk_err = SdkSubprocessError(
-                message=summary,
-                stderr=stderr,
-                kind=kind,
-                original_exc=exc,
-            )
+            sdk_err = sdk_error_from_exception(exc)
             return self._error_result(
                 sdk_err.format_user_message(),
-                sdk_stderr=stderr,
-                sdk_error_kind=kind,
+                sdk_stderr=sdk_err.stderr,
+                sdk_error_kind=sdk_err.kind,
             )
 
     async def _run_agent_check(

--- a/src/attune/workflows/doc_audit/workflow.py
+++ b/src/attune/workflows/doc_audit/workflow.py
@@ -20,16 +20,13 @@ import claude_agent_sdk
 from ..agent_sdk_adapter import (
     AgentRunResult,
     AgentSDKResultAdapter,
-    SdkSubprocessError,
-    _last_subprocess_argv,
     build_result_text,
-    capture_subprocess_failure,
-    classify_subprocess_failure,
     collect_agent_output,
     get_max_budget_usd,
     get_subagent_model,
     iter_agent_messages,
     resolve_cwd_for_path,
+    sdk_error_from_exception,
     sdk_isolation_kwargs,
 )
 from ..base import BaseWorkflow, ModelTier
@@ -180,15 +177,11 @@ class DocAuditWorkflow(BaseWorkflow):
             # a structured WorkflowResult rather than crashing. Phase 6
             # of docs/specs/sdk-error-message-fidelity/.
             logger.exception("Agent SDK doc audit failed: %s", type(exc).__name__)
-            stderr = capture_subprocess_failure(_last_subprocess_argv(exc))
-            kind, summary = classify_subprocess_failure(stderr)
-            sdk_err = SdkSubprocessError(
-                message=summary, stderr=stderr, kind=kind, original_exc=exc
-            )
+            sdk_err = sdk_error_from_exception(exc)
             return self._error_result(
                 sdk_err.format_user_message(),
-                sdk_stderr=stderr,
-                sdk_error_kind=kind,
+                sdk_stderr=sdk_err.stderr,
+                sdk_error_kind=sdk_err.kind,
             )
 
     async def _run_agent_audit(

--- a/src/attune/workflows/document_gen/workflow.py
+++ b/src/attune/workflows/document_gen/workflow.py
@@ -19,16 +19,13 @@ import claude_agent_sdk
 from ..agent_sdk_adapter import (
     AgentRunResult,
     AgentSDKResultAdapter,
-    SdkSubprocessError,
-    _last_subprocess_argv,
     build_result_text,
-    capture_subprocess_failure,
-    classify_subprocess_failure,
     collect_agent_output,
     get_max_budget_usd,
     get_subagent_model,
     iter_agent_messages,
     resolve_cwd_for_path,
+    sdk_error_from_exception,
     sdk_isolation_kwargs,
 )
 from ..base import BaseWorkflow, ModelTier
@@ -181,15 +178,11 @@ class DocumentGenerationWorkflow(BaseWorkflow):
             # a structured WorkflowResult rather than crashing. Phase 6
             # of docs/specs/sdk-error-message-fidelity/.
             logger.exception("Agent SDK doc generation failed: %s", type(exc).__name__)
-            stderr = capture_subprocess_failure(_last_subprocess_argv(exc))
-            kind, summary = classify_subprocess_failure(stderr)
-            sdk_err = SdkSubprocessError(
-                message=summary, stderr=stderr, kind=kind, original_exc=exc
-            )
+            sdk_err = sdk_error_from_exception(exc)
             return self._error_result(
                 sdk_err.format_user_message(),
-                sdk_stderr=stderr,
-                sdk_error_kind=kind,
+                sdk_stderr=sdk_err.stderr,
+                sdk_error_kind=sdk_err.kind,
             )
 
     async def _run_agent_gen(

--- a/src/attune/workflows/perf_audit.py
+++ b/src/attune/workflows/perf_audit.py
@@ -24,16 +24,13 @@ import claude_agent_sdk
 from .agent_sdk_adapter import (
     AgentRunResult,
     AgentSDKResultAdapter,
-    SdkSubprocessError,
-    _last_subprocess_argv,
     build_result_text,
-    capture_subprocess_failure,
-    classify_subprocess_failure,
     collect_agent_output,
     get_max_budget_usd,
     get_subagent_model,
     iter_agent_messages,
     resolve_cwd_for_path,
+    sdk_error_from_exception,
     sdk_isolation_kwargs,
 )
 from .base import BaseWorkflow, ModelTier
@@ -205,18 +202,11 @@ class PerformanceAuditWorkflow(BaseWorkflow):
                 "Agent SDK perf audit failed: %s",
                 type(exc).__name__,
             )
-            stderr = capture_subprocess_failure(_last_subprocess_argv(exc))
-            kind, summary = classify_subprocess_failure(stderr)
-            sdk_err = SdkSubprocessError(
-                message=summary,
-                stderr=stderr,
-                kind=kind,
-                original_exc=exc,
-            )
+            sdk_err = sdk_error_from_exception(exc)
             return self._error_result(
                 sdk_err.format_user_message(),
-                sdk_stderr=stderr,
-                sdk_error_kind=kind,
+                sdk_stderr=sdk_err.stderr,
+                sdk_error_kind=sdk_err.kind,
             )
 
     async def _run_agent_audit(

--- a/src/attune/workflows/rag_code_gen.py
+++ b/src/attune/workflows/rag_code_gen.py
@@ -27,17 +27,14 @@ import claude_agent_sdk
 from .agent_sdk_adapter import (
     AgentRunResult,
     AgentSDKResultAdapter,
-    SdkSubprocessError,
-    _last_subprocess_argv,
     build_result_text,
-    capture_subprocess_failure,
-    classify_subprocess_failure,
     collect_agent_output,
     get_max_budget_usd,
     get_task_budget,
     get_thinking_config,
     iter_agent_messages,
     resolve_cwd_for_path,
+    sdk_error_from_exception,
     sdk_isolation_kwargs,
 )
 from .base import BaseWorkflow, ModelTier
@@ -311,15 +308,11 @@ class RagCodeGenWorkflow(BaseWorkflow):
                 "RAG generation failed: %s",
                 type(exc).__name__,
             )
-            stderr = capture_subprocess_failure(_last_subprocess_argv(exc))
-            kind, summary = classify_subprocess_failure(stderr)
-            sdk_err = SdkSubprocessError(
-                message=summary, stderr=stderr, kind=kind, original_exc=exc
-            )
+            sdk_err = sdk_error_from_exception(exc)
             return None, self._error_result(
                 sdk_err.format_user_message(),
-                sdk_stderr=stderr,
-                sdk_error_kind=kind,
+                sdk_stderr=sdk_err.stderr,
+                sdk_error_kind=sdk_err.kind,
             )
 
     def _assemble_result(

--- a/src/attune/workflows/refactor_plan.py
+++ b/src/attune/workflows/refactor_plan.py
@@ -22,16 +22,13 @@ import claude_agent_sdk
 from .agent_sdk_adapter import (
     AgentRunResult,
     AgentSDKResultAdapter,
-    SdkSubprocessError,
-    _last_subprocess_argv,
     build_result_text,
-    capture_subprocess_failure,
-    classify_subprocess_failure,
     collect_agent_output,
     get_max_budget_usd,
     get_subagent_model,
     iter_agent_messages,
     resolve_cwd_for_path,
+    sdk_error_from_exception,
     sdk_isolation_kwargs,
 )
 from .base import BaseWorkflow, ModelTier
@@ -198,18 +195,11 @@ class RefactorPlanWorkflow(BaseWorkflow):
             # classify the real claude CLI stderr instead of showing
             # the legacy three-cause menu.
             logger.exception("Agent SDK refactor plan failed: %s", type(exc).__name__)
-            stderr = capture_subprocess_failure(_last_subprocess_argv(exc))
-            kind, summary = classify_subprocess_failure(stderr)
-            sdk_err = SdkSubprocessError(
-                message=summary,
-                stderr=stderr,
-                kind=kind,
-                original_exc=exc,
-            )
+            sdk_err = sdk_error_from_exception(exc)
             return self._error_result(
                 sdk_err.format_user_message(),
-                sdk_stderr=stderr,
-                sdk_error_kind=kind,
+                sdk_stderr=sdk_err.stderr,
+                sdk_error_kind=sdk_err.kind,
             )
 
     async def _run_agent_plan(

--- a/src/attune/workflows/release_prep.py
+++ b/src/attune/workflows/release_prep.py
@@ -19,16 +19,13 @@ import claude_agent_sdk
 from .agent_sdk_adapter import (
     AgentRunResult,
     AgentSDKResultAdapter,
-    SdkSubprocessError,
-    _last_subprocess_argv,
     build_result_text,
-    capture_subprocess_failure,
-    classify_subprocess_failure,
     collect_agent_output,
     get_max_budget_usd,
     get_subagent_model,
     iter_agent_messages,
     resolve_cwd_for_path,
+    sdk_error_from_exception,
     sdk_isolation_kwargs,
 )
 from .base import BaseWorkflow, ModelTier
@@ -175,15 +172,11 @@ class ReleasePreparationWorkflow(BaseWorkflow):
             # a structured WorkflowResult rather than crashing. Phase 5
             # of docs/specs/sdk-error-message-fidelity/.
             logger.exception("Agent SDK release prep failed: %s", type(exc).__name__)
-            stderr = capture_subprocess_failure(_last_subprocess_argv(exc))
-            kind, summary = classify_subprocess_failure(stderr)
-            sdk_err = SdkSubprocessError(
-                message=summary, stderr=stderr, kind=kind, original_exc=exc
-            )
+            sdk_err = sdk_error_from_exception(exc)
             return self._error_result(
                 sdk_err.format_user_message(),
-                sdk_stderr=stderr,
-                sdk_error_kind=kind,
+                sdk_stderr=sdk_err.stderr,
+                sdk_error_kind=sdk_err.kind,
             )
 
     async def _run_agent_prep(

--- a/src/attune/workflows/research_synthesis.py
+++ b/src/attune/workflows/research_synthesis.py
@@ -25,16 +25,13 @@ import claude_agent_sdk
 from .agent_sdk_adapter import (
     AgentRunResult,
     AgentSDKResultAdapter,
-    SdkSubprocessError,
-    _last_subprocess_argv,
     build_result_text,
-    capture_subprocess_failure,
-    classify_subprocess_failure,
     collect_agent_output,
     get_max_budget_usd,
     get_subagent_model,
     iter_agent_messages,
     resolve_cwd_for_path,
+    sdk_error_from_exception,
     sdk_isolation_kwargs,
 )
 from .base import BaseWorkflow, ModelTier
@@ -193,15 +190,11 @@ class ResearchSynthesisWorkflow(BaseWorkflow):
             # a structured WorkflowResult rather than crashing. Phase 5
             # of docs/specs/sdk-error-message-fidelity/.
             logger.exception("Agent SDK research synthesis failed: %s", type(exc).__name__)
-            stderr = capture_subprocess_failure(_last_subprocess_argv(exc))
-            kind, summary = classify_subprocess_failure(stderr)
-            sdk_err = SdkSubprocessError(
-                message=summary, stderr=stderr, kind=kind, original_exc=exc
-            )
+            sdk_err = sdk_error_from_exception(exc)
             return self._error_result(
                 sdk_err.format_user_message(),
-                sdk_stderr=stderr,
-                sdk_error_kind=kind,
+                sdk_stderr=sdk_err.stderr,
+                sdk_error_kind=sdk_err.kind,
             )
 
     async def _run_agent_synthesis(

--- a/src/attune/workflows/security_audit.py
+++ b/src/attune/workflows/security_audit.py
@@ -25,11 +25,7 @@ import claude_agent_sdk
 from .agent_sdk_adapter import (
     AgentRunResult,
     AgentSDKResultAdapter,
-    SdkSubprocessError,
-    _last_subprocess_argv,
     build_result_text,
-    capture_subprocess_failure,
-    classify_subprocess_failure,
     collect_agent_output,
     collect_subagent_transcripts,
     format_subagent_transcripts_markdown,
@@ -39,6 +35,7 @@ from .agent_sdk_adapter import (
     get_thinking_config,
     iter_agent_messages,
     resolve_cwd_for_path,
+    sdk_error_from_exception,
     sdk_isolation_kwargs,
 )
 from .base import BaseWorkflow, ModelTier
@@ -214,18 +211,11 @@ class SecurityAuditWorkflow(BaseWorkflow):
                 "Agent SDK security audit failed: %s",
                 type(exc).__name__,
             )
-            stderr = capture_subprocess_failure(_last_subprocess_argv(exc))
-            kind, summary = classify_subprocess_failure(stderr)
-            sdk_err = SdkSubprocessError(
-                message=summary,
-                stderr=stderr,
-                kind=kind,
-                original_exc=exc,
-            )
+            sdk_err = sdk_error_from_exception(exc)
             return self._error_result(
                 sdk_err.format_user_message(),
-                sdk_stderr=stderr,
-                sdk_error_kind=kind,
+                sdk_stderr=sdk_err.stderr,
+                sdk_error_kind=sdk_err.kind,
             )
 
     async def _run_agent_audit(

--- a/src/attune/workflows/simplify_code.py
+++ b/src/attune/workflows/simplify_code.py
@@ -25,16 +25,13 @@ import claude_agent_sdk
 from .agent_sdk_adapter import (
     AgentRunResult,
     AgentSDKResultAdapter,
-    SdkSubprocessError,
-    _last_subprocess_argv,
     build_result_text,
-    capture_subprocess_failure,
-    classify_subprocess_failure,
     collect_agent_output,
     get_max_budget_usd,
     get_subagent_model,
     iter_agent_messages,
     resolve_cwd_for_path,
+    sdk_error_from_exception,
     sdk_isolation_kwargs,
 )
 from .base import BaseWorkflow, ModelTier
@@ -188,15 +185,11 @@ class SimplifyCodeWorkflow(BaseWorkflow):
             # a structured WorkflowResult rather than crashing. Phase 5
             # of docs/specs/sdk-error-message-fidelity/.
             logger.exception("Agent SDK code simplification failed: %s", type(exc).__name__)
-            stderr = capture_subprocess_failure(_last_subprocess_argv(exc))
-            kind, summary = classify_subprocess_failure(stderr)
-            sdk_err = SdkSubprocessError(
-                message=summary, stderr=stderr, kind=kind, original_exc=exc
-            )
+            sdk_err = sdk_error_from_exception(exc)
             return self._error_result(
                 sdk_err.format_user_message(),
-                sdk_stderr=stderr,
-                sdk_error_kind=kind,
+                sdk_stderr=sdk_err.stderr,
+                sdk_error_kind=sdk_err.kind,
             )
 
     async def _run_agent_simplify(

--- a/src/attune/workflows/test_audit/workflow.py
+++ b/src/attune/workflows/test_audit/workflow.py
@@ -21,16 +21,13 @@ import claude_agent_sdk
 from ..agent_sdk_adapter import (
     AgentRunResult,
     AgentSDKResultAdapter,
-    SdkSubprocessError,
-    _last_subprocess_argv,
     build_result_text,
-    capture_subprocess_failure,
-    classify_subprocess_failure,
     collect_agent_output,
     get_max_budget_usd,
     get_subagent_model,
     iter_agent_messages,
     resolve_cwd_for_path,
+    sdk_error_from_exception,
     sdk_isolation_kwargs,
 )
 from ..base import BaseWorkflow, ModelTier
@@ -216,15 +213,11 @@ class TestAuditWorkflow(BaseWorkflow):
             # a structured WorkflowResult rather than crashing. Phase 6
             # of docs/specs/sdk-error-message-fidelity/.
             logger.exception("Agent SDK test audit failed: %s", type(exc).__name__)
-            stderr = capture_subprocess_failure(_last_subprocess_argv(exc))
-            kind, summary = classify_subprocess_failure(stderr)
-            sdk_err = SdkSubprocessError(
-                message=summary, stderr=stderr, kind=kind, original_exc=exc
-            )
+            sdk_err = sdk_error_from_exception(exc)
             return self._error_result(
                 sdk_err.format_user_message(),
-                sdk_stderr=stderr,
-                sdk_error_kind=kind,
+                sdk_stderr=sdk_err.stderr,
+                sdk_error_kind=sdk_err.kind,
             )
 
     async def _run_agent_audit(

--- a/tests/unit/workflows/test_iter_agent_messages.py
+++ b/tests/unit/workflows/test_iter_agent_messages.py
@@ -23,9 +23,17 @@ from attune.workflows.agent_sdk_adapter import iter_agent_messages
 class _FakeResultMessage:
     """Stand-in for ``claude_agent_sdk.ResultMessage``."""
 
-    def __init__(self, subtype: str = "success", is_error: bool = False):
+    def __init__(
+        self,
+        subtype: str = "success",
+        is_error: bool = False,
+        result: str | None = None,
+        errors: list[str] | None = None,
+    ):
         self.subtype = subtype
         self.is_error = is_error
+        self.result = result
+        self.errors = errors
 
 
 class _FakeQuery:
@@ -136,6 +144,120 @@ async def test_clean_stream_passes_through():
 # during teardown — the exact failure class iter_agent_messages exists
 # to fix.
 _UNWRAPPED_LOOP_RE = re.compile(r"async for .+ in claude_agent_sdk\.query\(")
+
+
+# The SDK's ProcessError replacement names only the result SUBTYPE and
+# drops the result body — for an api_error result that subtype is
+# literally "success" (#2227). These tests pin the upgrade path: the
+# error ResultMessage's own text, captured in-stream, drives a
+# classified SdkSubprocessError instead.
+_REPLACEMENT = Exception("Claude Code returned an error result: success")
+
+_QUOTA_TEXT = (
+    "API Error: 400 You have reached your specified API usage limits. "
+    "You will regain access on 2026-09-01 at 00:00 UTC."
+)
+_ORG_DISABLED_TEXT = (
+    "Your organization has disabled Claude subscription access for "
+    "Claude Code · Use an Anthropic API key instead"
+)
+
+
+@pytest.mark.asyncio
+async def test_error_result_text_upgrades_raise_to_classified_error():
+    """#2227: usage-limit result text → SdkSubprocessError(api_quota)."""
+    err = _FakeResultMessage(subtype="success", is_error=True, result=_QUOTA_TEXT)
+    with pytest.raises(adapter.SdkSubprocessError) as exc_info:
+        await _drain(_FakeQuery([err], raise_after=_REPLACEMENT))
+    caught = exc_info.value
+    assert caught.kind == "api_quota"
+    assert _QUOTA_TEXT in caught.stderr
+    assert caught.original_exc is _REPLACEMENT
+    assert caught.__cause__ is _REPLACEMENT
+
+
+@pytest.mark.asyncio
+async def test_org_disabled_subscription_classifies_as_auth():
+    """#2227: the org-disabled subscription text classifies as auth."""
+    err = _FakeResultMessage(subtype="success", is_error=True, result=_ORG_DISABLED_TEXT)
+    with pytest.raises(adapter.SdkSubprocessError) as exc_info:
+        await _drain(_FakeQuery([err], raise_after=_REPLACEMENT))
+    assert exc_info.value.kind == "auth"
+    assert "ANTHROPIC_API_KEY" in exc_info.value.message
+
+
+@pytest.mark.asyncio
+async def test_error_result_without_text_propagates_original():
+    """No capturable error text → the original exception, unchanged."""
+    err = _FakeResultMessage(subtype="error_during_execution", is_error=True)
+    with pytest.raises(Exception, match="error result: success"):
+        await _drain(_FakeQuery([err], raise_after=_REPLACEMENT))
+
+
+@pytest.mark.asyncio
+async def test_errors_list_joined_when_result_absent():
+    """The errors list alone is enough to build the classified raise."""
+    err = _FakeResultMessage(
+        subtype="error_during_execution",
+        is_error=True,
+        errors=["rate_limit: too many requests"],
+    )
+    with pytest.raises(adapter.SdkSubprocessError) as exc_info:
+        await _drain(_FakeQuery([err], raise_after=_REPLACEMENT))
+    assert exc_info.value.kind == "rate_limit"
+
+
+def test_sdk_error_from_exception_fast_path(monkeypatch):
+    """An already-classified SdkSubprocessError is returned untouched.
+
+    The re-probe runs in a different env than the SDK child and can
+    report an unrelated auth condition (#2227) — it must not run.
+    """
+
+    def _boom(*args, **kwargs):  # pragma: no cover - fails the test if hit
+        raise AssertionError("probe must not run on the fast path")
+
+    monkeypatch.setattr(adapter, "capture_subprocess_failure", _boom)
+    err = adapter.SdkSubprocessError(message="m", stderr="s", kind="api_quota", original_exc=None)
+    assert adapter.sdk_error_from_exception(err) is err
+
+
+def test_sdk_error_from_exception_fallback_probes(monkeypatch):
+    """A bare SDK exception still goes through probe + classification."""
+    monkeypatch.setattr(adapter, "capture_subprocess_failure", lambda argv: _QUOTA_TEXT)
+    out = adapter.sdk_error_from_exception(Exception("Command failed with exit code 1"))
+    assert out.kind == "api_quota"
+    assert _QUOTA_TEXT in out.stderr
+
+
+def test_probe_env_mirrors_sdk_child(monkeypatch):
+    """The health probe must run in the SDK child's env, not the parent's.
+
+    A desktop session's CLAUDE_CODE_ENTRYPOINT flips the CLI to host/
+    subscription auth and reports an unrelated error (#2227) — the probe
+    strips CLAUDECODE and forces the sdk-py entrypoint, mirroring
+    claude_agent_sdk's subprocess env construction.
+    """
+    monkeypatch.setenv("CLAUDECODE", "1")
+    monkeypatch.setenv("CLAUDE_CODE_ENTRYPOINT", "claude-desktop")
+    monkeypatch.setenv("ATTUNE_SDK_ERROR_PROBE", "1")
+    seen: dict = {}
+
+    def _fake_run(args, **kwargs):
+        seen["env"] = kwargs.get("env")
+
+        class _R:
+            returncode = 1
+            stderr = "probe stderr"
+            stdout = ""
+
+        return _R()
+
+    monkeypatch.setattr(adapter.subprocess, "run", _fake_run)
+    adapter.capture_subprocess_failure([])
+    assert seen["env"] is not None
+    assert "CLAUDECODE" not in seen["env"]
+    assert seen["env"]["CLAUDE_CODE_ENTRYPOINT"] == "sdk-py"
 
 
 def test_every_workflow_query_loop_is_wrapped():

--- a/tests/unit/workflows/test_sdk_error_fidelity_phase2.py
+++ b/tests/unit/workflows/test_sdk_error_fidelity_phase2.py
@@ -46,7 +46,7 @@ class TestCodeReviewPhase2:
         with (
             patch("attune.workflows.code_review.claude_agent_sdk", mock_sdk),
             patch(
-                "attune.workflows.code_review.capture_subprocess_failure",
+                "attune.workflows.agent_sdk_adapter.capture_subprocess_failure",
                 return_value=(
                     "Error: You have reached your specified API usage limits. "
                     "Regain access on 2026-06-01."
@@ -73,7 +73,7 @@ class TestCodeReviewPhase2:
         with (
             patch("attune.workflows.code_review.claude_agent_sdk", mock_sdk),
             patch(
-                "attune.workflows.code_review.capture_subprocess_failure",
+                "attune.workflows.agent_sdk_adapter.capture_subprocess_failure",
                 return_value="401 Unauthorized: invalid api key",
             ),
         ):
@@ -99,7 +99,7 @@ class TestDependencyCheckPhase2:
                 mock_sdk,
             ),
             patch(
-                "attune.workflows.dependency_check.capture_subprocess_failure",
+                "attune.workflows.agent_sdk_adapter.capture_subprocess_failure",
                 return_value="429 Too Many Requests: rate limit exceeded",
             ),
         ):

--- a/tests/unit/workflows/test_sdk_error_fidelity_phase4.py
+++ b/tests/unit/workflows/test_sdk_error_fidelity_phase4.py
@@ -44,7 +44,7 @@ class TestBugPredictPhase4:
         with (
             patch("attune.workflows.bug_predict.claude_agent_sdk", mock_sdk),
             patch(
-                "attune.workflows.bug_predict.capture_subprocess_failure",
+                "attune.workflows.agent_sdk_adapter.capture_subprocess_failure",
                 return_value=(
                     "Error: You have reached your specified API usage limits. "
                     "Regain access on 2026-06-01."
@@ -75,7 +75,7 @@ class TestPerfAuditPhase4:
         with (
             patch("attune.workflows.perf_audit.claude_agent_sdk", mock_sdk),
             patch(
-                "attune.workflows.perf_audit.capture_subprocess_failure",
+                "attune.workflows.agent_sdk_adapter.capture_subprocess_failure",
                 return_value="401 Unauthorized: invalid api key",
             ),
         ):
@@ -100,7 +100,7 @@ class TestRefactorPlanPhase4:
         with (
             patch("attune.workflows.refactor_plan.claude_agent_sdk", mock_sdk),
             patch(
-                "attune.workflows.refactor_plan.capture_subprocess_failure",
+                "attune.workflows.agent_sdk_adapter.capture_subprocess_failure",
                 return_value="429 Too Many Requests: rate limit exceeded",
             ),
         ):
@@ -124,7 +124,7 @@ class TestSecurityAuditPhase4:
         with (
             patch("attune.workflows.security_audit.claude_agent_sdk", mock_sdk),
             patch(
-                "attune.workflows.security_audit.capture_subprocess_failure",
+                "attune.workflows.agent_sdk_adapter.capture_subprocess_failure",
                 return_value=(
                     "Failed to authenticate. API Error: 401 Invalid " "authentication credentials"
                 ),

--- a/tests/unit/workflows/test_sdk_error_fidelity_phase5.py
+++ b/tests/unit/workflows/test_sdk_error_fidelity_phase5.py
@@ -41,7 +41,7 @@ class TestSimplifyCodePhase5:
         with (
             patch("attune.workflows.simplify_code.claude_agent_sdk", mock_sdk),
             patch(
-                "attune.workflows.simplify_code.capture_subprocess_failure",
+                "attune.workflows.agent_sdk_adapter.capture_subprocess_failure",
                 return_value="401 Unauthorized: invalid api key",
             ),
         ):
@@ -73,7 +73,7 @@ class TestDeepReviewPhase5:
         with (
             patch("attune.workflows.deep_review.claude_agent_sdk", mock_sdk),
             patch(
-                "attune.workflows.deep_review.capture_subprocess_failure",
+                "attune.workflows.agent_sdk_adapter.capture_subprocess_failure",
                 return_value=(
                     "Failed to authenticate. API Error: 401 Invalid " "authentication credentials"
                 ),
@@ -102,7 +102,7 @@ class TestResearchSynthesisPhase5:
         with (
             patch("attune.workflows.research_synthesis.claude_agent_sdk", mock_sdk),
             patch(
-                "attune.workflows.research_synthesis.capture_subprocess_failure",
+                "attune.workflows.agent_sdk_adapter.capture_subprocess_failure",
                 return_value="429 Too Many Requests: rate limit exceeded",
             ),
         ):
@@ -136,7 +136,7 @@ class TestRagCodeGenPhase5:
         with (
             patch("attune.workflows.rag_code_gen.claude_agent_sdk", mock_sdk),
             patch(
-                "attune.workflows.rag_code_gen.capture_subprocess_failure",
+                "attune.workflows.agent_sdk_adapter.capture_subprocess_failure",
                 return_value=("Error: You have reached your specified API usage limits."),
             ),
             patch(
@@ -164,7 +164,7 @@ class TestReleasePrepPhase5:
         with (
             patch("attune.workflows.release_prep.claude_agent_sdk", mock_sdk),
             patch(
-                "attune.workflows.release_prep.capture_subprocess_failure",
+                "attune.workflows.agent_sdk_adapter.capture_subprocess_failure",
                 return_value="401 Unauthorized",
             ),
         ):

--- a/tests/unit/workflows/test_sdk_error_fidelity_phase6.py
+++ b/tests/unit/workflows/test_sdk_error_fidelity_phase6.py
@@ -51,7 +51,7 @@ class TestTestAuditPhase6:
                 mock_sdk,
             ),
             patch(
-                "attune.workflows.test_audit.workflow.capture_subprocess_failure",
+                "attune.workflows.agent_sdk_adapter.capture_subprocess_failure",
                 return_value="401 Unauthorized: invalid api key",
             ),
         ):
@@ -80,7 +80,7 @@ class TestDocAuditPhase6:
                 mock_sdk,
             ),
             patch(
-                "attune.workflows.doc_audit.workflow.capture_subprocess_failure",
+                "attune.workflows.agent_sdk_adapter.capture_subprocess_failure",
                 return_value="429 Too Many Requests: rate limit exceeded",
             ),
         ):
@@ -108,7 +108,7 @@ class TestDocumentGenPhase6:
                 mock_sdk,
             ),
             patch(
-                "attune.workflows.document_gen.workflow.capture_subprocess_failure",
+                "attune.workflows.agent_sdk_adapter.capture_subprocess_failure",
                 return_value=("Error: You have reached your specified API usage limits."),
             ),
         ):


### PR DESCRIPTION
Closes #2227.

## What the investigation found (all verified live, $0)

1. **The `opentelemetry` ModuleNotFoundError is benign** — it is claude_agent_sdk 0.2.116's own best-effort OTEL trace-context injection, caught and logged at DEBUG. Not a cause.
2. **Both failure conditions wear the same mask.** The bundled CLI emits `subtype:"success", is_error:true` for api_error results, and the SDK's ProcessError replacement raises only the SUBTYPE — `"Claude Code returned an error result: success"` — dropping the result body that held the real cause.
3. **Tonight's real cause on the runner path: API usage-limit 400** ("You have reached your specified API usage limits. You will regain access on 2026-09-01 at 00:00 UTC"), not the subscription condition.
4. **The stderr health probe reported a DIFFERENT condition** because it re-ran a bare `claude` in the parent env: a desktop session's `CLAUDE_CODE_ENTRYPOINT=claude-desktop` flips the CLI to host/subscription auth → "organization has disabled Claude subscription access" (org policy, verified). The SDK child itself runs with `sdk-py` entrypoint and uses the API key.

## Fixes

- `iter_agent_messages` captures an `is_error` ResultMessage's own `result`/`errors` text in-stream and upgrades the SDK's info-free raise to a classified `SdkSubprocessError`.
- New `sdk_error_from_exception()` helper with a fast-path (never re-probe an already-classified error); all 14 workflow catch-alls converted (net −60 lines).
- `capture_subprocess_failure` probe now mirrors the SDK child env (strips `CLAUDECODE`, forces `CLAUDE_CODE_ENTRYPOINT=sdk-py`) so it reproduces the condition the child actually hit.
- New classifier entry: org-disabled-subscription → `auth` with an actionable message.

## Receipt (behavioral, before/after on the exact #2227 repro)

Before: `What Went Wrong: The claude CLI subprocess failed without producing any error output.` (sdk_error_kind=unknown)
After: `What Went Wrong: Anthropic API quota reached for this account.` (kind=api_quota, real text in sdk_stderr)

Tests: 203 adapter/fidelity tests serially + 2939 workflows suite + 2008 ops/gates. Phase2/4/5/6 probe patches retargeted to the adapter namespace (the helper resolves the probe there for every workflow).

## Not fixed here (known, separate)

- The ANTHROPIC_API_KEY is at its configured usage cap until 2026-09-01 — console setting, not code. Runner-launched workflows will now SAY that clearly.
- #2213 (test-gen Write tool) and the CLI `--json` emission of `str(WorkflowResult)` remain open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
