### PR TITLE
perf(telemetry): batch feedback_loop reads via retrieve_many (#2237)

### DIFF
--- a/src/attune/telemetry/feedback_loop.py
+++ b/src/attune/telemetry/feedback_loop.py
@@ -267,19 +267,7 @@ class FeedbackLoop:
                 else f"feedback:{workflow_name}:{stage_name}:*"
             )
             keys = self.memory.keys(pattern)
-
-            entries: list[FeedbackEntry] = []
-            for key in keys:
-                data = self._retrieve_feedback(key)
-                if data:
-                    try:
-                        entries.append(FeedbackEntry.from_dict(data))
-                    except Exception as e:  # noqa: BLE001
-                        logger.error(f"Failed to parse feedback entry {key}: {e}")
-                        continue
-                if len(entries) >= limit:
-                    break
-
+            entries = self._parse_entries(self._retrieve_feedback_many(keys), limit)
             entries.sort(key=lambda e: e.timestamp, reverse=True)
             return entries[:limit]
         except Exception as e:  # noqa: BLE001
@@ -293,6 +281,42 @@ class FeedbackLoop:
         except Exception as e:  # noqa: BLE001
             logger.debug(f"Failed to retrieve feedback: {e}")
             return None
+
+    def _retrieve_feedback_many(self, keys: list[str]) -> list[tuple[str, Any]]:
+        """Fetch feedback records for ``keys`` in one backend call.
+
+        #2237: the per-key ``retrieve`` loop paid one round trip per
+        record (N+1). ``retrieve_many`` is part of the MemoryBackend
+        protocol and batches server-side; a backend without it (e.g. the
+        in-process fallback store, where reads are free) degrades to the
+        per-key path. NOTE: batching deliberately goes through the
+        backend, never a raw Redis MGET — the AMS backend's ``_client``
+        is an HTTP client, not redis-py, so a raw-client batch would
+        read a different surface than ``retrieve`` writes.
+        """
+        retrieve_many = getattr(self.memory, "retrieve_many", None)
+        if callable(retrieve_many):
+            try:
+                got = retrieve_many(list(keys))
+                return [(key, got.get(key)) for key in keys]
+            except Exception as e:  # noqa: BLE001
+                logger.debug(f"Batched feedback retrieve failed; falling back: {e}")
+        return [(key, self._retrieve_feedback(key)) for key in keys]
+
+    @staticmethod
+    def _parse_entries(records: list[tuple[str, Any]], limit: int) -> list[FeedbackEntry]:
+        """Parse raw records into entries, skipping malformed ones."""
+        entries: list[FeedbackEntry] = []
+        for key, data in records:
+            if data:
+                try:
+                    entries.append(FeedbackEntry.from_dict(data))
+                except Exception as e:  # noqa: BLE001
+                    logger.error(f"Failed to parse feedback entry {key}: {e}")
+                    continue
+            if len(entries) >= limit:
+                break
+        return entries
 
     def get_quality_stats(
         self,
@@ -316,6 +340,17 @@ class FeedbackLoop:
         if not history:
             return None
 
+        tier_str = tier.value if isinstance(tier, ModelTier) else (tier or "all")
+        return self._stats_from_history(workflow_name, stage_name, tier_str, history)
+
+    @staticmethod
+    def _stats_from_history(
+        workflow_name: str,
+        stage_name: str,
+        tier_str: str,
+        history: list[FeedbackEntry],
+    ) -> QualityStats:
+        """Compute stats over an already-fetched, newest-first history."""
         quality_scores = [entry.quality_score for entry in history]
         avg_quality = sum(quality_scores) / len(quality_scores)
         min_quality = min(quality_scores)
@@ -329,8 +364,6 @@ class FeedbackLoop:
             recent_trend = (recent_avg - older_avg) / max(older_avg, 0.1)
         else:
             recent_trend = 0.0
-
-        tier_str = tier.value if isinstance(tier, ModelTier) else (tier or "all")
 
         return QualityStats(
             workflow_name=workflow_name,
@@ -479,18 +512,29 @@ class FeedbackLoop:
 
         """
         try:
+            # #2237: one scan + ONE batched fetch, grouped in memory —
+            # previously O(combos x (scan + N per-key reads)) via nested
+            # get_quality_stats -> get_feedback_history calls.
             keys = self.memory.keys(f"feedback:{workflow_name}:*")
 
-            stage_tier_combos: set[tuple[str, str]] = set()
+            combo_keys: dict[tuple[str, str], list[str]] = {}
             for key in keys:
                 parts = key.split(":")
                 if len(parts) >= 4:
-                    stage_tier_combos.add((parts[2], parts[3]))
+                    combo_keys.setdefault((parts[2], parts[3]), []).append(key)
+
+            records = dict(self._retrieve_feedback_many(keys))
 
             underperforming = []
-            for stage_name, tier in stage_tier_combos:
-                stats = self.get_quality_stats(workflow_name, stage_name, tier=tier)
-                if stats and stats.avg_quality < quality_threshold:
+            for (stage_name, tier), keys_for_combo in combo_keys.items():
+                entries = self._parse_entries(
+                    [(k, records.get(k)) for k in keys_for_combo], limit=100
+                )
+                if not entries:
+                    continue
+                entries.sort(key=lambda e: e.timestamp, reverse=True)
+                stats = self._stats_from_history(workflow_name, stage_name, tier, entries)
+                if stats.avg_quality < quality_threshold:
                     underperforming.append((f"{stage_name}/{tier}", stats))
 
             underperforming.sort(key=lambda x: x[1].avg_quality)

--- a/tests/unit/gates/test_broad_except_ratchet.py
+++ b/tests/unit/gates/test_broad_except_ratchet.py
@@ -286,7 +286,10 @@ _BASELINE: dict[str, int] = {
     "src/attune/telemetry/cli_analysis.py": 1,
     "src/attune/telemetry/cli_automation.py": 4,
     "src/attune/telemetry/event_streaming.py": 6,
-    "src/attune/telemetry/feedback_loop.py": 6,
+    # +1 (#2237): _retrieve_feedback_many's batched-read guard — a
+    # failing retrieve_many degrades to the per-key path (logged);
+    # backend transport errors are inherently open-ended.
+    "src/attune/telemetry/feedback_loop.py": 7,
     "src/attune/telemetry/lessons/__init__.py": 1,
     "src/attune/telemetry/memory_events.py": 1,
     "src/attune/telemetry/usage_ping.py": 4,

--- a/tests/unit/telemetry/test_feedback_loop.py
+++ b/tests/unit/telemetry/test_feedback_loop.py
@@ -481,3 +481,105 @@ class TestFeedbackLoopBranches:
             loop.record_feedback("wf5", "s5", "cheap", 0.9)
         rec = loop.recommend_tier("wf5", "s5", current_tier=ModelTier.CHEAP)
         assert rec is not None
+
+
+class _BatchBackend:
+    """MemoryBackend stub whose retrieve_many IS the per-key contract.
+
+    Per the #2162 transport-swap lesson: the batched read is defined in
+    terms of the single read, so tests configuring payloads the old way
+    keep working, and call counters expose which transport actually ran.
+    """
+
+    def __init__(self):
+        self._data = {}
+        self.retrieve_calls = 0
+        self.retrieve_many_calls = 0
+
+    def stash(self, key, value, ttl=None, agent_id=None):
+        self._data[key] = value
+        return True
+
+    def retrieve(self, key, agent_id=None):
+        self.retrieve_calls += 1
+        return self._data.get(key)
+
+    def retrieve_many(self, keys, agent_id=None):
+        self.retrieve_many_calls += 1
+        return {k: self._data.get(k) for k in keys}
+
+    def keys(self, pattern="*"):
+        import fnmatch
+
+        return [k for k in self._data if fnmatch.fnmatch(k, pattern)]
+
+    def delete(self, key, agent_id=None):
+        return self._data.pop(key, None) is not None
+
+
+class TestBatchedRetrieval:
+    """#2237: history and underperforming-stages read in one batch."""
+
+    def _seed(self, loop, stage, tier, scores):
+        for i, score in enumerate(scores):
+            loop.record_feedback(
+                workflow_name="wf",
+                stage_name=stage,
+                tier=tier,
+                quality_score=score,
+                metadata={"seed_index": i},
+            )
+
+    def test_history_uses_one_batched_read(self):
+        backend = _BatchBackend()
+        loop = FeedbackLoop(memory=backend)
+        self._seed(loop, "review", "cheap", [0.9, 0.8, 0.7])
+
+        entries = loop.get_feedback_history("wf", "review", tier="cheap")
+
+        assert len(entries) == 3  # payloads were actually read
+        assert backend.retrieve_many_calls == 1
+        assert backend.retrieve_calls == 0  # no per-key N+1
+
+    def test_history_falls_back_without_retrieve_many(self):
+        class _NoBatchBackend(_BatchBackend):
+            retrieve_many = None  # not callable -> per-key fallback
+
+        backend = _NoBatchBackend()
+        loop = FeedbackLoop(memory=backend)
+        self._seed(loop, "review", "cheap", [0.9, 0.8])
+        entries = loop.get_feedback_history("wf", "review", tier="cheap")
+        assert len(entries) == 2
+        assert backend.retrieve_calls == 2  # per-key fallback ran
+
+    def test_underperforming_stages_single_batch_across_combos(self):
+        backend = _BatchBackend()
+        loop = FeedbackLoop(memory=backend)
+        self._seed(loop, "review", "cheap", [0.2, 0.3, 0.25])  # bad
+        self._seed(loop, "review", "premium", [0.95, 0.9])  # good
+        self._seed(loop, "summarize", "cheap", [0.5, 0.4])  # bad
+
+        under = loop.get_underperforming_stages("wf", quality_threshold=0.7)
+
+        labels = [label for label, _ in under]
+        # Both bad combos flagged, worst first; the good combo absent.
+        assert labels[0] == "review/cheap"
+        assert "summarize/cheap" in labels
+        assert "review/premium" not in labels
+        # The stats are real (computed from actually-read payloads).
+        by_label = dict(under)
+        assert by_label["review/cheap"].sample_count == 3
+        # ONE batched read served every combo — not one scan+N per combo.
+        assert backend.retrieve_many_calls == 1
+        assert backend.retrieve_calls == 0
+
+    def test_malformed_record_skipped_others_kept(self):
+        backend = _BatchBackend()
+        loop = FeedbackLoop(memory=backend)
+        self._seed(loop, "review", "cheap", [0.9, 0.8])
+        # Corrupt one stored record: from_dict will raise on it.
+        bad_key = next(iter(backend._data))
+        backend._data[bad_key] = {"not": "a feedback entry"}
+
+        entries = loop.get_feedback_history("wf", "review", tier="cheap")
+        assert len(entries) == 1


### PR DESCRIPTION
Closes #2237.

- `get_feedback_history`: N+1 per-key reads → one `retrieve_many` call (protocol-level batching; both FileStashBackend and AMSMemoryBackend implement it), per-key fallback for backends without it.
- `get_underperforming_stages`: was O(combos × (scan + N reads)) via nested `get_quality_stats` → one scan + ONE batched fetch, grouped in memory; stats math extracted unchanged into `_stats_from_history`.

**Deviation from the issue's suggested fix, with reason:** the issue (following the report) suggested `mget_json` on the raw client — but this module's Redis backend is `AMSMemoryBackend`, whose `_client` is an HTTP MemoryAPIClient, not redis-py. A raw MGET would read a different surface than `retrieve()` writes (the phantom-read class). Protocol-level `retrieve_many` is the correct batch seam.

Tests follow the #2162 transport-swap lesson: the stub's batched read is defined in terms of its single read; call counters assert which transport ran (batch=1, per-key=0) alongside positive result assertions; malformed-record skip pinned. 650 telemetry tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
