### PR TITLE
fix: hardening batch — six verified sites, two calibrated out (#2242)

### DIFF
--- a/src/attune/cost_tracker.py
+++ b/src/attune/cost_tracker.py
@@ -19,6 +19,7 @@ Licensed under the Apache License, Version 2.0
 import atexit
 import heapq
 import json
+import threading
 from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any
@@ -627,13 +628,18 @@ def cmd_costs(args: Any) -> int:
 
 # Singleton for global tracking
 _tracker: CostTracker | None = None
+_tracker_lock = threading.Lock()
 
 
 def get_tracker(storage_dir: str = ".attune") -> CostTracker:
     """Get or create the global cost tracker."""
     global _tracker
     if _tracker is None:
-        _tracker = CostTracker(storage_dir)
+        # #2242: double-checked under a lock — the bare check raced
+        # under multi-threaded init, constructing two instances.
+        with _tracker_lock:
+            if _tracker is None:
+                _tracker = CostTracker(storage_dir)
     return _tracker
 
 

--- a/src/attune/discovery.py
+++ b/src/attune/discovery.py
@@ -9,6 +9,7 @@ Licensed under the Apache License, Version 2.0
 
 import json
 import logging
+import threading
 from datetime import datetime
 from pathlib import Path
 
@@ -269,13 +270,18 @@ class DiscoveryEngine:
 
 # Singleton instance
 _engine: DiscoveryEngine | None = None
+_engine_lock = threading.Lock()
 
 
 def get_engine(storage_dir: str = ".attune") -> DiscoveryEngine:
     """Get or create the global discovery engine."""
     global _engine
     if _engine is None:
-        _engine = DiscoveryEngine(storage_dir)
+        # #2242: double-checked under a lock — the bare check raced
+        # under multi-threaded init, constructing two instances.
+        with _engine_lock:
+            if _engine is None:
+                _engine = DiscoveryEngine(storage_dir)
     return _engine
 
 

--- a/src/attune/memory/security/audit_logger.py
+++ b/src/attune/memory/security/audit_logger.py
@@ -137,11 +137,14 @@ class AuditLogger(
             os.chmod(self.log_dir, 0o700)
             logger.info(f"Audit log directory initialized: {self.log_dir}")
         except Exception as e:  # noqa: BLE001
-            # INTENTIONAL: Fallback to local directory on
-            # any init error (permissions, disk, etc.)
+            # INTENTIONAL: Fallback on any init error (permissions,
+            # disk, etc.). Fixed home-relative location — a cwd-relative
+            # ./logs lands wherever the process happened to start — and
+            # the same 0o700 as the primary dir (#2242).
             logger.error(f"Failed to initialize audit log directory: {e}")
-            self.log_dir = Path("./logs")
+            self.log_dir = Path.home() / ".attune" / "logs" / "audit"
             self.log_dir.mkdir(parents=True, exist_ok=True)
+            os.chmod(self.log_dir, 0o700)
             self.log_path = self.log_dir / self.log_filename
             logger.warning(f"Using fallback log directory: {self.log_dir}")
 

--- a/src/attune/memory/security/audit_logger.py
+++ b/src/attune/memory/security/audit_logger.py
@@ -144,7 +144,12 @@ class AuditLogger(
             logger.error(f"Failed to initialize audit log directory: {e}")
             self.log_dir = Path.home() / ".attune" / "logs" / "audit"
             self.log_dir.mkdir(parents=True, exist_ok=True)
-            os.chmod(self.log_dir, 0o700)
+            try:
+                os.chmod(self.log_dir, 0o700)
+            except OSError as chmod_err:
+                # Best-effort on the fallback: a chmod refusal must not
+                # take audit logging down entirely.
+                logger.warning(f"Could not restrict fallback log dir perms: {chmod_err}")
             self.log_path = self.log_dir / self.log_filename
             logger.warning(f"Using fallback log directory: {self.log_dir}")
 

--- a/src/attune/memory/session_stash.py
+++ b/src/attune/memory/session_stash.py
@@ -469,7 +469,10 @@ def _record_rejection(count: int, source: str, cwd: str | None) -> None:
         )
     except Exception:  # noqa: BLE001
         # INTENTIONAL: feedback telemetry must never break a deletion.
-        pass
+        # Logged (unlike a bare pass) so masked failures stay visible —
+        # this was the one silent swallow among the file's 13 logging
+        # siblings (#2242).
+        logger.debug("memory_feedback telemetry emit failed", exc_info=True)
 
 
 def forget_entries(

--- a/src/attune/models/retry.py
+++ b/src/attune/models/retry.py
@@ -7,6 +7,7 @@ Copyright 2025 Smart-AI-Memory
 Licensed under the Apache License, Version 2.0
 """
 
+import random
 from dataclasses import dataclass, field
 
 
@@ -22,6 +23,11 @@ class RetryPolicy:
     max_delay_ms: int = 30000
     exponential_backoff: bool = True
     backoff_multiplier: float = 2.0
+    #: Randomize each delay within [base/2, base] ("equal jitter").
+    #: Without it, concurrent callers that failed together retry in
+    #: lockstep and re-trigger shared rate limits (#2242). Set False
+    #: for deterministic delays (tests, reproductions).
+    jitter: bool = True
     retry_on_errors: list[str] = field(
         default_factory=lambda: [
             "rate_limit",
@@ -42,10 +48,15 @@ class RetryPolicy:
 
         """
         if not self.exponential_backoff:
-            return self.initial_delay_ms
-
-        delay = self.initial_delay_ms * (self.backoff_multiplier ** (attempt - 1))
-        return min(int(delay), self.max_delay_ms)
+            base = self.initial_delay_ms
+        else:
+            raw = self.initial_delay_ms * (self.backoff_multiplier ** (attempt - 1))
+            base = min(int(raw), self.max_delay_ms)
+        if not self.jitter:
+            return base
+        # Equal jitter: uniform in [base/2, base]. random is fine here —
+        # this is herd-spreading, not cryptography.
+        return int(base / 2 + random.random() * base / 2)  # noqa: S311
 
     def should_retry(self, error_type: str, attempt: int) -> bool:
         """Check if should retry for this error.

--- a/src/attune/ops/routes/runner.py
+++ b/src/attune/ops/routes/runner.py
@@ -97,6 +97,21 @@ async def _read_run_body(request: Request) -> tuple[str | None, str | None]:
     return raw_path, raw_trigger
 
 
+def _workflow_exists(name: str) -> bool | None:
+    """Whether ``name`` is in the live workflow registry.
+
+    Returns ``None`` (indeterminate) when registry introspection fails —
+    the caller fails OPEN on that, matching data.py's telemetry-rollup
+    convention: availability over strictness on an introspection bug.
+    """
+    try:
+        return name in {w.name for w in data.list_workflows(include_hidden=True)}
+    except Exception:  # noqa: BLE001
+        # INTENTIONAL: fail-open marker; the route proceeds.
+        logger.warning("ops.run: workflow registry introspection failed", exc_info=True)
+        return None
+
+
 @router.post("/workflows/{name}/run")
 async def start_run(
     name: str,
@@ -105,6 +120,18 @@ async def start_run(
 ) -> JSONResponse:
     _ensure_allowed(request)
     svc = _service(request)
+
+    # Defense in depth (#2242): validate the workflow name against the
+    # live registry UNCONDITIONALLY, not only on the scope branch. The
+    # spawn is fixed-argv/no-shell either way; this keeps an unknown
+    # name from ever reaching the subprocess layer.
+    if _workflow_exists(name) is False:
+        # Direct JSONResponse (not HTTPException): the app's 404 handler
+        # renders HTML for non-/api/ paths, and run clients parse JSON.
+        return JSONResponse(
+            status_code=404,
+            content={"detail": f"unknown workflow '{name}'"},
+        )
 
     scope, trigger = await _read_run_body(request)
     if scope is not None:

--- a/src/attune/wizards/base.py
+++ b/src/attune/wizards/base.py
@@ -363,6 +363,30 @@ class BaseWizard(ABC):
                 return s
         return None
 
+    def _required_step(self, step_id: str) -> WizardStep:
+        """Find a step by ID, raising a clear error when absent.
+
+        #2242: bare ``next(s for s in self.steps if s.id == ...)`` raised
+        an opaque ``StopIteration`` when a wizard's step list drifted
+        from the IDs its handlers expect.
+
+        Args:
+            step_id: Step identifier to look up.
+
+        Returns:
+            The matching ``WizardStep``.
+
+        Raises:
+            ValueError: If no step with ``step_id`` exists.
+        """
+        step = self._find_step(step_id)
+        if step is None:
+            raise ValueError(
+                f"wizard '{type(self).__name__}' has no step {step_id!r} "
+                f"(steps: {[s.id for s in self.steps]})"
+            )
+        return step
+
     # -----------------------------------------------------------------
     # TASK_DECOMPOSE step
     # -----------------------------------------------------------------

--- a/src/attune/wizards/builtin/refactor_wizard.py
+++ b/src/attune/wizards/builtin/refactor_wizard.py
@@ -243,7 +243,7 @@ class RefactorWizard(BaseWizard):
         }
 
         self.process_step_result(
-            next(s for s in self.steps if s.id == "analyze"),
+            self._required_step("analyze"),
             combined,
         )
         self._session.complete_step("analyze", result=combined)

--- a/src/attune/wizards/builtin/security_wizard.py
+++ b/src/attune/wizards/builtin/security_wizard.py
@@ -286,7 +286,7 @@ class SecurityWizard(BaseWizard):
         }
 
         self.process_step_result(
-            next(s for s in self.steps if s.id == "scan"),
+            self._required_step("scan"),
             combined,
         )
         self._session.complete_step("scan", result=combined)
@@ -327,7 +327,7 @@ class SecurityWizard(BaseWizard):
         }
 
         self.process_step_result(
-            next(s for s in self.steps if s.id == "generate_fixes"),
+            self._required_step("generate_fixes"),
             combined,
         )
         self._session.complete_step("generate_fixes", result=combined)

--- a/tests/models/test_fallback.py
+++ b/tests/models/test_fallback.py
@@ -238,6 +238,7 @@ class TestRetryPolicy:
         policy = RetryPolicy(
             initial_delay_ms=500,
             exponential_backoff=False,
+            jitter=False,
         )
 
         assert policy.get_delay_ms(1) == 500
@@ -250,6 +251,7 @@ class TestRetryPolicy:
             initial_delay_ms=1000,
             exponential_backoff=True,
             backoff_multiplier=2.0,
+            jitter=False,
         )
 
         assert policy.get_delay_ms(1) == 1000
@@ -263,6 +265,7 @@ class TestRetryPolicy:
             max_delay_ms=15000,
             exponential_backoff=True,
             backoff_multiplier=2.0,
+            jitter=False,
         )
 
         # Third attempt would be 40000 without cap

--- a/tests/unit/gates/test_broad_except_ratchet.py
+++ b/tests/unit/gates/test_broad_except_ratchet.py
@@ -244,6 +244,10 @@ _BASELINE: dict[str, int] = {
     "src/attune/ops/memory_data.py": 6,
     "src/attune/ops/routes/bulletin.py": 1,
     "src/attune/ops/routes/dashboard.py": 5,
+    # _workflow_exists (#2242): registry introspection is a fail-open
+    # availability guard — any introspection error must degrade to
+    # "indeterminate", never take the run endpoint down. Logged.
+    "src/attune/ops/routes/runner.py": 1,
     "src/attune/ops/routes/specs.py": 2,
     "src/attune/ops/runner.py": 3,
     "src/attune/ops/session_summarizer.py": 2,

--- a/tests/unit/memory/security/test_audit_logger.py
+++ b/tests/unit/memory/security/test_audit_logger.py
@@ -107,7 +107,10 @@ class TestInitialization:
         assert audit_logger.log_dir == expected
         assert audit_logger.log_path == expected / "audit.jsonl"
         assert expected.is_dir()
-        assert (expected.stat().st_mode & 0o777) == 0o700
+        # POSIX-only: Windows chmod is a near-no-op and reports 0o777
+        # (known Windows-lane class; see the os.geteuid skipif lesson).
+        if os.name == "posix":
+            assert (expected.stat().st_mode & 0o777) == 0o700
 
 
 class TestWriting:

--- a/tests/unit/memory/security/test_audit_logger.py
+++ b/tests/unit/memory/security/test_audit_logger.py
@@ -97,12 +97,17 @@ class TestInitialization:
             return original_mkdir(path, *args, **kwargs)
 
         monkeypatch.setattr(Path, "mkdir", fail_first_mkdir)
+        # #2242: fallback is home-relative (never cwd-relative ./logs)
+        # and carries the same 0o700 as the primary directory.
+        monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path / "home"))
 
         audit_logger = AuditLogger(log_dir=str(tmp_path / "unavailable"))
 
-        assert audit_logger.log_dir == Path("./logs")
-        assert audit_logger.log_path == Path("./logs/audit.jsonl")
-        assert (tmp_path / "logs").is_dir()
+        expected = tmp_path / "home" / ".attune" / "logs" / "audit"
+        assert audit_logger.log_dir == expected
+        assert audit_logger.log_path == expected / "audit.jsonl"
+        assert expected.is_dir()
+        assert (expected.stat().st_mode & 0o777) == 0o700
 
 
 class TestWriting:

--- a/tests/unit/models/test_routing_and_cost.py
+++ b/tests/unit/models/test_routing_and_cost.py
@@ -411,6 +411,7 @@ class TestFallbackActivation:
             initial_delay_ms=1000,
             exponential_backoff=True,
             backoff_multiplier=2.0,
+            jitter=False,
         )
 
         # Test delay calculation

--- a/tests/unit/ops/test_runner.py
+++ b/tests/unit/ops/test_runner.py
@@ -45,6 +45,10 @@ def _missing_cmd(_workflow: str) -> tuple[str, ...]:
 
 def _make_app(tmp_path, monkeypatch, *, allow_run, command_builder, executor=None):
     monkeypatch.setenv("ATTUNE_HOME", str(tmp_path / "attune-home"))
+    # #2242: start_run validates names against the live registry. These
+    # tests exercise the runner with synthetic names ("x"), so accept
+    # any name here; the dedicated 404/fail-open tests patch their own.
+    monkeypatch.setattr("attune.ops.routes.runner._workflow_exists", lambda name: True)
     # `testserver` is TestClient's default base_url host; `test` is the
     # AsyncClient(base_url="http://test") host. Add both to the
     # allowlist so the security middleware (PR #253-impl) doesn't 400
@@ -592,3 +596,36 @@ async def test_line_over_64k_does_not_fail_run(tmp_path, monkeypatch):
         assert not any("[runner error]" in ln for ln in run.lines)
         assert any(len(ln) >= 200_000 for ln in run.lines)
         assert any("end-long" in ln for ln in run.lines)
+
+
+def test_run_unknown_workflow_404s(tmp_path, monkeypatch):
+    """#2242: a name absent from the registry never reaches the spawn layer."""
+    app, _ = _make_app(
+        tmp_path,
+        monkeypatch,
+        allow_run=True,
+        command_builder=lambda _: ("noop",),
+    )
+    monkeypatch.setattr(
+        "attune.ops.routes.runner._workflow_exists",
+        lambda name: name == "real-workflow",
+    )
+    with TestClient(app) as client:
+        resp = client.post("/workflows/not-a-workflow/run")
+    assert resp.status_code == 404
+    assert "unknown workflow" in resp.json()["detail"]
+
+
+def test_run_registry_introspection_failure_fails_open(tmp_path, monkeypatch):
+    """Registry errors must not take the runner down (availability)."""
+    app, _ = _make_app(
+        tmp_path,
+        monkeypatch,
+        allow_run=True,
+        command_builder=lambda _: ("noop",),
+    )
+
+    monkeypatch.setattr("attune.ops.routes.runner._workflow_exists", lambda name: None)
+    with TestClient(app) as client:
+        resp = client.post("/workflows/x/run")
+    assert resp.status_code == 201  # fail-open: run proceeds

--- a/tests/unit/test_coverage_batch21.py
+++ b/tests/unit/test_coverage_batch21.py
@@ -29,7 +29,7 @@ class TestRetryPolicy:
     def test_get_delay_linear(self):
         from attune.models.retry import RetryPolicy
 
-        policy = RetryPolicy(initial_delay_ms=500, exponential_backoff=False)
+        policy = RetryPolicy(initial_delay_ms=500, exponential_backoff=False, jitter=False)
         assert policy.get_delay_ms(1) == 500
         assert policy.get_delay_ms(3) == 500
 
@@ -37,7 +37,10 @@ class TestRetryPolicy:
         from attune.models.retry import RetryPolicy
 
         policy = RetryPolicy(
-            initial_delay_ms=1000, backoff_multiplier=2.0, exponential_backoff=True
+            initial_delay_ms=1000,
+            backoff_multiplier=2.0,
+            exponential_backoff=True,
+            jitter=False,
         )
         assert policy.get_delay_ms(1) == 1000
         assert policy.get_delay_ms(2) == 2000
@@ -51,8 +54,20 @@ class TestRetryPolicy:
             max_delay_ms=3000,
             backoff_multiplier=10.0,
             exponential_backoff=True,
+            jitter=False,
         )
         assert policy.get_delay_ms(4) == 3000
+
+    def test_get_delay_jitter_stays_in_equal_jitter_band(self):
+        """#2242: default jitter spreads delays within [base/2, base]."""
+        from attune.models.retry import RetryPolicy
+
+        policy = RetryPolicy(
+            initial_delay_ms=1000, backoff_multiplier=2.0, exponential_backoff=True
+        )
+        samples = {policy.get_delay_ms(2) for _ in range(50)}  # base = 2000
+        assert all(1000 <= s <= 2000 for s in samples)
+        assert len(samples) > 1  # actually randomized, not constant
 
     def test_should_retry_within_limit(self):
         from attune.models.retry import RetryPolicy

--- a/tests/unit/wizards/test_base.py
+++ b/tests/unit/wizards/test_base.py
@@ -1,0 +1,33 @@
+class TestRequiredStep:
+    """#2242: missing step ids raise a clear error, not StopIteration."""
+
+    @staticmethod
+    def _stub(steps):
+        from attune.wizards.base import BaseWizard
+
+        class _Stub:
+            _find_step = BaseWizard._find_step
+            _required_step = BaseWizard._required_step
+
+            def __init__(self, inner_steps):
+                self.steps = inner_steps
+
+        return _Stub(steps)
+
+    def test_missing_step_raises_value_error(self):
+        from types import SimpleNamespace
+
+        stub = self._stub([SimpleNamespace(id="present")])
+        try:
+            stub._required_step("absent")
+        except ValueError as exc:
+            assert "absent" in str(exc) and "present" in str(exc)
+        else:
+            raise AssertionError("expected ValueError")
+
+    def test_present_step_returned(self):
+        from types import SimpleNamespace
+
+        step = SimpleNamespace(id="scan")
+        stub = self._stub([step])
+        assert stub._required_step("scan") is step


### PR DESCRIPTION
Closes #2242.

Six fixed (each site verified against source first), two calibrated out with reasons posted to the issue:

**Fixed**
- `audit_logger` fallback → home-relative `~/.attune/logs/audit` + 0o700 (was cwd-relative `./logs`, no chmod); test updated to pin the new behavior including the mode bits.
- ops runner `start_run` → unconditional registry validation via a `_workflow_exists` helper; fail-open (indeterminate) on introspection errors; JSON 404 (the app's 404 handler renders HTML for non-/api/ paths). New 404 + fail-open tests.
- `session_stash` memory-feedback swallow now logs (`exc_info`) — the one silent swallow among 13 logging siblings.
- `RetryPolicy` equal jitter on by default (herd-breaking, delay ∈ [base/2, base]); `jitter=False` keeps determinism — pinned-value tests updated to pass it, new jitter-band test.
- Wizard step lookups → `BaseWizard._required_step` (clear ValueError with the step inventory) at all 3 bare-`next()` sites.
- `get_engine`/`get_tracker` singletons → double-checked locking.

**Calibrated out (false positives)**
- `prompts/examples.py` `shell=True` strings are deliberate vulnerable one-shot *inputs* for the security-audit workflow — the first example is an eval-based snippet by design.
- `redis_bootstrap` `print()` is verbose-flag console UX.

Broad-except ratchet: +1 baseline entry (`ops/routes/runner.py`, fail-open introspection guard) with the reason at the call site, per the ratchet's own escape-hatch protocol.

Receipts: 6,010 tests green across ops/models/wizards/memory/gates/telemetry + batch21; hooks clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
