### PR TITLE
perf: batch round trips in project_index, ops sessions, roundtable ledger (#2241)

### DIFF
--- a/src/attune/ops/data.py
+++ b/src/attune/ops/data.py
@@ -648,15 +648,21 @@ def list_recent_sessions_with_paths(
                     mtime.isoformat(),
                 )
 
+    # #2241: parse newest-by-mtime first and stop at the limit instead
+    # of parsing every session JSONL before limiting. mtime is a proxy
+    # for last_activity (the file is appended on activity), so parsing
+    # the newest `limit` files covers the final top-`limit` ordering;
+    # the parsed slice is still sorted by last_activity below.
+    candidates = sorted(by_id.values(), key=lambda item: item[0], reverse=True)
     out: list[tuple[Session, Path]] = []
-    for _mtime, jsonl in by_id.values():
+    for _mtime, jsonl in candidates:
+        if limit is not None and limit >= 0 and len(out) >= limit:
+            break
         session = parse(jsonl)
         if session is None:
             continue
         out.append((session, jsonl))
     out.sort(key=lambda item: item[0].last_activity or "", reverse=True)
-    if limit is not None and limit >= 0:
-        out = out[:limit]
     return out
 
 

--- a/src/attune/project_index/index.py
+++ b/src/attune/project_index/index.py
@@ -67,6 +67,11 @@ class ProjectIndex:
         self._records: dict[str, FileRecord] = {}
         self._summary: ProjectSummary = ProjectSummary()
         self._generated_at: datetime | None = None
+        # #2241 dependency-lookup cache; bumped on structural mutation.
+        self._structure_version = 0
+        self._dep_cache_version = -1
+        self._dotted_paths: list[tuple[str, FileRecord]] = []
+        self._import_memo: dict[str, FileRecord | None] = {}
 
         # Index file path
         self._index_path = self.project_root / self.DEFAULT_INDEX_PATH
@@ -105,6 +110,7 @@ class ProjectIndex:
             self._records = {}
             for path, record_data in data.get("files", {}).items():
                 self._records[path] = FileRecord.from_dict(record_data)
+            self._structure_version += 1
 
             # Load timestamp
             if data.get("generated_at"):
@@ -167,12 +173,14 @@ class ProjectIndex:
                 json.dumps(self._summary.to_dict()),
             )
 
-            # Store each file record
-            for path, record in self._records.items():
+            # Store all file records in one round trip (#2241: this was
+            # one hset per record — thousands of sequential round trips).
+            if self._records:
                 self.redis_client.hset(
                     f"{prefix}:files",
-                    path,
-                    json.dumps(record.to_dict()),
+                    mapping={
+                        path: json.dumps(record.to_dict()) for path, record in self._records.items()
+                    },
                 )
 
             # Store metadata
@@ -378,6 +386,7 @@ class ProjectIndex:
             # Update records
             for record in new_records:
                 self._records[record.path] = record
+            self._structure_version += 1
 
         # Remove deleted files
         files_removed = 0
@@ -385,6 +394,7 @@ class ProjectIndex:
             if deleted_file and deleted_file in self._records:
                 del self._records[deleted_file]
                 files_removed += 1
+                self._structure_version += 1
 
         # Rebuild dependency graph if requested
         if analyze_dependencies:
@@ -591,13 +601,28 @@ class ProjectIndex:
         record = self._records.get(path)
         if not record:
             return []
-        # Match imports to paths
+        # #2241: this scanned every record per import (quadratic across
+        # calls, with two str.replace per comparison). The dotted-path
+        # list is now computed once per index structure and each import's
+        # resolution memoized; both invalidate via _structure_version.
+        if self._dep_cache_version != self._structure_version:
+            self._dotted_paths = [
+                (p.replace("/", ".").replace("\\", "."), r) for p, r in self._records.items()
+            ]
+            self._import_memo = {}
+            self._dep_cache_version = self._structure_version
         results = []
         for imp in record.imports:
-            for other_path, other_record in self._records.items():
-                if imp in other_path.replace("/", ".").replace("\\", "."):
-                    results.append(other_record)
-                    break
+            if imp in self._import_memo:
+                hit = self._import_memo[imp]
+            else:
+                hit = next(
+                    (r for dotted, r in self._dotted_paths if imp in dotted),
+                    None,
+                )
+                self._import_memo[imp] = hit
+            if hit is not None:
+                results.append(hit)
         return results
 
     # ===== Statistics =====

--- a/src/attune/roundtable/board.py
+++ b/src/attune/roundtable/board.py
@@ -391,9 +391,14 @@ class Board:
     def ledger_read(self) -> list[dict[str, Any]]:
         """Return all rotation-ledger records in reservation order."""
         run_ids = self.client.lrange(LEDGER_ORDER_KEY, 0, -1) or []
-        records: list[dict[str, Any]] = []
+        if not run_ids:
+            return []
+        # #2241: one pipelined round trip instead of one hgetall per run.
+        pipe = self.client.pipeline()
         for run_id in run_ids:
-            raw = self.client.hgetall(self.ledger_record_key(str(run_id)))
+            pipe.hgetall(self.ledger_record_key(str(run_id)))
+        records: list[dict[str, Any]] = []
+        for raw in pipe.execute():
             if raw:
                 raw["served"] = raw.get("served") == "1"
                 records.append(raw)

--- a/tests/unit/project_index/test_index_core.py
+++ b/tests/unit/project_index/test_index_core.py
@@ -124,7 +124,13 @@ class TestSyncToRedis:
         idx.redis_client = MagicMock()
         idx._sync_to_redis()
         assert idx.redis_client.set.call_count >= 2  # summary + meta
-        assert idx.redis_client.hset.call_count == 3  # one per record
+        # #2241: ONE hset carrying every record as a mapping (was one
+        # call per record). Assert the payload, not just the count, so
+        # the batch actually contains the records.
+        assert idx.redis_client.hset.call_count == 1
+        mapping = idx.redis_client.hset.call_args.kwargs["mapping"]
+        assert len(mapping) == 3
+        assert all(isinstance(v, str) for v in mapping.values())
 
     def test_exception_is_swallowed(self, tmp_path):
         idx = _populated(tmp_path)
@@ -368,3 +374,27 @@ class TestRefreshIncremental:
 
         assert "src/new.py" in idx._records
         assert updated == 1
+
+
+class TestDependencyLookupCache:
+    """#2241: memoized import resolution must invalidate on mutation."""
+
+    def test_results_unchanged_and_cache_reused(self, tmp_path):
+        idx = _populated(tmp_path)
+        first = idx.get_dependencies("src/a.py")
+        version = idx._dep_cache_version
+        second = idx.get_dependencies("src/a.py")
+        assert [r.path for r in first] == [r.path for r in second]
+        assert idx._dep_cache_version == version  # no rebuild between calls
+
+    def test_structural_mutation_invalidates(self, tmp_path):
+        idx = _populated(tmp_path)
+        idx.get_dependencies("src/a.py")
+        cached_version = idx._dep_cache_version
+        # Structural mutation (delete a record the queried file does NOT
+        # depend on — deleting the queried record itself would early-return
+        # before the cache is consulted) bumps the version...
+        del idx._records["tests/test_a.py"]
+        idx._structure_version += 1  # as the mutation sites do
+        idx.get_dependencies("src/a.py")
+        assert idx._dep_cache_version != cached_version


### PR DESCRIPTION
Partially addresses #2241 — the four mechanical, semantics-preserving wins; the four design-level items stay on the issue.

- `get_dependencies`: per-structure dotted-path cache + per-import memo, invalidated by a `_structure_version` counter at the three structural mutation sites. Substring-match semantics unchanged; regression tests pin reuse AND invalidation.
- `_sync_to_redis`: one `hset(mapping=…)` for all records; the test now asserts the batch payload (transport-swap lesson: never just the call count).
- `list_sessions`: newest-by-mtime-first parse, stop at limit (mtime as activity proxy — commented); final ordering still by `last_activity`.
- `ledger_read`: pipelined hgetalls.

Not here, with reasons on the issue: git_extractor one-shot `git log -p` rewrite (parsing-heavy — own change with golden tests), event_streaming registry set (design), usage_tracker incremental reads (documented tradeoff), deferred-save mode (API design).

Receipts: full tree 25,324 passed; touched-module suites green; hooks clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
