### PR TITLE
feat(test-gen): write real test files — Write tool, validated output_dir, truthful result keys (#2213)

### DIFF
--- a/docs/specs/workflow-behavioral-validation/records/20260824T043208-test-gen.json
+++ b/docs/specs/workflow-behavioral-validation/records/20260824T043208-test-gen.json
@@ -1,0 +1,18 @@
+{
+  "workflow": "test-gen",
+  "fixture": "tests/fixtures/workflow_probes/",
+  "receipt_type": "executed-tests",
+  "verdict": "pass",
+  "cost_usd": 0.6521,
+  "duration_s": 160.2,
+  "ran_at": "2026-08-24T04:32:08Z",
+  "runner_version": "0.3.0",
+  "git_sha": "1e70fdb96",
+  "evidence": {
+    "emitted_test_chars": 3160,
+    "files_written": 1,
+    "meta_tests_generated": 1,
+    "pytest_tail": ".......................                                                  [100%]\n23 passed in 0.02s",
+    "reason": "emitted tests (files_on_disk) imported, ran, and passed"
+  }
+}

--- a/docs/specs/workflow-behavioral-validation/registry.md
+++ b/docs/specs/workflow-behavioral-validation/registry.md
@@ -19,7 +19,7 @@ new records; `--check` is the CI drift guard.
 | security-audit | PASS | 0.3983 | 106.8 | 2026-08-23T20:55:00Z | 7d66113a0 | `records/2026-08-23-security-audit.json` |
 | simplify-code | PASS | 0.3336 | 80.9 | 2026-08-23T23:16:00Z | e80953386 | `records/2026-08-23-simplify-code.json` |
 | test-audit | PASS | 0.4725 | 89.8 | 2026-08-23T23:18:00Z | e80953386 | `records/2026-08-23-test-audit.json` |
-| test-gen | FAIL | 0.6233 | 160.8 | 2026-08-23T21:25:00Z | 7d66113a0 | `records/2026-08-23-test-gen.json` |
+| test-gen | PASS | 0.6521 | 160.2 | 2026-08-24T04:32:08Z | 1e70fdb96 | `records/20260824T043208-test-gen.json` |
 
 ## Not yet probed
 

--- a/scripts/workflow_probe_runner.py
+++ b/scripts/workflow_probe_runner.py
@@ -418,36 +418,60 @@ async def probe_test_gen(budget: float) -> ProbeResult:
                 cost_usd=_cost_of(result),
                 duration_s=dur,
             )
-        code = _extract_test_code(_raw_text(result))
-        if not code.strip():
-            return ProbeResult(
-                name="test-gen",
-                passed=False,
-                reason=(
-                    "workflow emitted no runnable test code "
-                    "(the report contained no pytest-shaped code fence)"
-                ),
-                cost_usd=_cost_of(result),
-                duration_s=dur,
-                evidence={"emitted_test_chars": 0},
+        # #2213: the workflow now WRITES test files (Write tool, scoped
+        # to <path>/tests/generated). Prefer executing the real files it
+        # wrote; fall back to fence extraction for regression coverage
+        # of the old prose-only failure mode.
+        meta = getattr(result, "metadata", None) or {}
+        gen_dir = work / "tests" / "generated"
+        real_files = sorted(gen_dir.glob("test_*.py")) if gen_dir.is_dir() else []
+        if real_files:
+            proc = subprocess.run(
+                [sys.executable, "-m", "pytest", "-q", *map(str, real_files)],
+                cwd=str(work),
+                capture_output=True,
+                text=True,
+                timeout=180,
             )
-
-        test_file = work / "test_probe_generated.py"
-        test_file.write_text(code, encoding="utf-8")
-        proc = subprocess.run(
-            [sys.executable, "-m", "pytest", "-q", str(test_file)],
-            cwd=str(work),
-            capture_output=True,
-            text=True,
-            timeout=180,
-        )
+            source_note = "files_on_disk"
+            emitted_chars = sum(len(p.read_text(encoding="utf-8")) for p in real_files)
+        else:
+            code = _extract_test_code(_raw_text(result))
+            if not code.strip():
+                return ProbeResult(
+                    name="test-gen",
+                    passed=False,
+                    reason=(
+                        "workflow wrote no test files and emitted no "
+                        "runnable test code (no files under "
+                        "tests/generated, no pytest-shaped code fence)"
+                    ),
+                    cost_usd=_cost_of(result),
+                    duration_s=dur,
+                    evidence={
+                        "emitted_test_chars": 0,
+                        "files_written": 0,
+                        "meta_tests_generated": meta.get("tests_generated"),
+                    },
+                )
+            test_file = work / "test_probe_generated.py"
+            test_file.write_text(code, encoding="utf-8")
+            proc = subprocess.run(
+                [sys.executable, "-m", "pytest", "-q", str(test_file)],
+                cwd=str(work),
+                capture_output=True,
+                text=True,
+                timeout=180,
+            )
+            source_note = "report_fence"
+            emitted_chars = len(code)
 
     tail = "\n".join((proc.stdout + proc.stderr).splitlines()[-8:])
     passed = proc.returncode == 0
     reason = (
-        "emitted tests imported, ran, and passed"
+        f"emitted tests ({source_note}) imported, ran, and passed"
         if passed
-        else f"emitted tests did not pass (pytest rc={proc.returncode})"
+        else f"emitted tests ({source_note}) did not pass (pytest rc={proc.returncode})"
     )
     return ProbeResult(
         name="test-gen",
@@ -455,7 +479,12 @@ async def probe_test_gen(budget: float) -> ProbeResult:
         reason=reason,
         cost_usd=_cost_of(result),
         duration_s=dur,
-        evidence={"emitted_test_chars": len(code), "pytest_tail": tail},
+        evidence={
+            "emitted_test_chars": emitted_chars,
+            "files_written": len(real_files),
+            "meta_tests_generated": meta.get("tests_generated"),
+            "pytest_tail": tail,
+        },
     )
 
 

--- a/src/attune/workflows/agent_sdk_adapter.py
+++ b/src/attune/workflows/agent_sdk_adapter.py
@@ -1159,6 +1159,45 @@ async def _guard_bash_tool(
     }
 
 
+def make_edit_scope_guard(scope_paths: list[Path]):
+    """Build a PreToolUse hook denying Edit/Write outside ``scope_paths``.
+
+    Prevention layer for the scope contract (codex D11 lane finding):
+    the deny happens at tool-call time, not just in the post-run
+    receipt diff.
+    """
+    resolved_scope = [p.resolve() for p in scope_paths]
+
+    async def _guard_edit_tool(
+        input_data: dict[str, Any],
+        tool_use_id: str | None,
+        context: Any,
+    ) -> dict[str, Any]:
+        raw = str((input_data.get("tool_input") or {}).get("file_path", ""))
+        if not raw:
+            return {}
+        try:
+            target = Path(raw).resolve()
+        except (OSError, RuntimeError):
+            target = None
+        if target is not None and any(
+            target == allowed or allowed in target.parents for allowed in resolved_scope
+        ):
+            return {}
+        return {
+            "hookSpecificOutput": {
+                "hookEventName": "PreToolUse",
+                "permissionDecision": "deny",
+                "permissionDecisionReason": (
+                    f"path {raw!r} is outside the allowed write scope; "
+                    "allowed: " + ", ".join(str(p) for p in resolved_scope)
+                ),
+            }
+        }
+
+    return _guard_edit_tool
+
+
 def sdk_isolation_kwargs() -> dict[str, Any]:
     """``ClaudeAgentOptions`` kwargs isolating the SDK subprocess session.
 

--- a/src/attune/workflows/fix_workflow.py
+++ b/src/attune/workflows/fix_workflow.py
@@ -28,6 +28,7 @@ from .agent_sdk_adapter import (
     collect_agent_output,
     get_max_budget_usd,
     iter_agent_messages,
+    make_edit_scope_guard,
     resolve_cwd_for_path,
     sdk_isolation_kwargs,
 )
@@ -57,45 +58,6 @@ run tests yourself):
 Read the scoped files, make the minimal in-place edit, then reply
 with a short summary listing exactly which files you changed and
 what remains uncertain."""
-
-
-def make_edit_scope_guard(scope_paths: list[Path]):
-    """Build a PreToolUse hook denying Edit/Write outside ``scope_paths``.
-
-    Prevention layer for the scope contract (codex D11 lane finding):
-    the deny happens at tool-call time, not just in the post-run
-    receipt diff.
-    """
-    resolved_scope = [p.resolve() for p in scope_paths]
-
-    async def _guard_edit_tool(
-        input_data: dict[str, Any],
-        tool_use_id: str | None,
-        context: Any,
-    ) -> dict[str, Any]:
-        raw = str((input_data.get("tool_input") or {}).get("file_path", ""))
-        if not raw:
-            return {}
-        try:
-            target = Path(raw).resolve()
-        except (OSError, RuntimeError):
-            target = None
-        if target is not None and any(
-            target == allowed or allowed in target.parents for allowed in resolved_scope
-        ):
-            return {}
-        return {
-            "hookSpecificOutput": {
-                "hookEventName": "PreToolUse",
-                "permissionDecision": "deny",
-                "permissionDecisionReason": (
-                    f"path {raw!r} is outside the fix contract's scope; "
-                    "allowed: " + ", ".join(str(p) for p in resolved_scope)
-                ),
-            }
-        }
-
-    return _guard_edit_tool
 
 
 class FixWorkflow(BaseWorkflow):

--- a/src/attune/workflows/test_gen/workflow.py
+++ b/src/attune/workflows/test_gen/workflow.py
@@ -31,6 +31,7 @@ from ..agent_sdk_adapter import (
     get_max_budget_usd,
     get_subagent_model,
     iter_agent_messages,
+    make_edit_scope_guard,
     resolve_cwd_for_path,
     sdk_isolation_kwargs,
 )
@@ -66,12 +67,18 @@ Analyze the codebase at {path} using the three specialized subagents \
 below. Each subagent should focus on its domain and produce structured \
 markdown output.
 
+The test-writer MUST write the generated pytest files to disk under \
+{output_dir} using the Write tool — one file per source module, named \
+test_<module>.py (create the directory implicitly by writing into it). \
+Generated tests must be runnable: real imports, no placeholder bodies.
+
 After all subagents finish, synthesize their output into a single \
 report with these sections:
 
 ## Summary
 Overall test generation summary — how many functions were analyzed, \
-how many test cases were designed, and how many test files were written.
+how many test cases were designed, and the exact paths of the test \
+files written to {output_dir}.
 
 ## Coverage
 Current coverage analysis and areas that need testing.
@@ -116,8 +123,32 @@ class TestGenerationWorkflow(BaseWorkflow):
         super().__init__(**kwargs)
 
     input_schema = InputSchema(
-        optional_fields={"path": str, "depth": str},
+        optional_fields={"path": str, "depth": str, "output_dir": str},
     )
+
+    @staticmethod
+    def _resolve_output_dir(resolved_path: str, output_dir: str | None) -> Path | None:
+        """Resolve and validate where generated tests are written.
+
+        Default: ``<path>/tests/generated`` for a directory target, or
+        ``<parent>/tests/generated`` for a single-file target. An
+        explicit ``output_dir`` must resolve INSIDE the target's base
+        directory — a path outside it returns ``None`` (#2213; the
+        Write-scope guard enforces the same boundary at tool-call time).
+        """
+        base = Path(resolved_path)
+        if not base.is_dir():
+            base = base.parent
+        if output_dir is None:
+            return base / "tests" / "generated"
+        candidate = Path(output_dir)
+        if not candidate.is_absolute():
+            candidate = base / candidate
+        candidate = candidate.resolve()
+        base = base.resolve()
+        if candidate != base and base not in candidate.parents:
+            return None
+        return candidate
 
     async def execute(self, **kwargs: Any) -> WorkflowResult:
         """Execute the Agent SDK test generation.
@@ -143,12 +174,26 @@ class TestGenerationWorkflow(BaseWorkflow):
         resolved_path = str(Path(path_arg).resolve())
         max_turns = _DEPTH_MAX_TURNS.get(depth, 20)
 
+        output_dir = self._resolve_output_dir(resolved_path, kwargs.get("output_dir"))
+        if output_dir is None:
+            return self._error_result("output_dir must resolve inside the target path's directory")
+        # Snapshot so only THIS run's files are reported (#2213).
+        preexisting = set(output_dir.rglob("*.py")) if output_dir.is_dir() else set()
+
         started_at = datetime.now()
 
         try:
-            run_result = await self._run_agent_gen(resolved_path, max_turns, depth=depth)
+            run_result = await self._run_agent_gen(
+                resolved_path, max_turns, depth=depth, output_dir=output_dir
+            )
             self._track_sdk_run_telemetry(stage="agent", agent_run_result=run_result)
             completed_at = datetime.now()
+
+            generated = (
+                sorted(str(p) for p in output_dir.rglob("*.py") if p not in preexisting)
+                if output_dir.is_dir()
+                else []
+            )
 
             return AgentSDKResultAdapter.from_agent_output(
                 report_title="Test generation",
@@ -160,6 +205,13 @@ class TestGenerationWorkflow(BaseWorkflow):
                     "path": resolved_path,
                     "depth": depth,
                     "max_turns": max_turns,
+                    # #2213: these keys make the MCP handler's
+                    # tests_generated/output_path/generated_files
+                    # surfaces truthful — counted from disk, not
+                    # from the model's own claims.
+                    "generated_files": generated,
+                    "tests_generated": len(generated),
+                    "output_path": str(output_dir),
                 },
                 agent_run_result=run_result,
             )
@@ -181,7 +233,11 @@ class TestGenerationWorkflow(BaseWorkflow):
             return self._error_result(f"Agent SDK error: {type(exc).__name__}: {exc}")
 
     async def _run_agent_gen(
-        self, resolved_path: str, max_turns: int, depth: str = "standard"
+        self,
+        resolved_path: str,
+        max_turns: int,
+        depth: str = "standard",
+        output_dir: Path | None = None,
     ) -> AgentRunResult:
         """Run the Agent SDK test generation and return result text.
 
@@ -189,23 +245,34 @@ class TestGenerationWorkflow(BaseWorkflow):
             resolved_path: Absolute path to generate tests for.
             max_turns: Maximum agent turns.
             depth: Agent depth for budget calculation.
+            output_dir: Directory the test-writer may Write into
+                (#2213). Writes outside it are denied at tool-call
+                time by the scope guard.
 
         Returns:
             AgentRunResult with findings and SDK metadata.
         """
+        output_dir = output_dir or self._resolve_output_dir(resolved_path, None)
+        iso = sdk_isolation_kwargs()
+        iso["hooks"]["PreToolUse"] = [
+            *iso["hooks"]["PreToolUse"],
+            claude_agent_sdk.HookMatcher(
+                matcher="Write", hooks=[make_edit_scope_guard([output_dir])]
+            ),
+        ]
         assistant_parts: list[str] = []
         result_parts: list[str] = []
         run_result = AgentRunResult(result_text="No results returned.")
         async for message in iter_agent_messages(
             claude_agent_sdk.query(
-                prompt=_TASK_PROMPT_TEMPLATE.format(path=resolved_path),
+                prompt=_TASK_PROMPT_TEMPLATE.format(path=resolved_path, output_dir=output_dir),
                 options=claude_agent_sdk.ClaudeAgentOptions(
-                    **sdk_isolation_kwargs(),
+                    **iso,
                     system_prompt=_SYSTEM_PROMPT,
                     cwd=resolve_cwd_for_path(resolved_path),
                     max_budget_usd=get_max_budget_usd(depth),
-                    allowed_tools=["Read", "Glob", "Grep", "Agent"],
-                    permission_mode="default",
+                    allowed_tools=["Read", "Glob", "Grep", "Write", "Agent"],
+                    permission_mode="acceptEdits",
                     max_turns=max_turns,
                     agents={
                         "function-identifier": claude_agent_sdk.AgentDefinition(
@@ -247,9 +314,14 @@ class TestGenerationWorkflow(BaseWorkflow):
                                 "appropriate, include type hints, add "
                                 "docstrings, and follow the naming convention "
                                 "test_{function}_{scenario}_{expected}. Group "
-                                "related tests in classes."
+                                "related tests in classes. WRITE each test "
+                                "file to disk with the Write tool under "
+                                f"{output_dir} (one file per source module, "
+                                "named test_<module>.py); do not merely print "
+                                "the code. The tests must be runnable: real "
+                                "imports, no placeholder bodies."
                             ),
-                            tools=["Read", "Glob", "Grep"],
+                            tools=["Read", "Glob", "Grep", "Write"],
                             model=get_subagent_model("test-writer"),
                         ),
                     },

--- a/tests/unit/cli_commands/test_fix_receipt.py
+++ b/tests/unit/cli_commands/test_fix_receipt.py
@@ -321,7 +321,7 @@ def test_edit_scope_guard_denies_outside_and_allows_inside(tmp_path: Path) -> No
         guard({"tool_input": {"file_path": str(tmp_path / "outside.py")}}, None, None)
     )
     assert denied["hookSpecificOutput"]["permissionDecision"] == "deny"
-    assert "outside the fix contract's scope" in (
+    assert "outside the allowed write scope" in (
         denied["hookSpecificOutput"]["permissionDecisionReason"]
     )
 

--- a/tests/unit/workflows/test_gen/test_write_tool_output.py
+++ b/tests/unit/workflows/test_gen/test_write_tool_output.py
@@ -1,0 +1,135 @@
+"""#2213 regression: test-gen writes real files and reports them truthfully.
+
+The workflow previously had no Write tool (subagents could only describe
+tests), while the MCP handler surfaced ``tests_generated``/``output_path``
+keys the workflow never produced. These tests pin the wiring: the
+Write-capable options shape, the validated output_dir, and result
+metadata counted from DISK (not from the model's own claims).
+
+Copyright 2026 Smart-AI-Memory
+Licensed under Apache 2.0
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from attune.workflows.agent_sdk_adapter import AgentRunResult
+from attune.workflows.test_gen.workflow import TestGenerationWorkflow
+
+
+@pytest.fixture
+def workflow():
+    return TestGenerationWorkflow()
+
+
+class TestResolveOutputDir:
+    def test_default_for_directory_target(self, tmp_path):
+        out = TestGenerationWorkflow._resolve_output_dir(str(tmp_path), None)
+        assert out == tmp_path / "tests" / "generated"
+
+    def test_default_for_file_target(self, tmp_path):
+        target = tmp_path / "mod.py"
+        target.write_text("x = 1\n")
+        out = TestGenerationWorkflow._resolve_output_dir(str(target), None)
+        assert out == tmp_path / "tests" / "generated"
+
+    def test_relative_output_dir_anchors_inside(self, tmp_path):
+        out = TestGenerationWorkflow._resolve_output_dir(str(tmp_path), "gen")
+        assert out == (tmp_path / "gen").resolve()
+
+    def test_outside_output_dir_rejected(self, tmp_path):
+        outside = tmp_path.parent / "elsewhere"
+        out = TestGenerationWorkflow._resolve_output_dir(str(tmp_path), str(outside))
+        assert out is None
+
+    def test_traversal_rejected(self, tmp_path):
+        out = TestGenerationWorkflow._resolve_output_dir(str(tmp_path), "../escape")
+        assert out is None
+
+
+class TestExecuteReportsDiskTruth:
+    def test_metadata_counts_files_written_this_run(self, workflow, tmp_path):
+        out_dir = tmp_path / "tests" / "generated"
+        out_dir.mkdir(parents=True)
+        (out_dir / "test_preexisting.py").write_text("# old\n")
+
+        async def fake_run(resolved_path, max_turns, depth="standard", output_dir=None):
+            (output_dir / "test_mod.py").write_text("def test_ok():\n    assert True\n")
+            return AgentRunResult(result_text="wrote tests")
+
+        with patch.object(workflow, "_run_agent_gen", side_effect=fake_run):
+            result = asyncio.run(workflow.execute(path=str(tmp_path)))
+
+        assert result.success is True
+        meta = result.metadata
+        assert meta["output_path"] == str(out_dir)
+        assert meta["tests_generated"] == 1  # preexisting file excluded
+        assert meta["generated_files"] == [str(out_dir / "test_mod.py")]
+
+    def test_no_files_written_reports_zero(self, workflow, tmp_path):
+        with patch.object(workflow, "_run_agent_gen", new_callable=AsyncMock) as mock_run:
+            mock_run.return_value = AgentRunResult(result_text="prose only")
+            result = asyncio.run(workflow.execute(path=str(tmp_path)))
+        assert result.metadata["tests_generated"] == 0
+        assert result.metadata["generated_files"] == []
+
+    def test_outside_output_dir_is_an_error_result(self, workflow, tmp_path):
+        result = asyncio.run(workflow.execute(path=str(tmp_path), output_dir="/somewhere/else"))
+        assert result.success is False
+        assert "output_dir" in result.error
+
+
+class TestSdkOptionsShape:
+    @patch("attune.workflows.test_gen.workflow.claude_agent_sdk")
+    def test_write_tool_granted_and_guarded(self, mock_sdk, workflow, tmp_path):
+        import claude_agent_sdk
+
+        captured: dict = {}
+
+        def capture_options(**kwargs):
+            captured.update(kwargs)
+            return claude_agent_sdk.ClaudeAgentOptions(**kwargs)
+
+        async def fake_query(*args, **kwargs):
+            if False:  # pragma: no cover - empty async generator
+                yield None
+
+        mock_sdk.query = lambda prompt, options: fake_query()
+        mock_sdk.ClaudeAgentOptions = capture_options
+        mock_sdk.AgentDefinition = claude_agent_sdk.AgentDefinition
+        mock_sdk.ResultMessage = claude_agent_sdk.ResultMessage
+        mock_sdk.HookMatcher = claude_agent_sdk.HookMatcher
+
+        asyncio.run(
+            workflow._run_agent_gen(str(tmp_path), 10, output_dir=tmp_path / "tests" / "generated")
+        )
+
+        assert "Write" in captured["allowed_tools"]
+        assert captured["permission_mode"] == "acceptEdits"
+        write_matchers = [m for m in captured["hooks"]["PreToolUse"] if m.matcher == "Write"]
+        assert len(write_matchers) == 1
+        writer = captured["agents"]["test-writer"]
+        assert "Write" in writer.tools
+        assert "Write tool" in writer.prompt
+
+    @pytest.mark.asyncio
+    async def test_scope_guard_denies_write_outside_output_dir(self, tmp_path):
+        from attune.workflows.agent_sdk_adapter import make_edit_scope_guard
+
+        out_dir = tmp_path / "tests" / "generated"
+        guard = make_edit_scope_guard([out_dir])
+
+        inside = await guard({"tool_input": {"file_path": str(out_dir / "test_a.py")}}, None, None)
+        assert inside == {}
+
+        outside = await guard({"tool_input": {"file_path": str(tmp_path / "evil.py")}}, None, None)
+        decision = outside["hookSpecificOutput"]["permissionDecision"]
+        assert decision == "deny"
+
+
+def _sync_guard_result(coro):
+    return asyncio.run(coro)


### PR DESCRIPTION
Closes #2213.

test-gen could only *describe* tests (no Write tool anywhere in its toolset), while the MCP handler surfaced `tests_generated`/`output_path` keys the workflow never produced — the "working" verdict was exit-0 only.

- **Write pipeline**: test-writer subagent + orchestrator get `Write`; `permission_mode="acceptEdits"` (the fix_workflow precedent); a Write-scope PreToolUse guard denies writes outside `output_dir`. `make_edit_scope_guard` moved to `agent_sdk_adapter` as the shared home (fix_workflow re-imports; its import path still works).
- **Validated `output_dir`** input: defaults to `<path>/tests/generated`; explicit values must resolve inside the target's directory (traversal rejected), enforced both at intake and at tool-call time.
- **Truthful result keys**: `generated_files` / `tests_generated` / `output_path` counted **from disk** (pre-run snapshot diff) — never from the model's claims.
- **Probe upgrade**: the planted-defect probe now executes the REAL files written under `tests/generated` (fence extraction kept as regression fallback), with `files_written`/`meta_tests_generated` evidence.

Receipts: 212 test_gen/fix/MCP-handler tests + 2,973 workflows tests green. Live-fire probe run in flight — result posted as a comment when it lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
