### PR TITLE
feat(scripts): with_timeout — portable bounded-run helper

### DIFF
--- a/scripts/with_timeout.py
+++ b/scripts/with_timeout.py
@@ -45,16 +45,26 @@ def main(argv: list[str]) -> int:
         return USAGE_EXIT
 
     cmd = argv[2:]
-    # New process group so a timeout kills children too (a bare
+    # POSIX: new session so a timeout kills children too (a bare
     # proc.kill() strands grandchildren, which is the original hang).
-    proc = subprocess.Popen(cmd, start_new_session=True)  # noqa: S603
+    # Windows has no killpg; taskkill /T below kills the tree instead.
+    posix = os.name == "posix"
+    proc = subprocess.Popen(cmd, start_new_session=posix)  # noqa: S603
     try:
         return proc.wait(timeout=seconds)
     except subprocess.TimeoutExpired:
-        try:
-            os.killpg(proc.pid, signal.SIGKILL)
-        except (ProcessLookupError, PermissionError):
-            proc.kill()
+        if posix:
+            try:
+                os.killpg(proc.pid, signal.SIGKILL)
+            except (ProcessLookupError, PermissionError):
+                proc.kill()
+        else:
+            subprocess.run(  # noqa: S603
+                ["taskkill", "/F", "/T", "/PID", str(proc.pid)],
+                capture_output=True,
+                check=False,
+            )
+            proc.kill()  # idempotent backstop if taskkill missed it
         proc.wait()
         print(
             f"with_timeout: command exceeded {seconds:g}s and was killed",

--- a/scripts/with_timeout.py
+++ b/scripts/with_timeout.py
@@ -1,0 +1,67 @@
+"""Bounded command runner — a portable `timeout(1)` for macOS.
+
+macOS ships no `timeout` binary (GNU coreutils), so ad-hoc bounded
+runs during diagnosis either hang forever or grow bespoke kill logic
+(retro 2026-08-24 item 7: a hung diagnostic cost dead time twice).
+
+Usage::
+
+    python scripts/with_timeout.py 30 -- cmd arg1 arg2
+
+Exit codes follow GNU timeout's convention: the command's own exit
+code when it finishes in time, 124 on timeout, 125 for usage errors.
+The whole process group is killed on timeout so children die too.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under Apache 2.0
+"""
+
+from __future__ import annotations
+
+import os
+import signal
+import subprocess
+import sys
+
+TIMEOUT_EXIT = 124
+USAGE_EXIT = 125
+
+
+def main(argv: list[str]) -> int:
+    """Run ``argv`` as ``<seconds> -- <cmd...>`` with a hard bound."""
+    if len(argv) < 3 or argv[1] != "--":
+        print(
+            "usage: with_timeout.py <seconds> -- <command> [args...]",
+            file=sys.stderr,
+        )
+        return USAGE_EXIT
+    try:
+        seconds = float(argv[0])
+    except ValueError:
+        print(f"invalid seconds value: {argv[0]!r}", file=sys.stderr)
+        return USAGE_EXIT
+    if seconds <= 0:
+        print("seconds must be positive", file=sys.stderr)
+        return USAGE_EXIT
+
+    cmd = argv[2:]
+    # New process group so a timeout kills children too (a bare
+    # proc.kill() strands grandchildren, which is the original hang).
+    proc = subprocess.Popen(cmd, start_new_session=True)  # noqa: S603
+    try:
+        return proc.wait(timeout=seconds)
+    except subprocess.TimeoutExpired:
+        try:
+            os.killpg(proc.pid, signal.SIGKILL)
+        except (ProcessLookupError, PermissionError):
+            proc.kill()
+        proc.wait()
+        print(
+            f"with_timeout: command exceeded {seconds:g}s and was killed",
+            file=sys.stderr,
+        )
+        return TIMEOUT_EXIT
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tests/unit/scripts/test_with_timeout.py
+++ b/tests/unit/scripts/test_with_timeout.py
@@ -1,0 +1,45 @@
+"""Tests for scripts/with_timeout.py (retro 2026-08-24 item 7).
+
+Copyright 2026 Smart-AI-Memory
+Licensed under Apache 2.0
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+SCRIPT = str(Path(__file__).resolve().parents[3] / "scripts" / "with_timeout.py")
+
+
+def _run(*args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, SCRIPT, *args],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+
+def test_fast_command_exit_code_propagates():
+    ok = _run("10", "--", sys.executable, "-c", "raise SystemExit(0)")
+    assert ok.returncode == 0
+    fail = _run("10", "--", sys.executable, "-c", "raise SystemExit(7)")
+    assert fail.returncode == 7
+
+
+def test_hung_command_killed_at_bound():
+    t0 = time.monotonic()
+    result = _run("1", "--", sys.executable, "-c", "import time; time.sleep(60)")
+    elapsed = time.monotonic() - t0
+    assert result.returncode == 124
+    assert elapsed < 15  # killed at the bound, not after 60s
+    assert "exceeded" in result.stderr
+
+
+def test_usage_errors_are_125():
+    assert _run("nope", "--", "true").returncode == 125
+    assert _run("5", "true").returncode == 125  # missing --
+    assert _run("-3", "--", "true").returncode == 125


### PR DESCRIPTION
Retro 2026-08-24 item 7: macOS lacks GNU `timeout`, and hung diagnostics cost dead time twice that session. `python scripts/with_timeout.py 30 -- cmd args` — new process group (children die too), exit-code propagation, 124/125 GNU conventions. 3 behavioral tests (propagation, kill-at-bound wall-clock, usage errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)