### PR TITLE
feat(probes): gate-group probes land corrected — 3 fresh PASS records

### DIFF
--- a/docs/specs/workflow-behavioral-validation/dispositions.md
+++ b/docs/specs/workflow-behavioral-validation/dispositions.md
@@ -15,29 +15,17 @@ Format (parsed by `scripts/project_probe_registry.py`):
 - **doc-gen** — BROKEN class from the fleet roundtable (Sev3,
   deterministic SDK failure); generative probes come last (D5): fix
   first, then probe by executing the emitted output.
-- **doc-orchestrator** — fail-open group (roundtable Sev5, "no gaps"
-  after its scout failed); probe lands with the gate-group batch and
-  must assert the DEGRADED behavior #2209 adds.
 - **fix** — requires a `goal` argument (dashboard-unrunnable class from
   the roundtable); needs a purpose-built fixture + invocation, not the
   shared analytical workdir.
-- **health-check** — fail-open group (roundtable Sev2, fabricated
-  100/100); probe lands with the gate-group batch and must assert
-  DEGRADED/N-A rendering per #2209, not a numeric score.
-- **orchestrated-health-check** — same gate-group batch as
-  health-check (it is the orchestrated variant of the same surface).
+- **orchestrated-health-check** — same class as `health-check`
+  (`OrchestratedHealthCheckWorkflow` serves both registry names); the
+  health-check probe + record covers this surface.
 - **rag-code-gen** — requires a `query` argument (dashboard-unrunnable
   class); generative batch (D5), probe must execute/resolve the cited
   output.
-- **release-gate** — deterministic rule-based gate (the roundtable's
-  honest-degrade counterexample); a planted failing-gate fixture probe
-  is planned with the gate-group batch.
-- **release-prep** — same deterministic gate family as release-gate;
-  covered indirectly by release-notes' metric-crosscheck probe until
-  the gate-group batch lands.
+- **release-gate** — same class as `release-prep`
+  (`ReleasePrepTeamWorkflow` serves both registry names); covered by
+  the release-prep probe + record (currently FAIL — #2221).
 - **research-synthesis** — BROKEN class from the fleet roundtable
   (Sev6, dies after ~229s); fix first, then probe.
-- **secure-release** — fail-open group (roundtable Sev1, GO on a dead
-  gate — fixed in #2208); its probe is the highest-teeth one in the
-  gate-group batch: a fixture whose sub-workflow fails MUST yield
-  NO_GO.

--- a/docs/specs/workflow-behavioral-validation/records/20260823T235122-doc-orchestrator.json
+++ b/docs/specs/workflow-behavioral-validation/records/20260823T235122-doc-orchestrator.json
@@ -1,0 +1,17 @@
+{
+  "workflow": "doc-orchestrator",
+  "fixture": "tests/fixtures/workflow_probes/",
+  "receipt_type": "fail-closed-gate",
+  "verdict": "fail",
+  "cost_usd": 0.0,
+  "duration_s": 4.4,
+  "ran_at": "2026-08-23T23:51:22Z",
+  "runner_version": "0.3.0",
+  "git_sha": "0836ddfac",
+  "evidence": {
+    "degraded": false,
+    "items_found": 0,
+    "reason": "claimed a real scan found no gaps on a fixture with a planted doc gap",
+    "defect_issue": "#2220 \u2014 empty ProjectIndex read counts as a performed scan"
+  }
+}

--- a/docs/specs/workflow-behavioral-validation/records/20260823T235122-health-check.json
+++ b/docs/specs/workflow-behavioral-validation/records/20260823T235122-health-check.json
@@ -1,0 +1,17 @@
+{
+  "workflow": "health-check",
+  "fixture": "tests/fixtures/workflow_probes/",
+  "receipt_type": "fail-closed-gate",
+  "verdict": "pass",
+  "cost_usd": 0.0,
+  "duration_s": 2.5,
+  "ran_at": "2026-08-23T23:51:22Z",
+  "runner_version": "0.3.0",
+  "git_sha": "0836ddfac",
+  "evidence": {
+    "degraded": true,
+    "grade": "A",
+    "score": null,
+    "reason": "honest incomplete-data verdict (degraded=True, grade=A)"
+  }
+}

--- a/docs/specs/workflow-behavioral-validation/records/20260823T235122-release-prep.json
+++ b/docs/specs/workflow-behavioral-validation/records/20260823T235122-release-prep.json
@@ -1,0 +1,16 @@
+{
+  "workflow": "release-prep",
+  "fixture": "tests/fixtures/workflow_probes/",
+  "receipt_type": "fail-closed-gate",
+  "verdict": "fail",
+  "cost_usd": 0.0,
+  "duration_s": 1.9,
+  "ran_at": "2026-08-23T23:51:22Z",
+  "runner_version": "0.3.0",
+  "git_sha": "0836ddfac",
+  "evidence": {
+    "gate_success": true,
+    "reason": "PASSED release gates on a fixture with no tests (fabrication)",
+    "defect_issue": "#2221 \u2014 gates PASS a planted failing test"
+  }
+}

--- a/docs/specs/workflow-behavioral-validation/records/20260823T235122-secure-release.json
+++ b/docs/specs/workflow-behavioral-validation/records/20260823T235122-secure-release.json
@@ -1,0 +1,19 @@
+{
+  "workflow": "secure-release",
+  "fixture": "tests/fixtures/workflow_probes/",
+  "receipt_type": "fail-closed-gate",
+  "verdict": "fail",
+  "cost_usd": 1.196,
+  "duration_s": 219.2,
+  "ran_at": "2026-08-23T23:51:22Z",
+  "runner_version": "0.3.0",
+  "git_sha": "0836ddfac",
+  "evidence": {
+    "go_no_go": "GO",
+    "critical_count": 0,
+    "high_count": 0,
+    "blockers": 0,
+    "reason": "returned GO on a planted-critical fixture (fail-open)",
+    "defect_issue": "#2219 \u2014 phantom 'assessment' key zeroes sub-audit findings"
+  }
+}

--- a/docs/specs/workflow-behavioral-validation/records/20260824T043657-doc-orchestrator.json
+++ b/docs/specs/workflow-behavioral-validation/records/20260824T043657-doc-orchestrator.json
@@ -1,0 +1,16 @@
+{
+  "workflow": "doc-orchestrator",
+  "fixture": "tests/fixtures/workflow_probes/",
+  "receipt_type": "fail-closed-gate",
+  "verdict": "pass",
+  "cost_usd": 0.0,
+  "duration_s": 0.8,
+  "ran_at": "2026-08-24T04:36:57Z",
+  "runner_version": "0.3.0",
+  "git_sha": "bc59a5dce",
+  "evidence": {
+    "degraded": false,
+    "items_found": 14,
+    "reason": "honest scan (degraded=False, items_found=14)"
+  }
+}

--- a/docs/specs/workflow-behavioral-validation/records/20260824T044128-release-prep.json
+++ b/docs/specs/workflow-behavioral-validation/records/20260824T044128-release-prep.json
@@ -1,0 +1,16 @@
+{
+  "workflow": "release-prep",
+  "fixture": "tests/fixtures/workflow_probes/",
+  "receipt_type": "fail-closed-gate",
+  "verdict": "pass",
+  "cost_usd": 0.0,
+  "duration_s": 2.0,
+  "ran_at": "2026-08-24T04:41:28Z",
+  "runner_version": "0.3.0",
+  "git_sha": "bc59a5dce",
+  "evidence": {
+    "approved": false,
+    "confidence": "low",
+    "reason": "honest BLOCKED verdict on a fixture with a planted failing test"
+  }
+}

--- a/docs/specs/workflow-behavioral-validation/records/20260824T044128-secure-release.json
+++ b/docs/specs/workflow-behavioral-validation/records/20260824T044128-secure-release.json
@@ -1,0 +1,18 @@
+{
+  "workflow": "secure-release",
+  "fixture": "tests/fixtures/workflow_probes/",
+  "receipt_type": "fail-closed-gate",
+  "verdict": "pass",
+  "cost_usd": 1.1601,
+  "duration_s": 234.6,
+  "ran_at": "2026-08-24T04:41:28Z",
+  "runner_version": "0.3.0",
+  "git_sha": "bc59a5dce",
+  "evidence": {
+    "go_no_go": "NO_GO",
+    "critical_count": 1,
+    "high_count": 2,
+    "blockers": 1,
+    "reason": "fail-closed: planted-critical fixture yielded NO_GO"
+  }
+}

--- a/docs/specs/workflow-behavioral-validation/registry.md
+++ b/docs/specs/workflow-behavioral-validation/registry.md
@@ -13,9 +13,13 @@ new records; `--check` is the CI drift guard.
 | dependency-check | PASS | 0.4505 | 77.1 | 2026-08-23T21:20:00Z | 7d66113a0 | `records/2026-08-23-dependency-check.json` |
 | discovery-sweep | FAIL | 2.5867 | 194.8 | 2026-08-23T21:55:00Z | 7d66113a0 | `records/2026-08-23-discovery-sweep.json` |
 | doc-audit | PASS | 0.3783 | 81.7 | 2026-08-23T23:20:00Z | e80953386 | `records/2026-08-23-doc-audit.json` |
+| doc-orchestrator | FAIL | 0.0000 | 4.4 | 2026-08-23T23:51:22Z | 0836ddfac | `records/20260823T235122-doc-orchestrator.json` |
+| health-check | PASS | 0.0000 | 2.5 | 2026-08-23T23:51:22Z | 0836ddfac | `records/20260823T235122-health-check.json` |
 | perf-audit | PASS | 0.2964 | 292.5 | 2026-08-23T23:12:00Z | e80953386 | `records/2026-08-23-perf-audit.json` |
 | refactor-plan | PASS | 0.3421 | 87.7 | 2026-08-23T23:59:00Z | 11965cb6f | `records/2026-08-23-refactor-plan.json` |
 | release-notes | PASS | 0.4689 | 88.7 | 2026-08-23T21:30:00Z | 7d66113a0 | `records/2026-08-23-release-notes.json` |
+| release-prep | FAIL | 0.0000 | 1.9 | 2026-08-23T23:51:22Z | 0836ddfac | `records/20260823T235122-release-prep.json` |
+| secure-release | FAIL | 1.1960 | 219.2 | 2026-08-23T23:51:22Z | 0836ddfac | `records/20260823T235122-secure-release.json` |
 | security-audit | PASS | 0.3983 | 106.8 | 2026-08-23T20:55:00Z | 7d66113a0 | `records/2026-08-23-security-audit.json` |
 | simplify-code | PASS | 0.3336 | 80.9 | 2026-08-23T23:16:00Z | e80953386 | `records/2026-08-23-simplify-code.json` |
 | test-audit | PASS | 0.4725 | 89.8 | 2026-08-23T23:18:00Z | e80953386 | `records/2026-08-23-test-audit.json` |
@@ -27,12 +31,8 @@ Workflows with NO run-record. Per the spec, absence is 'not yet probed', never '
 
 - **bug-predict** — exercised as a discovery-sweep lane (8 findings in the 2026-08-23 sweep record); no standalone probe yet. Candidate for the analytical batch's next increment.
 - **doc-gen** — BROKEN class from the fleet roundtable (Sev3, deterministic SDK failure); generative probes come last (D5): fix first, then probe by executing the emitted output.
-- **doc-orchestrator** — fail-open group (roundtable Sev5, "no gaps" after its scout failed); probe lands with the gate-group batch and must assert the DEGRADED behavior #2209 adds.
 - **fix** — requires a `goal` argument (dashboard-unrunnable class from the roundtable); needs a purpose-built fixture + invocation, not the shared analytical workdir.
-- **health-check** — fail-open group (roundtable Sev2, fabricated 100/100); probe lands with the gate-group batch and must assert DEGRADED/N-A rendering per #2209, not a numeric score.
-- **orchestrated-health-check** — same gate-group batch as health-check (it is the orchestrated variant of the same surface).
+- **orchestrated-health-check** — same class as `health-check` (`OrchestratedHealthCheckWorkflow` serves both registry names); the health-check probe + record covers this surface.
 - **rag-code-gen** — requires a `query` argument (dashboard-unrunnable class); generative batch (D5), probe must execute/resolve the cited output.
-- **release-gate** — deterministic rule-based gate (the roundtable's honest-degrade counterexample); a planted failing-gate fixture probe is planned with the gate-group batch.
-- **release-prep** — same deterministic gate family as release-gate; covered indirectly by release-notes' metric-crosscheck probe until the gate-group batch lands.
+- **release-gate** — same class as `release-prep` (`ReleasePrepTeamWorkflow` serves both registry names); covered by the release-prep probe + record (currently FAIL — #2221).
 - **research-synthesis** — BROKEN class from the fleet roundtable (Sev6, dies after ~229s); fix first, then probe.
-- **secure-release** — fail-open group (roundtable Sev1, GO on a dead gate — fixed in #2208); its probe is the highest-teeth one in the gate-group batch: a fixture whose sub-workflow fails MUST yield NO_GO.

--- a/docs/specs/workflow-behavioral-validation/registry.md
+++ b/docs/specs/workflow-behavioral-validation/registry.md
@@ -13,13 +13,13 @@ new records; `--check` is the CI drift guard.
 | dependency-check | PASS | 0.4505 | 77.1 | 2026-08-23T21:20:00Z | 7d66113a0 | `records/2026-08-23-dependency-check.json` |
 | discovery-sweep | FAIL | 2.5867 | 194.8 | 2026-08-23T21:55:00Z | 7d66113a0 | `records/2026-08-23-discovery-sweep.json` |
 | doc-audit | PASS | 0.3783 | 81.7 | 2026-08-23T23:20:00Z | e80953386 | `records/2026-08-23-doc-audit.json` |
-| doc-orchestrator | FAIL | 0.0000 | 4.4 | 2026-08-23T23:51:22Z | 0836ddfac | `records/20260823T235122-doc-orchestrator.json` |
+| doc-orchestrator | PASS | 0.0000 | 0.8 | 2026-08-24T04:36:57Z | bc59a5dce | `records/20260824T043657-doc-orchestrator.json` |
 | health-check | PASS | 0.0000 | 2.5 | 2026-08-23T23:51:22Z | 0836ddfac | `records/20260823T235122-health-check.json` |
 | perf-audit | PASS | 0.2964 | 292.5 | 2026-08-23T23:12:00Z | e80953386 | `records/2026-08-23-perf-audit.json` |
 | refactor-plan | PASS | 0.3421 | 87.7 | 2026-08-23T23:59:00Z | 11965cb6f | `records/2026-08-23-refactor-plan.json` |
 | release-notes | PASS | 0.4689 | 88.7 | 2026-08-23T21:30:00Z | 7d66113a0 | `records/2026-08-23-release-notes.json` |
-| release-prep | FAIL | 0.0000 | 1.9 | 2026-08-23T23:51:22Z | 0836ddfac | `records/20260823T235122-release-prep.json` |
-| secure-release | FAIL | 1.1960 | 219.2 | 2026-08-23T23:51:22Z | 0836ddfac | `records/20260823T235122-secure-release.json` |
+| release-prep | PASS | 0.0000 | 2.0 | 2026-08-24T04:41:28Z | bc59a5dce | `records/20260824T044128-release-prep.json` |
+| secure-release | PASS | 1.1601 | 234.6 | 2026-08-24T04:41:28Z | bc59a5dce | `records/20260824T044128-secure-release.json` |
 | security-audit | PASS | 0.3983 | 106.8 | 2026-08-23T20:55:00Z | 7d66113a0 | `records/2026-08-23-security-audit.json` |
 | simplify-code | PASS | 0.3336 | 80.9 | 2026-08-23T23:16:00Z | e80953386 | `records/2026-08-23-simplify-code.json` |
 | test-audit | PASS | 0.4725 | 89.8 | 2026-08-23T23:18:00Z | e80953386 | `records/2026-08-23-test-audit.json` |

--- a/scripts/workflow_probe_runner.py
+++ b/scripts/workflow_probe_runner.py
@@ -484,7 +484,10 @@ async def probe_discovery_sweep(budget: float) -> ProbeResult:
             "discovery-sweep",
             path=str(work),
             sources=sources,
-            budget_usd=min(budget, 5.0),
+            # Scale the sweep budget with lane count — a flat $5 cap
+            # under-budgeted 7 LLM lanes to ~$0.7 each (queue fix,
+            # 2026-08-24); the caller's --budget stays the hard cap.
+            budget_usd=min(budget, 1.5 * max(len(sources), 1)),
             output_format="json",
         )
         dur = time.monotonic() - t0
@@ -785,10 +788,10 @@ def _make_analytical_probe(name: str) -> Callable[[float], Any]:
 # --------------------------------------------------------------------------
 
 
-async def _run_gate_workflow(name: str, **kwargs: Any) -> Any:
+async def _run_gate_workflow(name: str, _ctor: dict[str, Any] | None = None, **kwargs: Any) -> Any:
     from attune.workflows import get_workflow
 
-    return await get_workflow(name)().execute(**kwargs)
+    return await get_workflow(name)(**(_ctor or {})).execute(**kwargs)
 
 
 async def probe_secure_release(budget: float) -> ProbeResult:
@@ -880,7 +883,11 @@ async def probe_doc_orchestrator(budget: float) -> ProbeResult:
             encoding="utf-8",
         )
         t0 = time.monotonic()
-        result = await _run_gate_workflow("doc-orchestrator", path=str(work))
+        # dry_run: scout-only (a constructor flag, not an execute kwarg)
+        # — the probe validates the SCAN's honesty, not doc generation.
+        result = await _run_gate_workflow(
+            "doc-orchestrator", _ctor={"dry_run": True}, path=str(work)
+        )
         dur = time.monotonic() - t0
 
     degraded = bool(getattr(result, "degraded", False))
@@ -923,12 +930,28 @@ async def probe_release_prep(budget: float) -> ProbeResult:
         result = await _run_gate_workflow("release-prep", path=str(work))
         dur = time.monotonic() - t0
 
-    success = bool(getattr(result, "success", True))
-    passed = not success
+    # #2221 correction: release-prep's execute() returns success=True
+    # even when BLOCKED (exit-0 contract) — the verdict lives in
+    # metadata["approved"]. Reading success made this probe vacuous.
+    meta = getattr(result, "metadata", None) or {}
+    approved = meta.get("approved")
+    if approved is None:
+        return ProbeResult(
+            name="release-prep",
+            passed=False,
+            reason=(
+                "metadata['approved'] missing — cannot judge the gate "
+                "(phantom-read guard: success is always True here)"
+            ),
+            cost_usd=_cost_of(result),
+            duration_s=dur,
+            evidence={"metadata_keys": sorted(meta)},
+        )
+    passed = approved is False
     reason = (
-        "honest FAIL verdict on an untested fixture"
+        "honest BLOCKED verdict on a fixture with a planted failing test"
         if passed
-        else "PASSED release gates on a fixture with no tests (fabrication)"
+        else "APPROVED a release on a fixture with a planted failing test (fabrication)"
     )
     return ProbeResult(
         name="release-prep",
@@ -936,7 +959,7 @@ async def probe_release_prep(budget: float) -> ProbeResult:
         reason=reason,
         cost_usd=_cost_of(result),
         duration_s=dur,
-        evidence={"gate_success": success},
+        evidence={"approved": approved, "confidence": meta.get("confidence")},
     )
 
 

--- a/scripts/workflow_probe_runner.py
+++ b/scripts/workflow_probe_runner.py
@@ -82,6 +82,12 @@ _EST_COST_USD: dict[str, float] = {
     "simplify-code": 1.2,
     "test-audit": 0.9,
     "doc-audit": 2.9,
+    # Gate group (D5 batch 2) — secure-release bills its sub-audit;
+    # the others were $0-class in the fleet probe / rule-based.
+    "secure-release": 1.5,
+    "health-check": 0.3,
+    "doc-orchestrator": 0.3,
+    "release-prep": 0.0,
 }
 
 PROBE_ORDER = [
@@ -97,6 +103,10 @@ PROBE_ORDER = [
     "simplify-code",
     "test-audit",
     "doc-audit",
+    "secure-release",
+    "health-check",
+    "doc-orchestrator",
+    "release-prep",
 ]
 
 
@@ -765,6 +775,171 @@ def _make_analytical_probe(name: str) -> Callable[[float], Any]:
     return lambda budget: _probe_analytical(name, budget)
 
 
+# --------------------------------------------------------------------------
+# Gate-group probes (Phase 3, D5 batch 2) — assert the FAIL-CLOSED /
+# DEGRADED behavior #2207-#2209 added. These workflows return their own
+# result objects (not WorkflowResult), so each probe reads the merged
+# result surface directly and the receipt is the honest verdict, never
+# a score. All calls go through _run_gate_workflow so unit tests can
+# stub the workflow without an LLM.
+# --------------------------------------------------------------------------
+
+
+async def _run_gate_workflow(name: str, **kwargs: Any) -> Any:
+    from attune.workflows import get_workflow
+
+    return await get_workflow(name)().execute(**kwargs)
+
+
+async def probe_secure_release(budget: float) -> ProbeResult:
+    """A planted-critical fixture must NOT get a GO (P7, #2208)."""
+    import time
+
+    _budget_env(budget)
+    with tempfile.TemporaryDirectory() as tmp:
+        work = Path(tmp)
+        shutil.copy(
+            FIXTURES / "security" / "vulnerable_service.py",
+            work / "vulnerable_service.py",
+        )
+        t0 = time.monotonic()
+        result = await _run_gate_workflow("secure-release", path=str(work))
+        dur = time.monotonic() - t0
+
+    go_no_go = getattr(result, "go_no_go", "?")
+    passed = go_no_go != "GO"
+    reason = (
+        f"fail-closed: planted-critical fixture yielded {go_no_go}"
+        if passed
+        else "returned GO on a planted-critical fixture (fail-open)"
+    )
+    return ProbeResult(
+        name="secure-release",
+        passed=passed,
+        reason=reason,
+        cost_usd=float(getattr(result, "total_cost", 0.0) or 0.0),
+        duration_s=dur,
+        evidence={
+            "go_no_go": go_no_go,
+            "critical_count": getattr(result, "critical_count", None),
+            "high_count": getattr(result, "high_count", None),
+            "blockers": len(getattr(result, "blockers", []) or []),
+        },
+    )
+
+
+async def probe_health_check(budget: float) -> ProbeResult:
+    """A bare, unmeasurable dir must surface DEGRADED/N-A — never a
+    fabricated perfect grade (#2209)."""
+    import time
+
+    _budget_env(budget)
+    with tempfile.TemporaryDirectory() as tmp:
+        work = Path(tmp)
+        shutil.copy(FIXTURES / "testgen" / "orders.py", work / "orders.py")
+        t0 = time.monotonic()
+        result = await _run_gate_workflow("health-check", path=str(work))
+        dur = time.monotonic() - t0
+
+    degraded = bool(getattr(result, "degraded", False))
+    grade = str(getattr(result, "grade", "?"))
+    passed = degraded or grade == "N/A"
+    reason = (
+        f"honest incomplete-data verdict (degraded={degraded}, grade={grade})"
+        if passed
+        else f"fabricated a complete verdict (grade={grade}, degraded=False) on an unmeasurable dir"
+    )
+    report = result.to_dict() if hasattr(result, "to_dict") else {}
+    return ProbeResult(
+        name="health-check",
+        passed=passed,
+        reason=reason,
+        cost_usd=float(report.get("total_cost", 0.0) or 0.0),
+        duration_s=dur,
+        evidence={"degraded": degraded, "grade": grade, "score": report.get("score")},
+    )
+
+
+async def probe_doc_orchestrator(budget: float) -> ProbeResult:
+    """No fabricated 'no gaps': either the scan is honestly DEGRADED,
+    or it ran and found the planted doc gap (#2209)."""
+    import time
+
+    _budget_env(budget)
+    with tempfile.TemporaryDirectory() as tmp:
+        work = Path(tmp)
+        shutil.copy(
+            FIXTURES / "analytical" / "sample_service.py",
+            work / "sample_service.py",
+        )
+        # An unambiguous, coarse-granularity doc gap: NO module
+        # docstring at all (index-based scans may not see per-function
+        # gaps; a bare module is a gap at every granularity).
+        (work / "undocumented_util.py").write_text(
+            "def helper(x):\n    return x * 2\n\n\n" "def other_helper(y):\n    return y - 1\n",
+            encoding="utf-8",
+        )
+        t0 = time.monotonic()
+        result = await _run_gate_workflow("doc-orchestrator", path=str(work))
+        dur = time.monotonic() - t0
+
+    degraded = bool(getattr(result, "degraded", False))
+    items_found = int(getattr(result, "items_found", 0) or 0)
+    passed = degraded or items_found > 0
+    reason = (
+        f"honest scan (degraded={degraded}, items_found={items_found})"
+        if passed
+        else "claimed a real scan found no gaps on a fixture with a planted doc gap"
+    )
+    return ProbeResult(
+        name="doc-orchestrator",
+        passed=passed,
+        reason=reason,
+        cost_usd=float(getattr(result, "total_cost", 0.0) or 0.0),
+        duration_s=dur,
+        evidence={"degraded": degraded, "items_found": items_found},
+    )
+
+
+async def probe_release_prep(budget: float) -> ProbeResult:
+    """The deterministic gate must FAIL an untested fixture — a PASS on
+    a dir with no tests is fabrication ($0, rule-based)."""
+    import time
+
+    _budget_env(budget)
+    with tempfile.TemporaryDirectory() as tmp:
+        work = Path(tmp)
+        _stage(work)
+        # A test that FAILS: any release gate that actually runs the
+        # suite must FAIL this fixture — a PASS is proof the gate never
+        # engaged the planted failure (absence-as-pass, P7).
+        (work / "test_planted_failure.py").write_text(
+            '"""Planted failing test for the release-prep gate probe."""\n\n\n'
+            "def test_planted_failure():\n"
+            "    assert False, 'planted: the release gate must see this failure'\n",
+            encoding="utf-8",
+        )
+        t0 = time.monotonic()
+        result = await _run_gate_workflow("release-prep", path=str(work))
+        dur = time.monotonic() - t0
+
+    success = bool(getattr(result, "success", True))
+    passed = not success
+    reason = (
+        "honest FAIL verdict on an untested fixture"
+        if passed
+        else "PASSED release gates on a fixture with no tests (fabrication)"
+    )
+    return ProbeResult(
+        name="release-prep",
+        passed=passed,
+        reason=reason,
+        cost_usd=_cost_of(result),
+        duration_s=dur,
+        evidence={"gate_success": success},
+    )
+
+
 PROBES: dict[str, Callable[[float], Any]] = {
     "security-audit": probe_security_audit,
     "dependency-check": probe_dependency_check,
@@ -772,6 +947,10 @@ PROBES: dict[str, Callable[[float], Any]] = {
     "discovery-sweep": probe_discovery_sweep,
     "release-notes": probe_release_notes,
     **{name: _make_analytical_probe(name) for name in _ANALYTICAL},
+    "secure-release": probe_secure_release,
+    "health-check": probe_health_check,
+    "doc-orchestrator": probe_doc_orchestrator,
+    "release-prep": probe_release_prep,
 }
 
 
@@ -808,6 +987,10 @@ _RECEIPT_TYPES: dict[str, str] = {
     "discovery-sweep": "lane-accounting",
     "release-notes": "metric-crosscheck",
     **dict.fromkeys(_ANALYTICAL, "named-defect"),
+    "secure-release": "fail-closed-gate",
+    "health-check": "fail-closed-gate",
+    "doc-orchestrator": "fail-closed-gate",
+    "release-prep": "fail-closed-gate",
 }
 
 

--- a/tests/unit/scripts/test_workflow_probe_runner.py
+++ b/tests/unit/scripts/test_workflow_probe_runner.py
@@ -364,17 +364,26 @@ def test_doc_orchestrator_probe_rejects_fabricated_no_gaps() -> None:
 
 
 def test_release_prep_probe_requires_honest_fail() -> None:
-    # The deterministic gate must FAIL an untested fixture; a PASS is
-    # fabrication.
-    class _Passed:
+    # #2221 correction: release-prep's execute() returns success=True
+    # even when BLOCKED — the verdict is metadata["approved"]. The
+    # probe judges THAT key; a missing key is a phantom-read failure,
+    # never a silent pass.
+    class _Approved:
         success = True
         cost_report = None
+        metadata = {"approved": True, "confidence": "high"}
 
-    class _Failed(_Passed):
-        success = False
+    class _Blocked(_Approved):
+        metadata = {"approved": False, "confidence": "low"}
 
-    assert not _with_gate_stub(_Passed(), runner.probe_release_prep).passed
-    assert _with_gate_stub(_Failed(), runner.probe_release_prep).passed
+    class _NoKey(_Approved):
+        metadata = {"confidence": "high"}
+
+    assert not _with_gate_stub(_Approved(), runner.probe_release_prep).passed
+    assert _with_gate_stub(_Blocked(), runner.probe_release_prep).passed
+    missing = _with_gate_stub(_NoKey(), runner.probe_release_prep)
+    assert not missing.passed
+    assert "approved" in missing.reason
 
 
 def test_every_probe_has_a_receipt_type() -> None:

--- a/tests/unit/scripts/test_workflow_probe_runner.py
+++ b/tests/unit/scripts/test_workflow_probe_runner.py
@@ -284,6 +284,99 @@ def test_write_record_is_append_only(tmp_path) -> None:
     assert first.exists() and second.exists()
 
 
+def _with_gate_stub(result_obj, probe_coro_factory):
+    """Run one gate probe with _run_gate_workflow stubbed to result_obj."""
+    import asyncio
+
+    async def fake(name, **kwargs):
+        return result_obj
+
+    original = runner._run_gate_workflow
+    runner._run_gate_workflow = fake
+    try:
+        return asyncio.run(probe_coro_factory(1.0))
+    finally:
+        runner._run_gate_workflow = original
+
+
+def test_secure_release_probe_fails_on_go() -> None:
+    # The Sev1 shape: GO on a planted-critical fixture must FAIL the
+    # probe; NO_GO and CONDITIONAL both pass (fail-closed).
+    class _Go:
+        go_no_go = "GO"
+        total_cost = 1.0
+        critical_count = 0
+        high_count = 0
+        blockers: list = []
+
+    class _NoGo(_Go):
+        go_no_go = "NO_GO"
+
+    class _Cond(_Go):
+        go_no_go = "CONDITIONAL"
+
+    assert not _with_gate_stub(_Go(), runner.probe_secure_release).passed
+    assert _with_gate_stub(_NoGo(), runner.probe_secure_release).passed
+    assert _with_gate_stub(_Cond(), runner.probe_secure_release).passed
+
+
+def test_health_check_probe_rejects_fabricated_perfection() -> None:
+    # The Sev2 shape: a complete-looking grade with degraded=False on an
+    # unmeasurable dir fails; degraded=True or grade N/A passes.
+    class _Fabricated:
+        degraded = False
+        grade = "A"
+
+        def to_dict(self):
+            return {"score": 100, "total_cost": 0.0}
+
+    class _Honest(_Fabricated):
+        degraded = True
+        grade = "C"
+
+    class _NA(_Fabricated):
+        degraded = False
+        grade = "N/A"
+
+    assert not _with_gate_stub(_Fabricated(), runner.probe_health_check).passed
+    assert _with_gate_stub(_Honest(), runner.probe_health_check).passed
+    assert _with_gate_stub(_NA(), runner.probe_health_check).passed
+
+
+def test_doc_orchestrator_probe_rejects_fabricated_no_gaps() -> None:
+    # The Sev5 shape: "scan found no gaps" (degraded=False, 0 items) on
+    # a fixture WITH a planted doc gap fails; honest degraded or a scan
+    # that found the gap passes.
+    class _NoGaps:
+        degraded = False
+        items_found = 0
+        total_cost = 0.0
+
+    class _Degraded(_NoGaps):
+        degraded = True
+
+    class _Found(_NoGaps):
+        items_found = 3
+
+    assert not _with_gate_stub(_NoGaps(), runner.probe_doc_orchestrator).passed
+    assert _with_gate_stub(_Degraded(), runner.probe_doc_orchestrator).passed
+    assert _with_gate_stub(_Found(), runner.probe_doc_orchestrator).passed
+
+
+def test_release_prep_probe_requires_honest_fail() -> None:
+    # The deterministic gate must FAIL an untested fixture; a PASS is
+    # fabrication.
+    class _Passed:
+        success = True
+        cost_report = None
+
+    class _Failed(_Passed):
+        success = False
+
+    assert not _with_gate_stub(_Passed(), runner.probe_release_prep).passed
+    assert _with_gate_stub(_Failed(), runner.probe_release_prep).passed
+
+
 def test_every_probe_has_a_receipt_type() -> None:
     # A probe without a receipt-type mapping would silently default;
     # keep the map total over the fleet of probes.


### PR DESCRIPTION
Lands the gate-group probe batch (queue item 5 from the post-14.1.0 starter): the unpushed `claude/gate-group-probes` work cherry-picked onto current main, with all four queued corrections applied BEFORE any billed validation:

- **release-prep probe** judges `metadata["approved"]` (#2221 correction — `execute()` returns `success=True` even when BLOCKED, so the old read was vacuous); a missing key is a phantom-read FAILURE. Unit test pins approved/blocked/missing-key.
- **doc-orchestrator probe** runs `dry_run=True` (constructor flag via a `_ctor` passthrough) — validates scan honesty without generation spend.
- **discovery-sweep probe** budget scales with lane count (flat $5 under-budgeted 7 LLM lanes).
- **secure-release probe** re-run against the #2222 fix.

Fresh live records, all PASS ($1.16 total): secure-release fail-closed NO_GO on the planted-critical fixture; release-prep honest BLOCKED on a planted failing test ($0); doc-orchestrator honest scan finding 14 gaps ($0, dry-run). Registry re-projected (CI's `--check` guard is satisfied); 403 scripts-suite tests green.

Supersedes the unpushed `claude/gate-group-probes` branch (this is the fold — that branch can be deleted after merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
