### PR TITLE
chore: retro fixes — ci_local.sh CI mirror + probe-runner --run append

### DIFF
--- a/scripts/ci_local.sh
+++ b/scripts/ci_local.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Run the test suite EXACTLY as CI's test lane does (retro 2026-08-24
+# item 3.2). Two local-run mistakes this mirrors away:
+#
+#   1. Scope: CI collects the WHOLE tests/ tree — local sweeps scoped
+#      to tests/unit missed top-level tests/models + tests/security
+#      failures twice on 2026-08-24.
+#   2. Auth: CI sets ANTHROPIC_API_KEY to the EMPTY STRING (keyless).
+#      Unsetting it instead lets load_dotenv inject the real key from
+#      ~/.attune/anthropic.env and a "keyless" run spends real money
+#      (corpus lesson, 2026-06-10).
+#
+# Mirrors .github/workflows/tests.yml's test-lane invocation. If that
+# workflow's pytest line changes, change this in the same PR —
+# tests/unit/scripts/test_ci_local_mirror.py pins the two stay in sync.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+ANTHROPIC_API_KEY="" pytest -n auto --timeout=60 --timeout-method=thread -m "not network and not integration" "$@"

--- a/scripts/workflow_probe_runner.py
+++ b/scripts/workflow_probe_runner.py
@@ -1126,8 +1126,13 @@ def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "--run",
-        default="",
-        help="comma-separated probe names to run (billed)",
+        action="append",
+        default=[],
+        help=(
+            "probe names to run (billed); comma-separated and/or "
+            "repeated — earlier a repeated --run silently kept only "
+            "the last value (retro 2026-08-24 item 3.3)"
+        ),
     )
     parser.add_argument("--all", action="store_true", help="run every probe (billed)")
     parser.add_argument(
@@ -1159,7 +1164,7 @@ def main(argv: list[str] | None = None) -> int:
     if args.all:
         selected = list(PROBE_ORDER)
     elif args.run:
-        selected = [p.strip() for p in args.run.split(",") if p.strip()]
+        selected = [p.strip() for chunk in args.run for p in chunk.split(",") if p.strip()]
     else:
         selected = []
 

--- a/tests/unit/scripts/test_ci_local_mirror.py
+++ b/tests/unit/scripts/test_ci_local_mirror.py
@@ -1,0 +1,37 @@
+"""Drift guard: scripts/ci_local.sh mirrors CI's test-lane invocation.
+
+Retro 2026-08-24 item 3.2: local runs scoped to tests/unit missed
+CI-visible failures twice in one night. The script exists so "run what
+CI runs" is one command; this test fails if the two invocations drift.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under Apache 2.0
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+CI_PYTEST_LINE = (
+    'pytest -n auto --timeout=60 --timeout-method=thread -m "not network and not integration"'
+)
+
+
+def test_script_matches_ci_invocation() -> None:
+    script = (REPO_ROOT / "scripts" / "ci_local.sh").read_text(encoding="utf-8")
+    assert CI_PYTEST_LINE in script
+
+
+def test_ci_workflow_still_uses_that_invocation() -> None:
+    workflow = (REPO_ROOT / ".github" / "workflows" / "tests.yml").read_text(encoding="utf-8")
+    assert CI_PYTEST_LINE in workflow, (
+        "tests.yml's pytest line changed — update scripts/ci_local.sh "
+        "and this constant in the same PR"
+    )
+
+
+def test_script_is_keyless_by_empty_string() -> None:
+    script = (REPO_ROOT / "scripts" / "ci_local.sh").read_text(encoding="utf-8")
+    assert 'ANTHROPIC_API_KEY=""' in script  # empty, never unset

--- a/tests/unit/scripts/test_workflow_probe_runner.py
+++ b/tests/unit/scripts/test_workflow_probe_runner.py
@@ -391,3 +391,19 @@ def test_every_probe_has_a_receipt_type() -> None:
     # keep the map total over the fleet of probes.
     for name in runner.PROBE_ORDER:
         assert name in runner._RECEIPT_TYPES
+
+
+def test_run_flag_accepts_repeats_and_commas() -> None:
+    # Retro 2026-08-24 item 3.3: repeated --run silently kept only the
+    # last value (argparse default store); it now appends and flattens.
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--run", action="append", default=[])
+    ns = parser.parse_args(["--run", "a,b", "--run", "c"])
+    flat = [p.strip() for chunk in ns.run for p in chunk.split(",") if p.strip()]
+    assert flat == ["a", "b", "c"]
+
+
+def test_unknown_probe_rejected_with_repeated_flags() -> None:
+    assert runner.main(["--run", "security-audit", "--run", "not-a-real-probe"]) == 1


### PR DESCRIPTION
Two ratified retro items shipped, one closed with a receipt:

- **3.2** `scripts/ci_local.sh` — CI's exact test-lane invocation (whole tree, keyless-by-empty-string) + a drift guard pinning it to tests.yml.
- **3.3** probe-runner `--run` now appends and comma-flattens (a repeated flag silently kept only the last value — one batch ran 1 of 3 probes).
- **3.1** (on-save hook strips imports) — **invalid premise, receipted**: the hook has ignored F401/F811 since #2029 and a live probe survives it. No change shipped.

D12 (autonomous-session arming) recorded in the auto-merge memory. 411 scripts-suite tests green; `ci_local.sh --collect-only` gathers the full 25k-test tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)