### PR TITLE
chore(scripts): bg_run.sh — raw-log wrapper for background runs

### DIFF
--- a/scripts/bg_run.sh
+++ b/scripts/bg_run.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Run a command writing RAW output to a log — never pipe a background
+# run (retro 2026-08-24 item 3.1: `... | tail` and `... | grep` buffer
+# until exit, so the task's output file stays EMPTY for the whole run
+# and progress is invisible; hit live twice in one day, and the trap
+# is documented in the lessons corpus).
+#
+# Usage:  scripts/bg_run.sh <logfile> <command> [args...]
+# Filter at READ time instead:  tail -f <logfile> | grep PASS
+set -euo pipefail
+if [ "$#" -lt 2 ]; then
+  echo "usage: bg_run.sh <logfile> <command> [args...]" >&2
+  exit 125
+fi
+log="$1"; shift
+"$@" >"$log" 2>&1


### PR DESCRIPTION
Retro item 3.1: never pipe a backgrounded run — tail/grep buffer until exit and the log stays empty for the whole run (hit twice on 2026-08-24). `scripts/bg_run.sh <log> <cmd...>` writes raw output; filter at read time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)