### PR TITLE
ci: add repository-signed control proof

### DIFF
--- a/.agent-vigil-control-policy.json
+++ b/.agent-vigil-control-policy.json
@@ -1,0 +1,19 @@
+{
+  "schemaVersion": "agent-vigil-control-policy/v1",
+  "policyId": "attune-signed-control-v1",
+  "organization": "Smart-AI-Memory",
+  "maxAgeHours": 168,
+  "repositories": [
+    {
+      "repository": "Smart-AI-Memory/attune-ai",
+      "requiredCheck": "Attune signed control proof",
+      "allowedControls": [
+        "Smart-AI-Memory/attune-governance@sha256:0000000000000000000000000000000000000000000000000000000000000000"
+      ],
+      "requiredChallenges": [
+        "collaboration-projection",
+        "workflow-policy"
+      ]
+    }
+  ]
+}

--- a/.github/workflows/agent-vigil-control-proof.yml
+++ b/.github/workflows/agent-vigil-control-proof.yml
@@ -1,0 +1,173 @@
+name: Attune signed control proof
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - ".agent-vigil-control-policy.json"
+      - ".github/workflows/agent-vigil-control-proof.yml"
+  schedule:
+    - cron: "23 8 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  certify:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Check out Attune AI
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Run Attune control challenges
+        shell: bash
+        run: |
+          set +e
+          python -m pip install -e ".[dev]" >"$RUNNER_TEMP/dependencies.log" 2>&1
+          dependencies_status=$?
+          cat "$RUNNER_TEMP/dependencies.log"
+
+          if [[ "$dependencies_status" -eq 0 ]]; then
+            python scripts/project_collaboration_contract.py --check >"$RUNNER_TEMP/collaboration-projection.log" 2>&1
+            echo "$?" >"$RUNNER_TEMP/collaboration-projection.status"
+            pytest -q tests/unit/ci/test_workflow_yaml.py tests/unit/ci/test_ci_spend_guard.py >"$RUNNER_TEMP/workflow-policy.log" 2>&1
+            echo "$?" >"$RUNNER_TEMP/workflow-policy.status"
+          else
+            printf 'dependency installation failed with exit code %s\n' "$dependencies_status" >"$RUNNER_TEMP/collaboration-projection.log"
+            printf 'dependency installation failed with exit code %s\n' "$dependencies_status" >"$RUNNER_TEMP/workflow-policy.log"
+            echo "$dependencies_status" >"$RUNNER_TEMP/collaboration-projection.status"
+            echo "$dependencies_status" >"$RUNNER_TEMP/workflow-policy.status"
+          fi
+
+          cat "$RUNNER_TEMP/collaboration-projection.log"
+          cat "$RUNNER_TEMP/workflow-policy.log"
+          exit 0
+
+      - name: Build signed proof payload
+        shell: bash
+        run: |
+          node <<'NODE'
+          const crypto = require("node:crypto");
+          const fs = require("node:fs");
+          const path = require("node:path");
+          const root = process.env.RUNNER_TEMP;
+          const readStatus = (name) => Number(fs.readFileSync(path.join(root, `${name}.status`), "utf8").trim());
+          const digest = (name) => `sha256:${crypto.createHash("sha256").update(fs.readFileSync(path.join(root, `${name}.log`))).digest("hex")}`;
+          const result = (id) => {
+            const passed = readStatus(id) === 0;
+            return { id, expected: "PASS", actual: passed ? "PASS" : "ERROR", passed, evidenceHash: digest(id) };
+          };
+          const challenges = [result("collaboration-projection"), result("workflow-policy")];
+          const passed = challenges.filter((challenge) => challenge.passed).length;
+          const payload = {
+            control: { vendor: "Smart-AI-Memory", product: "attune-governance", version: process.env.GITHUB_SHA },
+            sourceCommit: process.env.GITHUB_SHA,
+            generatedAt: new Date().toISOString(),
+            status: passed === challenges.length ? "PASS" : "HOLD",
+            challenges,
+            summary: { passed, total: challenges.length },
+            limits: [
+              "The signer reports command exit status and retained log hashes.",
+              "Agent Vigil verifies the signed claim but does not reconstruct the Attune AI test environment."
+            ]
+          };
+          fs.writeFileSync(path.join(root, "control-proof-payload.json"), `${JSON.stringify(payload, null, 2)}\n`, { mode: 0o600 });
+          NODE
+
+      - name: Check out Agent Vigil
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: sulmusic2-star/agent-vigil
+          ref: be3161fb7a85a4d69af6356e6c453ffd72ebac97
+          path: .agent-vigil-tool
+
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: .agent-vigil-tool/package-lock.json
+
+      - name: Build Agent Vigil
+        working-directory: .agent-vigil-tool
+        run: npm ci && npm run build
+
+      - id: signing-key
+        name: Configure the repository signing key
+        shell: bash
+        env:
+          SIGNING_KEY: ${{ secrets.AGENT_VIGIL_SIGNING_KEY }}
+        run: |
+          if [[ -z "$SIGNING_KEY" ]]; then
+            echo "configured=false" >>"$GITHUB_OUTPUT"
+            echo "AGENT_VIGIL_SIGNING_KEY is not configured" >&2
+            exit 0
+          fi
+          if grep -q 'sha256:0000000000000000000000000000000000000000000000000000000000000000' .agent-vigil-control-policy.json; then
+            echo "configured=false" >>"$GITHUB_OUTPUT"
+            echo "the control policy still contains the placeholder signer identity" >&2
+            exit 0
+          fi
+          umask 077
+          printf '%s' "$SIGNING_KEY" >"$RUNNER_TEMP/provider-private.pem"
+          openssl pkey -in "$RUNNER_TEMP/provider-private.pem" -pubout -out "$RUNNER_TEMP/provider-public.pem"
+          echo "configured=true" >>"$GITHUB_OUTPUT"
+
+      - name: Sign and verify the control proof
+        if: steps.signing-key.outputs.configured == 'true'
+        shell: bash
+        run: |
+          set +e
+          cli=".agent-vigil-tool/dist/cli.js"
+          node "$cli" certify sign "$RUNNER_TEMP/control-proof-payload.json" --private-key "$RUNNER_TEMP/provider-private.pem" --output "$RUNNER_TEMP/signed-control-proof.json"
+          test -s "$RUNNER_TEMP/signed-control-proof.json" || exit 1
+          node "$cli" certify record-signed "$RUNNER_TEMP/signed-control-proof.json" --public-key "$RUNNER_TEMP/provider-public.pem" --organization Smart-AI-Memory --repository Smart-AI-Memory/attune-ai --required-check "Attune signed control proof" --output "$RUNNER_TEMP/control-certificate.json"
+          test -s "$RUNNER_TEMP/control-certificate.json" || exit 1
+          node "$cli" certify add "$RUNNER_TEMP/control-certificate.json" --corpus "$RUNNER_TEMP/control-corpus.jsonl"
+          test -s "$RUNNER_TEMP/control-corpus.jsonl" || exit 1
+          node "$cli" certify status --corpus "$RUNNER_TEMP/control-corpus.jsonl" --policy .agent-vigil-control-policy.json --format json --output "$RUNNER_TEMP/control-status.json"
+          test -s "$RUNNER_TEMP/control-status.json" || exit 1
+          exit 0
+
+      - name: Retain the certificate bundle
+        if: always() && steps.signing-key.outputs.configured == 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: attune-signed-control-${{ github.run_id }}
+          retention-days: 90
+          if-no-files-found: error
+          path: |
+            ${{ runner.temp }}/collaboration-projection.log
+            ${{ runner.temp }}/workflow-policy.log
+            ${{ runner.temp }}/control-proof-payload.json
+            ${{ runner.temp }}/signed-control-proof.json
+            ${{ runner.temp }}/control-certificate.json
+            ${{ runner.temp }}/control-corpus.jsonl
+            ${{ runner.temp }}/control-status.json
+            ${{ runner.temp }}/provider-public.pem
+            .agent-vigil-control-policy.json
+
+      - name: Enforce fresh status
+        if: always()
+        shell: bash
+        env:
+          CONFIGURED: ${{ steps.signing-key.outputs.configured }}
+        run: |
+          if [[ "$CONFIGURED" != "true" ]]; then
+            echo "signed control proof is not configured" >&2
+            exit 1
+          fi
+          node -e 'const fs=require("node:fs"); const p=process.env.RUNNER_TEMP+"/control-status.json"; const r=JSON.parse(fs.readFileSync(p,"utf8")); if(r.status!=="PASS"||r.summary.fresh!==r.summary.total) process.exit(1)'


### PR DESCRIPTION
## Description

Add a weekly and manually triggered signed control proof for Attune's existing collaboration and workflow-policy gates.

The workflow records command exit status and SHA-256 hashes of the retained logs, signs that small payload with an Attune-controlled Ed25519 key, verifies it with [Agent Vigil v0.16.0](https://github.com/sulmusic2-star/agent-vigil/releases/tag/v0.16.0), and retains the proof, certificate, policy, public key, logs, corpus entry, and freshness result for 90 days. It does not upload an agent transcript.

This is a draft because the repository owner must create the signing key, store it as `AGENT_VIGIL_SIGNING_KEY`, and replace the all-zero key ID in `.agent-vigil-control-policy.json` before merge. The placeholder fails closed.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🎨 Code style update (formatting, renaming)
- [ ] ♻️ Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] ✅ Test update
- [x] 🔧 Build/config update
- [ ] 🔒 Security fix

## Related Issues

No existing issue.

## Changes Made

- Run `project_collaboration_contract.py --check` and the repository's workflow-policy tests.
- Sign the exact-commit results with a repository-owned key.
- Pin the accepted signer in policy and require a fresh certificate no more than 168 hours old.
- Retain a self-contained certificate bundle for 90 days.

## Testing

- [ ] All existing tests pass
- [ ] Added new tests for new functionality
- [ ] Tested on multiple Python versions (3.10, 3.11, 3.12)
- [ ] Tested on multiple platforms (Linux, macOS, Windows)
- [x] Manual testing performed

### Test Commands Run

```bash
python scripts/project_collaboration_contract.py --check
python -m pytest -o addopts='' -q tests/unit/ci/test_workflow_yaml.py tests/unit/ci/test_ci_spend_guard.py
actionlint .github/workflows/agent-vigil-control-proof.yml
```

Results on candidate commit `b65e5d76a139551333681f72a8e3a3c21fd17e04`:

- Repository preflight: 81 governance tests passed.
- Workflow-policy suite: 340 passed, 1 skipped.
- Actionlint: passed.
- Disposable-key integration run: `FRESH`.
- Wrong public key: rejected.
- Altered evidence hash: rejected.
- Placeholder policy: `HOLD`.
- Certificate evaluated after 169 hours: `STALE`.

The disposable local key was destroyed. It is not the key proposed for Attune.

## Checklist

- [x] My code follows the project's code style (Black, Ruff)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
- [ ] I have updated the CHANGELOG.md (if applicable)
- [x] Pre-commit hooks pass without errors

## Additional Context

Agent Vigil verifies the signed claim, exact source commit, signer identity, evidence hashes, required challenges, and freshness. It does not independently reconstruct Attune's test environment or prove that a GitHub ruleset requires this workflow.

The private key stays in an Attune repository secret. The retained artifact contains only the public key.

## License Acknowledgment

- [x] I confirm that my contributions are made under the Apache License 2.0
- [x] I have read and agree to the [Contributing Guidelines](../CONTRIBUTING.md)

---

**For Reviewers:**

- [ ] Code quality and style
- [ ] Test coverage
- [ ] Documentation updates
- [ ] Breaking changes identified
- [ ] Security considerations reviewed
- [ ] Performance impact assessed

## Hosted smoke run

A fork-only smoke child of the prior candidate changed only the policy key ID to a disposable fork-owned signer and ran this workflow on GitHub's Ubuntu runner: [run 32739035831](https://github.com/sulmusic2-star/attune-ai/actions/runs/32739035831).

All steps passed in 1 minute 2 seconds. The retained V2 certificate reported `FRESH` for two required challenges. The fork secret was deleted after the artifact was downloaded. The workflow and policy diff is unchanged after rebasing onto current `main`. This verifies the hosted workflow path; it is not an Attune-owned signature and is not presented as independent adoption.
