### PR TITLE
fix(probes): scrub env for test-gen's emitted-test subprocesses

### DIFF
--- a/scripts/workflow_probe_runner.py
+++ b/scripts/workflow_probe_runner.py
@@ -528,6 +528,35 @@ def _extract_test_code(text: str) -> str:
     return "\n\n".join(blocks)
 
 
+def _scrubbed_env() -> dict[str, str]:
+    """Env for subprocesses that execute LLM-emitted code.
+
+    LLM-emitted code runs with a SCRUBBED env (codex D11 lane on
+    #2273, critical): the runner's env holds live credentials
+    (ANTHROPIC_API_KEY et al.) that emitted examples and tests have
+    no business reading. The scrub is an ALLOWLIST of
+    platform-essential vars — on Windows a Python child without
+    SYSTEMROOT dies at startup ("_Py_HashRandomization_Init: failed
+    to get random numbers", live on main 2026-08-24; fixed in #2279);
+    credentials stay excluded either way. On macOS/Linux, PATH alone
+    suffices — pytest needs no HOME/TMPDIR, and ``python -m`` puts
+    the cwd on sys.path for staged-module imports.
+    """
+    return {
+        k: os.environ[k]
+        for k in (
+            "PATH",
+            "SYSTEMROOT",
+            "PATHEXT",
+            "COMSPEC",
+            "TEMP",
+            "TMP",
+            "WINDIR",
+        )
+        if k in os.environ
+    }
+
+
 async def probe_test_gen(budget: float) -> ProbeResult:
     import time
 
@@ -562,6 +591,7 @@ async def probe_test_gen(budget: float) -> ProbeResult:
                 capture_output=True,
                 text=True,
                 timeout=180,
+                env=_scrubbed_env(),
             )
             source_note = "files_on_disk"
             emitted_chars = sum(len(p.read_text(encoding="utf-8")) for p in real_files)
@@ -593,6 +623,7 @@ async def probe_test_gen(budget: float) -> ProbeResult:
                 capture_output=True,
                 text=True,
                 timeout=180,
+                env=_scrubbed_env(),
             )
             source_note = "report_fence"
             emitted_chars = len(code)
@@ -1124,28 +1155,7 @@ async def probe_doc_gen(budget: float) -> ProbeResult:
                 capture_output=True,
                 text=True,
                 timeout=120,
-                # LLM-emitted code runs with a SCRUBBED env (codex D11
-                # lane, critical): the runner's env holds live
-                # credentials (ANTHROPIC_API_KEY et al.) that a doc
-                # example has no business reading. The scrub is an
-                # ALLOWLIST of platform-essential vars — on Windows a
-                # Python child without SYSTEMROOT dies at startup
-                # ("_Py_HashRandomization_Init: failed to get random
-                # numbers", live on main 2026-08-24); credentials stay
-                # excluded either way.
-                env={
-                    k: os.environ[k]
-                    for k in (
-                        "PATH",
-                        "SYSTEMROOT",
-                        "PATHEXT",
-                        "COMSPEC",
-                        "TEMP",
-                        "TMP",
-                        "WINDIR",
-                    )
-                    if k in os.environ
-                },
+                env=_scrubbed_env(),
             )
             if proc.returncode != 0:
                 tail = "\n".join((proc.stdout + proc.stderr).splitlines()[-4:])

--- a/tests/unit/scripts/test_workflow_probe_runner.py
+++ b/tests/unit/scripts/test_workflow_probe_runner.py
@@ -870,3 +870,81 @@ def test_run_selected_crashed_probe_records_the_budget_cap(monkeypatch) -> None:
     ledger = Path(os.environ["ATTUNE_SESSION_LEDGER_PATH"])
     entries = [json.loads(line) for line in ledger.read_text().splitlines()]
     assert entries[0]["cost_usd"] == 3.0
+
+
+def test_emitted_tests_run_with_scrubbed_env_files_on_disk() -> None:
+    # Codex D11 lane on #2273 (critical), same class as probe_doc_gen's
+    # scrub: LLM-emitted test code must not see the runner's
+    # credentials. A canary in the runner env must be invisible to the
+    # pytest subprocess — the staged test FAILS if it can read it, so
+    # a leak fails this test via out.passed.
+    import asyncio
+    import os as _os
+    from pathlib import Path as _Path
+
+    class _R:
+        success = True
+        error = None
+        metadata: dict = {}
+        final_output = "x"
+        cost_report = None
+        summary = ""
+
+    async def fake_run(name, **kwargs):
+        gen = _Path(kwargs["path"]) / "tests" / "generated"
+        gen.mkdir(parents=True)
+        (gen / "test_probe_canary.py").write_text(
+            "import os\n\n"
+            "def test_env_scrubbed():\n"
+            "    assert os.environ.get('PROBE_ENV_CANARY') is None\n",
+            encoding="utf-8",
+        )
+        return _R()
+
+    original = runner._run_workflow
+    runner._run_workflow = fake_run
+    _os.environ["PROBE_ENV_CANARY"] = "leaked"
+    try:
+        out = asyncio.run(runner.probe_test_gen(1.0))
+    finally:
+        runner._run_workflow = original
+        del _os.environ["PROBE_ENV_CANARY"]
+    assert out.passed, out.reason
+    assert out.evidence["files_written"] == 1
+
+
+def test_emitted_tests_run_with_scrubbed_env_report_fence() -> None:
+    # Same canary for the fallback path: fence-extracted test code is
+    # executed with the scrubbed env too.
+    import asyncio
+    import os as _os
+
+    class _R:
+        success = True
+        error = None
+        metadata = {
+            "raw_result_text": (
+                "```python\n"
+                "import os\n\n"
+                "def test_env_scrubbed():\n"
+                "    assert os.environ.get('PROBE_ENV_CANARY') is None\n"
+                "```\n"
+            )
+        }
+        final_output = "x"
+        cost_report = None
+        summary = ""
+
+    async def fake_run(name, **kwargs):
+        return _R()
+
+    original = runner._run_workflow
+    runner._run_workflow = fake_run
+    _os.environ["PROBE_ENV_CANARY"] = "leaked"
+    try:
+        out = asyncio.run(runner.probe_test_gen(1.0))
+    finally:
+        runner._run_workflow = original
+        del _os.environ["PROBE_ENV_CANARY"]
+    assert out.passed, out.reason
+    assert out.evidence["files_written"] == 0


### PR DESCRIPTION
## What

The codex D11 lane on #2273 (2026-08-24) found that executing LLM-emitted code in a subprocess that inherits the runner env exposes live credentials (`ANTHROPIC_API_KEY` et al.). `probe_doc_gen` was fixed in #2273/#2279; `probe_test_gen` had the **same exposure** — both of its pytest `subprocess.run` calls (the `files_on_disk` and `report_fence` paths) inherited the full env.

Both now run with the same platform-var allowlist #2279 gave doc-gen (`PATH` + `SYSTEMROOT`/`PATHEXT`/`COMSPEC`/`TEMP`/`TMP`/`WINDIR` when present — a PATH-only scrub kills Python children on Windows: missing `SYSTEMROOT` → `_Py_HashRandomization_Init` fatal, live on main 2026-08-24).

With three call sites needing the identical allowlist, it's extracted into one `_scrubbed_env()` helper used by doc-gen's example runner and both test-gen pytest runs — three inline copies of a 7-key dict is a drift hazard.

## Receipts

- **Env sufficiency, verified on macOS**: a real pytest subprocess with the scrubbed env passes — pytest needs no `HOME`/`TMPDIR`, and `python -m pytest` puts cwd on `sys.path` so the staged `orders` module still imports. Windows sufficiency receipt = this PR's own required Windows lanes running the new canary tests (the same allowlist already un-redded main for doc-gen in #2279).
- **Canary tests** (mirroring `test_emitted_examples_run_with_scrubbed_env`): `test_emitted_tests_run_with_scrubbed_env_files_on_disk` and `..._report_fence`, one per subprocess path. A `PROBE_ENV_CANARY` var set in the runner env must be invisible to the emitted-test subprocess, asserted from inside the staged test.
- **Mutation-checked** (pre-rebase, PATH-only form): with the `env=` scrub removed, both canary tests FAIL — they're load-bearing, not vacuous. The allowlist keeps the same mechanism and the canary var stays excluded.
- **Suites run post-rebase**: `tests/unit/scripts/test_workflow_probe_runner.py` + `tests/unit/gates` → 432 passed.

## Note on prior receipts

No billed probe re-run was made for this change. The existing executed-tests receipt for `test-gen` (workflow-behavioral-validation records) was produced **pre-scrub**, i.e. with the full runner env inherited by the pytest subprocess. The behavior asserted (emitted tests run and pass) is unaffected by the scrub for well-behaved generated tests; the next scheduled billed run will produce a post-scrub receipt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
