### PR TITLE
feat(telemetry): pass form_id through the collect handler for stage-latency joins

### DIFF
--- a/.agents/skills/elicit/SKILL.md
+++ b/.agents/skills/elicit/SKILL.md
@@ -35,10 +35,15 @@ ordinary Socratic-ambiguity judgement wouldn't already ask.
 
 ## Step 0 — check the template library first (V7)
 
-Recurring fork classes are stored as named JSON templates
-(`src/attune/elicitation/templates/`). **Reach for a template before
-hand-building**: a reused template makes answers comparable across
-sessions (joinable on `FormResponse.template_id`).
+Recurring fork classes are stored as named JSON templates in the
+`attune_forms` package (`attune_forms/templates/` in the installed
+wheel; new templates land in the attune-forms repo). **Reach for a
+template before hand-building**: a reused template makes answers
+comparable across sessions (joinable on `FormResponse.template_id`),
+and from attune-forms 0.8.0 each cast is telemetry-tagged
+`template:<name>` vs `dict` — the adoption signal is measured, so
+hand-building a form a template already covers shows up in the log.
+Check `list_templates()` first; only hand-build when nothing matches.
 
 ```python
 from attune.elicitation import form_from_template, list_templates

--- a/plugin/help/generated/references/skill-elicit.md
+++ b/plugin/help/generated/references/skill-elicit.md
@@ -31,10 +31,15 @@ ordinary Socratic-ambiguity judgement wouldn't already ask.
 
 ## Step 0 — check the template library first (V7)
 
-Recurring fork classes are stored as named JSON templates
-(`src/attune/elicitation/templates/`). **Reach for a template before
-hand-building**: a reused template makes answers comparable across
-sessions (joinable on `FormResponse.template_id`).
+Recurring fork classes are stored as named JSON templates in the
+`attune_forms` package (`attune_forms/templates/` in the installed
+wheel; new templates land in the attune-forms repo). **Reach for a
+template before hand-building**: a reused template makes answers
+comparable across sessions (joinable on `FormResponse.template_id`),
+and from attune-forms 0.8.0 each cast is telemetry-tagged
+`template:<name>` vs `dict` — the adoption signal is measured, so
+hand-building a form a template already covers shows up in the log.
+Check `list_templates()` first; only hand-build when nothing matches.
 
 ```python
 from attune.elicitation import form_from_template, list_templates

--- a/plugin/skills/elicit/SKILL.md
+++ b/plugin/skills/elicit/SKILL.md
@@ -37,10 +37,15 @@ ordinary Socratic-ambiguity judgement wouldn't already ask.
 
 ## Step 0 — check the template library first (V7)
 
-Recurring fork classes are stored as named JSON templates
-(`src/attune/elicitation/templates/`). **Reach for a template before
-hand-building**: a reused template makes answers comparable across
-sessions (joinable on `FormResponse.template_id`).
+Recurring fork classes are stored as named JSON templates in the
+`attune_forms` package (`attune_forms/templates/` in the installed
+wheel; new templates land in the attune-forms repo). **Reach for a
+template before hand-building**: a reused template makes answers
+comparable across sessions (joinable on `FormResponse.template_id`),
+and from attune-forms 0.8.0 each cast is telemetry-tagged
+`template:<name>` vs `dict` — the adoption signal is measured, so
+hand-building a form a template already covers shows up in the log.
+Check `list_templates()` first; only hand-build when nothing matches.
 
 ```python
 from attune.elicitation import form_from_template, list_templates

--- a/src/attune/mcp/server.py
+++ b/src/attune/mcp/server.py
@@ -942,13 +942,13 @@ class AttuneMCPServer(MemoryHandlersMixin, WorkflowHandlersMixin, HandoffHandler
             "responses": response.responses,
             "response_id": response.response_id,
         }
-        hint = self._maybe_keyboard_hint()
+        hint = self._maybe_keyboard_hint(form)
         if hint:
             result["hint"] = hint
         return result
 
     @staticmethod
-    def _maybe_keyboard_hint() -> str | None:
+    def _maybe_keyboard_hint(form: Any = None) -> str | None:
         """Record the submission and return D17's one-time keyboard hint.
 
         A validated submission is the only honest place to count "forms
@@ -959,12 +959,23 @@ class AttuneMCPServer(MemoryHandlersMixin, WorkflowHandlersMixin, HandoffHandler
 
         Best-effort: a telemetry problem must never break the submission
         the user just made.
+
+        Args:
+            form: The validated ``FormSchema``, when the caller has one —
+                its ``form_id`` (attune-forms >= 0.8.0) joins this
+                submission to its ``form_rendered`` event for the
+                stage-latency read-back.
         """
         try:
             from attune.elicitation import keyboard_mode_enabled
             from attune.telemetry.form_events import log_submission, maybe_keyboard_hint
 
-            log_submission()
+            try:
+                log_submission(form_id=getattr(form, "form_id", "") or "")
+            except TypeError:
+                # attune-forms < 0.8.0: zero-arg signature, no form_id
+                # on FormSchema — the submission still counts.
+                log_submission()
             return maybe_keyboard_hint(keyboard_mode=keyboard_mode_enabled())
         except (OSError, ValueError, ImportError) as exc:
             logger.debug("keyboard-mode hint skipped: %s", exc)

--- a/tests/unit/elicitation/test_select_form_surface.py
+++ b/tests/unit/elicitation/test_select_form_surface.py
@@ -277,11 +277,18 @@ _RICH = {
 _TRIVIAL = {"title": "T", "fields": [{"id": "q", "type": "boolean", "text": "Proceed?"}]}
 
 
+def _surface_events() -> list[dict]:
+    """The routing decisions only: attune-forms >= 0.8.0 interleaves
+    ``form_build`` / ``form_rendered`` stage events into the same log, so
+    counting raw lines would break on the dependency upgrade."""
+    return [e for e in _events() if e.get("event") == "form_surface"]
+
+
 def test_render_widget_handler_records_the_decision() -> None:
     result = _run("_handle_elicitation_render_widget", _RICH)
     assert result["success"] is True
 
-    events = _events()
+    events = _surface_events()
     assert len(events) == 1
     assert events[0]["chosen"] == "widget"
     assert events[0]["surface"] == "widget"
@@ -294,7 +301,7 @@ def test_render_form_handler_records_disagreement_and_nudges() -> None:
     assert result["success"] is True
     assert "surface_note" in result  # the nudge back toward the widget
 
-    events = _events()
+    events = _surface_events()
     assert len(events) == 1
     assert events[0]["chosen"] == "ask"
     assert events[0]["surface"] == "widget"
@@ -306,7 +313,7 @@ def test_render_form_handler_stays_quiet_when_ask_is_correct() -> None:
     result = _run("_handle_elicitation_render_form", _TRIVIAL)
     assert "surface_note" not in result
 
-    events = _events()
+    events = _surface_events()
     assert events[0]["agreed"] is True
     assert events[0]["reason"] == "trivial_form"
 

--- a/tests/unit/mcp/test_server_elicitation.py
+++ b/tests/unit/mcp/test_server_elicitation.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+import unittest.mock
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, PropertyMock, patch
 
@@ -115,7 +116,11 @@ async def test_collect_response_returns_validated_answers_and_hint(tmp_path):
             {"form": FORM, "answers": {"target": "src", "depth": "quick"}}
         )
 
-    log_submission.assert_called_once_with()
+    # Called with the form's telemetry join key — an empty string on
+    # attune-forms 0.7.x (no FormSchema.form_id yet), the content hash
+    # on >= 0.8.0. Asserting the kwarg shape keeps this green on both.
+    log_submission.assert_called_once()
+    assert set(log_submission.call_args.kwargs) == {"form_id"}
     assert result["success"] is True
     assert result["responses"] == {"target": "src", "depth": "quick"}
     # forms 0.7.0 appends an 8-hex uniqueness suffix to the response id.
@@ -166,6 +171,40 @@ def test_keyboard_hint_swallows_expected_errors(error, failing_seam):
         result = server_module.AttuneMCPServer._maybe_keyboard_hint()
 
     assert result is None
+
+
+def test_keyboard_hint_falls_back_to_zero_arg_log_submission():
+    """attune-forms < 0.8.0 has ``log_submission()`` with no params —
+    the TypeError falls back to the legacy call instead of dropping the
+    submission (or the hint) on the floor."""
+    log_submission = unittest.mock.Mock(side_effect=[TypeError("old signature"), None])
+    with (
+        patch("attune.telemetry.form_events.log_submission", log_submission),
+        patch("attune.telemetry.form_events.maybe_keyboard_hint", return_value="Press K"),
+        patch("attune.elicitation.keyboard_mode_enabled", return_value=False),
+    ):
+        result = server_module.AttuneMCPServer._maybe_keyboard_hint(
+            SimpleNamespace(form_id="abc123")
+        )
+
+    assert result == "Press K"
+    assert log_submission.call_count == 2
+    assert log_submission.call_args_list[0].kwargs == {"form_id": "abc123"}
+    assert log_submission.call_args_list[1] == unittest.mock.call()
+
+
+def test_keyboard_hint_passes_empty_form_id_without_form():
+    """The zero-arg call path (older in-tree callers, tests) still works:
+    no form object degrades to an empty join key, never an AttributeError."""
+    with (
+        patch("attune.telemetry.form_events.log_submission") as log_submission,
+        patch("attune.telemetry.form_events.maybe_keyboard_hint", return_value=None),
+        patch("attune.elicitation.keyboard_mode_enabled", return_value=False),
+    ):
+        result = server_module.AttuneMCPServer._maybe_keyboard_hint()
+
+    assert result is None
+    log_submission.assert_called_once_with(form_id="")
 
 
 def test_elicitation_session_is_empty_outside_request():

--- a/tests/unit/telemetry/test_form_events.py
+++ b/tests/unit/telemetry/test_form_events.py
@@ -17,6 +17,7 @@ from pathlib import Path
 
 import pytest
 
+import attune.telemetry.form_events as form_events_module
 from attune.telemetry.form_events import (
     _MAX_BYTES,
     _rotate_if_huge,
@@ -226,3 +227,55 @@ class TestInferenceRate:
         assert rate["fields_inferred"] == 4
         assert rate["fully_inferred"] == 1
         assert rate["inferred_share"] == round(4 / 6, 3)
+
+
+# ---------------------------------------------------------------------------
+# Stage telemetry (attune-forms >= 0.8.0) — skipped, not failed, when the
+# installed wheel predates form_id / stage events, so this file stays green
+# across the dependency floor. The implementation's own suite lives in the
+# attune-forms repo; what belongs HERE is the alias-module seam attune-ai
+# actually consumes.
+# ---------------------------------------------------------------------------
+
+
+_STAGE_EVENTS = pytest.mark.skipif(
+    not hasattr(form_events_module, "stage_latency"),
+    reason="stage telemetry needs attune-forms >= 0.8.0",
+)
+
+
+@_STAGE_EVENTS
+class TestStageEventsThroughAlias:
+    def test_stage_loggers_and_latency_round_trip(self, _isolated_home: Path) -> None:
+        form_events_module.log_form_build("f1", source="dict", question_count=2)
+        form_events_module.log_form_rendered("f1", duration_ms=3.0, html_bytes=1024)
+        form_events_module.log_submission(form_id="f1")
+
+        events = [
+            json.loads(line)
+            for line in _events_file(_isolated_home).read_text(encoding="utf-8").splitlines()
+        ]
+        assert [e["event"] for e in events] == [
+            "form_build",
+            "form_rendered",
+            "form_submitted",
+        ]
+        assert {e["form_id"] for e in events} == {"f1"}
+
+        stats = form_events_module.stage_latency()
+        assert stats["builds"] == stats["renders"] == stats["submissions"] == 1
+        assert stats["joined"] == 1
+        assert stats["render_ms"] == {"p50": 3.0, "p95": 3.0, "n": 1}
+
+    def test_form_id_flows_from_dict_to_submission(self, _isolated_home: Path) -> None:
+        """The seam receipt: attune.elicitation's re-exported pipeline and
+        the telemetry alias land on one join key."""
+        from attune.elicitation import form_from_dict
+
+        definition = {
+            "title": "Scope",
+            "fields": [{"id": "goal", "text": "Goal?", "type": "text_input"}],
+        }
+        first = form_from_dict(dict(definition))
+        second = form_from_dict(dict(definition))
+        assert first.form_id and first.form_id == second.form_id


### PR DESCRIPTION
Chair-approved 2026-08-24 (route "1 — measure first"): form telemetry had only `form_surface` + a payload-less `form_submitted`, so per-stage latency was not computable. The implementation lives in attune-forms 0.8.0 (Smart-AI-Memory/attune-forms#59 — `FormSchema.form_id` content-hash join key, `form_build`/`form_rendered`/`form_submitted(form_id)` stage events, `stage_latency()` p50/p95 read-back). This PR is the attune-ai half.

## What's here

- **`_maybe_keyboard_hint(form)`** passes the validated form's `form_id` to `log_submission`, with a `TypeError` fallback so the collect handler works unchanged on attune-forms 0.7.x (zero-arg signature). **No dependency floor bump** — the telemetry lights up automatically when 0.8.0 is installed.
- **Guarded stage tests** through the `attune.telemetry.form_events` alias — `skipif` on the installed capability: skip on 0.7.x (CI today), run on ≥ 0.8.0.
- **Forward-compat fix caught in the act:** three `test_select_form_surface.py` tests counted raw log lines (`len(events) == 1`) and would go red the day 0.8.0 lands (stage events interleave into the same file). They now filter `form_surface` events — the count-assertion drift class from lessons, fixed before it fired.
- **elicit skill Step 0:** the template-store path claim `src/attune/elicitation/templates/` was fiction (that directory has never existed in this repo — templates live in the `attune_forms` package). Fixed, plus the new `template:<name>` vs `dict` cast-source adoption signal named. Mirrors (`.agents/`) and the help reference re-projected.

## Receipts

- Full suite: **25 189 passed, 259 skipped, 6 xfailed** (whole `tests` tree, not per-suite spot runs).
- Dual-mode verification: `tests/unit/telemetry` + `tests/unit/elicitation` + `tests/unit/mcp/test_server_elicitation.py` run **513 passed / 2 skipped** against installed 0.7.0 (CI parity) and **515 passed / 0 skipped** with `PYTHONPATH` pointing at the 0.8.0 source.
- New/changed handler paths covered: normal call shape, TypeError fallback, no-form degradation.

## Template-adoption finding (the chair's investigation ask)

The elicit skill already says templates-first (Step 0). Today's from-scratch decision form wasn't a skill-text failure — the library holds exactly **one** template (`session-contract`), so a decision-form fork class has nothing to cast. Under promote-on-repeat (R5), the recurring decision-form shape is a template candidate on its next recurrence; the new `build_sources` mix in `stage_latency()` now measures adoption instead of assuming it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)