### PR TITLE
fix(probes): allowlist platform env vars in example subprocesses — un-red main

### DIFF
--- a/scripts/workflow_probe_runner.py
+++ b/scripts/workflow_probe_runner.py
@@ -1124,8 +1124,25 @@ async def probe_doc_gen(budget: float) -> ProbeResult:
                 # LLM-emitted code runs with a SCRUBBED env (codex D11
                 # lane, critical): the runner's env holds live
                 # credentials (ANTHROPIC_API_KEY et al.) that a doc
-                # example has no business reading.
-                env={"PATH": os.environ.get("PATH", "")},
+                # example has no business reading. The scrub is an
+                # ALLOWLIST of platform-essential vars — on Windows a
+                # Python child without SYSTEMROOT dies at startup
+                # ("_Py_HashRandomization_Init: failed to get random
+                # numbers", live on main 2026-08-24); credentials stay
+                # excluded either way.
+                env={
+                    k: os.environ[k]
+                    for k in (
+                        "PATH",
+                        "SYSTEMROOT",
+                        "PATHEXT",
+                        "COMSPEC",
+                        "TEMP",
+                        "TMP",
+                        "WINDIR",
+                    )
+                    if k in os.environ
+                },
             )
             if proc.returncode != 0:
                 tail = "\n".join((proc.stdout + proc.stderr).splitlines()[-4:])


### PR DESCRIPTION
Main went red at the #2273 squash (`ea46702f2`) on two lanes; this PR fixes the deterministic one and documents the other:

- **windows-3.10** (deterministic, this fix): the scrubbed example env lacked `SYSTEMROOT`, so Python children died at startup (`_Py_HashRandomization_Init`). The scrub is now an allowlist of platform-essential vars — credentials stay excluded, canary test unchanged and still passing. Why the PR matrix missed it: the final rebase push spawned a re-scoped matrix (no win-3.10/ubuntu-3.14 lanes) and `test-matrix-complete` blessed their absence.
- **ubuntu-3.14** (flake-class, evidence attached): the capabilities projector saw 50 registered tools vs README's 61 on that lane only. A fresh local 3.14 env registers all 61, the same lockfile was green 40 min earlier, and the diff adds only tests — consistent with a latent xdist order-dependence re-dealt by added tests. A rerun of the failed jobs is in flight as the discriminating probe; if 3.14 reds again on the identical tree I'll dig further under a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
