### PR TITLE
fix(capabilities): re-discover plugins in derive_values — kill the polluted-cache flake

### DIFF
--- a/scripts/project_capabilities.py
+++ b/scripts/project_capabilities.py
@@ -154,6 +154,17 @@ def derive_values(repo: Path) -> dict[str, int]:
                 "tools would be silently missing from the count"
             ) from exc
 
+    # Re-discover from the REAL entry points, always. The registry keeps a
+    # module-level discovery cache and a global-singleton registry; when an
+    # in-process caller (the test suite) runs after a test that touched
+    # either under mocked entry_points, the cached plugin set is wrong and
+    # the derived count silently drops every plugin tool (2026-08-24: 50
+    # vs 61 on whichever xdist worker happened to schedule a registry test
+    # first — the subprocess CLI path never saw it). Derivation must
+    # describe the checked-out revision, not a prior test's cache.
+    from attune.plugins.registry import clear_discovery_cache
+
+    clear_discovery_cache()
     tools = EmpathyMCPServer().tools
     if not isinstance(tools, dict) or not tools:
         raise ProjectionError(

--- a/tests/unit/scripts/test_project_capabilities.py
+++ b/tests/unit/scripts/test_project_capabilities.py
@@ -567,3 +567,29 @@ def test_independent_gates_do_not_import_projector():
             if line.lstrip().startswith(("import ", "from ")) and "project_capabilities" in line
         ]
         assert not imports, f"{rel} imports the projector: {imports}"
+
+
+# --- Discovery-cache pollution immunity -----------------------------------
+
+
+def test_derive_values_immune_to_polluted_discovery_cache():
+    """In-process derivation re-discovers from the REAL entry points.
+
+    Regression for the 2026-08-24 main-red flake: registry tests that run
+    earlier on the same xdist worker can leave the module-level discovery
+    cache filled under mocked ``entry_points`` (an empty plugin set). The
+    old derivation then reported the server WITHOUT its plugin tools
+    (50 vs 61) while the subprocess CLI path — immune by construction —
+    stayed green on the very same lane. ``derive_values`` must describe
+    the checked-out revision, not a prior test's cache.
+    """
+    import attune.plugins.registry as registry_mod
+
+    clean = proj.derive_values(REPO_ROOT)
+    registry_mod._discovery_cache = {}  # what a mocked-discovery test leaves behind
+    registry_mod._global_registry = None
+    try:
+        poisoned_run = proj.derive_values(REPO_ROOT)
+    finally:
+        registry_mod.clear_discovery_cache()
+    assert poisoned_run == clean


### PR DESCRIPTION
Second half of today's main-red firefight (#2279 fixed the Windows `SYSTEMROOT` env half; this fixes the flake that remains).

## The flake

`test_real_manifest_repairs_bumped_values_on_copies` fails intermittently across unrelated lanes — ubuntu-3.14 on main's `ea46702f2` run, win-3.12 on docs-only #2277, win-3.10 on #2278 — always the same shape: `mcp_registered_tool_count` derives **50** while the docs say **61** (exactly the plugin tools missing).

## Root cause (verified, not theorized)

`attune.plugins.registry` keeps a module-level `_discovery_cache` and a `_global_registry` singleton. A registry test that runs FIRST on the same xdist worker under mocked `entry_points` leaves an **empty plugin set cached process-wide** (the cleanup conftest only covers `tests/plugins/`). The in-process derivation then builds a server with no plugin tools. The pin: `TestSubprocessCli::test_check_is_green_on_synced_repo` — same env, subprocess, immune by construction — **passed on the very lanes where the in-process test failed**, which rules out the environment and leaves cache state. #2273 adding 243 test lines to `tests/unit/scripts/` reshuffled worker scheduling, which is why it surfaced today.

## Fix

`derive_values()` calls `clear_discovery_cache()` before constructing the server — a derivation describes the checked-out revision, never a prior test's cache. This is squarely inside the module's own charter ("environment-dependent discovery fails closed"; a polluted cache isn't the environment).

## Receipts

- Regression test poisons the cache and asserts derived values match a clean run — **verified red without the fix** (stash/run/pop), green with it.
- `tests/unit/scripts/test_project_capabilities.py`: 48 passed; `tests/unit/gates`: 349 passed.

Unblocks #2277 and #2278 (both currently red on this flake's lanes) once merged into their bases or rerun against green main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)