### PR TITLE
fix(website): URL-encode blog tag slugs in sitemap and canonical URLs

### DIFF
--- a/website/app/blog/tag/[tag]/page.tsx
+++ b/website/app/blog/tag/[tag]/page.tsx
@@ -27,7 +27,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   return generateSEOMetadata({
     title: `Posts tagged '${tag}' — Attune AI Blog`,
     description: `${posts.length} article${posts.length === 1 ? '' : 's'} tagged with '${tag}' on the Attune AI blog. Claude Code tutorials, agent patterns, and AI workflow guides.`,
-    url: `https://smartaimemory.com/blog/tag/${tag}`,
+    url: `https://smartaimemory.com/blog/tag/${encodeURIComponent(tag)}`,
     keywords: [tag, 'Claude Code', 'Attune AI', 'AI developer blog'],
   });
 }

--- a/website/app/sitemap.ts
+++ b/website/app/sitemap.ts
@@ -60,7 +60,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
   // Blog tag archive pages
   const tags = getAllTags();
   const tagPages = tags.map((tag) => ({
-    url: `${baseUrl}/blog/tag/${tag}`,
+    url: `${baseUrl}/blog/tag/${encodeURIComponent(tag)}`,
     lastModified: new Date(),
     changeFrequency: 'weekly' as const,
     priority: 0.5,


### PR DESCRIPTION
## Summary

Blog tags containing spaces ("AI workflows", "Claude Code", "attune fix") emitted invalid sitemap `<loc>` entries and unencoded canonical URLs on tag pages. Found while assembling the URL list for search-engine index submission.

- `website/app/sitemap.ts` — wrap tag in `encodeURIComponent` for sitemap URLs
- `website/app/blog/tag/[tag]/page.tsx` — same for the canonical URL in page metadata

Matches the existing `encodeURIComponent` usage in tag links across blog pages. `generateStaticParams` is untouched — Next.js encodes route params itself and the page already decodes.

## Receipt

`next build` in the worktree (fresh `npm ci`): generated `sitemap.xml.body` has 87 URLs, **0 with raw spaces**; spaced tags render as `blog/tag/AI%20workflows`, `blog/tag/Claude%20Code`, `blog/tag/attune%20fix`.

Website-only change — no changelog entry per policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
