### PR TITLE
chore(website): drop placeholder google-site-verification meta tag

### DIFF
--- a/website/lib/metadata.ts
+++ b/website/lib/metadata.ts
@@ -116,11 +116,8 @@ export function generateMetadata(config?: SEOConfig): Metadata {
       apple: '/apple-touch-icon.png',
     },
     manifest: '/site.webmanifest',
-    verification: {
-      google: 'YOUR_VERIFICATION_CODE_HERE', // TODO: Replace with Google Search Console code
-      // yandex: 'yandex-verification-code',
-      // bing: 'bing-verification-code',
-    },
+    // Search-engine ownership is verified out-of-band: Google via a DNS
+    // TXT record, Bing via /BingSiteAuth.xml — no meta tags needed.
   };
 }
 


### PR DESCRIPTION
Removes the dead `google-site-verification` meta tag — the head rendered the literal placeholder `YOUR_VERIFICATION_CODE_HERE`, which Google can never match. Ownership is verified out-of-band (Google: DNS TXT record; Bing: `/BingSiteAuth.xml` shipped in #2283), so the whole `verification` block goes.

Receipt: `next build` green; built homepage has zero `google-site-verification` occurrences.

Website-only change — no changelog per policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
