### PR TITLE
docs(rules): fix retired attune_author import in templateKinds verify command (chair-read)

### DIFF
--- a/.claude/rules/attune/website-content-accuracy.md
+++ b/.claude/rules/attune/website-content-accuracy.md
@@ -31,7 +31,7 @@ and the guard disagree, the guard wins and this table is the bug.
 | `workflows` | `python -c "from attune.workflows import discover_workflows; print(len(set(discover_workflows().values())))"` |
 | `skills` | `ls -d plugin/skills/*/ \| wc -l` |
 | `mcpTools` | `python -c "from attune.mcp import tool_schemas as t; print(sum(len(getattr(t, n)()) for n in dir(t) if n.startswith('get_') and n.endswith('_tools')))"` |
-| `templateKinds` | `python -c "from attune_author.generator import _ALL_TEMPLATE_NAMES as a; print(len(a))"` |
+| `templateKinds` | `python -c "from attune.authoring.generator import _ALL_TEMPLATE_NAMES as a; print(len(a))"` |
 | `wizards` | `python -c "from attune.wizards import list_wizards; print(len(list_wizards()))"` |
 | Version number | `python -c "from attune import __version__; print(__version__)"` |
 


### PR DESCRIPTION
## What

One-line fix in `.claude/rules/attune/website-content-accuracy.md`: the
`templateKinds` row of the Required Verification Commands table still
derived the count via `from attune_author.generator import
_ALL_TEMPLATE_NAMES`. The `attune_author` package was retired 2026-07
(attune-author-consolidation spec), so the prescribed command now fails.
The live location is `attune.authoring.generator`.

## Receipts

Both probes run 2026-08-25 against this worktree
(`PYTHONPATH=<worktree>/src`, main venv python):

- Old command: `ModuleNotFoundError: No module named 'attune_author'`
- New command: imports and prints `15`

## Why it matters

This is exactly the class the rule doc warns about in its own text: the
PR #1703 incident came from a stale verification command in this same
table — an author followed the prescribed command correctly and got the
wrong count. A rule that prescribes a command is load-bearing; a
prescribed command that no longer runs is a latent regression.

## Chair-read

`.claude/rules/` text is authored rule/contract-adjacent surface, so
this is opened as chair-read per the collaboration contract. Scope is a
single derivation-path correction — no count, policy, or governance
semantics change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
