### PR TITLE
fix(website): migrate eslint config to native flat presets from eslint-config-next 16

### DIFF
--- a/website/eslint.config.mjs
+++ b/website/eslint.config.mjs
@@ -1,16 +1,9 @@
-import { dirname } from "path";
-import { fileURLToPath } from "url";
-import { FlatCompat } from "@eslint/eslintrc";
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
-
-const compat = new FlatCompat({
-  baseDirectory: __dirname,
-});
+import nextCoreWebVitals from "eslint-config-next/core-web-vitals";
+import nextTypescript from "eslint-config-next/typescript";
 
 const eslintConfig = [
-  ...compat.extends("next/core-web-vitals", "next/typescript"),
+  ...nextCoreWebVitals,
+  ...nextTypescript,
   {
     ignores: [
       "node_modules/**",
@@ -57,6 +50,13 @@ const eslintConfig = [
       "no-return-await": "error",
       "no-throw-literal": "error",
       "no-useless-catch": "error",
+
+      // React-Compiler-era rules new in eslint-config-next 16 flag
+      // pre-existing shipped patterns (theme/localStorage hydration,
+      // initial-fetch effects); warn until those sites are refactored
+      "react-hooks/set-state-in-effect": "warn",
+      "react-hooks/immutability": "warn",
+      "react-hooks/static-components": "warn",
 
       // TypeScript strict rules
       "@typescript-eslint/no-unused-vars": ["error", {

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -33,7 +33,6 @@
         "uuid": "^14.0.1"
       },
       "devDependencies": {
-        "@eslint/eslintrc": "^3",
         "@tailwindcss/postcss": "^4",
         "@types/bcryptjs": "^2.4.6",
         "@types/node": "^20",

--- a/website/package.json
+++ b/website/package.json
@@ -46,7 +46,6 @@
     "uuid": "^14.0.1"
   },
   "devDependencies": {
-    "@eslint/eslintrc": "^3",
     "@tailwindcss/postcss": "^4",
     "@types/bcryptjs": "^2.4.6",
     "@types/node": "^20",


### PR DESCRIPTION
## What

`npm run lint` in `website/` crashed during config loading — ConfigValidator/ConfigArrayFactory stack out of `@eslint/eslintrc`, ending in `TypeError: Converting circular structure to JSON` — before any source file was parsed.

**Root cause:** there is no `.eslintrc*` in the tree; `eslint.config.mjs` (flat config) routed `next/core-web-vitals` and `next/typescript` through `FlatCompat`. `eslint-config-next@16` ships those presets as **native flat-config arrays**, which the eslintrc compat shim cannot validate (even its error formatter dies on the circular plugin references). Next's build no longer runs eslint at all in v16, which is why builds stayed green.

## Fix

- Import `eslint-config-next/core-web-vitals` and `eslint-config-next/typescript` directly (both verified to export flat-config arrays with clean ESM interop); drop `FlatCompat` and the now-unused `@eslint/eslintrc` devDependency.
- Downgrade three React-Compiler-era rules new in this preset (`react-hooks/set-state-in-effect`, `react-hooks/immutability`, `react-hooks/static-components`) to `warn` — they flag 5 pre-existing shipped patterns (theme/localStorage hydration in `lib/theme-provider.tsx`, initial-fetch effect in `useTelemetryData.ts`, wizard callbacks, an inline chart component) that need real refactors, tracked separately.

## Receipt

`npm run lint` after fresh `npm ci` on Node 22.18: **exit 0, 0 errors, 8 warnings** (previously: hard crash before parsing).

Website-only change, no changelog (per `website/CLAUDE.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
