### PR TITLE
fix(website): refactor 5 react-hooks v6 sites, restore preset rule severities

### DIFF
--- a/website/components/SBARWizard.tsx
+++ b/website/components/SBARWizard.tsx
@@ -167,26 +167,34 @@ export default function SBARWizard() {
 
   const currentStepConfig = SBAR_STEPS[currentStep - 1];
 
-  // Initialize wizard on mount
-  useEffect(() => {
-    startWizard();
-  }, []);
+  // State updates happen in the promise callbacks once the response
+  // arrives, never synchronously
+  const initializeWizardSession = () =>
+    fetch('/api/wizards/sbar/start', { method: 'POST' })
+      .then((response) => response.json())
+      .then((data) => {
+        setWizardId(data.data?.wizard_session?.wizard_id || data.wizard_id || `local_${Date.now()}`);
+        setCurrentStep(1);
+      })
+      .catch(() => {
+        // Use local session if API unavailable
+        setWizardId(`local_${Date.now()}`);
+      })
+      .finally(() => {
+        setIsLoading(false);
+      });
 
   const startWizard = async () => {
     setIsLoading(true);
     setError('');
-    try {
-      const response = await fetch('/api/wizards/sbar/start', { method: 'POST' });
-      const data = await response.json();
-      setWizardId(data.data?.wizard_session?.wizard_id || data.wizard_id || `local_${Date.now()}`);
-      setCurrentStep(1);
-    } catch {
-      // Use local session if API unavailable
-      setWizardId(`local_${Date.now()}`);
-    } finally {
-      setIsLoading(false);
-    }
+    await initializeWizardSession();
   };
+
+  // Initialize wizard on mount (isLoading/error already hold their reset
+  // values here, so the session setup runs without the startWizard resets)
+  useEffect(() => {
+    void initializeWizardSession();
+  }, []);
 
   const updateFormData = (section: keyof SbarData, value: string) => {
     setFormData(prev => ({ ...prev, [section]: value }));

--- a/website/components/WizardPlayground.tsx
+++ b/website/components/WizardPlayground.tsx
@@ -22,34 +22,35 @@ export default function WizardPlayground({ category }: WizardPlaygroundProps) {
   const [isLoadingWizards, setIsLoadingWizards] = useState(true);
   const [error, setError] = useState('');
 
+  // isLoadingWizards starts true, and state updates happen in the promise
+  // callbacks once the response arrives — nothing synchronous in the effect
+  const fetchWizards = () =>
+    fetch('/api/wizards')
+      .then((response) => response.json())
+      .then((data) => {
+        let allWizards = data.wizards || [];
+
+        // Filter by category if specified
+        if (category) {
+          allWizards = allWizards.filter((w: Wizard) => w.category === category);
+        }
+
+        setWizards(allWizards);
+        setError('');
+      })
+      .catch((err: unknown) => {
+        console.error('Error fetching wizards:', err);
+        setError('Failed to load wizards. Backend may be unavailable.');
+      })
+      .finally(() => {
+        setIsLoadingWizards(false);
+      });
+
   // Fetch wizards on component mount
   useEffect(() => {
-    fetchWizards();
+    void fetchWizards();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [category]);
-
-  const fetchWizards = async () => {
-    setIsLoadingWizards(true);
-    try {
-      const response = await fetch('/api/wizards');
-      const data = await response.json();
-
-      let allWizards = data.wizards || [];
-
-      // Filter by category if specified
-      if (category) {
-        allWizards = allWizards.filter((w: Wizard) => w.category === category);
-      }
-
-      setWizards(allWizards);
-      setError('');
-    } catch (err) {
-      console.error('Error fetching wizards:', err);
-      setError('Failed to load wizards. Backend may be unavailable.');
-    } finally {
-      setIsLoadingWizards(false);
-    }
-  };
 
   const executeWizard = async () => {
     if (!selectedWizard || !inputData.trim()) {

--- a/website/components/charts/SavingsBarChart.tsx
+++ b/website/components/charts/SavingsBarChart.tsx
@@ -25,56 +25,56 @@ interface SavingsBarChartProps {
   className?: string;
 }
 
+// Format currency
+const formatCurrency = (value: number) => `$${value.toFixed(4)}`;
+
+// Color based on savings percentage
+const getColor = (percent: number) => {
+  if (percent >= 60) return '#10b981'; // Green
+  if (percent >= 40) return '#3b82f6'; // Blue
+  if (percent >= 20) return '#f59e0b'; // Amber
+  return '#ef4444'; // Red
+};
+
+// Custom tooltip; recharts injects active/payload/label into the content element
+const CustomTooltip = ({
+  active,
+  label,
+  workflows,
+}: {
+  active?: boolean;
+  label?: string;
+  workflows: WorkflowSavings[];
+}) => {
+  if (!active) return null;
+
+  const workflow = workflows.find((d) => d.name === label);
+  if (!workflow) return null;
+
+  return (
+    <div className="bg-white border border-gray-200 rounded-lg shadow-lg p-3">
+      <p className="font-semibold text-gray-900 mb-2">{label}</p>
+      <div className="space-y-1 text-sm">
+        <p className="text-gray-600">
+          Actual Cost: <span className="font-medium text-indigo-600">{formatCurrency(workflow.cost)}</span>
+        </p>
+        <p className="text-gray-600">
+          Baseline: <span className="font-medium text-gray-500">{formatCurrency(workflow.baseline)}</span>
+        </p>
+        <p className="text-gray-600">
+          Savings: <span className="font-medium text-green-600">{formatCurrency(workflow.savings)}</span>
+        </p>
+        <p className="text-gray-600">
+          Savings %: <span className="font-medium text-green-600">{workflow.savingsPercent.toFixed(0)}%</span>
+        </p>
+      </div>
+    </div>
+  );
+};
+
 export default function SavingsBarChart({ data, className = '' }: SavingsBarChartProps) {
   // Sort by savings percentage descending
   const sortedData = [...data].sort((a, b) => b.savingsPercent - a.savingsPercent);
-
-  // Format currency
-  const formatCurrency = (value: number) => `$${value.toFixed(4)}`;
-
-  // Color based on savings percentage
-  const getColor = (percent: number) => {
-    if (percent >= 60) return '#10b981'; // Green
-    if (percent >= 40) return '#3b82f6'; // Blue
-    if (percent >= 20) return '#f59e0b'; // Amber
-    return '#ef4444'; // Red
-  };
-
-  // Custom tooltip
-  const CustomTooltip = ({
-    active,
-    payload,
-    label,
-  }: {
-    active?: boolean;
-    payload?: Array<{ value: number; name: string }>;
-    label?: string;
-  }) => {
-    if (!active || !payload || !payload.length) return null;
-
-    const workflow = sortedData.find((d) => d.name === label);
-    if (!workflow) return null;
-
-    return (
-      <div className="bg-white border border-gray-200 rounded-lg shadow-lg p-3">
-        <p className="font-semibold text-gray-900 mb-2">{label}</p>
-        <div className="space-y-1 text-sm">
-          <p className="text-gray-600">
-            Actual Cost: <span className="font-medium text-indigo-600">{formatCurrency(workflow.cost)}</span>
-          </p>
-          <p className="text-gray-600">
-            Baseline: <span className="font-medium text-gray-500">{formatCurrency(workflow.baseline)}</span>
-          </p>
-          <p className="text-gray-600">
-            Savings: <span className="font-medium text-green-600">{formatCurrency(workflow.savings)}</span>
-          </p>
-          <p className="text-gray-600">
-            Savings %: <span className="font-medium text-green-600">{workflow.savingsPercent.toFixed(0)}%</span>
-          </p>
-        </div>
-      </div>
-    );
-  };
 
   return (
     <div className={`bg-white rounded-xl shadow-sm border border-gray-200 p-6 ${className}`}>
@@ -101,7 +101,7 @@ export default function SavingsBarChart({ data, className = '' }: SavingsBarChar
               axisLine={{ stroke: '#e5e7eb' }}
               width={75}
             />
-            <Tooltip content={<CustomTooltip />} />
+            <Tooltip content={<CustomTooltip workflows={sortedData} />} />
             <Legend
               wrapperStyle={{ paddingTop: '10px' }}
               formatter={(value) => (

--- a/website/components/telemetry/hooks/useTelemetryData.ts
+++ b/website/components/telemetry/hooks/useTelemetryData.ts
@@ -176,42 +176,49 @@ export function useTelemetryData(
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
 
-  const fetchTelemetry = useCallback(async () => {
-    try {
-      setLoading(true);
-      setError(null);
-
-      // Build query parameters
-      const params = new URLSearchParams();
-      if (since) {
-        params.set('since', since.toISOString());
-      }
-      if (workflowName) {
-        params.set('workflow', workflowName);
-      }
-      if (limit) {
-        params.set('limit', limit.toString());
-      }
-
-      // Fetch from API
-      const response = await fetch(`/api/telemetry?${params.toString()}`);
-
-      if (!response.ok) {
-        throw new Error(`HTTP error! status: ${response.status}`);
-      }
-
-      const stats: TelemetryStats = await response.json();
-      setData(stats);
-    } catch (err) {
-      setError(err instanceof Error ? err : new Error('Unknown error'));
-    } finally {
-      setLoading(false);
+  const fetchTelemetry = useCallback(() => {
+    // Build query parameters
+    const params = new URLSearchParams();
+    if (since) {
+      params.set('since', since.toISOString());
     }
+    if (workflowName) {
+      params.set('workflow', workflowName);
+    }
+    if (limit) {
+      params.set('limit', limit.toString());
+    }
+
+    // Fetch from API; state updates happen in the promise callbacks once
+    // the response arrives, never synchronously
+    return fetch(`/api/telemetry?${params.toString()}`)
+      .then((response) => {
+        if (!response.ok) {
+          throw new Error(`HTTP error! status: ${response.status}`);
+        }
+        return response.json();
+      })
+      .then((stats: TelemetryStats) => {
+        setData(stats);
+        setError(null);
+      })
+      .catch((err: unknown) => {
+        setError(err instanceof Error ? err : new Error('Unknown error'));
+      })
+      .finally(() => {
+        setLoading(false);
+      });
   }, [workflowName, since, limit]);
 
-  // Initial fetch
+  const refresh = useCallback(() => {
+    setLoading(true);
+    setError(null);
+    void fetchTelemetry();
+  }, [fetchTelemetry]);
+
+  // Initial fetch (loading already starts true, so no state reset needed here)
   useEffect(() => {
-    fetchTelemetry();
+    void fetchTelemetry();
   }, [fetchTelemetry]);
 
   // Auto-refresh
@@ -219,16 +226,16 @@ export function useTelemetryData(
     if (refreshInterval <= 0) return;
 
     const intervalId = setInterval(() => {
-      fetchTelemetry();
+      refresh();
     }, refreshInterval);
 
     return () => clearInterval(intervalId);
-  }, [refreshInterval, fetchTelemetry]);
+  }, [refreshInterval, refresh]);
 
   return {
     data,
     loading,
     error,
-    refresh: fetchTelemetry,
+    refresh,
   };
 }

--- a/website/eslint.config.mjs
+++ b/website/eslint.config.mjs
@@ -51,13 +51,6 @@ const eslintConfig = [
       "no-throw-literal": "error",
       "no-useless-catch": "error",
 
-      // React-Compiler-era rules new in eslint-config-next 16 flag
-      // pre-existing shipped patterns (theme/localStorage hydration,
-      // initial-fetch effects); warn until those sites are refactored
-      "react-hooks/set-state-in-effect": "warn",
-      "react-hooks/immutability": "warn",
-      "react-hooks/static-components": "warn",
-
       // TypeScript strict rules
       "@typescript-eslint/no-unused-vars": ["error", {
         argsIgnorePattern: "^_",

--- a/website/lib/theme-provider.tsx
+++ b/website/lib/theme-provider.tsx
@@ -1,6 +1,13 @@
 'use client';
 
-import { createContext, useContext, useEffect, useState, ReactNode } from 'react';
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useSyncExternalStore,
+  ReactNode,
+} from 'react';
 
 type Theme = 'light' | 'dark' | 'system';
 
@@ -12,37 +19,47 @@ interface ThemeContextType {
 
 const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
 
+const THEME_STORAGE_KEY = 'theme';
+// localStorage 'storage' events only fire in OTHER tabs; this event covers
+// same-tab writes so useSyncExternalStore sees them
+const THEME_CHANGE_EVENT = 'attune-theme-change';
+
+function subscribeToStoredTheme(callback: () => void) {
+  window.addEventListener('storage', callback);
+  window.addEventListener(THEME_CHANGE_EVENT, callback);
+  return () => {
+    window.removeEventListener('storage', callback);
+    window.removeEventListener(THEME_CHANGE_EVENT, callback);
+  };
+}
+
+function getStoredTheme(): Theme {
+  return (localStorage.getItem(THEME_STORAGE_KEY) as Theme) || 'system';
+}
+
+function subscribeToSystemTheme(callback: () => void) {
+  const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+  mediaQuery.addEventListener('change', callback);
+  return () => mediaQuery.removeEventListener('change', callback);
+}
+
+function getSystemTheme(): 'light' | 'dark' {
+  return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+}
+
 export function ThemeProvider({ children }: { children: ReactNode }) {
-  const [theme, setThemeState] = useState<Theme>('system');
-  const [resolvedTheme, setResolvedTheme] = useState<'light' | 'dark'>('light');
+  const theme = useSyncExternalStore<Theme>(
+    subscribeToStoredTheme,
+    getStoredTheme,
+    () => 'system'
+  );
+  const systemTheme = useSyncExternalStore<'light' | 'dark'>(
+    subscribeToSystemTheme,
+    getSystemTheme,
+    () => 'light'
+  );
 
-  // Initialize theme from localStorage
-  useEffect(() => {
-    const storedTheme = localStorage.getItem('theme') as Theme;
-    if (storedTheme) {
-      setThemeState(storedTheme);
-    }
-  }, []);
-
-  // Update resolved theme based on system preference or user selection
-  useEffect(() => {
-    const updateResolvedTheme = () => {
-      if (theme === 'system') {
-        const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-        setResolvedTheme(prefersDark ? 'dark' : 'light');
-      } else {
-        setResolvedTheme(theme as 'light' | 'dark');
-      }
-    };
-
-    updateResolvedTheme();
-
-    if (theme === 'system') {
-      const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
-      mediaQuery.addEventListener('change', updateResolvedTheme);
-      return () => mediaQuery.removeEventListener('change', updateResolvedTheme);
-    }
-  }, [theme]);
+  const resolvedTheme = theme === 'system' ? systemTheme : theme;
 
   // Apply theme to document
   useEffect(() => {
@@ -52,10 +69,10 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
     root.style.colorScheme = resolvedTheme;
   }, [resolvedTheme]);
 
-  const setTheme = (newTheme: Theme) => {
-    setThemeState(newTheme);
-    localStorage.setItem('theme', newTheme);
-  };
+  const setTheme = useCallback((newTheme: Theme) => {
+    localStorage.setItem(THEME_STORAGE_KEY, newTheme);
+    window.dispatchEvent(new Event(THEME_CHANGE_EVENT));
+  }, []);
 
   return (
     <ThemeContext.Provider value={{ theme, setTheme, resolvedTheme }}>


### PR DESCRIPTION
## Summary

Follow-up to #2287, which downgraded three React-Compiler-era rules
(`react-hooks/set-state-in-effect`, `react-hooks/immutability`,
`react-hooks/static-components`) to `"warn"` because five pre-existing
sites failed them. This PR refactors those sites properly and deletes
the three overrides (and their comment) from `website/eslint.config.mjs`,
so the rules run at their `eslint-config-next` preset defaults again.

## The five sites

| Site | Rule | Fix |
|------|------|-----|
| `lib/theme-provider.tsx` | set-state-in-effect | Rebuilt on `useSyncExternalStore`: localStorage (+ a same-tab change event) is the theme store, `matchMedia` is the system-theme store, `resolvedTheme` is derived. Bonus: cross-tab theme sync via the `storage` event. |
| `components/telemetry/hooks/useTelemetryData.ts` | set-state-in-effect | Fetch path sets state only in promise callbacks; loading/error resets moved into a `refresh()` wrapper used by the interval and manual refresh. |
| `components/SBARWizard.tsx` | immutability | `initializeWizardSession` (promise callbacks, no sync setState) split out of `startWizard` and declared above the mount effect. `startWizard` keeps its resets for the Start-Over button path. |
| `components/WizardPlayground.tsx` | immutability | `fetchWizards` declared above the effect, promise-callback form; `isLoadingWizards` already starts `true`, so no sync reset needed. |
| `components/charts/SavingsBarChart.tsx` | static-components | `CustomTooltip` + pure helpers hoisted to module scope; `sortedData` flows in via a `workflows` prop, recharts still injects `active`/`label`. |

Note: `async/await` bodies are traced wholesale by `set-state-in-effect`
(even setState after an `await` flags), which is why the fetch paths use
explicit `.then/.catch/.finally` chains — the rule's sanctioned
"setState in a callback when external state changes" shape.

## Receipts

- `npm run lint` in `website/`: **exit 0, 0 errors** (3 pre-existing warnings untouched: framework-docs navigation, indexnow-ping console).
- `npx tsc --noEmit`: clean.
- Live dev-server verification: homepage loads with no React/hydration errors; theme toggle switches to dark (root class, `colorScheme`, localStorage all updated); reload rehydrates the stored theme correctly.

Website-only change → no changelog (per `website/CLAUDE.md`), Python suite no-ops via the `website_only` gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
