### PR TITLE
test(coverage): de-omit 6 hooks/scripts entries (#1569 omit-audit)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -731,12 +731,13 @@ omit = [
     # 2026-07-29 (#1569 omit-audit pass 2): their Interactive labels
     # were false — dedicated suites in tests/unit/meta_workflows/
     # measure them 99-100% keylessly.
-    # Hook scripts (run as standalone processes via Claude Code)
-    "*/hooks/scripts/evaluate_session.py",  # Standalone hook
-    "*/hooks/scripts/first_time_init.py",  # Standalone hook
-    "*/hooks/scripts/session_end.py",  # Standalone hook
-    "*/hooks/scripts/session_start.py",  # Standalone hook
-    "*/hooks/scripts/telemetry_hook.py",  # Standalone hook
+    # Hook-script entries removed 2026-08-25 (#1569 omit-audit,
+    # hooks/scripts probe): every Standalone-hook label was false.
+    # session_end.py / session_start.py no longer exist (dead
+    # entries); evaluate_session (100%), first_time_init (88%),
+    # telemetry_hook (93%), and help_freshness_nudge (91%) all
+    # measure via their EXISTING tests/unit/hooks/ suites with
+    # path-based coverage.
     # Core module stubs
     "*/core_modules/interaction.py",  # Interaction stubs
     "*/core_modules/short_term_memory.py",  # Memory stubs
@@ -759,7 +760,10 @@ omit = [
     "*/core_modules/__init__.py",  # Core modules init
     # Models main entry
     "*/models/__main__.py",  # Models CLI entry point
-    "*/hooks/scripts/help_freshness_nudge.py",  # Standalone hook script (not importable via pytest)
+    # help_freshness_nudge.py entry removed 2026-08-25 (#1569
+    # omit-audit, hooks/scripts probe): the "not importable via
+    # pytest" label was false — tests/unit/hooks/
+    # test_help_freshness_nudge.py measures it 91%.
 ]
 branch = true
 # parallel + concurrency: ensure xdist workers flush coverage data


### PR DESCRIPTION
#1569 omit-audit, hooks/scripts probe — the issue's named highest-yield item. Probe result: **every "Standalone hook" label in the class was false**, precision 6 hits / 6 real / 0 false positives:

| Entry | Finding |
|---|---|
| `session_end.py`, `session_start.py` | Files no longer exist anywhere — dead omit entries |
| `evaluate_session.py` | **100%** via existing `tests/unit/hooks/test_evaluate_session.py` |
| `first_time_init.py` | **88%** via existing suite |
| `telemetry_hook.py` | **93%** via existing suites (incl. `test_cross_platform.py`) |
| `help_freshness_nudge.py` | **91%** via existing suite (its label said "not importable via pytest") |

Measured with path-based coverage (branch on), per the #1569 rubric note that module-name `--cov` silently reports 0% for file-path-loaded hooks. 299 stmts, 92% aggregate — all four above the 85% floor, so inclusion moves project coverage negligibly from 96.16%.

**No test changes** — the suites already existed; only the omit labels were wrong. Diff is the pyproject omit list only, with dated reason comments per the file's convention.

**Receipts:** gates sweep 383 passed serially; the 5 hook suites 79 passed serially; TOML parse verified (25 omit entries remain, 0 hooks entries). One artifact noted for honesty: under a stripped-config coverage invocation (`--rcfile=/dev/null`) one telemetry test fails; the same 5-suite combo passes clean without coverage and the suite passes alone — measurement-harness artifact, not a product or ordering bug.

Closes nothing — #1569 is a living program anchor and stays open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
