### PR TITLE
docs(release-15): D5 timing inversion + D6 passenger-1 correction (chair-read)

### DIFF
--- a/docs/specs/release-15-manifest/decisions.md
+++ b/docs/specs/release-15-manifest/decisions.md
@@ -67,9 +67,42 @@ upstream. When the lock adopts 1.x, that PR carries a **live-fire
 receipt requirement** (real SDK round-trip on the locked env, not
 the scratch env). Issue #2243 stays open to track lock adoption.
 
-## D4 — Timing (chair constraint, recorded verbatim 2026-08-24)
+## D4 — Timing (chair constraint, recorded verbatim 2026-08-24) — SUPERSEDED by D5
 
 > the major must NOT ship before mid-to-late September 2026.
 > attune-ai's first external user begins onboarding 2026-09-01 and
 > a stable 14.x during his first weeks is worth more than the
 > architecture.
+
+## D5 — Timing INVERTED: ship before 2026-09-01; the class starts on 15.0.0 (RATIFIED chair 2026-08-25 — supersedes D4)
+
+The 2026-09-01 onboarding is a **class** (cohort), not a lone
+user, and the chair wants the class working on 15.0.0 from day
+one. This inverts D4's premise: instead of holding the major so
+the first weeks happen on stable 14.x, the major ships BEFORE the
+class arrives — they never see the legacy surfaces or a
+mid-course breaking change.
+
+Consequences:
+
+- **The 14.x deprecation story is no longer a prerequisite.**
+  Warning shims protect existing external consumers; telemetry
+  signal is ~0 and the class starts fresh on 15.0.0. Items
+  already landed (`AttuneMCPServer` alias, dual-read entry-point
+  discovery, level-tool `DeprecationWarning`s) simply ride until
+  their 15.0.0 removal. The one unlanded item (old `BaseWorkflow`
+  warning on instantiation, deprecation-story item 3) is DROPPED,
+  not built.
+- **Window:** ~6 days from ruling (2026-08-25 → 2026-08-31). The
+  squeeze is CI cycles and the release-audit sitting, not code
+  volume.
+
+## D6 — Passenger 1 correction: attune.exceptions removal already SHIPPED (recorded lead 2026-08-25)
+
+D1/passenger 1 describe the removal as parked on
+`claude/eager-mendeleev-3352e2` awaiting a boarding rebase. Stale:
+it merged as PR #2177 (`093cd7acd`, `feat!: remove the legacy
+attune.exceptions hierarchy`) and shipped in 14.0.0 —
+`src/attune/exceptions.py` is absent from `origin/main` (verified
+2026-08-25 against `f2f3fe97a`). Nothing boards for it; the
+parked branch is superseded and can be deleted.

--- a/docs/specs/release-15-manifest/decisions.md
+++ b/docs/specs/release-15-manifest/decisions.md
@@ -106,3 +106,32 @@ attune.exceptions hierarchy`) and shipped in 14.0.0 —
 `src/attune/exceptions.py` is absent from `origin/main` (verified
 2026-08-25 against `f2f3fe97a`). Nothing boards for it; the
 parked branch is superseded and can be deleted.
+
+## D7 — D2 scope clarification: PUBLIC level surface only (RATIFIED chair 2026-08-25)
+
+Executing D2 against the tree surfaced a two-layer reality the
+ruling's text did not distinguish:
+
+- **Shallow public knobs** — plugin `BaseWorkflow.empathy_level` +
+  `get_empathy_level()`, `PluginRegistry.find_workflows_by_level`
+  (+ `workflows_by_level` stats), `UnifiedAgentConfig.empathy_level`,
+  agent_factory `AgentConfig.empathy_level` + factory param,
+  agents_md frontmatter parsing/validation +
+  `get_by_empathy_level`, the two MCP level tools,
+  `MetricsCollector.record_metric(empathy_level=…)` (top-level
+  public export; SQLite column migration), and the first-run
+  config template.
+- **The engine** — `EmpathyLLM` (llm/core.py) is itself a
+  five-level progression machine (`_determine_level`,
+  `_level_1_reactive`…`_level_5_systems`,
+  `CollaborationState.current_level`/`level_history`), imported by
+  14 modules. D2's "llm state" item, executed literally, guts a
+  live class with no specced replacement.
+
+**RULING (chair, 2026-08-25): 15.0.0 removes the public level
+surface only** (the shallow list above — the user-visible API is
+level-free). `EmpathyLLM`'s internal progression stays as
+un-exported implementation detail (it is not in `attune.__all__`);
+its redesign or retirement is spun off as its own post-15 issue.
+llm/state, learning/evaluator internals, and the security audit
+log's level field ride along untouched as internals.

--- a/docs/specs/release-15-manifest/requirements.md
+++ b/docs/specs/release-15-manifest/requirements.md
@@ -3,6 +3,9 @@
 **Status:** approved (2026-08-24) — merged as the major's scope
 document (#2262); D2 RATIFIED same day (Option B — `empathy_level`
 dies with the framework), so no gating decision remains open.
+**Amended 2026-08-25:** D5 inverts the timing (ship BEFORE
+2026-09-01 — the onboarding cohort is a class that starts on
+15.0.0); D6 records passenger 1 as already shipped in 14.0.0.
 **Slug:** `release-15-manifest`
 **Provenance:** several pre-authorized breaking changes were
 assembling toward the next major with no single document scoping
@@ -10,25 +13,25 @@ it — the exceptions-removal hold (chair, 2026-08-22), issue #2238's
 breaking half, and the #2243 migration question. This manifest is a
 scope document, not implementation.
 
-## Timing constraint (chair, recorded verbatim)
+## Timing constraint (D5 — supersedes the original D4 text)
 
-> the major must NOT ship before mid-to-late September 2026.
-> attune-ai's first external user begins onboarding 2026-09-01 and
-> a stable 14.x during his first weeks is worth more than the
-> architecture.
+**Ship BEFORE 2026-09-01.** The onboarding cohort is a class that
+starts working on attune-ai 2026-09-01, and the chair ruled
+(2026-08-25) that the class starts on 15.0.0 — the major ships
+before they arrive rather than breaking mid-course. The original
+D4 constraint (verbatim in [decisions.md](decisions.md)) read the
+onboarding as a lone user best served by weeks of stable 14.x; D5
+inverts it.
 
 ## Passengers
 
-### 1. `attune.exceptions` removal (first passenger — pre-authorized)
+### 1. `attune.exceptions` removal — ✅ ALREADY SHIPPED (D6)
 
-Done on branch `claude/eager-mendeleev-3352e2` (92a3714b7, `feat!:
-remove the legacy attune.exceptions hierarchy`); chair
-PRE-AUTHORIZED into the next major 2026-08-22 (D1). Branch state
-verified 2026-08-24: exists locally, 1 commit ahead of the
-merge-base, and `git merge-tree` against current `origin/main`
-shows two content conflicts — `CHANGELOG.md` and
-`src/attune/__init__.py` — both mechanical (version-churn overlap),
-not structural. Rebase at boarding time.
+Merged as PR #2177 (`093cd7acd`) and shipped in 14.0.0;
+`src/attune/exceptions.py` is absent from `origin/main` (verified
+2026-08-25). The D1 pre-authorization was discharged by that
+merge. Nothing boards for this item; the parked branch
+`claude/eager-mendeleev-3352e2` is superseded.
 
 ### 2. Empathy-framework excision remainder — breaking half (#2238)
 
@@ -86,28 +89,26 @@ unblocks #2238's breaking half.
   the adapter split (PR #2253, MERGED 2026-08-24). Only if a
   public import path must move does a slice of it board the major.
 
-## Deprecation story (14.x pre-work, so 15.0.0 removes rather than surprises)
+## Deprecation story — MOOT per D5 (2026-08-25)
 
-Land in 14.x, each with a `DeprecationWarning`:
+The 14.x warning window protected existing external consumers;
+telemetry signal is ~0 and the class starts fresh on 15.0.0, so
+the window is dropped. State at ruling time: items 1 and 2
+(rename+alias, dual-read discovery) and the level-tool warnings
+had already landed in 14.x and simply ride until their 15.0.0
+removal; item 3's old-contract instantiation warning was never
+built and is dropped rather than built.
 
-1. `AttuneMCPServer` rename with `EmpathyMCPServer` alias.
-2. Dual-read entry-point discovery: `attune.workflows` alongside
-   `empathy.workflows`; keep `attune_framework.plugins` legacy
-   read; delete the never-read `empathy_framework.plugins`
-   declaration (removable in 14.x — nothing reads it).
-3. The replacement plugin `BaseWorkflow` contract published
-   alongside the old one (old contract warns on instantiation) —
-   per D2, level-free signature; `attune_get_level`/
-   `attune_set_level` also warn in 14.x ahead of their 15.0.0
-   deletion.
-4. `attune.exceptions` needs no 14.x shim — the removal branch is
-   the pre-authorized cutover itself.
+## Sequencing (per D5)
 
-## Sequencing
-
-1. 14.x: #2253 ✅ merged → #2239 layering → deprecation-story items
-   1–3.
-2. D2 ✅ ruled 2026-08-24 (Option B) — #2238's breaking half is
-   unblocked.
-3. 15.0.0 (not before mid-to-late September 2026): board passenger
-   1 (rebase), passenger 2 including the D2 level removal.
+1. Record D5/D6 (this amendment).
+2. #2238's breaking half, all in the 15.0.0 window: the D2
+   `empathy_level` end-to-end removal (incl.
+   `attune_get_level`/`attune_set_level` deletion and the
+   level-free plugin `BaseWorkflow` contract), the
+   `EmpathyMCPServer` alias removal, and entry-point
+   standardization on `attune.*` (drop the `empathy.workflows`
+   read and the legacy plugin groups).
+3. Release prep + release-audit sitting + tag/publish, complete
+   BEFORE 2026-09-01. #2239 layering does not board unless a
+   public import path must move.


### PR DESCRIPTION
## Summary

Records two chair-driven amendments to the 15.0.0 manifest (chair-read — this PR records rulings already made in-session, it does not propose them):

- **D5 (chair, 2026-08-25) — timing inverted, supersedes D4.** The 2026-09-01 onboarding is a **class** that starts on 15.0.0. The major ships **before 09-01**; the 14.x deprecation window is dropped (already-landed shims ride until their 15.0.0 removal; the never-built old-`BaseWorkflow` instantiation warning is dropped, not built).
- **D6 (lead) — passenger 1 already shipped.** The `attune.exceptions` removal merged as #2177 (`093cd7acd`) and shipped in 14.0.0; `src/attune/exceptions.py` is absent from `origin/main` (verified 2026-08-25 against `f2f3fe97a`). Manifest text still described it as parked on `claude/eager-mendeleev-3352e2`; that branch is superseded.
- Requirements sequencing rewritten to the compressed window.

Docs-only; no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
