### PR TITLE
fix(models): SDK adapter robustness — redact in-stream errors, safe budget env, shlex string argv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **SDK adapter robustness** (codex D11 scoped re-lane findings on
+  #2295; all three predate the move). The in-stream error path in
+  `iter_agent_messages` now redacts the captured ResultMessage error
+  text before it enters `SdkSubprocessError.stderr` (matching the
+  probe path's existing redaction); a malformed
+  `ATTUNE_MAX_BUDGET_USD` env value falls back to the depth default
+  with a warning instead of crashing option construction; and a
+  string-valued exception `cmd` is shlex-split into argv (POSIX-aware,
+  Windows-safe) instead of being wrapped as `[cmd]`, which made
+  `subprocess.run` treat the whole command line as an executable path
+  and report a misleading not-found. Both back-compat facades also
+  declare `__all__` now, making the re-export surface explicit.
+
 ### Changed
 
 - **SDK adapter core moved to the models layer** (#2239 slice 1). The

--- a/src/attune/models/sdk_adapter.py
+++ b/src/attune/models/sdk_adapter.py
@@ -27,6 +27,8 @@ from typing import Any
 
 import claude_agent_sdk
 
+from attune.ops.session_redaction import redact
+
 # Only what this module actually uses. The historical re-export
 # surface (full sdk_errors + AgentSDKResultAdapter) lives on the
 # workflows.agent_sdk_adapter facade, not here.
@@ -238,10 +240,14 @@ async def iter_agent_messages(query: AsyncIterator[Any]) -> AsyncIterator[Any]:
                 )
                 return
             if last_error_result_text is not None:
-                kind, summary = classify_subprocess_failure(last_error_result_text)
+                # stderr travels into logs and WorkflowResult errors;
+                # the probe path (capture_subprocess_failure) already
+                # redacts its output — the in-stream path must match.
+                redacted = redact(last_error_result_text).text
+                kind, summary = classify_subprocess_failure(redacted)
                 raise SdkSubprocessError(
                     message=summary,
-                    stderr=last_error_result_text,
+                    stderr=redacted,
                     kind=kind,
                     original_exc=exc,
                 ) from exc
@@ -617,8 +623,15 @@ def get_max_budget_usd(
         return explicit
     override = os.environ.get("ATTUNE_MAX_BUDGET_USD")
     if override is not None:
-        val = float(override)
-        return val if val > 0 else None
+        try:
+            val = float(override)
+        except ValueError:
+            logger.warning(
+                "ATTUNE_MAX_BUDGET_USD=%r is not a number; " "falling back to the depth default",
+                override,
+            )
+        else:
+            return val if val > 0 else None
     return _DEFAULT_BUDGET_USD.get(depth, 10.00)
 
 
@@ -834,6 +847,12 @@ def get_subagent_model(agent_name: str) -> str | None:
     ``"inherit"``. The literal ``"inherit"`` is normalized to
     ``None`` so callers can pass the return value directly to the
     SDK ``AgentDefinition.model`` field.
+
+    The env overrides deliberately perform NO allowlist validation
+    of the model value: they are an operator escape hatch, so a new
+    model name works without a code change. A typo surfaces as an
+    SDK-level model error at run time rather than being silently
+    coerced here.
 
     Args:
         agent_name: Name of the subagent (e.g. ``"security-reviewer"``).

--- a/src/attune/models/sdk_errors.py
+++ b/src/attune/models/sdk_errors.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import logging
 import os
 import re
+import shlex
 import shutil
 import subprocess
 from dataclasses import dataclass
@@ -469,6 +470,25 @@ def capture_subprocess_failure(
         return probe_note + f"(capture-call also failed: {type(exc).__name__}: {exc})"
 
 
+def _split_string_cmd(cmd: str) -> list[str]:
+    """Split a string-valued exception ``cmd`` into argv.
+
+    Wrapping the whole command line as ``[cmd]`` makes
+    ``subprocess.run`` treat it as one executable path and report a
+    misleading not-found. POSIX lexing mangles Windows backslash
+    paths, so on Windows split in non-POSIX mode and strip the
+    quotes the lexer preserves.
+    """
+    try:
+        if os.name == "nt":
+            return [tok.strip('"') for tok in shlex.split(cmd, posix=False)]
+        return shlex.split(cmd)
+    except ValueError:
+        # Unbalanced quotes — a whitespace split still beats the
+        # single-element argv's misleading not-found diagnostic.
+        return cmd.split()
+
+
 def _last_subprocess_argv(exc: BaseException) -> list[str]:
     """Extract the failing argv from an SDK ``Exception('Command failed ...')``.
 
@@ -483,8 +503,12 @@ def _last_subprocess_argv(exc: BaseException) -> list[str]:
     1. ``exc.args[0]`` if it's already a ``list[str]`` (some SDK
        versions stash the argv there).
     2. ``exc.__cause__.cmd`` — ``subprocess.CalledProcessError``-shaped
-       wrap.
-    3. ``exc.cmd`` — direct attribute on the exception.
+       wrap. A string-valued ``cmd`` is shlex-split into argv (see
+       :func:`_split_string_cmd`) — never wrapped as ``[cmd]``, which
+       would make the re-run treat the whole line as an executable
+       path.
+    3. ``exc.cmd`` — direct attribute on the exception; same
+       string-splitting rule.
     4. Fallback: empty list — the installed claude_agent_sdk raises a
        bare ``Exception`` with the argv stored nowhere, so ``[]`` is the
        normal result. The caller's ``capture_subprocess_failure([])``
@@ -509,13 +533,13 @@ def _last_subprocess_argv(exc: BaseException) -> list[str]:
         if isinstance(cmd, list) and all(isinstance(x, str) for x in cmd):
             return cmd
         if isinstance(cmd, str):
-            return [cmd]
+            return _split_string_cmd(cmd)
 
     # Shape 3: direct .cmd on the exception
     cmd = getattr(exc, "cmd", None)
     if isinstance(cmd, list) and all(isinstance(x, str) for x in cmd):
         return cmd
     if isinstance(cmd, str):
-        return [cmd]
+        return _split_string_cmd(cmd)
 
     return []

--- a/src/attune/workflows/agent_sdk_adapter.py
+++ b/src/attune/workflows/agent_sdk_adapter.py
@@ -57,3 +57,43 @@ from .sdk_output_parser import (  # noqa: F401
     _SUGGESTION_RE,
     AgentSDKResultAdapter,
 )
+
+# The re-export surface IS this module's purpose — __all__ makes that
+# explicit (and keeps scanners from reading the imports as unused).
+__all__ = [
+    # adapter core (attune.models.sdk_adapter)
+    "_DEFAULT_TASK_BUDGET_TOKENS",
+    "_SUBAGENT_MODEL_MAP",
+    "SDK_SUBPROCESS_ENV_VAR",
+    "AgentRunResult",
+    "_guard_bash_tool",
+    "build_result_text",
+    "collect_agent_output",
+    "collect_subagent_transcripts",
+    "format_subagent_transcripts_markdown",
+    "get_max_budget_usd",
+    "get_subagent_model",
+    "get_task_budget",
+    "get_thinking_config",
+    "iter_agent_messages",
+    "make_edit_scope_guard",
+    "resolve_cwd_for_path",
+    "sdk_isolation_kwargs",
+    # error taxonomy (attune.models.sdk_errors)
+    "_CLASSIFIERS",
+    "_DEFAULT_BUDGET_USD",
+    "SdkErrorKind",
+    "SdkSubprocessError",
+    "_claude_health_probe_argv",
+    "_last_subprocess_argv",
+    "_sdk_error_probe_enabled",
+    "_stderr_carries_no_signal",
+    "capture_subprocess_failure",
+    "classify_subprocess_failure",
+    "sdk_error_from_exception",
+    "sdk_error_message",
+    # output parser (.sdk_output_parser)
+    "_CATEGORY_PATTERNS",
+    "_SUGGESTION_RE",
+    "AgentSDKResultAdapter",
+]

--- a/src/attune/workflows/sdk_errors.py
+++ b/src/attune/workflows/sdk_errors.py
@@ -27,3 +27,20 @@ from attune.models.sdk_errors import (  # noqa: F401
     sdk_error_from_exception,
     sdk_error_message,
 )
+
+# The re-export surface IS this module's purpose — __all__ makes that
+# explicit (and keeps scanners from reading the imports as unused).
+__all__ = [
+    "_CLASSIFIERS",
+    "_DEFAULT_BUDGET_USD",
+    "SdkErrorKind",
+    "SdkSubprocessError",
+    "_claude_health_probe_argv",
+    "_last_subprocess_argv",
+    "_sdk_error_probe_enabled",
+    "_stderr_carries_no_signal",
+    "capture_subprocess_failure",
+    "classify_subprocess_failure",
+    "sdk_error_from_exception",
+    "sdk_error_message",
+]

--- a/tests/unit/workflows/test_agent_sdk_adapter.py
+++ b/tests/unit/workflows/test_agent_sdk_adapter.py
@@ -15,6 +15,7 @@ from datetime import datetime, timezone
 
 import pytest
 
+import attune.models.sdk_adapter as mod
 from attune.models.sdk_adapter import (
     AgentRunResult,
     collect_agent_output,
@@ -690,6 +691,20 @@ class TestGetMaxBudgetUsd:
         monkeypatch.setenv("ATTUNE_MAX_BUDGET_USD", "0")
         assert get_max_budget_usd("deep") is None
 
+    def test_env_var_malformed_falls_back_to_depth_default(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A non-numeric ATTUNE_MAX_BUDGET_USD falls back to the depth default."""
+        monkeypatch.setenv("ATTUNE_MAX_BUDGET_USD", "ten dollars")
+        assert get_max_budget_usd("quick") == 2.00
+
+    def test_env_var_malformed_unknown_depth_lands_on_standard(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Malformed env + unknown depth still lands on the standard default."""
+        monkeypatch.setenv("ATTUNE_MAX_BUDGET_USD", "$5")
+        assert get_max_budget_usd("unknown") == 10.00
+
 
 @pytest.mark.unit
 class TestSdkErrorMessage:
@@ -879,14 +894,10 @@ class TestGetTaskBudgetCliProbe:
 
     def setup_method(self) -> None:
         """Reset the module-level cache before each test."""
-        import attune.models.sdk_adapter as mod
-
         mod._CLI_SUPPORTS_TASK_BUDGET = None
 
     def test_returns_none_when_cli_lacks_flag(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Given a CLI whose --help omits --task-budget, returns None."""
-        import attune.models.sdk_adapter as mod
-
         fake_help = (
             "Usage: claude [options]\n"
             "  --max-budget-usd <amount>  Max dollars\n"
@@ -910,8 +921,6 @@ class TestGetTaskBudgetCliProbe:
 
     def test_returns_budget_when_cli_supports_flag(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Given a CLI whose --help mentions --task-budget, returns a TaskBudget."""
-        import attune.models.sdk_adapter as mod
-
         fake_help = "  --task-budget <tokens>  Token cap per task\n"
 
         def fake_run(cmd, **kwargs):
@@ -932,8 +941,6 @@ class TestGetTaskBudgetCliProbe:
 
     def test_probe_result_is_cached(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Probe runs at most once per process; subsequent calls hit cache."""
-        import attune.models.sdk_adapter as mod
-
         call_count = {"n": 0}
 
         def fake_run(cmd, **kwargs):
@@ -956,7 +963,6 @@ class TestGetTaskBudgetCliProbe:
 
     def test_probe_timeout_disables_feature(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """If the probe times out, treat the CLI as unsupported."""
-        import attune.models.sdk_adapter as mod
 
         def fake_run(cmd, **kwargs):
             raise mod.subprocess.TimeoutExpired(cmd=cmd, timeout=5)
@@ -969,8 +975,6 @@ class TestGetTaskBudgetCliProbe:
 
     def test_missing_cli_disables_feature(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """When no CLI is found anywhere, return False without probing."""
-        import attune.models.sdk_adapter as mod
-
         monkeypatch.setattr(mod.shutil, "which", lambda _: None)
         monkeypatch.setattr(mod.Path, "is_file", lambda self: False)
 

--- a/tests/unit/workflows/test_iter_agent_messages.py
+++ b/tests/unit/workflows/test_iter_agent_messages.py
@@ -17,7 +17,7 @@ from pathlib import Path
 import pytest
 
 import attune.models.sdk_adapter as adapter
-from attune.models.sdk_adapter import iter_agent_messages
+from attune.models import sdk_errors
 
 
 class _FakeResultMessage:
@@ -72,7 +72,7 @@ def _patch_result_message(monkeypatch):
 
 async def _drain(query):
     """Collect every message the wrapper yields."""
-    return [m async for m in iter_agent_messages(query)]
+    return [m async for m in adapter.iter_agent_messages(query)]
 
 
 _TEARDOWN = Exception("Command failed with exit code 1")
@@ -176,6 +176,28 @@ async def test_error_result_text_upgrades_raise_to_classified_error():
     assert caught.__cause__ is _REPLACEMENT
 
 
+# Fake key, not a real credential — shaped to trip the redactor.
+_FAKE_KEY = "sk-ant-AAAAaaaa1111BBBB2222CCCC3333dddd"  # pragma: allowlist secret
+
+
+@pytest.mark.asyncio
+async def test_error_result_text_is_redacted_before_exception():
+    """A secret-shaped string in the error result never enters stderr."""
+    err = _FakeResultMessage(
+        subtype="success",
+        is_error=True,
+        result=f"{_QUOTA_TEXT}\nfailing key: {_FAKE_KEY}",
+    )
+    with pytest.raises(adapter.SdkSubprocessError) as exc_info:
+        await _drain(_FakeQuery([err], raise_after=_REPLACEMENT))
+    caught = exc_info.value
+    assert _FAKE_KEY not in caught.stderr
+    assert "sk-ant" not in caught.stderr
+    assert "<redacted>" in caught.stderr
+    # Classification still runs on the surviving prose.
+    assert caught.kind == "api_quota"
+
+
 @pytest.mark.asyncio
 async def test_org_disabled_subscription_classifies_as_auth():
     """#2227: the org-disabled subscription text classifies as auth."""
@@ -217,8 +239,6 @@ def test_sdk_error_from_exception_fast_path(monkeypatch):
     def _boom(*args, **kwargs):  # pragma: no cover - fails the test if hit
         raise AssertionError("probe must not run on the fast path")
 
-    from attune.models import sdk_errors
-
     monkeypatch.setattr(sdk_errors, "capture_subprocess_failure", _boom)
     err = adapter.SdkSubprocessError(message="m", stderr="s", kind="api_quota", original_exc=None)
     assert sdk_errors.sdk_error_from_exception(err) is err
@@ -226,8 +246,6 @@ def test_sdk_error_from_exception_fast_path(monkeypatch):
 
 def test_sdk_error_from_exception_fallback_probes(monkeypatch):
     """A bare SDK exception still goes through probe + classification."""
-    from attune.models import sdk_errors
-
     monkeypatch.setattr(sdk_errors, "capture_subprocess_failure", lambda argv: _QUOTA_TEXT)
     out = sdk_errors.sdk_error_from_exception(Exception("Command failed with exit code 1"))
     assert out.kind == "api_quota"
@@ -256,8 +274,6 @@ def test_probe_env_mirrors_sdk_child(monkeypatch):
             stdout = ""
 
         return _R()
-
-    from attune.models import sdk_errors
 
     monkeypatch.setattr(sdk_errors.subprocess, "run", _fake_run)
     sdk_errors.capture_subprocess_failure([])

--- a/tests/unit/workflows/test_sdk_error_fidelity.py
+++ b/tests/unit/workflows/test_sdk_error_fidelity.py
@@ -267,14 +267,47 @@ class TestLastSubprocessArgv:
 
     def test_handles_cause_cmd_as_string(self):
         """Some subprocess errors store .cmd as a single string instead
-        of a list — wrap in a single-element list."""
+        of a list — shlex-split into argv, so subprocess.run doesn't
+        treat the whole command line as one executable path."""
         called = subprocess.CalledProcessError(
             returncode=1,
             cmd="claude -p test",
         )
         wrapper = Exception("Command failed")
         wrapper.__cause__ = called
-        assert _last_subprocess_argv(wrapper) == ["claude -p test"]
+        assert _last_subprocess_argv(wrapper) == ["claude", "-p", "test"]
+
+    def test_direct_cmd_string_is_shlex_split(self, monkeypatch):
+        """Shape 3 with a string .cmd is split into argv, quotes honored.
+
+        POSIX pinned: single-quote grouping is a POSIX lexing rule, so
+        this must not float with the CI platform's real os.name.
+        """
+        from attune.models import sdk_errors
+
+        monkeypatch.setattr(sdk_errors.os, "name", "posix")
+        exc = Exception("Command failed")
+        exc.cmd = "claude -p 'hello world'"
+        assert _last_subprocess_argv(exc) == ["claude", "-p", "hello world"]
+
+    def test_string_cmd_unbalanced_quote_falls_back_to_whitespace_split(self):
+        """Unbalanced quotes must not crash extraction; whitespace-split."""
+        exc = Exception("Command failed")
+        exc.cmd = 'claude -p "unterminated'
+        assert _last_subprocess_argv(exc) == ["claude", "-p", '"unterminated']
+
+    def test_string_cmd_windows_backslash_paths_survive(self, monkeypatch):
+        """On Windows, non-POSIX lexing keeps backslash paths intact."""
+        from attune.models import sdk_errors
+
+        monkeypatch.setattr(sdk_errors.os, "name", "nt")
+        exc = Exception("Command failed")
+        exc.cmd = r'"C:\Users\dev\claude.exe" -p test'
+        assert _last_subprocess_argv(exc) == [
+            r"C:\Users\dev\claude.exe",
+            "-p",
+            "test",
+        ]
 
     def test_ignores_args_zero_when_not_list_of_str(self):
         """Don't false-positive on non-string args[0]."""


### PR DESCRIPTION
## Summary

Three pre-existing robustness issues in the SDK adapter modules (post-#2295 locations: `src/attune/models/sdk_adapter.py`, `src/attune/models/sdk_errors.py`), surfaced by the codex D11 scoped re-lane on #2295 and triaged real by the lead. All predate the move; none were introduced by it.

1. **(high) In-stream error path skips redaction** — `iter_agent_messages` stored the ResultMessage-derived error text in `SdkSubprocessError.stderr` unredacted, while the probe path (`capture_subprocess_failure`) already redacts. Fixed: the in-stream text runs through `attune.ops.session_redaction.redact()` before classification and the exception. Pinned with a secret-shaped fixture asserting the key is masked and classification survives.
2. **(medium) `get_max_budget_usd` crashed on a malformed `ATTUNE_MAX_BUDGET_USD`** — `float(...)` was uncaught. Fixed: specific `ValueError` catch, warning log, depth-default fallback. Pinned with two malformed-env tests.
3. **(medium) String-valued exception `cmd` wrapped as `[cmd]`** — `subprocess.run` then treated the whole command line as an executable path and produced a misleading not-found diagnostic. Fixed: `_split_string_cmd` shlex-splits (POSIX-aware; on Windows, non-POSIX lexing + double-quote strip so backslash paths survive; whitespace-split fallback on unbalanced quotes). The stale pin (`test_handles_cause_cmd_as_string`, which asserted the buggy behavior) updated; three new pins including a monkeypatched-`nt` case.

Also folded (retro-ratified "do now", resp-20260825-110035-90c9285a): `__all__` on both back-compat facades (`workflows/agent_sdk_adapter.py`, `workflows/sdk_errors.py`) — the honest fix for the recurring CodeQL "unused import" class on re-export facades — plus the module-alias import hoist in the two test files CodeQL flagged. Facade census: these two are the only `# noqa: F401` re-export facades in the adapter surface; no wider sweep needed.

## Design notes (no code change)

- **Dormant re-execution design in `capture_subprocess_failure`:** re-running a recovered argv is dormant today because the SDK exposes no argv (`_last_subprocess_argv` normally returns `[]` → health probe). If a future claude-agent-sdk starts exposing argv, re-running a full agent command would **re-bill and duplicate side effects** — consider a probe-only allowlist at that point.
- **`get_subagent_model` env override deliberately skips an allowlist** (operator escape hatch: new model names work without a code change; typos surface as SDK-level errors). Now documented in its docstring.

## Receipts

- Touched suites serial: 168 passed (`test_iter_agent_messages`, `test_sdk_error_fidelity`, `test_agent_sdk_adapter`, `test_sdk_adapter_layering`)
- Ratchet gates: `tests/unit/gates/ tests/unit/quality/` — 384 passed
- Full tree: `pytest tests` — **25,251 passed, 265 skipped, 6 xfailed** (2:51)
- Pinned black pre-flighted before staging; monkeypatch targets are the defining `attune.models.*` modules throughout; no new broad excepts (specific `ValueError`), no ratchet baseline changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
