### PR TITLE
feat(hooks): refuse dirty-tree branch switches and hard resets (chair-read)

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -388,6 +388,25 @@ as pickable work.
   PR body.
 - Before every commit: `git branch --show-current` — confirm the
   checkout you edited is on the branch you mean to ship.
+- **More than one branch in flight → one worktree each** (chair,
+  2026-08-25). Juggling concurrent branches through a single checkout
+  is what produces wrong-branch commits, vacuous pushes, and resets
+  that eat unrelated work; separate worktrees make the whole class
+  impossible because there is no switch to get wrong. Single-branch
+  work stays in one checkout — the policy is deliberately scoped to
+  concurrency, since every worktree costs a ~460 MB venv and the pile
+  is already large.
+  *Enforcer: `src/attune/hooks/scripts/dirty_switch_guard.py` — a
+  PreToolUse hook that refuses a branch switch or `git reset --hard`
+  while the tree is dirty (new-branch creation, path-scoped restores,
+  and explicit `--force` stay allowed).*
+- **Reap the worktree when its PR merges.** A worktree outlives its
+  branch otherwise; delete it in the same step that confirms the
+  squash, never in a bulk sweep that might delete the session's own
+  worktree or one holding an open PR.
+- Never suppress stderr on a state-changing git command
+  (`2>/dev/null` on a `checkout`/`commit`/`push` turns a loud refusal
+  into a silent no-op you will then reason from).
 - Don't touch other agents' worktrees under `.claude/worktrees/`.
 
 ### Single-source projections

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -381,6 +381,25 @@ as pickable work.
   PR body.
 - Before every commit: `git branch --show-current` — confirm the
   checkout you edited is on the branch you mean to ship.
+- **More than one branch in flight → one worktree each** (chair,
+  2026-08-25). Juggling concurrent branches through a single checkout
+  is what produces wrong-branch commits, vacuous pushes, and resets
+  that eat unrelated work; separate worktrees make the whole class
+  impossible because there is no switch to get wrong. Single-branch
+  work stays in one checkout — the policy is deliberately scoped to
+  concurrency, since every worktree costs a ~460 MB venv and the pile
+  is already large.
+  *Enforcer: `src/attune/hooks/scripts/dirty_switch_guard.py` — a
+  PreToolUse hook that refuses a branch switch or `git reset --hard`
+  while the tree is dirty (new-branch creation, path-scoped restores,
+  and explicit `--force` stay allowed).*
+- **Reap the worktree when its PR merges.** A worktree outlives its
+  branch otherwise; delete it in the same step that confirms the
+  squash, never in a bulk sweep that might delete the session's own
+  worktree or one holding an open PR.
+- Never suppress stderr on a state-changing git command
+  (`2>/dev/null` on a `checkout`/`commit`/`push` turns a loud refusal
+  into a silent no-op you will then reason from).
 - Don't touch other agents' worktrees under `.claude/worktrees/`.
 
 ### Single-source projections

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -67,6 +67,12 @@
             "command": "PY=$(command -v python3 || command -v python) && \"$PY\" \"$CLAUDE_PROJECT_DIR/src/attune/hooks/scripts/worktree_path_guard.py\"",
             "timeout": 5,
             "statusMessage": "Worktree path check..."
+          },
+          {
+            "type": "command",
+            "command": "PY=$(command -v python3 || command -v python) && \"$PY\" \"$CLAUDE_PROJECT_DIR/src/attune/hooks/scripts/dirty_switch_guard.py\"",
+            "timeout": 15,
+            "statusMessage": "Dirty-tree switch check..."
           }
         ]
       }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -388,6 +388,25 @@ as pickable work.
   PR body.
 - Before every commit: `git branch --show-current` — confirm the
   checkout you edited is on the branch you mean to ship.
+- **More than one branch in flight → one worktree each** (chair,
+  2026-08-25). Juggling concurrent branches through a single checkout
+  is what produces wrong-branch commits, vacuous pushes, and resets
+  that eat unrelated work; separate worktrees make the whole class
+  impossible because there is no switch to get wrong. Single-branch
+  work stays in one checkout — the policy is deliberately scoped to
+  concurrency, since every worktree costs a ~460 MB venv and the pile
+  is already large.
+  *Enforcer: `src/attune/hooks/scripts/dirty_switch_guard.py` — a
+  PreToolUse hook that refuses a branch switch or `git reset --hard`
+  while the tree is dirty (new-branch creation, path-scoped restores,
+  and explicit `--force` stay allowed).*
+- **Reap the worktree when its PR merges.** A worktree outlives its
+  branch otherwise; delete it in the same step that confirms the
+  squash, never in a bulk sweep that might delete the session's own
+  worktree or one holding an open PR.
+- Never suppress stderr on a state-changing git command
+  (`2>/dev/null` on a `checkout`/`commit`/`push` turns a loud refusal
+  into a silent no-op you will then reason from).
 - Don't touch other agents' worktrees under `.claude/worktrees/`.
 
 ### Single-source projections

--- a/content/collaboration/contract.md
+++ b/content/collaboration/contract.md
@@ -360,6 +360,25 @@ as pickable work.
   PR body.
 - Before every commit: `git branch --show-current` — confirm the
   checkout you edited is on the branch you mean to ship.
+- **More than one branch in flight → one worktree each** (chair,
+  2026-08-25). Juggling concurrent branches through a single checkout
+  is what produces wrong-branch commits, vacuous pushes, and resets
+  that eat unrelated work; separate worktrees make the whole class
+  impossible because there is no switch to get wrong. Single-branch
+  work stays in one checkout — the policy is deliberately scoped to
+  concurrency, since every worktree costs a ~460 MB venv and the pile
+  is already large.
+  *Enforcer: `src/attune/hooks/scripts/dirty_switch_guard.py` — a
+  PreToolUse hook that refuses a branch switch or `git reset --hard`
+  while the tree is dirty (new-branch creation, path-scoped restores,
+  and explicit `--force` stay allowed).*
+- **Reap the worktree when its PR merges.** A worktree outlives its
+  branch otherwise; delete it in the same step that confirms the
+  squash, never in a bulk sweep that might delete the session's own
+  worktree or one holding an open PR.
+- Never suppress stderr on a state-changing git command
+  (`2>/dev/null` on a `checkout`/`commit`/`push` turns a loud refusal
+  into a silent no-op you will then reason from).
 - Don't touch other agents' worktrees under `.claude/worktrees/`.
 
 ### Single-source projections

--- a/src/attune/hooks/scripts/dirty_switch_guard.py
+++ b/src/attune/hooks/scripts/dirty_switch_guard.py
@@ -1,0 +1,290 @@
+"""PreToolUse hook: refuse branch switches and hard resets that carry uncommitted work.
+
+Catches the wrong-branch-state bug class. Uncommitted changes follow you
+across a ``git checkout <branch>``, so work written for branch A lands on
+branch B; and ``git reset --hard`` discards uncommitted work outright,
+including work that merely rode along from another task.
+
+Origin (2026-08-25, one session, three fires):
+
+1. A chair-ruled fix was committed onto a sibling branch after an
+   unreturned switch. ``git push origin <name>`` then exited 0 having
+   pushed the *unchanged* ref, and the PR was armed for auto-merge on a
+   head that did not contain the fix.
+2. ``git reset --hard HEAD~1``, run as cleanup for a verification
+   experiment, destroyed ~40 minutes of finished, uncommitted work on a
+   different feature that was riding in the working tree.
+3. ``git checkout <branch> 2>/dev/null`` failed *because* of that
+   uncommitted work; the suppressed stderr turned a loud refusal into a
+   silent no-op, and the next command read the wrong branch's file.
+
+Meets the promotion criteria in
+[`docs/specs/enforcement-vs-documentation/`](../../../../docs/specs/enforcement-vs-documentation/):
+recurrence (3 fires), cost (~40 min of lost work plus a defective
+auto-merge arm), and a mechanical check (``git status --porcelain``).
+
+What is NOT blocked, deliberately:
+
+- ``git checkout -b`` / ``git switch -c`` — creating a branch carries the
+  changes to the new branch by design, which is the normal "I started in
+  the wrong place" recovery.
+- ``git checkout -- <path>`` — a path-scoped restore, not a branch switch.
+- ``git checkout --force`` / ``git switch --force`` — the operator has
+  stated the intent explicitly.
+- Anything at all when the tree is clean.
+
+Escape hatch: set ``ATTUNE_ALLOW_DIRTY_SWITCH=1`` for a session that
+genuinely needs to move a dirty tree around.
+
+Claude Code Protocol:
+    stdin: JSON with tool_name and tool_input
+    exit 0: allow tool call
+    exit 2: block tool call (stderr printed to user)
+
+Metrics: appends one line to ~/.attune/enforcement-metrics.jsonl per
+fire so the periodic retirement review can compute hit rate,
+false-alarm rate, and days-since-last-hit.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under Apache 2.0
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shlex
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+ENFORCEMENT_NAME = "dirty-switch-guard"
+METRICS_LOG = Path.home() / ".attune" / "enforcement-metrics.jsonl"
+ALLOW_ENV = "ATTUNE_ALLOW_DIRTY_SWITCH"
+
+#: Flags that mean "make a new branch" — carrying changes is intended.
+_NEW_BRANCH_FLAGS = {"-b", "-B", "-c", "-C"}
+
+#: Flags that state the destructive intent explicitly.
+_FORCE_FLAGS = {"-f", "--force", "--discard-changes"}
+
+#: Shell operators that separate one command from the next.
+_SEPARATORS = {"&&", "||", ";", "|", "&"}
+
+
+def _log_metric(outcome: str, detail: str | None = None) -> None:
+    """Append one record to the enforcement metrics log.
+
+    ``outcome`` is one of ``"fired"`` (blocked), ``"allowed"`` (ran and
+    permitted), or ``"unknown"`` (could not determine state; never
+    blocks).
+    """
+    try:
+        METRICS_LOG.parent.mkdir(parents=True, exist_ok=True)
+        record = {
+            "ts": datetime.now(timezone.utc).isoformat(),
+            "enforcement": ENFORCEMENT_NAME,
+            "outcome": outcome,
+            "detail": detail,
+        }
+        with METRICS_LOG.open("a", encoding="utf-8") as f:
+            f.write(json.dumps(record) + "\n")
+    except OSError:
+        # INTENTIONAL: metrics are best-effort; never block on them.
+        pass
+
+
+def _is_git(argv: list[str]) -> bool:
+    """True if ``argv`` invokes git (bare, or behind an env/path prefix)."""
+    for token in argv:
+        if "=" in token and not token.startswith("-"):
+            continue  # leading VAR=value assignment
+        if token in ("env", "command", "sudo"):
+            continue
+        return Path(token).name == "git"
+    return False
+
+
+def _git_args(argv: list[str]) -> list[str]:
+    """Return the arguments following the ``git`` token itself."""
+    for idx, token in enumerate(argv):
+        if Path(token).name == "git":
+            return argv[idx + 1 :]
+    return []
+
+
+def git_invocations(command: str) -> list[list[str]]:
+    """Return the git arg-lists in ``command``, one per invocation.
+
+    A single Bash call may chain several commands, so each is inspected
+    separately — a dangerous one must not hide behind a harmless leading
+    command.
+    """
+    # punctuation_chars is required, not cosmetic: plain shlex.split
+    # leaves "hi;" as one token, so `echo hi; git reset --hard` would
+    # parse as a single harmless invocation and slip past the guard.
+    try:
+        lexer = shlex.shlex(command, posix=True, punctuation_chars=True)
+        lexer.whitespace_split = True
+        tokens = list(lexer)
+    except ValueError:
+        return []  # unbalanced quotes: cannot parse, so cannot judge
+
+    invocations: list[list[str]] = []
+    current: list[str] = []
+    for token in tokens:
+        if token in _SEPARATORS:
+            if current:
+                invocations.append(current)
+            current = []
+            continue
+        current.append(token)
+    if current:
+        invocations.append(current)
+
+    return [_git_args(inv) for inv in invocations if _is_git(inv)]
+
+
+def is_branch_switch(args: list[str]) -> bool:
+    """True if ``args`` is a branch-changing checkout/switch.
+
+    False for new-branch creation, path-scoped restores, and explicit
+    ``--force`` — each a deliberate act whose effect the operator has
+    already stated.
+    """
+    if not args or args[0] not in ("checkout", "switch"):
+        return False
+
+    rest = args[1:]
+    if any(flag in _NEW_BRANCH_FLAGS for flag in rest):
+        return False
+    if any(flag in _FORCE_FLAGS for flag in rest):
+        return False
+    if "--" in rest:
+        return False  # path-scoped restore
+
+    # A bare `git checkout` / `git switch` with no target changes nothing.
+    return any(not token.startswith("-") for token in rest)
+
+
+def is_hard_reset(args: list[str]) -> bool:
+    """True if ``args`` is a ``git reset --hard`` against any target."""
+    return bool(args) and args[0] == "reset" and "--hard" in args[1:]
+
+
+def dirty_paths(cwd: Path | None = None) -> list[str] | None:
+    """Return uncommitted paths, or None if git state cannot be read."""
+    try:
+        result = subprocess.run(
+            ["git", "status", "--porcelain"],
+            cwd=str(cwd) if cwd else None,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=10,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if result.returncode != 0:
+        return None
+    return [line[3:] for line in result.stdout.splitlines() if line.strip()]
+
+
+def block_message(action: str, paths: list[str]) -> str:
+    """The refusal text, naming the work at risk and the ways forward."""
+    shown = paths[:8]
+    listing = "\n".join(f"    {p}" for p in shown)
+    if len(paths) > len(shown):
+        listing += f"\n    … and {len(paths) - len(shown)} more"
+    consequence = (
+        "those changes would follow you onto the other branch"
+        if action == "switch"
+        else "those changes would be DESTROYED"
+    )
+    return (
+        f"[{ENFORCEMENT_NAME}] refusing: {len(paths)} uncommitted change(s) "
+        f"in the working tree, and {consequence}.\n"
+        f"{listing}\n\n"
+        "Commit them, stash them (git stash -u), or state the intent "
+        "explicitly (--force for a switch). To disable for this session: "
+        f"{ALLOW_ENV}=1"
+    )
+
+
+def main(context: dict[str, Any]) -> int:
+    """Block dirty-tree branch switches and hard resets.
+
+    Returns the exit code: ``0`` for allow, ``2`` for block.
+    """
+    if context.get("tool_name") != "Bash":
+        return 0
+
+    command = context.get("tool_input", {}).get("command", "")
+    if not command:
+        return 0
+
+    if os.environ.get(ALLOW_ENV) == "1":
+        _log_metric("allowed", "escape hatch set")
+        return 0
+
+    action = None
+    for args in git_invocations(command):
+        if is_branch_switch(args):
+            action = "switch"
+            break
+        if is_hard_reset(args):
+            action = "reset"
+            break
+    if action is None:
+        return 0
+
+    paths = dirty_paths()
+    if paths is None:
+        # Not a git tree, or git unreadable — degrade to allow.
+        _log_metric("unknown", action)
+        return 0
+    if not paths:
+        _log_metric("allowed", f"{action} on a clean tree")
+        return 0
+
+    print(block_message(action, paths), file=sys.stderr)
+    _log_metric("fired", f"{action} with {len(paths)} dirty path(s)")
+    return 2
+
+
+def _read_stdin_context() -> dict[str, Any]:
+    """Parse the hook context from stdin; empty dict when unavailable."""
+    try:
+        raw = sys.stdin.read()
+    except (OSError, ValueError):
+        return {}
+    if not raw.strip():
+        return {}
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError:
+        return {}
+    return parsed if isinstance(parsed, dict) else {}
+
+
+if __name__ == "__main__":
+    from _bootstrap import ensure_utf8_stdio
+
+    ensure_utf8_stdio()
+    from _sdk_gate import exit_if_sdk_subprocess
+
+    exit_if_sdk_subprocess()
+    ctx = _read_stdin_context()
+    if not ctx:
+        sys.exit(0)
+    try:
+        sys.exit(main(ctx))
+    except Exception as exc:  # noqa: BLE001
+        # INTENTIONAL: a hook bug must never block real work.
+        print(
+            f"[{ENFORCEMENT_NAME}] hook error (allowing): {type(exc).__name__}: {exc}",
+            file=sys.stderr,
+        )
+        sys.exit(0)

--- a/tests/unit/gates/test_broad_except_ratchet.py
+++ b/tests/unit/gates/test_broad_except_ratchet.py
@@ -141,6 +141,10 @@ _BASELINE: dict[str, int] = {
     "src/attune/handoff/memory_link.py": 5,
     "src/attune/help/feedback.py": 1,
     "src/attune/help/polish.py": 1,
+    # dirty_switch_guard: the PreToolUse __main__ block catches broadly
+    # so a bug in the guard can never block real work — a guard that
+    # crashes must fail OPEN (exit 0), matching every sibling hook here.
+    "src/attune/hooks/scripts/dirty_switch_guard.py": 1,
     "src/attune/hooks/scripts/evaluate_session.py": 3,
     # format_on_save added 1 for library-review L3 (PR #2117): the
     # PostToolUse exit-0-always contract must survive wrong-typed

--- a/tests/unit/gates/test_path_validation_gate.py
+++ b/tests/unit/gates/test_path_validation_gate.py
@@ -78,6 +78,11 @@ ALLOWLIST = frozenset(
         # user- or LLM-supplied — same class as gates/envelope.py.
         "src/attune/gates/session_ledger.py",
         "src/attune/handoff/packet.py",
+        # dirty_switch_guard writes only the constant enforcement-metrics
+        # log (~/.attune/enforcement-metrics.jsonl) — no interpolation, no
+        # user- or LLM-supplied component. Same shape and same path as
+        # worktree_path_guard below.
+        "src/attune/hooks/scripts/dirty_switch_guard.py",
         "src/attune/hooks/scripts/worktree_path_guard.py",
         "src/attune/help/feedback.py",
         "src/attune/help/generator.py",

--- a/tests/unit/hooks/test_dirty_switch_guard.py
+++ b/tests/unit/hooks/test_dirty_switch_guard.py
@@ -11,6 +11,9 @@ Licensed under the Apache License, Version 2.0
 from __future__ import annotations
 
 import importlib.util
+import io
+import json
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -183,6 +186,131 @@ class TestFailsOpen:
     def test_dirty_paths_returns_none_outside_a_repo(self, mod, tmp_path, monkeypatch):
         monkeypatch.chdir(tmp_path)
         assert mod.dirty_paths() is None
+
+
+class TestGitDetection:
+    """``git`` must be recognized behind the prefixes people actually type."""
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "GIT_AUTHOR_NAME=x git checkout main",
+            "env git checkout main",
+            "sudo git checkout main",
+            "/usr/bin/git checkout main",
+        ],
+    )
+    def test_prefixed_git_is_still_git(self, mod, command):
+        invocations = mod.git_invocations(command)
+        assert invocations, f"git not detected in: {command}"
+        assert mod.is_branch_switch(invocations[0]) is True
+
+    def test_a_lookalike_binary_is_not_git(self, mod):
+        assert mod.git_invocations("gitk checkout main") == []
+        assert mod.git_invocations("mygit checkout main") == []
+
+
+class TestMetricsLogging:
+    """Metrics are best-effort and must never block the tool call."""
+
+    def test_metric_row_is_written(self, mod, tmp_path, monkeypatch):
+        log = tmp_path / "metrics.jsonl"
+        monkeypatch.setattr(mod, "METRICS_LOG", log)
+
+        mod._log_metric("fired", "switch with 2 dirty path(s)")
+
+        rows = [json.loads(line) for line in log.read_text().splitlines()]
+        assert len(rows) == 1
+        assert rows[0]["enforcement"] == mod.ENFORCEMENT_NAME
+        assert rows[0]["outcome"] == "fired"
+        assert rows[0]["detail"] == "switch with 2 dirty path(s)"
+        assert rows[0]["ts"]
+
+    def test_unwritable_log_is_swallowed(self, mod, tmp_path, monkeypatch):
+        """An unwritable metrics path must not raise into the hook."""
+        blocker = tmp_path / "not-a-dir"
+        blocker.write_text("x")
+        monkeypatch.setattr(mod, "METRICS_LOG", blocker / "sub" / "metrics.jsonl")
+
+        mod._log_metric("fired", "detail")  # must not raise
+
+    def test_escape_hatch_records_an_allowed_metric(self, mod, tmp_path, monkeypatch):
+        log = tmp_path / "metrics.jsonl"
+        monkeypatch.setattr(mod, "METRICS_LOG", log)
+        monkeypatch.setenv(mod_allow_env(), "1")
+
+        assert mod.main(_ctx("git checkout main")) == 0
+        assert "escape hatch" in log.read_text()
+
+
+class TestStdinContextParsing:
+    """Malformed hook input must degrade to allow, never crash."""
+
+    def test_valid_json_object_parses(self, mod, monkeypatch):
+        monkeypatch.setattr("sys.stdin", io.StringIO('{"tool_name": "Bash"}'))
+        assert mod._read_stdin_context() == {"tool_name": "Bash"}
+
+    def test_empty_stdin_yields_empty_context(self, mod, monkeypatch):
+        monkeypatch.setattr("sys.stdin", io.StringIO("   "))
+        assert mod._read_stdin_context() == {}
+
+    def test_malformed_json_yields_empty_context(self, mod, monkeypatch):
+        monkeypatch.setattr("sys.stdin", io.StringIO("{not json"))
+        assert mod._read_stdin_context() == {}
+
+    def test_non_object_json_yields_empty_context(self, mod, monkeypatch):
+        """A JSON array is valid JSON but not a hook context."""
+        monkeypatch.setattr("sys.stdin", io.StringIO("[1, 2]"))
+        assert mod._read_stdin_context() == {}
+
+
+class TestScriptEntryPoint:
+    """A non-mocked round trip through the real script, as Claude Code runs it."""
+
+    @pytest.fixture
+    def repo(self, tmp_path):
+        subprocess.run(["git", "init", "-q", "-b", "main"], cwd=tmp_path, check=True)
+        subprocess.run(["git", "config", "user.email", "t@t.invalid"], cwd=tmp_path, check=True)
+        subprocess.run(["git", "config", "user.name", "t"], cwd=tmp_path, check=True)
+        (tmp_path / "f.txt").write_text("one")
+        subprocess.run(["git", "add", "-A"], cwd=tmp_path, check=True)
+        subprocess.run(
+            ["git", "commit", "-q", "--no-gpg-sign", "-m", "first"], cwd=tmp_path, check=True
+        )
+        return tmp_path
+
+    def _run(self, repo, payload: str):
+        env = dict(os.environ)
+        env.pop(mod_allow_env(), None)
+        return subprocess.run(
+            [sys.executable, str(SCRIPT_PATH)],
+            input=payload,
+            cwd=repo,
+            capture_output=True,
+            text=True,
+            check=False,
+            env=env,
+        )
+
+    def test_dirty_switch_exits_2_with_the_files_named(self, repo):
+        (repo / "f.txt").write_text("uncommitted")
+        result = self._run(
+            repo, '{"tool_name":"Bash","tool_input":{"command":"git checkout main"}}'
+        )
+        assert result.returncode == 2
+        assert "f.txt" in result.stderr
+
+    def test_clean_switch_exits_0(self, repo):
+        result = self._run(
+            repo, '{"tool_name":"Bash","tool_input":{"command":"git checkout main"}}'
+        )
+        assert result.returncode == 0
+
+    def test_empty_stdin_exits_0(self, repo):
+        assert self._run(repo, "").returncode == 0
+
+    def test_malformed_stdin_exits_0(self, repo):
+        assert self._run(repo, "{not json").returncode == 0
 
 
 def mod_allow_env() -> str:

--- a/tests/unit/hooks/test_dirty_switch_guard.py
+++ b/tests/unit/hooks/test_dirty_switch_guard.py
@@ -1,0 +1,190 @@
+"""Tests for the dirty-switch guard PreToolUse hook.
+
+Covers the pure command classification (which git invocations are
+branch-changing or destructive), the block decision against a REAL git
+repository, and the fail-open paths — a hook bug must never block work.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under the Apache License, Version 2.0
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCRIPT_PATH = REPO_ROOT / "src" / "attune" / "hooks" / "scripts" / "dirty_switch_guard.py"
+
+
+@pytest.fixture(scope="module")
+def mod():
+    spec = importlib.util.spec_from_file_location("_dirty_switch_guard", SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None
+    m = importlib.util.module_from_spec(spec)
+    sys.modules["_dirty_switch_guard"] = m
+    spec.loader.exec_module(m)
+    return m
+
+
+def _ctx(command: str) -> dict:
+    return {"tool_name": "Bash", "tool_input": {"command": command}}
+
+
+class TestBranchSwitchClassification:
+    """Only branch-CHANGING checkouts count."""
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "git checkout main",
+            "git switch main",
+            "git checkout claude/some-branch",
+        ],
+    )
+    def test_plain_switches_are_branch_switches(self, mod, command):
+        args = mod.git_invocations(command)[0]
+        assert mod.is_branch_switch(args) is True
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "git checkout -b new-branch",
+            "git switch -c new-branch",
+            "git checkout -B existing",
+            # Carrying changes onto a NEW branch is the normal recovery.
+        ],
+    )
+    def test_new_branch_creation_is_allowed(self, mod, command):
+        args = mod.git_invocations(command)[0]
+        assert mod.is_branch_switch(args) is False
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "git checkout -- src/file.py",
+            "git checkout main -- src/file.py",
+        ],
+    )
+    def test_path_scoped_restore_is_not_a_switch(self, mod, command):
+        args = mod.git_invocations(command)[0]
+        assert mod.is_branch_switch(args) is False
+
+    def test_explicit_force_is_allowed(self, mod):
+        args = mod.git_invocations("git checkout --force main")[0]
+        assert mod.is_branch_switch(args) is False
+
+    def test_bare_checkout_changes_nothing(self, mod):
+        args = mod.git_invocations("git checkout")[0]
+        assert mod.is_branch_switch(args) is False
+
+    def test_non_git_commands_yield_no_invocations(self, mod):
+        assert mod.git_invocations("echo git checkout main") == []
+        assert mod.git_invocations("ls -la") == []
+
+
+class TestHardResetClassification:
+    def test_hard_reset_detected(self, mod):
+        args = mod.git_invocations("git reset --hard HEAD~1")[0]
+        assert mod.is_hard_reset(args) is True
+
+    def test_soft_and_mixed_resets_are_not_destructive(self, mod):
+        assert mod.is_hard_reset(mod.git_invocations("git reset --soft HEAD~1")[0]) is False
+        assert mod.is_hard_reset(mod.git_invocations("git reset HEAD~1")[0]) is False
+
+
+class TestChainedCommands:
+    """A dangerous invocation must not hide behind a harmless one."""
+
+    def test_switch_after_a_harmless_command_is_still_seen(self, mod):
+        invocations = mod.git_invocations("git status && git checkout main")
+        assert any(mod.is_branch_switch(a) for a in invocations)
+
+    def test_reset_after_a_semicolon_is_still_seen(self, mod):
+        invocations = mod.git_invocations("echo hi; git reset --hard HEAD~1")
+        assert any(mod.is_hard_reset(a) for a in invocations)
+
+    def test_unparseable_command_degrades_to_no_invocations(self, mod):
+        assert mod.git_invocations('git checkout "unbalanced') == []
+
+
+class TestAgainstRealRepository:
+    """The decision is only useful if it reads real git state."""
+
+    @pytest.fixture
+    def repo(self, tmp_path, monkeypatch):
+        subprocess.run(["git", "init", "-q", "-b", "main"], cwd=tmp_path, check=True)
+        subprocess.run(["git", "config", "user.email", "t@t.invalid"], cwd=tmp_path, check=True)
+        subprocess.run(["git", "config", "user.name", "t"], cwd=tmp_path, check=True)
+        (tmp_path / "f.txt").write_text("one")
+        subprocess.run(["git", "add", "-A"], cwd=tmp_path, check=True)
+        subprocess.run(
+            ["git", "commit", "-q", "--no-gpg-sign", "-m", "first"], cwd=tmp_path, check=True
+        )
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv(mod_allow_env(), raising=False)
+        return tmp_path
+
+    def test_clean_tree_allows_the_switch(self, mod, repo):
+        assert mod.main(_ctx("git checkout main")) == 0
+
+    def test_dirty_tree_blocks_the_switch(self, mod, repo):
+        (repo / "f.txt").write_text("uncommitted edit")
+        assert mod.main(_ctx("git checkout main")) == 2
+
+    def test_dirty_tree_blocks_a_hard_reset(self, mod, repo):
+        (repo / "new.txt").write_text("unsaved work")
+        assert mod.main(_ctx("git reset --hard HEAD~1")) == 2
+
+    def test_dirty_tree_still_allows_new_branch_creation(self, mod, repo):
+        (repo / "f.txt").write_text("uncommitted edit")
+        assert mod.main(_ctx("git checkout -b rescue")) == 0
+
+    def test_dirty_tree_allows_unrelated_commands(self, mod, repo):
+        (repo / "f.txt").write_text("uncommitted edit")
+        assert mod.main(_ctx("git status")) == 0
+        assert mod.main(_ctx("pytest tests")) == 0
+
+    def test_escape_hatch_allows_a_dirty_switch(self, mod, repo, monkeypatch):
+        (repo / "f.txt").write_text("uncommitted edit")
+        monkeypatch.setenv(mod_allow_env(), "1")
+        assert mod.main(_ctx("git checkout main")) == 0
+
+    def test_block_message_names_the_files(self, mod, repo):
+        (repo / "f.txt").write_text("uncommitted edit")
+        paths = mod.dirty_paths()
+        message = mod.block_message("switch", paths)
+        assert "f.txt" in message
+        assert "follow you onto the other branch" in message
+
+    def test_reset_message_says_destroyed(self, mod, repo):
+        message = mod.block_message("reset", ["a.py"])
+        assert "DESTROYED" in message
+
+
+class TestFailsOpen:
+    """A guard that crashes must never block real work."""
+
+    def test_non_bash_tools_pass_through(self, mod):
+        assert mod.main({"tool_name": "Edit", "tool_input": {"file_path": "x"}}) == 0
+
+    def test_empty_command_passes_through(self, mod):
+        assert mod.main(_ctx("")) == 0
+
+    def test_outside_a_git_tree_degrades_to_allow(self, mod, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)  # not a repo
+        monkeypatch.delenv(mod_allow_env(), raising=False)
+        assert mod.main(_ctx("git checkout main")) == 0
+
+    def test_dirty_paths_returns_none_outside_a_repo(self, mod, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        assert mod.dirty_paths() is None
+
+
+def mod_allow_env() -> str:
+    """The escape-hatch variable name, kept in one place."""
+    return "ATTUNE_ALLOW_DIRTY_SWITCH"


### PR DESCRIPTION
## Summary

**(chair-read)** — governance/enforcement surface: a new PreToolUse guard, the collaboration contract, and two gate baselines.

Chair-ruled 2026-08-25 after **three fires in a single session**, all the same shape — uncommitted work riding across a branch switch:

1. A chair-ruled fix was committed onto a **sibling branch** after an unreturned switch. `git push origin <name>` then exited 0 having pushed the *unchanged* ref, and #2299 was armed for auto-merge on a head that did not contain the fix.
2. `git reset --hard HEAD~1`, run as cleanup for a verification experiment, **destroyed ~40 minutes** of finished uncommitted work belonging to a different feature.
3. `git checkout <branch> 2>/dev/null` failed *because* of that uncommitted work; the suppressed stderr turned a loud refusal into a silent no-op that was then reasoned from.

## The guard

Blocks a branch switch or `git reset --hard` while the working tree is dirty.

**Deliberately not blocked:** new-branch creation (`-b`/`-c` carries changes by design — that's the normal "started in the wrong place" recovery), path-scoped restores (`git checkout -- file`), explicit `--force`, and anything on a clean tree. Escape hatch `ATTUNE_ALLOW_DIRTY_SWITCH=1`. **Fails open** on any error or outside a git tree — a guard must never block real work.

## The policy (scoped, not blanket)

Chair chose scope over a blanket rule: **more than one branch in flight → one worktree each**; single-branch work stays in one checkout. Blanket "always" would mint a ~460 MB venv per task, and 34 worktrees (~15 GB, mostly stale) already exist. Paired with a **reaping rule** — delete the worktree when its PR merges — and a ban on suppressing stderr on state-changing git commands.

## Receipts

- **28 hook tests**: command classification, decisions against **real git repositories**, and every fail-open path
- **Full tree: 25,227 passed**
- **Non-mocked live round trip**: real stdin through the real script exited 2 and named this worktree's own four dirty files
- **A test caught a real evasion gap mid-build**: plain `shlex.split` leaves `hi;` as one token, so `echo hi; git reset --hard` parsed as a single harmless invocation and slipped past. Fixed with `punctuation_chars` tokenization; the chained-command cases are pinned.

Two gate baselines updated with reasons: broad-except (the fail-open `__main__` handler, matching every sibling hook) and path-validation (the constant `~/.attune/enforcement-metrics.jsonl` path, same shape as `worktree_path_guard`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
