### PR TITLE
fix(agent-factory): measure durations with monotonic clock, de-flake timing test

### DIFF
--- a/src/attune/agent_factory/decorators.py
+++ b/src/attune/agent_factory/decorators.py
@@ -48,7 +48,7 @@ def safe_agent_operation(operation_name: str) -> Callable[[F], F]:
         @wraps(func)
         async def wrapper(self, *args, **kwargs):
             """Execute the operation with logging, timing, and error capture."""
-            start_time = time.time()
+            start_time = time.monotonic()
             agent_name = getattr(self, "name", self.__class__.__name__)
 
             logger.debug(f"[{agent_name}] Starting {operation_name}")
@@ -56,13 +56,13 @@ def safe_agent_operation(operation_name: str) -> Callable[[F], F]:
             try:
                 result = await func(self, *args, **kwargs)
 
-                elapsed = time.time() - start_time
+                elapsed = time.monotonic() - start_time
                 logger.debug(f"[{agent_name}] Completed {operation_name} in {elapsed:.2f}s")
 
                 return result
 
             except Exception as e:  # noqa: BLE001
-                elapsed = time.time() - start_time
+                elapsed = time.monotonic() - start_time
                 logger.error(f"[{agent_name}] {operation_name} failed after {elapsed:.2f}s: {e}")
 
                 # Add to audit trail if available
@@ -150,6 +150,9 @@ def retry_on_failure(
 def log_performance(threshold_seconds: float = 1.0) -> Callable[[F], F]:
     """Decorator to log slow operations.
 
+    Elapsed time is measured with ``time.monotonic()``, so a wall-clock
+    adjustment mid-call cannot distort the duration.
+
     Args:
         threshold_seconds: Log warning if operation exceeds this duration
 
@@ -167,11 +170,11 @@ def log_performance(threshold_seconds: float = 1.0) -> Callable[[F], F]:
         @wraps(func)
         async def wrapper(*args, **kwargs):
             """Time the function and log a warning if it exceeds the threshold."""
-            start_time = time.time()
+            start_time = time.monotonic()
 
             result = await func(*args, **kwargs)
 
-            elapsed = time.time() - start_time
+            elapsed = time.monotonic() - start_time
             func_name = func.__name__
 
             if elapsed > threshold_seconds:

--- a/tests/agent_factory/test_llm_toolkit_decorators.py
+++ b/tests/agent_factory/test_llm_toolkit_decorators.py
@@ -239,12 +239,53 @@ class TestRetryOnFailure:
 # =============================================================================
 
 
+class _ScriptedClock:
+    """Stand-in for the ``time`` module returning exact, scripted readings.
+
+    Substituted for ``attune.agent_factory.decorators.time`` so elapsed
+    durations are decided by the test rather than measured from a real
+    clock on a loaded CI runner. Each reading list is consumed in order
+    and its final value repeats.
+
+    Args:
+        monotonic_readings: Successive ``time.monotonic()`` return values.
+        wall_readings: Successive ``time.time()`` return values. Defaults
+            to ``monotonic_readings``. Set these apart to simulate a
+            wall-clock adjustment during the decorated call.
+    """
+
+    def __init__(
+        self,
+        monotonic_readings: list[float],
+        wall_readings: list[float] | None = None,
+    ) -> None:
+        self._monotonic = list(monotonic_readings)
+        self._wall = list(monotonic_readings if wall_readings is None else wall_readings)
+
+    @staticmethod
+    def _next(readings: list[float]) -> float:
+        """Pop the next reading, repeating the last one once exhausted."""
+        return readings.pop(0) if len(readings) > 1 else readings[0]
+
+    def monotonic(self) -> float:
+        """Return the next scripted monotonic reading."""
+        return self._next(self._monotonic)
+
+    def time(self) -> float:
+        """Return the next scripted wall-clock reading."""
+        return self._next(self._wall)
+
+
 class TestLogPerformance:
     """Tests for log_performance decorator."""
 
     @pytest.mark.asyncio
-    async def test_fast_operation_no_warning(self):
+    async def test_fast_operation_no_warning(self, monkeypatch):
         """Test fast operation doesn't log warning."""
+        monkeypatch.setattr(
+            "attune.agent_factory.decorators.time",
+            _ScriptedClock([100.0, 100.1]),
+        )
 
         @log_performance(threshold_seconds=1.0)
         async def fast_operation():
@@ -257,12 +298,92 @@ class TestLogPerformance:
             mock_logger.warning.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_slow_operation_logs_warning(self):
+    async def test_slow_operation_logs_warning(self, monkeypatch):
         """Test slow operation logs warning."""
+        monkeypatch.setattr(
+            "attune.agent_factory.decorators.time",
+            _ScriptedClock([100.0, 105.0]),
+        )
+
+        @log_performance(threshold_seconds=1.0)
+        async def slow_operation():
+            return "slow"
+
+        with patch("attune.agent_factory.decorators.logger") as mock_logger:
+            result = await slow_operation()
+
+            assert result == "slow"
+            mock_logger.warning.assert_called_once()
+            assert "Slow operation" in str(mock_logger.warning.call_args)
+
+    @pytest.mark.asyncio
+    async def test_backward_wall_clock_jump_still_logs_warning(self, monkeypatch):
+        """A backward wall-clock jump must not suppress the slow-operation warning.
+
+        Regression guard for the monotonic fix: the operation really takes
+        5s, but the wall clock is set back 1s mid-call. Measuring with
+        ``time.time()`` yields a negative elapsed and silently skips the
+        warning; ``time.monotonic()`` is unaffected.
+        """
+        monkeypatch.setattr(
+            "attune.agent_factory.decorators.time",
+            _ScriptedClock(
+                monotonic_readings=[100.0, 105.0],
+                wall_readings=[1_000_000.0, 999_999.0],
+            ),
+        )
+
+        @log_performance(threshold_seconds=1.0)
+        async def slow_operation():
+            return "slow"
+
+        with patch("attune.agent_factory.decorators.logger") as mock_logger:
+            result = await slow_operation()
+
+            assert result == "slow"
+            mock_logger.warning.assert_called_once()
+            assert "Slow operation" in str(mock_logger.warning.call_args)
+
+    @pytest.mark.asyncio
+    async def test_forward_wall_clock_jump_logs_no_false_warning(self, monkeypatch):
+        """A forward wall-clock jump must not fabricate a slow-operation warning.
+
+        Regression guard for the monotonic fix: the operation takes 0.1s,
+        but the wall clock jumps forward 500s mid-call. Measuring with
+        ``time.time()`` reports a spurious 500s and warns; ``time.monotonic()``
+        is unaffected.
+        """
+        monkeypatch.setattr(
+            "attune.agent_factory.decorators.time",
+            _ScriptedClock(
+                monotonic_readings=[100.0, 100.1],
+                wall_readings=[1_000_000.0, 1_000_500.0],
+            ),
+        )
+
+        @log_performance(threshold_seconds=1.0)
+        async def fast_operation():
+            return "quick"
+
+        with patch("attune.agent_factory.decorators.logger") as mock_logger:
+            result = await fast_operation()
+
+            assert result == "quick"
+            mock_logger.warning.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_real_sleep_over_threshold_logs_warning(self):
+        """End-to-end check against the real clock, with a 15x margin.
+
+        The deterministic tests above pin the comparison logic; this one
+        confirms the decorator reads a clock that advances with real time.
+        The margin is wide enough to absorb a loaded runner and the ~15.6ms
+        monotonic granularity on Windows -- do not narrow it.
+        """
 
         @log_performance(threshold_seconds=0.01)
         async def slow_operation():
-            await asyncio.sleep(0.02)
+            await asyncio.sleep(0.15)
             return "slow"
 
         with patch("attune.agent_factory.decorators.logger") as mock_logger:


### PR DESCRIPTION
## Bug 1 — wrong clock (the real defect)

`safe_agent_operation` and `log_performance` measured elapsed duration with
`time.time()`, the adjustable wall clock. An NTP correction or manual clock
change mid-call yields a wrong `elapsed`:

- **negative** → `elapsed > threshold_seconds` is false, silently suppressing
  the slow-operation warning
- **spuriously huge** → a false `Slow operation` warning

It is also coarser than `time.monotonic()` on Windows. Both decorators now use
`time.monotonic()`, which is what the stdlib prescribes for measuring a duration.

Swept the whole file; five duration sites moved:

| Site | Function |
|------|----------|
| `decorators.py:51`, `:59`, `:65` | `safe_agent_operation` |
| `decorators.py:173`, `:177` | `log_performance` |

`time.time_ns()` at `:250` is **left alone** — it builds an operation id, which
is a legitimate wall-clock timestamp, not a duration.

## Bug 2 — the flaky test

`test_slow_operation_logs_warning` asserted that `asyncio.sleep(0.02)` tripped a
`threshold_seconds=0.01` decorator — a 2x margin on a real measurement, under
pytest-xdist on shared runners, against a clock whose Windows granularity is
~15.6ms.

It failed on `test (windows-latest, 3.11)` for #2301 (run 32874932128) on a diff
that only removed the EmpathyMCPServer alias and legacy entry-point groups —
code that cannot influence a timing decorator — while `main` was green on the
same test. A flake, and it cost a full ~14-minute Windows lane rerun.

Both directions are now **deterministic**: a scripted clock is monkeypatched over
the decorators module's `time`, so elapsed is exact and nothing sleeps. One
real-sleep test is kept for integration realism at a **15x** margin (0.15s sleep
vs 0.01s threshold), wide enough to absorb both a loaded runner and the ~15.6ms
granularity.

⚠️ **Do not narrow that margin.** Moving to `time.monotonic()` fixes the
clock-adjustment bug but does **not** make the clock finer on Windows — CPython
uses `GetTickCount64` there until 3.13 switches to `QueryPerformanceCounter`.
A reader who sees this fix land and concludes "the clock is precise now" would
reintroduce the flake. There is a comment saying so at the assertion site.

## Receipts

- `tests/agent_factory/test_llm_toolkit_decorators.py` — **32 passed**
- **The two clock-jump guards are not fiction.** Reverted the source to
  `time.time()` and re-ran them; both failed with exactly the predicted
  symptoms — the forward jump fabricated
  `Slow operation: fast_operation took 500.00s`, the backward jump suppressed
  the warning entirely. Then restored.
- `tests/unit/gates/ tests/unit/quality/` — **384 passed** (ratchet sweep)
- Full `pytest tests` keyless (`ANTHROPIC_API_KEY=""`) —
  **25202 passed, 263 skipped, 6 xfailed**
- `black` + `ruff` pre-flighted before staging; commit GPG-signed (`%G?` = `G`)
- **No new `except` clauses**, so no broad-except ratchet baseline change

## Notes

Other modules repo-wide use `time.time()` for durations
(`tools.py`, `llm/security.py`, `resilience/health.py`, and others). Out of
scope here — chair-callable as a follow-up sweep if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
