### PR TITLE
docs(release-15): record D8 rulings + add the 15.0.0 upgrade guide (chair-read)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+15.0.0 finishes the Empathy-framework excision begun in 9.0.0: the
+public `empathy_level` surface, the `EmpathyMCPServer` alias, and the
+legacy entry-point groups are all removed. CLI, plugin, and MCP users
+upgrade with no code changes; third-party plugins that subclass the
+plugin contract, register entry points, or pass a level are affected.
+Upgrading? The
+[15.0.0 upgrade guide](docs/migration/upgrading-to-15.0.0.md) has a
+one-glance "are you affected?" table.
+
 ### Removed (BREAKING — 15.0.0)
 
 - **Legacy Empathy-era names are gone** (release-15-manifest,

--- a/docs/migration/upgrading-to-15.0.0.md
+++ b/docs/migration/upgrading-to-15.0.0.md
@@ -33,11 +33,16 @@ passes a level.
 The alias was deprecated in 14.x and is removed. The class itself is
 unchanged — only the old name went away.
 
-```python
-# before
-from attune.mcp import EmpathyMCPServer
+Before:
 
-# after
+<!-- doc-import-skip: 15.0.0-removed API, shown for migration -->
+```python
+from attune.mcp import EmpathyMCPServer
+```
+
+After:
+
+```python
 from attune.mcp import AttuneMCPServer
 ```
 

--- a/docs/migration/upgrading-to-15.0.0.md
+++ b/docs/migration/upgrading-to-15.0.0.md
@@ -1,0 +1,142 @@
+# Upgrading to 15.0.0
+
+15.0.0 finishes the Empathy-framework excision that began in 9.0.0.
+Everything it removes is a public surface that pointed at a retired
+contract: the 1–5 `empathy_level` knob, the `EmpathyMCPServer` name,
+and the legacy entry-point groups. **If you use attune-ai through
+the CLI, the plugin, or the MCP tools, you upgrade with no code
+changes.** The removals bite in exactly one place — third-party code
+that subclasses the plugin contract, registers entry points, or
+passes a level.
+
+## Do you need to change anything?
+
+| Situation | What's different in 15.0.0 | What to do |
+|---|---|---|
+| You import `EmpathyMCPServer` (§1) | the alias is gone | import `AttuneMCPServer` |
+| You register workflows under `empathy.workflows` (§2) | the group is no longer read | re-register under `attune.workflows` |
+| You register plugins under `attune_framework.plugins` or `empathy_framework.plugins` (§2) | neither group is read | re-register under `attune.plugins` |
+| You subclass `attune.plugins.base.BaseWorkflow` (§3) | `__init__` no longer takes `empathy_level`; `get_empathy_level()` is gone | drop the argument and the call |
+| You pass `empathy_level` to `AgentConfig` or `UnifiedAgentConfig` (§3) | the field is gone | drop it |
+| You call `PluginRegistry.find_workflows_by_level()` or `AgentRegistry.get_by_empathy_level()` (§3) | both are gone | filter on your own metadata |
+| You call the `attune_get_level` / `attune_set_level` MCP tools (§3) | both are deleted | remove the calls |
+| You read `workflows_by_level` from plugin statistics (§3) | the block is gone | drop the read |
+| You have `empathy_level:` in agents.md frontmatter (§4) | the key is ignored, not an error | nothing — remove it at your leisure |
+| You have an existing metrics database (§4) | the legacy column is dropped on first open | nothing — it migrates itself |
+
+**If none of these describe you, you're done — upgrade normally.**
+
+---
+
+## 1. `EmpathyMCPServer` is gone
+
+The alias was deprecated in 14.x and is removed. The class itself is
+unchanged — only the old name went away.
+
+```python
+# before
+from attune.mcp import EmpathyMCPServer
+
+# after
+from attune.mcp import AttuneMCPServer
+```
+
+## 2. Entry-point discovery is `attune.*` only
+
+Discovery previously read a three-way split of groups. 15.0.0 reads
+one group per kind:
+
+| Kind | Read in 15.0.0 | No longer read |
+|---|---|---|
+| Workflows | `attune.workflows` | `empathy.workflows` |
+| Plugins | `attune.plugins` | `attune_framework.plugins`, `empathy_framework.plugins` |
+
+If your package declares a legacy group, your workflow or plugin
+will simply stop being discovered — silently, since an unreadable
+group is indistinguishable from having none. Update `pyproject.toml`:
+
+```toml
+# before
+[project.entry-points."empathy.workflows"]
+my_workflow = "my_pkg.workflows:MyWorkflow"
+
+# after
+[project.entry-points."attune.workflows"]
+my_workflow = "my_pkg.workflows:MyWorkflow"
+```
+
+Re-install the package after editing so the metadata is regenerated.
+
+## 3. The `empathy_level` knob is gone from every public API
+
+The 1–5 level was defined by the retired framework, so it retires
+with it rather than surviving under a new name.
+
+```python
+# before
+class MyWorkflow(BaseWorkflow):
+    def __init__(self):
+        super().__init__(name="mine", domain="software", empathy_level=3)
+
+# after
+class MyWorkflow(BaseWorkflow):
+    def __init__(self):
+        super().__init__(name="mine", domain="software")
+```
+
+The current signature is
+`BaseWorkflow.__init__(self, name, domain, category=None)`.
+
+Removed alongside it: `get_empathy_level()`, the `empathy_level`
+field on `AgentConfig` (`attune.agent_factory.base`) and
+`UnifiedAgentConfig` (`attune.config.agent_config`),
+`PluginRegistry.find_workflows_by_level()`, the `workflows_by_level`
+statistics block, `AgentRegistry.get_by_empathy_level()`, the
+`empathy_level` parameter of `MetricsCollector.record_metric()`, and
+the `attune_get_level` / `attune_set_level` MCP tools.
+
+If you were using the level to select among your own workflows, keep
+your own mapping — the framework no longer has an opinion about what
+1–5 means.
+
+## 4. Two things that migrate themselves
+
+**agents.md frontmatter.** A leftover `empathy_level:` key parses as
+ignored. It is not an error, so you can remove it whenever you like.
+
+**Metrics databases.** An existing metrics database keeps its old
+`empathy_level` column until first open under 15.0.0, at which point
+the column is dropped automatically. No manual migration, no data
+loss beyond that column.
+
+## What did NOT change
+
+`EmpathyLLM`'s internal five-level progression is untouched. It is an
+un-exported implementation detail, not part of the public surface,
+and its future is tracked separately. If you are reaching into it,
+you are using a private API and it may still move.
+
+## Not sure whether anything applies?
+
+Grep your project:
+
+```bash
+grep -rn \
+  -e "empathy_level" \
+  -e "EmpathyMCPServer" \
+  -e "empathy.workflows" \
+  -e "empathy_framework.plugins" \
+  -e "attune_framework.plugins" \
+  -e "attune_get_level" \
+  -e "attune_set_level" \
+  -e "find_workflows_by_level" \
+  -e "get_by_empathy_level" \
+  .
+```
+
+No hits means no changes are needed.
+
+## See also
+
+- [CHANGELOG](https://github.com/Smart-AI-Memory/attune-ai/blob/main/CHANGELOG.md) — the full 15.0.0 entry
+- [Upgrading to 13.0.0](upgrading-to-13.0.0.md) — the previous guide

--- a/docs/specs/release-15-manifest/decisions.md
+++ b/docs/specs/release-15-manifest/decisions.md
@@ -135,3 +135,51 @@ un-exported implementation detail (it is not in `attune.__all__`);
 its redesign or retirement is spun off as its own post-15 issue.
 llm/state, learning/evaluator internals, and the security audit
 log's level field ride along untouched as internals.
+
+## D8 — Cut timing, `analyze()` deferral, and the upgrade guide (RATIFIED chair 2026-08-25, via form)
+
+Three rulings from one form, taken after the lead pushed back on
+cutting the same day. Recorded together because they were decided
+together and the second is the reason the first moved.
+
+**Cut timing: 2026-08-26, not 2026-08-25.** The manifest's
+sequencing steps 1 and 2 are complete — passenger 1 discharged in
+14.0.0 (D6), the `empathy_level` public surface removed in #2299,
+and the `EmpathyMCPServer` alias plus entry-point standardization
+in #2301. Only step 3 (release prep, release-audit sitting,
+tag/publish) remained. The chair moved the cut one day to let the
+upgrade guide land first; the D5 window (ship before 2026-09-01)
+is unaffected — five days of margin remain.
+
+**`analyze()` dead contract: DEFERRED, a 16.0.0 is accepted.**
+`attune.plugins.base.BaseWorkflow` still declares an abstract
+`analyze()` the engine cannot run (its own docstring says so), and
+passenger 2's problem statement names that clause alongside the
+`empathy_level` parameter — but the sequencing list names only "the
+level-free `BaseWorkflow` contract", which #2299 delivered. The
+lead's counter-case, raised before the ruling and recorded here
+because the chair decided against it: replacing that contract is
+breaking, so deferring it means a future 16.0.0 — and the
+2026-09-01 cohort lands on 15.0.0, so a September major would break
+them mid-course, the outcome D5 inverted the timing to prevent. The
+chair ruled to defer with that consequence in view. #2238 stays
+open on this clause; it does not board 15.0.0.
+
+**Upgrade guide: written before the tag.** `docs/migration/
+upgrading-to-15.0.0.md`, following the `upgrading-to-13.0.0.md`
+precedent. The cohort is the audience, and 15.0.0 removes public
+API in three families (level surface, legacy names, entry-point
+groups).
+
+**Release-prep precondition added by the chair (same message):**
+the ops dashboard's memory page had to work before the release.
+Root cause was infrastructure, not the page — `redis-stack-server`
+was installed but nothing was running, and plain `redis-server`
+reproduces a subtler failure (no RediSearch, so `FT.CREATE` fails,
+hydration aborts, and the index never exists while `PING` still
+answers `PONG`). Fixed by starting `redis-stack-server` against a
+0600 `~/.attune/redis.conf` carrying `requirepass`; hydration then
+loaded 14 nodes, 1,151 lessons, 204 file pointers, 8 rules, and 122
+edges, and `/memory` renders live counts. The page's degradation
+contract was correct throughout — it rendered the documented
+unreachable state, never a 500.


### PR DESCRIPTION
Records the chair's three rulings from the 2026-08-25 form as **D8**,
and adds the upgrade guide that ruling requires.

## Why this is marked `(chair-read)`

The diff is docs-only and would otherwise be Class-1 auto-merged
within minutes. D8 is the durable record of a ruling that will later
be cited as "the chair ruled X" — including a counter-case the chair
decided **against**. If my transcription is wrong, the error becomes
authoritative. Please confirm D8 says what you decided before this
merges. Deliberately **not armed**.

## The three rulings

1. **Cut moves to 2026-08-26**, so the upgrade guide lands first.
   Sequencing steps 1–2 are complete; only release prep, the audit
   sitting, and tag/publish remain. D5's window keeps five days.
2. **#2238's dead `analyze()` abstract is deferred; a 16.0.0 is
   accepted.** My counter-case is recorded verbatim in D8 precisely
   because it was rejected: replacing that contract is breaking, so
   deferring commits to a later major, and the 2026-09-01 cohort
   lands on 15.0.0.
3. **Upgrade guide before the tag.**

D8 also records the release-prep precondition you added (the ops
memory page) and its root cause — `redis-stack-server` installed but
nothing running, with plain `redis-server` reproducing a subtler
failure: no RediSearch, so `FT.CREATE` fails, hydration aborts, and
the index never exists while `PING` still answers `PONG`.

## The guide

Follows `upgrading-to-13.0.0.md`: a one-glance "are you affected?"
table, then one section per removal family — legacy names,
entry-point groups, the level surface, and the two self-migrating
items. The headline for readers: **CLI, plugin, and MCP users need no
code changes.**

Every API claim was verified against the merged tree rather than
copied from the CHANGELOG, which caught two drafting errors of mine:
`create_agent` is a factory *method* taking an `AgentConfig`, not a
module-level function, and `AgentConfig` lives in
`attune.agent_factory.base`, not `attune.config.agent_config`.

| Verified absent | Verified present |
|---|---|
| `EmpathyMCPServer`, `get_empathy_level`, `find_workflows_by_level`, `get_by_empathy_level`, `attune_get_level`, `attune_set_level`, `empathy_level` on `AgentConfig`/`UnifiedAgentConfig` and `record_metric` | `AttuneMCPServer`, `BaseWorkflow(name, domain, category=None)`, the metrics `DROP COLUMN` migration, single-group discovery |

## Receipts

- `mkdocs build --strict` — exit 0, no warnings on the new page.
  Note `build` is **not** in the required-checks set, so a
  required-checks-only poller is blind to it.
- The guide's grep one-liner was **live-fired** against a scratch
  project carrying three legacy usages: found all three, ignored the
  clean file. Rewritten as multi-line `-e` flags — copy-safe, and
  under the 80-col rule (the single-line form was 202 chars).
- CHANGELOG links the guide by absolute GitHub URL — a `docs/` page
  cannot relative-link the repo-root CHANGELOG under mkdocs strict.
- `tests/unit/gates` + `quality` + `docs` + doc-import-drift — 391 passed.
- Full `pytest tests` keyless — 25216 passed, 257 skipped, 6 xfailed.
- Brand-drift gate (G5, the empathy ratchet) passes despite the guide
  necessarily naming every removed legacy identifier.

## Receipt gap

`~/attune-ai` (the main checkout) is 24 commits behind `origin/main`
and not clean, so the memory hydration that informs release work read
a stale tree. Not caused by this PR, but worth clearing before
tomorrow's cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
