### PR TITLE
docs(architecture): regenerate the v11.0.0 metric tables, fix the tool count

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -111,30 +111,44 @@ Tier 5 — Entry Points
      cli_router ←── commands ──→ wizards
 ```
 
-### Codebase Metrics (v11.0.0)
+### Codebase Metrics (15.0.0)
+
+Measured 2026-08-25 against `src/attune/` by AST walk; tests by
+`pytest --collect-only`. Regenerate with the same method before a
+major — the previous table was stamped v11.0.0 and had drifted.
 
 | Metric | Value |
 |--------|-------|
-| Python files | 731 |
-| Lines of code | 189,910 |
-| Functions (incl. methods) | 5,154 |
-| Classes | 889 |
-| Subpackages | 50 |
-| Tests | 23,597 collected |
+| Python files | 758 |
+| Lines of code | 197,932 |
+| Functions (incl. methods) | 5,310 |
+| Classes | 892 |
+| Subpackages | 90 |
+| Tests | 25,510 collected |
 
-### Key Coupling Metrics (v11.0.0)
+### Key Coupling Metrics (15.0.0)
 
-Dependents = files under `src/attune/` importing the module.
+Dependents = distinct files under `src/attune/` that import the
+module, excluding the module's own files. Both absolute
+(`attune.x.y`) and relative (`from .y`) imports are resolved, and
+importing a submodule credits its parent package.
 
 | Module | Dependents | Role |
 |--------|-----------|------|
-| security/path_validation | 77 | Path traversal guard |
-| config | 26 | Configuration |
-| models | 52 | Model registry, tiers |
-| memory | 53 | Unified storage API |
-| meta_workflows | 31 | Orchestration hub |
-| workflows | 59 | Workflow engine |
-| mcp | 49 core tools | Claude Code integration |
+| security/path_validation | 82 | Path traversal guard |
+| models | 55 | Model registry, tiers |
+| memory | 32 | Unified storage API |
+| workflows | 27 | Workflow engine |
+| config | 20 | Configuration |
+| telemetry | 14 | Usage and feedback signals |
+| meta_workflows | 10 | Orchestration hub |
+| mcp | 1 | Claude Code integration |
+
+`mcp` has one in-tree dependent because it is an entry point, not a
+library — it is imported by the MCP client, not by other modules. It
+serves **48 core tools** (the sum of `mcp/tool_schemas.py`'s schema
+getters), and 59 in a default install once the bundled `attune_redis`
+plugin contributes its 11.
 
 ---
 

--- a/scripts/measure_architecture_metrics.py
+++ b/scripts/measure_architecture_metrics.py
@@ -1,0 +1,129 @@
+"""Measure the numbers in ``docs/ARCHITECTURE.md`` from the tree.
+
+The architecture doc's metric tables drift silently: the previous pair
+was stamped v11.0.0 and still claimed 23,597 tests when the suite
+collected 25,510, and gave the ``mcp`` row a tool count in a column
+that means dependents. Numbers nobody can re-derive cannot be checked,
+so this script IS the method the doc cites.
+
+Run before a major and paste the output into the two tables::
+
+    python scripts/measure_architecture_metrics.py
+
+Read-only: it parses source and writes nothing.
+"""
+
+from __future__ import annotations
+
+import ast
+import collections
+import pathlib
+
+SRC = pathlib.Path(__file__).resolve().parent.parent / "src" / "attune"
+
+#: Rows of the coupling table, in display order after sorting by count.
+TRACKED_MODULES = (
+    "attune.security.path_validation",
+    "attune.models",
+    "attune.memory",
+    "attune.workflows",
+    "attune.config",
+    "attune.telemetry",
+    "attune.meta_workflows",
+    "attune.mcp",
+)
+
+
+def _dotted_name(path: pathlib.Path) -> str:
+    """Return the ``attune.x.y`` module name for a source file."""
+    parts = list(path.relative_to(SRC.parent).with_suffix("").parts)
+    if parts[-1] == "__init__":
+        parts.pop()
+    return ".".join(parts)
+
+
+def _imported_targets(node: ast.AST, package: str) -> list[str]:
+    """Return the module names one import statement refers to.
+
+    Relative imports are resolved against ``package`` so that a
+    subpackage's ``from .config import X`` is not miscounted as a
+    dependency on the top-level ``attune.config``.
+    """
+    if isinstance(node, ast.Import):
+        return [alias.name for alias in node.names]
+    if not isinstance(node, ast.ImportFrom):
+        return []
+    if not node.level:
+        return [node.module] if node.module else []
+    base = package.split(".")
+    if node.level > 1:
+        base = base[: len(base) - (node.level - 1)]
+    return [".".join(base + ([node.module] if node.module else []))]
+
+
+def measure() -> dict[str, object]:
+    """Walk the tree once and return every number the doc reports."""
+    files = sorted(p for p in SRC.rglob("*.py") if "__pycache__" not in str(p))
+    functions = classes = lines = 0
+    dependents: dict[str, set[str]] = collections.defaultdict(set)
+
+    for path in files:
+        text = path.read_text(encoding="utf-8", errors="replace")
+        lines += text.count("\n") + (0 if text.endswith("\n") else 1)
+        tree = ast.parse(text)
+
+        for node in ast.walk(tree):
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                functions += 1
+            elif isinstance(node, ast.ClassDef):
+                classes += 1
+
+        module = _dotted_name(path)
+        package = module if path.name == "__init__.py" else module.rsplit(".", 1)[0]
+        for node in ast.walk(tree):
+            for target in _imported_targets(node, package):
+                if not target.startswith("attune"):
+                    continue
+                # Credit the target and every ancestor package: importing
+                # attune.memory.store is a dependency on attune.memory too.
+                parts = target.split(".")
+                for i in range(2, len(parts) + 1):
+                    dependents[".".join(parts[:i])].add(str(path))
+
+    return {
+        "files": len(files),
+        "lines": lines,
+        "functions": functions,
+        "classes": classes,
+        "subpackages": len({p.parent for p in files if (p.parent / "__init__.py").exists()}),
+        "dependents": dependents,
+    }
+
+
+def _count_external(dependents: dict[str, set[str]], module: str) -> int:
+    """Dependents of ``module`` excluding files inside the module itself."""
+    prefix = str(SRC.parent / module.replace(".", "/"))
+    return sum(1 for f in dependents.get(module, ()) if not f.startswith(prefix))
+
+
+def main() -> None:
+    """Print both ARCHITECTURE.md tables' values."""
+    m = measure()
+    print("Codebase Metrics")
+    print(f"  Python files              {m['files']:,}")
+    print(f"  Lines of code             {m['lines']:,}")
+    print(f"  Functions (incl. methods) {m['functions']:,}")
+    print(f"  Classes                   {m['classes']:,}")
+    print(f"  Subpackages               {m['subpackages']:,}")
+    print("  Tests                     run: pytest tests --collect-only -q")
+    print()
+    print("Key Coupling Metrics")
+    deps = m["dependents"]
+    assert isinstance(deps, dict)
+    rows = [(mod, _count_external(deps, mod)) for mod in TRACKED_MODULES]
+    for mod, count in sorted(rows, key=lambda r: -r[1]):
+        print(f"  {mod.removeprefix('attune.'):28s} {count:4d}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Replaces both v11.0.0-stamped metric tables in `ARCHITECTURE.md` with
measured current values, and fixes a wrong tool count.

Chair asked whether the stale table should be replaced rather than
footnoted. Replaced — a footnote on one row of a wholesale-stale table
is a patch on a rotting surface.

## The `mcp` row was a category error, not just a stale number

The column means **dependents** (files importing the module) and every
other row is such a count. The `mcp` row held a *tool* count — and a
wrong one: 49, where the true core count is **48**.

**48 is verified, not asserted.** Summing `mcp/tool_schemas.py`'s
schema getters gives exactly 48, which independently confirms the
CHANGELOG's "50 → 48" (48 + the two deleted level tools = 50).

| Figure | Value | Source |
|---|---|---|
| Core tools | 48 | sum of schema getters |
| Plugin-contributed | 11 | bundled `attune_redis` (6 `redis_*`, 5 `session_memory_*`) |
| Runtime total served | 59 | `_handle_list_tools()` |
| Old `ARCHITECTURE.md` claim | 49 | wrong, and stale even pre-15.0.0 |

Only `ARCHITECTURE.md` was ever wrong; the CHANGELOG was right.

## A number I refused to ship

My first pass at the dependents column used grep. It reported
`config=44` where the table claimed 26 — it could not reproduce the
table's own baseline, so I threw it away rather than publish a number
I could not re-derive. The replacement is an AST walk that resolves
relative imports against the importing file's package (the grep's
over-count came from crediting any `from .config` to top-level
`attune.config`) and credits ancestor packages for submodule imports.

## Validating a method against unreproducible predecessors

The old numbers can't be re-derived, so the new method is checked by
what *shouldn't* move:

- functions 5,154 → 5,310 and classes 889 → 892 — small growth, as expected
- lines-per-file 261, against the old table's 260
- the coupling numbers that moved a lot moved as the refactors predict —
  `workflows` 59 → 27, tracking the #2239 layering work that removed
  `models` → `workflows` imports

## The method is now committed

`scripts/measure_architecture_metrics.py` makes "regenerate with the
same method" an instruction someone can follow rather than an
aspiration. Read-only; its output reproduces the committed tables
exactly.

## Receipts

- Script output byte-matches the table values it documents.
- `mkdocs build --strict` — exit 0. Note `build` is **not** in the
  required-checks set, so required-checks-only polling is blind to it.
- `tests/unit/gates` + `quality` + `docs` + `scripts` + doc-import-drift
  — 839 passed. A new script can trip the path-validation and
  broad-except ratchets; it trips neither (no `except` clauses, and its
  only file access is `read_text`).
- Full `pytest tests` keyless — 25216 passed, 257 skipped, 6 xfailed.

## Unrelated finding, flagged not fixed

With Redis and AMS now running locally,
`tests/memory/test_ams_backend_integration.py::test_search_is_namespace_isolated`
failed once under the parallel full run and passed both in isolation
(6 passed) and on a full re-run. It is an intermittent write→index
lag flake that was previously invisible because the test skips when
AMS is absent. CI is unaffected (AMS isn't up there, so it still
skips), but local release-prep runs can hit it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
