### PR TITLE
fix(memory): distinguish "answers PING" from "the index can exist" (retro items 5, 8)

### DIFF
--- a/docs/migration/upgrading-to-15.0.0.md
+++ b/docs/migration/upgrading-to-15.0.0.md
@@ -104,6 +104,24 @@ If you were using the level to select among your own workflows, keep
 your own mapping — the framework no longer has an opinion about what
 1–5 means.
 
+### Heads-up: `BaseWorkflow.analyze()` is not settled
+
+`attune.plugins.base.BaseWorkflow` still declares an abstract
+`analyze()` that the engine does not call — this class is for
+plugin-internal analyzers you invoke yourself, and workflows
+discovered via entry points subclass
+`attune.workflows.base.BaseWorkflow` (whose entry point is
+`execute()`) instead.
+
+That dead abstract is known and is **expected to change in a future
+major** (tracked in
+[#2238](https://github.com/Smart-AI-Memory/attune-ai/issues/2238); the
+15.0.0 manifest deferred it deliberately). It does not affect your
+15.0.0 upgrade — the signature above is what 15.0.0 ships — but if you
+are writing a new plugin today, prefer
+`attune.workflows.base.BaseWorkflow` for anything the engine should
+run, and expect the plugin-internal contract to be revised.
+
 ## 4. Two things that migrate themselves
 
 **agents.md frontmatter.** A leftover `empathy_level:` key parses as

--- a/src/attune/memory/features.py
+++ b/src/attune/memory/features.py
@@ -18,7 +18,7 @@ from enum import Enum
 logger = logging.getLogger(__name__)
 
 #: States that warn loudly, once per session (R3: never self-healing).
-_LOUD_STATES = frozenset({"degraded_auth"})
+_LOUD_STATES = frozenset({"degraded_auth", "degraded_search"})
 
 #: State values already warned about this process (loud-once scope).
 _warned_states: set[str] = set()
@@ -32,6 +32,26 @@ _CRED_RE = re.compile(r"://([^/@:\s]*):[^@\s]*@")
 def _scrub_secrets(text: str) -> str:
     """Mask the password of any credentialed URL embedded in text."""
     return _CRED_RE.sub(r"://\1:***@", text)
+
+
+def _has_search_module(modules: object) -> bool:
+    """Return True when a ``MODULE LIST`` reply advertises search.
+
+    redis-py returns a list of per-module mappings whose keys and values
+    may be ``str`` or ``bytes`` depending on ``decode_responses``, so the
+    reply is flattened and matched case-insensitively rather than
+    indexed by a shape that varies.
+    """
+    if not isinstance(modules, list | tuple):
+        return False
+    for entry in modules:
+        values = entry.values() if isinstance(entry, dict) else [entry]
+        for value in values:
+            if isinstance(value, bytes):
+                value = value.decode("utf-8", "replace")
+            if isinstance(value, str) and "search" in value.lower():
+                return True
+    return False
 
 
 def _warn_once(report: "RedisHealthReport") -> None:
@@ -75,6 +95,10 @@ class RedisHealthState(Enum):
       never self-heal, so it warns loudly ONCE per session.
     - ``DEGRADED_CONNECTIVITY``: server absent or transient failure —
       stays silent (may self-heal; matches today's quiet fallback).
+    - ``DEGRADED_SEARCH``: the server answers PING but carries no
+      search module, so the derived memory index cannot exist. Never
+      self-heals (it needs a different server binary), so it warns
+      loudly ONCE — see :meth:`MemoryFeatures.classify_memory_index_health`.
     - ``DISABLED``: mock mode requested intentionally
       (``ATTUNE_REDIS_MOCK=true``) — distinguished from broken.
     """
@@ -82,6 +106,7 @@ class RedisHealthState(Enum):
     HEALTHY = "healthy"
     DEGRADED_AUTH = "degraded_auth"
     DEGRADED_CONNECTIVITY = "degraded_connectivity"
+    DEGRADED_SEARCH = "degraded_search"
     DISABLED = "disabled"
 
 
@@ -321,6 +346,81 @@ class MemoryFeatures:
             redacted_url=resolved.redacted_url,
             overrides=resolved.overrides,
         )
+
+    @staticmethod
+    def classify_memory_index_health(
+        env: Mapping[str, str] | None = None,
+    ) -> RedisHealthReport:
+        """Classify whether the DERIVED memory index can exist.
+
+        ``classify_redis_health`` answers "does the connection work".
+        That is not the same question as "can the index exist": a plain
+        ``redis-server`` answers PING perfectly while carrying no search
+        module, so ``FT.CREATE`` fails, hydration aborts, and recall is
+        dark behind a server that looks healthy. Distinguishing the two
+        is the whole point of this function — the connection-level
+        report cannot see the difference, and a caller that needs the
+        index will otherwise read PONG as success.
+
+        Connection-level states pass through unchanged. Only a HEALTHY
+        connection is probed further, and only a missing search module
+        downgrades it to :attr:`RedisHealthState.DEGRADED_SEARCH`.
+
+        ``check_redis`` is deliberately NOT routed through this: plain
+        Redis stays valid for key/value use, and only callers that need
+        the index should treat a missing module as degraded.
+
+        Args:
+            env: Environment mapping (defaults to ``os.environ``;
+                injectable for tests).
+
+        Returns:
+            A :class:`RedisHealthReport`; never raises (P15).
+
+        """
+        report = MemoryFeatures.classify_redis_health(env)
+        if report.state is not RedisHealthState.HEALTHY:
+            return report
+
+        from attune.memory.config import resolve_redis_connection
+        from attune.memory.recall_redis import connect_recall_redis
+
+        try:
+            # Probe the SAME endpoint the connection report just cleared,
+            # resolved from the same env — otherwise an injected env is
+            # classified against one server and probed against another.
+            url = resolve_redis_connection(env).url
+            client = connect_recall_redis(url)
+            modules = client.execute_command("MODULE", "LIST")
+        except Exception:  # noqa: BLE001
+            # INTENTIONAL broad catch (P15 never-block): an unexpected
+            # probe failure must not turn a working connection into an
+            # error. Report the connection's own verdict instead.
+            logger.debug("MODULE LIST probe failed", exc_info=True)
+            return report
+
+        if _has_search_module(modules):
+            return report
+
+        return RedisHealthReport(
+            RedisHealthState.DEGRADED_SEARCH,
+            "server answers PING but has no search module — the derived "
+            "memory index cannot be created (needs redis-stack-server, "
+            "not plain redis-server)",
+            redacted_url=report.redacted_url,
+            overrides=report.overrides,
+        )
+
+    @staticmethod
+    def check_memory_index() -> bool:
+        """Return True when the derived memory index can exist.
+
+        Routes the never-self-healing search-module class through the
+        loud-once notice, mirroring :meth:`check_redis`.
+        """
+        report = MemoryFeatures.classify_memory_index_health()
+        _warn_once(report)
+        return report.state is RedisHealthState.HEALTHY
 
     @staticmethod
     def check_redis() -> bool:

--- a/tests/unit/gates/test_broad_except_ratchet.py
+++ b/tests/unit/gates/test_broad_except_ratchet.py
@@ -183,7 +183,12 @@ _BASELINE: dict[str, int] = {
     # to degraded_connectivity, pinned by TestNeverBlock's RuntimeError case.
     # 2 -> 1 for library-review H1: the three per-module ping probes collapsed
     # into config.ping_redis, so their broad excepts collapsed with them.
-    "src/attune/memory/features.py": 1,
+    # 1 -> 2 for classify_memory_index_health (retro item 8, 2026-08-25): the
+    # MODULE LIST probe is a P15 never-block path — an unexpected failure must
+    # fall back to the connection-level verdict, never turn a working
+    # connection into an error. Pinned by TestMemoryIndexHealth's probe-raises
+    # case.
+    "src/attune/memory/features.py": 2,
     "src/attune/memory/file_stash.py": 1,
     "src/attune/memory/lessons.py": 2,
     "src/attune/memory/long_term_integration.py": 2,

--- a/tests/unit/memory/test_redis_degradation_classes.py
+++ b/tests/unit/memory/test_redis_degradation_classes.py
@@ -202,3 +202,99 @@ class TestNeverBlock:
         """The seam always yields a typed report, never an exception."""
         r = MemoryFeatures.classify_redis_health(env={"REDIS_URL": "redis://127.0.0.1:1/0"})
         assert isinstance(r, RedisHealthReport)
+
+
+class TestMemoryIndexHealth:
+    """`classify_memory_index_health` — PING is not the index question.
+
+    Retro item 8 (2026-08-25): a plain ``redis-server`` answers PING
+    while carrying no search module, so ``FT.CREATE`` fails, hydration
+    aborts, and recall is dark behind a server that looks healthy.
+    Verified live against both binaries before these tests were written.
+    """
+
+    ENV = {"REDIS_URL": "redis://h:6379/0"}
+
+    @staticmethod
+    def _healthy_conn(modules):
+        """Patch a healthy connection whose MODULE LIST returns `modules`."""
+        ping_client = MagicMock()
+        ping_client.ping.return_value = True
+        probe_client = MagicMock()
+        probe_client.execute_command.return_value = modules
+        return ping_client, probe_client
+
+    def test_search_module_present_stays_healthy(self):
+        ping_client, probe = self._healthy_conn([{"name": "search", "ver": 20811}])
+        with (
+            patch.object(redis_lib.Redis, "from_url", return_value=ping_client),
+            patch("attune.memory.recall_redis.connect_recall_redis", return_value=probe),
+        ):
+            r = MemoryFeatures.classify_memory_index_health(env=self.ENV)
+        assert r.state is RedisHealthState.HEALTHY
+
+    def test_no_search_module_is_degraded_search(self):
+        ping_client, probe = self._healthy_conn([{"name": "bf", "ver": 1}])
+        with (
+            patch.object(redis_lib.Redis, "from_url", return_value=ping_client),
+            patch("attune.memory.recall_redis.connect_recall_redis", return_value=probe),
+        ):
+            r = MemoryFeatures.classify_memory_index_health(env=self.ENV)
+        assert r.state is RedisHealthState.DEGRADED_SEARCH
+        assert "no search module" in r.detail
+        assert "redis-stack-server" in r.detail
+
+    def test_empty_module_list_is_degraded_search(self):
+        """Plain redis-server reports no modules at all."""
+        ping_client, probe = self._healthy_conn([])
+        with (
+            patch.object(redis_lib.Redis, "from_url", return_value=ping_client),
+            patch("attune.memory.recall_redis.connect_recall_redis", return_value=probe),
+        ):
+            r = MemoryFeatures.classify_memory_index_health(env=self.ENV)
+        assert r.state is RedisHealthState.DEGRADED_SEARCH
+
+    def test_connection_level_failure_passes_through_unprobed(self):
+        """A dead connection keeps its own verdict — not degraded_search."""
+        exc = redis_lib.exceptions.ConnectionError("Connection refused")
+        with patch.object(redis_lib.Redis, "from_url", return_value=_client_raising(exc)):
+            r = MemoryFeatures.classify_memory_index_health(env=self.ENV)
+        assert r.state is RedisHealthState.DEGRADED_CONNECTIVITY
+
+    def test_probe_failure_falls_back_to_connection_verdict(self):
+        """P15 never-block: a raising probe must not manufacture an error.
+
+        Pins the broad except that raised the ratchet baseline to 2.
+        """
+        ping_client = MagicMock()
+        ping_client.ping.return_value = True
+        with (
+            patch.object(redis_lib.Redis, "from_url", return_value=ping_client),
+            patch(
+                "attune.memory.recall_redis.connect_recall_redis",
+                side_effect=RuntimeError("boom"),
+            ),
+        ):
+            r = MemoryFeatures.classify_memory_index_health(env=self.ENV)
+        assert r.state is RedisHealthState.HEALTHY
+
+    def test_check_memory_index_warns_loudly_once(self, caplog):
+        """degraded_search never self-heals, so it joins the loud classes."""
+        ping_client, probe = self._healthy_conn([])
+        with (
+            patch.object(redis_lib.Redis, "from_url", return_value=ping_client),
+            patch("attune.memory.recall_redis.connect_recall_redis", return_value=probe),
+            caplog.at_level(logging.WARNING, logger=FEATURES_LOGGER),
+        ):
+            assert MemoryFeatures.check_memory_index() is False
+            assert MemoryFeatures.check_memory_index() is False
+        assert sum("degraded_search" in r.getMessage() for r in caplog.records) == 1
+
+    def test_check_redis_is_unaffected_by_a_missing_module(self):
+        """Plain Redis stays valid for key/value use — the gate is separate."""
+        ping_client, probe = self._healthy_conn([])
+        with (
+            patch.object(redis_lib.Redis, "from_url", return_value=ping_client),
+            patch("attune.memory.recall_redis.connect_recall_redis", return_value=probe),
+        ):
+            assert MemoryFeatures.check_redis() is True


### PR DESCRIPTION
Two ruled items from the 2026-08-25 retro.

## Item 8 — "answers PING" is not "the index can exist"

This session lost three diagnostic rounds to a masking failure.
`classify_redis_health` reports HEALTHY on *"resolved connection
answers PING"* — but a plain `redis-server` answers PING perfectly
while carrying **no search module**, so `FT.CREATE` fails, hydration
aborts, and recall goes dark behind a server that looks fine.

`classify_memory_index_health()` asks the second question. Connection-
level states pass through untouched; only a HEALTHY connection is
probed further, and only a missing search module downgrades it to the
new `DEGRADED_SEARCH` — which joins `DEGRADED_AUTH` in the loud-once
classes, because a missing module never self-heals (it needs a
different server binary).

**`check_redis()` is deliberately NOT routed through this.** Plain
Redis stays valid for key/value use, and failing the general gate
would break deployments that never wanted search. Only callers needing
the derived index should care, so `check_memory_index()` is the opt-in
gate. A test pins that `check_redis` is unaffected by a missing
module, so a later "simplification" can't quietly merge the two.

**Verified live against both binaries before the tests were written:**

| Server | Result |
|---|---|
| plain `redis-server` on :6399 | `degraded_search` |
| `redis-stack-server` on :6379 | `healthy` |

The mocked tests encode observed behavior rather than a guess about it.

**One correctness bug found while writing it:** the probe originally
called `connect_recall_redis()` with no argument, so an injected `env`
was *classified* against one server and *probed* against the ambient
one — untestable, and wrong under any non-default config. It now
resolves the URL from the same env it was handed.

## Item 5 — the guide taught a contract we know will break

§3 showed the cohort how to subclass plugin `BaseWorkflow` while
saying nothing about its `analyze()` abstract being dead and slated to
change (D8 deferred it to a future major). Readers landing on 15.0.0
had no way to know. A "Heads-up" subsection now names it, points at
[#2238](https://github.com/Smart-AI-Memory/attune-ai/issues/2238),
states plainly that it does not affect the 15.0.0 upgrade, and steers
new plugins toward `attune.workflows.base.BaseWorkflow` for anything
the engine should run.

## Receipts

- Live-fire against both binaries (table above), before writing tests.
- `test_redis_degradation_classes.py` — 27 passed, **7 new**: both
  directions, connection-failure pass-through, the P15 probe-raises
  fallback, loud-once, and the `check_redis` independence pin.
- Broad-except ratchet baseline `features.py` 1 → 2, reason recorded
  in the same commit, pinned by the probe-raises test.
- `tests/unit/gates` + `quality` + `memory` — 2503 passed.
- Full `pytest tests` keyless — 25223 passed, 257 skipped, 6 xfailed.
- `doc-import-audit` exit 0 — the **real script** this time, not the
  similarly-named drift test that fooled me on #2304 — and
  `mkdocs --strict` exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
