### PR TITLE
test(memory): poll AMS index visibility instead of the hook-sized readback (retro item 4)

### DIFF
--- a/tests/memory/test_ams_backend_integration.py
+++ b/tests/memory/test_ams_backend_integration.py
@@ -179,6 +179,31 @@ def test_session_stash_round_trip():
         be.close()
 
 
+def _wait_until_searchable(backend, query, marker, timeout_s=30.0):
+    """Poll ``backend``'s own namespace until ``marker`` is searchable.
+
+    AMS indexes long-term memories on a background task, so a write is
+    acknowledged before it is findable. The production readback is
+    deliberately short (it runs inside a Stop hook), which makes it a
+    poor gate for a test on a loaded runner — this polls to the
+    property the test needs instead of to a latency budget.
+
+    Uses ``time.monotonic`` so a wall-clock adjustment mid-poll cannot
+    end the loop early or hang it.
+
+    Returns:
+        The matching record, or None if it never appeared.
+    """
+    deadline = time.monotonic() + timeout_s
+    while True:
+        for record in backend.search(query, limit=20):
+            if marker in (record.get("text") or ""):
+                return record
+        if time.monotonic() >= deadline:
+            return None
+        time.sleep(1)
+
+
 def test_search_is_namespace_isolated():
     """A namespace-scoped search must EXCLUDE other namespaces' records.
 
@@ -210,22 +235,28 @@ def test_search_is_namespace_isolated():
         )
     )
     try:
-        assert (
-            be_a.remember(f"{marker_a}: {shared}", memory_id=marker_a, topics=["type:note"]) is True
-        )
-        assert (
-            be_b.remember(f"{marker_b}: {shared}", memory_id=marker_b, topics=["type:note"]) is True
-        )
+        # `remember` confirms with a readback bounded at ~6.3 s so it can run
+        # inside a Stop hook; under a loaded parallel run AMS indexing can
+        # exceed that and return False for a write that lands moments later.
+        # The return value is kept for diagnosis, but searchability — polled
+        # below — is what this test actually needs.
+        ack_a = be_a.remember(f"{marker_a}: {shared}", memory_id=marker_a, topics=["type:note"])
+        ack_b = be_b.remember(f"{marker_b}: {shared}", memory_id=marker_b, topics=["type:note"])
 
-        # Wait until A's own record is indexed/searchable from A's namespace.
-        hit_a = None
-        for _ in range(15):
-            results_a = be_a.search(shared, limit=20)
-            hit_a = next((r for r in results_a if marker_a in (r.get("text") or "")), None)
-            if hit_a is not None:
-                break
-            time.sleep(1)
-        assert hit_a is not None, f"A's own record not searchable from A for {marker_a!r}"
+        # BOTH records must be searchable in their OWN namespace before the
+        # isolation assertion means anything. Confirming only A would let a
+        # never-indexed B pass vacuously: "B's marker is absent from A" is
+        # trivially true when B was never written.
+        hit_a = _wait_until_searchable(be_a, shared, marker_a)
+        assert hit_a is not None, (
+            f"A's own record not searchable from A for {marker_a!r} " f"(remember returned {ack_a})"
+        )
+        hit_b = _wait_until_searchable(be_b, shared, marker_b)
+        assert hit_b is not None, (
+            f"B's own record not searchable from B for {marker_b!r} "
+            f"(remember returned {ack_b}) — without this the isolation "
+            f"assertion below would pass vacuously"
+        )
 
         # Isolation: B's marker must NOT surface in A's search, even though the
         # shared text would rank B's record highly if namespaces leaked.


### PR DESCRIPTION
Retro item 4, ruled `do now`.

`test_search_is_namespace_isolated` went red once under the parallel
suite and passed in isolation and on a full re-run. It's a
write-then-search indexing-lag flake, **newly reachable because Redis
and AMS now actually run locally** — the test had been silently
SKIPPING for as long as AMS was down, so its green history proved
nothing about it.

## Root cause: a budget mismatch, not a bug

`remember()` confirms via a readback bounded at ~6.3 s (3 attempts,
2 s each) because it runs **inside a Stop hook**, where a stalled AMS
would otherwise hold the hook past its runner limit and lose the very
stash the readback exists to keep.

That budget is right for the hook and too short for a loaded parallel
test run, where AMS indexing can exceed it and return `False` for a
write that lands moments later. **Extending the production retries
would trade a real hook timeout for a test convenience**, so the fix
belongs in the test.

The test now polls searchability directly (`_wait_until_searchable`,
30 s, `time.monotonic`) and keeps `remember()`'s return only for the
failure message.

## The part worth reviewing

Relaxing that assertion *alone* would have **introduced** a vacuity
hole, so the guarantee is preserved through a stronger precondition
rather than dropped: **both** records must now be searchable in their
**own** namespace before the isolation assertion runs.

"B's marker is absent from A's search" is trivially true when B was
never indexed. The old `assert remember(...) is True` proved only that
B was readable **by id** — not that it was in the search index the
isolation claim is actually about. Confirming B's searchability is
strictly stronger than what it replaces.

## Receipts

- `tests/memory/test_ams_backend_integration.py` — 6 passed.
- **The new guard was proven to fire, not assumed.** Sabotaging B's
  write to never land failed the test with *"without this the
  isolation assertion below would pass vacuously"*. Sabotage reversed
  and re-verified clean — 0 occurrences, diff is the intended 45/14.
- Full `pytest tests` keyless — 25216 passed, 257 skipped, 6 xfailed.
- black + ruff pass.

## Note

CI is unaffected either way — AMS isn't up there, so this test still
skips. The flake only ever hit local runs, including release prep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
