### PR TITLE
feat(hooks): block `timeout` on macOS, where it does not exist

### DIFF
--- a/plugin/hooks/hooks.json
+++ b/plugin/hooks/hooks.json
@@ -98,6 +98,16 @@
             "timeout": 5
           }
         ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "PY=$(command -v python3 || command -v python) && \"$PY\" ${CLAUDE_PLUGIN_ROOT}/hooks/macos_timeout_guard.py",
+            "timeout": 3
+          }
+        ]
       }
     ],
     "PostToolUse": [

--- a/plugin/hooks/macos_timeout_guard.py
+++ b/plugin/hooks/macos_timeout_guard.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""PreToolUse(Bash) guard: `timeout` does not exist on macOS.
+
+`timeout(1)` is GNU coreutils. macOS ships neither it nor `gtimeout`
+unless coreutils is installed, so a Bash command that opens with
+`timeout ...` fails with `command not found: timeout` and the work
+inside it never runs — while the shell still reports the exit status of
+whatever came next, so the failure is easy to miss.
+
+Origin: measured, not guessed (2026-08-25 calibration). A full-text
+sweep of session transcripts found `command not found: timeout` in AT
+LEAST 18 distinct sessions between 2026-07-19 and 2026-08-25, spanning
+three repos (attune-ai, attune-forms, IndianRailroadTicketing). It is
+the single most repeated non-existent command in the corpus by a wide
+margin; every other unresolvable candidate appeared once or was a
+scanner artifact.
+
+18 is a FLOOR, not an estimate: the sweep can only see sessions where
+the error string survived into a stored transcript, so it undercounts
+by an unknown amount. The number is stated as a floor rather than
+rounded up because a guard whose justification is a guess cannot ask
+anyone to trust its judgment.
+
+The fix needs no new tooling: the Bash tool takes its own `timeout`
+parameter (milliseconds), which is what those 18 sessions wanted.
+
+Blocks (exit 2) only when ALL of these hold, so the guard self-disables
+rather than nagging:
+  - the platform is macOS,
+  - `timeout` is genuinely absent from PATH (install coreutils and this
+    guard stops firing on its own),
+  - `timeout` appears in COMMAND POSITION — not inside quotes, a
+    heredoc body, a comment, or as a flag like `--timeout 30`.
+
+Escape hatch: include ATTUNE_ALLOW_TIMEOUT=1 in the command.
+
+Claude Code Protocol:
+    stdin: JSON with tool_name and tool_input
+    exit 0: allow the call
+    exit 2: block the call, reason on stderr
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import shutil
+import sys
+
+#: Heredoc bodies are payloads, not commands — a script being WRITTEN
+#: may legitimately contain `timeout` for a Linux runner.
+_HEREDOC = re.compile(r"<<-?\s*(['\"]?)(\w+)\1.*?^\s*\2\s*$", re.S | re.M)
+
+#: `timeout` in command position: at the start, or after a separator,
+#: optionally preceded by env assignments (`TZ=UTC timeout 5 ...`).
+_TIMEOUT_CMD = re.compile(
+    r"(?:^|[;&|(]|\n)\s*(?:[A-Za-z_][A-Za-z0-9_]*=(?:\"[^\"]*\"|'[^']*'|\S*)\s+)*" r"timeout(?=\s)"
+)
+
+
+def _strip_noise(command: str) -> str:
+    """Remove heredoc bodies, quoted strings, and comments.
+
+    Each removal is replaced by a space rather than deleted so that
+    command separators around it keep their positions.
+    """
+    text = _HEREDOC.sub(" ", command)
+    text = re.sub(r"'[^']*'", " ", text)
+    text = re.sub(r'"[^"]*"', " ", text)
+    return re.sub(r"(?m)#.*$", " ", text)
+
+
+def uses_bare_timeout(command: str) -> bool:
+    """Return True when `command` invokes `timeout` as a program."""
+    return bool(_TIMEOUT_CMD.search(_strip_noise(command)))
+
+
+def main() -> int:
+    """Block a macOS Bash command that shells out to `timeout`."""
+    try:
+        payload = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError):
+        return 0  # Never block on a malformed payload.
+
+    if payload.get("tool_name") != "Bash":
+        return 0
+    command = (payload.get("tool_input") or {}).get("command") or ""
+    if "ATTUNE_ALLOW_TIMEOUT=1" in command:
+        return 0
+    if sys.platform != "darwin" or shutil.which("timeout"):
+        return 0
+    if not uses_bare_timeout(command):
+        return 0
+
+    print(
+        "Blocked: `timeout` is GNU coreutils and is not installed on this "
+        "Mac, so this command would fail with `command not found: timeout` "
+        "and the work inside it would never run (measured in at least 18 "
+        "sessions since 2026-07-19). Use the Bash tool's own `timeout` parameter "
+        "instead — it takes milliseconds, e.g. timeout: 480000 for 8 "
+        "minutes. Override once with ATTUNE_ALLOW_TIMEOUT=1.",
+        file=sys.stderr,
+    )
+    return 2
+
+
+if __name__ == "__main__":
+    from _sdk_gate import exit_if_sdk_subprocess
+
+    exit_if_sdk_subprocess()
+    sys.exit(main())

--- a/plugin/hooks/macos_timeout_guard.py
+++ b/plugin/hooks/macos_timeout_guard.py
@@ -53,9 +53,17 @@ _HEREDOC = re.compile(r"<<-?\s*(['\"]?)(\w+)\1.*?^\s*\2\s*$", re.S | re.M)
 
 #: `timeout` in command position: at the start, or after a separator,
 #: optionally preceded by env assignments (`TZ=UTC timeout 5 ...`).
-_TIMEOUT_CMD = re.compile(
-    r"(?:^|[;&|(]|\n)\s*(?:[A-Za-z_][A-Za-z0-9_]*=(?:\"[^\"]*\"|'[^']*'|\S*)\s+)*" r"timeout(?=\s)"
-)
+#:
+#: The env-assignment value is a plain \S* with NO alternation. An
+#: earlier draft offered quoted alternatives, which CodeQL correctly
+#: flagged as py/redos (high severity): \S* also matches a quoted
+#: string, so `""` was matchable two ways inside a repetition, giving
+#: exponential backtracking on input like `&A=` followed by many
+#: repetitions of `""\tA=`. The alternatives were never needed --
+#: _strip_noise removes quoted strings BEFORE this pattern runs. The
+#: repetition is bounded rather than open-ended so no input can drive
+#: it super-linearly.
+_TIMEOUT_CMD = re.compile(r"(?:^|[;&|(]|\n)\s*(?:[A-Za-z_][A-Za-z0-9_]*=\S*\s+){0,8}timeout(?=\s)")
 
 
 def _strip_noise(command: str) -> str:

--- a/tests/unit/hooks/test_macos_timeout_guard.py
+++ b/tests/unit/hooks/test_macos_timeout_guard.py
@@ -92,6 +92,44 @@ def test_non_bash_tool_ignored():
     assert _run("timeout 30 pytest", tool="Write").returncode == 0
 
 
+class TestRedosRegression:
+    """CodeQL `py/redos` (high) on the first draft — alert 185.
+
+    The env-assignment group offered quoted alternatives alongside
+    `\\S*`, which also matches a quoted string, so `""` was matchable
+    two ways inside a repetition. CodeQL named the shape exactly:
+    input starting `&A=` with many repetitions of `""\\tA=`.
+    """
+
+    def test_pathological_input_returns_promptly(self):
+        """The exact shape CodeQL named must not blow up.
+
+        Bounded generously (2 s) to separate REGIMES — linear vs
+        exponential — not to measure speed; the pre-fix pattern did not
+        finish this input in any practical time. Measured with
+        `time.monotonic` so a clock adjustment cannot end it early.
+        """
+        import time
+
+        evil = "&A=" + '""\tA=' * 40
+        start = time.monotonic()
+        uses_bare_timeout(evil)
+        assert time.monotonic() - start < 2.0
+
+    def test_quoted_env_value_still_detected(self):
+        """Dropping the quoted branches must not lose real coverage.
+
+        `_strip_noise` blanks the quoted value before matching, so the
+        assignment still parses and the invocation is still caught.
+        """
+        assert uses_bare_timeout('FOO="a b" timeout 5 ./x') is True
+
+    def test_many_env_assignments_still_detected(self):
+        """Within the bound, a long env prefix still matches."""
+        prefix = " ".join(f"V{i}=1" for i in range(6))
+        assert uses_bare_timeout(f"{prefix} timeout 5 ./x") is True
+
+
 def test_malformed_payload_never_blocks():
     r = subprocess.run(
         [sys.executable, str(GUARD)], input="not json", capture_output=True, text=True

--- a/tests/unit/hooks/test_macos_timeout_guard.py
+++ b/tests/unit/hooks/test_macos_timeout_guard.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Tests for macos_timeout_guard — calibrated against real commands.
+
+The TRUE cases are shapes drawn from the transcript sweep that found
+`command not found: timeout` in 18 sessions. The FALSE cases are the
+false-positive classes triaged out while writing the rule; each is
+pinned here because the discriminator is the fragile part and the
+easiest thing for a later simplification to drop.
+"""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+GUARD = Path(__file__).resolve().parents[3] / "plugin" / "hooks" / "macos_timeout_guard.py"
+sys.path.insert(0, str(GUARD.parent))
+from macos_timeout_guard import uses_bare_timeout  # noqa: E402
+
+FIRES = [
+    "timeout 480 uv run --extra docs mkdocs build --strict",
+    "timeout 30 pytest tests -q",
+    "cd /tmp && timeout 5 ./flaky",
+    "TZ=UTC timeout 5 ./probe",
+    "ATTUNE_X=1 TZ=UTC timeout 10 pytest",
+    "make build; timeout 60 ./deploy.sh",
+    "(timeout 3 curl localhost:8765)",
+    "foo | timeout 3 grep bar",
+    "timeout\t5 ./x",
+]
+
+QUIET = [
+    # `timeout` as an argument or flag, not a program
+    "pytest --timeout 30 tests/",
+    "curl --max-time 5 http://x",
+    "grep -rn 'timeout' src/",
+    'grep -n "timeout" README.md',
+    "git config --get http.timeout",
+    # env var that merely resembles it
+    "TIMEOUT=5 ./run.sh",
+    "export TIMEOUT_S=30",
+    # inside quotes — a string, not an invocation
+    'echo "timeout 5 foo"',
+    "echo 'timeout 5 foo'",
+    # heredoc body: a script being WRITTEN, possibly for a Linux runner
+    "cat > s.sh <<'EOF'\ntimeout 5 ./job\nEOF",
+    "cat > s.sh <<EOF\ntimeout 5 ./job\nEOF",
+    # comment
+    "# timeout 5 ./x\nls",
+    # substring of another program name
+    "timeoutctl status",
+    "./timeout-helper --run",
+    # bare mention with no argument
+    "which timeout",
+    "command -v timeout",
+]
+
+
+@pytest.mark.parametrize("cmd", FIRES)
+def test_detects_command_position(cmd):
+    assert uses_bare_timeout(cmd) is True, cmd
+
+
+@pytest.mark.parametrize("cmd", QUIET)
+def test_ignores_non_invocations(cmd):
+    assert uses_bare_timeout(cmd) is False, cmd
+
+
+def _run(command, tool="Bash"):
+    payload = json.dumps({"tool_name": tool, "tool_input": {"command": command}})
+    return subprocess.run(
+        [sys.executable, str(GUARD)], input=payload, capture_output=True, text=True
+    )
+
+
+@pytest.mark.skipif(sys.platform != "darwin", reason="guard is macOS-only")
+def test_blocks_end_to_end_on_macos():
+    r = _run("timeout 30 pytest")
+    assert r.returncode == 2
+    assert "not installed on this Mac" in r.stderr
+    assert "timeout: 480000" in r.stderr  # names the actual alternative
+
+
+@pytest.mark.skipif(sys.platform != "darwin", reason="guard is macOS-only")
+def test_escape_hatch_allows():
+    assert _run("ATTUNE_ALLOW_TIMEOUT=1 timeout 30 pytest").returncode == 0
+
+
+def test_non_bash_tool_ignored():
+    assert _run("timeout 30 pytest", tool="Write").returncode == 0
+
+
+def test_malformed_payload_never_blocks():
+    r = subprocess.run(
+        [sys.executable, str(GUARD)], input="not json", capture_output=True, text=True
+    )
+    assert r.returncode == 0


### PR DESCRIPTION
Blocks Bash commands that shell out to `timeout` on macOS, where it
does not exist.

## Built from a measurement, not a hunch

`timeout(1)` is GNU coreutils. macOS ships neither it nor `gtimeout`
unless coreutils is installed, so `timeout ...` dies with `command not
found` and the work inside never runs — while the shell still reports
the exit status of whatever followed, which is what makes it easy to
miss.

A full-text sweep of session transcripts found `command not found:
timeout` in **at least 18 distinct sessions** between 2026-07-19 and
2026-08-25, across three repos (attune-ai, attune-forms,
IndianRailroadTicketing). Every other unresolvable command appeared
once or was a scanner artifact.

**18 is a floor, not an estimate** — the sweep only sees sessions where
the error string survived into a stored transcript. It is stated as a
floor rather than rounded up, because a guard whose justification is a
guess cannot ask anyone to trust its judgment.

## The hypothesis this was commissioned to test failed

The calibration was meant to measure a *different* class: that I
recommend unverified mechanisms to the user often enough to gate. A
corpus scan for non-existent commands, after two narrowing rounds and
hand triage, produced **exactly one** candidate — in an archived
release note, where naming the then-current command is correct.

The adjacent *operational* class is the one with the base rate, and it
only surfaced because the probe ran before anything was built. Worth
recording as the reason to calibrate at all.

## Design choices

| Choice | Why |
|---|---|
| **Blocks**, doesn't advise | A CI-bound script is *written*, not executed here (heredocs excluded). Anything actually running `timeout` on this Mac is guaranteed to fail, so blocking costs nothing. |
| **Self-disables** | `shutil.which("timeout")` is consulted at run time — install coreutils and the guard silently retires. Non-darwin exits 0 immediately. |
| **Names the alternative** | The Bash tool's own `timeout` parameter, with a worked value. A guard that only says "no" makes you go find the fix. |

The detector matches **command position only** — heredoc bodies, quoted
strings, and comments are stripped first, so `grep -rn "timeout"`,
`pytest --timeout 30`, `TIMEOUT=5 ./run.sh`, `timeoutctl`, and a
heredoc writing a Linux script all stay quiet.

## Receipts

- **29 tests**: 9 true-positive shapes, **16 false-positive classes**
  pinned, 4 end-to-end (block, escape hatch, non-Bash ignored,
  malformed payload never blocks). Each false positive is one observed
  during calibration — the discriminator is the fragile part of any
  rule and the first thing a later "simplification" drops.
- **Live-fired in the harness** from a user-level copy before this
  port: `timeout 5 echo …` blocked with the guidance message, while
  `grep -rn "timeout"`, a flag usage, and a heredoc writing a `timeout`
  line all ran normally, and `ATTUNE_ALLOW_TIMEOUT=1` allowed through.
  Registered is not working; this is the working receipt.
- `test_sdk_subprocess_gate.py` **caught the first draft** missing
  `exit_if_sdk_subprocess` — an ungated plugin hook fires inside SDK
  workflow subprocesses and poisons the stream-json channel for
  subscription users. Added; drift guard passes.
- gates + quality + hooks + plugins — 1430 passed.
- Full `pytest tests` keyless — 25253 passed, 257 skipped, 6 xfailed.

## Known twin, deliberately not deleted

A working copy also lives at `~/.claude/hooks/macos_timeout_guard.py`
wired into user settings — that's how it was live-fired. It is now a
twin of this one (principle 3) and should be removed once the plugin
hook is confirmed firing. Queued to the starter rather than deleted
blind: removing a working guard on the assumption its replacement is
active is exactly the "registered is not working" failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
