### PR TITLE
release: 15.0.0 — one obvious way to do each thing

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "Persistent memory and receipt-verified workflows for Claude Code. Spec-driven development with an approval loop, plus 28 auto-triggering skills: security audits, code review, test generation, release prep.",
-    "version": "14.1.0"
+    "version": "15.0.0"
   },
   "plugins": [
     {
       "name": "attune-ai",
       "description": "Persistent memory and receipt-verified workflows for Claude Code. /spec carries an idea through brainstorm, requirements, design, and task execution with quality gates and your approval at each stage. Backed by 28 auto-triggering skills — security audits, code reviews, test generation, bug prediction, and release preparation. For help content tools, also install attune-help from this marketplace; authoring ships built in via the attune.authoring module.",
       "source": "./plugin",
-      "version": "14.1.0",
+      "version": "15.0.0",
       "author": {
         "name": "Smart AI Memory",
         "email": "patrick.roebuck@smartaimemory.com"

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,4 +1,4 @@
-# Attune AI Framework v14.1.0
+# Attune AI Framework v15.0.0
 
 AI-powered developer workflows with cost optimization and multi-agent orchestration.
 
@@ -601,7 +601,7 @@ attune_redis/          # Redis plugin — BUNDLED, ships in the attune-ai
 
 ---
 
-**Version:** 14.1.0 | **License:** Apache 2.0 | **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)
+**Version:** 15.0.0 | **License:** Apache 2.0 | **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)
 
 ## Lessons — core
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [15.0.0] - 2026-08-26
+
 15.0.0 finishes the Empathy-framework excision begun in 9.0.0: the
 public `empathy_level` surface, the `EmpathyMCPServer` alias, and the
 legacy entry-point groups are all removed. CLI, plugin, and MCP users

--- a/README.md
+++ b/README.md
@@ -135,54 +135,59 @@ memory storage and recall, and every local transform.
      release with the headline feature; the displaced content moves to
      a permanent section below. Don't stack a second "New in" here. -->
 
-## New in 14.1.0 — workflows that prove they work
+## New in 15.0.0 — one obvious way to do each thing
 
-Every workflow in your catalog now comes with evidence behind it.
-14.1.0 ships a **planted-defect validation harness**: each workflow is
-run against a fixture carrying a known bug — a real `eval()`, a real
+**Every attune surface now has exactly one name, one contract, and one
+place to register.** 15.0.0 completes a consolidation that has run
+across the last several releases: what the docs describe is what the
+library has, with no second spelling of it kept alive out of habit.
+
+What that buys you:
+
+- **One entry point per extension.** Workflows register under
+  `attune.workflows`, plugins under `attune.plugins`. That is the whole
+  rule. Three groups used to be in play and only some were actually
+  read, so a registration that looked correct could quietly never
+  load — that class of silent miss is gone.
+- **One name for the MCP server**, `AttuneMCPServer`, everywhere it
+  appears.
+- **Nothing vestigial to learn.** The 1–5 level dial is retired from
+  every public API — the plugin contract, both agent configs, the
+  registries, and the two MCP tools that read it. Its meaning came
+  from a framework attune no longer ships, so every new user had to
+  ask what it did. Now nobody has to. The core MCP tool surface is 48
+  tools, all of them live.
+- **A smaller surface to hold in your head**, which is the whole
+  point: less API, and all of it real.
+
+**Upgrading is a no-op** if you use the CLI, the plugin, or the MCP
+tools. If you write third-party plugins or workflows, the
+[15.0.0 upgrade guide](docs/migration/upgrading-to-15.0.0.md) opens
+with an "are you affected?" table — ten rows, each with its one-line
+fix, and two that need nothing from you at all: a legacy
+`empathy_level:` key in `agents.md` is now ignored rather than an
+error, and an existing metrics database migrates itself on first open.
+
+<details>
+<summary>Previously new in 14.1.0 — workflows that prove they work</summary>
+
+Every workflow in your catalog comes with evidence behind it. 14.1.0
+shipped a **planted-defect validation harness**: each workflow is run
+against a fixture carrying a known bug — a real `eval` call, a real
 CVE pin, a module with no docstrings — and has to *find it* to keep
 its "working" badge. Not "exited 0": actually caught the planted
 defect, with the cost and verdict recorded in a tracked registry you
 can read.
 
-You feel that in three places immediately:
-
-- **Your release gate tells the truth.** `secure-release` now reads
-  its sub-audits' real findings — a planted-critical fixture that used
-  to sail through as GO now comes back NO_GO with the criticals
-  counted. If an audit ever scores low while yielding zero readable
-  findings, you get a warning instead of silence.
-- **Your doc scan finds real gaps.** The documentation orchestrator
-  now detects modules with missing docstrings out of the box, and when
-  it can't assess something it says "not assessed" — never a
-  fabricated "no gaps found."
-- **Every discovery-sweep lane earns its budget.** Lanes get
-  measured-cost budget floors: each one either runs with enough money
-  to finish or tells you it skipped — no more lanes silently dying at
-  $0 mid-sweep.
-
-And the catalogs are honest about the rest: the few workflows still
-being repaired are hidden from the dashboard, CLI list, and MCP catalog
-until their probes pass — so everything you *can* click actually works.
-
-<details>
-<summary>Previously new in 14.0.0 — the release checks its own diff</summary>
-
-`/release audit` answers a question the other release checks don't ask:
-**what class of defect could *this* release have introduced?** It
-resolves the range from your last release tag, proves the gates that
-were green are still green *on this exact commit*, sweeps the changed
-package surface with a calibrated rule pack, and hands you a capped
-one-page residual — never a diff dump. Three models then sit on it for
-a single round and either accept or amend a pre-filled disposition per
-item. You rule; `/release publish` refuses to tag until every item
-carries a ruling, and records that ruling next to the commit it was
-made about. The packet also states how many files were swept against
-how many changed, so an empty result can never be mistaken for a clean
-one.
-
-14.0.0 also removed `attune.exceptions` (the retired Empathy-era tree):
-the migration is to delete the handler, not repoint the import.
+That shows up in three places: `secure-release` reads its sub-audits'
+real findings (a planted-critical fixture that used to sail through as
+GO comes back NO_GO); the documentation orchestrator detects missing
+docstrings and says "not assessed" rather than fabricating "no gaps
+found"; and every discovery-sweep lane gets a measured-cost budget
+floor, so a lane either runs with enough money to finish or tells you
+it skipped. The few workflows still being repaired are hidden from the
+dashboard, CLI list, and MCP catalog until their probes pass — so
+everything you *can* click actually works.
 
 </details>
 

--- a/docs/reference/API_REFERENCE.md
+++ b/docs/reference/API_REFERENCE.md
@@ -1,6 +1,6 @@
 # Attune AI API Reference
 
-**Version:** 14.1.0
+**Version:** 15.0.0
 **License:** Apache License 2.0
 **Copyright:** 2025-2026 Smart AI Memory, LLC
 
@@ -1133,5 +1133,5 @@ msg = format_error(
 
 ---
 
-**Version:** 14.1.0 | **License:** Apache 2.0
+**Version:** 15.0.0 | **License:** Apache 2.0
 **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)

--- a/plugin/.claude-plugin/marketplace.json
+++ b/plugin/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "Spec-driven development for Claude Code — /spec plans, reviews, and executes with quality gates; plus security audits, code reviews, test generation, and release prep from /attune.",
-    "version": "14.1.0"
+    "version": "15.0.0"
   },
   "plugins": [
     {
       "name": "attune-ai",
       "description": "Spec-driven development for Claude Code — /spec plans, reviews, and executes with quality gates; plus security audits, code reviews, test generation, and release prep from /attune.",
       "source": "./",
-      "version": "14.1.0",
+      "version": "15.0.0",
       "author": {
         "name": "Smart AI Memory",
         "email": "patrick.roebuck@smartaimemory.com"

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "attune-ai",
-  "version": "14.1.0",
+  "version": "15.0.0",
   "description": "Persistent memory and receipt-verified workflows for Claude Code — /spec plans, reviews, and executes with quality gates; plus security audits, code reviews, test generation, and release prep from /attune.",
   "author": {
     "name": "Smart AI Memory",

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -4,7 +4,7 @@ Spec-driven development for Claude Code — turn requirements
 into reliable software. <!-- cap:skill_count -->28 auto-triggering skills<!-- /cap -->, zero
 commands: say what you need and Claude picks the right skill.
 
-**Version:** 14.1.0 | **License:** Apache 2.0
+**Version:** 15.0.0 | **License:** Apache 2.0
 
 > **Fix Receipts** (`/fix`) — new in 11.2.0. Say `fix this and
 > prove it`.

--- a/plugin/core/__init__.py
+++ b/plugin/core/__init__.py
@@ -5,4 +5,4 @@ This module provides the core workflow functionality when the full
 attune-ai package is not installed via pip.
 """
 
-__version__ = "14.1.0"
+__version__ = "15.0.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "attune-ai"
-version = "14.1.0"
+version = "15.0.0"
 description = "Persistent memory and receipt-verified workflows for Claude Code — plugin, MCP server, and spec-driven dev framework."
 readme = {file = "README.md", content-type = "text/markdown"}
 requires-python = ">=3.10"

--- a/tests/unit/hooks/test_worktree_path_guard.py
+++ b/tests/unit/hooks/test_worktree_path_guard.py
@@ -73,7 +73,7 @@ def two_git_trees(tmp_path):
             ["git", "init", "--quiet"],
             cwd=tree,
             check=True,
-            timeout=5,
+            timeout=30,
         )
     return tree_a, tree_b
 
@@ -190,7 +190,7 @@ class TestAllowlist:
         fake_home = tmp_path / "fake-home"
         memory = fake_home / ".attune" / "memory"
         memory.mkdir(parents=True)
-        subprocess.run(["git", "init", "--quiet"], cwd=memory, check=True, timeout=5)
+        subprocess.run(["git", "init", "--quiet"], cwd=memory, check=True, timeout=30)
         # ~ expands via HOME on POSIX, USERPROFILE on Windows.
         monkeypatch.setenv("HOME", str(fake_home))
         monkeypatch.setenv("USERPROFILE", str(fake_home))

--- a/uv.lock
+++ b/uv.lock
@@ -299,7 +299,7 @@ wheels = [
 
 [[package]]
 name = "attune-ai"
-version = "14.1.0"
+version = "15.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "agent-memory-client" },

--- a/website/app/page.tsx
+++ b/website/app/page.tsx
@@ -38,7 +38,7 @@ export default function Home() {
                 test_homepage_badge_includes_package_version guard scans
                 this file for vX.Y.Z and compares it to the package. */}
             <div className="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-[var(--surface-container-high)] text-[var(--primary)] text-xs font-bold tracking-widest mb-8 uppercase">
-              <span>v14.1.0</span>
+              <span>v15.0.0</span>
               <span className="w-1 h-1 rounded-full bg-[var(--primary)]" aria-hidden="true"></span>
               <span className="opacity-80">Persistent memory for AI coding agents</span>
             </div>

--- a/website/lib/features.ts
+++ b/website/lib/features.ts
@@ -22,7 +22,7 @@
  * copy; never hard-code a count in a page or a prose string.
  * Verified against the live Python code per the
  * website-content-accuracy rule (last verified 2026-08-25,
- * attune-ai 14.1.0):
+ * attune-ai 15.0.0):
  *
  *   workflows: distinct classes in attune.workflows.discover_workflows()
  *     (D4, claim-drift-gates, 2026-07-12: the prior count used
@@ -85,7 +85,7 @@ export const PRODUCTS: Product[] = [
     id: "attune-ai",
     name: "Attune AI",
     pypiName: "attune-ai",
-    version: "14.1.0",
+    version: "15.0.0",
     tagline: "Generate, maintain, and serve help from your code",
     installCommand: "pip install attune-ai",
     marketplaceInstall:
@@ -129,7 +129,7 @@ export const PRODUCTS: Product[] = [
     id: "claude-code-plugin",
     name: "Claude Code Plugin",
     pypiName: "attune-ai",
-    version: "14.1.0",
+    version: "15.0.0",
     tagline: "Progressive help right in your terminal",
     installCommand:
       "claude plugin marketplace add Smart-AI-Memory/attune-ai",


### PR DESCRIPTION
Release prep for the **15.0.0 major** — `docs/specs/release-15-manifest`,
manifest sequencing step 3's prep half. Cut date 2026-08-26 (D8); the
D5 window closes 2026-09-01, so five days of margin remain.

Steps 1 and 2 were already complete on `main`: passenger 1 discharged
in 14.0.0 (D6), the public `empathy_level` surface removed in #2299,
and the `EmpathyMCPServer` alias plus entry-point standardization in
#2301. Nothing new boards here — chair ruled "cut as-is" this session.

## What's in the diff

- **Version bump 14.1.0 → 15.0.0** across all 10 sites via
  `scripts/bump_version.py`, plus `uv.lock` (one line).
- **Changelog promotion.** `[Unreleased]` → `[15.0.0] - 2026-08-26`,
  fresh empty `[Unreleased]` above. The section was already written by
  the passenger PRs; nothing was authored here.
- **README rotating slot** → the 15.0.0 headline; the 14.1.0 content
  moves into the collapsed "previously new in" block, following the
  14.1.0 precedent. Rewritten once after chair feedback that the first
  draft read negatively — it now leads with the property the library
  has (one name, one contract, one place to register) rather than with
  what was removed.
- **`website/lib/features.ts`** count-provenance comment now names the
  15.0.0 tree. The counts themselves were already current
  (`mcpTools: 48`).
- **Queued test-fixture fix folded in** (chair, this session): the two
  `git init` subprocess timeouts in
  `tests/unit/hooks/test_worktree_path_guard.py` go 5s → 30s. The 5s
  bound flaked the windows-3.11 lane on #2295 — sole error in 25,183
  passed — and cost a lane plus a rerun.

## Receipts

| Probe | Result |
|---|---|
| Full local suite, keyless (`ANTHROPIC_API_KEY=""`) | **25,298 passed**, 259 skipped, 6 xfailed, 90s |
| Base `main` @ `5099cdf82` | Tests run `32896893878` completed/**success**, zero non-success jobs (re-fetched, not trusting the watcher exit code) |
| Touched guard suites (website version accuracy, plugin config validation, worktree path guard) | 69 passed |
| `scripts/check_badge_freshness.py` | Badge freshness OK |
| Pre-commit, all hooks on changed files | Passed (incl. G5 brand-drift gate) |
| Commit signature | `%G?` = `G` |

`SKIP=check-docs-freshness` on the release commit is the sanctioned
release-prep skip (the stale count spikes on any version bump —
version-hash noise, not real staleness); `/coach maintain` is queued
post-release.

## Not in this PR

The release-audit sitting and tag/publish are separate, chair-gated
steps. Per D8 the `analyze()` dead contract stays deferred to a
future major, and #2239's layering does not board.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
