### PR TITLE
fix(sitting): a failed seat says why, and a never-authenticated call is not spend [HOLD until v15.0.0 is tagged]

### DIFF
--- a/docs/specs/session-spend-ledger/decisions.md
+++ b/docs/specs/session-spend-ledger/decisions.md
@@ -1,9 +1,12 @@
 # Session Spend Ledger — Decisions
 
-All decisions below are **PROPOSED** (lead, 2026-08-24), implemented
-in the same PR so the chair reads working code, not hypotheticals.
-Each is cheap to re-rule; none is one-way. Counter-cases are stated
-per D11d COUNTER-CASE.
+D1–D6 are **PROPOSED** (lead, 2026-08-24), implemented in the same PR
+so the chair reads working code, not hypotheticals. Each is cheap to
+re-rule; none is one-way. Counter-cases are stated per D11d
+COUNTER-CASE.
+
+**D7 is CONFIRMED** (chair, 2026-08-25) — it clarifies D5's scope
+rather than ratifying it, so D5 itself stays PROPOSED.
 
 ---
 
@@ -112,6 +115,62 @@ and are neither checked nor recorded (R4).
   mid-workflow records the per-run budget cap, not $0 — its
   cost_report is lost with the exception, and the conservative
   bound is the most it could have billed (D11 lane, 2026-08-24).
+
+---
+
+## D7 — D5 sizes the estimate, not what counts as spend (CONFIRMED 2026-08-25)
+
+Raised while fixing #2311. The `claude` seat was recorded absent at
+three consecutive release-audit sittings; root cause was an expired
+OAuth session, reproduced live (exit 1, stdout `Failed to authenticate:
+OAuth session expired and could not be refreshed`). Each of those runs
+had recorded the flat `$0.25` seat estimate — roughly `$0.75` of spend
+against the cap for calls that never reached a provider.
+
+`tests/unit/roundtable/test_routine_session_ledger.py::
+test_failed_but_spawned_seat_still_records` asserted in its docstring
+that "a timeout **or auth failure** may still have billed — overcount,
+never undercount (D5)". That reading would keep charging for calls that
+provably consumed nothing.
+
+**RULING (chair, 2026-08-25): D5 does not say that.** Its scope is the
+MAGNITUDE of the estimate recorded for a call that did, or may have,
+consumed tokens. It is silent on a call that never reached the
+provider, and such a call is not spend. Verified across all three
+surfaces stating D5 — the first reading of this question cited only
+one, which was not enough to support the claim:
+
+| Surface | Text | Covers a never-authenticated call? |
+|---|---|---|
+| [decisions.md D5](#d5--seat-spend-is-a-flat-conservative-estimate-proposed) | flat estimate "deliberately above the typical single-reply `claude -p` cost, so the ledger overcounts rather than undercounts" | no — magnitude only |
+| `src/attune/gates/session_ledger.py` `seat_estimate_usd` | "Flat conservative estimate for one **billed** `claude` seat call" | no — presupposes the call billed |
+| `scripts/workflow_probe_runner.py` (crashed-probe path) | "A probe that crashed mid-workflow **may have billed** … record the per-run budget cap as the conservative bound" | no — conditions on "may have billed" |
+
+The probe-runner surface is the closest analogue in the tree and draws
+the same line: the conservative bound applies BECAUSE the call may have
+billed.
+
+Consequences, shipped in #2312:
+
+- `attune.roundtable.routine.unbilled_failure(exit_code, output)`
+  excludes only provably-free failures — binary-not-found (127) and a
+  deliberately tight set of never-authenticated output signatures.
+- Ambiguous failures (timeouts, mid-stream crashes) still record, so
+  the conservative default is unchanged everywhere else.
+- The test's docstring is narrowed in place, with the reason recorded
+  next to it.
+
+**Counter-case (D11d COUNTER-CASE).** The exclusion matches on output
+text, so a call that billed and *then* emitted a matching auth message
+would be undercounted. Judged unreachable for a single short
+`claude -p` invocation, since authentication precedes the request — but
+a signature list that grows carelessly could make it reachable, which
+is why the list is kept tight and its rationale is stated at the
+constant. If seat estimates ever drift from `usage.jsonl` actuals, this
+exclusion is the first thing to re-measure.
+
+D5 itself remains PROPOSED; this clarifies its scope, and does not
+ratify it.
 
 ---
 

--- a/docs/specs/session-spend-ledger/decisions.md
+++ b/docs/specs/session-spend-ledger/decisions.md
@@ -142,7 +142,7 @@ one, which was not enough to support the claim:
 
 | Surface | Text | Covers a never-authenticated call? |
 |---|---|---|
-| [decisions.md D5](#d5--seat-spend-is-a-flat-conservative-estimate-proposed) | flat estimate "deliberately above the typical single-reply `claude -p` cost, so the ledger overcounts rather than undercounts" | no — magnitude only |
+| D5 above, in this file | flat estimate "deliberately above the typical single-reply `claude -p` cost, so the ledger overcounts rather than undercounts" | no — magnitude only |
 | `src/attune/gates/session_ledger.py` `seat_estimate_usd` | "Flat conservative estimate for one **billed** `claude` seat call" | no — presupposes the call billed |
 | `scripts/workflow_probe_runner.py` (crashed-probe path) | "A probe that crashed mid-workflow **may have billed** … record the per-run budget cap as the conservative bound" | no — conditions on "may have billed" |
 

--- a/src/attune/classes/sitting.py
+++ b/src/attune/classes/sitting.py
@@ -19,6 +19,16 @@ An ABSENT seat is a valid outcome, never a fabricated one. A seat whose
 reply does not parse is recorded as ``format_noncompliant`` with its raw
 text preserved; the stage does not invent amendments on its behalf.
 
+A seat that was never reachable (``absent``) and a seat that RAN and
+FAILED (``failed``) are different facts and are recorded differently.
+Conflating them cost three consecutive sittings: the ``claude`` seat's
+OAuth session had expired, the CLI said so on stdout and exited 1, and
+every run recorded a bare ``absent`` while discarding the diagnosis
+(issue #2311). Every non-replied seat now carries a ``reason`` into
+:meth:`SeatReply.as_dict`, so the emitted sitting states WHY a seat did
+not speak. Contract principle 7 — a failed gatekeeper fails the gate;
+absence is not a pass — applies to the seats themselves.
+
 Copyright 2025 Smart AI Memory, LLC
 Licensed under the Apache License, Version 2.0
 """
@@ -51,6 +61,13 @@ SEATS: tuple[str, ...] = ("claude", "codex", "antigravity")
 #: than this is composing rather than amending.
 SEAT_REPLY_CHARS = 4000
 
+#: How much of a non-replied seat's output is kept as its ``reason``.
+#: Enough for a CLI's one-line diagnosis plus context, not a dump.
+REASON_CHARS = 400
+
+#: ``run_command`` maps a missing binary to 127 and a timeout to 124.
+_EXIT_NOT_FOUND = 127
+
 _AMEND = re.compile(
     r"^\s*AMEND\s+(?P<item>\S+)\s*->\s*(?P<disp>[A-Z-]+)\s*:\s*(?P<reason>.+?)\s*$",
     re.MULTILINE,
@@ -77,20 +94,25 @@ class SeatReply:
     """What one seat said. ``status`` is never inferred as agreement."""
 
     seat: str
-    status: str  # "replied" | "absent" | "format_noncompliant"
+    status: str  # "replied" | "absent" | "failed" | "format_noncompliant"
     amendments: tuple[SeatAmendment, ...] = field(default=())
     gate_ranking: tuple[str, ...] = field(default=())
     closing: str = ""
     raw: str = ""
 
     def as_dict(self) -> dict[str, Any]:
-        return {
+        emitted: dict[str, Any] = {
             "seat": self.seat,
             "status": self.status,
             "amendments": [a.as_dict() for a in self.amendments],
             "gate_ranking": list(self.gate_ranking),
             "closing": self.closing,
         }
+        # A seat that did not reply must say why. Dropping this is what
+        # let an expired credential read as three silent absences.
+        if self.status != "replied":
+            emitted["reason"] = self.raw[:REASON_CHARS].strip()
+        return emitted
 
 
 @dataclass(frozen=True)
@@ -104,11 +126,39 @@ class Sitting:
         return {
             "packet_hash": self.packet_hash,
             "replies": [r.as_dict() for r in self.replies],
+            # Stated, not left to be counted. Three sittings ran at two
+            # seats without that ever being visible in the output.
+            "census": self.census,
         }
 
     @property
     def seats_present(self) -> tuple[str, ...]:
         return tuple(r.seat for r in self.replies if r.status == "replied")
+
+    @property
+    def seats_failed(self) -> tuple[str, ...]:
+        """Seats that ran and failed — a different fact from absent."""
+        return tuple(r.seat for r in self.replies if r.status == "failed")
+
+    @property
+    def census(self) -> dict[str, Any]:
+        """How many of the expected seats actually spoke, and who did not.
+
+        ``short_handed`` is the loud bit: a sitting below full strength
+        is a degraded cross-model check, and the chair should read that
+        from the record rather than infer it from a missing name.
+        """
+        present = self.seats_present
+        return {
+            "expected": len(self.replies),
+            "replied": len(present),
+            "short_handed": len(present) < len(self.replies),
+            "not_replied": {
+                r.seat: {"status": r.status, "reason": r.raw[:REASON_CHARS].strip()}
+                for r in self.replies
+                if r.status != "replied"
+            },
+        }
 
     def amendments_for(self, item_id: str) -> tuple[SeatAmendment, ...]:
         """Every seat amendment naming ``item_id``."""
@@ -161,10 +211,21 @@ def build_sitting_brief(packet: Packet) -> str:
 
 
 def parse_seat_reply(seat: str, exit_code: int, text: str) -> SeatReply:
-    """Parse one seat's reply. Never fabricates content on its behalf."""
+    """Parse one seat's reply. Never fabricates content on its behalf.
+
+    Non-zero exits split two ways, because they are different facts: 127
+    means the seat was never reachable (``absent``), anything else means
+    it RAN and FAILED (``failed``) and its output carries the diagnosis.
+    Both keep that output as ``raw``, which ``as_dict`` emits as
+    ``reason`` — see the module docstring and issue #2311.
+    """
     body = (text or "").strip()
-    if exit_code != 0 or not body:
+    if exit_code == _EXIT_NOT_FOUND:
         return SeatReply(seat=seat, status="absent", raw=body)
+    if exit_code != 0:
+        return SeatReply(seat=seat, status="failed", raw=body)
+    if not body:
+        return SeatReply(seat=seat, status="absent", raw="exited 0 with no output")
 
     amendments = tuple(
         SeatAmendment(
@@ -219,8 +280,9 @@ def hold_sitting(
         seats: Seat names, in stable order.
 
     Returns:
-        A :class:`Sitting`. Seats that fail or say nothing are ABSENT —
-        absence is recorded, never read as agreement.
+        A :class:`Sitting`. A seat that was unreachable is ``absent``, a
+        seat that ran and failed is ``failed``, and both carry the
+        reason — neither is ever read as agreement.
 
     """
     from attune.roundtable.routine import SEAT_RECIPES, default_invoke_seat
@@ -240,7 +302,7 @@ def hold_sitting(
         try:
             exit_code, text = runner(recipe, brief)
         except (OSError, ValueError) as exc:  # a seat CLI that is not installed
-            replies.append(SeatReply(seat=seat, status="absent", raw=str(exc)))
+            replies.append(SeatReply(seat=seat, status="failed", raw=str(exc)))
             continue
         replies.append(parse_seat_reply(seat, exit_code, text))
 

--- a/src/attune/roundtable/routine.py
+++ b/src/attune/roundtable/routine.py
@@ -175,6 +175,52 @@ def run_command(
     return proc.returncode, out[-TAIL_CHARS:]
 
 
+#: Output signatures of a failure that never reached the provider, so
+#: no tokens were consumed. Matched case-insensitively against the CLI's
+#: combined output. Kept DELIBERATELY tight: a false positive here
+#: under-reports real spend, which is worse than over-reporting, so only
+#: messages that unambiguously mean "never authenticated" belong.
+_UNBILLED_SIGNATURES: tuple[str, ...] = (
+    "failed to authenticate",
+    "oauth session expired",
+    "invalid api key",
+    "authentication_error",
+    "please run /login",
+)
+
+#: run_command maps a missing binary to this — nothing ever spawned.
+_EXIT_NOT_FOUND = 127
+
+
+def unbilled_failure(exit_code: int, output: str) -> bool:
+    """Did this seat invocation provably consume nothing?
+
+    A successful call always bills, and an ambiguous failure (a timeout,
+    a crash mid-stream) MAY have billed — both return False so the
+    ledger keeps its conservative default. Only two cases are provably
+    free: the binary was never found, and the CLI refused before
+    authenticating.
+
+    The auth case was invisible until issue #2311: three release-audit
+    sittings each recorded a flat seat estimate against a ``claude``
+    seat whose OAuth session had expired, so the session cap was being
+    eaten by calls that never reached the provider.
+
+    Args:
+        exit_code: The seat process's exit status.
+        output: Its combined stdout/stderr tail, as run_command returns.
+
+    Returns:
+        True only when no provider call can have happened.
+    """
+    if exit_code == _EXIT_NOT_FOUND:
+        return True
+    if exit_code == 0:
+        return False
+    haystack = (output or "").lower()
+    return any(signature in haystack for signature in _UNBILLED_SIGNATURES)
+
+
 def default_invoke_seat(
     recipe: Sequence[str],
     brief: str,
@@ -207,9 +253,9 @@ def default_invoke_seat(
     else:
         argv = [brief if part == "{brief}" else part for part in recipe]
         result = run_command(argv, provider_clean=True, reply_chars=reply_chars)
-    if billed and result[0] != 127:
-        # 127 = binary not found — nothing spawned, nothing billed.
-        # Every other exit (including a timeout) may have billed.
+    if billed and not unbilled_failure(*result):
+        # Everything not provably free may have billed — a timeout most
+        # of all — so the conservative default is still to record.
         session_ledger.record(f"seat:{recipe[0]}", session_ledger.seat_estimate_usd())
     return result
 

--- a/tests/unit/classes/test_sitting.py
+++ b/tests/unit/classes/test_sitting.py
@@ -80,8 +80,17 @@ class TestBriefEncodesTheRoleLimits:
 
 
 class TestAbsenceIsNeverAgreement:
-    def test_nonzero_exit_is_absent(self):
+    def test_nonzero_exit_is_failed_not_absent(self):
+        """It RAN and failed — a different fact from never reachable."""
         reply = parse_seat_reply("codex", 1, "boom")
+
+        assert reply.status == "failed"
+        assert reply.amendments == ()
+        assert reply.raw == "boom", "the diagnosis is kept, not discarded"
+
+    def test_binary_not_found_is_absent(self):
+        """127 is the one exit that means nothing ever spawned."""
+        reply = parse_seat_reply("codex", 127, "codex: not found")
 
         assert reply.status == "absent"
         assert reply.amendments == ()
@@ -101,14 +110,49 @@ class TestAbsenceIsNeverAgreement:
 
         assert reply.status == "format_noncompliant"
 
-    def test_a_missing_seat_binary_is_absent_not_fatal(self):
+    def test_a_seat_runner_that_raises_is_not_fatal(self):
         def explode(recipe, brief):
             raise OSError("codex: command not found")
 
         sitting = hold_sitting(_packet(1), invoke=explode)
 
-        assert {r.status for r in sitting.replies} == {"absent"}
+        assert {r.status for r in sitting.replies} == {"failed"}
         assert sitting.seats_present == ()
+
+    def test_a_seat_that_did_not_reply_says_why(self):
+        """Issue #2311: three sittings recorded a bare 'absent' while the
+        CLI's own one-line diagnosis sat in raw and was never emitted.
+        """
+        auth_error = "Failed to authenticate: OAuth session expired and could not be refreshed"
+
+        emitted = parse_seat_reply("claude", 1, auth_error).as_dict()
+
+        assert emitted["status"] == "failed"
+        assert auth_error in emitted["reason"]
+
+    def test_a_replying_seat_carries_no_reason_field(self):
+        emitted = parse_seat_reply(
+            "codex", 0, "NO AMENDMENTS\nGATE-RANK: C4b\nCLOSING: fine"
+        ).as_dict()
+
+        assert emitted["status"] == "replied"
+        assert "reason" not in emitted
+
+    def test_census_states_short_handedness_rather_than_implying_it(self):
+        """A two-seat sitting must SAY it was short-handed."""
+
+        def only_codex_answers(recipe, brief):
+            if recipe[0] == "codex":
+                return 0, "NO AMENDMENTS\nGATE-RANK: C4b\nCLOSING: ok"
+            return 1, "Failed to authenticate: OAuth session expired"
+
+        census = hold_sitting(_packet(1), invoke=only_codex_answers).as_dict()["census"]
+
+        assert census["replied"] == 1
+        assert census["expected"] == 3
+        assert census["short_handed"] is True
+        assert set(census["not_replied"]) == {"claude", "antigravity"}
+        assert "authenticate" in census["not_replied"]["claude"]["reason"].lower()
 
 
 class TestParsingAReply:

--- a/tests/unit/roundtable/test_routine_session_ledger.py
+++ b/tests/unit/roundtable/test_routine_session_ledger.py
@@ -61,12 +61,63 @@ class TestSeatSeam:
         assert not _ledger_path().exists()
 
     def test_failed_but_spawned_seat_still_records(self, monkeypatch) -> None:
-        """A timeout or auth failure may still have billed — overcount,
-        never undercount (D5)."""
+        """An AMBIGUOUS failure may still have billed — overcount, never
+        undercount (D5).
+
+        Narrowed 2026-08-25 (#2311): this docstring used to read "a
+        timeout or auth failure", but D5's text rules the ESTIMATE'S
+        MAGNITUDE, not whether a call that never reached the provider
+        records. A refusal-before-authentication is provably free and is
+        now excluded; a timeout, which may have billed, still records.
+        """
         monkeypatch.setattr(routine, "run_command", lambda *a, **k: (124, "timed out"))
         default_invoke_seat(("claude", "-p", "{brief}"), "hi")
         entries = [json.loads(line) for line in _ledger_path().read_text().splitlines()]
         assert len(entries) == 1
+
+    def test_an_ambiguous_nonzero_exit_still_records(self, monkeypatch) -> None:
+        """The conservative default survives the #2311 narrowing: only
+        recognised never-authenticated output is excluded, not every
+        failure."""
+        monkeypatch.setattr(routine, "run_command", lambda *a, **k: (1, "segmentation fault"))
+        default_invoke_seat(("claude", "-p", "{brief}"), "hi")
+        entries = [json.loads(line) for line in _ledger_path().read_text().splitlines()]
+        assert len(entries) == 1
+
+    def test_a_never_authenticated_seat_records_nothing(self, monkeypatch) -> None:
+        """#2311: three release-audit sittings each charged $0.25 against
+        a claude seat whose OAuth session had expired. No token was ever
+        consumed — auth precedes the request — so the cap was being eaten
+        by calls that never reached the provider.
+
+        The failure string is the one the CLI actually emitted, captured
+        live on 2026-08-25.
+        """
+        monkeypatch.setattr(
+            routine,
+            "run_command",
+            lambda *a, **k: (
+                1,
+                "Failed to authenticate: OAuth session expired and could not be refreshed",
+            ),
+        )
+        code, _ = default_invoke_seat(("claude", "-p", "{brief}"), "hi")
+
+        assert code == 1
+        assert not _ledger_path().exists(), "an unauthenticated call is not spend"
+
+    def test_the_cap_check_still_fires_before_an_auth_failure(self, monkeypatch) -> None:
+        """Excluding auth failures from RECORDING must not weaken the
+        pre-spawn refusal — the cap is checked before we know how the
+        call will fail."""
+        monkeypatch.setenv("ATTUNE_SESSION_SPEND_CAP_USD", "0")
+        monkeypatch.setattr(
+            routine,
+            "run_command",
+            lambda *a, **k: pytest.fail("subprocess spawned despite the spend refusal"),
+        )
+        with pytest.raises(SessionSpendCapError):
+            default_invoke_seat(("claude", "-p", "{brief}"), "hi")
 
 
 class TestRoutineUpfrontRefusal:


### PR DESCRIPTION
> [!WARNING]
> **DO NOT MERGE UNTIL `v15.0.0` IS TAGGED.** The release-audit manifest
> is bound to head SHA `1e463a4e4`; merging this moves `main` and
> `/release publish` will refuse with `sha-mismatch`. Verified — the
> gate returns `REFUSED [sha-mismatch] manifest rules on 1e463a4e4,
> tagging <other>`.

Closes #2311 (defects 1-3; defect 4, the seat-auth preflight, is left
on the issue).

## The bug

The `claude` seat was recorded **absent at three consecutive
release-audit sittings**. Root cause was one expired OAuth session.
The reason it survived three releases is that the instrument threw away
the answer: the CLI printed its diagnosis and `as_dict` dropped it.

Reproduced live by replicating `run_command`'s env handling:

```
exit_code: 1
stdout:  'Failed to authenticate: OAuth session expired and could not be refreshed'
stderr:  ''
```

`ANTHROPIC_API_KEY` was unset, so the documented fallback ("API key,
else stored login") had neither path. After `claude /login`, the same
probe returns exit 0 and the seat sat in a re-run sitting — where it
amended all five residual items after reading each locus, including
correctly identifying one as a false positive.

## Visibility (defects 1, 3)

`absent` and `failed` are different facts and are now recorded
differently: 127 means never reachable, anything else means it ran and
failed. Every non-replied seat carries a `reason` into `as_dict`, and
`Sitting` gains a `census` block stating `expected` / `replied` /
`short_handed` plus the per-seat reason — so a two-seat sitting *says*
it was short-handed instead of leaving the chair to notice a missing
name. Contract principle 7 (a failed gatekeeper fails the gate) applies
to the seats themselves.

## Billing (defect 2)

Each failed sitting charged the flat `$0.25` estimate for a call that
never reached the provider — auth precedes the request, so no token was
consumed — quietly eating a `$10` session cap. New
`unbilled_failure(exit_code, output)` excludes only provably-free
failures: binary-not-found, and a **deliberately tight** set of
never-authenticated signatures. Timeouts and ambiguous crashes still
record.

## D5 reading — CHAIR-CONFIRMED 2026-08-25 (keep the billing fix)

`test_failed_but_spawned_seat_still_records` asserted in its docstring
that *"a timeout **or auth failure** may still have billed — overcount,
never undercount (D5)"*.

D5's actual text rules the **estimate's magnitude** (flat $0.25,
"deliberately above the typical single-reply cost, so the ledger
overcounts rather than undercounts") and says nothing about a call that
never reached the provider. So the "or auth failure" is the test
author's extension, not the decision — and D5 is `PROPOSED` with the
chair ruling still open.

**Chair confirmed the narrowing.** Verified across all three surfaces
that state D5 — the original flag cited only the first:

| Surface | On D5 | Covers a never-authenticated call? |
|---|---|---|
| `docs/specs/session-spend-ledger/decisions.md:81` | flat estimate "deliberately above the typical single-reply `claude -p` cost" | no — rules the estimate's MAGNITUDE |
| `src/attune/gates/session_ledger.py:202` | "Flat conservative estimate for one **billed** `claude` seat call" | no — its contract presupposes the call billed |
| `scripts/workflow_probe_runner.py:1565` | "A probe that crashed mid-workflow **may have billed**… record the per-run budget cap as the conservative bound" | no — explicitly conditions on "may have billed" |

All three govern how much to record when a call did or might have
consumed tokens. The probe-runner surface, the closest analogue in the
tree, draws the same line this fix draws. Only the test docstring had
generalised "may have billed" into "any non-zero exit".

Honest counter-case, unchanged: a text-matched signature could in
principle appear in output from a call that billed and *then* failed,
which would undercount. Judged unreachable for a single short `-p`
invocation, since auth precedes the request — but that is the argument
against.

## Receipts

| Probe | Result |
|---|---|
| Live auth failure reproduced | exit 1 + the verbatim message |
| Live fix after `claude /login` | exit 0, correct format; seat sat and amended 5 items |
| `unbilled_failure` discriminator | 7/7 cases, incl. the verbatim CLI string, timeout-still-bills, exit-0-wins |
| **Mutation test** | reverting either fix makes the new tests FAIL (`KeyError: 'reason'`; ledger records again) |
| Full tree, keyless | **25,305 passed**, 259 skipped, 6 xfailed |
| pre-commit, all hooks | green on changed files |
| Signature | `%G?` = `G` |

Mutation-testing is included because two of these tests assert an
*absence* (no ledger file, no recorded spend), and the corpus has a
standing lesson about emptiness-asserting tests passing for the wrong
reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
