### PR TITLE
refactor(models): kill the last models->workflows upward import (#2239 Edge 1)

### DIFF
--- a/docs/specs/models-workflows-layering/requirements.md
+++ b/docs/specs/models-workflows-layering/requirements.md
@@ -56,17 +56,45 @@ Two adjacent structural problems make a naive move actively harmful:
   explicitly NON-compliant: the annotation alone re-creates
   Edge 1 (cross-review finding, 2026-08-25).
   **Config-construction ownership:** the `workflows.yaml` read
-  happens at the topmost workflows-layer call site only;
-  models-layer intermediaries (`models/resilient_executor.py`)
-  receive the mapping through their own constructors and pass it
-  down — injection chains upward, no models module reads
-  `workflows.yaml` or imports the config type (cross-review
-  finding, 2026-08-25). Callers to migrate (verified 2026-08-24):
-  `workflows/escalation/chain.py`,
-  `workflows/escalation/evaluator.py`,
-  `workflows/executor_mixin.py`, `models/resilient_executor.py`.
-  The receipt is the slice-1 pattern: the subprocess
-  no-upward-import probe extended to `attune.models.empathy_executor`.
+  happens at the topmost workflows-layer call site only; no models
+  module reads `workflows.yaml` or imports the config type
+  (cross-review finding, 2026-08-25).
+
+  **Caller list corrected 2026-08-26 (execution).** The
+  2026-08-24 list named four sites; re-grepped against the tree at
+  execution time, only ONE is a migration site:
+  - `workflows/executor_mixin.py:133` — constructs with
+    `provider=self._provider_str`, the only path that can be
+    `"hybrid"`. **The injection site.**
+  - `workflows/escalation/chain.py:112` and
+    `workflows/escalation/evaluator.py:163` — both hardcode
+    `provider="anthropic"`, so the hybrid read never fired for
+    them. Nothing to inject; untouched.
+  - `models/resilient_executor.py` — **not a caller.** The
+    `EmpathyLLMExecutor` mentions at lines 40–41 are a `>>>`
+    docstring example; the class takes a pre-built
+    `executor: Any`. There is no constructor to thread a mapping
+    through, so "injection chains upward through models-layer
+    intermediaries" describes a chain that does not exist. The
+    requirement's intent is unchanged — it is one hop, not a chain.
+
+  **Receipt amended 2026-08-26 — the named probe is NOT sufficient
+  on its own.** R1 originally named "the subprocess
+  no-upward-import probe extended to
+  `attune.models.empathy_executor`". Verified by mutation at
+  execution time: that probe observes what a module import LOADS,
+  so it is blind to a LAZY function-local import — and both #2239
+  cycle edges were exactly that shape. Reinstating the original
+  lazy `_load_hybrid_config` left the subprocess probe GREEN.
+  (This also means slice 1's probe never proved slice 1; it proves
+  the eager import graph stays clean, which is real but weaker
+  than claimed.) The binding receipt is therefore a **static AST
+  scan** — `test_no_models_module_imports_workflows_at_any_scope`
+  — asserting no module under `src/attune/models/` imports
+  `attune.workflows` at any scope, mutation-verified red against
+  eager, lazy-function-local, and relative (`from ..workflows`)
+  shapes. The subprocess probe is extended as specified and kept,
+  since it additionally pins the eager import graph.
 - **R2 — sequencing against the 15.0.0 empathy excision (#2238).**
   Edge 1 lives in `EmpathyLLMExecutor`'s module — the LIVE EmpathyLLM,
   not the dead EmpathyOS — so the excision does NOT moot it (verified

--- a/src/attune/models/empathy_executor.py
+++ b/src/attune/models/empathy_executor.py
@@ -48,6 +48,7 @@ class EmpathyLLMExecutor:
         telemetry_store: TelemetryBackend | TelemetryStore | None = None,
         use_thinking: bool = False,
         thinking_budget: int = 10000,
+        hybrid_config: dict[str, str] | None = None,
         **llm_kwargs: Any,
     ):
         """Initialize the EmpathyLLM executor.
@@ -60,6 +61,10 @@ class EmpathyLLMExecutor:
             use_thinking: Enable extended thinking for complex analysis.
                 Adds a thinking step before generating output.
             thinking_budget: Max tokens for thinking (default: 10000).
+            hybrid_config: Tier -> model_id mapping for hybrid provider mode,
+                injected by the workflows-layer caller that owns the
+                ``workflows.yaml`` read. The models layer never reads that
+                config itself (#2239 Edge 1 / spec R1).
             **llm_kwargs: Additional arguments for EmpathyLLM.
 
         """
@@ -73,23 +78,12 @@ class EmpathyLLMExecutor:
         self._llm = empathy_llm
         self._telemetry = telemetry_store
         self._hybrid_llms: dict[str, Any] = {}  # Cache per-provider LLMs for hybrid mode
-        self._hybrid_config: dict[str, str] | None = None  # tier -> model_id mapping
-
-        # Load hybrid config if provider is hybrid
-        if provider == "hybrid":
-            self._load_hybrid_config()
-
-    def _load_hybrid_config(self) -> None:
-        """Load hybrid tier->model mapping from workflows.yaml."""
-        try:
-            from attune.workflows.config import WorkflowConfig
-
-            config = WorkflowConfig.load()
-            if config.custom_models and "hybrid" in config.custom_models:
-                self._hybrid_config = config.custom_models["hybrid"]
-                logger.info(f"Loaded hybrid config: {self._hybrid_config}")
-        except Exception as e:  # noqa: BLE001
-            logger.warning(f"Failed to load hybrid config: {e}")
+        # tier -> model_id mapping, injected by the workflows-layer caller.
+        # Empty mappings normalize to None so `not self._hybrid_config`
+        # keeps meaning "no hybrid routing" (see _get_llm_for_tier).
+        self._hybrid_config: dict[str, str] | None = hybrid_config or None
+        if provider == "hybrid" and self._hybrid_config:
+            logger.info(f"Hybrid config injected: {self._hybrid_config}")
 
     def _get_provider_for_model(self, model_id: str) -> str:
         """Determine which provider a model belongs to based on its ID."""

--- a/src/attune/workflows/executor_mixin.py
+++ b/src/attune/workflows/executor_mixin.py
@@ -19,6 +19,7 @@ Licensed under the Apache License, Version 2.0
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 from datetime import datetime
 from typing import TYPE_CHECKING, Any
@@ -27,6 +28,8 @@ from attune.models import (
     ExecutionContext,
     LLMExecutor,
 )
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -53,6 +56,26 @@ class StepResult:
 
 if TYPE_CHECKING:
     from .step_config import WorkflowStepConfig
+
+
+def _load_hybrid_tier_models() -> dict[str, str] | None:
+    """Read the hybrid tier -> model_id mapping from ``workflows.yaml``.
+
+    Owns the config read on behalf of the models layer, which must not
+    import ``attune.workflows.config`` (#2239 Edge 1). Returns ``None``
+    when the mapping is absent or unreadable — hybrid routing then falls
+    back to the single configured provider, preserving the behavior the
+    executor had while it read the config itself.
+    """
+    try:
+        from attune.workflows.config import WorkflowConfig
+
+        config = WorkflowConfig.load()
+        if config.custom_models and "hybrid" in config.custom_models:
+            return config.custom_models["hybrid"]
+    except Exception as e:  # noqa: BLE001 - config read is best-effort
+        logger.warning(f"Failed to load hybrid config: {e}")
+    return None
 
 
 class ExecutorMixin:
@@ -129,6 +152,13 @@ class ExecutorMixin:
         if getattr(self, "_use_thinking", False):
             executor_kwargs["use_thinking"] = True
             executor_kwargs["thinking_budget"] = getattr(self, "_thinking_budget", 10000)
+
+        # Hybrid mode routes each tier to a different model. The workflows
+        # layer owns the workflows.yaml read and injects the resolved
+        # mapping; the models layer never imports the config type (#2239
+        # Edge 1 / models-workflows-layering R1).
+        if self._provider_str == "hybrid":
+            executor_kwargs["hybrid_config"] = _load_hybrid_tier_models()
 
         base_executor = EmpathyLLMExecutor(**executor_kwargs)
 

--- a/tests/unit/gates/test_broad_except_ratchet.py
+++ b/tests/unit/gates/test_broad_except_ratchet.py
@@ -235,7 +235,10 @@ _BASELINE: dict[str, int] = {
     "src/attune/metrics/prompt_metrics.py": 1,
     "src/attune/models/auth_cli.py": 4,
     "src/attune/models/auth_strategy.py": 3,
-    "src/attune/models/empathy_executor.py": 2,
+    # Lowered 2 -> 1 (#2239 Edge 1): the broad catch around the
+    # workflows.yaml read moved out of the models layer with the read
+    # itself; see workflows/executor_mixin.py below.
+    "src/attune/models/empathy_executor.py": 1,
     "src/attune/models/provider_config.py": 2,
     "src/attune/models/resilient_executor.py": 2,
     "src/attune/models/single_turn.py": 2,
@@ -327,6 +330,12 @@ _BASELINE: dict[str, int] = {
     "src/attune/wizards/builtin/security_wizard.py": 3,
     "src/attune/wizards/decomposer.py": 1,
     "src/attune/wizards/registry.py": 3,
+    # The hybrid workflows.yaml read relocated here from
+    # models/empathy_executor.py (#2239 Edge 1). The catch is
+    # best-effort by contract: a broken/absent config degrades to
+    # "no hybrid routing" rather than failing workflow construction,
+    # which is the pre-inversion behavior this PR must preserve.
+    "src/attune/workflows/executor_mixin.py": 1,
     "src/attune/workflows/__init__.py": 2,
     "src/attune/models/sdk_adapter.py": 4,
     "src/attune/workflows/base.py": 1,

--- a/tests/unit/models/test_empathy_executor_new.py
+++ b/tests/unit/models/test_empathy_executor_new.py
@@ -305,92 +305,48 @@ class TestEmpathyLLMExecutorErrorHandling:
                 )
 
 
-class TestEmpathyLLMExecutorLoadHybridConfig:
-    """Tests for _load_hybrid_config and hybrid config initialization."""
+class TestEmpathyLLMExecutorHybridConfigInjection:
+    """Hybrid tier->model mapping is INJECTED, never read by this layer.
 
-    def test_load_hybrid_config_with_matching_config(self):
-        """Test _load_hybrid_config sets _hybrid_config when hybrid key exists."""
-        from unittest.mock import MagicMock
+    The executor used to call ``_load_hybrid_config``, which imported
+    ``attune.workflows.config`` — the #2239 Edge 1 upward import. That read
+    now lives at the workflows-layer call site
+    (``workflows.executor_mixin._load_hybrid_tier_models``); these tests pin
+    the models-layer half of the contract. The boundary itself is guarded by
+    ``tests/unit/models/test_sdk_adapter_layering.py``.
+    """
 
-        from attune.models.empathy_executor import EmpathyLLMExecutor
-        from attune.workflows.config import WorkflowConfig
+    def test_injected_config_is_stored(self):
+        """A mapping passed to the constructor becomes _hybrid_config."""
+        mapping = {"cheap": "claude-haiku-4", "capable": "claude-sonnet-4"}
+        executor = EmpathyLLMExecutor(provider="hybrid", hybrid_config=mapping)
+        assert executor._hybrid_config == mapping
 
-        executor = EmpathyLLMExecutor.__new__(EmpathyLLMExecutor)
-        executor._provider = "hybrid"
-        executor._hybrid_config = None
-        executor._hybrid_llms = {}
-        executor._api_key = None
-        executor._llm = None
-        executor._llm_kwargs = {}
-        executor._telemetry = None
+    def test_no_injection_leaves_config_none(self):
+        """Hybrid provider without an injected mapping gets None, not a read.
 
-        mock_config = MagicMock(spec=WorkflowConfig)
-        mock_config.custom_models = {
-            "hybrid": {"cheap": "claude-haiku-4", "capable": "claude-sonnet-4"}
-        }
-
-        with patch("attune.workflows.config.WorkflowConfig.load", return_value=mock_config):
-            executor._load_hybrid_config()
-
-        assert executor._hybrid_config == {"cheap": "claude-haiku-4", "capable": "claude-sonnet-4"}
-
-    def test_load_hybrid_config_no_hybrid_key(self):
-        """Test _load_hybrid_config leaves _hybrid_config as None when no hybrid key."""
-        from unittest.mock import MagicMock
-
-        from attune.models.empathy_executor import EmpathyLLMExecutor
-        from attune.workflows.config import WorkflowConfig
-
-        executor = EmpathyLLMExecutor.__new__(EmpathyLLMExecutor)
-        executor._provider = "hybrid"
-        executor._hybrid_config = None
-        executor._hybrid_llms = {}
-        executor._api_key = None
-        executor._llm = None
-        executor._llm_kwargs = {}
-        executor._telemetry = None
-
-        mock_config = MagicMock(spec=WorkflowConfig)
-        mock_config.custom_models = {}
-
-        with patch("attune.workflows.config.WorkflowConfig.load", return_value=mock_config):
-            executor._load_hybrid_config()
-
+        This is the pre-inversion behavior for an absent ``hybrid`` key:
+        _get_llm_for_tier falls back to the single configured provider.
+        """
+        executor = EmpathyLLMExecutor(provider="hybrid")
         assert executor._hybrid_config is None
 
-    def test_load_hybrid_config_exception_swallowed(self):
-        """Test _load_hybrid_config silently handles exceptions."""
-        from attune.models.empathy_executor import EmpathyLLMExecutor
-
-        executor = EmpathyLLMExecutor.__new__(EmpathyLLMExecutor)
-        executor._provider = "hybrid"
-        executor._hybrid_config = None
-        executor._hybrid_llms = {}
-        executor._api_key = None
-        executor._llm = None
-        executor._llm_kwargs = {}
-        executor._telemetry = None
-
-        with patch(
-            "attune.workflows.config.WorkflowConfig.load",
-            side_effect=Exception("config error"),
-        ):
-            # Should not raise - exception is logged/swallowed
-            executor._load_hybrid_config()
-
+    def test_empty_mapping_normalizes_to_none(self):
+        """An empty dict means "no hybrid routing", same as absent."""
+        executor = EmpathyLLMExecutor(provider="hybrid", hybrid_config={})
         assert executor._hybrid_config is None
 
-    def test_hybrid_constructor_calls_load(self):
-        """Test that hybrid provider triggers _load_hybrid_config."""
-        with patch.object(EmpathyLLMExecutor, "_load_hybrid_config") as mock_load:
-            EmpathyLLMExecutor(provider="hybrid")
-            mock_load.assert_called_once()
+    def test_non_hybrid_provider_ignores_nothing_and_still_stores(self):
+        """Injection is provider-agnostic; only routing consults the mapping."""
+        mapping = {"cheap": "claude-haiku-4"}
+        executor = EmpathyLLMExecutor(provider="anthropic", hybrid_config=mapping)
+        assert executor._hybrid_config == mapping
+        # _get_llm_for_tier short-circuits on provider != "hybrid"
+        assert executor._provider == "anthropic"
 
-    def test_non_hybrid_constructor_skips_load(self):
-        """Test that non-hybrid provider does not call _load_hybrid_config."""
-        with patch.object(EmpathyLLMExecutor, "_load_hybrid_config") as mock_load:
-            EmpathyLLMExecutor(provider="anthropic")
-            mock_load.assert_not_called()
+    def test_executor_has_no_config_loader(self):
+        """The upward-importing loader is gone, not merely unused."""
+        assert not hasattr(EmpathyLLMExecutor, "_load_hybrid_config")
 
 
 class TestEmpathyLLMExecutorGetLlm:

--- a/tests/unit/models/test_sdk_adapter_layering.py
+++ b/tests/unit/models/test_sdk_adapter_layering.py
@@ -1,12 +1,15 @@
-"""Layering receipts for #2239 slice 1 — the SDK adapter's models-layer home.
+"""Layering receipts for #2239 — the models layer imports nothing upward.
 
 Two properties, each of which fails loudly on regression:
 
 1. ``attune.models`` never imports ``attune.workflows``: importing the
-   adapter core (and ``single_turn``, its models-layer consumer) must
-   load zero workflows modules. This is the cycle edge the slice
-   removed — a reintroduced upward import fails here in a clean
-   subprocess, immune to import-order luck in the test session.
+   adapter core, ``single_turn``, ``empathy_executor``, and the package
+   root must load zero workflows modules. These are the two cycle edges
+   the layering work removed (slice 1 = the SDK adapter, Edge 1 =
+   ``empathy_executor``'s ``WorkflowConfig`` read, inverted to a
+   constructor-injected ``dict[str, str]`` per spec R1) — a reintroduced
+   upward import fails here in a clean subprocess, immune to import-order
+   luck in the test session.
 2. The back-compat surfaces (``attune.workflows.agent_sdk_adapter``
    facade, ``attune.workflows.sdk_errors`` shim) re-export the SAME
    objects as the defining modules. A facade that drifts to a copy or
@@ -26,8 +29,10 @@ import pytest
 
 _PROBE = """
 import sys
+import attune.models
 import attune.models.sdk_adapter
 import attune.models.single_turn
+import attune.models.empathy_executor
 loaded = sorted(m for m in sys.modules if m.startswith("attune.workflows"))
 if loaded:
     raise SystemExit(f"attune.workflows leaked into attune.models: {loaded}")
@@ -37,7 +42,13 @@ print("clean")
 
 @pytest.mark.unit
 def test_models_sdk_adapter_imports_no_workflows_modules() -> None:
-    """Importing the adapter core + single_turn loads no workflows module."""
+    """Importing the models layer loads no workflows module.
+
+    Covers both former cycle edges: the SDK adapter core (slice 1) and
+    ``empathy_executor`` (Edge 1). ``attune.models`` itself is imported
+    too, so a new upward import anywhere the package root re-exports is
+    caught, not just in the three named modules.
+    """
     result = subprocess.run(
         [sys.executable, "-c", _PROBE],
         capture_output=True,
@@ -97,3 +108,55 @@ def test_facade_does_not_re_export_the_mutable_probe_cache() -> None:
     import attune.workflows.agent_sdk_adapter as facade
 
     assert not hasattr(facade, "_CLI_SUPPORTS_TASK_BUDGET")
+
+
+@pytest.mark.unit
+def test_no_models_module_imports_workflows_at_any_scope() -> None:
+    """No module under ``attune/models/`` imports ``attune.workflows`` — at
+    any scope, including function-local.
+
+    The subprocess probe above only observes what a module import LOADS, so
+    it is blind to a lazy function-local import: both #2239 cycle edges were
+    exactly that shape, and both would pass it. Verified by mutation
+    2026-08-26 — reinstating the original lazy ``_load_hybrid_config`` left
+    the subprocess probe green. This static scan is the guard that actually
+    fails on the regression the spec cares about; the subprocess probe stays
+    because it additionally proves the eager import graph is clean.
+    """
+    import ast
+    from pathlib import Path
+
+    models_dir = Path(__file__).resolve().parents[3] / "src" / "attune" / "models"
+    assert models_dir.is_dir(), models_dir
+
+    offenders: list[str] = []
+    for path in sorted(models_dir.rglob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                for alias in node.names:
+                    if alias.name == "attune.workflows" or alias.name.startswith(
+                        "attune.workflows."
+                    ):
+                        offenders.append(f"{path.name}:{node.lineno} import {alias.name}")
+            elif isinstance(node, ast.ImportFrom):
+                # Absolute: from attune.workflows... import X
+                if (
+                    node.level == 0
+                    and node.module
+                    and (
+                        node.module == "attune.workflows"
+                        or node.module.startswith("attune.workflows.")
+                    )
+                ):
+                    offenders.append(f"{path.name}:{node.lineno} from {node.module}")
+                # Relative escaping models/ into a sibling workflows package:
+                # from ..workflows import X  (level >= 2 from attune.models.*)
+                elif node.level >= 2 and (node.module or "").startswith("workflows"):
+                    dots = "." * node.level
+                    offenders.append(f"{path.name}:{node.lineno} from {dots}{node.module}")
+
+    assert not offenders, (
+        "attune.models must not import attune.workflows (#2239 layering). "
+        f"Offenders: {offenders}"
+    )

--- a/tests/unit/workflows/test_executor_mixin_hybrid.py
+++ b/tests/unit/workflows/test_executor_mixin_hybrid.py
@@ -1,0 +1,92 @@
+"""Workflows-layer ownership of the hybrid tier->model config read (#2239).
+
+Edge 1 of the models<->workflows cycle was ``EmpathyLLMExecutor`` reading
+``workflows.yaml`` itself. Spec ``models-workflows-layering`` R1 inverts it:
+the workflows layer resolves the mapping and injects it as a models-owned
+primitive (``dict[str, str]``). These tests pin the workflows half —
+the read happens here, and only for hybrid providers.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under the Apache License, Version 2.0
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from attune.workflows.executor_mixin import _load_hybrid_tier_models
+
+
+@pytest.mark.unit
+class TestLoadHybridTierModels:
+    """The relocated config read, formerly EmpathyLLMExecutor._load_hybrid_config."""
+
+    def test_returns_mapping_when_hybrid_key_present(self) -> None:
+        mock_config = MagicMock()
+        mock_config.custom_models = {
+            "hybrid": {"cheap": "claude-haiku-4", "capable": "claude-sonnet-4"}
+        }
+        with patch("attune.workflows.config.WorkflowConfig.load", return_value=mock_config):
+            assert _load_hybrid_tier_models() == {
+                "cheap": "claude-haiku-4",
+                "capable": "claude-sonnet-4",
+            }
+
+    def test_returns_none_when_no_hybrid_key(self) -> None:
+        mock_config = MagicMock()
+        mock_config.custom_models = {}
+        with patch("attune.workflows.config.WorkflowConfig.load", return_value=mock_config):
+            assert _load_hybrid_tier_models() is None
+
+    def test_returns_none_when_load_raises(self) -> None:
+        """A broken config degrades to no hybrid routing, never an exception.
+
+        Matches the pre-inversion behavior: the read was best-effort and its
+        failure was logged, not propagated to workflow construction.
+        """
+        with patch(
+            "attune.workflows.config.WorkflowConfig.load",
+            side_effect=Exception("config error"),
+        ):
+            assert _load_hybrid_tier_models() is None
+
+
+@pytest.mark.unit
+class TestDefaultExecutorInjection:
+    """_create_default_executor injects the mapping only for hybrid providers."""
+
+    @staticmethod
+    def _mixin(provider: str):
+        from attune.workflows.executor_mixin import ExecutorMixin
+
+        obj = ExecutorMixin.__new__(ExecutorMixin)
+        obj._provider_str = provider
+        obj._api_key = None
+        obj._telemetry_backend = None
+        obj._enable_tier_fallback = True  # skip the ResilientExecutor wrapper
+        return obj
+
+    def test_hybrid_provider_reads_and_injects(self) -> None:
+        mixin = self._mixin("hybrid")
+        mapping = {"cheap": "claude-haiku-4"}
+        with patch(
+            "attune.workflows.executor_mixin._load_hybrid_tier_models",
+            return_value=mapping,
+        ) as mock_load:
+            executor = mixin._create_default_executor()
+        mock_load.assert_called_once()
+        assert executor._hybrid_config == mapping
+
+    def test_non_hybrid_provider_does_not_read_config(self) -> None:
+        """The workflows.yaml read is skipped entirely off the hybrid path.
+
+        Pins the cost property, not just the wiring: a config load on every
+        default-executor creation would be a silent regression.
+        """
+        mixin = self._mixin("anthropic")
+        with patch("attune.workflows.executor_mixin._load_hybrid_tier_models") as mock_load:
+            executor = mixin._create_default_executor()
+        mock_load.assert_not_called()
+        assert executor._hybrid_config is None


### PR DESCRIPTION
Executes **D1** of `docs/specs/models-workflows-layering/` — the last
upward import from `attune.models` into `attune.workflows`, and the
remaining half of #2239.

`EmpathyLLMExecutor` read `workflows.yaml` itself via a lazy
`from attune.workflows.config import WorkflowConfig`. Per R1 the read
moves to the workflows-layer call site and the executor takes a
models-owned primitive instead.

## Changes

- **`models/empathy_executor.py`** — `_load_hybrid_config` deleted;
  constructor gains `hybrid_config: dict[str, str] | None`. Empty
  mappings normalize to `None` so `not self._hybrid_config` keeps
  meaning "no hybrid routing".
- **`workflows/executor_mixin.py`** — new `_load_hybrid_tier_models()`
  owns the config read; `_create_default_executor` injects it **only**
  when the provider is `"hybrid"`, so non-hybrid workflows do no extra
  config load.

`grep` confirms zero `attune.workflows` imports remain under
`src/attune/models/`.

## Two spec amendments (in `requirements.md`, same PR)

**1. R1's caller list was stale.** Of the four sites it named, re-grepped
at execution time:

| R1 named | Reality |
|---|---|
| `workflows/executor_mixin.py:133` | Real — the only path where provider can be `"hybrid"`. The injection site. |
| `workflows/escalation/chain.py:112` | Hardcodes `provider="anthropic"`; the hybrid read never fired. Untouched. |
| `workflows/escalation/evaluator.py:163` | Same. Untouched. |
| `models/resilient_executor.py` | **Not a caller** — the `EmpathyLLMExecutor` mentions at lines 40–41 are a `>>>` docstring example; the class takes a pre-built `executor: Any`. |

So R1's "injection chains upward through models-layer intermediaries"
describes a chain that does not exist. It is one hop. The requirement's
intent is unchanged.

**2. R1's named receipt does not work.** R1 names "the subprocess
no-upward-import probe extended to `attune.models.empathy_executor`".
Mutation-tested: reinstating the original lazy `_load_hybrid_config`
left that probe **GREEN**. It observes what a module import *loads*, so
it is blind to a lazy function-local import — the shape **both** #2239
cycle edges actually had. It follows that slice 1's probe (#2295) never
proved slice 1 either; it pins the eager import graph, which is real but
weaker than claimed.

Added `test_no_models_module_imports_workflows_at_any_scope` — a static
AST scan over `src/attune/models/**/*.py`. Mutation matrix:

| Import shape | Subprocess probe | New AST guard |
|---|---|---|
| eager `import attune.workflows.config` | fail | **fail** |
| lazy function-local | **pass** ← the gap | **fail** |
| relative `from ..workflows.config` | fail | **fail** |
| clean tree | pass | pass |

Both are kept — the subprocess probe still pins the eager import graph,
which the AST scan cannot see.

## Behavior note — stated, not glossed

Constructing `EmpathyLLMExecutor(provider="hybrid")` **directly**,
outside `executor_mixin`, no longer auto-loads the mapping; callers
inject it. This is inherent to R1 — the upward import cannot be removed
while the models layer still reads the config — so D1 implies it. In-tree
there are no such callers, and `"hybrid"` is already a deprecated
provider value (`provider_config.py:28`, `workflows/compat.py:91`). It is
a public class, so this is a real if narrow API change.

## Ratchet

Broad-except baseline updated **both** directions with a reason comment
at each site: `empathy_executor` 2 → 1 (the catch moved out with the
read), `executor_mixin` 0 → 1 (a broken config degrades to no hybrid
routing rather than failing workflow construction — the pre-inversion
behavior).

## Receipts

- `tests/unit/models/test_sdk_adapter_layering.py` — 4 passed, AST guard
  mutation-verified red against all three regression shapes.
- `tests/unit/models/test_empathy_executor_new.py` — 63 passed (hybrid
  tests migrated per R5; the patch target for the deleted method is
  gone, replaced by injection-semantics tests).
- `tests/unit/workflows/test_executor_mixin_hybrid.py` — 5 passed (new);
  both wiring mutations caught (injection removed → red; unconditional
  read → red).
- `tests/unit/gates` — 379 passed.
- **Full local tree: 25,328 passed, 256 skipped, 7 xfailed in 87s**
  (`PYTHONPATH=$PWD/src python -m pytest tests`).

  Worth recording because the first attempt looked like a 3.5-hour hang
  and was not this diff: a test fixture's `git commit -qm seed`
  inherited global `commit.gpgsign=true` and blocked on a GUI pinentry
  dialog at 0% CPU with zero pytest output. With the key cached the same
  command finishes in 87 seconds. 133 git-commit call sites in the suite,
  exactly one of which disables `gpgsign` — chipped separately, not
  widened into this PR.

Refs #2239

