### PR TITLE
fix(tests): stop suite git commits from invoking GPG and hanging forever

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -735,6 +735,57 @@ def _disable_help_telemetry(monkeypatch):
     monkeypatch.setenv("ATTUNE_HELP_TELEMETRY", "0")
 
 
+@pytest.fixture(scope="session")
+def _hermetic_git_config(tmp_path_factory):
+    """Build the suite's stand-in global/system git config.
+
+    Session-scoped: the files are identical for every test, so writing
+    them once per worker beats writing them ~25k times.
+    """
+    root = tmp_path_factory.mktemp("gitconfig")
+    git_global = root / "global"
+    git_global.write_text(
+        "[user]\n"
+        "\tname = attune-test\n"
+        "\temail = attune-test@example.invalid\n"
+        "[commit]\n"
+        "\tgpgsign = false\n"
+        "[tag]\n"
+        "\tgpgsign = false\n",
+        encoding="utf-8",
+    )
+    git_system = root / "system"
+    git_system.write_text("", encoding="utf-8")
+    return git_global, git_system
+
+
+@pytest.fixture(autouse=True, scope="function")
+def _isolate_git_config(_hermetic_git_config, monkeypatch):
+    """Run every test's git against a hermetic global config.
+
+    Dozens of fixtures build throwaway repos and commit into them. They
+    inherit the developer's real ``~/.gitconfig``, so a global
+    ``commit.gpgsign = true`` makes each seed commit invoke GPG ->
+    pinentry. Under pytest there is no TTY for the passphrase prompt, so
+    the commit BLOCKS FOREVER at 0% CPU and pytest prints nothing — a
+    silent hang indistinguishable from a slow test (observed 2026-08-26:
+    a full run wedged 3.5h on a ``commit -qm seed`` subprocess).
+
+    Pinning ``GIT_CONFIG_GLOBAL``/``GIT_CONFIG_SYSTEM`` fixes the whole
+    class in one place instead of at each call site, and covers the other
+    signing verbs (``merge``, ``revert``, ``cherry-pick``, ``tag``) too.
+    Identity is supplied as *config*, not ``GIT_AUTHOR_*`` env vars, so a
+    fixture's own ``git config user.email ...`` still wins — env vars
+    would silently override those and change what tests observe.
+
+    Same idiom as ``tests/scripts/test_audit_worktrees.py``, promoted from
+    that one file to the whole suite.
+    """
+    git_global, git_system = _hermetic_git_config
+    monkeypatch.setenv("GIT_CONFIG_GLOBAL", str(git_global))
+    monkeypatch.setenv("GIT_CONFIG_SYSTEM", str(git_system))
+
+
 @pytest.fixture(autouse=True, scope="function")
 def _isolate_attune_home(tmp_path, monkeypatch):
     """Route ~/.attune writes to a per-test tmp dir.

--- a/tests/unit/gates/test_git_signing_gate.py
+++ b/tests/unit/gates/test_git_signing_gate.py
@@ -1,0 +1,92 @@
+"""Gate: git commits made from inside the test suite must never sign.
+
+A global ``commit.gpgsign = true`` on the developer's machine makes every
+throwaway-repo fixture invoke GPG -> pinentry. Under pytest there is no TTY
+to answer the prompt, so the commit blocks forever at 0% CPU and pytest
+prints NOTHING — a full run was observed wedged 3.5h on a single
+``git commit -qm seed`` (2026-08-26).
+
+The suite-wide fix is the ``_isolate_git_config`` autouse fixture in
+``tests/conftest.py``. These tests are its receipt: they fail if it is
+deleted, weakened, or ordered away — on a signing developer machine AND on
+a keyless CI runner, which reach the failure by different routes.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+# A hang is the failure mode under test, so every git call is bounded.
+_TIMEOUT = 60
+
+
+def _git(repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", "-C", str(repo), *args],
+        capture_output=True,
+        text=True,
+        timeout=_TIMEOUT,
+    )
+
+
+def test_effective_commit_gpgsign_is_false() -> None:
+    """The suite's effective git config must resolve signing to off.
+
+    Portable in both directions: without the fixture a signing developer
+    machine reports ``true``, and a CI runner with no global config reports
+    nothing at all (exit 1). Only the fixture produces ``false``.
+    """
+    result = subprocess.run(
+        ["git", "config", "--get", "commit.gpgsign"],
+        capture_output=True,
+        text=True,
+        timeout=_TIMEOUT,
+    )
+
+    assert result.stdout.strip() == "false", (
+        "commit.gpgsign does not resolve to 'false' inside the suite — the "
+        "_isolate_git_config fixture in tests/conftest.py is not in effect. "
+        "Test fixtures that commit will invoke GPG and can hang forever."
+    )
+
+
+def test_a_commit_from_the_suite_is_unsigned(tmp_path: Path) -> None:
+    """Behavioral receipt: a real commit completes and carries no signature.
+
+    ``gpg.program`` is pointed at a path that does not exist, so an attempt
+    to sign fails INSTANTLY instead of hanging on pinentry — a regression
+    here is a fast red test, never another silent 3.5h wedge.
+    """
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    assert _git(repo, "init", "-q").returncode == 0
+    (repo / "f.py").write_text("x = 1\n", encoding="utf-8")
+    assert _git(repo, "add", ".").returncode == 0
+
+    never = tmp_path / "gpg-must-not-run"
+    result = _git(repo, "-c", f"gpg.program={never}", "commit", "-qm", "seed")
+
+    assert (
+        result.returncode == 0
+    ), f"commit failed, so signing was attempted: {result.stderr.strip()}"
+    signature = _git(repo, "log", "-1", "--format=%G?").stdout.strip()
+    assert signature == "N", f"expected an unsigned commit, got %G? = {signature!r}"
+
+
+def test_fixture_supplies_an_identity_a_fixture_can_override(tmp_path: Path) -> None:
+    """Identity comes from config, so a fixture's own ``user.email`` wins.
+
+    Pinning identity via ``GIT_AUTHOR_*``/``GIT_COMMITTER_*`` env vars would
+    silently OUTRANK every fixture that sets ``user.email`` locally, changing
+    what those tests observe. This pins the weaker, correct mechanism.
+    """
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    assert _git(repo, "init", "-q").returncode == 0
+    assert _git(repo, "config", "user.email", "fixture@example.invalid").returncode == 0
+    (repo / "f.py").write_text("x = 1\n", encoding="utf-8")
+    assert _git(repo, "add", ".").returncode == 0
+    assert _git(repo, "commit", "-qm", "seed").returncode == 0
+
+    assert _git(repo, "log", "-1", "--format=%ae").stdout.strip() == ("fixture@example.invalid")


### PR DESCRIPTION
## The bug

A global `commit.gpgsign = true` makes every throwaway-repo test fixture
sign its seed commit, which invokes `gpg` → `pinentry-mac`. Under pytest
there is no TTY to answer the prompt, so **the commit blocks forever at 0%
CPU and pytest prints nothing** — indistinguishable from "still running".

Observed 2026-08-26: a full `pytest tests` run wedged **3.5 hours** on

```
PID 36519 (alive 3h20m): git -c user.email=t@t -c user.name=t commit -qm seed
```

## The fix

One autouse fixture in `tests/conftest.py` pins `GIT_CONFIG_GLOBAL` /
`GIT_CONFIG_SYSTEM` at a hermetic config with signing off.

This is the same idiom `tests/scripts/test_audit_worktrees.py` already
uses ("Hermetic git: no global config (GPG signing, hooks)"), promoted
from that one file to the whole suite. It covers **all 68 git-commit call
sites across 26 test files**, every future one, and the other signing
verbs (`merge`, `revert`, `cherry-pick`, `tag`) — rather than a helper
that each of 68 sites must remember to call.

Identity is supplied as **config**, not `GIT_AUTHOR_*` env vars, so a
fixture's own `git config user.email ...` still wins. Env vars would
silently outrank those and change what existing tests observe.

Existing per-file workarounds are left in place — still correct, zero cost,
and churning 21 files buys nothing.

## Why not a static scan gate

The task suggested a static rule ("no test file invokes `git commit`
without disabling signing"). I calibrated it on the real tree first, and
it does not survive contact:

| Rule | Flagged | Real | Precision |
|---|---|---|---|
| Per-site: no inline `-c commit.gpgsign=false` | 63 | 3 | **5%** |
| Per-file: file never mentions `gpgsign` | 5 | 2 | **40%** |

The false positives come from **four** different idioms already in the tree
for disabling signing:

1. `-c commit.gpgsign=false` inline
2. `git config commit.gpgsign false` in local repo config
3. `--no-gpg-sign` on the commit (`test_dirty_switch_guard.py`, `test_chair_arm.py`)
4. a signing-disabled helper imported from a sibling conftest (`test_verify.py`
   imports `git` from `tests/unit/handoff/conftest.py`)

A scanner would need all four plus cross-module import resolution — and
after this fix, per-file disabling is *unnecessary*, so such a gate would
flag correct code. So the gate here is **behavioral**, not static:
`tests/unit/gates/test_git_signing_gate.py` asserts the effective config
and commits for real. It fails if the fixture is removed on a signing dev
machine (`gpgsign` → `true`) **and** on a keyless CI runner (key absent
entirely), reaching the failure by different routes. Its `gpg.program`
points at a nonexistent path so a regression fails in **0.3s** instead of
hanging the suite again.

## Note on the premise

The reported "known offenders" list was 2/5 accurate — `test_fix_loop.py`
and `test_teeth.py` already disable signing (lines 24 and 36, above the
cited commit lines). Likewise "exactly ONE references `gpgsign`": 26 files
do. Real offenders were `test_fix_phase3.py` and `test_fix_receipt.py`.
The fix is suite-wide regardless, so the corrected scope did not change it.

## Receipts

**Before** — fixture disabled, `gpg.program` pointed at a stub that blocks
forever (deterministic; does not depend on agent-cache state):

```
tests/unit/cli_commands/test_fix_receipt.py
  → wedges in os.waitpid, killed by pytest-timeout at 40s
  → stub log: "BLOCKING-GPG INVOKED"
```

**After** — same hostile global config, fixture enabled:

```
test_fix_receipt.py + test_fix_loop.py + test_fix_phase3.py
  → 60 passed in 25.87s
  → stub NEVER invoked
```

**Gate mutation** — fixture set `autouse=False`: both signing tests fail in
0.33s (no hang).

**GPG agent cache cleared** — `gpgconf --kill gpg-agent`, then the two
named files: see the comment below.

**Full tree** — `pytest tests -n auto`: **25551 passed**, 30 failed. All 30
are live-LLM tests failing on `Anthropic API quota reached for this
account` (usage limit resets 2026-09-01); the identical failures reproduce
on unmodified `origin/main`, verified by reverting the conftest and
re-running three of them.

## ⚠️ Heads-up for the reviewer

Verifying this required `gpgconf --kill gpg-agent`, which clears the cached
GPG passphrase. **Your next `git commit` on this machine will prompt for the
passphrase** (pinentry dialog) — that is expected, not a new problem. Tick
"Save in Keychain" to re-cache it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
