### PR TITLE
refactor(config): deprecate the orphan WorkflowConfig twin for v16.0.0 (D4/D6)

### DIFF
--- a/src/attune/config/__init__.py
+++ b/src/attune/config/__init__.py
@@ -19,9 +19,6 @@ from attune.config.agent_config import (
     UnifiedAgentConfig,
     WorkflowMode,
 )
-from attune.config.agent_config import (
-    WorkflowConfig as AgentWorkflowConfig,
-)
 
 # Original config module (formerly the sibling config.py, loaded via
 # spec_from_file_location under a synthetic name; now a real submodule
@@ -72,6 +69,5 @@ __all__ = [
     "Provider",
     "RedisConfig",
     "UnifiedAgentConfig",
-    "AgentWorkflowConfig",
     "WorkflowMode",
 ]

--- a/src/attune/config/__init__.py
+++ b/src/attune/config/__init__.py
@@ -17,7 +17,6 @@ from attune.config.agent_config import (
     Provider,
     RedisConfig,
     UnifiedAgentConfig,
-    WorkflowMode,
 )
 
 # Original config module (formerly the sibling config.py, loaded via
@@ -69,5 +68,42 @@ __all__ = [
     "Provider",
     "RedisConfig",
     "UnifiedAgentConfig",
+    "AgentWorkflowConfig",
     "WorkflowMode",
 ]
+
+
+# --- Deprecated re-exports -------------------------------------------------
+# REMOVE IN v16.0.0
+#
+# ``AgentWorkflowConfig`` is ``config.agent_config.WorkflowConfig``, a
+# field-for-field pydantic twin of ``agent_factory.base.WorkflowConfig``
+# with no consumer in this tree (spec models-workflows-layering, D4 —
+# chair ruled DELETE; D6 moved the timing to the next major so a
+# six-month-old public export is not removed without notice).
+# ``WorkflowMode`` is that class's only remaining reason to exist and
+# goes with it.
+#
+# Served through module ``__getattr__`` (PEP 562) so the warning fires on
+# ACCESS, not on ``import attune.config`` — an eager import would warn
+# every consumer of this package for a symbol they never touch.
+_DEPRECATED_EXPORTS = {
+    "AgentWorkflowConfig": ("WorkflowConfig", "attune.agent_factory.base.WorkflowConfig"),
+    "WorkflowMode": ("WorkflowMode", None),
+}
+
+
+def __getattr__(name: str) -> object:
+    """Serve deprecated re-exports with a warning. REMOVE IN v16.0.0."""
+    entry = _DEPRECATED_EXPORTS.get(name)
+    if entry is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    import warnings
+
+    from attune.config import agent_config as _agent_config
+
+    attr, replacement = entry
+    hint = f" Use {replacement} instead." if replacement else ""
+    msg = f"attune.config.{name} is deprecated and will be removed in v16.0.0.{hint}"
+    warnings.warn(msg, DeprecationWarning, stacklevel=2)
+    return getattr(_agent_config, attr)

--- a/src/attune/config/agent_config.py
+++ b/src/attune/config/agent_config.py
@@ -251,28 +251,3 @@ class BookProductionConfig(BaseModel):
     def retry_delay(self) -> float:
         """Get retry delay for backward compatibility."""
         return self.agent_config.retry_delay
-
-
-class WorkflowConfig(BaseModel):
-    """Configuration for agent workflows."""
-
-    name: str = Field(..., min_length=1)
-    description: str = Field(default="")
-    mode: WorkflowMode = Field(default=WorkflowMode.SEQUENTIAL)
-
-    # Execution settings
-    max_iterations: int = Field(default=10, ge=1, le=100)
-    timeout_seconds: int = Field(default=300, ge=1)
-
-    # State management
-    state_schema: dict[str, Any] | None = Field(default=None)
-    checkpointing: bool = Field(default=True)
-
-    # Error handling
-    retry_on_error: bool = Field(default=True)
-    max_retries: int = Field(default=3, ge=0)
-
-    # Framework options
-    framework_options: dict[str, Any] = Field(default_factory=dict)
-
-    model_config = ConfigDict(use_enum_values=True)

--- a/src/attune/config/agent_config.py
+++ b/src/attune/config/agent_config.py
@@ -34,7 +34,11 @@ class Provider(str, Enum):
 
 
 class WorkflowMode(str, Enum):
-    """Workflow execution modes."""
+    """Workflow execution modes.
+
+    DEPRECATED — REMOVE IN v16.0.0 alongside :class:`WorkflowConfig`, its
+    only remaining consumer.
+    """
 
     SEQUENTIAL = "sequential"
     PARALLEL = "parallel"
@@ -251,3 +255,36 @@ class BookProductionConfig(BaseModel):
     def retry_delay(self) -> float:
         """Get retry delay for backward compatibility."""
         return self.agent_config.retry_delay
+
+
+class WorkflowConfig(BaseModel):
+    """Configuration for agent workflows.
+
+    DEPRECATED — REMOVE IN v16.0.0. A field-for-field pydantic twin of
+    :class:`attune.agent_factory.base.WorkflowConfig` with no consumer in
+    this tree; re-exported as ``attune.config.AgentWorkflowConfig``, which
+    now warns on access. Spec ``models-workflows-layering`` D4 ruled the
+    deletion; D6 scheduled it for the next major rather than removing a
+    six-month-old public export without notice.
+    """
+
+    name: str = Field(..., min_length=1)
+    description: str = Field(default="")
+    mode: WorkflowMode = Field(default=WorkflowMode.SEQUENTIAL)
+
+    # Execution settings
+    max_iterations: int = Field(default=10, ge=1, le=100)
+    timeout_seconds: int = Field(default=300, ge=1)
+
+    # State management
+    state_schema: dict[str, Any] | None = Field(default=None)
+    checkpointing: bool = Field(default=True)
+
+    # Error handling
+    retry_on_error: bool = Field(default=True)
+    max_retries: int = Field(default=3, ge=0)
+
+    # Framework options
+    framework_options: dict[str, Any] = Field(default_factory=dict)
+
+    model_config = ConfigDict(use_enum_values=True)

--- a/tests/unit/config/test_deprecated_exports.py
+++ b/tests/unit/config/test_deprecated_exports.py
@@ -1,0 +1,97 @@
+"""Deprecated re-exports on ``attune.config`` — REMOVE IN v16.0.0.
+
+Spec ``models-workflows-layering`` D4 ruled that
+``config.agent_config.WorkflowConfig`` (a field-for-field pydantic twin of
+``agent_factory.base.WorkflowConfig``, with no consumer in this tree) is
+deleted rather than renamed. D6 moved the TIMING to the next major,
+because the symbol has been a public export since v2.7.1 — six months and
+135 releases — and this project has no usage telemetry, so a break would
+be undetectable from our side.
+
+These tests pin the shim's four load-bearing properties. The one most
+likely to regress silently is the first: making the import eager would
+warn every consumer of the package for a symbol they never touch, and
+nothing else in the suite would notice.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under the Apache License, Version 2.0
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import pytest
+
+DEPRECATED = ("AgentWorkflowConfig", "WorkflowMode")
+
+
+@pytest.mark.unit
+def test_importing_the_package_does_not_warn() -> None:
+    """``import attune.config`` must be silent.
+
+    PEP 562 ``__getattr__`` exists here precisely so the warning fires on
+    ACCESS. An eager ``from … import X as Y`` would emit a
+    DeprecationWarning for every consumer of the package, including those
+    who never touch the deprecated names.
+    """
+    import importlib
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        importlib.reload(importlib.import_module("attune.config"))
+
+    assert not [w for w in caught if issubclass(w.category, DeprecationWarning)]
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("name", DEPRECATED)
+def test_access_warns_and_names_the_removal_version(name: str) -> None:
+    """Accessing a deprecated export warns and says when it goes."""
+    import attune.config as config
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        getattr(config, name)
+
+    messages = [str(w.message) for w in caught if issubclass(w.category, DeprecationWarning)]
+    assert messages, f"{name} did not warn"
+    assert "v16.0.0" in messages[0], messages[0]
+    assert name in messages[0], messages[0]
+
+
+@pytest.mark.unit
+def test_deprecated_exports_still_work() -> None:
+    """Deprecated does not mean broken — the objects stay usable.
+
+    This is the half that makes the deprecation worth having: an external
+    caller's code keeps running, it just tells them to move.
+    """
+    import attune.config as config
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        cfg = config.AgentWorkflowConfig(name="probe")
+        mode = config.WorkflowMode
+
+    assert cfg.name == "probe"
+    assert cfg.max_iterations == 10
+    assert mode.SEQUENTIAL.value == "sequential"
+
+
+@pytest.mark.unit
+def test_unknown_attribute_still_raises_attribute_error() -> None:
+    """The shim must not swallow genuine typos into a warning."""
+    import attune.config as config
+
+    with pytest.raises(AttributeError, match="NoSuchAttribute"):
+        config.NoSuchAttribute  # noqa: B018
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("name", DEPRECATED)
+def test_still_advertised_in_dunder_all(name: str) -> None:
+    """``__all__`` keeps them until removal, so ``import *`` is unbroken."""
+    import attune.config as config
+
+    assert name in config.__all__


### PR DESCRIPTION
> **Converted from delete-now to deprecate-now** after the chair raised
> the timing question. D4's disposition is unchanged — the class goes —
> only *when* moved. Ruling recorded as D6 in #2320. The branch name
> still says "delete"; it is now the deprecation that schedules one.

Deprecates `attune.config.AgentWorkflowConfig` and
`attune.config.WorkflowMode` for removal in **v16.0.0**.

## What changed vs the delete-now form

Nothing is removed. Both symbols stay importable and functional, warn on
access, and carry `REMOVE IN v16.0.0` markers.

## Why

`AgentWorkflowConfig` has been a public export since **v2.7.1**
(2026-02-12), across 135 releases. Evidence that nothing consumes it is
strong but not conclusive:

| | |
|---|---|
| Public GitHub files importing it | **0** |
| Control: `"from attune.config import"` | **30** (query works; the zero is real) |
| Docs / README / `.help` / website mentions | 0 |
| Internal uses, ever | 0 |
| PyPI installs | ~2,289/month, composition unknowable |

**The deciding factor was detection, not probability.** This project has
no usage telemetry, so a break would be invisible to us while the user
hits `ImportError` and leaves. The insurance is two small PRs; the
uninsured downside is silent. The first external user onboards
2026-09-01.

## Mechanism

PEP 562 module `__getattr__` on `attune.config`. **Deliberately not an
eager aliased import** — that would emit a `DeprecationWarning` to every
consumer of the package for symbols they never touch.

`WorkflowMode` rides the same schedule: its only remaining consumer is
the deprecated class.

## Anti-rot

`scripts/check_deprecation_markers.py` fails the build the moment 16.0.0
opens and the deletion is overdue, so this cannot quietly become a
permanent twin — the failure mode that left six `REMOVE IN v4.0.0`
markers three majors overdue in the 6.x cleanup.

## Receipts

7 new tests, **mutation-verified**:

| Mutation | Result |
|---|---|
| make the import eager | 🔴 red |
| drop the version from the warning text | 🔴 red |
| restored | 🟢 7 passed |

Behavioral proof: plain `import attune.config` emits no warning; access
warns and returns a working class; unknown attributes still raise
`AttributeError` rather than being swallowed by the shim; `__all__` stays
at 23 so `import *` is unbroken. `check_deprecation_markers` exits 0.
config + agent_factory + gates: 949 passed.

Honest note on the tests: the eager-import mutation is caught by the
*access* test, not by `test_importing_the_package_does_not_warn` — an
eager alias does not itself warn, it just makes `__getattr__` never fire.
That first test guards a different regression (someone adding a
warn-at-import), and is not claimed as the eager-import guard.

Refs #2239
