### PR TITLE
refactor(config): rename the workflows section to WorkflowsConfig (D5)

### DIFF
--- a/src/attune/config/sections/__init__.py
+++ b/src/attune/config/sections/__init__.py
@@ -13,7 +13,7 @@ from attune.config.sections.environment import EnvironmentConfig
 from attune.config.sections.persistence import PersistenceConfig
 from attune.config.sections.routing import RoutingConfig
 from attune.config.sections.telemetry import TelemetryConfig
-from attune.config.sections.workflows import WorkflowConfig
+from attune.config.sections.workflows import WorkflowsConfig
 
 __all__ = [
     "AnalysisConfig",
@@ -22,5 +22,21 @@ __all__ = [
     "PersistenceConfig",
     "RoutingConfig",
     "TelemetryConfig",
-    "WorkflowConfig",
+    "WorkflowConfig",  # REMOVE IN v16.0.0 — deprecated alias
+    "WorkflowsConfig",
 ]
+
+
+def __getattr__(name: str) -> object:
+    """Serve the deprecated `WorkflowConfig` name. REMOVE IN v16.0.0."""
+    if name != "WorkflowConfig":
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    import warnings
+
+    warnings.warn(
+        "attune.config.sections.WorkflowConfig is deprecated and will be "
+        "removed in v16.0.0. Use WorkflowsConfig instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return WorkflowsConfig

--- a/src/attune/config/sections/workflows.py
+++ b/src/attune/config/sections/workflows.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass
 
 
 @dataclass
-class WorkflowConfig:
+class WorkflowsConfig:
     """Workflow execution configuration.
 
     Controls default workflow behavior, execution settings,
@@ -37,7 +37,7 @@ class WorkflowConfig:
         }
 
     @classmethod
-    def from_dict(cls, data: dict) -> "WorkflowConfig":
+    def from_dict(cls, data: dict) -> "WorkflowsConfig":
         """Create from dictionary."""
         return cls(
             default_workflow=data.get("default_workflow", "code-review"),
@@ -45,3 +45,27 @@ class WorkflowConfig:
             timeout_seconds=data.get("timeout_seconds", 300),
             cache_results=data.get("cache_results", True),
         )
+
+
+# REMOVE IN v16.0.0 — deprecated alias for the pre-rename name.
+# Renamed to `WorkflowsConfig` so it matches its module and config key,
+# as its six sibling sections already do (AnalysisConfig, AuthConfig,
+# EnvironmentConfig, PersistenceConfig, RoutingConfig, TelemetryConfig).
+# Spec models-workflows-layering D2/D5.
+#
+# Served via module __getattr__ (PEP 562) so the warning fires on ACCESS.
+# A plain module-level alias would be silent, and a user would learn of
+# the rename only when v16.0.0 broke them.
+def __getattr__(name: str) -> object:
+    """Serve the deprecated `WorkflowConfig` name. REMOVE IN v16.0.0."""
+    if name != "WorkflowConfig":
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    import warnings
+
+    warnings.warn(
+        "attune.config.sections.workflows.WorkflowConfig is deprecated and "
+        "will be removed in v16.0.0. Use WorkflowsConfig instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return WorkflowsConfig

--- a/src/attune/config/unified.py
+++ b/src/attune/config/unified.py
@@ -13,7 +13,7 @@ from attune.config.sections.environment import EnvironmentConfig
 from attune.config.sections.persistence import PersistenceConfig
 from attune.config.sections.routing import RoutingConfig
 from attune.config.sections.telemetry import TelemetryConfig
-from attune.config.sections.workflows import WorkflowConfig
+from attune.config.sections.workflows import WorkflowsConfig
 
 
 @dataclass
@@ -39,7 +39,7 @@ class UnifiedConfig:
 
     auth: AuthConfig = field(default_factory=AuthConfig)
     routing: RoutingConfig = field(default_factory=RoutingConfig)
-    workflows: WorkflowConfig = field(default_factory=WorkflowConfig)
+    workflows: WorkflowsConfig = field(default_factory=WorkflowsConfig)
     analysis: AnalysisConfig = field(default_factory=AnalysisConfig)
     persistence: PersistenceConfig = field(default_factory=PersistenceConfig)
     telemetry: TelemetryConfig = field(default_factory=TelemetryConfig)
@@ -89,7 +89,7 @@ class UnifiedConfig:
         return cls(
             auth=AuthConfig.from_dict(data.get("auth", {})),
             routing=RoutingConfig.from_dict(data.get("routing", {})),
-            workflows=WorkflowConfig.from_dict(data.get("workflows", {})),
+            workflows=WorkflowsConfig.from_dict(data.get("workflows", {})),
             analysis=AnalysisConfig.from_dict(data.get("analysis", {})),
             persistence=PersistenceConfig.from_dict(data.get("persistence", {})),
             telemetry=TelemetryConfig.from_dict(data.get("telemetry", {})),

--- a/tests/unit/config/test_config_validation.py
+++ b/tests/unit/config/test_config_validation.py
@@ -13,7 +13,7 @@ from attune.config.sections.environment import EnvironmentConfig
 from attune.config.sections.persistence import PersistenceConfig
 from attune.config.sections.routing import RoutingConfig
 from attune.config.sections.telemetry import TelemetryConfig
-from attune.config.sections.workflows import WorkflowConfig
+from attune.config.sections.workflows import WorkflowsConfig
 from attune.config.unified import UnifiedConfig
 from attune.config.validation import ConfigValidator, ValidationError, validate_config
 
@@ -295,7 +295,7 @@ class TestWorkflowsValidation:
 
     def test_timeout_zero(self):
         """Test that timeout_seconds <= 0 is invalid."""
-        workflows = WorkflowConfig(timeout_seconds=0)
+        workflows = WorkflowsConfig(timeout_seconds=0)
         validator = ConfigValidator()
         errors = validator.validate_section(workflows, "workflows")
         matched = [e for e in errors if e.key == "workflows.timeout_seconds"]
@@ -303,15 +303,15 @@ class TestWorkflowsValidation:
 
     def test_timeout_negative(self):
         """Test that negative timeout_seconds is invalid."""
-        workflows = WorkflowConfig(timeout_seconds=-10)
+        workflows = WorkflowsConfig(timeout_seconds=-10)
         validator = ConfigValidator()
         errors = validator.validate_section(workflows, "workflows")
         matched = [e for e in errors if e.key == "workflows.timeout_seconds"]
         assert len(matched) == 1
 
     def test_valid_workflows_config(self):
-        """Test that a default WorkflowConfig produces no errors."""
-        workflows = WorkflowConfig()
+        """Test that a default WorkflowsConfig produces no errors."""
+        workflows = WorkflowsConfig()
         validator = ConfigValidator()
         errors = validator.validate_section(workflows, "workflows")
         assert errors == []
@@ -521,7 +521,7 @@ class TestValidateSection:
         [
             ("auth", lambda: AuthConfig(strategy="subscription")),
             ("routing", RoutingConfig),
-            ("workflows", WorkflowConfig),
+            ("workflows", WorkflowsConfig),
             ("analysis", AnalysisConfig),
             ("persistence", PersistenceConfig),
             ("telemetry", TelemetryConfig),

--- a/tests/unit/config/test_sections_rename_aliases.py
+++ b/tests/unit/config/test_sections_rename_aliases.py
@@ -1,0 +1,106 @@
+"""`WorkflowsConfig` rename — deprecated alias contract. REMOVE IN v16.0.0.
+
+Spec ``models-workflows-layering`` D2/D5: ``config.sections.workflows``
+held the only section class not named after its own module — its six
+siblings are ``AnalysisConfig``, ``AuthConfig``, ``EnvironmentConfig``,
+``PersistenceConfig``, ``RoutingConfig``, ``TelemetryConfig``. It is now
+``WorkflowsConfig``, with the old name served as a deprecated alias on
+BOTH public paths until the next major.
+
+The identity assertion is the load-bearing one: an alias that drifts to a
+copy silently vacates every monkeypatch and isinstance check aimed at it
+(the #2162 class).
+
+Copyright 2026 Smart-AI-Memory
+Licensed under the Apache License, Version 2.0
+"""
+
+from __future__ import annotations
+
+import importlib
+import warnings
+
+import pytest
+
+# Both public paths the old name was reachable through.
+PATHS = ("attune.config.sections", "attune.config.sections.workflows")
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("path", PATHS)
+def test_new_name_does_not_warn(path: str) -> None:
+    """The rename must be free for callers who already moved."""
+    module = importlib.import_module(path)
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        _ = module.WorkflowsConfig  # access IS the trigger under PEP 562
+    assert not [w for w in caught if issubclass(w.category, DeprecationWarning)]
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("path", PATHS)
+def test_old_name_warns_and_names_the_version(path: str) -> None:
+    module = importlib.import_module(path)
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        _ = module.WorkflowConfig  # access IS the trigger under PEP 562
+    messages = [str(w.message) for w in caught if issubclass(w.category, DeprecationWarning)]
+    assert messages, f"{path}.WorkflowConfig did not warn"
+    assert "v16.0.0" in messages[0], messages[0]
+    assert "WorkflowsConfig" in messages[0], messages[0]
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("path", PATHS)
+def test_alias_is_the_same_object_not_a_copy(path: str) -> None:
+    """Identity, not equality — a copy would vacate patches silently."""
+    from attune.config.sections.workflows import WorkflowsConfig
+
+    module = importlib.import_module(path)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        assert module.WorkflowConfig is WorkflowsConfig
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("path", PATHS)
+def test_unknown_attribute_still_raises(path: str) -> None:
+    """The shim must not swallow typos into a deprecation warning."""
+    module = importlib.import_module(path)
+    with pytest.raises(AttributeError, match="NoSuchThing"):
+        _ = module.NoSuchThing
+
+
+@pytest.mark.unit
+def test_unified_config_uses_the_new_name() -> None:
+    """The live consumer is migrated, not riding the alias."""
+    from attune.config.sections.workflows import WorkflowsConfig
+    from attune.config.unified import UnifiedConfig
+
+    cfg = UnifiedConfig()
+    assert isinstance(cfg.workflows, WorkflowsConfig)
+
+
+@pytest.mark.unit
+def test_sibling_sections_follow_the_same_convention() -> None:
+    """Pins the convention the rename restored.
+
+    If a future section lands misnamed, this fails and says why.
+    """
+    import attune.config.sections as sections
+
+    for module_name, expected in (
+        ("analysis", "AnalysisConfig"),
+        ("auth", "AuthConfig"),
+        ("environment", "EnvironmentConfig"),
+        ("persistence", "PersistenceConfig"),
+        ("routing", "RoutingConfig"),
+        ("telemetry", "TelemetryConfig"),
+        ("workflows", "WorkflowsConfig"),
+    ):
+        mod = importlib.import_module(f"attune.config.sections.{module_name}")
+        assert hasattr(mod, expected), (
+            f"{module_name}.py should define {expected} — section classes are "
+            f"named after their module (spec models-workflows-layering D5)"
+        )
+        assert hasattr(sections, expected)


### PR DESCRIPTION
Executes the `config/sections` half of **D5**. Second of three rename
PRs; one per class, as sequenced in `decisions.md`.

`config/sections/workflows.py` held the only section class not named
after its own module:

| module | class |
|---|---|
| `analysis.py` | `AnalysisConfig` |
| `auth.py` | `AuthConfig` |
| `environment.py` | `EnvironmentConfig` |
| `persistence.py` | `PersistenceConfig` |
| `routing.py` | `RoutingConfig` |
| `telemetry.py` | `TelemetryConfig` |
| `workflows.py` | `WorkflowConfig` ← the only break |

Now `WorkflowsConfig`, matching both its module and its `workflows:`
config key. **Not an invented name** — the rename restores a convention
six of seven siblings already follow.

## Deprecated aliases

Three live sites migrated (`config/sections/__init__`, `config/unified`,
the validation test). The old name stays available on **both** public
paths it was reachable through:

- `attune.config.sections.WorkflowConfig`
- `attune.config.sections.workflows.WorkflowConfig`

Each served by its own PEP 562 `__getattr__` with a
`DeprecationWarning` naming v16.0.0 and the replacement. Per D2: aliases
first, hard rename at the next major.

The warning fires on **access**, not on package import — an eager alias
would warn every consumer of `attune.config.sections` for a name they
never touch.

`REMOVE IN v16.0.0` markers mean `check_deprecation_markers.py` fails
the build the moment 16.0.0 opens, so the aliases cannot rot into
permanent duplicates.

## Receipts

10 new tests, **mutation-verified**:

| Mutation | Result |
|---|---|
| alias returns a subclass copy instead of the class | 🔴 red |
| alias stops warning (silent alias) | 🔴 red |
| restored | 🟢 10 passed |

The identity test is the load-bearing one — an alias that drifts to a
copy silently vacates every monkeypatch and `isinstance` check aimed at
it, which is the #2162 class.

One test pins the **sibling convention itself**, so a future misnamed
section fails with the reason rather than quietly joining the exception.

Full tree: **25,335 passed**, 256 skipped, 7 xfailed.
`check_deprecation_markers` exits 0.

Refs #2239
