### PR TITLE
refactor(agent_factory): rename WorkflowConfig to AgentGraphConfig (D5)

### DIFF
--- a/docs/specs/models-workflows-layering/design.md
+++ b/docs/specs/models-workflows-layering/design.md
@@ -84,7 +84,16 @@ over `WorkflowGraphConfig` because the neighbourhood prefixes with
 `Agent` (`AgentRole`, `AgentCapability`, `AgentConfig`), and the fields
 it carries (`state_schema`, `checkpointing`, `framework_options`,
 `mode` ∈ sequential/parallel/graph/conversation) are graph-construction
-concerns. Cost: `agent_factory/__init__` export + 7 test modules.
+concerns.
+
+  **Cost corrected 2026-08-26 at execution time: 127 references across
+  21 files, not the "8 sites" stated above.** The original figure counted
+  IMPORTING FILES, not references — a 15x underestimate, and the chair's
+  D5 ruling was made against it. Re-put to the chair with the true number
+  and re-ruled PROCEED. The risk profile is unchanged (mechanical,
+  alias-protected, no in-scope file references a different
+  `WorkflowConfig`); only churn and reviewability moved. 104 of the 127
+  are test references.
 
 ## Sequencing
 

--- a/src/attune/agent_factory/__init__.py
+++ b/src/attune/agent_factory/__init__.py
@@ -33,10 +33,10 @@ Licensed under the Apache License, Version 2.0
 from attune.agent_factory.base import (
     AgentCapability,
     AgentConfig,
+    AgentGraphConfig,
     AgentRole,
     BaseAdapter,
     BaseAgent,
-    WorkflowConfig,
 )
 from attune.agent_factory.factory import AgentFactory
 from attune.agent_factory.framework import Framework
@@ -49,5 +49,21 @@ __all__ = [
     "BaseAdapter",
     "BaseAgent",
     "Framework",
-    "WorkflowConfig",
+    "AgentGraphConfig",
+    "WorkflowConfig",  # REMOVE IN v16.0.0 — deprecated alias
 ]
+
+
+def __getattr__(name: str) -> object:
+    """Serve the deprecated `WorkflowConfig` name. REMOVE IN v16.0.0."""
+    if name != "WorkflowConfig":
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    import warnings
+
+    warnings.warn(
+        "attune.agent_factory.WorkflowConfig is deprecated and will be "
+        "removed in v16.0.0. Use AgentGraphConfig instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return AgentGraphConfig

--- a/src/attune/agent_factory/adapters/autogen_adapter.py
+++ b/src/attune/agent_factory/adapters/autogen_adapter.py
@@ -15,11 +15,11 @@ from collections.abc import AsyncGenerator, Callable
 
 from attune.agent_factory.base import (
     AgentConfig,
+    AgentGraphConfig,
     AgentRole,
     BaseAdapter,
     BaseAgent,
     BaseWorkflow,
-    WorkflowConfig,
 )
 
 # Lazy import
@@ -107,7 +107,7 @@ class AutoGenWorkflow(BaseWorkflow):
 
     def __init__(
         self,
-        config: WorkflowConfig,
+        config: AgentGraphConfig,
         agents: list[BaseAgent],
         group_chat=None,
         manager=None,
@@ -274,7 +274,7 @@ class AutoGenAdapter(BaseAdapter):
 
         return AutoGenAgent(config, autogen_agent=ag_agent)
 
-    def create_workflow(self, config: WorkflowConfig, agents: list[BaseAgent]) -> AutoGenWorkflow:
+    def create_workflow(self, config: AgentGraphConfig, agents: list[BaseAgent]) -> AutoGenWorkflow:
         """Create an AutoGen GroupChat workflow."""
         if not self.is_available():
             raise ImportError("AutoGen not installed")

--- a/src/attune/agent_factory/adapters/haystack_adapter.py
+++ b/src/attune/agent_factory/adapters/haystack_adapter.py
@@ -16,11 +16,11 @@ from typing import Any
 from attune.agent_factory.base import (
     AgentCapability,
     AgentConfig,
+    AgentGraphConfig,
     AgentRole,
     BaseAdapter,
     BaseAgent,
     BaseWorkflow,
-    WorkflowConfig,
 )
 
 # Lazy import
@@ -114,7 +114,7 @@ class HaystackAgent(BaseAgent):
 class HaystackWorkflow(BaseWorkflow):
     """Workflow using Haystack Pipeline."""
 
-    def __init__(self, config: WorkflowConfig, agents: list[BaseAgent], pipeline=None):
+    def __init__(self, config: AgentGraphConfig, agents: list[BaseAgent], pipeline=None):
         """Initialize Haystack workflow.
 
         Args:
@@ -281,7 +281,9 @@ class HaystackAdapter(BaseAdapter):
 
         return pipeline
 
-    def create_workflow(self, config: WorkflowConfig, agents: list[BaseAgent]) -> HaystackWorkflow:
+    def create_workflow(
+        self, config: AgentGraphConfig, agents: list[BaseAgent]
+    ) -> HaystackWorkflow:
         """Create a Haystack Pipeline workflow."""
         if not self.is_available():
             raise ImportError("Haystack not installed")

--- a/src/attune/agent_factory/adapters/langchain_adapter.py
+++ b/src/attune/agent_factory/adapters/langchain_adapter.py
@@ -18,10 +18,10 @@ from pydantic import SecretStr
 from attune.agent_factory.base import (
     AgentCapability,
     AgentConfig,
+    AgentGraphConfig,
     BaseAdapter,
     BaseAgent,
     BaseWorkflow,
-    WorkflowConfig,
 )
 
 # Lazy imports for LangChain
@@ -142,7 +142,7 @@ class LangChainAgent(BaseAgent):
 class LangChainWorkflow(BaseWorkflow):
     """Workflow using LangChain's SequentialChain or custom routing."""
 
-    def __init__(self, config: WorkflowConfig, agents: list[BaseAgent], chain=None):
+    def __init__(self, config: AgentGraphConfig, agents: list[BaseAgent], chain=None):
         """Initialize LangChain workflow.
 
         Args:
@@ -321,7 +321,9 @@ class LangChainAdapter(BaseAdapter):
         chain = prompt | llm
         return LangChainAgent(config, chain=chain)
 
-    def create_workflow(self, config: WorkflowConfig, agents: list[BaseAgent]) -> LangChainWorkflow:
+    def create_workflow(
+        self, config: AgentGraphConfig, agents: list[BaseAgent]
+    ) -> LangChainWorkflow:
         """Create a LangChain workflow."""
         # For sequential mode, we can compose chains
         # For more complex modes, just wrap the agents

--- a/src/attune/agent_factory/adapters/langgraph_adapter.py
+++ b/src/attune/agent_factory/adapters/langgraph_adapter.py
@@ -18,10 +18,10 @@ from pydantic import SecretStr
 
 from attune.agent_factory.base import (
     AgentConfig,
+    AgentGraphConfig,
     BaseAdapter,
     BaseAgent,
     BaseWorkflow,
-    WorkflowConfig,
 )
 
 # Lazy imports
@@ -125,7 +125,7 @@ class LangGraphAgent(BaseAgent):
 class LangGraphWorkflow(BaseWorkflow):
     """Workflow using LangGraph's StateGraph."""
 
-    def __init__(self, config: WorkflowConfig, agents: list[BaseAgent], graph=None):
+    def __init__(self, config: AgentGraphConfig, agents: list[BaseAgent], graph=None):
         """Initialize LangGraph workflow.
 
         Args:
@@ -296,7 +296,9 @@ class LangGraphAdapter(BaseAdapter):
 
         return LangGraphAgent(config, runnable=chain)
 
-    def create_workflow(self, config: WorkflowConfig, agents: list[BaseAgent]) -> LangGraphWorkflow:
+    def create_workflow(
+        self, config: AgentGraphConfig, agents: list[BaseAgent]
+    ) -> LangGraphWorkflow:
         """Create a LangGraph StateGraph workflow."""
         if not self.is_available():
             raise ImportError("LangGraph not installed")

--- a/src/attune/agent_factory/adapters/native.py
+++ b/src/attune/agent_factory/adapters/native.py
@@ -20,10 +20,10 @@ from typing import Any
 
 from attune.agent_factory.base import (
     AgentConfig,
+    AgentGraphConfig,
     BaseAdapter,
     BaseAgent,
     BaseWorkflow,
-    WorkflowConfig,
 )
 
 
@@ -227,7 +227,7 @@ class NativeAdapter(BaseAdapter):
         llm = self._get_llm(config)
         return NativeAgent(config, llm=llm)
 
-    def create_workflow(self, config: WorkflowConfig, agents: list[BaseAgent]) -> NativeWorkflow:
+    def create_workflow(self, config: AgentGraphConfig, agents: list[BaseAgent]) -> NativeWorkflow:
         """Create a native workflow."""
         return NativeWorkflow(config, agents)
 

--- a/src/attune/agent_factory/adapters/wizard_adapter.py
+++ b/src/attune/agent_factory/adapters/wizard_adapter.py
@@ -17,11 +17,11 @@ import logging
 
 from attune.agent_factory.base import (
     AgentConfig,
+    AgentGraphConfig,
     AgentRole,
     BaseAdapter,
     BaseAgent,
     BaseWorkflow,
-    WorkflowConfig,
 )
 from attune.agent_factory.decorators import log_performance, safe_agent_operation
 
@@ -362,7 +362,7 @@ class WizardAdapter(BaseAdapter):
 
         return self.create_agent_from_wizard(wizard, name=name, **agent_kwargs)
 
-    def create_workflow(self, config: WorkflowConfig, agents: list[BaseAgent]) -> WizardWorkflow:
+    def create_workflow(self, config: AgentGraphConfig, agents: list[BaseAgent]) -> WizardWorkflow:
         """Create a workflow from wizard agents.
 
         Args:

--- a/src/attune/agent_factory/base.py
+++ b/src/attune/agent_factory/base.py
@@ -98,7 +98,7 @@ class AgentConfig:
 
 
 @dataclass
-class WorkflowConfig:
+class AgentGraphConfig:
     """Configuration for creating a workflow/graph."""
 
     name: str
@@ -184,7 +184,7 @@ class BaseWorkflow(ABC):
     Workflows orchestrate multiple agents to complete complex tasks.
     """
 
-    def __init__(self, config: WorkflowConfig, agents: list[BaseAgent]):
+    def __init__(self, config: AgentGraphConfig, agents: list[BaseAgent]):
         """Initialize base workflow with configuration and agents.
 
         Args:
@@ -255,7 +255,7 @@ class BaseAdapter(ABC):
         """
 
     @abstractmethod
-    def create_workflow(self, config: WorkflowConfig, agents: list[BaseAgent]) -> BaseWorkflow:
+    def create_workflow(self, config: AgentGraphConfig, agents: list[BaseAgent]) -> BaseWorkflow:
         """Create a workflow using this framework.
 
         Args:
@@ -310,3 +310,30 @@ class BaseAdapter(ABC):
                 tier,
                 "claude-sonnet-5",
             )
+
+
+# REMOVE IN v16.0.0 — deprecated alias for the pre-rename name.
+# Renamed to `AgentGraphConfig` so exactly one class in the tree holds the
+# bare name `WorkflowConfig` (the workflows.yaml-backed
+# `attune.workflows.config.WorkflowConfig`). Spec models-workflows-layering
+# D2/D5.
+#
+# Recorded honestly: inside THIS module the old name was already coherent,
+# sitting beside AgentConfig/BaseAgent/BaseWorkflow — the collision was only
+# visible globally. The chair ruled the one-bare-name intent outranks that,
+# with the counter-case in front of it.
+#
+# Served via module __getattr__ (PEP 562) so the warning fires on ACCESS.
+def __getattr__(name: str) -> object:
+    """Serve the deprecated `WorkflowConfig` name. REMOVE IN v16.0.0."""
+    if name != "WorkflowConfig":
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    import warnings
+
+    warnings.warn(
+        "attune.agent_factory.base.WorkflowConfig is deprecated and will be "
+        "removed in v16.0.0. Use AgentGraphConfig instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return AgentGraphConfig

--- a/src/attune/agent_factory/factory.py
+++ b/src/attune/agent_factory/factory.py
@@ -43,11 +43,11 @@ from typing import Any
 from attune.agent_factory.base import (
     AgentCapability,
     AgentConfig,
+    AgentGraphConfig,
     AgentRole,
     BaseAdapter,
     BaseAgent,
     BaseWorkflow,
-    WorkflowConfig,
 )
 from attune.agent_factory.framework import (
     Framework,
@@ -283,7 +283,7 @@ class AgentFactory:
             Workflow implementing BaseWorkflow interface
 
         """
-        config = WorkflowConfig(
+        config = AgentGraphConfig(
             name=name,
             description=description,
             mode=mode,

--- a/tests/agent_factory/test_agent_factory.py
+++ b/tests/agent_factory/test_agent_factory.py
@@ -125,14 +125,14 @@ class TestNativeAdapter:
     def test_native_adapter_create_workflow(self):
         """Test creating a workflow with native adapter."""
         from attune.agent_factory.adapters.native import NativeAdapter
-        from attune.agent_factory.base import AgentConfig, WorkflowConfig
+        from attune.agent_factory.base import AgentConfig, AgentGraphConfig
 
         adapter = NativeAdapter()
 
         agent1 = adapter.create_agent(AgentConfig(name="agent1"))
         agent2 = adapter.create_agent(AgentConfig(name="agent2"))
 
-        workflow_config = WorkflowConfig(name="test_workflow", mode="sequential")
+        workflow_config = AgentGraphConfig(name="test_workflow", mode="sequential")
         workflow = adapter.create_workflow(workflow_config, [agent1, agent2])
 
         assert workflow.config.name == "test_workflow"
@@ -290,7 +290,7 @@ class TestNativeWorkflow:
     async def test_native_workflow_sequential(self):
         """Test sequential workflow execution."""
         from attune.agent_factory.adapters.native import NativeAdapter
-        from attune.agent_factory.base import AgentConfig, WorkflowConfig
+        from attune.agent_factory.base import AgentConfig, AgentGraphConfig
 
         adapter = NativeAdapter()
 
@@ -298,7 +298,7 @@ class TestNativeWorkflow:
         agent2 = adapter.create_agent(AgentConfig(name="a2"))
 
         workflow = adapter.create_workflow(
-            WorkflowConfig(name="seq", mode="sequential"),
+            AgentGraphConfig(name="seq", mode="sequential"),
             [agent1, agent2],
         )
 
@@ -314,7 +314,7 @@ class TestNativeWorkflow:
     async def test_native_workflow_parallel(self):
         """Test parallel workflow execution."""
         from attune.agent_factory.adapters.native import NativeAdapter
-        from attune.agent_factory.base import AgentConfig, WorkflowConfig
+        from attune.agent_factory.base import AgentConfig, AgentGraphConfig
 
         adapter = NativeAdapter()
 
@@ -322,7 +322,7 @@ class TestNativeWorkflow:
         agent2 = adapter.create_agent(AgentConfig(name="a2"))
 
         workflow = adapter.create_workflow(
-            WorkflowConfig(name="par", mode="parallel"),
+            AgentGraphConfig(name="par", mode="parallel"),
             [agent1, agent2],
         )
 

--- a/tests/agent_factory/test_base.py
+++ b/tests/agent_factory/test_base.py
@@ -4,7 +4,7 @@ Tests the base classes and enums for the Agent Factory:
 - AgentRole enum
 - AgentCapability enum
 - AgentConfig dataclass
-- WorkflowConfig dataclass
+- AgentGraphConfig dataclass
 - BaseAgent abstract class
 - BaseWorkflow abstract class
 - BaseAdapter abstract class
@@ -15,11 +15,11 @@ import pytest
 from attune.agent_factory.base import (
     AgentCapability,
     AgentConfig,
+    AgentGraphConfig,
     AgentRole,
     BaseAdapter,
     BaseAgent,
     BaseWorkflow,
-    WorkflowConfig,
 )
 
 
@@ -234,46 +234,46 @@ class TestAgentConfig:
 
 
 class TestWorkflowConfig:
-    """Tests for WorkflowConfig dataclass."""
+    """Tests for AgentGraphConfig dataclass."""
 
     def test_minimal_creation(self):
         """Test creating config with just name."""
-        config = WorkflowConfig(name="test_workflow")
+        config = AgentGraphConfig(name="test_workflow")
         assert config.name == "test_workflow"
 
     def test_default_mode(self):
         """Test default mode is sequential."""
-        config = WorkflowConfig(name="workflow")
+        config = AgentGraphConfig(name="workflow")
         assert config.mode == "sequential"
 
     def test_default_max_iterations(self):
         """Test default max iterations is 10."""
-        config = WorkflowConfig(name="workflow")
+        config = AgentGraphConfig(name="workflow")
         assert config.max_iterations == 10
 
     def test_default_timeout(self):
         """Test default timeout is 300 seconds."""
-        config = WorkflowConfig(name="workflow")
+        config = AgentGraphConfig(name="workflow")
         assert config.timeout_seconds == 300
 
     def test_default_checkpointing(self):
         """Test checkpointing is enabled by default."""
-        config = WorkflowConfig(name="workflow")
+        config = AgentGraphConfig(name="workflow")
         assert config.checkpointing is True
 
     def test_default_retry_on_error(self):
         """Test retry on error is enabled by default."""
-        config = WorkflowConfig(name="workflow")
+        config = AgentGraphConfig(name="workflow")
         assert config.retry_on_error is True
 
     def test_default_max_retries(self):
         """Test default max retries is 3."""
-        config = WorkflowConfig(name="workflow")
+        config = AgentGraphConfig(name="workflow")
         assert config.max_retries == 3
 
     def test_full_config_creation(self):
         """Test creating config with all options."""
-        config = WorkflowConfig(
+        config = AgentGraphConfig(
             name="code_review_pipeline",
             description="Multi-agent code review",
             mode="parallel",
@@ -403,7 +403,7 @@ class TestBaseWorkflow:
 
     def test_init_sets_config(self):
         """Test init sets config."""
-        config = WorkflowConfig(name="test_workflow")
+        config = AgentGraphConfig(name="test_workflow")
         agent_config = AgentConfig(name="agent1")
         agent = ConcreteAgent(agent_config)
         workflow = ConcreteWorkflow(config, [agent])
@@ -411,7 +411,7 @@ class TestBaseWorkflow:
 
     def test_init_creates_agents_dict(self):
         """Test init creates agents dictionary by name."""
-        config = WorkflowConfig(name="workflow")
+        config = AgentGraphConfig(name="workflow")
         agent1_config = AgentConfig(name="researcher")
         agent2_config = AgentConfig(name="writer")
         agent1 = ConcreteAgent(agent1_config)
@@ -423,13 +423,13 @@ class TestBaseWorkflow:
 
     def test_init_empty_state(self):
         """Test init creates empty state."""
-        config = WorkflowConfig(name="workflow")
+        config = AgentGraphConfig(name="workflow")
         workflow = ConcreteWorkflow(config, [])
         assert workflow._state == {}
 
     def test_get_state_returns_copy(self):
         """Test get_state returns a copy."""
-        config = WorkflowConfig(name="workflow")
+        config = AgentGraphConfig(name="workflow")
         workflow = ConcreteWorkflow(config, [])
         workflow._state["key"] = "value"
 
@@ -439,7 +439,7 @@ class TestBaseWorkflow:
 
     def test_get_agent_existing(self):
         """Test getting existing agent by name."""
-        config = WorkflowConfig(name="workflow")
+        config = AgentGraphConfig(name="workflow")
         agent_config = AgentConfig(name="researcher")
         agent = ConcreteAgent(agent_config)
         workflow = ConcreteWorkflow(config, [agent])
@@ -449,7 +449,7 @@ class TestBaseWorkflow:
 
     def test_get_agent_nonexistent(self):
         """Test getting nonexistent agent returns None."""
-        config = WorkflowConfig(name="workflow")
+        config = AgentGraphConfig(name="workflow")
         workflow = ConcreteWorkflow(config, [])
 
         retrieved = workflow.get_agent("nonexistent")
@@ -458,7 +458,7 @@ class TestBaseWorkflow:
     @pytest.mark.asyncio
     async def test_run(self):
         """Test run method."""
-        config = WorkflowConfig(name="workflow")
+        config = AgentGraphConfig(name="workflow")
         workflow = ConcreteWorkflow(config, [])
         result = await workflow.run("input", {"key": "value"})
         assert result["output"] == "Workflow complete"
@@ -467,7 +467,7 @@ class TestBaseWorkflow:
     @pytest.mark.asyncio
     async def test_stream(self):
         """Test stream method."""
-        config = WorkflowConfig(name="workflow")
+        config = AgentGraphConfig(name="workflow")
         workflow = ConcreteWorkflow(config, [])
         stages = []
         async for update in workflow.stream("input"):
@@ -516,7 +516,7 @@ class TestBaseAdapter:
     def test_create_workflow(self):
         """Test create_workflow method."""
         adapter = ConcreteAdapter()
-        workflow_config = WorkflowConfig(name="test_workflow")
+        workflow_config = AgentGraphConfig(name="test_workflow")
         agent_config = AgentConfig(name="agent")
         agent = adapter.create_agent(agent_config)
         workflow = adapter.create_workflow(workflow_config, [agent])
@@ -580,12 +580,12 @@ class TestAgentConfigDefaults:
 
 
 class TestWorkflowConfigDefaults:
-    """Tests for WorkflowConfig default factory fields."""
+    """Tests for AgentGraphConfig default factory fields."""
 
     def test_framework_options_default_is_new_dict(self):
         """Test each config gets its own framework_options dict."""
-        config1 = WorkflowConfig(name="workflow1")
-        config2 = WorkflowConfig(name="workflow2")
+        config1 = AgentGraphConfig(name="workflow1")
+        config2 = AgentGraphConfig(name="workflow2")
         config1.framework_options["key"] = "value"
         assert "key" not in config2.framework_options
 

--- a/tests/agent_factory/test_llm_toolkit_agents.py
+++ b/tests/agent_factory/test_llm_toolkit_agents.py
@@ -16,8 +16,8 @@ from attune.agent_factory.adapters.native import (
 from attune.agent_factory.base import (
     AgentCapability,
     AgentConfig,
+    AgentGraphConfig,
     AgentRole,
-    WorkflowConfig,
 )
 from attune.agent_factory.factory import AgentFactory
 from attune.agent_factory.framework import Framework
@@ -164,7 +164,7 @@ class TestNativeWorkflow:
     @pytest.mark.asyncio
     async def test_run_sequential(self, agents):
         """Test running workflow sequentially."""
-        config = WorkflowConfig(name="test_workflow", mode="sequential")
+        config = AgentGraphConfig(name="test_workflow", mode="sequential")
         workflow = NativeWorkflow(config, agents)
 
         result = await workflow.run("Test input")
@@ -177,7 +177,7 @@ class TestNativeWorkflow:
     @pytest.mark.asyncio
     async def test_run_parallel(self, agents):
         """Test running workflow in parallel."""
-        config = WorkflowConfig(name="test_workflow", mode="parallel")
+        config = AgentGraphConfig(name="test_workflow", mode="parallel")
         workflow = NativeWorkflow(config, agents)
 
         result = await workflow.run("Test input")
@@ -189,7 +189,7 @@ class TestNativeWorkflow:
     @pytest.mark.asyncio
     async def test_run_with_initial_state(self, agents):
         """Test running workflow with initial state."""
-        config = WorkflowConfig(name="test_workflow")
+        config = AgentGraphConfig(name="test_workflow")
         workflow = NativeWorkflow(config, agents)
 
         result = await workflow.run("Test", initial_state={"key": "value"})
@@ -199,7 +199,7 @@ class TestNativeWorkflow:
     @pytest.mark.asyncio
     async def test_run_unknown_mode_defaults_to_sequential(self, agents):
         """Test that unknown mode defaults to sequential."""
-        config = WorkflowConfig(name="test_workflow", mode="unknown_mode")
+        config = AgentGraphConfig(name="test_workflow", mode="unknown_mode")
         workflow = NativeWorkflow(config, agents)
 
         result = await workflow.run("Test")
@@ -210,7 +210,7 @@ class TestNativeWorkflow:
     @pytest.mark.asyncio
     async def test_stream(self, agents):
         """Test streaming workflow."""
-        config = WorkflowConfig(name="test_workflow")
+        config = AgentGraphConfig(name="test_workflow")
         workflow = NativeWorkflow(config, agents)
 
         events = []
@@ -258,7 +258,7 @@ class TestNativeAdapter:
     def test_create_workflow(self):
         """Test creating a workflow."""
         adapter = NativeAdapter()
-        config = WorkflowConfig(name="test_workflow")
+        config = AgentGraphConfig(name="test_workflow")
         agents = [
             NativeAgent(AgentConfig(name="agent1")),
             NativeAgent(AgentConfig(name="agent2")),

--- a/tests/agent_factory/test_llm_toolkit_core.py
+++ b/tests/agent_factory/test_llm_toolkit_core.py
@@ -11,11 +11,11 @@ from datetime import datetime, timedelta
 from attune.agent_factory.base import (
     AgentCapability,
     AgentConfig,
+    AgentGraphConfig,
     AgentRole,
     BaseAdapter,
     BaseAgent,
     BaseWorkflow,
-    WorkflowConfig,
 )
 from attune.llm.levels import EmpathyLevel
 from attune.llm.state import CollaborationState, Interaction, PatternType, UserPattern
@@ -133,11 +133,11 @@ class TestAgentConfig:
 
 
 class TestWorkflowConfig:
-    """Tests for WorkflowConfig dataclass."""
+    """Tests for AgentGraphConfig dataclass."""
 
     def test_default_values(self):
         """Test default workflow configuration values."""
-        config = WorkflowConfig(name="test_workflow")
+        config = AgentGraphConfig(name="test_workflow")
 
         assert config.name == "test_workflow"
         assert config.description == ""
@@ -151,7 +151,7 @@ class TestWorkflowConfig:
 
     def test_custom_values(self):
         """Test custom workflow configuration values."""
-        config = WorkflowConfig(
+        config = AgentGraphConfig(
             name="custom_workflow",
             description="A custom workflow",
             mode="parallel",
@@ -288,7 +288,7 @@ class TestBaseWorkflow:
             async def stream(self, input_data, initial_state=None):
                 yield {"step": "test"}
 
-        config = WorkflowConfig(name="test_workflow")
+        config = AgentGraphConfig(name="test_workflow")
         agent1 = ConcreteAgent(AgentConfig(name="agent1"))
         agent2 = ConcreteAgent(AgentConfig(name="agent2"))
 
@@ -316,7 +316,7 @@ class TestBaseWorkflow:
             async def stream(self, input_data, initial_state=None):
                 yield {}
 
-        config = WorkflowConfig(name="state_workflow")
+        config = AgentGraphConfig(name="state_workflow")
         workflow = ConcreteWorkflow(config, [])
 
         workflow._state = {"key": "value"}
@@ -344,7 +344,7 @@ class TestBaseWorkflow:
             async def stream(self, input_data, initial_state=None):
                 yield {}
 
-        config = WorkflowConfig(name="agent_workflow")
+        config = AgentGraphConfig(name="agent_workflow")
         agent = ConcreteAgent(AgentConfig(name="my_agent"))
         workflow = ConcreteWorkflow(config, [agent])
 

--- a/tests/agent_factory/test_llm_toolkit_langgraph_adapter.py
+++ b/tests/agent_factory/test_llm_toolkit_langgraph_adapter.py
@@ -17,7 +17,7 @@ from attune.agent_factory.adapters.langgraph_adapter import (
     LangGraphWorkflow,
     _check_langgraph,
 )
-from attune.agent_factory.base import AgentConfig, AgentRole, WorkflowConfig
+from attune.agent_factory.base import AgentConfig, AgentGraphConfig, AgentRole
 
 # =============================================================================
 # _check_langgraph Tests
@@ -272,7 +272,7 @@ class TestLangGraphWorkflow:
 
     def test_init(self):
         """Test workflow initialization."""
-        config = WorkflowConfig(name="test_workflow")
+        config = AgentGraphConfig(name="test_workflow")
         workflow = LangGraphWorkflow(config, [], graph=None)
 
         assert workflow._graph is None
@@ -280,7 +280,7 @@ class TestLangGraphWorkflow:
 
     def test_init_with_graph(self):
         """Test initialization with graph."""
-        config = WorkflowConfig(name="test_workflow")
+        config = AgentGraphConfig(name="test_workflow")
         mock_graph = MagicMock()
         workflow = LangGraphWorkflow(config, [], graph=mock_graph)
 
@@ -288,7 +288,7 @@ class TestLangGraphWorkflow:
 
     def test_compile_graph_no_graph(self):
         """Test _compile_graph with no graph."""
-        config = WorkflowConfig(name="test_workflow")
+        config = AgentGraphConfig(name="test_workflow")
         workflow = LangGraphWorkflow(config, [])
 
         result = workflow._compile_graph()
@@ -296,7 +296,7 @@ class TestLangGraphWorkflow:
 
     def test_compile_graph_with_graph(self):
         """Test _compile_graph compiles the graph."""
-        config = WorkflowConfig(name="test_workflow")
+        config = AgentGraphConfig(name="test_workflow")
         mock_graph = MagicMock()
         mock_compiled = MagicMock()
         mock_graph.compile.return_value = mock_compiled
@@ -309,7 +309,7 @@ class TestLangGraphWorkflow:
 
     def test_compile_graph_caches_result(self):
         """Test _compile_graph caches the compiled graph."""
-        config = WorkflowConfig(name="test_workflow")
+        config = AgentGraphConfig(name="test_workflow")
         mock_graph = MagicMock()
         mock_compiled = MagicMock()
         mock_graph.compile.return_value = mock_compiled
@@ -326,7 +326,7 @@ class TestLangGraphWorkflow:
     @pytest.mark.asyncio
     async def test_run_with_string_input(self):
         """Test run with string input."""
-        config = WorkflowConfig(name="test_workflow")
+        config = AgentGraphConfig(name="test_workflow")
         workflow = LangGraphWorkflow(config, [])
 
         result = await workflow.run("test input")
@@ -336,7 +336,7 @@ class TestLangGraphWorkflow:
     @pytest.mark.asyncio
     async def test_run_with_dict_input(self):
         """Test run with dict input."""
-        config = WorkflowConfig(name="test_workflow")
+        config = AgentGraphConfig(name="test_workflow")
         workflow = LangGraphWorkflow(config, [])
 
         result = await workflow.run({"key": "value"})
@@ -346,7 +346,7 @@ class TestLangGraphWorkflow:
     @pytest.mark.asyncio
     async def test_run_with_initial_state(self):
         """Test run with initial state."""
-        config = WorkflowConfig(name="test_workflow")
+        config = AgentGraphConfig(name="test_workflow")
         workflow = LangGraphWorkflow(config, [])
 
         result = await workflow.run("test", initial_state={"extra": "data"})
@@ -356,7 +356,7 @@ class TestLangGraphWorkflow:
     @pytest.mark.asyncio
     async def test_run_with_compiled_async(self):
         """Test run with async compiled graph."""
-        config = WorkflowConfig(name="test_workflow")
+        config = AgentGraphConfig(name="test_workflow")
         mock_graph = MagicMock()
         mock_compiled = MagicMock()
         mock_compiled.ainvoke = AsyncMock(return_value={"messages": [{"content": "result"}]})
@@ -370,7 +370,7 @@ class TestLangGraphWorkflow:
     @pytest.mark.asyncio
     async def test_run_with_compiled_sync(self):
         """Test run with sync compiled graph."""
-        config = WorkflowConfig(name="test_workflow")
+        config = AgentGraphConfig(name="test_workflow")
         mock_graph = MagicMock()
         mock_compiled = MagicMock()
         mock_compiled.invoke = MagicMock(return_value={"output": "sync result"})
@@ -386,7 +386,7 @@ class TestLangGraphWorkflow:
     @pytest.mark.asyncio
     async def test_run_exception_handling(self):
         """Test run handles exceptions."""
-        config = WorkflowConfig(name="test_workflow")
+        config = AgentGraphConfig(name="test_workflow")
         mock_graph = MagicMock()
         mock_compiled = MagicMock()
         mock_compiled.ainvoke = AsyncMock(side_effect=Exception("Test error"))
@@ -401,7 +401,7 @@ class TestLangGraphWorkflow:
     @pytest.mark.asyncio
     async def test_run_sequential_fallback(self):
         """Test run falls back to sequential execution."""
-        config = WorkflowConfig(name="test_workflow")
+        config = AgentGraphConfig(name="test_workflow")
 
         agent_config = AgentConfig(name="agent1", role=AgentRole.RESEARCHER)
         mock_agent = LangGraphAgent(agent_config)
@@ -415,7 +415,7 @@ class TestLangGraphWorkflow:
     @pytest.mark.asyncio
     async def test_stream_with_astream(self):
         """Test stream with compiled graph that supports astream."""
-        config = WorkflowConfig(name="test_workflow")
+        config = AgentGraphConfig(name="test_workflow")
         mock_graph = MagicMock()
         mock_compiled = MagicMock()
 
@@ -437,7 +437,7 @@ class TestLangGraphWorkflow:
     @pytest.mark.asyncio
     async def test_stream_fallback(self):
         """Test stream fallback to run."""
-        config = WorkflowConfig(name="test_workflow")
+        config = AgentGraphConfig(name="test_workflow")
         workflow = LangGraphWorkflow(config, [])
 
         events = []
@@ -560,7 +560,7 @@ class TestLangGraphAdapter:
         """Test create_workflow raises when LangGraph not available."""
         adapter = LangGraphAdapter(api_key="test")
 
-        config = WorkflowConfig(name="test")
+        config = AgentGraphConfig(name="test")
 
         with patch.object(adapter, "is_available", return_value=False):
             with pytest.raises(ImportError, match="LangGraph not installed"):

--- a/tests/agent_factory/test_llm_toolkit_wizard_adapter.py
+++ b/tests/agent_factory/test_llm_toolkit_wizard_adapter.py
@@ -14,7 +14,7 @@ from attune.agent_factory.adapters.wizard_adapter import (
     WizardWorkflow,
     wrap_wizard,
 )
-from attune.agent_factory.base import AgentConfig, AgentRole, WorkflowConfig
+from attune.agent_factory.base import AgentConfig, AgentGraphConfig, AgentRole
 
 # =============================================================================
 # Mock Wizard Classes
@@ -265,7 +265,7 @@ class TestWizardWorkflow:
     @pytest.mark.asyncio
     async def test_run_empty_workflow(self):
         """Test running workflow with no agents."""
-        config = WorkflowConfig(name="test_workflow")
+        config = AgentGraphConfig(name="test_workflow")
         workflow = WizardWorkflow(config, [])
 
         result = await workflow.run("test input")
@@ -280,7 +280,7 @@ class TestWizardWorkflow:
         agent_config = AgentConfig(name="wizard1", role=AgentRole.RESEARCHER)
         agent = WizardAgent(wizard, agent_config)
 
-        workflow_config = WorkflowConfig(name="single_wizard")
+        workflow_config = AgentGraphConfig(name="single_wizard")
         workflow = WizardWorkflow(workflow_config, [agent])
 
         result = await workflow.run("test input")
@@ -298,7 +298,7 @@ class TestWizardWorkflow:
         agent1 = WizardAgent(wizard1, AgentConfig(name="wizard1", role=AgentRole.RESEARCHER))
         agent2 = WizardAgent(wizard2, AgentConfig(name="wizard2", role=AgentRole.SUMMARIZER))
 
-        workflow_config = WorkflowConfig(name="multi_wizard")
+        workflow_config = AgentGraphConfig(name="multi_wizard")
         workflow = WizardWorkflow(workflow_config, [agent1, agent2])
 
         result = await workflow.run("test input")
@@ -313,7 +313,7 @@ class TestWizardWorkflow:
         wizard = MockWizard()
         agent = WizardAgent(wizard, AgentConfig(name="wizard", role=AgentRole.RESEARCHER))
 
-        workflow_config = WorkflowConfig(name="stateful_workflow")
+        workflow_config = AgentGraphConfig(name="stateful_workflow")
         workflow = WizardWorkflow(workflow_config, [agent])
 
         initial_state = {"session_id": "123", "user": "test"}
@@ -328,7 +328,7 @@ class TestWizardWorkflow:
         wizard = MockWizard()
         agent = WizardAgent(wizard, AgentConfig(name="wizard", role=AgentRole.RESEARCHER))
 
-        workflow_config = WorkflowConfig(name="streaming_workflow")
+        workflow_config = AgentGraphConfig(name="streaming_workflow")
         workflow = WizardWorkflow(workflow_config, [agent])
 
         events = []
@@ -465,7 +465,7 @@ class TestWizardAdapter:
         wizard = MockWizard()
         agent = WizardAgent(wizard, AgentConfig(name="wizard", role=AgentRole.RESEARCHER))
 
-        workflow_config = WorkflowConfig(name="test_workflow")
+        workflow_config = AgentGraphConfig(name="test_workflow")
         workflow = adapter.create_workflow(workflow_config, [agent])
 
         assert isinstance(workflow, WizardWorkflow)

--- a/tests/agent_factory/test_native_adapter.py
+++ b/tests/agent_factory/test_native_adapter.py
@@ -16,7 +16,7 @@ from attune.agent_factory.adapters.native import (
     NativeAgent,
     NativeWorkflow,
 )
-from attune.agent_factory.base import AgentConfig, AgentRole, WorkflowConfig
+from attune.agent_factory.base import AgentConfig, AgentGraphConfig, AgentRole
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -73,15 +73,15 @@ def native_agent_with_llm(agent_config: AgentConfig, mock_llm: AsyncMock) -> Nat
 
 
 @pytest.fixture
-def workflow_config() -> WorkflowConfig:
+def workflow_config() -> AgentGraphConfig:
     """Workflow config for sequential execution."""
-    return WorkflowConfig(name="test-workflow", mode="sequential")
+    return AgentGraphConfig(name="test-workflow", mode="sequential")
 
 
 @pytest.fixture
-def parallel_workflow_config() -> WorkflowConfig:
+def parallel_workflow_config() -> AgentGraphConfig:
     """Workflow config for parallel execution."""
-    return WorkflowConfig(name="parallel-workflow", mode="parallel")
+    return AgentGraphConfig(name="parallel-workflow", mode="parallel")
 
 
 # ===================================================================
@@ -321,23 +321,23 @@ def _make_agent(name: str) -> NativeAgent:
 class TestNativeWorkflowCreation:
     """Tests for NativeWorkflow construction."""
 
-    def test_creation_stores_agents_by_name(self, workflow_config: WorkflowConfig) -> None:
+    def test_creation_stores_agents_by_name(self, workflow_config: AgentGraphConfig) -> None:
         a1 = _make_agent("a1")
         a2 = _make_agent("a2")
         wf = NativeWorkflow(workflow_config, [a1, a2])
         assert "a1" in wf.agents
         assert "a2" in wf.agents
 
-    def test_get_agent_returns_agent(self, workflow_config: WorkflowConfig) -> None:
+    def test_get_agent_returns_agent(self, workflow_config: AgentGraphConfig) -> None:
         a1 = _make_agent("a1")
         wf = NativeWorkflow(workflow_config, [a1])
         assert wf.get_agent("a1") is a1
 
-    def test_get_agent_returns_none_for_missing(self, workflow_config: WorkflowConfig) -> None:
+    def test_get_agent_returns_none_for_missing(self, workflow_config: AgentGraphConfig) -> None:
         wf = NativeWorkflow(workflow_config, [])
         assert wf.get_agent("nonexistent") is None
 
-    def test_get_state_initially_empty(self, workflow_config: WorkflowConfig) -> None:
+    def test_get_state_initially_empty(self, workflow_config: AgentGraphConfig) -> None:
         wf = NativeWorkflow(workflow_config, [])
         assert wf.get_state() == {}
 
@@ -352,7 +352,7 @@ class TestNativeWorkflowSequential:
 
     @pytest.mark.asyncio
     @pytest.mark.unit
-    async def test_sequential_run_chains_output(self, workflow_config: WorkflowConfig) -> None:
+    async def test_sequential_run_chains_output(self, workflow_config: AgentGraphConfig) -> None:
         a1 = _make_agent("a1")
         a2 = _make_agent("a2")
         wf = NativeWorkflow(workflow_config, [a1, a2])
@@ -365,7 +365,7 @@ class TestNativeWorkflowSequential:
 
     @pytest.mark.asyncio
     @pytest.mark.unit
-    async def test_sequential_run_sets_state(self, workflow_config: WorkflowConfig) -> None:
+    async def test_sequential_run_sets_state(self, workflow_config: AgentGraphConfig) -> None:
         a1 = _make_agent("a1")
         wf = NativeWorkflow(workflow_config, [a1])
         await wf.run("input-data")
@@ -376,7 +376,9 @@ class TestNativeWorkflowSequential:
 
     @pytest.mark.asyncio
     @pytest.mark.unit
-    async def test_sequential_run_with_initial_state(self, workflow_config: WorkflowConfig) -> None:
+    async def test_sequential_run_with_initial_state(
+        self, workflow_config: AgentGraphConfig
+    ) -> None:
         a1 = _make_agent("a1")
         wf = NativeWorkflow(workflow_config, [a1])
         await wf.run("go", initial_state={"key": "val"})
@@ -385,7 +387,7 @@ class TestNativeWorkflowSequential:
 
     @pytest.mark.asyncio
     @pytest.mark.unit
-    async def test_sequential_run_no_agents(self, workflow_config: WorkflowConfig) -> None:
+    async def test_sequential_run_no_agents(self, workflow_config: AgentGraphConfig) -> None:
         wf = NativeWorkflow(workflow_config, [])
         result = await wf.run("go")
         assert result["results"] == []
@@ -394,7 +396,7 @@ class TestNativeWorkflowSequential:
     @pytest.mark.asyncio
     @pytest.mark.unit
     async def test_unknown_mode_falls_back_to_sequential(self) -> None:
-        cfg = WorkflowConfig(name="wf", mode="unknown-mode")
+        cfg = AgentGraphConfig(name="wf", mode="unknown-mode")
         a1 = _make_agent("a1")
         wf = NativeWorkflow(cfg, [a1])
         result = await wf.run("go")
@@ -412,7 +414,7 @@ class TestNativeWorkflowParallel:
     @pytest.mark.asyncio
     @pytest.mark.unit
     async def test_parallel_run_invokes_all_agents(
-        self, parallel_workflow_config: WorkflowConfig
+        self, parallel_workflow_config: AgentGraphConfig
     ) -> None:
         a1 = _make_agent("a1")
         a2 = _make_agent("a2")
@@ -426,7 +428,7 @@ class TestNativeWorkflowParallel:
     @pytest.mark.asyncio
     @pytest.mark.unit
     async def test_parallel_all_receive_same_input(
-        self, parallel_workflow_config: WorkflowConfig
+        self, parallel_workflow_config: AgentGraphConfig
     ) -> None:
         a1 = _make_agent("a1")
         a2 = _make_agent("a2")
@@ -439,7 +441,7 @@ class TestNativeWorkflowParallel:
     @pytest.mark.asyncio
     @pytest.mark.unit
     async def test_parallel_agents_invoked_list(
-        self, parallel_workflow_config: WorkflowConfig
+        self, parallel_workflow_config: AgentGraphConfig
     ) -> None:
         a1 = _make_agent("a1")
         a2 = _make_agent("a2")
@@ -458,7 +460,7 @@ class TestNativeWorkflowStream:
 
     @pytest.mark.asyncio
     @pytest.mark.unit
-    async def test_stream_yields_start_output_end(self, workflow_config: WorkflowConfig) -> None:
+    async def test_stream_yields_start_output_end(self, workflow_config: AgentGraphConfig) -> None:
         a1 = _make_agent("a1")
         wf = NativeWorkflow(workflow_config, [a1])
         events = []
@@ -471,7 +473,7 @@ class TestNativeWorkflowStream:
 
     @pytest.mark.asyncio
     @pytest.mark.unit
-    async def test_stream_multiple_agents(self, workflow_config: WorkflowConfig) -> None:
+    async def test_stream_multiple_agents(self, workflow_config: AgentGraphConfig) -> None:
         a1 = _make_agent("a1")
         a2 = _make_agent("a2")
         wf = NativeWorkflow(workflow_config, [a1, a2])
@@ -492,7 +494,7 @@ class TestNativeWorkflowState:
 
     @pytest.mark.asyncio
     @pytest.mark.unit
-    async def test_get_state_returns_copy(self, workflow_config: WorkflowConfig) -> None:
+    async def test_get_state_returns_copy(self, workflow_config: AgentGraphConfig) -> None:
         a1 = _make_agent("a1")
         wf = NativeWorkflow(workflow_config, [a1])
         await wf.run("go")
@@ -561,7 +563,7 @@ class TestNativeAdapter:
     def test_create_workflow_returns_native_workflow(
         self,
         agent_config: AgentConfig,
-        workflow_config: WorkflowConfig,
+        workflow_config: AgentGraphConfig,
     ) -> None:
         adapter = NativeAdapter()
         agent = adapter.create_agent(agent_config)

--- a/tests/unit/agent_factory/test_agent_factory_smoke.py
+++ b/tests/unit/agent_factory/test_agent_factory_smoke.py
@@ -36,16 +36,16 @@ class TestImports:
         from attune.agent_factory import (
             AgentCapability,
             AgentConfig,
+            AgentGraphConfig,
             AgentRole,
             BaseAgent,
-            WorkflowConfig,
         )
 
         assert AgentCapability is not None
         assert AgentConfig is not None
         assert AgentRole is not None
         assert BaseAgent is not None
-        assert WorkflowConfig is not None
+        assert AgentGraphConfig is not None
 
 
 @pytest.mark.unit

--- a/tests/unit/agent_factory/test_agent_graph_config_alias.py
+++ b/tests/unit/agent_factory/test_agent_graph_config_alias.py
@@ -1,0 +1,89 @@
+"""`AgentGraphConfig` rename — deprecated alias contract. REMOVE IN v16.0.0.
+
+Spec ``models-workflows-layering`` D5: ``agent_factory.base`` held one of
+four classes named ``WorkflowConfig``. It is now ``AgentGraphConfig`` —
+the fields it carries (``mode`` ∈ sequential/parallel/graph/conversation,
+``state_schema``, ``checkpointing``, ``framework_options``) are
+graph-construction concerns, and the ``Agent`` prefix matches its
+neighbours ``AgentRole``/``AgentCapability``/``AgentConfig``.
+
+Recorded because the ruling turned on it: inside its own module the old
+name was already coherent, so this rename buys nothing locally — the
+collision was only visible globally, and the chair ruled the
+one-bare-name intent outranks local coherence.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under the Apache License, Version 2.0
+"""
+
+from __future__ import annotations
+
+import importlib
+import warnings
+
+import pytest
+
+PATHS = ("attune.agent_factory", "attune.agent_factory.base")
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("path", PATHS)
+def test_new_name_does_not_warn(path: str) -> None:
+    module = importlib.import_module(path)
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        _ = module.AgentGraphConfig  # access IS the trigger under PEP 562
+    assert not [w for w in caught if issubclass(w.category, DeprecationWarning)]
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("path", PATHS)
+def test_old_name_warns_and_names_the_version(path: str) -> None:
+    module = importlib.import_module(path)
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        _ = module.WorkflowConfig  # access IS the trigger under PEP 562
+    messages = [str(w.message) for w in caught if issubclass(w.category, DeprecationWarning)]
+    assert messages, f"{path}.WorkflowConfig did not warn"
+    assert "v16.0.0" in messages[0], messages[0]
+    assert "AgentGraphConfig" in messages[0], messages[0]
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("path", PATHS)
+def test_alias_is_the_same_object_not_a_copy(path: str) -> None:
+    """Identity — a copy would silently vacate patches (#2162 class)."""
+    from attune.agent_factory.base import AgentGraphConfig
+
+    module = importlib.import_module(path)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        assert module.WorkflowConfig is AgentGraphConfig
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("path", PATHS)
+def test_unknown_attribute_still_raises(path: str) -> None:
+    module = importlib.import_module(path)
+    with pytest.raises(AttributeError, match="NoSuchThing"):
+        _ = module.NoSuchThing
+
+
+@pytest.mark.unit
+def test_this_rename_no_longer_collides_with_the_canonical_name() -> None:
+    """D5's point: the bare name belongs to the ``workflows.yaml``-backed
+    class, and this one no longer competes for it.
+
+    Deliberately scoped to the two classes THIS branch can speak for. The
+    third former collision (``config.sections`` -> ``WorkflowsConfig``)
+    ships separately, so asserting it here would couple this PR to that
+    one's merge order and fail for a reason that is not about this diff.
+    The full three-way assertion belongs in a follow-up once both have
+    landed.
+    """
+    from attune.agent_factory.base import AgentGraphConfig
+    from attune.workflows.config import WorkflowConfig as Canonical
+
+    assert Canonical.__name__ == "WorkflowConfig"
+    assert AgentGraphConfig.__name__ == "AgentGraphConfig"
+    assert Canonical is not AgentGraphConfig

--- a/tests/unit/agent_factory/test_autogen_adapter_behavioral.py
+++ b/tests/unit/agent_factory/test_autogen_adapter_behavioral.py
@@ -21,8 +21,8 @@ from attune.agent_factory.adapters.autogen_adapter import (
 )
 from attune.agent_factory.base import (
     AgentConfig,
+    AgentGraphConfig,
     AgentRole,
-    WorkflowConfig,
 )
 
 # ---------------------------------------------------------------------------
@@ -46,7 +46,7 @@ def agent_config():
 @pytest.fixture()
 def workflow_config():
     """Create a basic workflow config."""
-    return WorkflowConfig(name="test-workflow", description="Test workflow")
+    return AgentGraphConfig(name="test-workflow", description="Test workflow")
 
 
 @pytest.fixture()
@@ -461,7 +461,7 @@ class TestAutoGenAdapterCreateAgent:
         """conversation mode builds a free-form GroupChat (no round_robin)."""
         adapter = AutoGenAdapter(api_key="sk-a")
         agent = AutoGenAgent(agent_config, autogen_agent=MagicMock())
-        cfg = WorkflowConfig(name="w", mode="conversation", max_iterations=5)
+        cfg = AgentGraphConfig(name="w", mode="conversation", max_iterations=5)
 
         adapter.create_workflow(cfg, [agent])
 
@@ -473,7 +473,7 @@ class TestAutoGenAdapterCreateAgent:
         """A non-conversation mode builds a round-robin GroupChat."""
         adapter = AutoGenAdapter(api_key="sk-a")
         agent = AutoGenAgent(agent_config, autogen_agent=MagicMock())
-        cfg = WorkflowConfig(name="w", mode="sequential", max_iterations=3)
+        cfg = AgentGraphConfig(name="w", mode="sequential", max_iterations=3)
 
         adapter.create_workflow(cfg, [agent])
 

--- a/tests/unit/agent_factory/test_haystack_adapter_behavioral.py
+++ b/tests/unit/agent_factory/test_haystack_adapter_behavioral.py
@@ -17,8 +17,8 @@ from attune.agent_factory.adapters.haystack_adapter import (
 from attune.agent_factory.base import (
     AgentCapability,
     AgentConfig,
+    AgentGraphConfig,
     AgentRole,
-    WorkflowConfig,
 )
 
 # ---------------------------------------------------------------------------
@@ -53,7 +53,7 @@ def rag_config():
 @pytest.fixture()
 def workflow_config():
     """Create a basic workflow config."""
-    return WorkflowConfig(
+    return AgentGraphConfig(
         name="test-workflow",
         description="Test workflow",
     )

--- a/tests/unit/agent_factory/test_langchain_adapter_runtime.py
+++ b/tests/unit/agent_factory/test_langchain_adapter_runtime.py
@@ -31,8 +31,8 @@ from attune.agent_factory.adapters.langchain_adapter import (
 from attune.agent_factory.base import (
     AgentCapability,
     AgentConfig,
+    AgentGraphConfig,
     AgentRole,
-    WorkflowConfig,
 )
 
 
@@ -166,26 +166,26 @@ class TestWorkflowRun:
     def test_chain_ainvoke(self):
         chain = MagicMock()
         chain.ainvoke = AsyncMock(return_value={"output": "chained"})
-        wf = LangChainWorkflow(WorkflowConfig(name="w"), [], chain=chain)
+        wf = LangChainWorkflow(AgentGraphConfig(name="w"), [], chain=chain)
         out = _run(wf.run("in"))
         assert out["output"] == "chained"
 
     def test_chain_sync_and_non_dict(self):
-        wf = LangChainWorkflow(WorkflowConfig(name="w"), [], chain=_SyncRunnable("flat"))
+        wf = LangChainWorkflow(AgentGraphConfig(name="w"), [], chain=_SyncRunnable("flat"))
         out = _run(wf.run("in"))
         assert out["output"] == "flat"
 
     def test_chain_exception(self):
         chain = MagicMock()
         chain.ainvoke = AsyncMock(side_effect=RuntimeError("chain boom"))
-        wf = LangChainWorkflow(WorkflowConfig(name="w"), [], chain=chain)
+        wf = LangChainWorkflow(AgentGraphConfig(name="w"), [], chain=chain)
         out = _run(wf.run("in"))
         assert "Error:" in out["output"]
 
     def test_no_chain_sequential_agents(self):
         a1, a2 = _agent_with("r1"), _agent_with("r2")
         a1.name, a2.name = "a1", "a2"
-        wf = LangChainWorkflow(WorkflowConfig(name="w"), [a1, a2])
+        wf = LangChainWorkflow(AgentGraphConfig(name="w"), [a1, a2])
         out = _run(wf.run("in"))
         assert out["output"] == "r2"
         assert len(out["results"]) == 2
@@ -194,7 +194,7 @@ class TestWorkflowRun:
 class TestWorkflowStream:
     def test_emits_agent_events(self):
         a = _agent_with("x")
-        wf = LangChainWorkflow(WorkflowConfig(name="w"), [a])
+        wf = LangChainWorkflow(AgentGraphConfig(name="w"), [a])
         events = _run(_collect(wf.stream("in")))
         kinds = [e["event"] for e in events]
         assert kinds == ["agent_start", "chunk", "agent_end"]
@@ -378,5 +378,5 @@ class TestCreateAgent:
 
 class TestCreateWorkflow:
     def test_returns_langchain_workflow(self):
-        wf = LangChainAdapter().create_workflow(WorkflowConfig(name="w"), [])
+        wf = LangChainAdapter().create_workflow(AgentGraphConfig(name="w"), [])
         assert isinstance(wf, LangChainWorkflow)

--- a/tests/unit/agent_factory/test_langgraph_adapter.py
+++ b/tests/unit/agent_factory/test_langgraph_adapter.py
@@ -21,7 +21,7 @@ from attune.agent_factory.adapters.langgraph_adapter import (
     LangGraphWorkflow,
     _check_langgraph,
 )
-from attune.agent_factory.base import AgentConfig, AgentRole, WorkflowConfig
+from attune.agent_factory.base import AgentConfig, AgentGraphConfig, AgentRole
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -33,7 +33,7 @@ def _agent_config(name="test-agent", role=AgentRole.COORDINATOR, api_key="sk-tes
 
 
 def _workflow_config(mode="sequential"):
-    return WorkflowConfig(name="test-wf", mode=mode)
+    return AgentGraphConfig(name="test-wf", mode=mode)
 
 
 def _make_agent(name="agent1"):


### PR DESCRIPTION
Third and last of the rename PRs. `agent_factory/base.WorkflowConfig`
becomes **`AgentGraphConfig`**, so exactly one class in the tree holds
the bare name — the `workflows.yaml`-backed
`attune.workflows.config.WorkflowConfig`.

The name reflects what it configures: `mode` ∈
sequential/parallel/graph/conversation, `state_schema`, `checkpointing`,
`framework_options` are graph-construction concerns, and the `Agent`
prefix matches its neighbours `AgentRole` / `AgentCapability` /
`AgentConfig`.

## ⚠ Scope correction — the ruling was made against a wrong number

D5 was ruled against **"8 sites"**. The real figure, measured at
execution time:

| | |
|---|---|
| `src/attune/agent_factory/` references | 23 |
| test references | 104 |
| **total** | **127 across 21 files** |

A **15× underestimate**, and mine — the original counted importing
*files*, not references. It is corrected in `design.md` in this commit.
Re-put to the chair with the true number and re-ruled **proceed**.

The risk profile is unchanged: mechanical, alias-protected, and no
in-scope file references a *different* `WorkflowConfig` (verified before
touching anything, so a scoped rename cannot cross wires). Only churn
and reviewability moved. 104 of 127 are test references.

## The counter-case, carried forward

Inside its own module the old name was already coherent, sitting beside
`AgentConfig` / `BaseAgent` / `BaseWorkflow` — this rename buys nothing
locally, and the collision was only ever visible globally. The chair
ruled the one-bare-name intent outranks that, with the counter-case in
front of it. That reasoning now lives in the alias comment so a future
reader doesn't have to reconstruct it from PR archaeology.

## Deprecated aliases

Old name stays on **both** public paths — `attune.agent_factory` and
`attune.agent_factory.base` — each via PEP 562 `__getattr__` warning on
**access** and naming v16.0.0. `REMOVE IN v16.0.0` markers keep
`check_deprecation_markers.py` honest.

## Receipts

9 new tests, **mutation-verified**:

| Mutation | Result |
|---|---|
| alias returns a subclass copy | 🔴 red |
| alias stops warning | 🔴 red |
| restored | 🟢 9 passed |

Full tree: **25,334 passed**, 256 skipped, 7 xfailed. agent_factory
suites 663 passed. `check_deprecation_markers` exits 0.

One test was deliberately **scoped down**: asserting all three former
collisions resolve would couple this PR to #2321's merge order and fail
for a reason unrelated to this diff. The three-way assertion belongs in
a follow-up once both land.

Refs #2239
