### PR TITLE
release: 15.1.0 — the models/workflows cycle, closed

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "Persistent memory and receipt-verified workflows for Claude Code. Spec-driven development with an approval loop, plus 28 auto-triggering skills: security audits, code review, test generation, release prep.",
-    "version": "15.0.0"
+    "version": "15.1.0"
   },
   "plugins": [
     {
       "name": "attune-ai",
       "description": "Persistent memory and receipt-verified workflows for Claude Code. /spec carries an idea through brainstorm, requirements, design, and task execution with quality gates and your approval at each stage. Backed by 28 auto-triggering skills — security audits, code reviews, test generation, bug prediction, and release preparation. For help content tools, also install attune-help from this marketplace; authoring ships built in via the attune.authoring module.",
       "source": "./plugin",
-      "version": "15.0.0",
+      "version": "15.1.0",
       "author": {
         "name": "Smart AI Memory",
         "email": "patrick.roebuck@smartaimemory.com"

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,4 +1,4 @@
-# Attune AI Framework v15.0.0
+# Attune AI Framework v15.1.0
 
 AI-powered developer workflows with cost optimization and multi-agent orchestration.
 
@@ -601,7 +601,7 @@ attune_redis/          # Redis plugin — BUNDLED, ships in the attune-ai
 
 ---
 
-**Version:** 15.0.0 | **License:** Apache 2.0 | **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)
+**Version:** 15.1.0 | **License:** Apache 2.0 | **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)
 
 ## Lessons — core
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,69 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [15.1.0] - 2026-08-26
+
+15.1.0 closes the models↔workflows dependency cycle
+([#2239](https://github.com/Smart-AI-Memory/attune-ai/issues/2239)) and
+resolves the four-way `WorkflowConfig` name collision it exposed. No
+breaking changes: every renamed or retired name still works and now
+warns, so upgrading is a no-op today and a one-line edit before 16.0.0.
+
+### Changed
+
+- **The `attune.models` layer no longer imports `attune.workflows`.**
+  `EmpathyLLMExecutor` read `workflows.yaml` itself through a lazy
+  upward import — the last edge of the cycle. It now takes a
+  models-owned `hybrid_config: dict[str, str] | None`, and the config
+  read moved to the workflows-layer call site, where it fires only for
+  hybrid providers. Pure wiring inversion; tier mapping is unchanged.
+- **`config.sections.WorkflowConfig` is now `WorkflowsConfig`.** It was
+  the only one of seven config sections not named after its own module
+  (`AnalysisConfig`, `AuthConfig`, `EnvironmentConfig`,
+  `PersistenceConfig`, `RoutingConfig`, `TelemetryConfig`).
+- **`agent_factory.WorkflowConfig` is now `AgentGraphConfig`**, naming
+  what it configures — `mode`, `state_schema`, `checkpointing`,
+  `framework_options` are graph-construction concerns — and matching
+  its neighbours `AgentRole` / `AgentCapability` / `AgentConfig`.
+
+### Deprecated
+
+Each of these still resolves and still works, emits a
+`DeprecationWarning` on access, and is removed in **16.0.0**:
+
+| Deprecated | Use instead |
+|---|---|
+| `attune.config.AgentWorkflowConfig` | `attune.agent_factory.AgentGraphConfig` |
+| `attune.config.WorkflowMode` | — (removed with the class above) |
+| `attune.config.sections.WorkflowConfig` | `WorkflowsConfig` |
+| `attune.config.sections.workflows.WorkflowConfig` | `WorkflowsConfig` |
+| `attune.agent_factory.WorkflowConfig` | `AgentGraphConfig` |
+| `attune.agent_factory.base.WorkflowConfig` | `AgentGraphConfig` |
+
+Warnings fire on **access**, not on import, so packages that never
+touch these names stay silent.
+
+### Fixed
+
+- Test fixtures no longer invoke the user's GPG signing key. A fixture's
+  `git commit` inherited a global `commit.gpgsign=true` and could block
+  indefinitely on a passphrase prompt no automated run can answer,
+  wedging the whole suite with no output.
+- A failed cross-provider seat now reports why it failed, and a call
+  that never authenticated is no longer counted as spend.
+
+### Internal
+
+- The layering boundary is enforced by a static AST scan asserting no
+  module under `attune/models/` imports `attune.workflows` at any scope.
+  The previous subprocess probe observed only what an import *loads*,
+  so it could not see a lazy function-local import — the shape both
+  cycle edges actually had.
+- A shrink-only gate pins the `WorkflowConfig` collision as resolved:
+  new classes by that name fail, and the one definition still awaiting
+  deletion is allowed only while it carries its removal marker.
+
+
 ## [15.0.0] - 2026-08-26
 
 15.0.0 finishes the Empathy-framework excision begun in 9.0.0: the

--- a/docs/reference/API_REFERENCE.md
+++ b/docs/reference/API_REFERENCE.md
@@ -1,6 +1,6 @@
 # Attune AI API Reference
 
-**Version:** 15.0.0
+**Version:** 15.1.0
 **License:** Apache License 2.0
 **Copyright:** 2025-2026 Smart AI Memory, LLC
 
@@ -1133,5 +1133,5 @@ msg = format_error(
 
 ---
 
-**Version:** 15.0.0 | **License:** Apache 2.0
+**Version:** 15.1.0 | **License:** Apache 2.0
 **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)

--- a/plugin/.claude-plugin/marketplace.json
+++ b/plugin/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "Spec-driven development for Claude Code — /spec plans, reviews, and executes with quality gates; plus security audits, code reviews, test generation, and release prep from /attune.",
-    "version": "15.0.0"
+    "version": "15.1.0"
   },
   "plugins": [
     {
       "name": "attune-ai",
       "description": "Spec-driven development for Claude Code — /spec plans, reviews, and executes with quality gates; plus security audits, code reviews, test generation, and release prep from /attune.",
       "source": "./",
-      "version": "15.0.0",
+      "version": "15.1.0",
       "author": {
         "name": "Smart AI Memory",
         "email": "patrick.roebuck@smartaimemory.com"

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "attune-ai",
-  "version": "15.0.0",
+  "version": "15.1.0",
   "description": "Persistent memory and receipt-verified workflows for Claude Code — /spec plans, reviews, and executes with quality gates; plus security audits, code reviews, test generation, and release prep from /attune.",
   "author": {
     "name": "Smart AI Memory",

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -4,7 +4,7 @@ Spec-driven development for Claude Code — turn requirements
 into reliable software. <!-- cap:skill_count -->28 auto-triggering skills<!-- /cap -->, zero
 commands: say what you need and Claude picks the right skill.
 
-**Version:** 15.0.0 | **License:** Apache 2.0
+**Version:** 15.1.0 | **License:** Apache 2.0
 
 > **Fix Receipts** (`/fix`) — new in 11.2.0. Say `fix this and
 > prove it`.

--- a/plugin/core/__init__.py
+++ b/plugin/core/__init__.py
@@ -5,4 +5,4 @@ This module provides the core workflow functionality when the full
 attune-ai package is not installed via pip.
 """
 
-__version__ = "15.0.0"
+__version__ = "15.1.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "attune-ai"
-version = "15.0.0"
+version = "15.1.0"
 description = "Persistent memory and receipt-verified workflows for Claude Code — plugin, MCP server, and spec-driven dev framework."
 readme = {file = "README.md", content-type = "text/markdown"}
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -299,7 +299,7 @@ wheels = [
 
 [[package]]
 name = "attune-ai"
-version = "15.0.0"
+version = "15.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "agent-memory-client" },

--- a/website/app/page.tsx
+++ b/website/app/page.tsx
@@ -38,7 +38,7 @@ export default function Home() {
                 test_homepage_badge_includes_package_version guard scans
                 this file for vX.Y.Z and compares it to the package. */}
             <div className="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-[var(--surface-container-high)] text-[var(--primary)] text-xs font-bold tracking-widest mb-8 uppercase">
-              <span>v15.0.0</span>
+              <span>v15.1.0</span>
               <span className="w-1 h-1 rounded-full bg-[var(--primary)]" aria-hidden="true"></span>
               <span className="opacity-80">Persistent memory for AI coding agents</span>
             </div>

--- a/website/lib/features.ts
+++ b/website/lib/features.ts
@@ -85,7 +85,7 @@ export const PRODUCTS: Product[] = [
     id: "attune-ai",
     name: "Attune AI",
     pypiName: "attune-ai",
-    version: "15.0.0",
+    version: "15.1.0",
     tagline: "Generate, maintain, and serve help from your code",
     installCommand: "pip install attune-ai",
     marketplaceInstall:
@@ -129,7 +129,7 @@ export const PRODUCTS: Product[] = [
     id: "claude-code-plugin",
     name: "Claude Code Plugin",
     pypiName: "attune-ai",
-    version: "15.0.0",
+    version: "15.1.0",
     tagline: "Progressive help right in your terminal",
     installCommand:
       "claude plugin marketplace add Smart-AI-Memory/attune-ai",


### PR DESCRIPTION
Prep only — **no tag, no publish.** This PR bumps the version and writes
the changelog; tagging waits for your go and for main to be green.

## What ships

15.1.0 closes
[#2239](https://github.com/Smart-AI-Memory/attune-ai/issues/2239) — the
models↔workflows dependency cycle — and resolves the four-way
`WorkflowConfig` name collision it exposed.

**No breaking changes.** Every renamed or retired name still resolves,
still works, and now warns. Upgrading is a no-op today and a one-line
edit before 16.0.0.

## Why now rather than batching it

**An unreleased deprecation is not a deprecation.** Six access paths are
scheduled for removal in 16.0.0, and anyone on 15.0.0 gets *no notice at
all* until those warnings are on PyPI. Shipping is what makes D6's
"give people notice" true rather than aspirational.

## Contents

- 14 commits since `v15.0.0`
- Version bumped across the 10 release-artifact sites via
  `scripts/bump_version.py` (dry-run verified every site before writing)
- `uv.lock` refreshed — diff is the version line only
- CHANGELOG entry: Changed / Deprecated / Fixed / Internal

## Receipts

| | |
|---|---|
| Full tree | **25,367 passed**, 256 skipped, 7 xfailed |
| `tests/unit/ci` + `tests/unit/gates` | 752 passed, 1 skipped |
| version-keyed tests (`-k version`) | 180 passed |
| `uv.lock` diff | 1 line |

## Not done in this PR

- **No tag.** `v15.1.0` is unpushed and `15.1.0` is free on PyPI.
- Main's `Tests` / `CodeQL` / `Pre-commit` lanes were still running on
  `816ce1ba0` when this was cut. They should be green before tagging —
  a release tag on a partial signal is the failure mode the release-prep
  discipline exists to prevent.

Refs #2239
