### PR TITLE
docs(bug-log): record the 15.1.0 post-release self-review (step 16)

### DIFF
--- a/docs/COVERAGE_BUG_LOG.md
+++ b/docs/COVERAGE_BUG_LOG.md
@@ -1587,6 +1587,82 @@ retro-tooling PR (bcrypt added to the [dev] extra + dev group);
 tests/unit/test_no_dead_suites.py now guards the class with an empty
 allowlist.
 
+## 2026-08-26 — post-release self-review, 15.1.0 (release-execute step 16)
+
+Two runner-launched runs against the shipped tree (`src` at
+`6f259a86e`, verified from the filesystem — `pyproject.toml` on disk
+AND the imported `__version__` both read 15.1.0, tree clean, 0 behind
+`origin/main`): `code-review` run `19ddfd91bd4c` (334s, cost not
+reported by the runner) and `bug-predict` run `ca0c52c6c121`, **58/100**
+(263s, **$2.19**). Both exit 0 with `sdk_error_kind: None` and a report
+present, so neither is the exit-0-with-traceback false success.
+
+**No finding blocked the release.** Every one sits in code 15.1.0 did
+not touch — the inverse of the 14.0.0 precedent, where the release's own
+headline feature carried the worst defect. Four worth recording:
+
+- **The 2026-08-22 "bug-predict emits zero structured findings" finding
+  STANDS, and has acquired a shape that hides it — classification: dead
+  surface, regressed in legibility.** That entry recorded 6/6 runs with
+  `sections=0, findings=0`. Today's run reports `sections=2`, which
+  reads as fixed to any check that counts sections. It is not: the
+  sections are `[Bugs=0, Next steps=6]`. **The findings section is still
+  empty in every completed run** (`ca0c52c6c121` Bugs=0,
+  `410497bd6f90` Bugs=0, `a6e92650d199` sections=0). All 15 bugs below
+  exist ONLY as prose in a markdown table; nothing structured consumes
+  them. Verified by reading `rows` per section across three run records,
+  not by counting sections — the first pass here DID count containers
+  and wrongly reported the bug fixed, which is the same units error as
+  the `grep -l` files-vs-references lesson from the same morning. Not
+  yet fixed.
+
+- **`agents/release/release_parsing.py:43` — contract violation,
+  HIGH, verified in source.** `_parse_response` is typed `-> dict` and
+  documented "never returns None", but Strategy 1 (XML delimiters) and
+  Strategy 2 (markdown-fenced) both `return json.loads(...)` unguarded.
+  An LLM emitting a fenced JSON ARRAY or bare scalar parses fine and
+  returns a non-dict; consumers (`quality_agent.py:79-84`,
+  `security_agent.py:158-163`) then raise TypeError, which is swallowed
+  and surfaces as a spurious release-gate failure with
+  `quality_score 0.0`. Strategy 3 already guards with
+  `text.startswith("{")` — the other two were never given the same
+  check. Failure mode bites DURING a release, which is where it is
+  least welcome. Fix: `isinstance(result, dict)` guard after each
+  `json.loads`, else fall through to the existing `{'parse_error': ...}`
+  default. Not yet fixed.
+
+- **`lessons/__init__.py:89` — unchecked negative index, HIGH, verified
+  in source.** `text[text.find(_LESSONS_HEADING):]`. When the heading is
+  absent `find` returns `-1` and `text[-1:]` silently slices the LAST
+  CHARACTER instead of raising, producing a silently-wrong lesson parse
+  rather than a loud failure. Not yet fixed.
+
+- **`workflow_patterns/structural.py:37` + `output.py:36` — reported
+  HIGH by code-review as "codegen silently ignores caller-supplied
+  names, ships silently broken output today". DOWNGRADED to Low on
+  verification.** Both lines do discard a `.get()` return value, but
+  each file discards exactly the name its own templates never reference
+  — confirmed by AST: `class_name` appears 1x in `structural.py`'s
+  `generate_code_sections` (the dead call itself) and `workflow_name`
+  1x in `output.py`'s. Nothing is ignored and no broken output ships;
+  they are vestigial statements worth deleting for clarity. Ruff cannot
+  catch them because `context.get(...)` is a CALL, so `B018`
+  (useless-expression) does not fire. **Recorded because the severity
+  was wrong, not the observation** — an unverified read of this finding
+  would have held the release.
+
+Remaining findings (structural, none blocking): two competing config
+systems half-migrated (`config/legacy.py` vs UnifiedConfig);
+`ModelTier` defined 5+ times and `ModelProvider` twice; `BaseWorkflow`
+composing 14 mixins behind a ~20-param constructor; a parallel
+mixin-AND-service layer for the same capabilities; `workflows/` as a
+133-file catch-all; `ops/routes/specs.py:93` doing synchronous
+filesystem work inside `async def` handlers on the event loop.
+`BaseWorkflow` is genuinely defined 3x (`agent_factory/base.py`,
+`plugins/base.py`, `workflows/base.py`) — unlike the `WorkflowConfig`
+collision, which 15.1.0 resolved and which now has a shrink-only gate.
+
+
 ## 2026-08-22 — post-release self-review, 14.0.0 (release-execute step 16)
 
 Two dashboard-launched runs against the shipped tree (`src` at


### PR DESCRIPTION
Step 16's receipt for 15.1.0. The bug-log entry **is** the receipt —
the release manifest cannot hold it (immutable, written pre-tag), and
until this is on main the step is not complete.

## Runs

| Workflow | Run | Time | Result |
|---|---|---|---|
| `code-review` | `19ddfd91bd4c` | 334s | report present, exit 0 |
| `bug-predict` | `ca0c52c6c121` | 263s | **58/100**, **$2.19**, exit 0 |

Tree verified **from the filesystem**, not a ref: `pyproject.toml` on
disk and the imported `__version__` both `15.1.0`, clean, 0 behind
`origin/main`. Both launched through the ops runner — MCP/CLI launches
call no `_persist_run` and would have recorded nothing.

**No finding blocked the release.** Every one is in code 15.1.0 did not
touch — the inverse of the 14.0.0 precedent.

## The one that matters most

**The 2026-08-22 "bug-predict emits zero structured findings" finding
stands, and is now harder to notice than when it was filed.** That entry
recorded `sections=0`. Today reports `sections=2` — which reads as
fixed. It is not:

```
ca0c52c6c121 (today)   sections=2   [Bugs=0, Next steps=6]
410497bd6f90           sections=2   [Bugs=0, Next steps=8]
a6e92650d199 (14.0.0)  sections=0   [(none)]
```

The findings section is empty in **every** completed run. All 15 bugs
exist only as prose in a markdown table; nothing structured consumes
them. A visible emptiness became an invisible one.

Recorded with an admission: my own first pass counted section
*containers* and reported the bug fixed. Same units error as the
`grep -l` files-vs-references lesson written earlier the same morning.

## Also recorded

- `release_parsing.py:43` — HIGH, verified. Strategies 1 & 2 return raw
  `json.loads`; a fenced array yields a non-dict from a `-> dict`
  function, TypeErrors downstream, gets swallowed, surfaces as a
  **spurious release-gate failure**. Strategy 3 already guards.
- `lessons/__init__.py:89` — HIGH, verified. `find()` returning `-1`
  makes the slice take the last character instead of failing.
- `workflow_patterns` dead reads — reported HIGH as *"ships silently
  broken output today"*, **downgraded to Low on verification**: each
  file discards exactly the name its templates never reference (1
  occurrence each, confirmed by AST). Recorded because the severity was
  wrong — an unverified read would have held the release.

Refs #2239
