### PR TITLE
chore(ci): stop quoting a coverage figure that cannot update itself

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -341,8 +341,14 @@ jobs:
 
     - name: Run tests with coverage
       # Coverage RATCHET: --cov-fail-under is a one-way valve, not a static
-      # floor. Main has measured 94.69–94.71% across recent runs (stable to
-      # ~0.02%); the gate sits at 94 (≈0.7pt headroom for normal churn). The
+      # floor. DO NOT quote a measured percentage here — the figure this
+      # comment carried (94.69–94.71%, "≈0.7pt headroom") went stale as main
+      # climbed, and on 2026-08-26 it was read as live during a release
+      # incident and produced a wrong diagnosis (the actual figure was
+      # 95.93%, ~2pt of room). The authoritative current number is the
+      # Codecov API, not a comment that cannot update itself:
+      #   curl -s "https://api.codecov.io/api/v2/github/Smart-AI-Memory/repos/attune-ai/report/?branch=main"
+      # Only the GATE below is normative. The
       # old 85 left a ~9.7pt silent-erosion slack — coverage could fall from
       # ~94.7 to 85 without CI noticing. RATCHET POLICY: only ever raise this
       # number (when main climbs and holds above floor+~1), never lower it to


### PR DESCRIPTION
Retro item 3, ruled `do now`.

The coverage-ratchet comment claimed main measures **94.69–94.71%** with **~0.7pt headroom** over the 94 gate. Codecov puts main at **95.93%** — about 1.2pt stale.

## It was not inert

During the 15.1.0 release the `coverage` job went red. I read that comment as live, inferred the new deprecation shims had eaten the headroom, and went looking for a coverage regression. There was none — the failure was an xdist worker crash, and coverage passed at **96.46%** in the same run.

A comment cannot update itself, so it should not carry a measurement. Replaced with a pointer to the Codecov API (authoritative) and a note that only the GATE value is normative.

Comment only — no behavior change.