### PR TITLE
chore(release): 16.0.0 — destructive-half major

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "Persistent memory and receipt-verified workflows for Claude Code. Spec-driven development with an approval loop, plus 28 auto-triggering skills: security audits, code review, test generation, release prep.",
-    "version": "15.1.0"
+    "version": "16.0.0"
   },
   "plugins": [
     {
       "name": "attune-ai",
       "description": "Persistent memory and receipt-verified workflows for Claude Code. /spec carries an idea through brainstorm, requirements, design, and task execution with quality gates and your approval at each stage. Backed by 28 auto-triggering skills — security audits, code reviews, test generation, bug prediction, and release preparation. For help content tools, also install attune-help from this marketplace; authoring ships built in via the attune.authoring module.",
       "source": "./plugin",
-      "version": "15.1.0",
+      "version": "16.0.0",
       "author": {
         "name": "Smart AI Memory",
         "email": "patrick.roebuck@smartaimemory.com"

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,4 +1,4 @@
-# Attune AI Framework v15.1.0
+# Attune AI Framework v16.0.0
 
 AI-powered developer workflows with cost optimization and multi-agent orchestration.
 
@@ -601,7 +601,7 @@ attune_redis/          # Redis plugin — BUNDLED, ships in the attune-ai
 
 ---
 
-**Version:** 15.1.0 | **License:** Apache 2.0 | **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)
+**Version:** 16.0.0 | **License:** Apache 2.0 | **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)
 
 ## Lessons — core
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [16.0.0] - 2026-08-27
+
+16.0.0 is the destructive half of the harness-lite architecture
+ruling (`docs/specs/release-16-manifest/` D1, chair-ruled via the
+full round table): dead framework-era modules deleted, every 15.x
+deprecation executed, ceremony entry-point seams collapsed. The
+constructive half — the extension system — ships in 16.x. Users of
+the CLI, plugin, and MCP tools upgrade with no code changes; see
+`docs/migration/upgrading-to-16.0.0.md` for the one grep that tells
+you whether any of this touches your code.
+
 ### Removed
 
-- **BREAKING (16.0.0-class): the `attune.plugins` and `attune.wizards`
+- **BREAKING: the `attune.plugins` and `attune.wizards`
   entry-point groups are collapsed to direct registration**
   (release-16-manifest D1 — both groups had exactly one effective
   configuration: attune registering its own bundled code). The plugin
@@ -25,7 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   unchanged. A drift guard pins the collapsed groups absent from
   pyproject.
 
-- **BREAKING (16.0.0-class): the six 15.x deprecation aliases from the
+- **BREAKING: the six 15.x deprecation aliases from the
   `WorkflowConfig` collision are gone** (spec `models-workflows-layering`
   D2/D4/D5/D6, timing pre-ruled): `attune.config.AgentWorkflowConfig`,
   `attune.config.WorkflowMode` (and their defining classes in
@@ -34,7 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (→ `AgentGraphConfig`). Every alias warned with this exact removal
   version throughout the 15.x line; the collision gate now pins the
   aliases as *absent*.
-- **BREAKING (16.0.0-class): seven root-level deprecation shims and
+- **BREAKING: seven root-level deprecation shims and
   facades deleted**:
   - `attune.coordination` — an ImportError shim since 6.8.0.
   - `attune.redis_memory`, `attune.redis_memory_storage`,
@@ -49,7 +60,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `attune.state_manager` — `StateManager`, deprecated since the
     9.0.0 Empathy retirement, is removed along with the last of the
     legacy-framework deprecation machinery in `attune.__init__`.
-- **BREAKING (16.0.0-class): nine dead framework-era root modules
+- **BREAKING: nine dead framework-era root modules
   deleted** (~2,200 lines, none imported anywhere in the live tree —
   verified by caller grep per module):
   - `attune.discovery` — the progressive-discovery engine had zero

--- a/docs/migration/upgrading-to-16.0.0.md
+++ b/docs/migration/upgrading-to-16.0.0.md
@@ -1,0 +1,60 @@
+# Upgrading to 16.0.0
+
+16.0.0 is the destructive half of the harness-lite architecture
+ruling (`docs/specs/release-16-manifest/`): it deletes dead
+framework-era modules, executes every deprecation the 15.x line
+warned about, and collapses the ceremony entry-point seams. **If you
+use attune-ai through the CLI, the plugin, or the MCP tools, you
+upgrade with no code changes.** The removals bite only Python code
+that imported the deleted modules or registered entry points. The
+constructive half — the new extension system — ships in 16.x; nothing
+in this release adds a new way to extend attune.
+
+## Do you need to change anything?
+
+Run this against your codebase:
+
+```bash
+grep -rnE "from attune\.(discovery|templates|template_engine|template_defs_\w+|pattern_cache|cache_stats|cache_monitor|vscode_bridge|coordination|persistence|state_manager|redis_memory\w*) import|attune\.config import.*(AgentWorkflowConfig|WorkflowMode)|WorkflowConfig" . --include='*.py'
+```
+
+No hits → you are done. Hits → the table below.
+
+## Removed modules
+
+| Removed | Replacement |
+|---|---|
+| `attune.discovery` | none (dead progressive-discovery engine; its tips live in the generated help) |
+| `attune.pattern_cache`, `attune.cache_stats`, `attune.cache_monitor` | none (dead cache-monitor cluster) |
+| `attune.vscode_bridge` | none (Empathy-era extension bridge) |
+| `attune.template_engine`, `attune.template_defs_basic`, `attune.template_defs_web`, `attune.templates` | none (`cmd_new` was never wired to the CLI) |
+| `attune.coordination` | removed in 6.8.0; the shim is now gone too |
+| `attune.redis_memory`, `attune.redis_memory_storage`, `attune.redis_memory_coordination`, `attune.redis_memory_patterns` | `attune_redis.AMSMemoryBackend` (bundled in the wheel) — see [redis-plugin-migration.md](redis-plugin-migration.md). *Note: earlier docstrings said these were "retained with no planned removal"; the 16.0.0 architecture ruling superseded that.* |
+| `attune.persistence` (facade) | `attune.pattern_persistence.PatternPersistence`, `attune.metrics_collector.MetricsCollector` — both still exported from `attune` top level |
+| `attune.state_manager` (`StateManager`) | none (deprecated since 9.0.0) |
+
+## Removed aliases (each warned through 15.x naming this release)
+
+| Old name | Use instead |
+|---|---|
+| `attune.config.AgentWorkflowConfig` | none — it was an unconsumed twin; `attune.workflows.config.WorkflowConfig` is the live workflows type |
+| `attune.config.WorkflowMode` | none (only consumer was the twin) |
+| `attune.config.sections.WorkflowConfig` | `attune.config.sections.WorkflowsConfig` |
+| `attune.agent_factory.WorkflowConfig` (and `.base.WorkflowConfig`) | `attune.agent_factory.AgentGraphConfig` |
+
+## Collapsed entry-point groups
+
+The `attune.plugins` and `attune.wizards` entry-point groups are no
+longer read; the dead `attune.workflows` reading path is deleted. The
+bundled plugins and built-in wizards load directly. If you registered
+an external wizard or plugin via these groups, that path is gone —
+the 16.x extension system is the successor. Two things still work
+unchanged:
+
+- **`attune.memory_backends`** — the one entry-point seam kept
+  (custom memory backends keep working as before).
+- **YAML wizards** in `.attune/wizards/*.yaml` — the config-driven
+  wizard path is data, not a Python seam, and is untouched.
+
+The `BasePlugin` / `register_mcp_tools()` class contract is also
+unchanged.

--- a/docs/reference/API_REFERENCE.md
+++ b/docs/reference/API_REFERENCE.md
@@ -1,6 +1,6 @@
 # Attune AI API Reference
 
-**Version:** 15.1.0
+**Version:** 16.0.0
 **License:** Apache License 2.0
 **Copyright:** 2025-2026 Smart AI Memory, LLC
 
@@ -1133,5 +1133,5 @@ msg = format_error(
 
 ---
 
-**Version:** 15.1.0 | **License:** Apache 2.0
+**Version:** 16.0.0 | **License:** Apache 2.0
 **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)

--- a/docs/specs/release-16-manifest/decisions.md
+++ b/docs/specs/release-16-manifest/decisions.md
@@ -66,3 +66,31 @@ code search ≈ 0 importers, control query ~30) is verified; the
 in-process-extension demand is the chair's forecast, stated as such
 — the design is sized so that if the demand never materializes, the
 carrying cost is the extension module + CLI, not a framework.
+
+## D2 — D1's mechanism CONFIRMED on the author-experience criterion (chair-ruled 2026-08-27)
+
+After 16.0.0's destructive half shipped, the chair revisited the
+extension-system mechanism (a downsized config-key-loader revision
+had been drafted in-session on 2026-08-26 and deliberately slept on).
+The lead put the question as WHICH CRITERION RULES — security posture
+from day one, smallest frozen surface, or third-party author
+experience — with the full argument set already on the round-table
+board (threads `q-core-plugins-vs-post-framework-001` and
+`q-16-release-reliability-001`). **The chair ruled: author
+experience.** Under that criterion D1 stands as written: the unified
+`attune.extensions` system with trust gating and the
+`enable`/`doctor` CLI ships as passenger 4, because the polished
+`pip install` + `enable` path is the ecosystem-creating surface the
+config-key loader cannot offer.
+
+Recorded against the counter-cases (all argued in-session, held on
+the board): the security delta between the designs is ~zero until
+third-party wheels exist; the reliability round located the
+least-tested layer exactly where D1 lives (mitigated by the
+now-permanent `scripts/release_artifact_smoke.py` gate); and the
+smallest-frozen-surface argument favored the downsize. The chair
+weighed the author-experience criterion as dominant with those
+counter-cases in front of them — the fourth and final lean on this
+decision, resolved by naming the criterion rather than re-litigating
+the designs. The phased-shipping open question in requirements.md
+remains open (contracts-first within 16.x is compatible with D1).

--- a/docs/specs/release-16-manifest/requirements.md
+++ b/docs/specs/release-16-manifest/requirements.md
@@ -1,10 +1,10 @@
 # 16.0.0 Major-Release Manifest
 
-**Status:** destructive half SHIPPED as 16.0.0 (2026-08-27 — PRs
-#2331, #2333, #2334, release PR; passengers 1-3 and 5 executed, D6's
-deprecations discharged). Remaining scope: passenger 4 (the
-extension system, 16.x) pending the chair's D2 ruling — see the
-`project_release16_d2_pending` state.
+**Status:** active (2026-08-27) — destructive half shipped as 16.0.0
+(PRs #2331, #2333, #2334 + release PR; passengers 1-3 and 5 executed,
+D6's deprecations discharged). Remaining scope: passenger 4 (the
+extension system, 16.x) per D1 as ruled — confirmed by D2
+(criterion: author experience).
 **Slug:** `release-16-manifest`
 **Provenance:** 16.0.0-class breaking work began accumulating the
 day 15.1.0 shipped — the dead-module deletion PR #2331, the D4/D6

--- a/docs/specs/release-16-manifest/requirements.md
+++ b/docs/specs/release-16-manifest/requirements.md
@@ -1,8 +1,10 @@
 # 16.0.0 Major-Release Manifest
 
-**Status:** draft (seeded 2026-08-26 from the round-table promotion
-on thread `q-core-plugins-vs-post-framework-001`; D1 is chair-ruled,
-the manifest as a whole awaits chair review)
+**Status:** destructive half SHIPPED as 16.0.0 (2026-08-27 — PRs
+#2331, #2333, #2334, release PR; passengers 1-3 and 5 executed, D6's
+deprecations discharged). Remaining scope: passenger 4 (the
+extension system, 16.x) pending the chair's D2 ruling — see the
+`project_release16_d2_pending` state.
 **Slug:** `release-16-manifest`
 **Provenance:** 16.0.0-class breaking work began accumulating the
 day 15.1.0 shipped — the dead-module deletion PR #2331, the D4/D6
@@ -25,7 +27,7 @@ the dissent register.
 
 ## Passengers
 
-### 1. Dead framework-era root modules — PR #2331 (open)
+### 1. Dead framework-era root modules — ✅ SHIPPED (#2331)
 
 Nine modules (~2,200 lines) deleted with caller-grep receipts:
 `discovery`, `pattern_cache`, `cache_stats`, `cache_monitor`,
@@ -34,7 +36,7 @@ Nine modules (~2,200 lines) deleted with caller-grep receipts:
 into its only consumer (`scripts/generate_tip_templates.py`).
 Merging this PR is what commits the next release to being 16.0.0.
 
-### 2. Root-level deprecation shims — delete
+### 2. Root-level deprecation shims — ✅ SHIPPED (#2333)
 
 The already-declared shims at package root, each announcing its
 replacement today: `coordination` (shim since 6.8.0),
@@ -42,7 +44,7 @@ replacement today: `coordination` (shim since 6.8.0),
 `redis_memory_patterns` (all "use attune_redis"), `persistence`
 (facade), `state_manager` (deprecated at 9.0.0).
 
-### 3. `models-workflows-layering` scheduled removals (D4/D6, D5/D2)
+### 3. `models-workflows-layering` scheduled removals — ✅ SHIPPED (#2333)
 
 - `config/agent_config.AgentWorkflowConfig` + `WorkflowMode` —
   deletion pre-ruled by that spec's D4, timing ruled by its D6; the
@@ -76,7 +78,7 @@ The shared consensus core plus Codex's mechanism, as ruled in D1:
   startup; a standalone package works without attune while its
   adapter works with it).
 
-### 5. Seam collapses (D1 — the destructive half)
+### 5. Seam collapses — ✅ SHIPPED (#2334)
 
 - `attune.plugins` and `attune.wizards` entry-point groups collapse
   to direct imports/registration (both have exactly one effective

--- a/plugin/.claude-plugin/marketplace.json
+++ b/plugin/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "Spec-driven development for Claude Code — /spec plans, reviews, and executes with quality gates; plus security audits, code reviews, test generation, and release prep from /attune.",
-    "version": "15.1.0"
+    "version": "16.0.0"
   },
   "plugins": [
     {
       "name": "attune-ai",
       "description": "Spec-driven development for Claude Code — /spec plans, reviews, and executes with quality gates; plus security audits, code reviews, test generation, and release prep from /attune.",
       "source": "./",
-      "version": "15.1.0",
+      "version": "16.0.0",
       "author": {
         "name": "Smart AI Memory",
         "email": "patrick.roebuck@smartaimemory.com"

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "attune-ai",
-  "version": "15.1.0",
+  "version": "16.0.0",
   "description": "Persistent memory and receipt-verified workflows for Claude Code — /spec plans, reviews, and executes with quality gates; plus security audits, code reviews, test generation, and release prep from /attune.",
   "author": {
     "name": "Smart AI Memory",

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -4,7 +4,7 @@ Spec-driven development for Claude Code — turn requirements
 into reliable software. <!-- cap:skill_count -->28 auto-triggering skills<!-- /cap -->, zero
 commands: say what you need and Claude picks the right skill.
 
-**Version:** 15.1.0 | **License:** Apache 2.0
+**Version:** 16.0.0 | **License:** Apache 2.0
 
 > **Fix Receipts** (`/fix`) — new in 11.2.0. Say `fix this and
 > prove it`.

--- a/plugin/core/__init__.py
+++ b/plugin/core/__init__.py
@@ -5,4 +5,4 @@ This module provides the core workflow functionality when the full
 attune-ai package is not installed via pip.
 """
 
-__version__ = "15.1.0"
+__version__ = "16.0.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "attune-ai"
-version = "15.1.0"
+version = "16.0.0"
 description = "Persistent memory and receipt-verified workflows for Claude Code — plugin, MCP server, and spec-driven dev framework."
 readme = {file = "README.md", content-type = "text/markdown"}
 requires-python = ">=3.10"

--- a/scripts/release_artifact_smoke.py
+++ b/scripts/release_artifact_smoke.py
@@ -1,0 +1,124 @@
+"""Clean-room artifact smoke gate (release-execute step 9).
+
+Run INSIDE a pristine venv where attune-ai was installed from the built
+artifact (wheel or sdist), with cwd OUTSIDE any repo checkout, e.g.:
+
+    uv build --out-dir /tmp/dist
+    python -m venv /tmp/smoke && /tmp/smoke/bin/pip install /tmp/dist/*.whl
+    cd /tmp && env -i PATH=/usr/bin:/bin /tmp/smoke/bin/python \
+        scripts/release_artifact_smoke.py <expected-version>
+
+Why it exists (round-table q-16-release-reliability-001, unanimous,
+2026-08-27): every other release receipt runs against the SOURCE TREE,
+and editable installs can resurrect deleted modules from a sibling
+checkout — so only an install of the built artifact into a clean venv
+tests what a user actually gets. The removal baselines below are the
+16.0.0 deletions; APPEND to them at future majors, never rewrite.
+
+Post-publish rider: re-run this against the artifact installed FROM
+PYPI, not just the locally built one.
+"""
+
+import importlib
+import importlib.metadata as ilmd
+import sys
+
+failures: list[str] = []
+
+# 0. Provenance: attune must resolve from site-packages, not a repo tree.
+import attune  # noqa: E402
+
+if "site-packages" not in (attune.__file__ or ""):
+    failures.append(f"attune resolves outside site-packages: {attune.__file__}")
+
+print(f"attune {attune.__version__} from {attune.__file__}")
+EXPECTED = sys.argv[1] if len(sys.argv) > 1 else "16.0.0"
+if attune.__version__ != EXPECTED:
+    failures.append(f"version is {attune.__version__}, expected {EXPECTED}")
+
+# 1. Deleted modules and shims must be genuinely gone.
+DEAD = [
+    "attune.discovery",
+    "attune.pattern_cache",
+    "attune.cache_stats",
+    "attune.cache_monitor",
+    "attune.vscode_bridge",
+    "attune.template_engine",
+    "attune.template_defs_basic",
+    "attune.template_defs_web",
+    "attune.templates",
+    "attune.coordination",
+    "attune.persistence",
+    "attune.state_manager",
+    "attune.redis_memory",
+    "attune.redis_memory_storage",
+    "attune.redis_memory_coordination",
+    "attune.redis_memory_patterns",
+]
+for mod in DEAD:
+    try:
+        importlib.import_module(mod)
+        failures.append(f"RESURRECTED: {mod} imports from the artifact")
+    except ModuleNotFoundError:
+        pass
+
+# 2. Deleted aliases must raise AttributeError.
+for modpath, attr in [
+    ("attune.config", "AgentWorkflowConfig"),
+    ("attune.config", "WorkflowMode"),
+    ("attune.config.sections", "WorkflowConfig"),
+    ("attune.agent_factory", "WorkflowConfig"),
+]:
+    m = importlib.import_module(modpath)
+    try:
+        getattr(m, attr)
+        failures.append(f"ALIAS ALIVE: {modpath}.{attr}")
+    except AttributeError:
+        pass
+
+# 3. Retained surfaces load: bundled attune_redis, memory backends seam.
+import attune_redis  # noqa: E402,F401
+
+eps = {ep.name for ep in ilmd.entry_points(group="attune.memory_backends")}
+if eps != {"file", "redis"}:
+    failures.append(f"memory_backends entry points: {sorted(eps)}")
+
+# 4. Collapsed groups must be absent from the artifact metadata.
+for group in ("attune.plugins", "attune.wizards", "attune.workflows"):
+    stale = [
+        ep.name for ep in ilmd.entry_points(group=group) if ep.dist and ep.dist.name == "attune-ai"
+    ]
+    if stale:
+        failures.append(f"stale entry points in {group}: {stale}")
+
+# 5. Behavioral enumeration parity (must match the source-tree receipt).
+from attune.wizards.registry import list_wizards  # noqa: E402
+
+wiz = sorted(w.wizard_id for w in list_wizards())
+if wiz != ["debug", "refactor", "release-prep", "security", "test-gen"]:
+    failures.append(f"wizards: {wiz}")
+
+from attune.plugins.registry import get_global_registry  # noqa: E402
+
+reg = get_global_registry()
+plugs = sorted(reg._plugins)
+if plugs != ["redis", "software"]:
+    failures.append(f"plugins: {plugs}")
+
+# 6. Public lazy exports repointed in the wheel.
+for name in ("MetricsCollector", "PatternPersistence"):
+    getattr(attune, name)
+for gone in ("StateManager",):
+    try:
+        getattr(attune, gone)
+        failures.append(f"export alive: attune.{gone}")
+    except AttributeError:
+        pass
+
+print()
+if failures:
+    print("SMOKE FAILURES:")
+    for f in failures:
+        print(" -", f)
+    sys.exit(1)
+print("CLEAN-ROOM SMOKE: all checks passed")

--- a/uv.lock
+++ b/uv.lock
@@ -299,7 +299,7 @@ wheels = [
 
 [[package]]
 name = "attune-ai"
-version = "15.1.0"
+version = "16.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "agent-memory-client" },

--- a/website/app/page.tsx
+++ b/website/app/page.tsx
@@ -38,7 +38,7 @@ export default function Home() {
                 test_homepage_badge_includes_package_version guard scans
                 this file for vX.Y.Z and compares it to the package. */}
             <div className="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-[var(--surface-container-high)] text-[var(--primary)] text-xs font-bold tracking-widest mb-8 uppercase">
-              <span>v15.1.0</span>
+              <span>v16.0.0</span>
               <span className="w-1 h-1 rounded-full bg-[var(--primary)]" aria-hidden="true"></span>
               <span className="opacity-80">Persistent memory for AI coding agents</span>
             </div>

--- a/website/lib/features.ts
+++ b/website/lib/features.ts
@@ -85,7 +85,7 @@ export const PRODUCTS: Product[] = [
     id: "attune-ai",
     name: "Attune AI",
     pypiName: "attune-ai",
-    version: "15.1.0",
+    version: "16.0.0",
     tagline: "Generate, maintain, and serve help from your code",
     installCommand: "pip install attune-ai",
     marketplaceInstall:
@@ -129,7 +129,7 @@ export const PRODUCTS: Product[] = [
     id: "claude-code-plugin",
     name: "Claude Code Plugin",
     pypiName: "attune-ai",
-    version: "15.1.0",
+    version: "16.0.0",
     tagline: "Progressive help right in your terminal",
     installCommand:
       "claude plugin marketplace add Smart-AI-Memory/attune-ai",


### PR DESCRIPTION
Release prep for **16.0.0**, the destructive half of the harness-lite architecture ruling (release-16-manifest D1). Carries: version bump (all sites via `bump_version.py`), changelog promotion with release intro, `docs/migration/upgrading-to-16.0.0.md` (one grep answers 'does this touch me'; records the redis_memory stale-promise supersession the D11 lane flagged), `uv.lock` (version line only), and manifest passenger statuses flipped to shipped.

Content shipped by #2331 / #2333 / #2334, all merged with full-tree receipts and D11 lanes. The constructive half (extension system) is deliberately absent — 16.x, pending the chair's D2 ruling.

Post-merge sequence: `/attune-release-check` + recall gate → verify content in merge SHA → tag → **manual pypi gate (Patrick's click)** → simple-index verify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)