### PR TITLE
feat(roundtable): add 'receipt' message kind to the board allowlist

### DIFF
--- a/src/attune/roundtable/board.py
+++ b/src/attune/roundtable/board.py
@@ -31,7 +31,8 @@ from typing import Any
 #: member-originated ``question``/``suggestion`` as first-class;
 #: V2-P4 adds ``event`` — append-only role-provenance events, RR-1 —
 #: and ``candidate`` — staged promotable items from producing runs,
-#: RR-6).
+#: RR-6; ``receipt`` is moderator-posted evidence that a promoted or
+#: agreed action was executed).
 KINDS: tuple[str, ...] = (
     "question",
     "position",
@@ -41,6 +42,7 @@ KINDS: tuple[str, ...] = (
     "halt",
     "event",
     "candidate",
+    "receipt",
 )
 
 #: Every board key lives under this prefix (R3).
@@ -69,7 +71,7 @@ LIBRARY_SOURCE = """#!lua name=attune_roundtable
 local KINDS = {
   question = true, position = true, synthesis = true,
   ruling = true, suggestion = true, halt = true,
-  event = true, candidate = true,
+  event = true, candidate = true, receipt = true,
 }
 
 local function validate(msg)
@@ -81,7 +83,8 @@ local function validate(msg)
   end
   if type(msg.kind) ~= 'string' or not KINDS[msg.kind] then
     return 'kind is required and must be one of: ' ..
-      'question|position|synthesis|ruling|suggestion|halt'
+      'question|position|synthesis|ruling|suggestion|halt|' ..
+      'event|candidate|receipt'
   end
   if type(msg.body) ~= 'string' or #msg.body == 0 then
     return 'body is required'

--- a/tests/unit/roundtable/test_board.py
+++ b/tests/unit/roundtable/test_board.py
@@ -59,7 +59,8 @@ def _fresh_thread() -> str:
 
 class TestSchemaAndKeys:
     def test_kinds_cover_spec_enum(self) -> None:
-        # question..halt: P0 enum; event + candidate: V2-P4 (RR-1/RR-6).
+        # question..halt: P0 enum; event + candidate: V2-P4 (RR-1/RR-6);
+        # receipt: moderator-posted execution evidence (2026-08-27).
         assert set(KINDS) == {
             "question",
             "position",
@@ -69,7 +70,16 @@ class TestSchemaAndKeys:
             "halt",
             "event",
             "candidate",
+            "receipt",
         }
+
+    def test_lua_allowlist_admits_every_python_kind(self) -> None:
+        # The Lua KINDS table is the enforcing copy (AC-1); pin it to
+        # the Python tuple so the two allowlists cannot drift.
+        from attune.roundtable.board import LIBRARY_SOURCE
+
+        for kind in KINDS:
+            assert f"{kind} = true" in LIBRARY_SOURCE
 
     def test_thread_key_uses_board_keyspace(self) -> None:
         assert Board.thread_key("t1") == THREAD_KEY_PREFIX + "t1"
@@ -145,6 +155,21 @@ class TestAgainstRealRedis:
         assert [m.id for m in msgs] == [id1, id2]
         assert msgs[0].ts is not None
         assert msgs[1].reply_to == id1
+
+    def test_receipt_kind_accepted_unknown_kind_rejected(self) -> None:
+        """The server-side allowlist admits ``receipt``; unknown kinds
+        (e.g. the ``note`` mislabel hit live 2026-08-27) still raise."""
+        redis = pytest.importorskip("redis")
+        board = _real_board_or_skip()
+        thread = _fresh_thread()
+        msg_id = board.post_message(
+            thread, author="claude@moderator", kind="receipt", body="executed: PR merged"
+        )
+        msgs = board.read_thread(thread)
+        assert [m.id for m in msgs] == [msg_id]
+        assert msgs[0].kind == "receipt"
+        with pytest.raises(redis.ResponseError, match="must be one of"):
+            board.post_message(thread, author="claude@moderator", kind="note", body="x")
 
     def test_ac1_malformed_message_rejected_atomically(self) -> None:
         """AC-1: server-side rejection, no partial write."""


### PR DESCRIPTION
## What

Adds a `receipt` message kind — moderator-posted evidence that a promoted/agreed action was executed — to the roundtable board's allowlist, in both places it lives:

- Python `KINDS` tuple in `src/attune/roundtable/board.py`
- Lua `KINDS` table in the `attune_roundtable` function library that `Board.ensure_functions()` installs

Also brings the Lua rejection message up to date: it still enumerated only the original six kinds, omitting `event` and `candidate`.

## Why

Hit live 2026-08-27 on thread `q-16-release-reliability-001`: the moderator tried to post an execution receipt as `kind='note'`, was rejected by `rt_post_message`, and had to mislabel it `'synthesis'`.

## Tests

- `test_kinds_cover_spec_enum` updated to include `receipt`
- New `test_lua_allowlist_admits_every_python_kind` (keyless — pins the Lua table to the Python tuple so the two allowlists cannot drift)
- New `test_receipt_kind_accepted_unknown_kind_rejected` (real Redis — receipt round-trips, `note` still rejected)

## Receipts

- Suite: `pytest tests/unit/roundtable/test_board.py` serially — 11 passed, 11 skipped (real-Redis lanes skip here: the test helper's bare `redis://localhost:6379/0` URL hits requirepass — pre-existing)
- Live-fire (non-mocked round trip via `Board()` + `resolve_redis_connection()` against the live authenticated Redis): `receipt` accepted (id assigned, read back), `kind='note'` rejected with `must be one of: question|position|synthesis|ruling|suggestion|halt|event|candidate|receipt`; scratch thread deleted. Updated library is now loaded live.

SKILL.md untouched — it does not enumerate the kind allowlist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
