### PR TITLE
feat: warn on stale external attune.plugins/attune.wizards entry points (16.0.x)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Stale entry-point detector**: at the plugin/wizard registries'
+  first load, attune scans installed distribution metadata once per
+  process and logs one warning per external package still declaring
+  entries in the removed `attune.plugins` / `attune.wizards` groups,
+  pointing at `docs/migration/upgrading-to-16.0.0.md`. Without it,
+  such extensions fail by silent non-loading with nothing greppable
+  in the user's own code. The scan is cached and fail-open — a
+  metadata error never affects startup.
+
 ## [16.0.0] - 2026-08-27
 
 16.0.0 is the destructive half of the harness-lite architecture

--- a/docs/migration/upgrading-to-16.0.0.md
+++ b/docs/migration/upgrading-to-16.0.0.md
@@ -48,8 +48,19 @@ The `attune.plugins` and `attune.wizards` entry-point groups are no
 longer read; the dead `attune.workflows` reading path is deleted. The
 bundled plugins and built-in wizards load directly. If you registered
 an external wizard or plugin via these groups, that path is gone —
-the 16.x extension system is the successor. Two things still work
-unchanged:
+the 16.x extension system is the successor.
+
+Because an unread entry point fails by *silent non-loading* (nothing
+in your own code errors), attune detects this at startup: if any
+installed package other than attune-ai still declares entries in
+these groups, the first plugin/wizard registry load logs one warning
+per package, naming it and pointing here. The scan runs once per
+process and is fail-open — a metadata error never affects startup.
+Until you migrate, Python wizard classes can be re-registered at
+runtime with `attune.wizards.registry.register_wizard()`, and plugin
+instances with `PluginRegistry.register_plugin()`.
+
+Two things still work unchanged:
 
 - **`attune.memory_backends`** — the one entry-point seam kept
   (custom memory backends keep working as before).

--- a/src/attune/plugins/registry.py
+++ b/src/attune/plugins/registry.py
@@ -59,6 +59,12 @@ class PluginRegistry:
         if self._auto_discovered:
             return
 
+        # One-time advisory scan for external dists still registering
+        # the entry-point groups 16.0.0 collapsed (silent non-loading).
+        from .stale_entry_points import warn_stale_entry_points
+
+        warn_stale_entry_points()
+
         self.logger.info("Loading built-in plugins...")
 
         # Build or reuse the discovery cache

--- a/src/attune/plugins/stale_entry_points.py
+++ b/src/attune/plugins/stale_entry_points.py
@@ -1,0 +1,92 @@
+"""Detect stale external ``attune.plugins`` / ``attune.wizards`` entries.
+
+16.0.0 collapsed both entry-point groups to direct registration
+(release-16-manifest D1), so a third-party distribution that still
+declares entries in them fails by SILENT non-loading — nothing in the
+user's own code is greppable, so the migration guide cannot reach them.
+This module is the cheap detector the 16.0 round table ratified: one
+scan of installed distribution metadata at startup, one warning line
+per offending distribution, pointing at the migration guide.
+
+Copyright 2026 Smart AI Memory, LLC
+Licensed under the Apache License, Version 2.0
+"""
+
+from __future__ import annotations
+
+import logging
+from importlib import metadata
+
+logger = logging.getLogger(__name__)
+
+#: Entry-point groups collapsed in 16.0.0. ``attune.memory_backends``
+#: (the one seam the architecture ruling keeps) is deliberately absent.
+STALE_GROUPS: frozenset[str] = frozenset({"attune.plugins", "attune.wizards"})
+
+MIGRATION_GUIDE = "docs/migration/upgrading-to-16.0.0.md"
+
+# Once-per-process guard: the scan runs at most once, however many
+# registries call in.
+_scan_done = False
+
+
+def _normalize(dist_name: str) -> str:
+    """Normalize a distribution name per PEP 503."""
+    return dist_name.strip().lower().replace("_", "-")
+
+
+def _find_stale_distributions() -> dict[str, list[str]]:
+    """Map external dist name -> sorted stale groups it still declares.
+
+    Iterates installed distributions directly (rather than
+    ``metadata.entry_points(group=...)``) so the owning distribution's
+    name is available uniformly across supported Python versions.
+    attune-ai itself is skipped — its own groups are pinned absent from
+    pyproject by a drift guard, and its dist is never the audience.
+    """
+    stale: dict[str, set[str]] = {}
+    for dist in metadata.distributions():
+        name = dist.metadata["Name"] or ""
+        if not name or _normalize(name) == "attune-ai":
+            continue
+        groups = {ep.group for ep in dist.entry_points} & STALE_GROUPS
+        if groups:
+            stale.setdefault(name, set()).update(groups)
+    return {name: sorted(groups) for name, groups in stale.items()}
+
+
+def warn_stale_entry_points() -> None:
+    """Warn once per process about stale external entry-point registrations.
+
+    Called from the plugin and wizard registries' first load. Fail-open
+    by contract: a metadata scan error is debug-logged and swallowed —
+    the warning is best-effort advice and must never affect startup.
+    """
+    global _scan_done
+    if _scan_done:
+        return
+    _scan_done = True
+
+    try:
+        stale = _find_stale_distributions()
+    except Exception:  # noqa: BLE001
+        # INTENTIONAL fail-open: reading arbitrary installed packages'
+        # metadata can raise anything; startup must not care.
+        logger.debug("Stale entry-point scan failed; skipping", exc_info=True)
+        return
+
+    for dist_name in sorted(stale):
+        logger.warning(
+            "Package '%s' registers entry points in %s, which attune-ai "
+            "16.0.0 no longer loads — its plugins/wizards are silently "
+            "ignored. See %s.",
+            dist_name,
+            ", ".join(f"'{g}'" for g in stale[dist_name]),
+            MIGRATION_GUIDE,
+        )
+
+
+def _reset_scan_cache() -> None:
+    """Reset the once-per-process guard (test hook)."""
+    global _scan_done
+    _scan_done = False

--- a/src/attune/wizards/registry.py
+++ b/src/attune/wizards/registry.py
@@ -1,7 +1,7 @@
 """Wizard registry and discovery.
 
-Maintains a registry of wizard classes, supports both programmatic
-registration, entry-point-based auto-discovery, and custom YAML wizards.
+Maintains a registry of wizard classes, supports programmatic
+registration, built-in loading, and custom YAML wizards.
 
 Copyright 2026 Smart-AI-Memory
 Licensed under Apache 2.0
@@ -51,7 +51,7 @@ def get_wizard(wizard_id: str) -> type[BaseWizard] | None:
     """Get a wizard class by ID.
 
     Checks the in-memory registry first, then falls back to
-    entry-point discovery, built-in loading, and custom YAML loading.
+    built-in loading and custom YAML loading.
 
     Args:
         wizard_id: Short identifier.
@@ -63,7 +63,7 @@ def get_wizard(wizard_id: str) -> type[BaseWizard] | None:
     if wizard_id in _WIZARD_REGISTRY:
         return _WIZARD_REGISTRY[wizard_id]
 
-    # Try entry point discovery and built-in loading
+    # Try built-in loading and custom YAML loading
     _load_builtins()
     _load_custom_wizards()
     return _WIZARD_REGISTRY.get(wizard_id)
@@ -188,6 +188,12 @@ def _load_builtins() -> None:
     """Load built-in wizards into the registry if not already loaded."""
     if "debug" in _WIZARD_REGISTRY:
         return  # Already loaded
+
+    # One-time advisory scan for external dists still registering the
+    # entry-point groups 16.0.0 collapsed (silent non-loading).
+    from attune.plugins.stale_entry_points import warn_stale_entry_points
+
+    warn_stale_entry_points()
 
     try:
         from .builtin import BUILTIN_WIZARDS

--- a/tests/unit/gates/test_broad_except_ratchet.py
+++ b/tests/unit/gates/test_broad_except_ratchet.py
@@ -280,6 +280,11 @@ _BASELINE: dict[str, int] = {
     "src/attune/patterns/resolver.py": 1,
     "src/attune/pipeline/orchestrator.py": 3,
     "src/attune/plugins/registry.py": 3,
+    # stale_entry_points.py added at 1 (2026-08-27): the 16.0.0 stale
+    # entry-point detector is fail-open by contract — reading arbitrary
+    # installed packages' metadata can raise anything, and the advisory
+    # scan must never affect startup.
+    "src/attune/plugins/stale_entry_points.py": 1,
     "src/attune/project_index/index.py": 1,
     "src/attune/redis_config.py": 1,
     "src/attune/resilience/circuit_breaker.py": 2,

--- a/tests/unit/plugins/test_stale_entry_points.py
+++ b/tests/unit/plugins/test_stale_entry_points.py
@@ -1,0 +1,210 @@
+# Licensed under the Apache License, Version 2.0
+# Copyright 2026 Smart AI Memory, LLC
+"""Tests for the 16.0.0 stale entry-point detector.
+
+The detector's contract (round-table q-16-release-reliability-001):
+one cached metadata scan per process, one warning line per external
+distribution still declaring ``attune.plugins`` / ``attune.wizards``
+entries, fail-open on any scan error.
+"""
+
+from __future__ import annotations
+
+import logging
+from types import SimpleNamespace
+
+import pytest
+
+from attune.plugins import stale_entry_points as sep
+
+
+def _dist(name: str | None, *groups: str) -> SimpleNamespace:
+    """Build a minimal fake distribution with one entry per group."""
+    return SimpleNamespace(
+        metadata={"Name": name},
+        entry_points=[
+            SimpleNamespace(group=group, name=f"ep-{i}") for i, group in enumerate(groups)
+        ],
+    )
+
+
+@pytest.fixture(autouse=True)
+def _fresh_scan_cache():
+    """Each test starts with the once-per-process guard cleared."""
+    sep._reset_scan_cache()
+    yield
+    sep._reset_scan_cache()
+
+
+def test_warns_once_per_external_dist(monkeypatch, caplog):
+    monkeypatch.setattr(
+        sep.metadata,
+        "distributions",
+        lambda: iter(
+            [
+                _dist("legacy-plugin-pkg", "attune.plugins"),
+                _dist("legacy-wizard-pkg", "attune.wizards", "console_scripts"),
+                _dist("unrelated-pkg", "console_scripts"),
+            ]
+        ),
+    )
+    with caplog.at_level(logging.WARNING, logger=sep.logger.name):
+        sep.warn_stale_entry_points()
+
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert len(warnings) == 2
+    messages = [r.getMessage() for r in warnings]
+    assert any("legacy-plugin-pkg" in m and "'attune.plugins'" in m for m in messages)
+    assert any("legacy-wizard-pkg" in m and "'attune.wizards'" in m for m in messages)
+    assert all(sep.MIGRATION_GUIDE in m for m in messages)
+    assert not any("unrelated-pkg" in m for m in messages)
+
+
+def test_one_line_per_dist_merges_both_groups(monkeypatch, caplog):
+    monkeypatch.setattr(
+        sep.metadata,
+        "distributions",
+        lambda: iter([_dist("double-pkg", "attune.plugins", "attune.wizards")]),
+    )
+    with caplog.at_level(logging.WARNING, logger=sep.logger.name):
+        sep.warn_stale_entry_points()
+
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert len(warnings) == 1
+    message = warnings[0].getMessage()
+    assert "'attune.plugins', 'attune.wizards'" in message
+
+
+def test_attune_ai_own_dist_is_skipped(monkeypatch, caplog):
+    monkeypatch.setattr(
+        sep.metadata,
+        "distributions",
+        lambda: iter(
+            [
+                _dist("attune-ai", "attune.plugins"),
+                _dist("Attune_AI", "attune.wizards"),  # normalization variant
+            ]
+        ),
+    )
+    with caplog.at_level(logging.WARNING, logger=sep.logger.name):
+        sep.warn_stale_entry_points()
+
+    assert not [r for r in caplog.records if r.levelno == logging.WARNING]
+
+
+def test_nameless_dist_is_skipped(monkeypatch, caplog):
+    monkeypatch.setattr(
+        sep.metadata,
+        "distributions",
+        lambda: iter([_dist(None, "attune.plugins")]),
+    )
+    with caplog.at_level(logging.WARNING, logger=sep.logger.name):
+        sep.warn_stale_entry_points()
+
+    assert not [r for r in caplog.records if r.levelno == logging.WARNING]
+
+
+def test_quiet_when_nothing_stale(monkeypatch, caplog):
+    monkeypatch.setattr(
+        sep.metadata,
+        "distributions",
+        lambda: iter([_dist("clean-pkg", "console_scripts")]),
+    )
+    with caplog.at_level(logging.WARNING, logger=sep.logger.name):
+        sep.warn_stale_entry_points()
+
+    assert not [r for r in caplog.records if r.levelno == logging.WARNING]
+
+
+def test_fail_open_on_scan_error(monkeypatch, caplog):
+    def _boom():
+        raise RuntimeError("corrupt metadata")
+
+    monkeypatch.setattr(sep.metadata, "distributions", _boom)
+    with caplog.at_level(logging.DEBUG, logger=sep.logger.name):
+        sep.warn_stale_entry_points()  # must not raise
+
+    assert not [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert any("skipping" in r.getMessage() for r in caplog.records)
+
+
+def test_scan_runs_once_per_process(monkeypatch):
+    calls = []
+
+    def _counting():
+        calls.append(1)
+        return iter([])
+
+    monkeypatch.setattr(sep.metadata, "distributions", _counting)
+    sep.warn_stale_entry_points()
+    sep.warn_stale_entry_points()
+    sep.warn_stale_entry_points()
+
+    assert len(calls) == 1
+
+
+def test_fail_open_result_is_also_cached(monkeypatch):
+    """A failed scan is not retried — the guard flips before the scan."""
+    calls = []
+
+    def _boom():
+        calls.append(1)
+        raise RuntimeError("corrupt metadata")
+
+    monkeypatch.setattr(sep.metadata, "distributions", _boom)
+    sep.warn_stale_entry_points()
+    sep.warn_stale_entry_points()
+
+    assert len(calls) == 1
+
+
+def test_real_metadata_round_trip(tmp_path, monkeypatch, caplog):
+    """Non-mocked round trip: a real dist-info on sys.path is detected.
+
+    Exercises the actual importlib.metadata boundary instead of fakes —
+    the scan must find a genuine ``*.dist-info`` declaring a collapsed
+    group, exactly as pip would have installed it.
+    """
+    dist_info = tmp_path / "legacy_ext-1.0.dist-info"
+    dist_info.mkdir()
+    (dist_info / "METADATA").write_text(
+        "Metadata-Version: 2.1\nName: legacy-ext\nVersion: 1.0\n",
+        encoding="utf-8",
+    )
+    (dist_info / "entry_points.txt").write_text(
+        "[attune.plugins]\nlegacy = legacy_ext:Plugin\n",
+        encoding="utf-8",
+    )
+    monkeypatch.syspath_prepend(str(tmp_path))
+
+    with caplog.at_level(logging.WARNING, logger=sep.logger.name):
+        sep.warn_stale_entry_points()
+
+    messages = [r.getMessage() for r in caplog.records if r.levelno == logging.WARNING]
+    assert any(
+        "legacy-ext" in m and "'attune.plugins'" in m and sep.MIGRATION_GUIDE in m for m in messages
+    )
+
+
+def test_plugin_registry_auto_discover_triggers_scan(monkeypatch):
+    """The plugin registry's first load runs the detector."""
+    from attune.plugins import registry as plugin_registry
+
+    calls = []
+    monkeypatch.setattr(sep, "warn_stale_entry_points", lambda: calls.append(1))
+    reg = plugin_registry.PluginRegistry()
+    reg.auto_discover()
+
+    assert calls == [1]
+
+
+def test_wizard_builtin_load_triggers_scan(monkeypatch):
+    """The wizard registry's built-in load runs the detector."""
+    from attune.wizards import registry as wizard_registry
+
+    calls = []
+    monkeypatch.setattr(sep, "warn_stale_entry_points", lambda: calls.append(1))
+    monkeypatch.setattr(wizard_registry, "_WIZARD_REGISTRY", {})
+    wizard_registry._load_builtins()
+
+    assert calls == [1]


### PR DESCRIPTION
## What

The cheap detector the round table ratified (thread
q-16-release-reliability-001): 16.0.0 collapsed the `attune.plugins`
and `attune.wizards` entry-point groups (release-16-manifest D1, #2334),
so anyone who registered external plugins/wizards through them now fails
by **silent non-loading** — nothing greppable in their own code, so the
migration guide cannot reach them. attune now tells them at startup.

## How

- **`attune.plugins.stale_entry_points`** — one scan of installed
  distribution metadata per process (module-level guard; a failed scan
  is also cached), one warning line per external dist naming the dist
  and the stale group(s), pointing at
  `docs/migration/upgrading-to-16.0.0.md`. Iterates
  `importlib.metadata.distributions()` directly so the owning dist's
  name is available uniformly across Pythons; attune-ai's own dist is
  skipped (its groups are already pinned absent from pyproject by the
  drift guard).
- **Fail-open by contract**: the scan body is wrapped in
  `except Exception` → debug log + return. Broad-except ratchet
  baseline raised `src/attune/plugins/stale_entry_points.py: 1` with
  the reason inline (per the ratchet's escape-hatch protocol).
- **Wired at both once-per-process surfaces**: `PluginRegistry.
  auto_discover()` and the wizard registry's `_load_builtins()` — a
  wizard-only process still gets the warning; the guard prevents
  duplicates.
- **`docs/migration/upgrading-to-16.0.0.md` created** — the guide the
  warning cites did not exist yet (16.0.0 is still Unreleased); covers
  §1 entry-point collapse (the detector's audience) plus the alias and
  root-module removals from the CHANGELOG. No python/json fences with
  removed symbols, so the doc-import audit is unaffected.
- Cleaned three stale "entry-point discovery" comments in
  `wizards/registry.py` left behind by the collapse.

## Receipts

- **Suite**: `pytest tests` (whole tree, xdist) — 24,914 passed,
  259 skipped, 3 xfailed.
- **Unit**: 11 tests in `tests/unit/plugins/test_stale_entry_points.py`
  — per-dist warning, group merge into one line, own-dist +
  nameless-dist skip, quiet-when-clean, fail-open on scan error,
  once-per-process cache (including the failed-scan case), and both
  registry trigger paths. Includes a **non-mocked round trip**: a real
  `*.dist-info` (METADATA + entry_points.txt) on `sys.path`, detected
  through actual `importlib.metadata`.
- **Live-fire**: real process, real dist-info, two
  `PluginRegistry().auto_discover()` calls →

  ```
  WARNING attune.plugins.stale_entry_points: Package 'legacy-ext' registers entry points in 'attune.wizards', which attune-ai 16.0.0 no longer loads — its plugins/wizards are silently ignored. See docs/migration/upgrading-to-16.0.0.md.
  ```

  Exactly one line across both startups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
