### PR TITLE
feat(hooks): starter reconciler flags a stale release_state memory

### DIFF
--- a/src/attune/hooks/scripts/starter_reconciler.py
+++ b/src/attune/hooks/scripts/starter_reconciler.py
@@ -439,6 +439,48 @@ def pypi_latest(pkg: str) -> str | None:
         return None
 
 
+#: Where per-project Claude memories keep the release-state pointer.
+RELEASE_STATE_GLOB = ".claude/projects/*/memory/release_state.md"
+RELEASE_STATE_MAX_BYTES = 65536
+_RELEASE_HEADLINE_RE = re.compile(r"\*\*(\d+\.\d+\.\d+[^\s*]*) IS PUBLISHED")
+
+
+def release_state_headline(pkg: str | None, home: Path | None = None) -> str | None:
+    """Headline version from the newest release_state memory naming ``pkg``.
+
+    The release-state memory is supposed to be updated at every release
+    (release-execute step 14) but nothing noticed when sessions skipped
+    it — it sat two majors stale on 2026-08-27. Comparing its headline
+    against the PyPI latest the reconciler already fetches turns that
+    silent staleness into a startup banner. Local file reads only; the
+    memory layer is optional, so every failure path degrades to None.
+    """
+    if not pkg:
+        return None
+    try:
+        root = home or Path.home()
+        best: tuple[float, str] | None = None
+        for path in root.glob(RELEASE_STATE_GLOB):
+            try:
+                text = path.read_text(encoding="utf-8", errors="replace")
+            except OSError:
+                continue
+            text = text[:RELEASE_STATE_MAX_BYTES]
+            if pkg not in text:
+                continue
+            match = _RELEASE_HEADLINE_RE.search(text)
+            if not match:
+                continue
+            mtime = path.stat().st_mtime
+            if best is None or mtime > best[0]:
+                best = (mtime, match.group(1))
+        return best[1] if best else None
+    except Exception:  # noqa: BLE001
+        # INTENTIONAL: session start must never break on the optional
+        # memory layer (odd layouts, permissions, glob errors).
+        return None
+
+
 def reconcile(text: str, pkg: str | None, cwd: Path | None) -> dict:
     """Check every extracted thread concurrently under ``WALL_BUDGET``.
 
@@ -457,6 +499,7 @@ def reconcile(text: str, pkg: str | None, cwd: Path | None) -> dict:
         "pr_ceiling": None,
         # Local file reads — outside the network executor by design.
         "specs": check_specs(text, cwd),
+        "release_state": release_state_headline(pkg),
     }
     # Widening: a starter is also stale when newer PRs landed on main that
     # it never names. Only worth a git call if it names *any* PR (else
@@ -517,6 +560,26 @@ def _spec_lines(specs: dict[str, str]) -> list[str]:
     return lines
 
 
+def _pypi_lines(results: dict) -> list[str]:
+    """Banner lines for the PyPI version and release-state drift."""
+    pypi = results["pypi"]
+    if pypi is None:
+        return []
+    versions = results["versions"]
+    suffix = f" (starter mentions: {', '.join(versions)})" if versions else ""
+    pkg = results.get("pkg") or ""
+    label_pkg = f"PyPI {pkg}".rstrip()
+    lines = [f"  {label_pkg} latest={pypi}{suffix}"]
+    headline = results.get("release_state")
+    if headline is not None and headline != pypi:
+        lines.append(
+            f"  ⚠ release_state memory headlines {headline} but PyPI"
+            f" latest={pypi} — the memory missed a release"
+            " (release-execute step 14); update it"
+        )
+    return lines
+
+
 def format_banner(
     results: dict,
     label: str,
@@ -533,7 +596,6 @@ def format_banner(
     prs = results["prs"]
     branches = results["branches"]
     pypi = results["pypi"]
-    versions = results["versions"]
     newer = results.get("newer_merges") or []
     specs = results.get("specs") or {}
     if not prs and not branches and pypi is None and not newer and not specs and not header_lines:
@@ -556,11 +618,7 @@ def format_banner(
             " — work may have landed since it was written"
         )
     lines.extend(_spec_lines(specs))
-    if pypi is not None:
-        suffix = f" (starter mentions: {', '.join(versions)})" if versions else ""
-        pkg = results.get("pkg") or ""
-        label_pkg = f"PyPI {pkg}".rstrip()
-        lines.append(f"  {label_pkg} latest={pypi}{suffix}")
+    lines.extend(_pypi_lines(results))
     return "\n".join(lines)
 
 

--- a/tests/unit/gates/test_broad_except_ratchet.py
+++ b/tests/unit/gates/test_broad_except_ratchet.py
@@ -159,7 +159,11 @@ _BASELINE: dict[str, int] = {
     # is wrapped to exit 0 instead of crashing to a non-blocking 1.
     "src/attune/hooks/scripts/security_guard.py": 1,
     "src/attune/hooks/scripts/starter_prompt_nudge.py": 1,
-    "src/attune/hooks/scripts/starter_reconciler.py": 3,
+    # starter_reconciler raised 3 -> 4 for the release-state drift check
+    # (2026-08-27 retro item): the optional memory-layer read must never
+    # break session start — glob/permission/layout failures degrade to
+    # "no headline", matching the hook's every-failure-is-a-no-op contract.
+    "src/attune/hooks/scripts/starter_reconciler.py": 4,
     # telemetry_hook added 1 for library-review L2 (PR #2117): the
     # PostToolUse exit-0-always contract must survive a non-dict
     # payload reaching record_telemetry, not only OSError.

--- a/tests/unit/hooks/test_starter_reconciler.py
+++ b/tests/unit/hooks/test_starter_reconciler.py
@@ -211,6 +211,46 @@ class TestReconcile:
         assert results["pypi"] == "1.2.3"
 
 
+# --- release_state_headline() -----------------------------------------
+
+
+class TestReleaseStateHeadline:
+    def _seed(self, home, project, body):
+        d = home / ".claude" / "projects" / project / "memory"
+        d.mkdir(parents=True)
+        (d / "release_state.md").write_text(body, encoding="utf-8")
+
+    def test_reads_headline_version(self, hook_module, tmp_path):
+        self._seed(tmp_path, "-Users-x-attune-ai", "**16.0.0 IS PUBLISHED** attune-ai wheel")
+        assert hook_module.release_state_headline("attune-ai", home=tmp_path) == "16.0.0"
+
+    def test_none_when_pkg_absent_from_file(self, hook_module, tmp_path):
+        self._seed(tmp_path, "-Users-x-other", "**2.0.0 IS PUBLISHED** other-pkg")
+        assert hook_module.release_state_headline("attune-ai", home=tmp_path) is None
+
+    def test_none_when_no_memory_exists(self, hook_module, tmp_path):
+        assert hook_module.release_state_headline("attune-ai", home=tmp_path) is None
+
+    def test_none_for_empty_pkg(self, hook_module, tmp_path):
+        assert hook_module.release_state_headline("", home=tmp_path) is None
+
+    def test_newest_file_wins(self, hook_module, tmp_path):
+        import os
+
+        self._seed(tmp_path, "-Users-x-a", "**15.0.0 IS PUBLISHED** attune-ai")
+        self._seed(tmp_path, "-Users-x-b", "**16.0.0 IS PUBLISHED** attune-ai")
+        old = tmp_path / ".claude/projects/-Users-x-a/memory/release_state.md"
+        os.utime(old, (1, 1))
+        assert hook_module.release_state_headline("attune-ai", home=tmp_path) == "16.0.0"
+
+    def test_unreadable_file_degrades(self, hook_module, tmp_path, monkeypatch):
+        self._seed(tmp_path, "-Users-x-attune-ai", "**16.0.0 IS PUBLISHED** attune-ai")
+        monkeypatch.setattr(
+            hook_module.Path, "read_text", lambda *a, **k: (_ for _ in ()).throw(OSError("nope"))
+        )
+        assert hook_module.release_state_headline("attune-ai", home=tmp_path) is None
+
+
 # --- format_banner() --------------------------------------------------
 
 
@@ -233,6 +273,31 @@ class TestFormatBanner:
         assert "claude/foo gone" in out
         assert "PyPI attune-ai latest=9.0.0" in out
         assert "starter mentions: 9.0.0, 8.5.0" in out
+
+    def test_release_state_drift_warns(self, hook_module, tmp_path):
+        results = {
+            "prs": {},
+            "branches": {},
+            "pypi": "16.0.0",
+            "versions": [],
+            "pkg": "attune-ai",
+            "release_state": "14.1.0",
+        }
+        out = hook_module.format_banner(results, "global", tmp_path / "s.md")
+        assert "release_state memory headlines 14.1.0" in out
+        assert "latest=16.0.0" in out
+
+    def test_release_state_in_sync_is_silent(self, hook_module, tmp_path):
+        results = {
+            "prs": {},
+            "branches": {},
+            "pypi": "16.0.0",
+            "versions": [],
+            "pkg": "attune-ai",
+            "release_state": "16.0.0",
+        }
+        out = hook_module.format_banner(results, "global", tmp_path / "s.md")
+        assert "memory headlines" not in out
 
     def test_empty_package_has_no_double_space(self, hook_module, tmp_path):
         results = {


### PR DESCRIPTION
Retro item 2 from the 16.0.0 close-out (chair-ratified): the release-state memory sat **two majors stale** — the 15.x releases skipped checklist step 14 and nothing noticed until a human opened the file the day 16.0.0 shipped.

The session-start reconciler already fetches PyPI latest; it now also reads the newest `release_state.md` headline (`~/.claude/projects/*/memory/`, local reads, fail-open on every path — absence, permissions, odd layouts all degrade to silence) and prints one drift line when the memory and PyPI disagree:

```
⚠ release_state memory headlines 14.1.0 but PyPI latest=16.0.0 — the memory missed a release (release-execute step 14); update it
```

**Receipts:** 105 tests green (8 new: headline parse, pkg filter, newest-file-wins, fail-open, drift render + in-sync silence); live-fire on the real environment (in sync today → silent, exit 0); broad-except baseline 3→4 with reason (must-not-crash hook path); `format_banner` kept under the complexity ratchet by extracting `_pypi_lines`; full tree green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)