### PR TITLE
fix(security): verify bearer tokens on all 17 backend API routes

### DIFF
--- a/backend/api/analysis.py
+++ b/backend/api/analysis.py
@@ -7,13 +7,13 @@ Input validation and error handling included for security.
 from typing import Any
 
 from fastapi import APIRouter, Depends, File, HTTPException, UploadFile, status
-from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from pydantic import BaseModel, field_validator
 
 from services.empathy_service import EmpathyService
 
+from .deps import get_verified_principal
+
 router = APIRouter(prefix="/api/analysis", tags=["analysis"])
-security = HTTPBearer()
 
 
 def get_empathy_service() -> EmpathyService:
@@ -111,14 +111,14 @@ class SessionConfig(BaseModel):
 async def create_session(
     request: SessionConfig,
     service: EmpathyService = Depends(get_empathy_service),
-    credentials: HTTPAuthorizationCredentials = Depends(security),
+    principal: dict[str, Any] = Depends(get_verified_principal),
 ):
     """Create a new analysis session.
 
     Args:
         request: Session configuration
         service: EmpathyService instance
-        credentials: Bearer token
+        principal: Verified JWT payload of the authenticated caller
 
     Returns:
         Session ID and metadata
@@ -140,14 +140,14 @@ async def create_session(
 async def get_session(
     session_id: str,
     service: EmpathyService = Depends(get_empathy_service),
-    credentials: HTTPAuthorizationCredentials = Depends(security),
+    principal: dict[str, Any] = Depends(get_verified_principal),
 ):
     """Get analysis session results.
 
     Args:
         session_id: Session identifier
         service: EmpathyService instance
-        credentials: Bearer token
+        principal: Verified JWT payload of the authenticated caller
 
     Returns:
         Session results and status
@@ -163,14 +163,14 @@ async def get_session(
 async def analyze_project(
     request: ProjectAnalysisRequest,
     service: EmpathyService = Depends(get_empathy_service),
-    credentials: HTTPAuthorizationCredentials = Depends(security),
+    principal: dict[str, Any] = Depends(get_verified_principal),
 ):
     """Analyze an entire project.
 
     Args:
         request: Project analysis configuration
         service: EmpathyService instance
-        credentials: Bearer token
+        principal: Verified JWT payload of the authenticated caller
 
     Returns:
         Project analysis results
@@ -195,7 +195,7 @@ async def analyze_file(
     file: UploadFile = File(...),
     language: str = "python",
     service: EmpathyService = Depends(get_empathy_service),
-    credentials: HTTPAuthorizationCredentials = Depends(security),
+    principal: dict[str, Any] = Depends(get_verified_principal),
 ):
     """Analyze a single uploaded file.
 
@@ -203,7 +203,7 @@ async def analyze_file(
         file: Uploaded file (max 10MB)
         language: Programming language (python, javascript, typescript, java, go, rust)
         service: EmpathyService instance
-        credentials: Bearer token
+        principal: Verified JWT payload of the authenticated caller
 
     Returns:
         File analysis results
@@ -275,14 +275,14 @@ async def analyze_file(
 async def get_analysis_history(
     limit: int = 10,
     offset: int = 0,
-    credentials: HTTPAuthorizationCredentials = Depends(security),
+    principal: dict[str, Any] = Depends(get_verified_principal),
 ):
     """Get user's analysis history.
 
     Args:
         limit: Number of results to return (max 100, default 10)
         offset: Pagination offset (min 0)
-        credentials: Bearer token
+        principal: Verified JWT payload of the authenticated caller
 
     Returns:
         List of past analyses
@@ -325,13 +325,13 @@ async def get_analysis_history(
 @router.delete("/session/{session_id}")
 async def delete_session(
     session_id: str,
-    credentials: HTTPAuthorizationCredentials = Depends(security),
+    principal: dict[str, Any] = Depends(get_verified_principal),
 ):
     """Delete an analysis session.
 
     Args:
         session_id: Session identifier
-        credentials: Bearer token
+        principal: Verified JWT payload of the authenticated caller
 
     Returns:
         Deletion confirmation

--- a/backend/api/auth.py
+++ b/backend/api/auth.py
@@ -16,7 +16,7 @@ from fastapi import APIRouter, Depends, HTTPException, Request, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from pydantic import BaseModel, EmailStr
 
-from backend.services.auth_service import AuthService
+from services.auth_service import AuthService
 
 router = APIRouter(prefix="/api/auth", tags=["auth"])
 security = HTTPBearer()

--- a/backend/api/deps.py
+++ b/backend/api/deps.py
@@ -1,0 +1,39 @@
+"""Shared authentication dependencies for API routers.
+
+Every protected endpoint must depend on ``get_verified_principal`` —
+it both extracts the bearer token AND verifies it. A bare
+``Depends(HTTPBearer())`` only checks that the Authorization header is
+syntactically valid, so any forged token would authenticate.
+
+Copyright 2025 Smart-AI-Memory
+Licensed under the Apache License, Version 2.0
+"""
+
+from typing import Any
+
+from fastapi import Depends
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+
+security = HTTPBearer()
+
+
+async def get_verified_principal(
+    credentials: HTTPAuthorizationCredentials = Depends(security),
+) -> dict[str, Any]:
+    """Extract and verify the bearer token, returning the decoded principal.
+
+    Args:
+        credentials: Bearer token from the Authorization header
+
+    Returns:
+        Decoded JWT payload (sub, user_id, name, exp, iat)
+
+    Raises:
+        HTTPException 401: If the token is invalid, expired, or forged
+
+    """
+    # Imported lazily so routers that share this dependency do not pull
+    # the auth service (jwt/bcrypt/database) into their import graph.
+    from .auth import get_auth_service
+
+    return get_auth_service().verify_token(credentials.credentials)

--- a/backend/api/subscriptions.py
+++ b/backend/api/subscriptions.py
@@ -2,12 +2,14 @@
 Handles license purchases, subscriptions, and team management.
 """
 
+from typing import Any
+
 from fastapi import APIRouter, Depends
-from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from pydantic import BaseModel, EmailStr
 
+from .deps import get_verified_principal
+
 router = APIRouter(prefix="/api/subscriptions", tags=["subscriptions"])
-security = HTTPBearer()
 
 
 class PurchaseRequest(BaseModel):
@@ -26,11 +28,11 @@ class TeamMemberRequest(BaseModel):
 
 
 @router.get("/")
-async def get_subscriptions(credentials: HTTPAuthorizationCredentials = Depends(security)):
+async def get_subscriptions(principal: dict[str, Any] = Depends(get_verified_principal)):
     """Get user's active subscriptions.
 
     Args:
-        credentials: Bearer token
+        principal: Verified JWT payload of the authenticated caller
 
     Returns:
         List of active subscriptions
@@ -55,13 +57,13 @@ async def get_subscriptions(credentials: HTTPAuthorizationCredentials = Depends(
 @router.post("/purchase")
 async def purchase_subscription(
     request: PurchaseRequest,
-    credentials: HTTPAuthorizationCredentials = Depends(security),
+    principal: dict[str, Any] = Depends(get_verified_principal),
 ):
     """Purchase a new subscription or additional licenses.
 
     Args:
         request: Purchase details
-        credentials: Bearer token
+        principal: Verified JWT payload of the authenticated caller
 
     Returns:
         Purchase confirmation and license keys
@@ -81,11 +83,11 @@ async def purchase_subscription(
 
 
 @router.get("/team")
-async def get_team_members(credentials: HTTPAuthorizationCredentials = Depends(security)):
+async def get_team_members(principal: dict[str, Any] = Depends(get_verified_principal)):
     """Get team members for organization subscription.
 
     Args:
-        credentials: Bearer token
+        principal: Verified JWT payload of the authenticated caller
 
     Returns:
         List of team members
@@ -110,13 +112,13 @@ async def get_team_members(credentials: HTTPAuthorizationCredentials = Depends(s
 @router.post("/team/members")
 async def add_team_member(
     request: TeamMemberRequest,
-    credentials: HTTPAuthorizationCredentials = Depends(security),
+    principal: dict[str, Any] = Depends(get_verified_principal),
 ):
     """Add a new team member.
 
     Args:
         request: Team member details
-        credentials: Bearer token
+        principal: Verified JWT payload of the authenticated caller
 
     Returns:
         Added team member info
@@ -132,13 +134,13 @@ async def add_team_member(
 @router.delete("/team/members/{user_id}")
 async def remove_team_member(
     user_id: str,
-    credentials: HTTPAuthorizationCredentials = Depends(security),
+    principal: dict[str, Any] = Depends(get_verified_principal),
 ):
     """Remove a team member.
 
     Args:
         user_id: User ID to remove
-        credentials: Bearer token
+        principal: Verified JWT payload of the authenticated caller
 
     Returns:
         Removal confirmation
@@ -148,11 +150,11 @@ async def remove_team_member(
 
 
 @router.get("/licenses")
-async def get_licenses(credentials: HTTPAuthorizationCredentials = Depends(security)):
+async def get_licenses(principal: dict[str, Any] = Depends(get_verified_principal)):
     """Get license information for the user's account.
 
     Args:
-        credentials: Bearer token
+        principal: Verified JWT payload of the authenticated caller
 
     Returns:
         License details
@@ -178,13 +180,13 @@ async def get_licenses(credentials: HTTPAuthorizationCredentials = Depends(secur
 @router.post("/licenses/{license_id}/deactivate")
 async def deactivate_license(
     license_id: str,
-    credentials: HTTPAuthorizationCredentials = Depends(security),
+    principal: dict[str, Any] = Depends(get_verified_principal),
 ):
     """Deactivate a license from a machine.
 
     Args:
         license_id: License ID to deactivate
-        credentials: Bearer token
+        principal: Verified JWT payload of the authenticated caller
 
     Returns:
         Deactivation confirmation

--- a/backend/api/users.py
+++ b/backend/api/users.py
@@ -5,11 +5,11 @@ Handles user profile management and settings.
 from typing import Any
 
 from fastapi import APIRouter, Depends
-from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from pydantic import BaseModel, EmailStr
 
+from .deps import get_verified_principal
+
 router = APIRouter(prefix="/api/users", tags=["users"])
-security = HTTPBearer()
 
 
 class UpdateProfileRequest(BaseModel):
@@ -21,11 +21,11 @@ class UpdateProfileRequest(BaseModel):
 
 
 @router.get("/profile")
-async def get_profile(credentials: HTTPAuthorizationCredentials = Depends(security)):
+async def get_profile(principal: dict[str, Any] = Depends(get_verified_principal)):
     """Get user profile information.
 
     Args:
-        credentials: Bearer token
+        principal: Verified JWT payload of the authenticated caller
 
     Returns:
         User profile data
@@ -44,13 +44,13 @@ async def get_profile(credentials: HTTPAuthorizationCredentials = Depends(securi
 @router.put("/profile")
 async def update_profile(
     request: UpdateProfileRequest,
-    credentials: HTTPAuthorizationCredentials = Depends(security),
+    principal: dict[str, Any] = Depends(get_verified_principal),
 ):
     """Update user profile.
 
     Args:
         request: Profile update data
-        credentials: Bearer token
+        principal: Verified JWT payload of the authenticated caller
 
     Returns:
         Updated profile
@@ -68,11 +68,11 @@ async def update_profile(
 
 
 @router.get("/usage")
-async def get_usage_stats(credentials: HTTPAuthorizationCredentials = Depends(security)):
+async def get_usage_stats(principal: dict[str, Any] = Depends(get_verified_principal)):
     """Get user usage statistics.
 
     Args:
-        credentials: Bearer token
+        principal: Verified JWT payload of the authenticated caller
 
     Returns:
         Usage statistics
@@ -87,11 +87,11 @@ async def get_usage_stats(credentials: HTTPAuthorizationCredentials = Depends(se
 
 
 @router.delete("/account")
-async def delete_account(credentials: HTTPAuthorizationCredentials = Depends(security)):
+async def delete_account(principal: dict[str, Any] = Depends(get_verified_principal)):
     """Delete user account.
 
     Args:
-        credentials: Bearer token
+        principal: Verified JWT payload of the authenticated caller
 
     Returns:
         Deletion confirmation

--- a/backend/services/auth_service.py
+++ b/backend/services/auth_service.py
@@ -23,7 +23,7 @@ from typing import Any
 import jwt
 from fastapi import HTTPException, status
 
-from backend.services.database import AuthDatabase
+from .database import AuthDatabase
 
 logger = logging.getLogger(__name__)
 

--- a/backend/services/database/__init__.py
+++ b/backend/services/database/__init__.py
@@ -1,5 +1,5 @@
 """Database services for backend API."""
 
-from backend.services.database.auth_db import AuthDatabase
+from .auth_db import AuthDatabase
 
 __all__ = ["AuthDatabase"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -238,6 +238,7 @@ dev = [
     "tiktoken>=0.7.0,<1.0.0",
     "aiohttp>=3.14.3,<4.0.0",  # webhook hooks + their SSRF/DNS-pinning tests; CVE floor per [all]
     "bcrypt>=4.0.0,<6.0.0",  # backend auth + its security tests (dead-suite class, 2026-08-16)
+    "email-validator>=2.0.0,<3.0.0",  # backend EmailStr routers + bearer-verification tests (dead-suite class, 2026-08-27)
 ]
 
 # Individual developers - lightweight, software development focused
@@ -424,6 +425,7 @@ dev = [
     "tiktoken>=0.7.0,<1.0.0",
     "aiohttp>=3.14.3,<4.0.0",  # webhook hooks + their SSRF/DNS-pinning tests; CVE floor per [all]
     "bcrypt>=4.0.0,<6.0.0",  # backend auth + its security tests (dead-suite class, 2026-08-16)
+    "email-validator>=2.0.0,<3.0.0",  # backend EmailStr routers + bearer-verification tests (dead-suite class, 2026-08-27)
 ]
 
 [project.scripts]

--- a/tests/backend/conftest.py
+++ b/tests/backend/conftest.py
@@ -3,11 +3,22 @@
 Sets JWT_SECRET_KEY for the test session if not already configured.
 The backend auth service raises ValueError at module level when the key
 is absent, which crashes pytest collection in CI where the key is not set.
+
+Also puts backend/ on sys.path: the backend runs with that directory as
+its root (main.py does ``from api import ...``), so router modules use
+imports like ``from services.empathy_service import ...`` that only
+resolve with backend/ importable.
 """
 
 import os
+import sys
+from pathlib import Path
 
 os.environ.setdefault(
     "JWT_SECRET_KEY",
     "test-only-secret-not-for-production",  # pragma: allowlist secret
 )
+
+_BACKEND_DIR = str(Path(__file__).resolve().parents[2] / "backend")
+if _BACKEND_DIR not in sys.path:
+    sys.path.insert(0, _BACKEND_DIR)

--- a/tests/backend/test_api_bearer_verification.py
+++ b/tests/backend/test_api_bearer_verification.py
@@ -1,0 +1,170 @@
+"""Security tests: every protected API route must VERIFY its bearer token.
+
+Regression guard for the 16.0.0 post-release finding (also flagged
+2026-08-02): users/subscriptions/analysis endpoints injected
+``Depends(HTTPBearer())`` but never called ``verify_token``, so any
+syntactically valid bearer header authenticated against destructive
+routes (account deletion, purchases, license deactivation, team-member
+removal).
+
+Coverage:
+1. A forged token (signed with the wrong key) is rejected with 401
+   on every route in the three previously-unprotected routers.
+2. A garbage non-JWT token is rejected with 401.
+3. A missing Authorization header is rejected (403 from HTTPBearer).
+4. A genuinely valid token still authenticates (200).
+5. Drift guard: the parametrized route table covers EVERY route in
+   those routers, so a new endpoint cannot ship untested.
+
+Copyright 2025 Smart-AI-Memory
+Licensed under the Apache License, Version 2.0
+"""
+
+from datetime import datetime, timedelta
+
+import pytest
+
+pytest.importorskip("bcrypt")
+pytest.importorskip("email_validator")  # routers declare EmailStr fields
+import jwt  # noqa: E402
+from fastapi import FastAPI  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+
+from backend.api import analysis, subscriptions, users  # noqa: E402
+from backend.services.auth_service import JWT_ALGORITHM, JWT_SECRET_KEY  # noqa: E402
+
+
+def _make_token(secret: str) -> str:
+    """Create a JWT with the given signing secret."""
+    payload = {
+        "sub": "user@example.com",
+        "user_id": 1,
+        "name": "Test User",
+        "exp": datetime.utcnow() + timedelta(minutes=30),
+        "iat": datetime.utcnow(),
+    }
+    return jwt.encode(payload, secret, algorithm=JWT_ALGORITHM)
+
+
+FORGED_TOKEN = _make_token("attacker-controlled-wrong-secret-key!!")  # pragma: allowlist secret
+GARBAGE_TOKEN = "not-a-jwt-at-all"
+
+
+@pytest.fixture(scope="module")
+def client() -> TestClient:
+    """App with the three previously-unprotected routers mounted."""
+    app = FastAPI()
+    app.include_router(users.router)
+    app.include_router(subscriptions.router)
+    app.include_router(analysis.router)
+    # The auth dependency must reject BEFORE any service work happens;
+    # a None service makes the test fail loudly if a handler ever runs.
+    app.dependency_overrides[analysis.get_empathy_service] = lambda: None
+    return TestClient(app)
+
+
+# (method, path, request kwargs) — one row per protected route.
+PROTECTED_ROUTES = [
+    # users
+    ("GET", "/api/users/profile", {}),
+    ("PUT", "/api/users/profile", {"json": {"name": "X"}}),
+    ("GET", "/api/users/usage", {}),
+    ("DELETE", "/api/users/account", {}),
+    # subscriptions
+    ("GET", "/api/subscriptions/", {}),
+    (
+        "POST",
+        "/api/subscriptions/purchase",
+        {"json": {"product": "book", "payment_method": "card"}},
+    ),
+    ("GET", "/api/subscriptions/team", {}),
+    (
+        "POST",
+        "/api/subscriptions/team/members",
+        {"json": {"email": "new@example.com"}},
+    ),
+    ("DELETE", "/api/subscriptions/team/members/user_1", {}),
+    ("GET", "/api/subscriptions/licenses", {}),
+    ("POST", "/api/subscriptions/licenses/lic_1/deactivate", {}),
+    # analysis
+    (
+        "POST",
+        "/api/analysis/session",
+        {"json": {"name": "s", "wizards": ["security_wizard"]}},
+    ),
+    ("GET", "/api/analysis/session/sess_1", {}),
+    ("POST", "/api/analysis/project", {"json": {"project_path": "/tmp/p"}}),
+    ("POST", "/api/analysis/file", {"files": {"file": ("a.py", b"print(1)")}}),
+    ("GET", "/api/analysis/history", {}),
+    ("DELETE", "/api/analysis/session/sess_1", {}),
+]
+
+ROUTE_IDS = [f"{m} {p}" for m, p, _ in PROTECTED_ROUTES]
+
+
+@pytest.mark.parametrize(("method", "path", "kwargs"), PROTECTED_ROUTES, ids=ROUTE_IDS)
+def test_forged_bearer_rejected(client, method, path, kwargs):
+    """A syntactically valid JWT signed with the wrong key must get 401."""
+    response = client.request(
+        method,
+        path,
+        headers={"Authorization": f"Bearer {FORGED_TOKEN}"},
+        **kwargs,
+    )
+    assert response.status_code == 401, (
+        f"{method} {path} accepted a forged bearer token "
+        f"(got {response.status_code}): token verification is missing"
+    )
+
+
+@pytest.mark.parametrize(("method", "path", "kwargs"), PROTECTED_ROUTES, ids=ROUTE_IDS)
+def test_garbage_bearer_rejected(client, method, path, kwargs):
+    """A non-JWT bearer value must get 401."""
+    response = client.request(
+        method,
+        path,
+        headers={"Authorization": f"Bearer {GARBAGE_TOKEN}"},
+        **kwargs,
+    )
+    assert response.status_code == 401
+
+
+@pytest.mark.parametrize(("method", "path", "kwargs"), PROTECTED_ROUTES, ids=ROUTE_IDS)
+def test_missing_auth_header_rejected(client, method, path, kwargs):
+    """No Authorization header must be rejected outright.
+
+    HTTPBearer returns 401 on FastAPI >= 0.135 and 403 on older versions.
+    """
+    response = client.request(method, path, **kwargs)
+    assert response.status_code in (401, 403)
+
+
+def test_valid_token_still_authenticates(client):
+    """A token signed with the real key passes verification (no lockout)."""
+    token = _make_token(JWT_SECRET_KEY)
+    headers = {"Authorization": f"Bearer {token}"}
+    assert client.get("/api/users/profile", headers=headers).status_code == 200
+    assert client.get("/api/subscriptions/", headers=headers).status_code == 200
+    assert client.get("/api/analysis/history", headers=headers).status_code == 200
+
+
+def test_route_table_covers_all_router_routes(client):
+    """Drift guard: every route in these routers appears in PROTECTED_ROUTES."""
+    expected = {
+        (method, route.path)
+        for router in (users.router, subscriptions.router, analysis.router)
+        for route in router.routes
+        for method in route.methods
+    }
+    listed = set()
+    for method, path, _ in PROTECTED_ROUTES:
+        # Map concrete test paths back to route templates.
+        template = (
+            path.replace("user_1", "{user_id}")
+            .replace("lic_1", "{license_id}")
+            .replace("sess_1", "{session_id}")
+        )
+        listed.add((method, template))
+    assert (
+        listed == expected
+    ), f"untested routes: {expected - listed}; stale rows: {listed - expected}"

--- a/tests/unit/api/test_analysis_behavioral.py
+++ b/tests/unit/api/test_analysis_behavioral.py
@@ -1,35 +1,48 @@
 """Behavioral tests for backend/api/analysis.py.
 
 Tests the Pydantic request models and their validators.
-Imports the module directly (not via the api package __init__)
-to avoid pulling in bcrypt and other heavy backend deps.
+Imports the module under a stub ``api`` package (bypassing the real
+api/__init__.py) to avoid pulling in bcrypt, email-validator, and
+other heavy backend deps. All sys.modules edits are reverted after
+the load so other tests in the same worker see a clean module table.
 """
 
 import importlib
 import sys
+import types
 from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
+from pydantic import ValidationError
 
 # Add backend/ to sys.path so the module can be imported
 _backend_dir = str(Path(__file__).resolve().parents[3] / "backend")
 if _backend_dir not in sys.path:
     sys.path.insert(0, _backend_dir)
 
-# Mock the services dependency so we don't pull in bcrypt/database
-sys.modules.setdefault("services", MagicMock())
-sys.modules.setdefault("services.empathy_service", MagicMock())
-
-from pydantic import ValidationError  # noqa: E402
-
-# Import the module directly, bypassing api/__init__.py
-_spec = importlib.util.spec_from_file_location(
-    "api_analysis",
-    Path(__file__).resolve().parents[3] / "backend" / "api" / "analysis.py",
-)
-_mod = importlib.util.module_from_spec(_spec)
-_spec.loader.exec_module(_mod)
+# Stub parent packages: a fake "api" package with the real search path
+# (so ``from .deps import ...`` resolves) and a mocked services package
+# (so analysis.py's EmpathyService import stays lightweight).
+_api_pkg = types.ModuleType("api")
+_api_pkg.__path__ = [str(Path(_backend_dir) / "api")]
+_STUBS = {
+    "api": _api_pkg,
+    "services": MagicMock(),
+    "services.empathy_service": MagicMock(),
+}
+_saved = {name: sys.modules.get(name) for name in _STUBS}
+_saved["api.deps"] = sys.modules.get("api.deps")
+_saved["api.analysis"] = sys.modules.get("api.analysis")
+sys.modules.update(_STUBS)
+try:
+    _mod = importlib.import_module("api.analysis")
+finally:
+    for _name, _val in _saved.items():
+        if _val is None:
+            sys.modules.pop(_name, None)
+        else:
+            sys.modules[_name] = _val
 
 ProjectAnalysisRequest = _mod.ProjectAnalysisRequest
 SessionConfig = _mod.SessionConfig

--- a/uv.lock
+++ b/uv.lock
@@ -394,6 +394,7 @@ dev = [
     { name = "bcrypt" },
     { name = "black" },
     { name = "coverage" },
+    { name = "email-validator" },
     { name = "fastapi" },
     { name = "httpx" },
     { name = "jinja2" },
@@ -499,6 +500,7 @@ dev = [
     { name = "bcrypt" },
     { name = "black" },
     { name = "coverage" },
+    { name = "email-validator" },
     { name = "fastapi" },
     { name = "httpx" },
     { name = "jinja2" },
@@ -553,6 +555,7 @@ requires-dist = [
     { name = "coverage", marker = "extra == 'dev'", specifier = ">=7.0,<8.0" },
     { name = "cryptography", specifier = ">=50.0.0" },
     { name = "defusedxml", specifier = ">=0.7.0,<1.0.0" },
+    { name = "email-validator", marker = "extra == 'dev'", specifier = ">=2.0.0,<3.0.0" },
     { name = "fastapi", marker = "extra == 'all'", specifier = ">=0.109.1,<1.0.0" },
     { name = "fastapi", marker = "extra == 'backend'", specifier = ">=0.109.1,<1.0.0" },
     { name = "fastapi", marker = "extra == 'dev'", specifier = ">=0.110.0,<1.0.0" },
@@ -689,6 +692,7 @@ dev = [
     { name = "bcrypt", specifier = ">=4.0.0,<6.0.0" },
     { name = "black", specifier = ">=24.3.0,<27.0" },
     { name = "coverage", specifier = ">=7.0,<8.0" },
+    { name = "email-validator", specifier = ">=2.0.0,<3.0.0" },
     { name = "fastapi", specifier = ">=0.110.0,<1.0.0" },
     { name = "httpx", specifier = ">=0.27.0,<1.0.0" },
     { name = "jinja2", specifier = ">=3.1.0,<4.0" },
@@ -1521,12 +1525,34 @@ wheels = [
 ]
 
 [[package]]
+name = "dnspython"
+version = "2.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/8b/57666417c0f90f08bcafa776861060426765fdb422eb10212086fb811d26/dnspython-2.8.0.tar.gz", hash = "sha256:181d3c6996452cb1189c4046c61599b84a5a86e099562ffde77d26984ff26d0f", size = 368251, upload-time = "2025-09-07T18:58:00.022Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/5a/18ad964b0086c6e62e2e7500f7edc89e3faa45033c71c1893d34eed2b2de/dnspython-2.8.0-py3-none-any.whl", hash = "sha256:01d9bbc4a2d76bf0db7c1f729812ded6d912bd318d3b1cf81d30c0f845dbf3af", size = 331094, upload-time = "2025-09-07T18:57:58.071Z" },
+]
+
+[[package]]
 name = "docstring-parser"
 version = "0.18.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e0/4d/f332313098c1de1b2d2ff91cf2674415cc7cddab2ca1b01ae29774bd5fdf/docstring_parser-0.18.0.tar.gz", hash = "sha256:292510982205c12b1248696f44959db3cdd1740237a968ea1e2e7a900eeb2015", size = 29341, upload-time = "2026-04-14T04:09:19.867Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/5f/ed01f9a3cdffbd5a008556fc7b2a08ddb1cc6ace7effa7340604b1d16699/docstring_parser-0.18.0-py3-none-any.whl", hash = "sha256:b3fcbed555c47d8479be0796ef7e19c2670d428d72e96da63f3a40122860374b", size = 22484, upload-time = "2026-04-14T04:09:18.638Z" },
+]
+
+[[package]]
+name = "email-validator"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "dnspython" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f5/22/900cb125c76b7aaa450ce02fd727f452243f2e91a61af068b40adba60ea9/email_validator-2.3.0.tar.gz", hash = "sha256:9fc05c37f2f6cf439ff414f8fc46d917929974a82244c20eb10231ba60c54426", size = 51238, upload-time = "2025-08-26T13:09:06.831Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/15/545e2b6cf2e3be84bc1ed85613edd75b8aea69807a71c26f4ca6a9258e82/email_validator-2.3.0-py3-none-any.whl", hash = "sha256:80f13f623413e6b197ae73bb10bf4eb0908faf509ad8362c5edeb0be7fd450b4", size = 35604, upload-time = "2025-08-26T13:09:05.858Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

**HIGH-severity recurring finding** (16.0.0 post-release review run 58395f0fbc57, also flagged 2026-08-02; receipt in docs/COVERAGE_BUG_LOG.md 2026-08-27 entry): the backend FastAPI app's `users`, `subscriptions`, and `analysis` routers — **17 endpoints** — injected `Depends(HTTPBearer())` but never called `verify_token`. Any syntactically valid bearer header authenticated against destructive routes: account deletion, purchases, license deactivation, team-member removal.

**Claim verified before fixing**: traced every `Depends(security)` site vs `verify_token` call site across `backend/api/*.py`. `auth.py`'s three bearer endpoints all verify via the service layer; all 17 endpoints in the other three routers verified nothing.

## Fix

- **`backend/api/deps.py`** — new `get_verified_principal` dependency that both extracts AND verifies the JWT (401 on forged/expired/invalid), applied uniformly to all 17 endpoints. The auth service import is lazy so shared routers don't pull jwt/bcrypt into their import graph.
- **Pre-existing deployed-boot import fixes** (surfaced by the live-import receipt): `auth.py`, `auth_service.py`, and `services/database/__init__.py` used repo-root-style `from backend...` imports that cannot resolve under the deployed launch (`cd backend && uvicorn main:app` per railway.toml/nixpacks.toml). Switched to backend-rooted/relative imports that resolve in both deploy and test contexts. (`main.py`'s `wizards.router` reference is a *separate* pre-existing boot blocker — `wizards.py` defines a standalone `app`, not a router — chipped as its own task, not fixed here.)
- **`tests/unit/api/test_analysis_behavioral.py`** — reworked its standalone module load to a stub-package load with sys.modules save/restore, so the new relative import resolves and its MagicMock stubs can no longer leak into other tests in the same worker.

## Security tests (`tests/backend/test_api_bearer_verification.py`)

- Forged bearer (JWT signed with wrong key) → **401 on every one of the 17 routes** (parametrized)
- Garbage non-JWT bearer → 401 on every route
- Missing Authorization header → rejected (401/403 across FastAPI versions)
- Validly-signed token still authenticates (200) — no lockout regression
- **Drift guard**: the route table is asserted equal to the routers' actual route sets, so a new endpoint cannot ship untested

## Receipts (all run, all green)

- Full test tree: `pytest tests` → **24,956 passed, 259 skipped, 3 xfailed, 0 failed** (159s)
- `tests/backend` + `tests/unit/backend` + `tests/unit/api`: 112 + 71 passed
- Ratchet gates `tests/unit/gates`: 392 passed (no new broad-except/path-validation sites)
- Live import under the deployed context (`cwd=backend`): all changed routers mount — 4 + 7 + 6 routes
- Cross-order poisoning probe: behavioral test then bearer tests in one process → green

## Notes

- `backend/` broad-except ratchet baselines untouched (no new catch sites).
- New-security-features-need-dedicated-tests lesson applied: every previously-unprotected route has an explicit forged-bearer rejection test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
