### PR TITLE
fix(backend): verify bearer tokens on 17 dormant api routes

### DIFF
--- a/backend/api/analysis.py
+++ b/backend/api/analysis.py
@@ -7,13 +7,12 @@ Input validation and error handling included for security.
 from typing import Any
 
 from fastapi import APIRouter, Depends, File, HTTPException, UploadFile, status
-from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from pydantic import BaseModel, field_validator
 
+from api.dependencies import require_principal
 from services.empathy_service import EmpathyService
 
 router = APIRouter(prefix="/api/analysis", tags=["analysis"])
-security = HTTPBearer()
 
 
 def get_empathy_service() -> EmpathyService:
@@ -111,14 +110,14 @@ class SessionConfig(BaseModel):
 async def create_session(
     request: SessionConfig,
     service: EmpathyService = Depends(get_empathy_service),
-    credentials: HTTPAuthorizationCredentials = Depends(security),
+    principal: dict[str, Any] = Depends(require_principal),
 ):
     """Create a new analysis session.
 
     Args:
         request: Session configuration
         service: EmpathyService instance
-        credentials: Bearer token
+        principal: Authenticated principal (verified JWT payload)
 
     Returns:
         Session ID and metadata
@@ -140,14 +139,14 @@ async def create_session(
 async def get_session(
     session_id: str,
     service: EmpathyService = Depends(get_empathy_service),
-    credentials: HTTPAuthorizationCredentials = Depends(security),
+    principal: dict[str, Any] = Depends(require_principal),
 ):
     """Get analysis session results.
 
     Args:
         session_id: Session identifier
         service: EmpathyService instance
-        credentials: Bearer token
+        principal: Authenticated principal (verified JWT payload)
 
     Returns:
         Session results and status
@@ -163,14 +162,14 @@ async def get_session(
 async def analyze_project(
     request: ProjectAnalysisRequest,
     service: EmpathyService = Depends(get_empathy_service),
-    credentials: HTTPAuthorizationCredentials = Depends(security),
+    principal: dict[str, Any] = Depends(require_principal),
 ):
     """Analyze an entire project.
 
     Args:
         request: Project analysis configuration
         service: EmpathyService instance
-        credentials: Bearer token
+        principal: Authenticated principal (verified JWT payload)
 
     Returns:
         Project analysis results
@@ -195,7 +194,7 @@ async def analyze_file(
     file: UploadFile = File(...),
     language: str = "python",
     service: EmpathyService = Depends(get_empathy_service),
-    credentials: HTTPAuthorizationCredentials = Depends(security),
+    principal: dict[str, Any] = Depends(require_principal),
 ):
     """Analyze a single uploaded file.
 
@@ -203,7 +202,7 @@ async def analyze_file(
         file: Uploaded file (max 10MB)
         language: Programming language (python, javascript, typescript, java, go, rust)
         service: EmpathyService instance
-        credentials: Bearer token
+        principal: Authenticated principal (verified JWT payload)
 
     Returns:
         File analysis results
@@ -275,14 +274,14 @@ async def analyze_file(
 async def get_analysis_history(
     limit: int = 10,
     offset: int = 0,
-    credentials: HTTPAuthorizationCredentials = Depends(security),
+    principal: dict[str, Any] = Depends(require_principal),
 ):
     """Get user's analysis history.
 
     Args:
         limit: Number of results to return (max 100, default 10)
         offset: Pagination offset (min 0)
-        credentials: Bearer token
+        principal: Authenticated principal (verified JWT payload)
 
     Returns:
         List of past analyses
@@ -325,13 +324,13 @@ async def get_analysis_history(
 @router.delete("/session/{session_id}")
 async def delete_session(
     session_id: str,
-    credentials: HTTPAuthorizationCredentials = Depends(security),
+    principal: dict[str, Any] = Depends(require_principal),
 ):
     """Delete an analysis session.
 
     Args:
         session_id: Session identifier
-        credentials: Bearer token
+        principal: Authenticated principal (verified JWT payload)
 
     Returns:
         Deletion confirmation

--- a/backend/api/dependencies.py
+++ b/backend/api/dependencies.py
@@ -1,0 +1,44 @@
+"""Shared FastAPI dependencies for the backend API.
+
+Provides a single verified-principal dependency so protected routes reject
+forged, invalid, or expired bearer tokens instead of accepting any non-empty
+``Authorization`` header. Replaces the bare ``HTTPBearer`` injection that only
+proved a header was *present*, never that the token was *valid*.
+
+Copyright 2025 Smart-AI-Memory
+Licensed under the Apache License, Version 2.0
+"""
+
+from typing import Any
+
+from fastapi import Depends
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+
+from backend.services.auth_service import verify_access_token
+
+# ``auto_error=True`` (default) rejects a missing/malformed Authorization
+# header with 403 before ``require_principal`` runs.
+security = HTTPBearer()
+
+
+def require_principal(
+    credentials: HTTPAuthorizationCredentials = Depends(security),
+) -> dict[str, Any]:
+    """Verify the bearer token and return the authenticated principal.
+
+    Use as ``principal: dict[str, Any] = Depends(require_principal)`` on any
+    route that must be authenticated. The returned payload is the decoded JWT
+    (``sub``, ``user_id``, ``name``, ...).
+
+    Args:
+        credentials: Bearer credentials extracted by ``HTTPBearer``.
+
+    Returns:
+        The decoded, verified token payload.
+
+    Raises:
+        HTTPException: 401 if the token is invalid or expired (403 for a
+            missing/malformed header, raised earlier by ``HTTPBearer``).
+
+    """
+    return verify_access_token(credentials.credentials)

--- a/backend/api/subscriptions.py
+++ b/backend/api/subscriptions.py
@@ -2,12 +2,14 @@
 Handles license purchases, subscriptions, and team management.
 """
 
+from typing import Any
+
 from fastapi import APIRouter, Depends
-from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from pydantic import BaseModel, EmailStr
 
+from api.dependencies import require_principal
+
 router = APIRouter(prefix="/api/subscriptions", tags=["subscriptions"])
-security = HTTPBearer()
 
 
 class PurchaseRequest(BaseModel):
@@ -26,11 +28,11 @@ class TeamMemberRequest(BaseModel):
 
 
 @router.get("/")
-async def get_subscriptions(credentials: HTTPAuthorizationCredentials = Depends(security)):
+async def get_subscriptions(principal: dict[str, Any] = Depends(require_principal)):
     """Get user's active subscriptions.
 
     Args:
-        credentials: Bearer token
+        principal: Authenticated principal (verified JWT payload)
 
     Returns:
         List of active subscriptions
@@ -55,13 +57,13 @@ async def get_subscriptions(credentials: HTTPAuthorizationCredentials = Depends(
 @router.post("/purchase")
 async def purchase_subscription(
     request: PurchaseRequest,
-    credentials: HTTPAuthorizationCredentials = Depends(security),
+    principal: dict[str, Any] = Depends(require_principal),
 ):
     """Purchase a new subscription or additional licenses.
 
     Args:
         request: Purchase details
-        credentials: Bearer token
+        principal: Authenticated principal (verified JWT payload)
 
     Returns:
         Purchase confirmation and license keys
@@ -81,11 +83,11 @@ async def purchase_subscription(
 
 
 @router.get("/team")
-async def get_team_members(credentials: HTTPAuthorizationCredentials = Depends(security)):
+async def get_team_members(principal: dict[str, Any] = Depends(require_principal)):
     """Get team members for organization subscription.
 
     Args:
-        credentials: Bearer token
+        principal: Authenticated principal (verified JWT payload)
 
     Returns:
         List of team members
@@ -110,13 +112,13 @@ async def get_team_members(credentials: HTTPAuthorizationCredentials = Depends(s
 @router.post("/team/members")
 async def add_team_member(
     request: TeamMemberRequest,
-    credentials: HTTPAuthorizationCredentials = Depends(security),
+    principal: dict[str, Any] = Depends(require_principal),
 ):
     """Add a new team member.
 
     Args:
         request: Team member details
-        credentials: Bearer token
+        principal: Authenticated principal (verified JWT payload)
 
     Returns:
         Added team member info
@@ -132,13 +134,13 @@ async def add_team_member(
 @router.delete("/team/members/{user_id}")
 async def remove_team_member(
     user_id: str,
-    credentials: HTTPAuthorizationCredentials = Depends(security),
+    principal: dict[str, Any] = Depends(require_principal),
 ):
     """Remove a team member.
 
     Args:
         user_id: User ID to remove
-        credentials: Bearer token
+        principal: Authenticated principal (verified JWT payload)
 
     Returns:
         Removal confirmation
@@ -148,11 +150,11 @@ async def remove_team_member(
 
 
 @router.get("/licenses")
-async def get_licenses(credentials: HTTPAuthorizationCredentials = Depends(security)):
+async def get_licenses(principal: dict[str, Any] = Depends(require_principal)):
     """Get license information for the user's account.
 
     Args:
-        credentials: Bearer token
+        principal: Authenticated principal (verified JWT payload)
 
     Returns:
         License details
@@ -178,13 +180,13 @@ async def get_licenses(credentials: HTTPAuthorizationCredentials = Depends(secur
 @router.post("/licenses/{license_id}/deactivate")
 async def deactivate_license(
     license_id: str,
-    credentials: HTTPAuthorizationCredentials = Depends(security),
+    principal: dict[str, Any] = Depends(require_principal),
 ):
     """Deactivate a license from a machine.
 
     Args:
         license_id: License ID to deactivate
-        credentials: Bearer token
+        principal: Authenticated principal (verified JWT payload)
 
     Returns:
         Deactivation confirmation

--- a/backend/api/users.py
+++ b/backend/api/users.py
@@ -5,11 +5,11 @@ Handles user profile management and settings.
 from typing import Any
 
 from fastapi import APIRouter, Depends
-from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from pydantic import BaseModel, EmailStr
 
+from api.dependencies import require_principal
+
 router = APIRouter(prefix="/api/users", tags=["users"])
-security = HTTPBearer()
 
 
 class UpdateProfileRequest(BaseModel):
@@ -21,11 +21,11 @@ class UpdateProfileRequest(BaseModel):
 
 
 @router.get("/profile")
-async def get_profile(credentials: HTTPAuthorizationCredentials = Depends(security)):
+async def get_profile(principal: dict[str, Any] = Depends(require_principal)):
     """Get user profile information.
 
     Args:
-        credentials: Bearer token
+        principal: Authenticated principal (verified JWT payload)
 
     Returns:
         User profile data
@@ -44,13 +44,13 @@ async def get_profile(credentials: HTTPAuthorizationCredentials = Depends(securi
 @router.put("/profile")
 async def update_profile(
     request: UpdateProfileRequest,
-    credentials: HTTPAuthorizationCredentials = Depends(security),
+    principal: dict[str, Any] = Depends(require_principal),
 ):
     """Update user profile.
 
     Args:
         request: Profile update data
-        credentials: Bearer token
+        principal: Authenticated principal (verified JWT payload)
 
     Returns:
         Updated profile
@@ -68,11 +68,11 @@ async def update_profile(
 
 
 @router.get("/usage")
-async def get_usage_stats(credentials: HTTPAuthorizationCredentials = Depends(security)):
+async def get_usage_stats(principal: dict[str, Any] = Depends(require_principal)):
     """Get user usage statistics.
 
     Args:
-        credentials: Bearer token
+        principal: Authenticated principal (verified JWT payload)
 
     Returns:
         Usage statistics
@@ -87,11 +87,11 @@ async def get_usage_stats(credentials: HTTPAuthorizationCredentials = Depends(se
 
 
 @router.delete("/account")
-async def delete_account(credentials: HTTPAuthorizationCredentials = Depends(security)):
+async def delete_account(principal: dict[str, Any] = Depends(require_principal)):
     """Delete user account.
 
     Args:
-        credentials: Bearer token
+        principal: Authenticated principal (verified JWT payload)
 
     Returns:
         Deletion confirmation

--- a/backend/services/auth_service.py
+++ b/backend/services/auth_service.py
@@ -74,6 +74,41 @@ JWT_SECRET_KEY = _get_jwt_secret_key()
 JWT_ALGORITHM = "HS256"
 JWT_EXPIRATION_MINUTES = 30
 
+
+def verify_access_token(token: str) -> dict[str, Any]:
+    """Decode and validate a JWT access token.
+
+    Stateless single-source of token verification, reused by both
+    ``AuthService.verify_token`` and the ``require_principal`` FastAPI
+    dependency so protected routes reject forged/expired bearers without
+    constructing the auth database.
+
+    Args:
+        token: JWT token string extracted from the ``Authorization`` header.
+
+    Returns:
+        The decoded token payload (``sub``, ``user_id``, ``name``, ...).
+
+    Raises:
+        HTTPException: 401 if the token is invalid or expired.
+
+    """
+    try:
+        return jwt.decode(token, JWT_SECRET_KEY, algorithms=[JWT_ALGORITHM])
+    except jwt.ExpiredSignatureError as e:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Token has expired",
+            headers={"WWW-Authenticate": "Bearer"},
+        ) from e
+    except jwt.InvalidTokenError as e:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid token",
+            headers={"WWW-Authenticate": "Bearer"},
+        ) from e
+
+
 # Rate limiting configuration
 MAX_FAILED_ATTEMPTS = 5
 LOCKOUT_MINUTES = 15
@@ -128,21 +163,7 @@ class AuthService:
             HTTPException: If token is invalid or expired
 
         """
-        try:
-            payload = jwt.decode(token, JWT_SECRET_KEY, algorithms=[JWT_ALGORITHM])
-            return payload
-        except jwt.ExpiredSignatureError as e:
-            raise HTTPException(
-                status_code=status.HTTP_401_UNAUTHORIZED,
-                detail="Token has expired",
-                headers={"WWW-Authenticate": "Bearer"},
-            ) from e
-        except jwt.InvalidTokenError as e:
-            raise HTTPException(
-                status_code=status.HTTP_401_UNAUTHORIZED,
-                detail="Invalid token",
-                headers={"WWW-Authenticate": "Bearer"},
-            ) from e
+        return verify_access_token(token)
 
     def login(self, email: str, password: str, ip_address: str | None = None) -> dict[str, Any]:
         """Authenticate user and return access token.

--- a/docs/COVERAGE_BUG_LOG.md
+++ b/docs/COVERAGE_BUG_LOG.md
@@ -1829,3 +1829,41 @@ compare) and persisted to `~/.attune/ops/runs/`:
 Pair total **$9.01** (band $5–10). Step 16 for 16.0.0 is DISCHARGED
 with receipts; findings are triage candidates, not filed issues. The
 release notes may now claim the review happened.
+
+## 2026-08-27 — backend/api bearer-token verification (dormant-code hardening)
+
+Verified and fixed the code-review lead (run `58395f0fbc57`) that
+"17 endpoints skip `verify_token`". **Classification: Class 1
+(latent security defect) in DORMANT code** — the `backend/`
+FastAPI app is deployed nowhere (verified 2026-08-27: no Vercel
+Python project, `smartaimemory.com/api/health` 404s, `BACKEND_URL`
+unset in prod), so this is hardening, not a live incident.
+
+**Verification (traced all 20 `Depends(security)` sites):** the "17"
+is confirmed exactly. The bare `HTTPBearer` proved a header was
+*present* (missing header → auto-reject) but never validated the
+token, so any non-empty bearer — forged or expired — was accepted
+and the handler returned 2xx.
+- **Genuinely unverified (17):** `analysis.py` ×6 (`create_session`,
+  `get_session`, `analyze_project`, `analyze_file`,
+  `get_analysis_history`, `delete_session`), `subscriptions.py` ×7,
+  `users.py` ×4.
+- **Already verified (3):** `auth.py` `refresh_token`,
+  `get_current_user`, `validate_license` — all reach
+  `AuthService.verify_token` (`jwt.decode`, raises 401).
+- **Adjacent finding, out of the 17-scope:** `wizards.py` has *zero*
+  auth dependency on its routes.
+
+**Fix:** single-sourced the JWT decode into module-level
+`auth_service.verify_access_token`; new `backend/api/dependencies.py`
+`require_principal` dependency verifies the token and returns the
+principal; the 17 routes now use `Depends(require_principal)`.
+Regression guard: `tests/unit/backend/test_api_bearer_verification.py`
+(58 tests) proves a forged bearer → 401 on each of the 17 via a real
+`TestClient`, plus expired-token and helper unit coverage. No new
+`except` sites (the two in `verify_token` were relocated within
+`auth_service.py`), so the broad-except ratchet is unaffected.
+
+Note: this is the FIX receipt for the finding recorded in the
+step-16 self-review entry above (run `58395f0fbc57`). Shipped in
+PR #2342.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -204,6 +204,11 @@ dev = [
     # Test dependencies for API and integration tests
     "httpx>=0.27.0,<1.0.0",  # For API testing
     "fastapi>=0.110.0,<1.0.0",  # For wizard API tests + attune.ops dashboard
+    # backend/api/*.py define pydantic EmailStr models (auth, users,
+    # subscriptions); pydantic imports email_validator at schema-build
+    # (import) time, so the backend bearer-verification + behavioral
+    # tests fail at collection without it. Matches backend/requirements.txt.
+    "email-validator>=2.3.0,<3.0.0",
     # attune.ops dashboard runtime ([ops] extra) — mirrored into [dev]
     # so worktree/dev syncs can run and test `python -m attune.ops`
     # without a separate `--extra ops`. Keep pins in lock-step with the
@@ -390,6 +395,11 @@ dev = [
     # Test dependencies for API and integration tests
     "httpx>=0.27.0,<1.0.0",  # For API testing
     "fastapi>=0.110.0,<1.0.0",  # For wizard API tests + attune.ops dashboard
+    # backend/api/*.py define pydantic EmailStr models (auth, users,
+    # subscriptions); pydantic imports email_validator at schema-build
+    # (import) time, so the backend bearer-verification + behavioral
+    # tests fail at collection without it. Matches backend/requirements.txt.
+    "email-validator>=2.3.0,<3.0.0",
     # attune.ops dashboard runtime ([ops] extra) — mirrored into [dev]
     # so worktree/dev syncs can run and test `python -m attune.ops`
     # without a separate `--extra ops`. Keep pins in lock-step with the

--- a/tests/unit/api/conftest.py
+++ b/tests/unit/api/conftest.py
@@ -1,0 +1,15 @@
+"""API unit test configuration.
+
+Sets JWT_SECRET_KEY for the test session if not already configured. The
+backend API routers now depend on ``api.dependencies.require_principal``,
+which transitively imports ``backend.services.auth_service`` — that module
+raises ValueError at import time when the key is absent (as in keyless CI).
+Mirrors ``tests/unit/backend/conftest.py``.
+"""
+
+import os
+
+os.environ.setdefault(
+    "JWT_SECRET_KEY",
+    "test-only-secret-not-for-production",  # pragma: allowlist secret
+)

--- a/tests/unit/backend/test_api_bearer_verification.py
+++ b/tests/unit/backend/test_api_bearer_verification.py
@@ -1,0 +1,196 @@
+"""Security regression tests for bearer-token verification on backend routes.
+
+Guards the fix for the 17 endpoints that injected ``Depends(security)``
+(a bare ``HTTPBearer``) but never verified the token — so any non-empty
+bearer string, forged or expired, was accepted and the handler returned
+2xx. Each route now depends on ``require_principal``, which decodes and
+validates the JWT.
+
+Coverage per previously-unverified route:
+- forged bearer  -> 401 (was: accepted)
+- valid bearer   -> passes auth (status not in {401, 403})
+- missing header -> 403 (HTTPBearer auto_error; invariant)
+
+Plus expired-token rejection and direct unit tests of the shared
+verification helpers.
+"""
+
+import os
+import sys
+from datetime import datetime, timedelta
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import jwt
+import pytest
+
+# The auth service evaluates JWT_SECRET_KEY at import time and raises if
+# it is unset. Set it before importing anything under backend.services.
+os.environ.setdefault(
+    "JWT_SECRET_KEY",
+    "test-only-secret-not-for-production",  # pragma: allowlist secret
+)
+
+# `backend` is a PEP-420 namespace package (needs repo root on the path);
+# the router modules import siblings as `api.*` (needs backend/ on the path).
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_BACKEND_DIR = _REPO_ROOT / "backend"
+for _p in (str(_REPO_ROOT), str(_BACKEND_DIR)):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+# Avoid pulling EmpathyService / analyzer deps at import time.
+sys.modules.setdefault("services", MagicMock())
+sys.modules.setdefault("services.empathy_service", MagicMock())
+
+from api import analysis, subscriptions, users  # noqa: E402
+from api.dependencies import require_principal  # noqa: E402
+from fastapi import FastAPI  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+
+from backend.services.auth_service import (  # noqa: E402
+    JWT_ALGORITHM,
+    JWT_SECRET_KEY,
+    verify_access_token,
+)
+
+
+def _make_token(**overrides) -> str:
+    """Mint a signed JWT valid under the test secret."""
+    payload = {
+        "sub": "user@example.com",
+        "user_id": "user_123",
+        "name": "Test User",
+        "exp": datetime.utcnow() + timedelta(minutes=30),
+        "iat": datetime.utcnow(),
+    }
+    payload.update(overrides)
+    return jwt.encode(payload, JWT_SECRET_KEY, algorithm=JWT_ALGORITHM)
+
+
+@pytest.fixture(scope="module")
+def client() -> TestClient:
+    """A TestClient over just the three previously-unverified routers."""
+    app = FastAPI()
+    app.include_router(analysis.router)
+    app.include_router(subscriptions.router)
+    app.include_router(users.router)
+    # Handlers run against MagicMock services on the valid-token path and may
+    # 500; that is fine — we only assert they get PAST authentication.
+    return TestClient(app, raise_server_exceptions=False)
+
+
+# (method, path, request-kwargs) for every previously-unverified endpoint.
+UNVERIFIED_ROUTES = [
+    # analysis.py (6)
+    ("POST", "/api/analysis/session", {"json": {"name": "s", "wizards": ["w"]}}),
+    ("GET", "/api/analysis/session/abc", {}),
+    ("POST", "/api/analysis/project", {"json": {"project_path": "/tmp/x"}}),
+    ("POST", "/api/analysis/file", {"files": {"file": ("a.py", b"print()")}}),
+    ("GET", "/api/analysis/history", {}),
+    ("DELETE", "/api/analysis/session/abc", {}),
+    # subscriptions.py (7)
+    ("GET", "/api/subscriptions/", {}),
+    (
+        "POST",
+        "/api/subscriptions/purchase",
+        {"json": {"product": "book", "payment_method": "card"}},
+    ),
+    ("GET", "/api/subscriptions/team", {}),
+    ("POST", "/api/subscriptions/team/members", {"json": {"email": "a@b.com"}}),
+    ("DELETE", "/api/subscriptions/team/members/u1", {}),
+    ("GET", "/api/subscriptions/licenses", {}),
+    ("POST", "/api/subscriptions/licenses/lic1/deactivate", {}),
+    # users.py (4)
+    ("GET", "/api/users/profile", {}),
+    ("PUT", "/api/users/profile", {"json": {}}),
+    ("GET", "/api/users/usage", {}),
+    ("DELETE", "/api/users/account", {}),
+]
+
+
+def test_seventeen_routes_enumerated():
+    """Pin the count so a route added without auth is noticed."""
+    assert len(UNVERIFIED_ROUTES) == 17
+
+
+@pytest.mark.parametrize("method,path,kwargs", UNVERIFIED_ROUTES)
+def test_forged_bearer_rejected(client, method, path, kwargs):
+    """A forged (unsigned-garbage) bearer must be rejected with 401."""
+    headers = {"Authorization": "Bearer not-a-real-jwt"}
+    resp = client.request(method, path, headers=headers, **kwargs)
+    assert (
+        resp.status_code == 401
+    ), f"{method} {path} accepted a forged bearer (got {resp.status_code})"
+
+
+@pytest.mark.parametrize("method,path,kwargs", UNVERIFIED_ROUTES)
+def test_missing_header_rejected(client, method, path, kwargs):
+    """No Authorization header -> rejected (HTTPBearer auto_error, 401/403)."""
+    resp = client.request(method, path, **kwargs)
+    assert resp.status_code in (
+        401,
+        403,
+    ), f"{method} {path} allowed a missing bearer (got {resp.status_code})"
+
+
+@pytest.mark.parametrize("method,path,kwargs", UNVERIFIED_ROUTES)
+def test_valid_bearer_passes_auth(client, method, path, kwargs):
+    """A valid token gets past auth (status is not an auth rejection)."""
+    headers = {"Authorization": f"Bearer {_make_token()}"}
+    resp = client.request(method, path, headers=headers, **kwargs)
+    assert resp.status_code not in (
+        401,
+        403,
+    ), f"{method} {path} rejected a valid bearer (got {resp.status_code})"
+
+
+def test_expired_bearer_rejected(client):
+    """An expired-but-well-signed token is rejected with 401."""
+    expired = _make_token(exp=datetime.utcnow() - timedelta(minutes=1))
+    resp = client.get("/api/users/profile", headers={"Authorization": f"Bearer {expired}"})
+    assert resp.status_code == 401
+
+
+# --- Direct unit tests of the shared verification helpers -----------------
+
+
+def test_verify_access_token_accepts_valid():
+    payload = verify_access_token(_make_token())
+    assert payload["sub"] == "user@example.com"
+    assert payload["user_id"] == "user_123"
+
+
+def test_verify_access_token_rejects_forged():
+    from fastapi import HTTPException
+
+    with pytest.raises(HTTPException) as exc:
+        verify_access_token("garbage.not.jwt")
+    assert exc.value.status_code == 401
+
+
+def test_verify_access_token_rejects_wrong_secret():
+    from fastapi import HTTPException
+
+    forged = jwt.encode({"sub": "x"}, "a-different-secret", algorithm=JWT_ALGORITHM)
+    with pytest.raises(HTTPException) as exc:
+        verify_access_token(forged)
+    assert exc.value.status_code == 401
+
+
+def test_require_principal_returns_payload_for_valid_token():
+    from fastapi.security import HTTPAuthorizationCredentials
+
+    creds = HTTPAuthorizationCredentials(scheme="Bearer", credentials=_make_token())
+    principal = require_principal(creds)
+    assert principal["user_id"] == "user_123"
+
+
+def test_require_principal_raises_for_forged_token():
+    from fastapi import HTTPException
+    from fastapi.security import HTTPAuthorizationCredentials
+
+    creds = HTTPAuthorizationCredentials(scheme="Bearer", credentials="nope")
+    with pytest.raises(HTTPException) as exc:
+        require_principal(creds)
+    assert exc.value.status_code == 401

--- a/uv.lock
+++ b/uv.lock
@@ -394,6 +394,7 @@ dev = [
     { name = "bcrypt" },
     { name = "black" },
     { name = "coverage" },
+    { name = "email-validator" },
     { name = "fastapi" },
     { name = "httpx" },
     { name = "jinja2" },
@@ -499,6 +500,7 @@ dev = [
     { name = "bcrypt" },
     { name = "black" },
     { name = "coverage" },
+    { name = "email-validator" },
     { name = "fastapi" },
     { name = "httpx" },
     { name = "jinja2" },
@@ -553,6 +555,7 @@ requires-dist = [
     { name = "coverage", marker = "extra == 'dev'", specifier = ">=7.0,<8.0" },
     { name = "cryptography", specifier = ">=50.0.0" },
     { name = "defusedxml", specifier = ">=0.7.0,<1.0.0" },
+    { name = "email-validator", marker = "extra == 'dev'", specifier = ">=2.3.0,<3.0.0" },
     { name = "fastapi", marker = "extra == 'all'", specifier = ">=0.109.1,<1.0.0" },
     { name = "fastapi", marker = "extra == 'backend'", specifier = ">=0.109.1,<1.0.0" },
     { name = "fastapi", marker = "extra == 'dev'", specifier = ">=0.110.0,<1.0.0" },
@@ -689,6 +692,7 @@ dev = [
     { name = "bcrypt", specifier = ">=4.0.0,<6.0.0" },
     { name = "black", specifier = ">=24.3.0,<27.0" },
     { name = "coverage", specifier = ">=7.0,<8.0" },
+    { name = "email-validator", specifier = ">=2.3.0,<3.0.0" },
     { name = "fastapi", specifier = ">=0.110.0,<1.0.0" },
     { name = "httpx", specifier = ">=0.27.0,<1.0.0" },
     { name = "jinja2", specifier = ">=3.1.0,<4.0" },
@@ -1521,12 +1525,34 @@ wheels = [
 ]
 
 [[package]]
+name = "dnspython"
+version = "2.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/8b/57666417c0f90f08bcafa776861060426765fdb422eb10212086fb811d26/dnspython-2.8.0.tar.gz", hash = "sha256:181d3c6996452cb1189c4046c61599b84a5a86e099562ffde77d26984ff26d0f", size = 368251, upload-time = "2025-09-07T18:58:00.022Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/5a/18ad964b0086c6e62e2e7500f7edc89e3faa45033c71c1893d34eed2b2de/dnspython-2.8.0-py3-none-any.whl", hash = "sha256:01d9bbc4a2d76bf0db7c1f729812ded6d912bd318d3b1cf81d30c0f845dbf3af", size = 331094, upload-time = "2025-09-07T18:57:58.071Z" },
+]
+
+[[package]]
 name = "docstring-parser"
 version = "0.18.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e0/4d/f332313098c1de1b2d2ff91cf2674415cc7cddab2ca1b01ae29774bd5fdf/docstring_parser-0.18.0.tar.gz", hash = "sha256:292510982205c12b1248696f44959db3cdd1740237a968ea1e2e7a900eeb2015", size = 29341, upload-time = "2026-04-14T04:09:19.867Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/5f/ed01f9a3cdffbd5a008556fc7b2a08ddb1cc6ace7effa7340604b1d16699/docstring_parser-0.18.0-py3-none-any.whl", hash = "sha256:b3fcbed555c47d8479be0796ef7e19c2670d428d72e96da63f3a40122860374b", size = 22484, upload-time = "2026-04-14T04:09:18.638Z" },
+]
+
+[[package]]
+name = "email-validator"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "dnspython" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f5/22/900cb125c76b7aaa450ce02fd727f452243f2e91a61af068b40adba60ea9/email_validator-2.3.0.tar.gz", hash = "sha256:9fc05c37f2f6cf439ff414f8fc46d917929974a82244c20eb10231ba60c54426", size = 51238, upload-time = "2025-08-26T13:09:06.831Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/15/545e2b6cf2e3be84bc1ed85613edd75b8aea69807a71c26f4ca6a9258e82/email_validator-2.3.0-py3-none-any.whl", hash = "sha256:80f13f623413e6b197ae73bb10bf4eb0908faf509ad8362c5edeb0be7fd450b4", size = 35604, upload-time = "2025-08-26T13:09:05.858Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Routine **dormant-code hardening** (not a live incident). The `backend/`
FastAPI app is deployed nowhere (verified 2026-08-27: no Vercel Python
project, `smartaimemory.com/api/health` 404s, `BACKEND_URL` unset in
prod). It injected a bare `HTTPBearer` via `Depends(security)` on 17
routes **without ever validating the token** — so any non-empty bearer,
forged or expired, was accepted and the handler returned 2xx.

## Verification (step 1 — before any fix)

Traced all **20** `Depends(security)` sites. The code-review lead (run
`58395f0fbc57`) figure of **17 unverified is confirmed exactly**:

| File | Unverified (fixed) | Already verified |
|------|:--:|:--:|
| `analysis.py` | 6 | 0 |
| `subscriptions.py` | 7 | 0 |
| `users.py` | 4 | 0 |
| `auth.py` | 0 | 3 (`refresh_token`, `get_current_user`, `validate_license` — all reach `AuthService.verify_token`) |

`HTTPBearer(auto_error=True)` already rejected a *missing* header; the
gap was that a *present-but-invalid* token was never checked. Vuln class:
"forged token accepted," not "no auth at all."

## Fix

- Single-source the JWT decode into `auth_service.verify_access_token`;
  `AuthService.verify_token` delegates to it (no `AuthDatabase`
  construction just to decode a token).
- New `backend/api/dependencies.py` `require_principal` dependency
  verifies the token and returns the principal (401 on invalid/expired).
- Rewire the 17 routes to `Depends(require_principal)`; `auth.py`'s 3
  token-ops routes left as-is (already verified).

## Receipts

- New `tests/unit/backend/test_api_bearer_verification.py` (**58 tests**,
  real `TestClient`): forged bearer → 401 on **each** of the 17, expired
  → 401, valid passes auth, plus helper unit tests.
- Keyless local pass of touched suites: **117 passed** (`env -u
  JWT_SECRET_KEY`), incl. the existing behavioral test in isolation and
  `tests/backend/test_auth_security.py`.
- `ruff` + `black` clean. **No new `except` sites** (the two in
  `verify_token` were relocated within `auth_service.py`), so the
  broad-except ratchet is unaffected.
- `tests/unit/api/conftest.py` sets `JWT_SECRET_KEY` so the new
  transitive `auth_service` import stays importable under keyless CI.
- Receipt appended to `docs/COVERAGE_BUG_LOG.md` (2026-08-27 entry — the
  one the earlier code-review referenced but had not actually written).

## Out of scope (flagged, not fixed)

`backend/api/wizards.py` has **zero** auth dependency on its routes — a
separate gap, tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
