### PR TITLE
test(hooks): tolerate float epsilon in starter-reconciler deadline clamp

### DIFF
--- a/tests/unit/hooks/test_starter_reconciler.py
+++ b/tests/unit/hooks/test_starter_reconciler.py
@@ -982,7 +982,11 @@ class TestSharedDeadline:
         monkeypatch.setattr(hook_module.subprocess, "run", fake_run)
         monkeypatch.setattr(hook_module, "_DEADLINE", time.monotonic() + 0.5)
         hook_module._run(["git", "status"], None)
-        assert captured["timeout"] <= 0.5
+        # Tolerate monotonic-clock float epsilon: (T0 + 0.5) - time.monotonic()
+        # can round to just over 0.5 because the ULP at monotonic's magnitude
+        # (~1e5-1e6 s) exceeds the microscopic elapsed time. Seen on
+        # windows-3.10 as 0.5000000000000568 (reddened main after #2338).
+        assert captured["timeout"] <= 0.5 + 1e-6
         assert captured["timeout"] < hook_module.SUBPROC_TIMEOUT
 
     def test_global_budget_under_registered_timeout(self, hook_module):


### PR DESCRIPTION
## Summary

Fixes **main going red** on `test (windows-latest, 3.10)` /
`test-matrix-complete` with:

```
FAILED tests/unit/hooks/test_starter_reconciler.py::TestSharedDeadline::
  test_run_clamps_timeout_to_remaining_budget - assert 0.5000000000000568 <= 0.5
```

## Root cause

The test asserts the clamped subprocess timeout is `<= 0.5`, but the
product computes it as `_DEADLINE - time.monotonic()`. `time.monotonic()`
returns large values (~1e5–1e6 s) where the float ULP (~1e-10) **exceeds**
the microscopic elapsed time between setting `_DEADLINE = monotonic() + 0.5`
and re-reading the clock inside `_run`. So `(T0 + 0.5) - (T0 + tiny)` can
round to just *over* 0.5 — mathematically ≤ 0.5, not in float. Brittle on
Windows clock granularity; the test arrived with #2338.

## Fix

Add a `1e-6` tolerance — comfortably above the ULP at monotonic's
magnitude, comfortably below any real clamp deviation. Test-only, no
product change.

## Verification

`TestSharedDeadline` (5 tests) green locally. CI is the real receipt for
the Windows lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
