### PR TITLE
fix(backend): mount wizards as a router; keep catalog public

### DIFF
--- a/backend/api/wizards.py
+++ b/backend/api/wizards.py
@@ -1,22 +1,27 @@
 #!/usr/bin/env python3
-"""Wizard Dashboard Backend API
-Provides REST endpoints for wizard data.
+"""Wizard catalog API endpoints.
+
+Serves the public catalog of available wizards. These routes are
+INTENTIONALLY UNAUTHENTICATED: they return only static, non-sensitive
+capability metadata (names, icons, feature lists, compliance tags,
+popularity) with no user data and no principal-scoped filtering, so a
+frontend can render the catalog before a user signs in. Unlike the
+user-scoped sibling routers (``users``, ``subscriptions``, ``analysis``),
+there is nothing here to gate behind a verified principal.
+
+Mounted by ``backend/main.py`` as ``wizards.router`` (prefix
+``/api/wizards``).
+
+Copyright 2025 Smart-AI-Memory
+Licensed under the Apache License, Version 2.0
 """
 
 import time
+from typing import Any
 
-from fastapi import FastAPI, HTTPException
-from fastapi.middleware.cors import CORSMiddleware
+from fastapi import APIRouter, HTTPException
 
-app = FastAPI(title="Empathy Wizard API", version="1.0.0")
-
-app.add_middleware(
-    CORSMiddleware,
-    allow_origins=["http://localhost:3000"],
-    allow_credentials=True,
-    allow_methods=["*"],
-    allow_headers=["*"],
-)
+router = APIRouter(prefix="/api/wizards", tags=["wizards"])
 
 # Calculate timestamps for realistic created/updated dates
 NOW = int(time.time() * 1000)
@@ -1061,21 +1066,38 @@ WIZARDS_DATA = [
 ]
 
 
-@app.get("/api/wizards")
-async def get_wizards():
+@router.get("")
+async def get_wizards() -> dict[str, Any]:
+    """List the full public catalog of available wizards.
+
+    Requires no authentication: this returns only static, public
+    capability metadata.
+
+    Returns:
+        The complete wizard catalog and its total count.
+
+    """
     return {"wizards": WIZARDS_DATA, "total": len(WIZARDS_DATA)}
 
 
-@app.get("/api/wizards/{wizard_id}")
-async def get_wizard(wizard_id: str):
+@router.get("/{wizard_id}")
+async def get_wizard(wizard_id: str) -> dict[str, Any]:
+    """Return public metadata for a single wizard by id.
+
+    Requires no authentication: this returns only static, public
+    capability metadata.
+
+    Args:
+        wizard_id: The wizard identifier (e.g. ``"healthcare"``).
+
+    Returns:
+        The wizard's public metadata.
+
+    Raises:
+        HTTPException: 404 if no wizard has the given id.
+
+    """
     wizard = next((w for w in WIZARDS_DATA if w["id"] == wizard_id), None)
     if not wizard:
         raise HTTPException(status_code=404, detail="Wizard not found")
     return wizard
-
-
-if __name__ == "__main__":
-    import uvicorn
-
-    print("🧙 Starting API at http://localhost:8000")
-    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/tests/unit/backend/test_wizards_router_public.py
+++ b/tests/unit/backend/test_wizards_router_public.py
@@ -1,0 +1,116 @@
+"""Wizards catalog router: mounts as ``router`` and stays intentionally public.
+
+Two things are pinned here:
+
+1. **Boot-bug regression guard.** ``backend/main.py`` mounts this module with
+   ``app.include_router(wizards.router)``. The module previously exposed a
+   standalone ``app = FastAPI(...)`` and *no* ``router`` attribute, so the
+   backend raised ``AttributeError`` at startup. These tests assert the module
+   exposes an ``APIRouter`` named ``router`` and no longer a standalone ``app``.
+
+2. **Intentional-public contract.** Unlike the user-scoped sibling routers
+   (``users``, ``subscriptions``, ``analysis``), the wizards routes return only
+   static, non-sensitive capability metadata with no principal-scoped filtering.
+   They are deliberately unauthenticated so a frontend can render the catalog
+   before sign-in. These tests assert both routes answer 200 with no bearer
+   token (and even with a forged one), documenting that the absence of auth is a
+   decision, not the original oversight.
+
+The module is loaded in isolation via ``importlib`` rather than
+``import api.wizards``: the ``api`` package ``__init__`` eagerly imports the
+sibling routers, whose pydantic ``EmailStr`` models require the optional
+``email-validator`` extra that is absent from the worktree venv. ``wizards.py``
+has zero backend-internal imports (only ``time``, ``typing``, ``fastapi``), so
+loading just that file keeps the test hermetic and free of those extras.
+
+Copyright 2025 Smart-AI-Memory
+Licensed under the Apache License, Version 2.0
+"""
+
+import importlib.util
+import pathlib
+
+import pytest
+from fastapi import APIRouter, FastAPI
+from fastapi.testclient import TestClient
+
+_WIZARDS_PATH = pathlib.Path(__file__).resolve().parents[3] / "backend" / "api" / "wizards.py"
+
+
+def _load_wizards_module():
+    """Load ``backend/api/wizards.py`` in isolation (no ``api`` package init)."""
+    spec = importlib.util.spec_from_file_location("wizards_under_test", _WIZARDS_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def wizards_module():
+    """The isolated wizards module under test."""
+    return _load_wizards_module()
+
+
+@pytest.fixture(scope="module")
+def client(wizards_module):
+    """A TestClient over a fresh app mounting only ``wizards.router``."""
+    app = FastAPI()
+    app.include_router(wizards_module.router)
+    return TestClient(app)
+
+
+class TestRouterShape:
+    """The module exposes the ``router`` that ``backend/main.py`` mounts."""
+
+    def test_exposes_apirouter_named_router(self, wizards_module):
+        """``wizards.router`` exists and is an ``APIRouter`` (boot-bug guard)."""
+        assert hasattr(
+            wizards_module, "router"
+        ), "backend/main.py mounts wizards.router; the module must expose it"
+        assert isinstance(wizards_module.router, APIRouter)
+
+    def test_no_standalone_app(self, wizards_module):
+        """The old standalone ``app`` is gone (main.py owns the FastAPI app)."""
+        assert not hasattr(wizards_module, "app")
+
+    def test_routes_registered_under_prefix(self, wizards_module):
+        """Both catalog routes are registered under the ``/api/wizards`` prefix."""
+        paths = {route.path for route in wizards_module.router.routes}
+        assert "/api/wizards" in paths
+        assert "/api/wizards/{wizard_id}" in paths
+
+
+class TestIntentionallyPublic:
+    """The catalog routes answer without authentication, by design."""
+
+    def test_list_public_no_auth(self, client):
+        """GET /api/wizards returns the catalog with no Authorization header."""
+        response = client.get("/api/wizards")
+        assert response.status_code == 200
+        body = response.json()
+        assert body["total"] == len(body["wizards"])
+        assert body["total"] > 0
+
+    def test_detail_public_no_auth(self, client):
+        """GET /api/wizards/{id} returns a wizard with no Authorization header."""
+        response = client.get("/api/wizards/healthcare")
+        assert response.status_code == 200
+        assert response.json()["id"] == "healthcare"
+
+    def test_detail_unknown_id_404(self, client):
+        """An unknown wizard id yields 404, not a 401/403 auth challenge."""
+        response = client.get("/api/wizards/does-not-exist")
+        assert response.status_code == 404
+
+    def test_forged_bearer_is_accepted(self, client):
+        """A forged bearer token does not gate the public catalog (200).
+
+        Contrast with the sibling routers, where ``require_principal`` rejects a
+        forged token with 401. The wizards catalog is deliberately open, so the
+        token is ignored rather than verified.
+        """
+        response = client.get(
+            "/api/wizards",
+            headers={"Authorization": "Bearer forged.not-a-real.jwt"},
+        )
+        assert response.status_code == 200


### PR DESCRIPTION
## Routine dormant-code hardening (not urgent)

The `backend/` FastAPI app is **dormant — deployed nowhere**, so this is
hardening, not a live incident.

### What was broken

`backend/main.py` mounts the wizards routes with
`app.include_router(wizards.router)`, but `backend/api/wizards.py`
exposed a standalone `app = FastAPI(...)` and **no `router`** — so the
backend raised `AttributeError` at import/boot. This converts the module
to an `APIRouter(prefix="/api/wizards")`, matching its sibling routers
and what `main.py` already expects.

### The two catalog routes are kept intentionally public

`GET /api/wizards` and `GET /api/wizards/{wizard_id}` return only static,
non-sensitive **capability metadata** (names, icons, feature lists,
compliance tags, popularity) with no user data and no principal-scoped
filtering, so a frontend can render the catalog **before sign-in**.
Unlike the user-scoped sibling routers, there is nothing here to gate
behind a verified principal.

This is a deliberate decision, recorded loudly so it survives a future
auth sweep:
- a module docstring stating the routes are `INTENTIONALLY UNAUTHENTICATED`;
- a `test_forged_bearer_is_accepted` test pinning that a forged bearer
  still returns `200` (contrast with the sibling routers, where
  `require_principal` rejects a forged token with `401`).

### Relationship to #2342

[#2342](https://github.com/Smart-AI-Memory/attune-ai/pull/2342)
(open) adds a shared `require_principal` JWT dependency and protects 17
user-scoped routes in `analysis`/`subscriptions`/`users`. `wizards.py`
was the one dormant module it left out. **This PR is fully independent**
of #2342 — it imports nothing from `api.dependencies` and adds no auth.
It is intentionally *not* a third protected surface: the wizards catalog
is public by design.

### Tests

`tests/unit/backend/test_wizards_router_public.py` (7 tests):
- **Router-shape / boot-bug guard** — the module exposes an `APIRouter`
  named `router`, no standalone `app`, both routes registered under the
  `/api/wizards` prefix.
- **Intentional-public contract** — list + detail return `200`
  unauthenticated, forged bearer still `200`, unknown id → `404`.

### Receipts

- `env -u JWT_SECRET_KEY pytest tests/unit/backend/ tests/unit/api/ -p no:xdist -o addopts= -q` → **48 passed**
- broad-except ratchet gate → **3 passed** (no new excepts, no baseline bump)
- `black` + `ruff` + `ruff-bare-exception-check` → **passed**

_Sequencing chaired via `/roundtable` (unanimous 3/3 for an independent PR)._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
