### PR TITLE
refactor(roundtable): generate the Lua kind allowlist from KINDS

### DIFF
--- a/src/attune/roundtable/board.py
+++ b/src/attune/roundtable/board.py
@@ -63,16 +63,24 @@ THREAD_TTL_SECONDS = 604_800
 #: clobber each other.
 LIBRARY_NAME = "attune_roundtable"
 
+#: Placeholders filled from :data:`KINDS` at import. Deliberately not
+#: valid Lua: if a substitution ever fails to fire, ``FUNCTION LOAD``
+#: rejects the library loudly instead of silently shipping an allowlist
+#: that disagrees with the Python tuple.
+_KINDS_PLACEHOLDER = "@@KINDS@@"
+_KIND_LIST_PLACEHOLDER = "@@KIND_LIST@@"
+
 #: The server-side library. Validation is deliberately here, not in
 #: Python: AC-1 requires Redis itself to reject a malformed message
 #: atomically no matter what client sent it.
-LIBRARY_SOURCE = """#!lua name=attune_roundtable
+#:
+#: The allowlist table and the error message that enumerates it are BOTH
+#: generated from :data:`KINDS` — they were hand-maintained copies, and
+#: the error message had silently omitted ``event``/``candidate`` from
+#: V2-P4 until 2026-08-27.
+_LIBRARY_TEMPLATE = """#!lua name=attune_roundtable
 
-local KINDS = {
-  question = true, position = true, synthesis = true,
-  ruling = true, suggestion = true, halt = true,
-  event = true, candidate = true, receipt = true,
-}
+local KINDS = { @@KINDS@@ }
 
 local function validate(msg)
   if type(msg) ~= 'table' then
@@ -82,9 +90,7 @@ local function validate(msg)
     return 'author is required'
   end
   if type(msg.kind) ~= 'string' or not KINDS[msg.kind] then
-    return 'kind is required and must be one of: ' ..
-      'question|position|synthesis|ruling|suggestion|halt|' ..
-      'event|candidate|receipt'
+    return 'kind is required and must be one of: @@KIND_LIST@@'
   end
   if type(msg.body) ~= 'string' or #msg.body == 0 then
     return 'body is required'
@@ -189,6 +195,12 @@ redis.register_function('rt_promote', promote)
 redis.register_function('rt_ledger_reserve', ledger_reserve)
 redis.register_function('rt_ledger_record', ledger_record)
 """
+
+#: The library actually loaded into Redis, with both copies of the kind
+#: allowlist resolved from :data:`KINDS`.
+LIBRARY_SOURCE = _LIBRARY_TEMPLATE.replace(
+    _KINDS_PLACEHOLDER, ", ".join(f"{kind} = true" for kind in KINDS)
+).replace(_KIND_LIST_PLACEHOLDER, "|".join(KINDS))
 
 
 @dataclass

--- a/tests/unit/roundtable/test_board.py
+++ b/tests/unit/roundtable/test_board.py
@@ -11,6 +11,7 @@ tests skip when localhost:6379 is unreachable.
 from __future__ import annotations
 
 import json
+import re
 import uuid
 
 import pytest
@@ -73,13 +74,35 @@ class TestSchemaAndKeys:
             "receipt",
         }
 
-    def test_lua_allowlist_admits_every_python_kind(self) -> None:
-        # The Lua KINDS table is the enforcing copy (AC-1); pin it to
-        # the Python tuple so the two allowlists cannot drift.
+    def test_lua_allowlist_matches_python_kinds_exactly(self) -> None:
+        """Both directions, anchored to the KINDS table itself.
+
+        The earlier form (``f"{kind} = true" in LIBRARY_SOURCE``) proved
+        only Python ⊆ Lua, and matched anywhere in the source: a kind
+        added to the Lua table alone left it green, which is the drift
+        it claimed to prevent.
+        """
         from attune.roundtable.board import LIBRARY_SOURCE
 
-        for kind in KINDS:
-            assert f"{kind} = true" in LIBRARY_SOURCE
+        table = re.search(r"local KINDS = \{(.*?)\}", LIBRARY_SOURCE, re.DOTALL)
+        assert table is not None, "no KINDS table in the Lua library"
+        assert set(re.findall(r"(\w+)\s*=\s*true", table.group(1))) == set(KINDS)
+
+    def test_lua_error_message_enumerates_every_kind(self) -> None:
+        """The 'must be one of' message is generated, not hand-listed.
+
+        It had silently omitted ``event``/``candidate`` from V2-P4 until
+        2026-08-27 — a third hand-maintained copy of the same list.
+        """
+        from attune.roundtable.board import LIBRARY_SOURCE
+
+        assert f"must be one of: {'|'.join(KINDS)}" in LIBRARY_SOURCE
+
+    def test_no_template_placeholder_reaches_redis(self) -> None:
+        """A missed substitution must never ship as loadable Lua."""
+        from attune.roundtable.board import LIBRARY_SOURCE
+
+        assert "@@" not in LIBRARY_SOURCE
 
     def test_thread_key_uses_board_keyspace(self) -> None:
         assert Board.thread_key("t1") == THREAD_KEY_PREFIX + "t1"


### PR DESCRIPTION
Follow-up to #2336, at Patrick's direction (he picked "arm now, fix as follow-up" when I raised this during that PR's read).

## The finding

#2336 added the `receipt` kind and had to edit the list in **three** places: the Python `KINDS` tuple, the Lua `KINDS` table, and the Lua error message that enumerates them. The third had already gone stale — the "must be one of" string still named only the six P0 kinds, silently omitting `event` and `candidate` since V2-P4. #2336 corrected that copy by hand, which fixes the instance and leaves the class armed for kind #10.

## The fix

Both Lua copies are generated from `KINDS` at import, so the list has one source.

```python
LIBRARY_SOURCE = _LIBRARY_TEMPLATE.replace(
    _KINDS_PLACEHOLDER, ", ".join(f"{kind} = true" for kind in KINDS)
).replace(_KIND_LIST_PLACEHOLDER, "|".join(KINDS))
```

The template keeps `@@KINDS@@` / `@@KIND_LIST@@` placeholders that are **deliberately not valid Lua**: a substitution that fails to fire makes `FUNCTION LOAD` reject the library loudly, rather than silently shipping an allowlist that disagrees with Python. An f-string was the obvious alternative and was rejected — the Lua library is full of braces, so it would have meant escaping every one of them.

`LIBRARY_SOURCE` keeps its name and public position, so `ensure_functions()` and every importer are untouched.

## The guard

#2336's drift guard asserted `f"{kind} = true" in LIBRARY_SOURCE` for each Python kind. That proves only Python ⊆ Lua, and matches **anywhere** in the source rather than inside the KINDS table — so a kind added to the Lua table alone kept it green, which is precisely the drift its comment claimed to prevent.

Replaced with three:

| Guard | Property established |
|---|---|
| `test_lua_allowlist_matches_python_kinds_exactly` | set equality, parsed out of the KINDS table itself — **both** directions, anchored |
| `test_lua_error_message_enumerates_every_kind` | the error message can't go stale again |
| `test_no_template_placeholder_reaches_redis` | a missed substitution never ships |

## Receipts

**Mutation** — added `smuggled = true` to the Lua table alone (the direction the old guard missed), then reverted:

- new guard: `FAILED tests/unit/roundtable/test_board.py::TestSchemaAndKeys::test_lua_allowlist_matches_python_kinds_exactly`
- old substring guard on that same mutant: **passes** — the gap, demonstrated rather than argued
- restored: new guard passes

**Live-fire against a real Redis** (throwaway instance on :6399 — the suite's own real-Redis tests hardcode an unauthenticated `localhost:6379` and skip here as in CI, so string assertions alone would not have proven the generated Lua is loadable):

```
FUNCTION LOAD: accepted the generated library
posted all 9 kinds — every one accepted
unknown kind rejected; message enumerates all 9:
    rt_post_message: kind is required and must be one of:
    question|position|synthesis|ruling|suggestion|halt|event|candidate|receipt
read back 9 messages
```

That error string is the visible fix: it named six kinds before, nine now.

**Full tree, keyless** — `24909 passed, 258 skipped, 3 xfailed`, plus 76 more in a follow-up run. The two `ERROR`s in the first run were environmental, not from this diff: a sibling branch's `pyproject` edit had re-synced the shared venv and removed `email-validator`, which two `backend/` test modules on `main` import via pydantic's `EmailStr`. Restoring the dep to the venv, both modules pass (76 passed). Neither file is touched by this PR.

`black --check` and `ruff check` clean on both changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
