### PR TITLE
release: v16.1.0 — stale entry-point detector, round-table receipts

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "Persistent memory and receipt-verified workflows for Claude Code. Spec-driven development with an approval loop, plus 28 auto-triggering skills: security audits, code review, test generation, release prep.",
-    "version": "16.0.0"
+    "version": "16.1.0"
   },
   "plugins": [
     {
       "name": "attune-ai",
       "description": "Persistent memory and receipt-verified workflows for Claude Code. /spec carries an idea through brainstorm, requirements, design, and task execution with quality gates and your approval at each stage. Backed by 28 auto-triggering skills — security audits, code reviews, test generation, bug prediction, and release preparation. For help content tools, also install attune-help from this marketplace; authoring ships built in via the attune.authoring module.",
       "source": "./plugin",
-      "version": "16.0.0",
+      "version": "16.1.0",
       "author": {
         "name": "Smart AI Memory",
         "email": "patrick.roebuck@smartaimemory.com"

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,4 +1,4 @@
-# Attune AI Framework v16.0.0
+# Attune AI Framework v16.1.0
 
 AI-powered developer workflows with cost optimization and multi-agent orchestration.
 
@@ -601,7 +601,7 @@ attune_redis/          # Redis plugin — BUNDLED, ships in the attune-ai
 
 ---
 
-**Version:** 16.0.0 | **License:** Apache 2.0 | **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)
+**Version:** 16.1.0 | **License:** Apache 2.0 | **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)
 
 ## Lessons — core
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [16.1.0] - 2026-08-28
+
+16.1.0 is a maintenance release on top of 16.0.0's destructive half.
+Its user-visible weight is the stale entry-point detector: after
+16.0.0 removed the `attune.plugins` / `attune.wizards` entry-point
+groups, an external extension still declaring them failed by silent
+non-loading, with nothing in the user's own code to grep for. That
+now warns, once per process, pointing at the migration guide. The
+rest is round-table plumbing and a release-state integrity check.
+
 ### Added
 
 - **Stale entry-point detector**: at the plugin/wizard registries'
@@ -17,6 +27,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   such extensions fail by silent non-loading with nothing greppable
   in the user's own code. The scan is cached and fail-open — a
   metadata error never affects startup.
+
+- **Round-table `receipt` message kind**: the board allowlist accepts
+  `receipt` — moderator-posted evidence that a promoted or agreed
+  action was actually executed, closing the loop the board previously
+  left open between a ruling and its execution.
+
+### Changed
+
+- **Starter reconciler flags a stale `release_state` memory**: the
+  SessionStart reconciler now reports when the recorded release state
+  has fallen behind what the repository and PyPI actually show,
+  instead of letting a session start from a stale premise.
+
+### Fixed
+
+- **Round-table kind list is single-sourced**: the Lua allowlist and
+  the "must be one of" error message are now generated from the
+  Python `KINDS` tuple. The error message had silently omitted
+  `event` and `candidate` since V2-P4 — it named six of the nine
+  valid kinds, so a caller rejected for a typo was told an incomplete
+  list of what to use instead.
 
 ## [16.0.0] - 2026-08-27
 

--- a/docs/reference/API_REFERENCE.md
+++ b/docs/reference/API_REFERENCE.md
@@ -1,6 +1,6 @@
 # Attune AI API Reference
 
-**Version:** 16.0.0
+**Version:** 16.1.0
 **License:** Apache License 2.0
 **Copyright:** 2025-2026 Smart AI Memory, LLC
 
@@ -1133,5 +1133,5 @@ msg = format_error(
 
 ---
 
-**Version:** 16.0.0 | **License:** Apache 2.0
+**Version:** 16.1.0 | **License:** Apache 2.0
 **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)

--- a/plugin/.claude-plugin/marketplace.json
+++ b/plugin/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "Spec-driven development for Claude Code — /spec plans, reviews, and executes with quality gates; plus security audits, code reviews, test generation, and release prep from /attune.",
-    "version": "16.0.0"
+    "version": "16.1.0"
   },
   "plugins": [
     {
       "name": "attune-ai",
       "description": "Spec-driven development for Claude Code — /spec plans, reviews, and executes with quality gates; plus security audits, code reviews, test generation, and release prep from /attune.",
       "source": "./",
-      "version": "16.0.0",
+      "version": "16.1.0",
       "author": {
         "name": "Smart AI Memory",
         "email": "patrick.roebuck@smartaimemory.com"

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "attune-ai",
-  "version": "16.0.0",
+  "version": "16.1.0",
   "description": "Persistent memory and receipt-verified workflows for Claude Code — /spec plans, reviews, and executes with quality gates; plus security audits, code reviews, test generation, and release prep from /attune.",
   "author": {
     "name": "Smart AI Memory",

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -4,7 +4,7 @@ Spec-driven development for Claude Code — turn requirements
 into reliable software. <!-- cap:skill_count -->28 auto-triggering skills<!-- /cap -->, zero
 commands: say what you need and Claude picks the right skill.
 
-**Version:** 16.0.0 | **License:** Apache 2.0
+**Version:** 16.1.0 | **License:** Apache 2.0
 
 > **Fix Receipts** (`/fix`) — new in 11.2.0. Say `fix this and
 > prove it`.

--- a/plugin/core/__init__.py
+++ b/plugin/core/__init__.py
@@ -5,4 +5,4 @@ This module provides the core workflow functionality when the full
 attune-ai package is not installed via pip.
 """
 
-__version__ = "16.0.0"
+__version__ = "16.1.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "attune-ai"
-version = "16.0.0"
+version = "16.1.0"
 description = "Persistent memory and receipt-verified workflows for Claude Code — plugin, MCP server, and spec-driven dev framework."
 readme = {file = "README.md", content-type = "text/markdown"}
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -299,7 +299,7 @@ wheels = [
 
 [[package]]
 name = "attune-ai"
-version = "16.0.0"
+version = "16.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "agent-memory-client" },

--- a/website/app/page.tsx
+++ b/website/app/page.tsx
@@ -38,7 +38,7 @@ export default function Home() {
                 test_homepage_badge_includes_package_version guard scans
                 this file for vX.Y.Z and compares it to the package. */}
             <div className="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-[var(--surface-container-high)] text-[var(--primary)] text-xs font-bold tracking-widest mb-8 uppercase">
-              <span>v16.0.0</span>
+              <span>v16.1.0</span>
               <span className="w-1 h-1 rounded-full bg-[var(--primary)]" aria-hidden="true"></span>
               <span className="opacity-80">Persistent memory for AI coding agents</span>
             </div>

--- a/website/lib/features.ts
+++ b/website/lib/features.ts
@@ -85,7 +85,7 @@ export const PRODUCTS: Product[] = [
     id: "attune-ai",
     name: "Attune AI",
     pypiName: "attune-ai",
-    version: "16.0.0",
+    version: "16.1.0",
     tagline: "Generate, maintain, and serve help from your code",
     installCommand: "pip install attune-ai",
     marketplaceInstall:
@@ -129,7 +129,7 @@ export const PRODUCTS: Product[] = [
     id: "claude-code-plugin",
     name: "Claude Code Plugin",
     pypiName: "attune-ai",
-    version: "16.0.0",
+    version: "16.1.0",
     tagline: "Progressive help right in your terminal",
     installCommand:
       "claude plugin marketplace add Smart-AI-Memory/attune-ai",


### PR DESCRIPTION
Release prep for **16.1.0** — a maintenance release on top of 16.0.0's destructive half.

## Why this release exists

Four commits have touched shipped code since `v16.0.0`, and none of them have reached users:

| PR | Change | Section |
|---|---|---|
| #2337 | stale external entry-point detector | Added |
| #2336 | round-table `receipt` message kind | Added |
| #2338 | starter reconciler flags stale `release_state` | Changed |
| #2346 | round-table kind list single-sourced | Fixed |

The weight is #2337. After 16.0.0 removed the `attune.plugins` / `attune.wizards` entry-point groups, an external extension still declaring them failed by **silent non-loading** — nothing in the user's own code to grep for. That now warns once per process and points at the migration guide.

#2337's own title says "(16.0.x)", so it was authored expecting a release that never got cut.

## Changelog honesty

Only #2337 had logged an entry. The other three shipped silently, so I wrote entries for them here — a changelog that omits shipped code is its own kind of fiction. #2346's entry names the actual user-facing symptom: the Lua `must be one of` message had listed six of the nine valid kinds since V2-P4, so a caller rejected for a typo was handed an incomplete list of the alternatives.

Bump is **minor**: two `Added` features, no breaking change.

## Explicitly NOT in this release

The `[backend]` optional extra still installs fastapi/uvicorn/bcrypt/PyJWT. Worth stating plainly, because it looks like an omission:

- the backend code it served **never shipped in the wheel** — verified against the published 16.0.0 artifact, which has zero `backend/` entries
- so the extra was already vestigial *before* #2345 deleted the source
- removing a published extra is a breaking change and belongs to the release-16 manifest's destructive scope, not a minor release

Likewise, #2345's 5,478-line Railway/backend retirement is **not** a headline here: it changed the shipped package by nothing. It gets no changelog entry because there is no user-visible change to describe.

## Receipts

- `scripts/bump_version.py 16.1.0` — 10 sites; `grep -rn '16\.0\.0'` leaves only changelog history, a `rich<16.0.0` cap, and node engine ranges
- `uv lock` → **one line** changed (`attune-ai 16.0.0 → 16.1.0`), no dependency cascade
- `black --check` + `ruff check` clean on the one touched Python file
- 16 version-drift and changelog gate tests pass
- Base: `main @ e328fea91` with a **completed-green** full matrix (the earlier `a546e3239` run was cancelled by the rapid-merge race; `e328fea91` is its descendant, so that content is covered)

`SKIP=check-docs-freshness` on the commit is the sanctioned release-prep skip — the stale count spikes on every version bump from version-hash noise, not real staleness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
