### PR TITLE
ci: require a changelog entry or an explicit opt-out on shipped code

### DIFF
--- a/.github/scripts/changelog_gate.py
+++ b/.github/scripts/changelog_gate.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Changelog-entry gate — a PR touching shipped code must DECLARE its
+user-visibility, either by writing a CHANGELOG entry or by labelling the
+PR ``no-changelog``.
+
+Why this exists (2026-08-28): 10 of the last 14 ``src/``-touching PRs
+merged with no changelog entry, and the omission stays invisible until
+someone cuts a release. ``release.yml`` only EXTRACTS notes at tag time,
+so it faithfully publishes whatever is there — a thin section reads as
+"a small release" rather than "a broken record". v16.1.0 shipped three
+changes (#2336, #2338, #2346) whose entries had to be reconstructed by
+hand during release prep.
+
+Why a DECLARATION and not an inference: keying the rule on the PR title
+was tried and rejected. The title is an author declaration rather than a
+property of the diff, and ``refactor:`` covers both user-visible config
+renames (#2321, #2319) and invisible internals (#2314, #2303) — so a
+title rule is imprecise in both directions and silently gameable. This
+gate instead asks the author to decide at the one moment they actually
+know, and records that decision as a label which, unlike an allowlist
+entry, dies with the PR instead of becoming permanent review debt.
+
+Exit 0 = satisfied, exit 1 = the PR must add an entry or the label.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+
+#: Path prefixes whose changes reach users through the published wheel.
+#: ``tests/`` and ``docs/`` are deliberately absent — they ship nothing.
+SHIPPED_PREFIXES: tuple[str, ...] = ("src/", "attune_redis/")
+
+#: The file an entry must land in.
+CHANGELOG = "CHANGELOG.md"
+
+#: Applying this label IS the declaration that the change is not
+#: user-visible. Per-PR and self-expiring by design.
+OPT_OUT_LABEL = "no-changelog"
+
+
+def touches_shipped_code(paths: list[str]) -> bool:
+    """Return True when any path reaches users through the wheel."""
+    return any(path.startswith(SHIPPED_PREFIXES) for path in paths)
+
+
+def is_satisfied(paths: list[str], labels: list[str]) -> bool:
+    """Return True when the PR has declared its user-visibility.
+
+    Satisfied three ways: it ships nothing, it edits the changelog, or it
+    carries the opt-out label.
+    """
+    if not touches_shipped_code(paths):
+        return True
+    if CHANGELOG in paths:
+        return True
+    return OPT_OUT_LABEL in labels
+
+
+def changed_paths(base_ref: str) -> list[str]:
+    """Paths changed against the merge base, or ``["src/"]`` on failure.
+
+    Fail-CLOSED: a diff we cannot compute is treated as touching shipped
+    code, so an infrastructure error asks for a declaration rather than
+    waving the PR through. This mirrors tests.yml's "run more, never
+    fewer required signals" fallback and contract principle 7 (a failed
+    gatekeeper fails the gate). The opt-out label stays available, so a
+    misfire costs one click rather than a blocked branch.
+    """
+    try:
+        subprocess.run(
+            ["git", "fetch", "--no-tags", "--quiet", "origin", base_ref],
+            check=False,
+            capture_output=True,
+        )
+        result = subprocess.run(
+            ["git", "diff", "--name-only", f"origin/{base_ref}...HEAD"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except (subprocess.CalledProcessError, OSError) as exc:
+        print(f"::warning::could not compute the diff ({exc}) - failing closed")
+        return ["src/"]
+    return [line for line in result.stdout.splitlines() if line]
+
+
+def main() -> int:
+    """Run the gate against the current PR; return a process exit code."""
+    parser = argparse.ArgumentParser(description="Changelog-entry gate")
+    parser.add_argument("--base-ref", default=os.environ.get("BASE_REF", ""))
+    parser.add_argument(
+        "--labels",
+        default=os.environ.get("PR_LABELS", ""),
+        help="comma-separated PR labels",
+    )
+    args = parser.parse_args()
+
+    if not args.base_ref:
+        print("no base ref (not a pull request) - gate does not apply")
+        return 0
+
+    paths = changed_paths(args.base_ref)
+    labels = [item.strip() for item in args.labels.split(",") if item.strip()]
+
+    print("changed files:")
+    for path in paths:
+        print(f"  {path}")
+    print(f"labels: {labels or '(none)'}")
+
+    if is_satisfied(paths, labels):
+        print("OK: user-visibility declared (entry present, label set, or nothing shipped)")
+        return 0
+
+    shipped = "\n  ".join(p for p in paths if p.startswith(SHIPPED_PREFIXES))
+    print(
+        f"::error::This PR changes shipped code but neither edits {CHANGELOG} "
+        f"nor carries the '{OPT_OUT_LABEL}' label. "
+        "Add an entry under [Unreleased] describing what a USER sees, or "
+        f"apply '{OPT_OUT_LABEL}' if the change is internal-only (refactors, "
+        "test-only fixes, import moves). "
+        f"Shipped paths in this PR: {shipped}"
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/changelog-gate.yml
+++ b/.github/workflows/changelog-gate.yml
@@ -1,0 +1,47 @@
+name: Changelog Entry Gate
+
+# Asks every PR that touches shipped code to DECLARE its user-visibility:
+# either an entry under CHANGELOG.md's [Unreleased], or the `no-changelog`
+# label. See .github/scripts/changelog_gate.py for why this is a declaration
+# rather than an inference from the PR title.
+#
+# NO path filter, deliberately. A path-filtered required check reports as
+# "missing" on a PR that touches none of its paths, which blocks that PR
+# forever — the trap that needed admin-merges for #1141/#1143/#1144 on
+# 2026-06-28. This workflow always runs and the script no-ops green when the
+# PR ships nothing, the same discipline as docs.yml and tests.yml's
+# website_only guard.
+#
+# `labeled`/`unlabeled` are present so applying `no-changelog` re-runs the
+# gate and flips it green without an empty commit to force a re-check.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: changelog-gate-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  changelog-entry:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # Full history: the gate diffs against origin/<base>...HEAD.
+          fetch-depth: 0
+
+      - name: Check for a changelog entry or an explicit opt-out
+        env:
+          BASE_REF: ${{ github.base_ref }}
+          PR_LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
+        # Runner python3 on purpose — the gate is stdlib-only, so pulling in
+        # setup-python would add a step and a pip-cache requirement for
+        # nothing.
+        run: python3 .github/scripts/changelog_gate.py

--- a/tests/unit/ci/test_workflow_yaml.py
+++ b/tests/unit/ci/test_workflow_yaml.py
@@ -60,6 +60,7 @@ ALL_USES = _collect_all_uses()
 WORKFLOWS_REQUIRING_CONCURRENCY = {
     "tests.yml",
     "pre-commit.yml",
+    "changelog-gate.yml",
     # codeql.yml removed post-v6.3.0 — GitHub's default CodeQL
     # setup owns code-scanning for this repo; the custom
     # workflow couldn't upload SARIF while default setup was

--- a/tests/unit/gates/test_changelog_gate.py
+++ b/tests/unit/gates/test_changelog_gate.py
@@ -1,0 +1,140 @@
+"""Pins the changelog-entry gate's decision rule.
+
+Origin (2026-08-28): 10 of the last 14 ``src/``-touching PRs merged with
+no CHANGELOG entry, and v16.1.0's notes had to be reconstructed by hand
+at release time. The gate makes the author declare user-visibility while
+they still know it.
+
+The fixtures below are drawn from REAL merged PRs, including the two the
+calibration pass identified as the reason a title-prefix rule was
+rejected — ``refactor:``-titled PRs that were nonetheless user-visible
+(#2321, #2319) alongside ``refactor:``/``fix:``-titled ones that were
+purely internal (#2314, #2303). Under a declaration rule all four land in
+the same bucket ("must declare"), which is exactly the point: the gate no
+longer has to guess which kind it is looking at. If a future change
+reintroduces title parsing, these cases are what it must still get right.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+_GATE = Path(__file__).resolve().parents[3] / ".github" / "scripts" / "changelog_gate.py"
+_spec = importlib.util.spec_from_file_location("changelog_gate", _GATE)
+assert _spec and _spec.loader
+changelog_gate = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(changelog_gate)
+
+is_satisfied = changelog_gate.is_satisfied
+touches_shipped_code = changelog_gate.touches_shipped_code
+OPT_OUT_LABEL = changelog_gate.OPT_OUT_LABEL
+
+
+class TestShippedCodeDetection:
+    """Only paths that reach a user through the wheel count."""
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "src/attune/roundtable/board.py",
+            "attune_redis/memory.py",
+        ],
+    )
+    def test_shipped_paths_are_detected(self, path: str) -> None:
+        assert touches_shipped_code([path]) is True
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "tests/unit/roundtable/test_board.py",
+            "docs/reference/API_REFERENCE.md",
+            "website/app/page.tsx",
+            "CHANGELOG.md",
+            ".github/workflows/tests.yml",
+            "scripts/bump_version.py",
+        ],
+    )
+    def test_unshipped_paths_are_ignored(self, path: str) -> None:
+        """tests/docs/website/scripts ship nothing — demanding prose for
+        them is the noise that gets a gate allowlisted into uselessness."""
+        assert touches_shipped_code([path]) is False
+
+
+class TestGateDecision:
+    """The three satisfying conditions, and the one failing one."""
+
+    def test_shipped_change_without_entry_or_label_fails(self) -> None:
+        assert is_satisfied(["src/attune/roundtable/board.py"], []) is False
+
+    def test_changelog_entry_satisfies(self) -> None:
+        assert is_satisfied(["src/attune/roundtable/board.py", "CHANGELOG.md"], []) is True
+
+    def test_opt_out_label_satisfies(self) -> None:
+        assert is_satisfied(["src/attune/roundtable/board.py"], [OPT_OUT_LABEL]) is True
+
+    def test_unrelated_labels_do_not_satisfy(self) -> None:
+        """Only the opt-out label counts; 'tests'/'core' must not leak
+        through as an accidental exemption."""
+        assert is_satisfied(["src/attune/models/auth.py"], ["tests", "core"]) is False
+
+    def test_pr_shipping_nothing_is_exempt(self) -> None:
+        assert is_satisfied(["tests/unit/test_x.py", "docs/guide.md"], []) is True
+
+    def test_empty_diff_is_exempt(self) -> None:
+        assert is_satisfied([], []) is True
+
+
+class TestRealPRFixtures:
+    """Cases from real merged PRs — the calibration record.
+
+    A title-prefix rule was rejected because it split these four the wrong
+    way. All must require a declaration; none may be silently exempt.
+    """
+
+    @pytest.mark.parametrize(
+        "pr, paths",
+        [
+            # refactor:-titled but USER-VISIBLE (a title rule would miss these)
+            ("#2321 config section rename", ["src/attune/config/core.py"]),
+            ("#2319 deprecate WorkflowConfig twin", ["src/attune/config/models.py"]),
+            # refactor:/fix:-titled and INTERNAL-ONLY (a title rule would
+            # either miss them or, if refactor: were required, cry wolf)
+            ("#2314 kill upward import", ["src/attune/models/router.py"]),
+            (
+                "#2303 monotonic clock de-flake",
+                ["src/attune/agent_factory/decorators.py"],
+            ),
+        ],
+    )
+    def test_all_four_require_a_declaration(self, pr: str, paths: list[str]) -> None:
+        assert is_satisfied(paths, []) is False, f"{pr} should require a declaration"
+
+    @pytest.mark.parametrize(
+        "pr, paths",
+        [
+            ("#2314 kill upward import", ["src/attune/models/router.py"]),
+            (
+                "#2303 monotonic clock de-flake",
+                ["src/attune/agent_factory/decorators.py"],
+            ),
+        ],
+    )
+    def test_internal_only_prs_clear_with_the_label(self, pr: str, paths: list[str]) -> None:
+        """The escape for genuinely internal work is one label, not an
+        allowlist entry that outlives the PR."""
+        assert is_satisfied(paths, [OPT_OUT_LABEL]) is True, pr
+
+
+class TestFailClosed:
+    """An uncomputable diff must ask for a declaration, not wave through."""
+
+    def test_diff_failure_sentinel_requires_declaration(self) -> None:
+        """``changed_paths`` returns ["src/"] when git fails; that sentinel
+        must land on the failing side (contract principle 7)."""
+        assert is_satisfied(["src/"], []) is False
+
+    def test_diff_failure_sentinel_still_respects_the_label(self) -> None:
+        assert is_satisfied(["src/"], [OPT_OUT_LABEL]) is True


### PR DESCRIPTION
Fixes the root cause behind v16.1.0's release prep, where three shipped changes (#2336, #2338, #2346) had no changelog entry and had to be written by hand at tag time.

## The measurement

**10 of the last 14 `src/`-touching PRs merged with no CHANGELOG entry (71%).** The omission is silent in both directions: the PR author sees green CI, and the release author sees a thin `[Unreleased]` section that reads as *"a small release"* rather than *"a broken record"*. `release.yml` only **extracts** notes at tag time, so it faithfully publishes whatever is there.

The costliest miss was #2346 — it fixed a Lua error message that had named six of nine valid kinds since V2-P4, so anyone rejected for a typo got an incomplete list of alternatives. Genuinely user-visible, and it would have shipped undescribed.

## What it does

A PR touching `src/` or `attune_redis/` must **either** edit `CHANGELOG.md` **or** carry the `no-changelog` label.

## Why a declaration, not an inference

My first design keyed on the PR title (`feat:`/`fix:` → require an entry). Calibration killed it. The title is an **author declaration rather than a property of the diff**, and `refactor:` splits the wrong way:

| PR | Title type | Actually user-visible? |
|---|---|---|
| #2321 config section rename | `refactor:` | **yes** |
| #2319 deprecate WorkflowConfig twin | `refactor:` | **yes** |
| #2314 kill upward import | `refactor:` | no |
| #2303 monotonic-clock de-flake | `fix:` | no |

A title rule misses the first two and cries wolf on the others, and it's silently gameable by retitling. Asking the author to decide — at the one moment they know — gives **100% recall**, and the label **dies with the PR** instead of becoming permanent allowlist debt (the review-debt property the repo's own gate lesson warns about).

Cost: one label click on internal PRs, roughly 10/week at the recent rate.

## Design notes

- **No path filter**, deliberately. A path-filtered *required* check reports as "missing" on PRs touching none of its paths and blocks them forever — the trap that needed admin-merges for #1141/#1143/#1144 on 2026-06-28. The workflow always runs; the script no-ops green when nothing shipped is touched.
- **`labeled`/`unlabeled` triggers**, so applying the label re-runs the gate rather than needing an empty commit.
- **Fail-closed** on an uncomputable diff, matching tests.yml's "run more, never fewer required signals" fallback and contract principle 7. The label keeps any misfire to one click.
- **Runner `python3`**, not `setup-python` — the script is stdlib-only, so setup-python would add a step and a pip-cache requirement for nothing.
- `changelog-gate.yml` added to `WORKFLOWS_REQUIRING_CONCURRENCY` so that invariant is pinned, not merely satisfied today.

## Receipts

Live round-trip against a **real git diff**, not only unit tests — the gate's boundary is git, so unit tests alone would be evidence inside the wrong boundary:

| Case | Result |
|---|---|
| ships nothing | exit **0** |
| `src/` touched, no entry, no label | exit **1**, actionable message naming the shipped paths |
| same diff + `no-changelog` label | exit **0** |
| same diff + a `CHANGELOG.md` edit | exit **0** |

Plus 22 new gate tests and 335 workflow-policy tests green (the new workflow satisfies timeout, SHA-pinning, version-comment and concurrency invariants); black + ruff clean.

The four real-PR fixtures above are pinned as tests — they are *why* title parsing was rejected, and what any future reintroduction of it must still get right.

## Note on making it required

This PR only adds the check. Promoting it to a **required** status check is a branch-protection change and yours to make — worth letting it run on a few PRs first to confirm the label workflow feels right before it can block anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
