### PR TITLE
chore(blurbs): align plugin README + PyPI description with DEC-11 precision copy

### DIFF
--- a/plugin/README.md
+++ b/plugin/README.md
@@ -1,7 +1,8 @@
 # attune-ai
 
-Spec-driven development for Claude Code — turn requirements
-into reliable software. <!-- cap:skill_count -->28 auto-triggering skills<!-- /cap -->, zero
+Persistent memory and receipt-verified workflows for Claude
+Code. Your agent stops starting from zero, and its word stops
+being the evidence. <!-- cap:skill_count -->28 auto-triggering skills<!-- /cap -->, zero
 commands: say what you need and Claude picks the right skill.
 
 **Version:** 16.1.0 | **License:** Apache 2.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "attune-ai"
 version = "16.1.0"
-description = "Persistent memory and receipt-verified workflows for Claude Code — plugin, MCP server, and spec-driven dev framework."
+description = "Persistent memory and receipt-verified workflows for Claude Code — plugin, MCP server, and CLI."
 readme = {file = "README.md", content-type = "text/markdown"}
 requires-python = ">=3.10"
 license = {file = "LICENSE"}


### PR DESCRIPTION
## What

Execution map item 4 of the positioning review ([positioning-2026-08-29.md](https://github.com/Smart-AI-Memory/attune-ai/pull/2355)) — the plugin/PyPI blurb pass:

- **plugin/README.md opening** (the marketplace-rendered first contact): the spec-first story ("Spec-driven development for Claude Code") is replaced with the ratified precision line plus the stops-starting-from-zero pair. The `cap:skill_count` fragment is preserved byte-identical.
- **pyproject `description`** (the PyPI card): "spec-driven dev framework" -> "CLI" as the trailing noun — DEC-12 keeps heavyweight vocabulary out of first-contact copy. This takes no position on the open harness-vs-plugin ruling; it just lists the three install surfaces factually.

**Audited, no edit needed**: `plugin/.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json` already open with the precision line.

## Receipts

- `scripts/project_capabilities.py --check`: clean after the edit (28 skills / 59 registered / 48 core)
- No test or script pins either replaced string (repo-wide grep)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
