### PR TITLE
site(positioning): DEC-11 hero + DEC-14 pillar fold

### DIFF
--- a/website/app/page.tsx
+++ b/website/app/page.tsx
@@ -43,13 +43,14 @@ export default function Home() {
               <span className="opacity-80">Persistent memory for AI coding agents</span>
             </div>
             <h1 className="text-5xl md:text-7xl font-extrabold tracking-tighter mb-8 leading-[1.1]">
-              Build software from{' '}
-              <span className="text-gradient">specifications</span>, not prompts.
+              Give your agent a <span className="text-gradient">memory</span>.
+              Make it show <span className="text-gradient">receipts</span>.
             </h1>
             <p className="text-lg md:text-xl text-[var(--text-secondary)] mb-10 max-w-2xl mx-auto leading-relaxed">
-              Attune gives AI coding agents persistent project memory and a
-              reliability layer that keeps changes grounded in your code,
-              aligned with your requirements, and verified before they ship.
+              Your agent stops starting from zero &mdash; and its word stops
+              being the evidence. Attune carries decisions, bugs, and lessons
+              across sessions, and verifies every change with probes re-run
+              independently of the agent that claims it finished.
             </p>
             <div className="flex flex-col sm:flex-row gap-4 justify-center">
               <Link

--- a/website/lib/features.ts
+++ b/website/lib/features.ts
@@ -355,29 +355,13 @@ export const PILLARS: Pillar[] = [
       "Local-first by default — no cloud required",
       "Redis semantic tier, client included (local Ollama embeddings)",
       "Automatic recall, or on demand with /recall",
+      // DEC-13/14: cross-provider portability is a property of the
+      // memory, not a separate pillar — anti-lock-in framing, exactly
+      // the three verified providers.
+      "Git-tracked files in your repo — served to Claude Code, Codex, or Antigravity alike. Switch agents; keep everything.",
     ],
     icon: "🧠",
     color: "secondary",
-  },
-  // 10.6.0 multi-LLM wave (launch plan; wording aligned with the
-  // shipped README "Multi-LLM collaboration" section).
-  {
-    id: "multi-llm",
-    tag: "Multi-LLM",
-    title: "Three AI agents, one project brain",
-    description:
-      "Claude Code, Codex, and Antigravity share the same project " +
-      "memory, hand off work with git-verified packets, and give " +
-      "each other second opinions on real diffs. The round table " +
-      "lets them deliberate a question — you chair what gets " +
-      "adopted.",
-    points: [
-      "Shared session memory via MCP — same tools in every agent",
-      "Handoffs re-verified against the actual git tree on resume",
-      "Cross-model review and deliberation — advisory; you decide",
-    ],
-    icon: "🤝",
-    color: "accent",
   },
   {
     id: "communication",
@@ -442,6 +426,9 @@ export const PILLARS: Pillar[] = [
     points: [
       "Verifies docs, code, and generated content",
       "Closes the loop the spec opened",
+      // DEC-14: cross-model review/deliberation live under the
+      // receipts culture, not a standalone multi-LLM pillar.
+      "Cross-model review and roundtable deliberation — advisory; you decide",
       "Built from the discipline that runs this project",
     ],
     icon: "✅",


### PR DESCRIPTION
## What

Execution map item 3 of the positioning review ([positioning-2026-08-29.md](https://github.com/Smart-AI-Memory/attune-ai/pull/2355)) — held until #2357 merged, now rebased onto main:

- **Homepage hero adopts the ratified DEC-11 persuasion pair**: "Give your agent a memory. Make it show receipts." with the stops-starting-from-zero subhead. Retires the spec-first H1 and the "reliability layer" phrasing (vendor-language the trust-layer pressure test rejected).
- **DEC-14 pillar fold**: the standalone multi-LLM pillar merges into the two it supports — cross-provider portability becomes the memory pillar's anti-lock-in point (DEC-13 copy, naming exactly Claude Code / Codex / Antigravity), and cross-model review/roundtable move under the verification pillar. Six pillars -> five; how-it-works and pricing render the array generically, no layout change.

## Receipts

- Rebased onto merged #2357; replayed commit signature verified `G` before push
- `tests/unit/test_website_version_accuracy.py`: 15 passed on the rebased branch (website-only PR — CI skips it)
- `tsc --noEmit`: clean for lib/ and app/ at authoring time

🤖 Generated with [Claude Code](https://claude.com/claude-code)
