### PR TITLE
docs(website): interpolate CAPABILITIES.skills in docs FAQ, drop stale 26-count

### DIFF
--- a/website/app/docs/page.tsx
+++ b/website/app/docs/page.tsx
@@ -45,8 +45,7 @@ const faqItems = [
   },
   {
     question: 'What Claude Code skills are included?',
-    answer:
-      '26 auto-invoking skills: security audit, smart test, code quality, bug prediction, doc generation, refactor planning, release prep, planning, spec-driven development, fix-test, workflow orchestration, RAG-grounded code generation, content verification, cross-session recall, memory and context, personal memory, image analysis, batch processing, capability catalog, discovery sweep, form-driven elicitation, the coach help system, the attune hub router, single-source feature-page authoring, cross-model diff review, and the multi-LLM round table.',
+    answer: `${CAPABILITIES.skills} auto-invoking skills, including security audit, smart test, code quality, bug prediction, doc generation, refactor planning, release prep, spec-driven development, outcome-first fixing, RAG-grounded code generation, cross-session recall, image analysis, batch processing, cross-model diff review, and the multi-LLM round table. Run the catalog skill for the full, always-current list.`,
   },
   {
     question: 'Where do I install attune-help from?',


### PR DESCRIPTION
## Summary

The docs-page FAQ answer "What Claude Code skills are included?" hardcoded **26 auto-invoking skills** with a full enumeration; the live registry (`CAPABILITIES.skills` in `website/lib/features.ts`, backed by `plugin/skills/`) is at **28** — the enumeration was missing `fix` and `docs-outbox`.

Per `.claude/rules/attune/website-content-accuracy.md`:

- Interpolate `CAPABILITIES.skills` in a template literal instead of hardcoding the count (the import was already present in the file).
- Trim the enumeration to a representative list (every named skill verified against `plugin/skills/`) that points at the catalog skill for the always-current inventory — a full list drifts silently on every skill add, and nothing guards this prose.

Website-only change → no changelog entry (per `website/CLAUDE.md`).

## Verification

- `pytest tests/unit/test_website_version_accuracy.py` — **15/15 passed locally** (website-only PRs skip the Python suite in CI, so the local run is the only enforcement).
- `ls -d plugin/skills/*/ | wc -l` → 28, matching `CAPABILITIES.skills`.
- `npx tsc --noEmit` — no errors in `app/docs/page.tsx` (remaining errors are pre-existing missing-node_modules noise in unrelated files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
