### PR TITLE
site(attune-ai-dev): DEC-11 landing tagline + retire framework phrasing

### DIFF
--- a/attune-ai-dev/index.html
+++ b/attune-ai-dev/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>attune-ai — persistent memory and receipt-verified workflows for Claude Code</title>
-  <meta name="description" content="Persistent memory and receipt-verified workflows for Claude Code — plugin, MCP server, and spec-driven dev framework. Cross-session memory, acceptance probes re-run independently, RAG grounding." />
+  <meta name="description" content="Persistent memory and receipt-verified workflows for Claude Code — plugin, MCP server, and CLI. Cross-session memory, acceptance probes re-run independently, RAG grounding." />
 
   <!-- Social sharing -->
   <meta property="og:title" content="attune-ai" />
@@ -185,14 +185,15 @@
       <span class="dot"></span>
       <span>MCP server</span>
       <span class="dot"></span>
-      <span>Python framework</span>
+      <span>CLI</span>
     </span>
 
     <h1>attune-ai</h1>
     <p class="tagline">
-      Persistent memory and receipt-verified workflows for Claude Code.
-      Your agent stops starting from zero — and its word stops being
-      the evidence.
+      Give your agent a memory. Make it show receipts.
+      Attune carries decisions, bugs, and lessons across sessions,
+      and verifies every change with probes re-run independently of
+      the agent that claims it finished.
     </p>
 
     <div class="install" aria-label="Install command">


### PR DESCRIPTION
## What

Chair-directed extension of the positioning execution map ([positioning-2026-08-29.md](https://github.com/Smart-AI-Memory/attune-ai/blob/main/docs/specs/product-direction-review/positioning-2026-08-29.md)) to the attune-ai.dev landing page:

- **Tagline** adopts the DEC-11 persuasion pair — "Give your agent a memory. Make it show receipts." — followed by the concrete elaboration (sessions carried, probes re-run independently). The H1 stays the package name; `<title>`, meta, and og keep the precision line, per the DEC-11 surface split.
- **"Framework" phrasing retired from first contact**: meta description "spec-driven dev framework" -> "CLI" (matching the PyPI description change in #2358); eyebrow "Python framework" -> "CLI".

## Receipts

- Rendered locally in the browser pane: eyebrow ("Claude Code plugin • MCP server • CLI"), new tagline, and install block all verified visually.
- Static single-file change; Vercel serves the committed HTML — no build script involved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
