### PR TITLE
site(metrics): coverage stat shows the real CI ratchet (94%+), drift-guarded

### DIFF
--- a/tests/unit/test_website_version_accuracy.py
+++ b/tests/unit/test_website_version_accuracy.py
@@ -82,6 +82,29 @@ class TestFeaturesVersionSync:
             "update the <span>vX.Y.Z</span> badge in website/app/page.tsx"
         )
 
+    def test_coverage_floor_matches_ci_gate(self):
+        """The site's coverage stat must equal the CI ratchet it advertises.
+
+        METRICS.coverageFloorPct renders as "NN%+" — a claim guaranteed by
+        the coverage job's --cov-fail-under gate in tests.yml, which is a
+        raise-only ratchet. If the ratchet rises without the site following,
+        the site silently undersells (the failure mode this stat replaced:
+        it showed the 85 secondary floor while actual coverage was ~96).
+        Bump METRICS.coverageFloorPct in the same PR that raises the gate.
+        """
+        workflow = REPO / ".github" / "workflows" / "tests.yml"
+        wf_matches = re.findall(r"--cov-fail-under=(\d+)", workflow.read_text(encoding="utf-8"))
+        assert wf_matches, "no --cov-fail-under gate found in tests.yml coverage job"
+        gate = max(int(m) for m in wf_matches)
+
+        site = re.search(r"coverageFloorPct:\s*(\d+)", FEATURES.read_text(encoding="utf-8"))
+        assert site, "no coverageFloorPct in website/lib/features.ts METRICS"
+        assert int(site.group(1)) == gate, (
+            f"features.ts coverageFloorPct {site.group(1)} != CI coverage gate "
+            f"{gate} (tests.yml --cov-fail-under) — the site stat must track "
+            "the ratchet; bump both together"
+        )
+
 
 # --- Layer 2: hermetic tests of the PyPI audit script -----------------
 

--- a/website/app/benchmarks/page.tsx
+++ b/website/app/benchmarks/page.tsx
@@ -47,22 +47,23 @@ const METHODOLOGIES: Methodology[] = [
     ],
   },
   {
-    stat: `${METRICS.coverageFloorPct}%`,
-    label: 'coverage floor, CI-enforced',
+    stat: `${METRICS.coverageFloorPct}%+`,
+    label: 'test coverage, CI-gated',
     what:
-      'The minimum line coverage the project accepts — a floor the build ' +
-      'enforces, not a marketing average. Actual coverage sits at or above ' +
-      'it by construction.',
+      'The line coverage CI enforces on every merge — a raise-only ' +
+      'ratchet, not a marketing average. Actual coverage sits at or above ' +
+      'it by construction: a run below this number fails the build.',
     how:
-      'Enforced identically in three places: pytest runs with ' +
-      '--cov-fail-under=85 (pyproject.toml), and Codecov gates both the ' +
-      'project total and every patch at 85%. One number everywhere — a PR ' +
-      'that drops changed-code coverage below the floor cannot merge.',
+      `The coverage job runs pytest with --cov-fail-under=${METRICS.coverageFloorPct} ` +
+      '(a one-way valve: raised when main climbs, never lowered to make a ' +
+      'red PR pass). Codecov additionally gates the project total and ' +
+      'every patch at 85%. The live figure is on Codecov.',
     gate:
-      'The threshold itself is drift-guarded: a unit test fails CI if the ' +
-      'configured coverage gate is ever lowered.',
+      'Drift-guarded twice: a unit test fails CI if the configured gate is ' +
+      'ever lowered, and another fails if this displayed number diverges ' +
+      'from the gate the workflow actually enforces.',
     sources: [
-      { label: 'pyproject.toml', href: `${REPO}/blob/main/pyproject.toml` },
+      { label: 'CI coverage gate (tests.yml)', href: `${REPO}/blob/main/.github/workflows/tests.yml` },
       { label: 'codecov.yml', href: `${REPO}/blob/main/codecov.yml` },
       { label: 'Live coverage on Codecov', href: 'https://codecov.io/gh/Smart-AI-Memory/attune-ai' },
     ],

--- a/website/app/page.tsx
+++ b/website/app/page.tsx
@@ -236,8 +236,8 @@ export default function Home() {
                 <div className="text-sm text-[var(--text-muted)] mt-1">automated tests</div>
               </div>
               <div>
-                <div className="text-4xl font-extrabold text-[var(--primary)]">{METRICS.coverageFloorPct}%</div>
-                <div className="text-sm text-[var(--text-muted)] mt-1">coverage floor, CI-enforced</div>
+                <div className="text-4xl font-extrabold text-[var(--primary)]">{METRICS.coverageFloorPct}%+</div>
+                <div className="text-sm text-[var(--text-muted)] mt-1">test coverage, CI-gated</div>
               </div>
               <div>
                 <div className="text-4xl font-extrabold text-[var(--primary)]">{METRICS.ragFaithfulness}</div>

--- a/website/components/TestsBadge.tsx
+++ b/website/components/TestsBadge.tsx
@@ -29,7 +29,7 @@ export default function TestsBadge({
         <polyline points="20 6 9 17 4 12" />
       </svg>
       <span>
-        {tests} tests | {coverage}% coverage
+        {tests} tests | {coverage}%+ coverage
       </span>
     </span>
   );

--- a/website/lib/features.ts
+++ b/website/lib/features.ts
@@ -60,15 +60,23 @@ export const CAPABILITIES = {
  *     freshness-guarded by scripts/check_badge_freshness.py in CI —
  *     it fails the build if actual collected tests fall below the
  *     floor or exceed it by more than the margin.
- *   coverageFloorPct: --cov-fail-under in pyproject + the codecov
- *     project/patch gates (one number, chair-ruled 2026-08-22).
+ *   coverageFloorPct: the CI coverage RATCHET — the
+ *     `--cov-fail-under` value in tests.yml's coverage job (a
+ *     raise-only valve; the authoritative merge gate). Displayed
+ *     as "NN%+": actual coverage sits at or above it by
+ *     construction, so the claim needs no freshness script.
+ *     Drift-guarded: test_coverage_floor_matches_ci_gate fails if
+ *     this number diverges from the workflow's gate (bump both
+ *     together when the ratchet rises). pyproject's fail_under=85
+ *     and the codecov 85% targets are looser secondary floors —
+ *     not this number.
  *   ragFaithfulness: attune-rag's measured MEAN faithfulness (40-query
  *     golden set, N=20 runs). The CI regression gate is locked at
  *     ≥ 0.9686 — say "mean 0.97, CI-gated", never "gated at ≥ 0.97".
  */
 export const METRICS = {
   testsFloor: "25,000+",
-  coverageFloorPct: 85,
+  coverageFloorPct: 94,
   ragFaithfulness: "0.97",
 } as const;
 


### PR DESCRIPTION
## What

The homepage coverage tile displayed **85%** (the secondary pyproject/codecov floor) while actual coverage is **95.91%** and the authoritative merge gate — tests.yml's `--cov-fail-under=94` raise-only ratchet — is 94. The founder read the tile as "coverage is 85%"; every visitor will too. An 11-point undersell on the site's best quality receipt.

Now the stat tracks the ratchet and renders **"94%+ test coverage, CI-gated"** — a claim the gate itself guarantees on every merge, so no freshness script is needed:

- `METRICS.coverageFloorPct` 85 -> 94; doc comment names the ratchet as source
- Homepage tile, benchmarks card, and the TestsBadge chip all render `NN%+`
- Benchmarks copy rewritten with ratchet semantics (codecov 85% gates named as secondary; live figure linked)
- **New drift guard** `test_coverage_floor_matches_ci_gate`: CI fails if the displayed number ever diverges from the workflow gate — when the ratchet rises, the site must follow in the same PR

## Receipts

- `tests/unit/test_website_version_accuracy.py`: **16 passed** including the new guard
- `tsc --noEmit` clean
- Rendered live on the dev server: tile reads "94%+ | test coverage, CI-gated" (verified via DOM query + screenshot)
- Actual coverage 95.91% verified via the Codecov API this session

🤖 Generated with [Claude Code](https://claude.com/claude-code)
