### PR TITLE
docs+readme: DEC-18 probe receipt — Antigravity spec-rung execution verified

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,10 +210,11 @@ agent's own word is never the evidence.
   executing; add `--run` for an attributed diff whose probes are
   re-run independently. Exit 0 only when the probes pass.
 - **Spec Ladders** (`/spec`) — spec-driven development, with
-  receipts: the approved spec *drives the agents*. Requirements,
-  design, and a gated task ladder the agent executes between your
-  approvals — workflows dispatched, every ruling recorded in a
-  decision file that outlives the session.
+  receipts: the approved spec *drives the agents* — Claude Code,
+  Codex, or Antigravity alike. Requirements, design, and a gated
+  task ladder the agent executes between your approvals —
+  workflows dispatched, every ruling recorded in a decision file
+  that outlives the session.
 - **Guided intakes** — `/fix` and `/spec` compose their contracts
   through a form: goal pre-filled, scope picker from paths you've
   touched, probe suggestions from matching tests.

--- a/docs/specs/product-direction-review/positioning-2026-08-29.md
+++ b/docs/specs/product-direction-review/positioning-2026-08-29.md
@@ -193,6 +193,23 @@ lead's two amendments:
   the two receipted providers) until a live-fire probe passes.
   Chair authorized the probe same-session ("go and verify").
 
+  **Probe receipt (2026-08-29, later same session): PASSED.** A
+  minimal throwaway spec (requirements/tasks/decisions) was
+  executed by Antigravity (`agy` 1.1.22, scoped workspace): the
+  seat created the spec'd file, checked the ladder box, and
+  appended the ruling — all three verified by the LEAD re-running
+  them centrally (file prints the exact required string, exit 0;
+  box checked; ruling line present), never by the seat's
+  self-report. Scope honestly stated: one rung with recorded
+  ruling, not the full gated /spec interview flow. This authorizes
+  the three-provider execution line in copy. Environment notes for
+  reproduction: agy's bundled datacloud_telemetry PreToolUse hook
+  is version-skewed against agy 1.1.22 (blocks ALL tool calls;
+  chair disabled it for the probe), and headless agy needs either
+  a permissions allow-rule or a scoped workspace with
+  auto-approval. Transcript: agy brain run d160cfba (10:54),
+  rendered copy delivered to the chair in-session.
+
 Copy: README Spec Ladders bullet, plugin README callout,
 how-it-works spec-gate card, and the reliability loop's Build
 stage all gain engine-framing ("the approved spec drives the


### PR DESCRIPTION
## What

Records the **passed** DEC-18 live-fire probe and ships the line it was holding:

- **Probe receipt** (recorded in [positioning-2026-08-29.md](https://github.com/Smart-AI-Memory/attune-ai/blob/main/docs/specs/product-direction-review/positioning-2026-08-29.md) DEC-18): Antigravity (agy 1.1.22, scoped workspace) executed a minimal attune spec ladder rung — created the spec'd file, checked the ladder box, appended the ruling. All three artifacts re-verified centrally by the lead (exact required output, exit 0, box checked, ruling present) — never the seat's self-report. Scope stated honestly: one rung with recorded ruling, not the full gated /spec interview flow.
- **README Spec Ladders bullet** gains the now-authorized three-provider line: "the approved spec drives the agents — Claude Code, Codex, or Antigravity alike."
- Environment reproduction notes recorded: agy's bundled datacloud_telemetry PreToolUse hook is version-skewed against 1.1.22 (blocks all tool calls; chair disabled it for the probe); headless agy needs an allow-rule or a scoped auto-approved workspace.

## Receipts

- Central re-run of the three probe artifacts, in-session (chair observed)
- Verbose agy transcript (run d160cfba) rendered and delivered to the chair
- `project_capabilities.py --check` clean after the README edit

🤖 Generated with [Claude Code](https://claude.com/claude-code)
