### PR TITLE
docs(readme): add --workflow fix to the Receipts showcase command

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ get back a receipt — not a promise:
 
 ```bash
 attune fix "imports resolve after the rename" \
+  --workflow fix \
   --scope src/attune/cli_minimal.py \
   --probe "pytest tests/unit/test_cli_minimal.py" \
   --run


### PR DESCRIPTION
Verified live 2026-08-29: the README Receipts showcase ran `attune fix ... --run` without `--workflow`, which refuses to route ("no --workflow given — Fix never guesses a route") and prints the candidate list instead of executing — the showcase could not produce the receipt it advertises.

**Fix:** add `--workflow fix` to the README command block (one line).

**Sweep receipt:** grepped `attune fix` across README.md, plugin/, .claude/skills/, docs/, scripts/, src/ — every other `--run` example already carries `--workflow fix` (docs/how-to/fix.md, docs/tutorials/fix.md, quickstarts, the CLI epilog); preview-only examples intentionally omit `--run` and are unaffected. `scripts/demo/` does not exist on this branch or origin/main.

**Verification receipt:** corrected command re-run in dry preview — routes cleanly (`Selected workflow: fix`), contract renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
