### PR TITLE
feat(cli): extend attune doctor into a full install diagnostic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -136,6 +136,14 @@ while preserving portable fallbacks and explicit chair authority.
   supplies a searchable, project-confined file and folder picker through
   `attune-forms 0.11.0`, while preserving manual text entry and the native
   MCP string-input fallback.
+- **`attune doctor` is now a full install diagnostic**: one run also
+  reports the installed versions of attune-rag, attune-verify, and
+  attune-forms (degrading to "not installed" — never raising) and the
+  Claude Code plugin state (`claude` CLI on PATH plus
+  `attune-ai@attune-ai` in `claude plugin list`, checked with a short
+  timeout and fail-open on every broken-environment path). Onboarding
+  surveys shrink from a 3-command paste block to "run `attune doctor`,
+  reply with the output".
 
 - **Fix previews now negotiate portable MCP Apps rendering**: clients that
   advertise the standard Attune UI MIME profile receive the shared

--- a/src/attune/cli_commands/utility_commands.py
+++ b/src/attune/cli_commands/utility_commands.py
@@ -9,6 +9,8 @@ Licensed under Apache 2.0
 from __future__ import annotations
 
 import logging
+import shutil
+import subprocess
 import sys
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -409,7 +411,20 @@ def cmd_doctor(args: Namespace) -> int:
         except ImportError:
             _warn(f"{pkg_name} not installed", "optional")
 
-    # 5. Redis connectivity
+    # 5. Related attune packages (installed versions)
+    from importlib.metadata import PackageNotFoundError
+    from importlib.metadata import version as _pkg_version
+
+    for pkg in ("attune-rag", "attune-verify", "attune-forms"):
+        try:
+            _ok(f"{pkg} {_pkg_version(pkg)}")
+        except PackageNotFoundError:
+            _warn(f"{pkg} not installed", "optional")
+        except Exception:  # noqa: BLE001
+            # INTENTIONAL: a diagnostic must never crash on broken metadata
+            _warn(f"{pkg} version unknown", "optional")
+
+    # 6. Redis connectivity
     #
     # Probe THE CONFIGURED endpoint, via the canonical resolver. A bare
     # ``redis.Redis(...)`` defaults to localhost:6379 no matter what
@@ -431,7 +446,7 @@ def cmd_doctor(args: Namespace) -> int:
         # INTENTIONAL: Redis is optional
         _warn("Redis server not reachable", "optional")
 
-    # 6. Workflows
+    # 7. Workflows
     try:
         from attune.workflows import discover_workflows
 
@@ -441,7 +456,7 @@ def cmd_doctor(args: Namespace) -> int:
         # INTENTIONAL: Workflow discovery is non-critical
         _fail(f"Workflow discovery failed: {e}")
 
-    # 7. Wizards
+    # 8. Wizards
     try:
         from attune.wizards import list_wizards
 
@@ -451,7 +466,7 @@ def cmd_doctor(args: Namespace) -> int:
         # INTENTIONAL: Wizard discovery is non-critical
         _warn(f"Wizard discovery: {e}")
 
-    # 8. MCP server
+    # 9. MCP server
     try:
         from attune.mcp.server import AttuneMCPServer
 
@@ -461,6 +476,29 @@ def cmd_doctor(args: Namespace) -> int:
     except Exception as e:  # noqa: BLE001
         # INTENTIONAL: MCP is optional
         _warn(f"MCP server: {e}")
+
+    # 10. Claude Code plugin (the CLI works without it)
+    claude_path = shutil.which("claude")
+    if claude_path is None:
+        _warn("claude CLI not found", "optional")
+    else:
+        try:
+            proc = subprocess.run(
+                [claude_path, "plugin", "list"],
+                capture_output=True,
+                text=True,
+                timeout=10,
+                check=False,
+            )
+            if proc.returncode != 0:
+                _warn("claude plugin list failed", "optional")
+            elif "attune-ai@attune-ai" in proc.stdout:
+                _ok("Claude Code plugin attune-ai@attune-ai installed")
+            else:
+                _warn("Claude Code plugin attune-ai not installed", "optional")
+        except (subprocess.TimeoutExpired, OSError):
+            # INTENTIONAL: a diagnostic must never crash on a broken CLI
+            _warn("claude plugin list unavailable", "optional")
 
     # Summary
     total = passed + optional + failed

--- a/tests/unit/cli_commands/test_utility_commands.py
+++ b/tests/unit/cli_commands/test_utility_commands.py
@@ -1142,8 +1142,19 @@ class TestCmdDoctorInstallDiagnostics:
         """Run cmd_doctor with the environment fully mocked.
 
         subprocess.run and shutil.which are always patched so no real
-        ``claude`` process can ever spawn from a test.
+        ``claude`` process can ever spawn from a test. Patches use direct
+        module-object references (monkeypatch.setattr on the modules the
+        code under test holds), NOT patch("attune....") target strings:
+        with sys.modules["attune"] faked, Python 3.10's mock resolves
+        such strings THROUGH the MagicMock (getattr chain) and patches a
+        mock attribute instead of the real module — 3.11+ uses
+        pkgutil.resolve_name and is unaffected, so the miss is invisible
+        on newer interpreters.
         """
+        import importlib.metadata as importlib_metadata
+        import shutil as shutil_module
+        import subprocess as subprocess_module
+
         monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
         args = types.SimpleNamespace()
 
@@ -1166,24 +1177,16 @@ class TestCmdDoctorInstallDiagnostics:
         elif run_result is not None:
             run_mock.return_value = run_result
 
-        version_patch = patch(
-            "importlib.metadata.version",
+        monkeypatch.setattr(
+            importlib_metadata,
+            "version",
             pkg_version if pkg_version is not None else MagicMock(return_value="0.0.0"),
         )
+        monkeypatch.setattr(shutil_module, "which", MagicMock(return_value=which))
+        monkeypatch.setattr(subprocess_module, "run", run_mock)
 
-        with (
-            version_patch,
-            patch(
-                "attune.cli_commands.utility_commands.shutil.which",
-                MagicMock(return_value=which),
-            ),
-            patch(
-                "attune.cli_commands.utility_commands.subprocess.run",
-                run_mock,
-            ),
-        ):
-            self._last_run_mock = run_mock
-            return cmd_doctor(args)
+        self._last_run_mock = run_mock
+        return cmd_doctor(args)
 
     def test_related_packages_installed(
         self,

--- a/tests/unit/cli_commands/test_utility_commands.py
+++ b/tests/unit/cli_commands/test_utility_commands.py
@@ -1119,3 +1119,237 @@ class TestCmdDoctor:
         captured = capsys.readouterr()
         assert "not installed" in captured.out
         assert "optional" in captured.out
+
+
+# ---------------------------------------------------------------------------
+# cmd_doctor — related packages + Claude Code plugin checks
+# ---------------------------------------------------------------------------
+
+
+class TestCmdDoctorInstallDiagnostics:
+    """Tests for the related-package and Claude plugin doctor checks."""
+
+    def _run_doctor(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        fake_module,
+        *,
+        which: str | None = None,
+        run_result: MagicMock | None = None,
+        run_side_effect: Exception | None = None,
+        pkg_version: MagicMock | None = None,
+    ) -> int:
+        """Run cmd_doctor with the environment fully mocked.
+
+        subprocess.run and shutil.which are always patched so no real
+        ``claude`` process can ever spawn from a test.
+        """
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+        args = types.SimpleNamespace()
+
+        mock_version = MagicMock()
+        mock_version.__version__ = "5.0.0"
+        fake_module("attune", mock_version)
+        fake_module(
+            "attune.workflows",
+            MagicMock(discover_workflows=MagicMock(return_value={})),
+        )
+        fake_module(
+            "attune.wizards",
+            MagicMock(list_wizards=MagicMock(return_value=[])),
+        )
+        fake_module("attune.mcp.server", MagicMock())
+
+        run_mock = MagicMock()
+        if run_side_effect is not None:
+            run_mock.side_effect = run_side_effect
+        elif run_result is not None:
+            run_mock.return_value = run_result
+
+        version_patch = patch(
+            "importlib.metadata.version",
+            pkg_version if pkg_version is not None else MagicMock(return_value="0.0.0"),
+        )
+
+        with (
+            version_patch,
+            patch(
+                "attune.cli_commands.utility_commands.shutil.which",
+                MagicMock(return_value=which),
+            ),
+            patch(
+                "attune.cli_commands.utility_commands.subprocess.run",
+                run_mock,
+            ),
+        ):
+            self._last_run_mock = run_mock
+            return cmd_doctor(args)
+
+    def test_related_packages_installed(
+        self,
+        capsys: pytest.CaptureFixture[str],
+        monkeypatch: pytest.MonkeyPatch,
+        fake_module,
+    ) -> None:
+        """Installed related packages report their versions as [OK] rows."""
+        result = self._run_doctor(
+            monkeypatch,
+            fake_module,
+            pkg_version=MagicMock(return_value="1.2.3"),
+        )
+
+        assert result == 0
+        out = capsys.readouterr().out
+        assert "[OK]   attune-rag 1.2.3" in out
+        assert "[OK]   attune-verify 1.2.3" in out
+        assert "[OK]   attune-forms 1.2.3" in out
+
+    def test_related_packages_not_installed(
+        self,
+        capsys: pytest.CaptureFixture[str],
+        monkeypatch: pytest.MonkeyPatch,
+        fake_module,
+    ) -> None:
+        """Missing related packages degrade to [--] rows, never raise."""
+        from importlib.metadata import PackageNotFoundError
+
+        result = self._run_doctor(
+            monkeypatch,
+            fake_module,
+            pkg_version=MagicMock(side_effect=PackageNotFoundError("x")),
+        )
+
+        assert result == 0
+        out = capsys.readouterr().out
+        assert "[--]   attune-rag not installed (optional)" in out
+        assert "[--]   attune-verify not installed (optional)" in out
+        assert "[--]   attune-forms not installed (optional)" in out
+
+    def test_related_packages_broken_metadata(
+        self,
+        capsys: pytest.CaptureFixture[str],
+        monkeypatch: pytest.MonkeyPatch,
+        fake_module,
+    ) -> None:
+        """Arbitrary metadata errors degrade to 'version unknown'."""
+        result = self._run_doctor(
+            monkeypatch,
+            fake_module,
+            pkg_version=MagicMock(side_effect=RuntimeError("boom")),
+        )
+
+        assert result == 0
+        out = capsys.readouterr().out
+        assert "[--]   attune-rag version unknown (optional)" in out
+
+    def test_claude_cli_not_found(
+        self,
+        capsys: pytest.CaptureFixture[str],
+        monkeypatch: pytest.MonkeyPatch,
+        fake_module,
+    ) -> None:
+        """No claude on PATH is an optional [--] row, not a failure."""
+        result = self._run_doctor(monkeypatch, fake_module, which=None)
+
+        assert result == 0
+        out = capsys.readouterr().out
+        assert "[--]   claude CLI not found (optional)" in out
+        self._last_run_mock.assert_not_called()
+
+    def test_claude_plugin_installed(
+        self,
+        capsys: pytest.CaptureFixture[str],
+        monkeypatch: pytest.MonkeyPatch,
+        fake_module,
+    ) -> None:
+        """Plugin present in `claude plugin list` reports [OK]."""
+        proc = MagicMock(returncode=0, stdout="attune-ai@attune-ai v16.1.0\n")
+        result = self._run_doctor(
+            monkeypatch,
+            fake_module,
+            which="/usr/local/bin/claude",
+            run_result=proc,
+        )
+
+        assert result == 0
+        out = capsys.readouterr().out
+        assert "[OK]   Claude Code plugin attune-ai@attune-ai installed" in out
+        call = self._last_run_mock.call_args
+        assert call.args[0] == ["/usr/local/bin/claude", "plugin", "list"]
+        assert call.kwargs["timeout"] == 10
+
+    def test_claude_plugin_not_installed(
+        self,
+        capsys: pytest.CaptureFixture[str],
+        monkeypatch: pytest.MonkeyPatch,
+        fake_module,
+    ) -> None:
+        """claude present but plugin absent reports optional [--]."""
+        proc = MagicMock(returncode=0, stdout="some-other-plugin@market\n")
+        result = self._run_doctor(
+            monkeypatch,
+            fake_module,
+            which="/usr/local/bin/claude",
+            run_result=proc,
+        )
+
+        assert result == 0
+        out = capsys.readouterr().out
+        assert "[--]   Claude Code plugin attune-ai not installed (optional)" in out
+
+    def test_claude_plugin_list_nonzero_exit(
+        self,
+        capsys: pytest.CaptureFixture[str],
+        monkeypatch: pytest.MonkeyPatch,
+        fake_module,
+    ) -> None:
+        """A failing `claude plugin list` degrades to [--], never raises."""
+        proc = MagicMock(returncode=1, stdout="", stderr="broken install")
+        result = self._run_doctor(
+            monkeypatch,
+            fake_module,
+            which="/usr/local/bin/claude",
+            run_result=proc,
+        )
+
+        assert result == 0
+        out = capsys.readouterr().out
+        assert "[--]   claude plugin list failed (optional)" in out
+
+    def test_claude_plugin_list_timeout(
+        self,
+        capsys: pytest.CaptureFixture[str],
+        monkeypatch: pytest.MonkeyPatch,
+        fake_module,
+    ) -> None:
+        """A hung claude CLI times out and degrades to [--]."""
+        import subprocess as _subprocess
+
+        result = self._run_doctor(
+            monkeypatch,
+            fake_module,
+            which="/usr/local/bin/claude",
+            run_side_effect=_subprocess.TimeoutExpired(cmd="claude", timeout=10),
+        )
+
+        assert result == 0
+        out = capsys.readouterr().out
+        assert "[--]   claude plugin list unavailable (optional)" in out
+
+    def test_claude_plugin_list_oserror(
+        self,
+        capsys: pytest.CaptureFixture[str],
+        monkeypatch: pytest.MonkeyPatch,
+        fake_module,
+    ) -> None:
+        """An unexecutable claude binary degrades to [--]."""
+        result = self._run_doctor(
+            monkeypatch,
+            fake_module,
+            which="/usr/local/bin/claude",
+            run_side_effect=OSError("not executable"),
+        )
+
+        assert result == 0
+        out = capsys.readouterr().out
+        assert "[--]   claude plugin list unavailable (optional)" in out

--- a/tests/unit/cli_commands/test_utility_commands.py
+++ b/tests/unit/cli_commands/test_utility_commands.py
@@ -1151,9 +1151,9 @@ class TestCmdDoctorInstallDiagnostics:
         pkgutil.resolve_name and is unaffected, so the miss is invisible
         on newer interpreters.
         """
-        import importlib.metadata as importlib_metadata
         import shutil as shutil_module
         import subprocess as subprocess_module
+        from importlib import metadata
 
         monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
         args = types.SimpleNamespace()
@@ -1178,7 +1178,7 @@ class TestCmdDoctorInstallDiagnostics:
             run_mock.return_value = run_result
 
         monkeypatch.setattr(
-            importlib_metadata,
+            metadata,
             "version",
             pkg_version if pkg_version is not None else MagicMock(return_value="0.0.0"),
         )

--- a/tests/unit/gates/test_broad_except_ratchet.py
+++ b/tests/unit/gates/test_broad_except_ratchet.py
@@ -114,7 +114,9 @@ _BASELINE: dict[str, int] = {
     "src/attune/cli_commands/memory_agent.py": 2,
     "src/attune/cli_commands/provider_commands.py": 2,
     "src/attune/cli_commands/telemetry_commands.py": 12,
-    "src/attune/cli_commands/utility_commands.py": 6,
+    # utility_commands: 7th site is cmd_doctor's related-package version
+    # probe — a diagnostic must never crash on broken package metadata.
+    "src/attune/cli_commands/utility_commands.py": 7,
     "src/attune/cli_commands/workflow_commands.py": 1,
     "src/attune/cli_minimal.py": 3,
     "src/attune/cli_router.py": 1,


### PR DESCRIPTION
## What

Extends `attune doctor` so ONE command answers the full install diagnostic for student onboarding — "run `attune doctor`, reply with the output" replaces the previous 3-command paste block (doctor + `pip show` + `claude plugin list`).

Two new check sections in `cmd_doctor` ([utility_commands.py](src/attune/cli_commands/utility_commands.py)):

1. **Related package versions** — attune-rag, attune-verify, attune-forms via `importlib.metadata.version`. Degrades to `[--] not installed (optional)` on `PackageNotFoundError` and `[--] version unknown` on any other metadata error. Never raises. (Reads attune-forms' *installed* metadata only — nothing in the attune-forms package is touched.)
2. **Claude Code plugin state** — `shutil.which("claude")`, then `claude plugin list` (list argv, no shell, 10s timeout, `check=False`). Four fail-open paths: CLI missing → `[--] claude CLI not found (optional)`; non-zero exit → `[--] claude plugin list failed`; timeout / OSError → `[--] claude plugin list unavailable`. Plugin found → `[OK] Claude Code plugin attune-ai@attune-ai installed`.

Existing `[OK]`/`[--]`/`[FAIL]` row format and pass summary unchanged; exit code semantics unchanged (new checks can only add OK/optional rows, never failures).

## Receipts

- **Live-fire**: real run from this worktree — 14 checks, 0 failures, including `[OK] attune-rag 1.1.0 / attune-verify 0.2.2 / attune-forms 0.10.0` and `[OK] Claude Code plugin attune-ai@attune-ai installed` (real `claude plugin list` round trip).
- **Suite**: full tree run — 24,979 passed, 258 skipped, 3 xfailed, 0 failures.
- **Coverage**: `utility_commands.py` at 95% (measured via the /tmp worktree recipe); all 16 missed lines are pre-existing branches — the new code is fully covered by 9 new tests that mock subprocess/metadata entirely (no real `claude` spawn) and pin every degradation path.
- **Ratchets**: broad-except baseline raised 6 → 7 with reason comment (the metadata probe — a diagnostic must never crash on broken metadata); sys.modules ratchet satisfied by using the `fake_module` fixture instead of `patch.dict`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
