### PR TITLE
fix(release): allow full coverage gate to finish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,7 +74,8 @@ while preserving portable fallbacks and explicit chair authority.
 
 - Release readiness coverage checks now allow the full test suite up to
   15 minutes to finish instead of timing out after two minutes and replacing
-  the real measurement with a low-confidence test-count estimate.
+  the real measurement with a low-confidence test-count estimate. Estimated
+  coverage remains diagnostic and can no longer approve the critical gate.
 
 - Pattern review queue and persistent pattern library now degrade
   gracefully when the memory backend fails (unreachable Redis, disk

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,10 @@ while preserving portable fallbacks and explicit chair authority.
 
 ### Fixed
 
+- Release readiness coverage checks now allow the full test suite up to
+  15 minutes to finish instead of timing out after two minutes and replacing
+  the real measurement with a low-confidence test-count estimate.
+
 - Pattern review queue and persistent pattern library now degrade
   gracefully when the memory backend fails (unreachable Redis, disk
   error, third-party backend missing a method) instead of raising

--- a/src/attune/agents/release/base_agent.py
+++ b/src/attune/agents/release/base_agent.py
@@ -38,12 +38,17 @@ logger = logging.getLogger(__name__)
 # =============================================================================
 
 
-def _run_command(cmd: list[str], cwd: str = ".") -> tuple[int, str, str]:
+def _run_command(
+    cmd: list[str],
+    cwd: str = ".",
+    timeout: int = 120,
+) -> tuple[int, str, str]:
     """Run a shell command safely and return (returncode, stdout, stderr).
 
     Args:
         cmd: Command and arguments as list
         cwd: Working directory
+        timeout: Maximum command runtime in seconds.
 
     Returns:
         Tuple of (return_code, stdout, stderr)
@@ -54,7 +59,7 @@ def _run_command(cmd: list[str], cwd: str = ".") -> tuple[int, str, str]:
             cmd,
             capture_output=True,
             text=True,
-            timeout=120,
+            timeout=timeout,
             cwd=cwd,
         )
         return result.returncode, result.stdout, result.stderr

--- a/src/attune/agents/release/coverage_agent.py
+++ b/src/attune/agents/release/coverage_agent.py
@@ -22,6 +22,8 @@ from .release_models import Tier
 
 logger = logging.getLogger(__name__)
 
+COVERAGE_TIMEOUT_SECONDS = 900
+
 
 class TestCoverageAgent(ReleaseAgent):
     """Runs pytest --cov and parses coverage report.
@@ -84,6 +86,7 @@ class TestCoverageAgent(ReleaseAgent):
                     "--timeout=30",
                 ],
                 cwd=codebase_path,
+                timeout=COVERAGE_TIMEOUT_SECONDS,
             )
 
             coverage_percent = self._parse_coverage_output(cov_stdout)

--- a/src/attune/agents/release/release_prep_team.py
+++ b/src/attune/agents/release/release_prep_team.py
@@ -274,13 +274,16 @@ class ReleasePrepTeam:
         coverage_pct = 0.0
         if coverage:
             coverage_pct = coverage.findings.get("coverage_percent", 0.0)
+        coverage_measured = bool(
+            coverage and coverage.success and not coverage.findings.get("estimated", False)
+        )
 
         gates.append(
             QualityGate(
                 name="Test Coverage",
                 threshold=self.quality_gates["min_coverage"],
                 actual=coverage_pct,
-                passed=coverage_pct >= self.quality_gates["min_coverage"],
+                passed=coverage_measured and coverage_pct >= self.quality_gates["min_coverage"],
                 critical=True,
             ),
         )

--- a/tests/unit/agents/release/test_specialized_agents.py
+++ b/tests/unit/agents/release/test_specialized_agents.py
@@ -96,9 +96,11 @@ class TestTestCoverageAgent:
             "Name              Stmts   Miss  Cover\n" "TOTAL              500     75    85%\n"
         )
 
-        def fake_run(cmd, cwd="."):
+        def fake_run(cmd, cwd=".", timeout=120):
             if "--co" in cmd:
+                assert timeout == 120
                 return (0, collect_output, "")
+            assert timeout == 900
             return (0, cov_output, "")
 
         with patch("attune.agents.release.coverage_agent._run_command", side_effect=fake_run):
@@ -116,7 +118,7 @@ class TestTestCoverageAgent:
         # Return enough ":: " lines so test_count > 200
         big_collect = "\n".join(f"test_foo::test_{i}" for i in range(250))
 
-        def fake_run(cmd, cwd="."):
+        def fake_run(cmd, cwd=".", timeout=120):
             if "--co" in cmd:
                 return (0, big_collect, "")
             return (0, "no coverage info here", "")
@@ -135,7 +137,7 @@ class TestTestCoverageAgent:
         agent = self._make_agent()
         big_collect = "\n".join(f"test_foo::test_{i}" for i in range(600))
 
-        def fake_run(cmd, cwd="."):
+        def fake_run(cmd, cwd=".", timeout=120):
             if "--co" in cmd:
                 return (0, big_collect, "")
             return (0, "no coverage info here", "")
@@ -154,7 +156,7 @@ class TestTestCoverageAgent:
         agent = self._make_agent()
         collect_output = "\n".join(f"test_foo::test_{i}" for i in range(150))
 
-        def fake_run(cmd, cwd="."):
+        def fake_run(cmd, cwd=".", timeout=120):
             if "--co" in cmd:
                 return (0, collect_output, "")
             return (0, "no coverage info here", "")
@@ -173,7 +175,7 @@ class TestTestCoverageAgent:
         agent = self._make_agent()
         collect_output = "\n".join(f"test_foo::test_{i}" for i in range(75))
 
-        def fake_run(cmd, cwd="."):
+        def fake_run(cmd, cwd=".", timeout=120):
             if "--co" in cmd:
                 return (0, collect_output, "")
             return (0, "no coverage info here", "")
@@ -192,7 +194,7 @@ class TestTestCoverageAgent:
         agent = self._make_agent()
         collect_output = "\n".join(f"test_foo::test_{i}" for i in range(25))
 
-        def fake_run(cmd, cwd="."):
+        def fake_run(cmd, cwd=".", timeout=120):
             if "--co" in cmd:
                 return (0, collect_output, "")
             return (0, "no coverage info here", "")
@@ -210,7 +212,7 @@ class TestTestCoverageAgent:
 
         agent = self._make_agent()
 
-        def fake_run(cmd, cwd="."):
+        def fake_run(cmd, cwd=".", timeout=120):
             return (0, "no coverage output", "")
 
         with patch("attune.agents.release.coverage_agent._run_command", side_effect=fake_run):
@@ -225,7 +227,7 @@ class TestTestCoverageAgent:
         agent = self._make_agent()
         cov_output = "TOTAL  200  40  80%\n"
 
-        def fake_run(cmd, cwd="."):
+        def fake_run(cmd, cwd=".", timeout=120):
             return (0, cov_output, "")
 
         with patch("attune.agents.release.coverage_agent._run_command", side_effect=fake_run):

--- a/tests/unit/agents/test_release_prep_team.py
+++ b/tests/unit/agents/test_release_prep_team.py
@@ -125,6 +125,28 @@ class TestEvaluateQualityGates:
 
         assert not coverage_gate.passed
 
+    def test_coverage_gate_fails_when_result_is_estimated(self):
+        """Estimated coverage cannot approve the critical release gate."""
+        team = self._make_team()
+
+        results = [
+            FakeAgentResult("Security Auditor", True, 9.0, {"critical_issues": 0}),
+            FakeAgentResult(
+                "Test Coverage",
+                True,
+                9.0,
+                {"coverage_percent": 85.0, "estimated": True},
+            ),
+            FakeAgentResult("Code Quality", True, 9.0, {"quality_score": 8.0}),
+            FakeAgentResult("Documentation", True, 9.0, {"coverage_percent": 90.0}),
+        ]
+
+        gates = team._evaluate_quality_gates(results)
+        coverage_gate = next(g for g in gates if g.name == "Test Coverage")
+
+        assert coverage_gate.actual == pytest.approx(85.0)
+        assert coverage_gate.passed is False
+
     def test_documentation_gate_not_critical(self):
         """Documentation gate is non-critical (warning only)."""
         team = self._make_team()


### PR DESCRIPTION
## Summary
- make the release agent command timeout configurable
- allow the full coverage probe up to 15 minutes while preserving the 2-minute default for other checks
- regression-test both timeout values

## Why
The v16.2.0 release gate timed out the 25,501-test coverage run at 120 seconds, discarded its output, and substituted a low-confidence 40% heuristic despite the real CI coverage gate passing. The release contract forbids overriding a failed hard gate.

## Receipts
- `uv run pytest tests/unit/agents/release/test_specialized_agents.py tests/unit/agents/release/test_base_agent.py -q -p no:xdist -o addopts=` — 76 passed
- `uv run ruff check ...` — passed
- pinned Black hook — passed
- full pre-commit commit hooks — passed
