### PR TITLE
fix(release): parse only coverage summary rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,10 @@ while preserving portable fallbacks and explicit chair authority.
 
 ### Fixed
 
+- Release readiness coverage parsing now accepts only the actual `TOTAL`
+  summary row, preventing percentages embedded in captured test output from
+  replacing the measured suite coverage.
+
 - Release readiness coverage checks now allow the full test suite up to
   15 minutes to finish instead of timing out after two minutes and replacing
   the real measurement with a low-confidence test-count estimate. Estimated

--- a/src/attune/agents/release/coverage_agent.py
+++ b/src/attune/agents/release/coverage_agent.py
@@ -154,9 +154,9 @@ class TestCoverageAgent(ReleaseAgent):
 
         # Alternate pattern: "X% coverage"
         match = re.search(
-            r"(\d+(?:\.\d+)?)\s*%\s*(?:coverage|total)",
+            r"^\s*(\d+(?:\.\d+)?)\s*%\s*(?:coverage|total)\b",
             output,
-            re.IGNORECASE,
+            re.IGNORECASE | re.MULTILINE,
         )
         if match:
             return float(match.group(1))

--- a/src/attune/agents/release/coverage_agent.py
+++ b/src/attune/agents/release/coverage_agent.py
@@ -145,10 +145,12 @@ class TestCoverageAgent(ReleaseAgent):
         """
         # Look for "TOTAL" line: "TOTAL    1234   567    54%"
         for line in output.splitlines():
-            if "TOTAL" in line:
-                match = re.search(r"(\d+)%", line)
-                if match:
-                    return float(match.group(1))
+            match = re.match(
+                r"^TOTAL\s+\d+\s+\d+(?:\s+\d+\s+\d+)?\s+(\d+(?:\.\d+)?)%\s*$",
+                line.strip(),
+            )
+            if match:
+                return float(match.group(1))
 
         # Alternate pattern: "X% coverage"
         match = re.search(

--- a/tests/unit/agents/release/test_specialized_agents.py
+++ b/tests/unit/agents/release/test_specialized_agents.py
@@ -72,6 +72,14 @@ class TestTestCoverageAgent:
 
         assert agent._parse_coverage_output(output) == pytest.approx(95.27)
 
+    def test_parse_coverage_output_ignores_incidental_coverage_text(self):
+        """Captured prose is not a measured coverage report."""
+        agent = self._make_agent()
+
+        result = agent._parse_coverage_output("captured output says 95% coverage for docs only")
+
+        assert result == pytest.approx(-1.0)
+
     def test_parse_coverage_output_alternate_pattern(self):
         """Parses '75% coverage' alternate pattern."""
         agent = self._make_agent()

--- a/tests/unit/agents/release/test_specialized_agents.py
+++ b/tests/unit/agents/release/test_specialized_agents.py
@@ -61,6 +61,17 @@ class TestTestCoverageAgent:
 
         assert result == pytest.approx(83.0)
 
+    def test_parse_coverage_output_ignores_non_summary_total_text(self):
+        """Only a real coverage TOTAL row may supply the percentage."""
+        agent = self._make_agent()
+        output = (
+            "test_parser.py::test_message PASSED [ 27%]\n"
+            "captured text containing TOTAL and 27%\n"
+            "TOTAL  66067  2586  20020  1058  95.27%\n"
+        )
+
+        assert agent._parse_coverage_output(output) == pytest.approx(95.27)
+
     def test_parse_coverage_output_alternate_pattern(self):
         """Parses '75% coverage' alternate pattern."""
         agent = self._make_agent()


### PR DESCRIPTION
## Summary
- anchor coverage parsing to real pytest-cov TOTAL summary rows
- preserve decimal coverage percentages
- add regression coverage for captured test output containing TOTAL and an unrelated percentage

## Release context
The 16.2.0 release gate measured the suite at 95.27%, but parsed 27% from an earlier captured-output line. This fix makes the deterministic gate consume the actual report summary.

## Receipts
- `uv run pytest tests/unit/agents/release/test_specialized_agents.py tests/unit/agents/test_release_prep_team.py -q` (66 passed)
- `uv run ruff check ...` (passed)
- pinned Black hook (passed)
- full commit hooks (passed)