### PR TITLE
docs(spec): host-surface-parity — roundtable round 1 transcript, spec, promotion

### DIFF
--- a/docs/reports/roundtable/q-fable-51-surface-overlap-001.md
+++ b/docs/reports/roundtable/q-fable-51-surface-overlap-001.md
@@ -1,0 +1,545 @@
+# Round table transcript — `q-fable-51-surface-overlap-001`
+
+**Convened:** 2026-09-02 (chair-dated 2026-09-03) · **Chair:** Patrick
+Roebuck · **Moderator:** Claude (Fable 5, this session) · **Roster:**
+Claude, Antigravity, Codex — all three seats answered (no absences).
+**Rounds:** 1 of a chair-ruled spend gate of 3 seat invocations / 1
+round; halted at the gate (board msg 7). A second round needs a fresh
+chair go.
+**Board thread:** `attune:roundtable:*` / `q-fable-51-surface-overlap-001`
+(TTL 7 days; this file is the durable record).
+**Receipts:** codex 43s (msg 2) · antigravity 92s, plan mode (msg 3) ·
+claude 129s / 62,710 subagent tokens, context-free general-purpose agent
+(msg 5). Question posted verbatim from
+`docs/specs/host-surface-parity/roundtable-question.md` (msg 1).
+**Promotion status:** NOT promoted — no chair rulings yet (R4 holds).
+Promotion candidates by board id: positions 2 (codex), 3 (antigravity),
+5 (claude); member questions 4 (antigravity), 6 (claude); synthesis 8.
+
+---
+
+## Message 1 — chair · question · round 1
+
+# Round-table question — `q-fable-51-surface-overlap-001`
+
+**Chair:** Patrick Roebuck · **Moderator:** Claude · **Roster:** Claude,
+Antigravity, Codex (fixed) · **Rounds:** 1 expected, 2 if the steelman
+provision fires (chair lean is recorded below), ceiling 3 (D3).
+**Spend gate (chair-ruled 2026-09-03):** 3 seat invocations, 1 round;
+a second round needs a fresh chair go.
+**Prepared:** 2026-09-03 by the Claude seat in a Cowork session.
+**Transcript:** the moderator writes the machine-local transcript to
+`~/.attune/reports/roundtable/q-fable-51-surface-overlap-001.md`; please
+also copy it to `docs/reports/roundtable/` so the Cowork seat (which
+sees only the repo) can read it and draft the promotion triage.
+
+## The question
+
+The 2026-09-01 host release (Claude Fable 5.1; Cowork and Claude Code)
+ships first-party versions of things attune-ai built as portable,
+verified, multi-provider systems: a structured question widget
+(`AskUserQuestion`), desktop-persistent project memory (`MEMORY.md` +
+typed topic files), a skill-proposal card, a multi-agent workflow
+runner, typed review findings, hosted artifacts with runtime state,
+scheduled tasks, and a file monitor.
+
+**Which of Attune's human↔AI communication and capability features
+does this release overlap, and where should the next two minors
+spend effort so the release is a tailwind rather than a headwind —
+without any host becoming the privileged surface, and without
+power users on Codex or Antigravity sacrificing anything?**
+
+## What each seat is asked to return
+
+Independently, text only, no tools (R1):
+
+1. A ruling on each proposed requirement R1–R8 in
+   `docs/specs/host-surface-parity/requirements.md`: **adopt / amend
+   (say how) / decline (say why)**.
+2. At least one requirement the Claude seat did **not** propose. The
+   chair has asked the table to be creative and not limited to the
+   brief.
+3. A position on the three open mechanics: D2 (`LOCAL` as enum member
+   vs routing label), D3 (no third capability contract), and whether
+   Task 7 (Ollama reranker as the Phase A example extension) should
+   wait for Phase B.
+4. Its own dissent register: where it disagrees with the Claude
+   seat's reading in the companion brief.
+
+## Facts taken as given (verified against the tree 2026-09-03)
+
+- attune-ai 16.2.0; attune-forms ≥ 0.12.2; `Surface.RICH / PORTABLE /
+  HEADLESS`; state-bound command workspaces shipped.
+- `CANONICAL_SEATS` is a literal three-tuple; `SEAT_RECIPES` fixed
+  argv; `PLAN_ONLY_SEATS = {"antigravity"}`; workspace gates require
+  exactly the fixed roster.
+- `ModelProvider` has one member (`ANTHROPIC`); tiers are
+  `CHEAP / CAPABLE / PREMIUM` in four copies plus the attune-rag
+  mirror with a drift guard.
+- `attune.extensions` (release-16-manifest passenger 4) is **not on
+  disk**; D1/D2 ruled; D3 phasing proposed, not ruled.
+- Chair rulings already made (this spec's D1, 2026-09-03): local
+  models start as a `LOCAL` tier for low-stakes roles, not a seat;
+  extensions are the seam for providers/backends/seats; the
+  deliverable is this spec.
+
+## Chair's lean (recorded so the steelman provision can fire)
+
+The chair leans toward adopting the parity rule (every host-specific
+capability ships with PORTABLE and HEADLESS twins, receipted, in the
+same change) and toward roster-as-data. Seats that agree should
+steelman the opposite; seats that disagree should say what the
+parity rule costs.
+
+## Companion material
+
+- Brief (Claude seat opening position): artifact
+  "Fable 5.1 and the Attune Surface", 2026-09-03.
+- Spec: `docs/specs/host-surface-parity/` (requirements, design,
+  tasks, decisions).
+- Discipline: attune-ai.dev/discipline, §2 (contract), §5 (memory),
+  §7 (verification), §9 (context budgeting).
+
+---
+
+## Message 2 — codex · position · round 1 · duration 43s
+
+1. Rulings on R1–R8
+
+**R1 — ADOPT.** Native structured questions are an additional projection target. Capability detection must happen before rendering, with unsupported forms falling through intact to PORTABLE. Add contract tests covering validation errors, multi-select ordering, “Other,” cancellation, and host-version capability changes.
+
+**R2 — AMEND.** Adopt same-change parity, but enforce it through a declared surface registry rather than filesystem enumeration. Every host-specific adapter must reference:
+
+- One canonical semantic form
+- PORTABLE and HEADLESS projections
+- A conformance receipt proving equivalent validated values
+
+Filesystem scanning is too easy to evade accidentally and too brittle around helpers and templates.
+
+Steelman against the chair’s parity lean: mandatory three-surface receipts increase the cost and latency of exploiting a new host feature, can force meaningless twins for capabilities with no portable analogue, and may reduce experimentation to the lowest common denominator. The answer is an explicit, expiring parity exception—not weakening the default gate.
+
+**R3 — AMEND.** Do not create a literal “second master.” The Attune promoted-lesson index remains authoritative; host files contain generated projections with provenance, generation version, bounded summaries, and links back to Attune truth. Each destination needs a delimited owned block so unrelated human edits remain legal. Projection must support removal and stale-entry cleanup, not merely regeneration after promotion.
+
+**R4 — ADOPT.** This is precisely the right use of a receipt: validate the existing path without inventing another integration. Record both advertised-profile and fallback cases, including stale revision, wrong contract hash, and replay rejection.
+
+**R5 — AMEND.** Define one host-neutral automation manifest and compile it into host scheduling/file-monitor configuration or cron plus CLI. Do not make host templates the primary definition. Require idempotency, overlap locking, debounce, spend attribution, and loop prevention. Watching `context_fit.jsonl` must not allow an Attune run’s own telemetry write to retrigger itself. Settling the budget clock should be separately asserted rather than treated as a side effect of the first monitor.
+
+**R6 — AMEND.** Adopt the roles and extension phasing, but make `LOCAL` a routing attribute outside the quality-tier enum. Preserve `CHEAP/CAPABLE/PREMIUM` as quality/cost policy. Locality, privacy, and execution venue are orthogonal dimensions. Keep `ModelProvider` unchanged and impose confidence thresholds plus escalation to a capable hosted model for consequential workflow decisions.
+
+**R7 — AMEND.** Move the roster to validated data, but model more than role names: execution mode, plan-only status, required capabilities, trust boundary, receipt responsibilities, and harness recipe must be explicit. Preserve the current roster through golden behavior tests. Extension-provided additional slots remain structurally representable but disabled until the required later chair authorization; R7 must not accidentally authorize seat four.
+
+**R8 — AMEND.** Record structured asks per terminal outcome, not only completed outcomes. Otherwise abandoned or blocked sessions—the most frustrating ones—vanish from the metric. Report at least:
+
+- Asks per accepted receipt
+- Zero-outcome/abandonment rate
+- Ask type and fallback frequency
+
+Keep this in the existing ledger and avoid recording answer contents.
+
+The overlap is real but mostly at the presentation and orchestration edges: native questioning overlaps forms, host memory overlaps lesson projection, skill proposals overlap discovery/proposal UX, workflow runners overlap orchestration, typed findings overlap Attune receipts/reviews, hosted artifacts overlap state-bound workspaces, and schedules/monitors overlap automation. Attune’s defensible layer is cross-host semantics, validation, policy, receipts, and reproducibility.
+
+2. Additional requirement
+
+**R9 — Portable capability negotiation and conformance kit**
+
+Every host adapter and extension publishes a machine-readable capability descriptor: supported question shapes, persistent-memory destinations, artifact runtime features, scheduling/monitoring support, action round-trip guarantees, and receipt schema versions.
+
+A shared conformance suite runs canonical transcripts against each adapter and proves:
+
+- Unsupported capabilities degrade deliberately
+- Semantic outputs remain equivalent
+- Receipts retain provenance and replay protection
+- Removing a host adapter leaves PORTABLE and HEADLESS execution usable
+- No workflow silently selects a privileged host
+
+This turns portability from a collection of twins into a testable protocol. It should be the foundation minor; native integrations and automation compilation should follow in the second minor.
+
+3. Open mechanics
+
+**D2 — Routing label outside the enum.** `LOCAL` describes execution locality, not model competence or price. Adding it beside `CHEAP/CAPABLE/PREMIUM` creates invalid comparisons and multiplies drift across five mirrored enums. Use a separate routing dimension such as `execution=local|hosted` or a constrained extension label. This honors the chair’s “LOCAL tier” product decision without encoding two unrelated axes in one enum.
+
+**D3 — Confirm “no third capability contract” for the next two minors.** Reranking is an optional memory-backend capability; classification and workflow roles belong to the workflow contract. A provider-level contract would prematurely generalize from Ollama and undermine the binding non-goal. Revisit only after two independently implemented extensions demonstrate needs that cannot fit either contract cleanly.
+
+**Task 7 phasing — Ship the Ollama reranker alone first.** It is the smallest real proof that extension discovery, optional capability advertisement, fallback, receipts, packaging, and failure isolation work. Phase B should depend on that evidence. Holding it for workflow extensions creates a larger debugging surface and delays validation of the seam.
+
+4. Dissent register
+
+**H1 — Mostly agree, with a boundary.** Tier 0 is a projection target only when it preserves the form’s semantics. “Single question” is insufficient by itself; validation, cancellation, defaults, multi-select behavior, and recommendation semantics must also fit. Otherwise use PORTABLE.
+
+**H2 — Agree on enforceability, disagree on the proposed mechanism.** Parity can be mechanical, but tree enumeration does not establish semantic coverage. A registered capability graph plus conformance receipts does.
+
+**H3 — Partly disagree.** “The host remembers; Attune recalls” is sound positioning, but copying lesson lines into several instruction files risks context pollution, stale projections, prompt-authority confusion, and collisions with human-maintained guidance. Project bounded, generated summaries and references—not an unconstrained second index.
+
+**H4 — Agree with qualification.** Local models should earn bounded roles before seats. However, “skeptic,” “countersign,” and “fact-check” must remain advisory probes with escalation thresholds; a weak local model must not manufacture the appearance of independent verification.
+
+**H5 — Amend.** Roster by role is necessary but insufficient. A seat is a role plus capabilities, trust boundary, execution semantics, and receipt obligations. Vendor-neutral configuration without those constraints can produce formally valid but behaviorally incomparable rosters.
+
+On Claude’s own dissent points: withdrawing the Claude-only memory bridge was correct. I agree that projected memory does not replace recall, but only if projection remains intentionally bounded; an overfull host notebook could both appear “good enough” and degrade prompt quality. LOCAL should remain outside the quality enum for the reasons above.
+
+---
+
+## Message 3 — antigravity · position · round 1 · duration 92s (plan mode)
+
+### 1. Rulings on Proposed Requirements R1–R8
+
+#### **R1 — Host Tier 0 Renderer**
+**Ruling: AMEND**
+*Amendment:* Do not hardcode the Tier 0 target to the specific constraints of Claude Fable 5.1’s `AskUserQuestion` (max 4 options, single question). In environments like Antigravity, native structured question tools (`ask_question`) inherently support multi-question forms (`questions: [...]`) with arbitrary option arrays.
+Tier 0 must be defined as a **Host Capability Adapter** governed by a capability descriptor (e.g., `max_options: int`, `supports_multi_question: bool`, `supports_free_text_escape: bool`). If the form fits within the detected host envelope, render natively; if it overflows, fall through cleanly to `PORTABLE`. Forcing every host into Claude's 4-option, single-question box unnecessarily degrades the UX in agent runtimes that possess richer native interactive form primitives.
+
+---
+
+#### **R2 — Surface Parity Gate**
+**Ruling: ADOPT (with Chair Lean Steelman)**
+*Steelman of the Anti-Parity Position:*
+> Mandating strict tripartite synchronization (`RICH`, `PORTABLE`, `HEADLESS`) enforced by a blocking drift-guard imposes an unsustainable velocity tax on frontend experimentation. When a host introduces a breakthrough interaction surface (such as interactive visual canvases, fluid artifact runtimes, or streaming graph visualizers), requiring developers to build, receipt, and maintain a semantically identical terminal ASCII and headless twin before shipping delays user value by weeks and bloats PRs by 300%. The result is often contrived, low-value headless mocks written solely to appease the drift guard, disincentivizing teams from taking full advantage of host-native UI differentiators.
+
+*Why Antigravity Still Adopts:* For an agentic CLI and automation platform, headless and terminal fidelity is not an afterthought—it is the foundation of headless CI/CD, batch processing, and non-interactive subagent execution. Without R2, multi-provider portability will quietly rot into a Claude Desktop-first monoculture.
+
+---
+
+#### **R3 — Memory Index Projection**
+**Ruling: AMEND**
+*Amendment:* Impose a strict **budget and relevance ceiling** on projected indices, and enforce sentinel marker boundaries.
+Projecting an unbounded one-line-per-lesson index into `.claude/CLAUDE.md`, `AGENTS.md`, and `.agents/AGENTS.md` creates severe static context-window bloat. In systems like Antigravity where subagents are spawned frequently with inherited project instructions, injecting dozens or hundreds of memory pointer lines imposes an unavoidable token tax on every turn, diluting prompt attention.
+R3 must project only a bounded top-$K$ active digest (e.g., max 25 entries prioritized by recent hit frequency and project scope), strictly bracketed by generated sentinel comments (`<!-- ATTUNE:MEMORY:START -->` ... `<!-- ATTUNE:MEMORY:END -->`) to allow safe co-existence with user-authored agent instructions. Hand edits within the sentinel block must fail closed on drift check, while leaving edits outside the block untouched.
+
+---
+
+#### **R4 — MCP Apps Round-Trip Receipt**
+**Ruling: ADOPT**
+*Rationale:* R4 establishes empirical verification over interface promises. Testing the Fix preview workspace through standard `ui://` profiles while asserting that nonces, contract hashes, and revisions remain unforgeable—and verifying that non-supporting hosts fall back cleanly to Markdown—ensures state-bound workspaces remain tamper-proof without speculative production churn.
+
+---
+
+#### **R5 — Scheduled and Monitored Delivery, Twinned**
+**Ruling: AMEND**
+*Amendment:* Prohibit autonomous, heavyweight LLM sweeps (`discovery-sweep`, `release-prep`) from triggering directly on raw file-system events.
+File monitor events (such as changes to `~/.attune/telemetry/context_fit.jsonl`) must only trigger **deterministic triage probes** or stage an item in the `docs-outbox` / notification tray. Full multi-turn agent sweeps must require:
+1. A configurable debounce window (minimum 60s),
+2. A strict circuit-breaker spend gate with an hourly execution cap, and
+3. User or explicit agent acknowledgment before spinning up token-intensive audits.
+Without this amendment, file-monitor loops risk runaway token spend during rapid edit-save cycles.
+
+---
+
+#### **R6 — Local-Model Roles via Extensions**
+**Ruling: AMEND**
+*Amendment:* Adopt the role-progression model (Phase A reranker, Phase B classification/triage/fact-check probes), but **reject adding `LOCAL` as an enum member of the model tier contract**.
+As detailed under Section 3 (D2), `LOCAL` is an orthogonal runtime deployment/locality attribute, not a model capability tier. R6 must route local models via an `ExecutionLocality` configuration tag on capability contracts rather than polluting the core tier enum.
+
+---
+
+#### **R7 — Roster as Data**
+**Ruling: ADOPT (with Chair Lean Steelman)**
+*Steelman of the Fixed-Roster Position:*
+> Hardcoded constants (`CANONICAL_SEATS = ("claude", "antigravity", "codex")`) provide compile-time type safety, exhaustive pattern matching, and zero-overhead execution guarantees. Moving seats into dynamic data (`roster.yaml`) introduces configuration-injection risks, runtime parse failures, schema drift, and an exponential explosion of test matrices. In a consensus round table where deterministic attestation and peer receipts are the entire value proposition, allowing dynamic rosters risks topology failure modes (e.g., configurations with zero reviewers, multiple unreceipted proposers, or missing moderators) that static types prevent by construction.
+
+*Why Antigravity Still Adopts:* Decoupling seat definitions from hardcoded Python literals is essential for enterprise deployments running isolated air-gapped models, private CI harnesses, or synthetic mock seats for automated testing. As long as the roster schema validates invariant roles (exactly one moderator, one reviewer, one proposer) and gates extensions behind signatures, configuration-as-data is strictly superior.
+
+---
+
+#### **R8 — Asks-per-Outcome**
+**Ruling: ADOPT**
+*Rationale:* Measuring "demandingness" purely by raw prompt interruptions penalizes structured, high-leverage alignment interactions. Normalizing structured inquiries against validated receipts (`asks / completed_outcome`) rewards agents for asking precise, high-yield clarifying questions up front while penalizing meandering, low-yield dialogue.
+
+---
+
+### 2. Antigravity-Proposed Requirements (Not in Claude Brief)
+
+#### **R9 — Typed Diagnostic & Review Finding Interchange (`DiagnosticSeam`)**
+*Motivation:*
+Claude Fable 5.1 introduces first-party "typed review findings." Codex interfaces natively with GitHub pull request review threads and diff hunks. Antigravity operates natively with IDE diagnostics, compiler errors, and target lint IDs (`TargetLintErrorIds`). Currently, Attune's audits (`deep_review`, `security_audit`, `bug_predict`) emit structured findings, but they do not project into host-native diagnostic trays.
+*Specification:*
+Attune defines a portable `ReviewFinding` interchange schema conforming to SARIF Level 2:
+$$\{ \text{finding\_id}, \text{rule\_id}, \text{severity}, \text{file\_path}, \text{line\_range}, \text{message}, \text{proposed\_fix\_diff}, \text{receipt\_hash} \}$$
+Attune projects these findings into:
+1. Fable 5.1 / Claude Code typed review cards,
+2. Codex/GitHub inline PR review threads,
+3. Antigravity IDE diagnostic collections / problem gutters,
+4. A portable SARIF/JSON stream for terminal/headless execution.
+Host UI actions (Dismiss, Accept, Defer, or Fix-with-Receipt) round-trip back into the Attune review ledger through a normalized callback receipt.
+
+#### **R10 — Multi-Agent Worktree Lease & Turn Attestation Protocol**
+*Motivation:*
+Fable 5.1 ships a multi-agent workflow runner; Antigravity orchestrates concurrent subagents across workspaces; R5 introduces background file-monitors and scheduled tasks. When multiple agents or background tasks operate simultaneously within a shared repository, git index lock contention and conflicting file overwrites occur. Furthermore, in multi-model round tables, there is currently no cryptographic proof that a turn attributed to Antigravity or Codex was not hallucinated or simulated by Claude.
+*Specification:*
+1. **Advisory File/Workspace Lease:** An ephemeral lock protocol (`.attune/locks/<scope>.lease`) with heartbeats and auto-expiry to prevent concurrent destructive writes between host runners and background tasks.
+2. **Turn Attestation Receipt:** Each round-table seat signs its output turn with an execution receipt (harness PID, model runtime fingerprint, nonce, and execution timestamp). The moderator gate verifies turn receipts before consensus promotion, eliminating seat simulation.
+
+---
+
+### 3. Position on Open Mechanics
+
+#### **D2: `LOCAL` as Member of Tier Enum vs. Routing Label**
+**Position: ROUTING LABEL OUTSIDE THE ENUM.**
+*Rationale:*
+1. **Dimensional Orthogonality:** `CHEAP`, `CAPABLE`, and `PREMIUM` describe reasoning depth, parameter capacity, and token cost along a vertical scale. `LOCAL` describes an execution topology / locality attribute along an orthogonal horizontal scale. A local model can be cheap (e.g., 1.5B Qwen), capable (e.g., 70B Llama 3.3), or highly specialized.
+2. **Blast Radius & Drift Guard Churn:** Adding `LOCAL` to the tier enum breaks four core source files and the `attune-rag` mirror, forcing unnecessary updates to drift guards, pricing calculation tables, and token-spend tracking logic that assume tiers represent Anthropic billing tiers.
+3. **Architectural Purity:** Locality should be specified as an execution preference:
+   ```python
+   # Correct abstraction
+   target_tier: ModelTier = ModelTier.CAPABLE
+   execution_locality: Locality = Locality.LOCAL_PREFERRED  # or LOCAL_REQUIRED / CLOUD_ONLY
+   ```
+   This allows an extension to route a `CHEAP` role to local Ollama when available, falling back to hosted cloud tiers as policy permits.
+
+#### **D3: Confirm or Challenge "No Third Capability Contract"**
+**Position: CONFIRM for Minor 16.3; CONDITIONAL CHALLENGE for Minor 16.4.**
+*Rationale:*
+- **Confirm for 16.3:** Deferring a general `ModelProvider` contract is the correct tactical decision. In 16.3, local models are strictly scoped to R6 roles (rerank, pre-sort, low-stakes probes). Because a workflow extension encapsulates its own execution transport (e.g., calling `localhost:11434` via `httpx` internally), it does not require Attune core to manage a generalized LLM provider interface. Keeping the contracts limited to `memory-backend` and `workflow` prevents premature API surface sprawl.
+- **Challenge for 16.4:** An embedding and scoring capability is currently wedged uncomfortably inside `memory-backend`. If local models expand into code-embedding, semantic search, or invariant evaluation, forcing them into `memory-backend` will leak retrieval concerns into scoring. In 16.4, Attune should formalize an `Evaluator`/`Embedding` seam rather than bloating `memory-backend`.
+
+#### **Task 7 Phasing: Ollama Reranker Alone vs. Waiting for Phase B**
+**Position: SHIP THE OLLAMA RERANKER ALONE IN PHASE A.**
+*Rationale:*
+1. **Canary for the Extension Seam:** `attune.extensions` is currently not on disk. Shipping the Ollama reranker alone isolates the extension discovery, loading, and lifecycle mechanisms from complex multi-agent orchestration.
+2. **Deterministic Verification:** Reranking has a closed, mathematically deterministic contract:
+   $$\text{rerank}(\text{query: str}, \text{candidates: list[Doc]}) \to \text{ranked\_ids: list[str]}$$
+   It requires zero prompt-engineering gymnastics, produces no generative hallucination, has no schema-parsing edge cases, and can be verified by exact automated test receipts.
+3. **Fast Feedback Loop:** Validating the extension seam on reranking in 16.3 de-risks IPC latency, process lifecycles, and Ollama connection failures before introducing generative workflow extensions in 16.4.
+
+---
+
+### 4. Antigravity Dissent Register
+
+| Item | Claude Seat Hypothesis / Register | Antigravity Dissent & Counter-Position |
+| :--- | :--- | :--- |
+| **Dissent 1 (on H1)** | **H1:** *Tier 0 is a render target, not a rival. Richer constructs keep their own renderers and are not degraded.* | **Dissent:** H1 defines Tier 0 exclusively by Claude Fable's 4-option, single-question limitation. Antigravity natively supports multi-question modals and rich options via its native tools. By conflating "Host Tier 0" with "Claude Fable 5.1 constraints," the Claude seat covertly turns a vendor limitation into a universal standard. Tier 0 must be parameterized by host capability metadata, not clamped to Claude's lowest common denominator. |
+| **Dissent 2 (on H2)** | **H2:** *Parity can be mechanical via identical validated output receipts across tiers.* | **Dissent:** Output identity is insufficient for parity. An interactive terminal or GUI permits user aborts, parameter backtracking, and inspectable intermediate diffs; a dumb headless pipe often consumes inputs blindly. The parity gate must assert **interaction lifecycle parity** (timeout semantics, abort handling, validation feedback loops), not merely that a mock input string yields an identical output token. |
+| **Dissent 3 (on H3)** | **H3:** *The host remembers; Attune recalls. Projecting memory index into MEMORY.md makes plain sessions benefit without diluting recall.* | **Dissent:** Projecting an unbounded index directly into prompt-injected files (`CLAUDE.md`, `AGENTS.md`) is hostile to context-window budgets. In agent runtimes that regularly spawn focused subagents, every injected index line steals attention and context budget on every single subagent turn. Furthermore, plain host sessions without Attune’s retrieval tooling hallucinate when attempting to follow raw index pointers. Projection must be an explicit, compact, LRU-budgeted cache. |
+| **Dissent 4 (on H4)** | **H4:** *Local models earn a role before a seat... not deliberation.* | **Dissent:** Barring local models from deliberation by principle contradicts Attune's creed: *"The receipt beats the promise."* In air-gapped enterprise environments, high-parameter local models (e.g., Llama-3.3-70B running on private vLLM clusters) are fully capable of serving as plan-only invariant reviewers. Eligibility for a seat must be governed by test-harness benchmark receipts, not dogmatic provider favoritism. |
+| **Dissent 5 (on Claude Dissent a)** | *Claude seat withdrew Claude-only memory bridge to avoid vendor preference.* | **Dissent:** Withdrawing the Claude-only bridge was necessary, but R3 replaced it with an unthrottled index dump across all files. The real solution is a pull-based memory tool or a tightly budgeted sentinel projection, not spraying pointers across every vendor instruction markdown file. |
+
+---
+
+### Follow-Up Question for the Table
+> *"When an interactive Fix workspace (R4) or a typed review finding (R9) is resolved inside a host-native UI by a human developer, what is the precise cryptographic schema for the return receipt that proves to peer seats (running in headless CI or across different host runtimes) that the action was executed by an authorized human chair rather than an unverified host subagent simulation?"*
+
+---
+
+## Message 4 — antigravity · question (R9 member-originated, reply_to 3)
+
+When an interactive Fix workspace (R4) or a typed review finding (R9) is resolved inside a host-native UI by a human developer, what is the precise cryptographic schema for the return receipt that proves to peer seats (running in headless CI or across different host runtimes) that the action was executed by an authorized human chair rather than an unverified host subagent simulation?
+
+---
+
+## Message 5 — claude · position · round 1 · duration 129s · 62,710 tokens
+
+## Section 1 — Rulings R1–R8
+
+**R1 — Host tier 0 renderer: AMEND (adopt the projection; parameterize the contract).**
+Adopt the mechanism — single-question projection, hard fall-through above the contract, identical validation on return. Amend one thing: the contract constants (four options, label+description, "(Recommended)" suffix, host "Other" escape) must live in a declared *host profile* record, not be inlined as Claude's AskUserQuestion shape. Tier 0 should be "project onto whatever structured-question contract the current host advertises," with the Claude profile merely the first entry. Otherwise R1 is the one place in attune-forms where a specific vendor's widget shape is hardcoded — exactly the quiet privileging the question forbids. Cost of the amendment is one dataclass and a lookup; benefit is that when Codex or Antigravity ships a native question widget, tier 0 lights up there with zero renderer changes.
+
+**R2 — Surface parity gate: AMEND (adopt the gate; add a drift-guarded, expiring spike allowlist).**
+I agree with the chair's lean, so the steelman first. The honest case against the parity rule: (1) it is a 3x tax charged *before* a host feature has proven value — the most expensive possible moment; (2) it produces parity theater — a HEADLESS "twin" of a live file-monitor wake is a cron poll nobody runs, written to satisfy a gate, and the gate cannot distinguish a real twin from a compliance artifact; (3) "in the same change" couples host-launch-speed work to portable design work, and host launches move on someone else's calendar; (4) for a team of one, tripling the render-test surface is the difference between shipping and not. That case is strong enough that pure ADOPT is wrong. Rule: adopt the gate, plus an `experiments:` allowlist entry with a mandatory expiry date (14–30 days), itself drift-guarded — the gate fails on any expired entry. A spike may exist untwinned; a shipped surface may not. This keeps "the receipt beats the promise" as the steady state while pricing exploration honestly. Also: the receipt clause "identical validated output" should read "identical validated *payload*" — see my H2 dissent.
+
+**R3 — Memory index projection: ADOPT.**
+The every-host projection is the correct answer to the release, and the seat's withdrawal of the Claude-only bridge was the right call for the right reason. Two implementation notes that don't rise to amendment: each projected block carries a generated-by header naming the regenerate command (the refuse-hand-edits behavior needs a visible explanation at the point of temptation), and per-host line budgets should be independent (CLAUDE.md's budget pressure is not AGENTS.md's).
+
+**R4 — MCP Apps round-trip receipt: ADOPT.**
+It is a receipt with a no-production-change clause; there is nothing to spend against. The replay-fails-closed and no-profile-fallback checks are the two things that will actually break under host drift, and this is the cheapest early-warning system on the list. Do it first among the eight.
+
+**R5 — Scheduled and monitored delivery, twinned: AMEND (portable twin is the master; host task is a binding).**
+Adopt the scope (discovery-sweep, bug-predict, release-prep; context_fit.jsonl as first monitored path; spend gate applies). Amend the ordering and ontology: the cron + attune CLI path is the *definition* of the scheduled behavior, and the host scheduled-task/file-monitor is a projection of that definition — not two parallel implementations that R2 later reconciles. Concretely: one template document per task, from which both the crontab line and the host task registration are generated. Twins that share a master cannot drift; twins written side by side will, and R2 will then catch drift you could have made impossible.
+
+**R6 — Local-model roles via extensions: ADOPT.**
+D1 is chair-ruled and this is its faithful implementation: two ruled contracts, roles not seats, no ModelProvider change, no third contract. Mechanics resolve per my D2 and phasing positions in Section 3.
+
+**R7 — Roster as data: AMEND (adopt, with a golden-roster receipt and a typed-slot check).**
+Steelman against, since I agree with the chair's lean: the literal three-tuple is the strongest invariant in the tree — "exactly these three, exactly these argv" is checkable by `==`; roster-as-data replaces it with "exactly whatever the roster says," which is a weaker gate wearing the same name, and data-driven rosters invite untested combinations and config sprawl for a roster that has changed zero times. The answer to that steelman is to keep the old invariant as a receipt: (a) a golden test asserting the default roster reproduces the current literals byte-for-byte in behavior — CANONICAL_SEATS, SEAT_RECIPES argv, PLAN_ONLY_SEATS membership — so the refactor is provably a no-op; (b) role slots are typed (plan-only reviewer / code-native proposer / moderator-with-receipts) and validated, so a roster edit that produces two moderators or zero plan-only reviewers fails loudly; (c) the fourth-slot-requires-enabled-extension rule is enforced in the roster loader, not in prose, since the non-goal binds this spec but the loader outlives it.
+
+**R8 — Asks-per-outcome: AMEND (record raw pairs; floor the gate; keep the old signal as a guard).**
+The reframing — structure per result, not interruptions per session — is right and worth adopting. Three defects to fix before friction_gate reads it: (1) sessions with zero completed outcomes make the ratio undefined exactly when friction is worst — a session with twelve asks and no receipt must still register, so keep asks-per-session as a secondary guard; (2) the metric is gameable by outcome inflation (splitting one result into three receipts halves the figure) — record raw numerator and denominator in the ledger, not the ratio; (3) friction_gate should act only above a minimum-outcomes floor so one weird session doesn't swing behavior. No new telemetry store, as proposed.
+
+## Section 2 — Requirements this seat proposes
+
+**R9 — Host capability matrix with a `surfaces doctor` probe (primary proposal).**
+"No host becomes the privileged surface" is currently a design intention with no enforcer. Ship one: a session-start probe (`attune surfaces doctor`) that records which contracts the current host actually advertises — structured question, memory surface, ui:// profile, scheduled tasks, file monitor — and writes a capability receipt. From accumulated receipts, a generated matrix (hosts × capabilities, each cell native / fallback-receipted / absent) lives in-tree and is drift-guarded: R2 proves every surface *has* twins; R9 proves the twins are *exercised* on real hosts, and makes "Cowork is quietly becoming the privileged surface" a red cell you can see rather than a vibe. Renderers consult the probe instead of sniffing per call. Crucially, the matrix must be assertable in CI with *no* host present (all-fallback column green), or HEADLESS parity is a promise again.
+
+**R10 — Tier provenance on every validated answer (secondary, cheap).**
+Every answer records which tier rendered it, and tier 0 additionally records fall-through rate and "Other"-selection rate. This is the instrument for my H1 dissent: if Other-rate climbs on tier 0, the four-option projection is truncating expressiveness in practice regardless of what the fall-through rule says on paper. One ledger field, no new store; feeds R8's outcome accounting for free.
+
+## Section 3 — Open mechanics
+
+**D2 — routing label, not enum member.** D1's binding language ("local models start as a LOCAL tier") names the user-facing concept; D2 asks how to implement it, and the answer is outside the enum. Three reasons. First, mechanics: the tier enum is duplicated by design in four files plus the attune-rag mirror with a drift guard — a new member is five coordinated edits, and every exhaustive match over tiers everywhere must now handle LOCAL, including code paths (attune-rag ranking, spend gates, provider routing) that must *never* receive it; the drift guard would then be guarding a member whose absence from mirrors is the correct state. Second, semantics: CHEAP/CAPABLE/PREMIUM is a quality-cost ladder within one provider; LOCAL is an orthogonal placement/privacy/latency property, not a rung — a local model can be CHEAP-grade today and CAPABLE-grade next quarter without moving "where it runs." Third, expressiveness: a routing label (`placement: local` on the role's routing record) lets a role say "CHEAP, prefer local, fall back hosted," which an enum member structurally cannot say. Keep the enum three; add the label where R6's roles are routed.
+
+**D3 — confirm no third capability contract, with a tripwire.** The two ruled contracts cover both phases of R6, and a provider-level contract is the general-Ollama-provider non-goal wearing a contract costume — it would recreate ModelProvider as a seam the day after deciding not to. Confirm the deferral. Tripwire for reopening: when a *second real* extension request arrives that fits neither contract without contortion (not a hypothetical in a spec — an implementer with code), reopen D3 with that implementer at the table. Contracts extracted from two concrete users are good; contracts designed for zero are speculation.
+
+**Task 7 phasing — reranker ships alone, first.** The reranker is the first real second implementer of the extension seam, and the seam learns more from one honest implementer shipping end-to-end than from two batched. It is also the safest possible probe: optional capability, offline-evaluable against a no-rerank baseline, and recall is unchanged when the extension is absent — failure is invisible to users and visible to receipts. Phase B's workflow extensions exercise the *other* contract; batching them means seam feedback from two contracts arrives entangled and late. Ship A, run the seam retro, then cut B with whatever the seam taught. The only argument for waiting — one release event instead of two — buys nothing, since extensions are enabled per-user anyway.
+
+## Section 4 — Dissent register
+
+**H1 (tier 0 not a rival) — dissent on gravity, not mechanism.** The fall-through rule protects existing rich forms, but it cannot protect *future* forms: once tier 0 exists, authors will shape new questions to fit four options because the native widget is frictionless — design-to-the-projection. The richer constructs then atrophy not by degradation but by disuse. That is how a render target becomes a rival without any rule being broken. R10's Other-rate and fall-through telemetry is the tripwire; without it H1 is unfalsifiable.
+
+**H2 (parity can be mechanical) — dissent on "identical validated output."** For single-question forms, byte-identical validated payloads across three renders is achievable and right. For stateful surfaces — the Fix workspace with revision, nonce, contract hash — byte identity across renders is false by construction. The gate must assert schema-identical validated payloads with nonce/revision fields normalized, or R2 either ossifies (no stateful surface can ever pass) or accumulates waivers (and a gate with waivers is a promise again).
+
+**H3 (host remembers, Attune recalls) — dissent on the seat's answer to its own pushback.** "A corpus with no recall is the demo; recall is the product" is a slogan standing where a receipt should be. R3 hands every host a curated, one-line-per-lesson index — which materially improves the *host's* native retrieval over that corpus. The positioning survives only while relevance-ranked recall measurably beats grep-over-the-projected-index. By the contract's own standard, that claim needs a benchmark receipt (recall vs. host-notebook baseline on real lookups), or the seat should stop making it.
+
+**H4 (role before seat) — dissent on fact-check probes.** Four of the five roles are genuinely low-stakes. Fact-check probes are not: a wrong local verdict that silently *passes* is worse than no probe, because it converts absence-of-signal into false assurance. If a probe's output ever gates anything, it must be advisory-labeled and countersigned by the hosted model; a local model may raise its hand, never wave things through.
+
+**H5 (roster by role, not vendor) — dissent on the taxonomy's honesty.** The three role names are the current three vendors described from behind. The falsifiable test of roster-as-data: can the moderator slot be filled by a non-Claude recipe, or two slots by one vendor, with *no* gate edits? If the gates encode assumptions that make the answer no, R7 as shipped is a rename, not a refactor — and the golden-roster receipt I attached to R7 should be joined, later, by exactly that swap test before any fourth slot is entertained.
+
+**On the seat's own register:** withdrawal (a) was correct and I confirm it. But note that R3's every-host projection still benefits hosts unevenly — the richest memory surface (Cowork's MEMORY.md + typed topics) extracts the most value from the same projection. Neutral output over unequal surfaces is not neutral outcome; that is precisely what R9's matrix exists to make visible rather than arguable.
+
+---
+
+**Follow-up question for the table:** What single receipt would the chair accept as proof that no host is privileged — the R9 matrix, the R2 gate, or something else — and can that receipt be produced in CI with no host present at all? If it cannot, HEADLESS parity is still a promise.
+
+---
+
+## Message 6 — claude · question (R9 member-originated, reply_to 5)
+
+What single receipt would the chair accept as proof that no host is privileged — the R9 matrix, the R2 gate, or something else — and can that receipt be produced in CI with no host present at all? If it cannot, HEADLESS parity is still a promise.
+
+---
+
+## Message 7 — moderator · halt
+
+spend gate reached: chair-ruled 3 seat invocations / 1 round complete; a second round needs a fresh chair go
+
+---
+
+## Message 8 — moderator · synthesis · round 1
+
+# Moderator synthesis — round 1 (all three seats answered; spend gate reached)
+
+## Unanimous (3/3)
+
+- **D2 — LOCAL is a routing label, NOT a tier-enum member.** All three seats,
+  independently, on the same grounds: locality is orthogonal to the
+  quality/cost ladder; an enum member is five coordinated edits (four copies +
+  attune-rag mirror) and forces every exhaustive tier match to handle a value
+  most code paths must never receive. Codex: `execution=local|hosted`
+  dimension. Antigravity: `ExecutionLocality` tag (`LOCAL_PREFERRED /
+  LOCAL_REQUIRED / CLOUD_ONLY`). Claude: `placement: local` on the role's
+  routing record, enabling "CHEAP, prefer local, fall back hosted". The seats
+  read chair ruling D1a's "LOCAL tier" as naming the user-facing concept, not
+  the enum mechanics.
+- **D3 — confirm no third capability contract**, each with a reopening
+  condition: Codex — revisit only after two independently implemented
+  extensions demonstrably fit neither contract; Claude — tripwire fires on a
+  second *real* implementer with code, who then sits at the table; Antigravity
+  — confirm for 16.3, conditionally challenge in 16.4 with an
+  Evaluator/Embedding seam if local models expand into embedding/scoring.
+- **Task 7 — ship the Ollama reranker alone, first.** All three: it is the
+  canary for the extension seam (discovery, optional capability advertisement,
+  fallback, receipts, failure isolation), deterministic and offline-verifiable,
+  and batching it with Phase B entangles seam feedback from two contracts.
+- **R4 — ADOPT** as written (3/3). Claude seat: do it first — cheapest
+  early-warning on the list. Codex: record both advertised-profile and
+  fallback cases including stale revision, wrong hash, replay rejection.
+- **Parity direction (chair's lean) — all three adopt**, and all three
+  independently guard against the same failure mode, parity theater:
+  Codex — enforce via a declared surface registry, not filesystem enumeration,
+  plus explicit *expiring* parity exceptions; Claude — a drift-guarded
+  `experiments:` allowlist with mandatory 14–30-day expiry (spikes may be
+  untwinned; shipped surfaces may not); Antigravity — adopts because headless
+  fidelity is the foundation of its own runtime, steelman recorded.
+
+## Convergent amendments (compatible, near-unanimous)
+
+- **R1 — parameterize tier 0 by host capability, don't hardcode Claude's
+  4-option shape** (Antigravity AMEND + Claude AMEND; Codex ADOPT with
+  capability detection + contract tests — same design). Antigravity's sharpest
+  point: its own native `ask_question` supports multi-question forms, so
+  clamping tier 0 to the Fable widget shape would covertly turn one vendor's
+  limitation into the universal standard.
+- **R3 — bound the projection** (Codex AMEND + Antigravity AMEND vs Claude
+  ADOPT-with-notes). Converged shape: generated, sentinel-bracketed blocks
+  (`ATTUNE:MEMORY:START/END`) with provenance headers; bounded top-K digest
+  (Antigravity: ~25 entries, hit-frequency prioritized); per-host independent
+  line budgets (Claude); stale-entry cleanup and removal support, not just
+  regeneration (Codex); hand edits inside the block fail closed, edits outside
+  stay legal. Codex explicitly rejects "second master" framing: Attune index
+  stays authoritative, host files hold projections with provenance.
+- **R5 — one master definition, host bindings generated from it** (Codex:
+  host-neutral automation manifest compiled to host config or cron+CLI;
+  Claude: the portable twin IS the definition, host task is a projection).
+  Antigravity adds operational guards: no autonomous LLM sweeps on raw file
+  events — deterministic triage probes only, ≥60s debounce, hourly
+  circuit-breaker cap, explicit acknowledgment before token-intensive audits;
+  telemetry writes must not retrigger their own monitor (loop prevention —
+  Codex names the same loop).
+- **R7 — roster as data, with stronger typing and a no-op proof** (3/3 adopt
+  direction). Converged asks: typed role slots validated for invariants
+  (exactly one moderator / plan-only reviewer / proposer — Antigravity,
+  Claude); golden behavior test proving the default roster reproduces current
+  literals byte-for-byte (Claude, Antigravity, Codex); model execution mode,
+  trust boundary, capabilities and receipt obligations on the slot, not just
+  a role name (Codex, echoed by Claude's H5 dissent); fourth-slot gating
+  enforced in the loader, not prose (Claude), disabled-until-chair-go
+  structural representation (Codex).
+- **R8 — record raw counts and terminal outcomes** (Codex AMEND + Claude
+  AMEND; Antigravity ADOPT). Codex: count asks per *terminal* outcome so
+  abandoned/blocked sessions don't vanish; report zero-outcome rate. Claude:
+  store raw numerator/denominator (ratio is gameable by outcome inflation),
+  keep asks-per-session as a secondary guard, minimum-outcomes floor before
+  friction_gate acts. Compatible; union is the amendment.
+- **R2 mechanics split (the one real disagreement inside a shared direction):**
+  Codex would replace filesystem enumeration with a declared surface registry
+  ("scanning is too easy to evade accidentally"); Claude keeps the gate but
+  fixes the receipt clause to "schema-identical validated payload" with
+  nonce/revision normalized (byte identity is false by construction for
+  stateful surfaces); Antigravity adds interaction-lifecycle parity (abort,
+  timeout, validation feedback), arguing output identity alone is
+  insufficient. These compose: registry-driven gate + payload-schema receipts
+  + lifecycle assertions — but the chair should rule the enforcement locus.
+
+## The seats' own proposals converge on one missing layer
+
+All three independently invented a **capability-descriptor / conformance
+layer**: Codex R9 (machine-readable capability descriptor per host adapter +
+shared conformance suite proving deliberate degradation, receipt provenance,
+no silent privileged-host selection — "portability as a testable protocol,
+the foundation minor"); Claude R9 (`attune surfaces doctor` probe + generated
+hosts×capabilities matrix, drift-guarded, assertable in CI with no host
+present); Antigravity's R1 capability descriptor is the same object. This is
+the strongest signal of the round: the table believes the missing enforcer of
+"no privileged surface" is a *declared, testable capability contract per
+host*, not more twins.
+
+Seat-unique proposals: Antigravity R9 — typed review-finding interchange
+(SARIF-conformant) projecting attune audit findings into Fable review cards,
+GitHub PR threads, IDE diagnostics, and a headless SARIF stream, with
+round-trip receipts; Antigravity R10 — advisory worktree leases + turn
+attestation receipts (anti-seat-simulation); Claude R10 — tier provenance +
+Other-rate/fall-through telemetry as the falsifier for H1's "not a rival"
+claim.
+
+## Dissent worth the chair's eyes
+
+- **H3 is the most-dissented hypothesis.** Codex: bounded projections or you
+  get context pollution and prompt-authority confusion. Antigravity: index
+  lines tax every subagent turn; plain hosts hallucinate following raw
+  pointers. Claude seat (against its own proposer): "recall is the product"
+  is a slogan where a receipt should be — demand a benchmark (recall vs
+  host-notebook baseline) or stop making the claim.
+- **H4 split:** Antigravity dissents on principle — seat eligibility should be
+  benchmark-receipted, not provider-dogma; an air-gapped 70B is a legitimate
+  plan-only reviewer. Codex and Claude hold the advisory-only line, both
+  flagging fact-check/skeptic probes as the danger: a weak local model
+  manufacturing the *appearance* of independent verification; a silent local
+  pass is worse than no probe (must be advisory-labeled + hosted-model
+  countersigned).
+- **H5:** Claude's falsifiable test — can the moderator slot take a non-Claude
+  recipe with zero gate edits? If not, R7 is a rename, not a refactor.
+
+## Open member questions (round 2 material, needs fresh chair go)
+
+1. (Antigravity, msg 4) What cryptographic receipt schema proves a host-UI
+   resolution was executed by the authorized human chair rather than a host
+   subagent simulation?
+2. (Claude, msg 6) What single receipt does the chair accept as proof no host
+   is privileged — and can it be produced in CI with no host present?
+
+## Moderator read (effort for the next two minors)
+
+16.3: R4 receipt (first), the merged capability-descriptor/conformance
+foundation (three-way R9 convergence), R1 with the host-profile amendment,
+D2 as routing label, Task 7 reranker alone. 16.4: R3 bounded projection, R5
+single-master automation templates, R7 roster-as-data with golden receipts,
+Phase B workflow extensions, R8. The release is a tailwind exactly where the
+table converged: the host is a projection target and a distribution channel;
+Attune's defensible layer (Codex's phrasing) is cross-host semantics,
+validation, policy, receipts, reproducibility.

--- a/docs/reports/roundtable/q-fable-51-surface-overlap-001.md
+++ b/docs/reports/roundtable/q-fable-51-surface-overlap-001.md
@@ -12,7 +12,10 @@ chair go.
 claude 129s / 62,710 subagent tokens, context-free general-purpose agent
 (msg 5). Question posted verbatim from
 `docs/specs/host-surface-parity/roundtable-question.md` (msg 1).
-**Promotion status:** NOT promoted — no chair rulings yet (R4 holds).
+**Promotion status:** PROMOTED 2026-09-02 (chair) — the reviewing
+session's recommended triage was ruled in full; per-item record in
+`docs/specs/host-surface-parity/decisions.md` D5 (D2/D3 ruled, D4
+amended-adopted, R9 adopted, round 2 deferred; D6 locus open).
 Promotion candidates by board id: positions 2 (codex), 3 (antigravity),
 5 (claude); member questions 4 (antigravity), 6 (claude); synthesis 8.
 

--- a/docs/specs/host-surface-parity/decisions.md
+++ b/docs/specs/host-surface-parity/decisions.md
@@ -1,0 +1,76 @@
+# Host Surface Parity — Decisions
+
+## D1 — Three chair rulings at intake (2026-09-03, chair)
+
+Recorded from the Cowork session that produced this spec. The Claude
+seat proposed; the chair ruled. The options declined are recorded so
+the table does not re-pitch them.
+
+**D1a — Local models' first job is a `LOCAL` tier for low-stakes
+roles.** Recall re-ranking, lesson classification, triage pre-sort,
+skeptic/countersign at low stakes, fact-check probes. Seats
+unchanged for now. *Declined:* a fourth round-table seat now;
+"both, LOCAL first" (the chair chose the narrower ruling; a seat
+remains a later, separate question).
+
+**D1b — Extensions are the seam.** Providers, memory backends and
+seats arrive through the trust-gated `attune.extensions` system
+ruled in release-16-manifest D1/D2. This spec sequences behind
+passenger 4 for R6 and never edits a roster tuple to add a vendor.
+*Declined:* keeping roster and providers as in-tree tuples this
+cycle.
+
+**D1c — The deliverable is a spec under `docs/specs/`.** This
+directory is the chair's R4 approval for these files and nothing
+else; the round-table brief artifact stays the companion page.
+*Declined:* a roadmap page only; both.
+
+## D2 — `LOCAL` tier mechanics (PROPOSED 2026-09-03 — NOT RULED)
+
+D1a names a `LOCAL` tier; the mechanics have two honest options.
+
+- **(a) Enum member.** Add `LOCAL = "local"` below `CHEAP` in all
+  four tier copies and the `attune-rag` mirror in one release, with
+  `tests/unit/test_model_tiers_drift.py` as the receipt. Pricing
+  zero; spend gate records tokens for volume. *Cost:* a coordinated
+  attune-rag release. *Benefit:* routing, telemetry tiles and cost
+  reports all understand the tier without special cases.
+- **(b) Routing label.** Leave the enum alone; add a `role → target`
+  table where a target is a tier or an enabled extension. *Cost:* a
+  second routing vocabulary beside the tier; ops tiles need a case
+  for "not a tier". *Benefit:* no cross-package release.
+
+**Seat's recommendation: (a).** The drift guard exists precisely to
+make this change safe, and a tier that ops can see is what lets a
+power user be demanding about where a role runs.
+
+## D3 — No third capability contract (PROPOSED 2026-09-03 — NOT RULED)
+
+release-16-manifest D1 ruled exactly two capability contracts:
+workflows and memory backends. A general "provider" contract — Ollama
+as a model provider for every workflow — would be a third. This spec
+does not propose it. Local models serve R6's roles as a
+memory-backend extension (rerank) and workflow extensions (roles),
+which fit the two ruled contracts and make the Ollama reranker the
+first real second implementer D2 named as its falsifier.
+
+If the chair later wants a provider-level contract, that is a
+release-16-manifest amendment, not a host-surface-parity task.
+
+## D4 — Parity is an enforcer, not a principle (PROPOSED 2026-09-03 — NOT RULED)
+
+Collaboration-contract principle 1 ("the receipt beats the promise")
+carries the *aspirational* label because no gate can check intent.
+For surfaces the check is mechanical: a RICH renderer or host hook
+either has its PORTABLE and HEADLESS twins receipted or it does not.
+R2 proposes `tests/unit/gates/test_surface_parity.py` as the
+enforcer for this case, and Task 1 lands it green before any new
+renderer exists so it gates rather than chases.
+
+## Open
+
+- Convene `q-fable-51-surface-overlap-001` before ruling R1–R8?
+- Coverage floor for this initiative (85% repository floor, or 90%
+  as in shared-command-workspaces D4).
+- D2 mechanics.
+- Whether Task 7 waits for Phase B or ships alone on Phase A.

--- a/docs/specs/host-surface-parity/decisions.md
+++ b/docs/specs/host-surface-parity/decisions.md
@@ -25,7 +25,24 @@ directory is the chair's R4 approval for these files and nothing
 else; the round-table brief artifact stays the companion page.
 *Declined:* a roadmap page only; both.
 
-## D2 — `LOCAL` tier mechanics (PROPOSED 2026-09-03 — NOT RULED)
+## D2 — `LOCAL` tier mechanics (RULED 2026-09-02, chair — routing label)
+
+**Ruling: option (b), routing label — superseding the seat's own
+recorded recommendation of (a).** Promoted from round-1 of
+`q-fable-51-surface-overlap-001`, where all three seats ruled (b)
+independently on the same grounds: locality is orthogonal to the
+quality/cost ladder; an enum member is five coordinated edits (four
+copies + the attune-rag mirror) and forces every exhaustive tier
+match to handle a value most code paths must never receive; a label
+(`placement: local` on the role's routing record) can express
+"CHEAP, prefer local, fall back hosted", which an enum member
+structurally cannot. D1a's "LOCAL tier" names the user-facing
+concept, not the enum mechanics. Same-change consequences applied:
+R6's tier-contract sentence and Task 8's enum-edit mechanics amended
+to the label. The ops-tile "not a tier" case named as (b)'s cost is
+accepted and lands with Task 8.
+
+The superseded proposal text is kept below for provenance.
 
 D1a names a `LOCAL` tier; the mechanics have two honest options.
 
@@ -42,9 +59,10 @@ D1a names a `LOCAL` tier; the mechanics have two honest options.
 
 **Seat's recommendation: (a).** The drift guard exists precisely to
 make this change safe, and a tier that ops can see is what lets a
-power user be demanding about where a role runs.
+power user be demanding about where a role runs. *(Superseded by the
+ruling above — the table was unanimous for (b).)*
 
-## D3 — No third capability contract (PROPOSED 2026-09-03 — NOT RULED)
+## D3 — No third capability contract (RULED 2026-09-02, chair — confirmed)
 
 release-16-manifest D1 ruled exactly two capability contracts:
 workflows and memory backends. A general "provider" contract — Ollama
@@ -57,7 +75,17 @@ first real second implementer D2 named as its falsifier.
 If the chair later wants a provider-level contract, that is a
 release-16-manifest amendment, not a host-surface-parity task.
 
-## D4 — Parity is an enforcer, not a principle (PROPOSED 2026-09-03 — NOT RULED)
+**Ruling (2026-09-02, promoted from round 1, all three seats
+confirming):** the deferral stands, with a recorded tripwire —
+D3 reopens when a **second real implementer with code** (not a
+hypothetical in a spec) fits neither ruled contract without
+contortion, and that implementer sits at the table for the
+reopening. Noted for 16.4: Antigravity's conditional challenge
+that embedding/scoring may deserve its own `Evaluator`/`Embedding`
+seam rather than bloating `memory-backend` — that is round-2 /
+tripwire material, not a ruling.
+
+## D4 — Parity gate mechanics (RULED 2026-09-02, chair — adopted as amended)
 
 Collaboration-contract principle 1 ("the receipt beats the promise")
 carries the *aspirational* label because no gate can check intent.
@@ -67,10 +95,134 @@ R2 proposes `tests/unit/gates/test_surface_parity.py` as the
 enforcer for this case, and Task 1 lands it green before any new
 renderer exists so it gates rather than chases.
 
+**Ruling (2026-09-02, promoted from round 1):** adopted with three
+amendments, one composed from each seat:
+
+- an `experiments:` allowlist with a **mandatory 14–30-day expiry**,
+  itself drift-guarded — the gate fails on any expired entry. A
+  spike may exist untwinned; a shipped surface may not (Claude;
+  Codex's "explicit, expiring parity exception" is the same rule).
+- the receipt clause reads **"schema-identical validated payload"**
+  with nonce/revision fields normalized — byte identity is false by
+  construction for stateful surfaces (Claude H2 dissent).
+- parity assertions include **interaction lifecycle** (abort,
+  timeout, validation-feedback semantics), not output identity
+  alone (Antigravity).
+
+The enforcement locus (filesystem enumeration vs. declared surface
+registry) is NOT ruled here — see D6.
+
+## D5 — Round-1 promotion of `q-fable-51-surface-overlap-001` (RULED 2026-09-02, chair)
+
+The chair ruled the reviewing session's recommended promotion triage
+in full ("Proceed with Recommended items using the Recommended
+promotion triage"). Basis: the committed round-1 transcript
+(`docs/reports/roundtable/q-fable-51-surface-overlap-001.md`,
+aac2b1013) and the reviewing session's fidelity check of the
+synthesis against the seat messages. Per-item record:
+
+- **R1 — AMEND, adopted.** The tier-0 contract constants (option
+  cap, multi-question support, free-text escape, recommendation
+  suffix) live in a declared **host-profile record**, with the
+  Fable/Claude profile merely the first entry; a form exceeding the
+  *current host's* profile falls through to PORTABLE intact.
+  Contract tests cover validation errors, multi-select ordering,
+  "Other", cancellation, and host capability change (Codex).
+  Antigravity's grounding: its native `ask_question` takes
+  multi-question forms, so hardcoding the 4-option Fable shape
+  would turn one vendor's limit into the universal standard.
+- **R2 — AMEND, adopted** per D4's amended ruling; locus open (D6).
+- **R3 — AMEND, adopted** (the seat's bare ADOPT was overruled by
+  the Codex/Antigravity convergence): generated, sentinel-bracketed
+  blocks (`ATTUNE:MEMORY:START/END`) with provenance headers naming
+  the regenerate command; **bounded top-K digest** (~25 entries,
+  hit-frequency prioritized) — never the unbounded index;
+  **per-host independent line budgets**; stale-entry cleanup and
+  removal, not only regeneration; hand edits inside the block fail
+  closed, edits outside stay legal. No "second master" framing: the
+  Attune promoted-lesson index stays the sole authority and host
+  files hold projections with provenance.
+- **R4 — ADOPT as written, first among the eight.** Receipts record
+  both advertised-profile and fallback cases, including stale
+  revision, wrong contract hash, and replay rejection.
+- **R5 — AMEND, adopted.** One **master automation definition** per
+  task; the crontab line and the host task/monitor registration are
+  both *generated* from it (twins that share a master cannot
+  drift). Operational guards: no autonomous LLM sweeps on raw
+  file-system events — deterministic triage probes or an outbox
+  stage only; ≥60s debounce; hourly circuit-breaker cap; explicit
+  acknowledgment before token-intensive audits; a run's own
+  telemetry write must not retrigger its monitor. The fit_source
+  budget-clock settlement is separately asserted.
+- **R6 — ADOPT** with D2's routing-label mechanics; requirement
+  text and Task 8 amended in this change.
+- **R7 — AMEND, adopted.** Typed role slots validated for
+  invariants (exactly one moderator-with-receipts, one plan-only
+  reviewer, one code-native proposer); slots carry execution mode,
+  trust boundary, required capabilities, and receipt obligations,
+  not just a role name; a **golden behavior test** proves the
+  default roster reproduces the current literals byte-for-byte
+  (`CANONICAL_SEATS`, `SEAT_RECIPES` argv, `PLAN_ONLY_SEATS`); the
+  fourth-slot-requires-enabled-extension rule is enforced **in the
+  roster loader**, structurally representable but disabled until a
+  chair go.
+- **R8 — AMEND, adopted** (union of the Codex and Claude
+  amendments): count structured asks per **terminal** outcome so
+  abandoned/blocked sessions register; store **raw numerator and
+  denominator**, never the ratio (outcome inflation games a ratio);
+  keep asks-per-session as a secondary guard; `friction_gate` acts
+  only above a minimum-outcomes floor; report zero-outcome rate and
+  fallback frequency; never record answer contents; no new store.
+- **R9 — ADOPT (new, the round's strongest signal).** The merged
+  capability-descriptor/conformance layer all three seats
+  independently proposed: a machine-readable **capability
+  descriptor** per host adapter and extension; an
+  `attune surfaces doctor` probe writing capability receipts; a
+  generated, drift-guarded **hosts × capabilities matrix**
+  (native / fallback-receipted / absent) in tree; a conformance
+  suite proving deliberate degradation, semantic equivalence,
+  receipt provenance and replay protection, PORTABLE + HEADLESS
+  usable with any adapter removed, and no silent privileged-host
+  selection. Must be **assertable in CI with no host present**
+  (all-fallback column green). This is the 16.3 foundation item.
+- **Noted, not adopted** (round-2 / design-input material):
+  Antigravity's SARIF finding-interchange proposal and its
+  worktree-lease + turn-attestation proposal (pairs with board
+  msg 4); Claude's tier-provenance/Other-rate telemetry (folds into
+  R1/R9 task design as the falsifier for H1's "not a rival" claim).
+- **Antigravity H4 dissent — noted, not reopened.** D1a's declined
+  fourth-seat option stands; seat eligibility remains a later,
+  separate question. The advisory-only line holds: fact-check
+  probes are advisory-labeled and hosted-model countersigned; a
+  local model may raise its hand, never wave things through.
+- **Round 2 — deferred.** Both member questions (msg 4: attestation
+  schema for host-UI resolutions; msg 6: the single
+  no-privileged-host receipt, producible in CI with no host) feed
+  R9's design rather than blocking any ruling above; they reopen
+  with a fresh chair go when R9 design work makes them concrete.
+
+**Sequencing (moderator read, adopted):** 16.3 — R4 receipt first,
+R9 foundation, R1 as amended, D2 label, Task 7 reranker alone.
+16.4 — R3, R5, R7, R8, Phase B workflow extensions.
+
+## D6 — R2 enforcement locus (OPEN)
+
+The one real disagreement inside the round's shared direction:
+Codex would replace filesystem enumeration with a **declared
+surface registry** ("scanning is too easy to evade accidentally and
+too brittle around helpers and templates"); the Claude seat kept
+the enumerating gate. The synthesis notes the positions compose
+(registry-driven gate + payload-schema receipts + lifecycle
+assertions). Not ruled at promotion; the chair rules the locus
+before Task 1 lands the gate.
+
 ## Open
 
-- Convene `q-fable-51-surface-overlap-001` before ruling R1–R8?
+- **D6 — R2 enforcement locus** (registry vs. enumeration); rule
+  before Task 1.
 - Coverage floor for this initiative (85% repository floor, or 90%
-  as in shared-command-workspaces D4).
-- D2 mechanics.
-- Whether Task 7 waits for Phase B or ships alone on Phase A.
+  as in shared-command-workspaces D4) — not addressed by round 1.
+
+Resolved 2026-09-02: the table was convened (round 1 complete,
+promoted in D5); D2 ruled (routing label); Task 7 ships alone on
+Phase A (D5).

--- a/docs/specs/host-surface-parity/decisions.md
+++ b/docs/specs/host-surface-parity/decisions.md
@@ -216,6 +216,51 @@ the enumerating gate. The synthesis notes the positions compose
 assertions). Not ruled at promotion; the chair rules the locus
 before Task 1 lands the gate.
 
+### Calibration probe (2026-09-03, lead — evidence for the ruling, per the probe-before-gate lesson)
+
+Probes run against the real tree and the installed attune-forms
+0.12.2; every claim below is verified by the named probe.
+
+1. **A filesystem enumerator in attune-ai is blind by construction,
+   not merely evadable.** `grep -r 'Surface\.RICH|Surface\.PORTABLE|
+   Surface\.HEADLESS' src/ plugin/` → **zero hits**; `grep -r
+   'ui://' src/` → zero. Every renderer lives in the separate
+   `attune-forms` distribution; attune-ai only *imports* it (10
+   modules, verified). R2's proposed
+   `tests/unit/gates/test_surface_parity.py` "enumerating every
+   RICH-tier renderer in the tree" would find nothing and pass
+   **vacuously green** — the vacuous-gate class, satisfied by the
+   very blindness it should catch. This is stronger than Codex's
+   stated brittleness argument.
+2. **The registry half-exists.** Installed attune-forms already
+   exports `ProjectionRenderers` with fields
+   `rich / portable / headless / retained` — literally the
+   three-twin record per surface — plus `HostCapabilities`,
+   `InteractionProfile`, and a `conformance` module
+   (`ConformanceReceipt/Report/Status/Finding`) matching the R9
+   convergence vocabulary (verified by import + field inspection).
+   The registry locus is wiring, not new construction.
+3. **Host hooks and templates DO live in this tree** (plugin/
+   hooks, `.claude/` hooks, and R5's future task templates), so
+   enumeration has a real domain there — and a registry-only gate
+   would miss an *unregistered* hook, which is the evasion Codex
+   worried about, pointed the other way.
+
+**Lead recommendation: hybrid, subject-local.** (a) Renderer parity
+is asserted against attune-forms' declared `ProjectionRenderers`
+registry — attune-ai's gate imports it and fails on any registered
+surface lacking a twin or receipt (same cross-package drift-guard
+pattern as the tier mirror). (b) Host-hook/template parity is
+asserted by filesystem enumeration in attune-ai, where those
+artifacts actually live. The D4 amendments (expiring allowlist,
+payload-schema receipts, lifecycle assertions) apply to both.
+**Counter-case (strongest argument against):** a hybrid is two
+mechanisms to maintain, and the registry side still trusts
+attune-forms to register every renderer — a sweep test *inside
+attune-forms* asserting "no renderer module escapes the registry"
+is the missing third leg, and it belongs to the attune-forms repo,
+which this spec does not control. NOT RULED — chair's call.
+
 ## Open
 
 - **D6 — R2 enforcement locus** (registry vs. enumeration); rule

--- a/docs/specs/host-surface-parity/decisions.md
+++ b/docs/specs/host-surface-parity/decisions.md
@@ -205,7 +205,20 @@ synthesis against the seat messages. Per-item record:
 R9 foundation, R1 as amended, D2 label, Task 7 reranker alone.
 16.4 — R3, R5, R7, R8, Phase B workflow extensions.
 
-## D6 — R2 enforcement locus (OPEN)
+## D6 — R2 enforcement locus (RULED 2026-09-03, chair — hybrid, subject-local)
+
+**Ruling: the lead's recommended hybrid** (chair picked option 1
+after the calibration probe below and a UX-impact read: the locus
+is CI-side with zero user-facing latency; the differences are in
+what each option fails to catch). Renderer parity is asserted
+against attune-forms' declared `ProjectionRenderers` registry via a
+cross-package drift guard; host-hook/template parity is asserted by
+filesystem enumeration in attune-ai where those artifacts live; the
+D4 amendments (expiring allowlist, payload-schema receipts,
+lifecycle assertions) apply to both. The counter-case's third leg —
+a "no renderer escapes the registry" sweep inside attune-forms —
+is accepted as part of the ruling and lands in the attune-forms
+repo alongside Task 1's gate here.
 
 The one real disagreement inside the round's shared direction:
 Codex would replace filesystem enumeration with a **declared
@@ -263,11 +276,9 @@ which this spec does not control. NOT RULED — chair's call.
 
 ## Open
 
-- **D6 — R2 enforcement locus** (registry vs. enumeration); rule
-  before Task 1.
 - Coverage floor for this initiative (85% repository floor, or 90%
   as in shared-command-workspaces D4) — not addressed by round 1.
 
-Resolved 2026-09-02: the table was convened (round 1 complete,
+Resolved 2026-09-02/03: the table was convened (round 1 complete,
 promoted in D5); D2 ruled (routing label); Task 7 ships alone on
-Phase A (D5).
+Phase A (D5); D6 ruled (hybrid, subject-local — 2026-09-03).

--- a/docs/specs/host-surface-parity/design.md
+++ b/docs/specs/host-surface-parity/design.md
@@ -1,0 +1,282 @@
+# Host Surface Parity — Design
+
+**Status:** draft (2026-09-03) — design proposed by the Claude seat
+against the verified baseline below; no task is authorized.
+**Last updated:** 2026-09-03
+
+## Verified baseline
+
+Every anchor below was read from the tree on 2026-09-03, not carried
+from spec text.
+
+- **Roster is literal.** `CANONICAL_SEATS: tuple[str, ...] =
+  ("claude", "antigravity", "codex")` at
+  [rotation.py:25](../../../src/attune/roundtable/rotation.py);
+  `SEAT_RECIPES` (fixed argv: `claude -p`, `agy --mode plan`,
+  `codex exec`) and `PLAN_ONLY_SEATS = {"antigravity"}` at
+  [routine.py:92–106](../../../src/attune/roundtable/routine.py);
+  `workspace.py` refuses `round_complete` unless the roster is
+  exactly the fixed three
+  ([workspace.py:258, 341](../../../src/attune/roundtable/workspace.py));
+  the brief preamble hard-codes "three-model round table".
+  `skeptic.py` and `countersign.py` import `CANONICAL_SEATS` for the
+  different-model rule.
+- **Provider registry is Claude-native.** `ModelProvider` has one
+  member, `ANTHROPIC`
+  ([registry.py:33](../../../src/attune/models/registry.py)).
+  `ModelTier` is `CHEAP / CAPABLE / PREMIUM`
+  ([registry.py:20](../../../src/attune/models/registry.py)) with
+  duplicates in `config/agent_config.py:25`,
+  `workflows/compat.py:50`, `workflows/progressive/core.py:24` and a
+  mirror in `attune-rag` guarded by
+  `tests/unit/test_model_tiers_drift.py`. Ollama appears only in
+  workflow config docstrings and comments; there is no Ollama client.
+- **Surfaces are negotiated.** `attune-forms` exposes
+  `Surface.RICH / PORTABLE / HEADLESS` and renders workspaces through
+  `workspace_to_widget_html()` and `workspace_to_markdown()`; the
+  host authority seam is `src/attune/elicitation/command_workspace.py`
+  with Fix as the witness
+  (`src/attune/elicitation/fix_workspace.py`, `src/attune/mcp/server.py`).
+- **Projection has one master and three targets.**
+  `MASTER_PATH = content/collaboration/contract.md`,
+  `CONTRACT_TARGETS = (AGENTS.md, .claude/CLAUDE.md)`,
+  `IDE_MIRROR_TARGET = .agents/AGENTS.md`
+  ([scripts/project_collaboration_contract.py:19–29](../../../scripts/project_collaboration_contract.py)).
+  The projector rejects symlinked targets and hand edits inside the
+  marked block.
+- **Memory promotion is a function.** `promote()` at
+  [promotion.py:142](../../../src/attune/memory/promotion.py);
+  `resolve_backend()` at
+  [session_stash.py:120](../../../src/attune/memory/session_stash.py)
+  resolves `attune.memory_backends` with two live implementations
+  (`file`, `redis`). Recall hooks: `plugin/hooks/jit_recall.py`,
+  `lesson_recall.py`, `session_recall.py`.
+  `.attune/next_session_starter.md` is already a per-session
+  projection of memory.
+- **Spend and friction exist.** `src/attune/gates/spend_gate.py`,
+  `src/attune/gates/session_ledger.py`, `plugin/hooks/friction_gate.py`.
+- **Context-fit telemetry has a writer and no data.**
+  [allocator.py:30](../../../src/attune/context/allocator.py) writes
+  `~/.attune/telemetry/context_fit.jsonl`; the file does not exist on
+  the chair's machine (TASKS.md, 2026-08-28).
+- **Host contracts observed 2026-09-03** (Cowork session tool
+  surface, described from the tool contracts):
+  `AskUserQuestion` — 1–4 questions, each 2–4 options with `label`
+  and `description`, `multiSelect`, an automatic "Other", and the
+  convention of putting the recommended option first with a
+  "(Recommended)" suffix. Project memory — `MEMORY.md` as an index of
+  one-line links (about 150 characters each) to topic files carrying
+  `name / description / type` frontmatter with `type` in
+  `user | feedback | project | reference`. Scheduled tasks — cron or
+  one-shot, each firing a fresh session with a standalone prompt.
+  Monitor — wake on file or process change.
+
+## Layer boundary
+
+```text
+host (Cowork / Claude Code / Codex / Antigravity / headless)
+          |
+          v
+attune-forms  Surface negotiation: RICH | PORTABLE | HEADLESS
+          |     + tier 0: host-native question projection   (R1)
+          |
+          v
+attune-ai   CommandWorkspaceHost + adapters        (unchanged)
+          | roster.yaml -> role slots -> harness recipes   (R7)
+          | projector: contract master + lesson-index master (R3)
+          | ledger: asks-per-outcome                       (R8)
+          |
+          v
+attune.extensions (release-16-manifest D3)
+          | Phase A  memory-backend contract  -> local reranker   (R6a)
+          | Phase B  workflow contract        -> local role workflows (R6b)
+          | later    roster slot supplier     -> fourth seat (non-goal here)
+          |
+          v
+parity gate (R2): every RICH renderer / host hook / host template
+has PORTABLE + HEADLESS twins and a three-render receipt
+```
+
+The gate sits under everything on purpose: it is the enforcer that
+lets the layers above adopt host features without the host becoming
+privileged.
+
+## R1 — Host tier 0 renderer
+
+`attune-forms` adds `render_host_question(form) -> HostQuestion |
+None`. It returns a payload only when the form is a single question
+whose control is a choice with 2–4 options; otherwise `None`, and the
+caller falls through to PORTABLE. Mapping:
+
+| Form construct        | Host field                                      |
+| --------------------- | ----------------------------------------------- |
+| question text         | `question`                                      |
+| short heading         | `header` (≤ 12 characters, truncated at a word) |
+| option label / detail | `options[].label` / `options[].description`     |
+| multi-select control  | `multiSelect: true`                             |
+| recommendation        | first option, label suffixed " (Recommended)"   |
+| free-text escape      | host-provided "Other" (no mapping needed)       |
+
+The response path reuses the existing validator: the host returns
+the chosen label(s) or free text; the renderer maps labels back to
+option ids and hands the answer to the same validation the widget and
+headless tiers use. A malformed answer is re-asked on the PORTABLE
+tier, never silently accepted.
+
+Decision, pushback, ranking, triage, assumption-review and progress
+constructs never project to tier 0; they are the vocabulary the host
+lacks and they stay on their own renderers.
+
+## R2 — Surface parity gate
+
+`tests/unit/gates/test_surface_parity.py` walks two inventories:
+
+1. **Renderers** — every function in `attune-forms` and
+   `src/attune/elicitation/` registered for `Surface.RICH` (including
+   R1's tier 0).
+2. **Host artifacts** — every file under `plugin/hooks/`,
+   `plugin/commands/`, and the templates R5 adds, tagged
+   host-specific by a header marker.
+
+For each item the gate requires a PORTABLE twin, a HEADLESS twin, and
+a receipt line in `docs/specs/host-surface-parity/receipts.md` naming
+one form, its three renders, and the identical validated output.
+Missing any of the three fails the test with the exact shortfall.
+The gate is added to the collaboration contract as the enforcer of
+principle 1 for surfaces, so the master's "aspirational" label comes
+off for this case. This is the Discipline article's §7 rule applied
+to surfaces — "if a property matters, something must fail when it
+stops being true" (attune-ai.dev/discipline).
+
+## R3 — Memory index projection
+
+The projector gains a second master, generated rather than authored:
+`content/collaboration/lesson-index.md`, produced by
+`scripts/project_lesson_index.py` from the promoted store. Each line
+is `- [<lesson name>](<store path>) — <one-line hook>` and the file
+carries a budget the projector drift-guards. The budget is in
+**bytes, not lines**, because every target is an always-loaded
+surface: the Discipline article's §9 sets a 20,000-byte ceiling on
+the eager-loaded rules corpus, and the projected lesson block counts
+against that ceiling wherever it lands. Default: 4,000 bytes
+(about 40 lines), adjustable per target, never above the residual
+headroom under the §9 ceiling.
+
+Targets, each inside a marked block the projector owns:
+
+- Cowork project memory: `MEMORY.md` (the host reads it at session
+  start; the line shape matches the host's index convention).
+- `.claude/CLAUDE.md` — a `<!-- attune:lessons:start -->` block next
+  to the existing contract block.
+- `AGENTS.md` and `.agents/AGENTS.md` — the same block, so Codex and
+  Antigravity read the same index.
+
+`promote()` calls the regenerator after a successful promotion;
+`attune memory project` regenerates on demand. Nothing in recall
+changes: recall still ranks from the store; the index is a courtesy
+to hosts that cannot call recall.
+
+## R4 — MCP Apps round-trip receipt
+
+A scripted run: open the Fix preview workspace in a Cowork session,
+capture (a) whether the host advertised the Attune UI MIME profile,
+(b) the widget or Markdown that rendered, (c) the
+`fix_workspace_collect_action` response with revision, nonce and
+contract hash, (d) a deliberate replay of the same action and its
+fail-closed refusal. The receipt goes in `receipts.md` under R4. If
+(a) is false, the receipt records the Markdown fallback and the task
+closes as "portable path verified; RICH path pending host support".
+
+## R5 — Scheduled and monitored delivery, twinned
+
+A new `plugin/templates/scheduled/` directory holds three task prompts (sweep,
+bug-predict, release-prep) written as standalone instructions for a
+fresh session, plus one monitor template for
+`~/.attune/telemetry/context_fit.jsonl`. Beside each host template
+sits its twin: a `cron` line and the `attune` CLI invocation that
+produces the same receipt in `.attune/workflow_runs.jsonl` with an
+`origin: scheduled` field. Both paths pass through the spend gate;
+the host template states the cap in its prompt.
+
+## R6 — Local-model roles via extensions
+
+**R6a — reranker (Phase A).** An in-repo example extension
+`extensions/attune-ext-local-rerank/` implements the memory-backend
+contract's optional `rerank(candidates, query) -> ranked` capability
+against an Ollama endpoint, falling back to the store's own ranking
+when Ollama is unreachable. It is the "minimal example extension"
+Phase A already requires — so it costs the extension work nothing
+extra and satisfies D2's demand for a real second implementer.
+Recall eval ([memory-recall-eval](../memory-recall-eval/requirements.md))
+runs with and without the reranker; the receipt is P@3 on the frozen
+benchmark, not a feeling.
+
+**R6b — role workflows (Phase B).** Extensions implementing the
+workflow contract for: lesson classification, triage pre-sort,
+low-stakes skeptic/countersign, fact-check probes. Each declares
+`tier: local` and is routed by role; each has a `PREMIUM`-tier
+fallback for stakes above a chair-set threshold.
+
+**Tier.** `LOCAL` is added below `CHEAP` in every tier copy and the
+`attune-rag` mirror in one release; the existing drift guard is the
+receipt. Pricing metadata is zero; the spend gate records tokens for
+volume, not cost. (Mechanics alternatives in decisions.md D2.)
+
+## R7 — Roster as data
+
+`src/attune/roundtable/roster.py` loads `roster.yaml` (default
+embedded, overridable in `.attune/`):
+
+```yaml
+slots:
+  - role: moderator        # receipts, board I/O, synthesis
+    seat: claude
+    recipe: ["claude", "-p", "{brief}"]
+  - role: plan_reviewer     # plan-only; cannot emit code
+    seat: antigravity
+    recipe: ["agy", "--add-dir", ".", "-p", "{brief}", "--mode", "plan"]
+    plan_only: true
+  - role: code_proposer     # code-native
+    seat: codex
+    recipe: ["codex", "exec", "--skip-git-repo-check", "-"]
+```
+
+`CANONICAL_SEATS`, `SEAT_RECIPES` and `PLAN_ONLY_SEATS` become
+derived views of the roster so every current import keeps working.
+Workspace gates compare against `len(roster.slots)`. The brief
+preamble is templated from the slot count and seat names. A slot
+whose `seat` is not one of the built-in three must name an enabled
+extension providing the recipe; otherwise the roster fails to load
+with the exact shortfall.
+
+## R8 — Asks-per-outcome
+
+The session ledger already records spend per seat invocation. It
+gains two counters: structured asks issued (any form rendered on any
+tier) and outcomes receipted (Fix receipts, workflow run receipts,
+promotions). `friction_gate` surfaces the ratio at session end. No
+new store; the ledger's existing JSONL carries the fields.
+
+## Sequencing
+
+| Increment | Depends on                          | Target                     |
+| --------- | ----------------------------------- | -------------------------- |
+| R2 gate   | nothing (test-first)                | next minor                 |
+| R1, R3    | R2 green                            | next minor                 |
+| R4, R5    | R2 green; host access               | next minor                 |
+| R7        | R2 green                            | next minor                 |
+| R8        | session-spend-ledger fields         | next minor                 |
+| R6a       | release-16-manifest Phase A shipped | the minor that ships A     |
+| R6b       | Phase B shipped                     | the minor that ships B     |
+
+Nothing here blocks passenger 4; R6a is the example extension Phase A
+already owes.
+
+## Receipts
+
+Each task in [tasks.md](tasks.md) names its receipt. The initiative's
+overall receipt is a single demo form rendered on five surfaces —
+Cowork tier 0, Claude Code widget, Codex Markdown, Antigravity
+Markdown, headless text — returning one identical validated answer,
+recorded in `receipts.md` and regenerable by
+`scripts/render_demo_forms.py`.

--- a/docs/specs/host-surface-parity/requirements.md
+++ b/docs/specs/host-surface-parity/requirements.md
@@ -6,9 +6,10 @@ the chair promoted the round in decisions.md **D5**: R4 adopted as
 written, R1/R2/R3/R5/R7/R8 adopted as amended (binding amendment
 text lives in D5), R6 adopted with D2's routing-label mechanics,
 R9 (capability-descriptor/conformance layer) adopted as the 16.3
-foundation. D6 (R2 enforcement locus) and the coverage floor remain
-open. No implementation authority is granted by this document; every
-task in [tasks.md](tasks.md) executes only behind its own chair go.
+foundation. D6 ruled 2026-09-03 (hybrid locus); only the coverage
+floor remains open. No implementation authority is granted by this
+document; every task in [tasks.md](tasks.md) executes only behind
+its own chair go.
 **Slug:** `host-surface-parity`
 **Provenance:** Cowork session with the Claude seat, 2026-09-03,
 chair Patrick Roebuck. Companion brief: the artifact "Fable 5.1 and

--- a/docs/specs/host-surface-parity/requirements.md
+++ b/docs/specs/host-surface-parity/requirements.md
@@ -1,0 +1,226 @@
+# Host Surface Parity — Requirements
+
+**Status:** draft (2026-09-03) — requirements proposed by the Claude
+seat; chair rulings D1a–D1c recorded in [decisions.md](decisions.md).
+No implementation authority is granted by this document; every task
+in [tasks.md](tasks.md) executes only behind its own chair go.
+**Slug:** `host-surface-parity`
+**Provenance:** Cowork session with the Claude seat, 2026-09-03,
+chair Patrick Roebuck. Companion brief: the artifact "Fable 5.1 and
+the Attune Surface" (Claude seat opening position, thread slug
+`q-fable-51-surface-overlap-001` proposed, not yet opened on the
+board). Antigravity and Codex have not deliberated this; the chair
+may convene the table before ruling any task.
+
+## Position in the existing stack
+
+This spec sits on four shipped seams and adds no new renderer,
+memory store, orchestration layer, or provider registry:
+
+- **Surfaces** — `attune-forms` already negotiates
+  `Surface.RICH / PORTABLE / HEADLESS`; the state-bound command
+  workspaces of 16.2.0 ([shared-command-workspaces](../shared-command-workspaces/requirements.md))
+  render through it with Markdown and terminal-receipt fallbacks.
+- **Projection** — the collaboration projector
+  ([cross-provider-collaboration-projector](../cross-provider-collaboration-projector/requirements.md))
+  owns one master (`content/collaboration/contract.md`) and projects
+  it to `AGENTS.md`, `.claude/CLAUDE.md`, and the Antigravity mirror
+  `.agents/AGENTS.md`.
+- **Memory** — stash → recall → promote, with `resolve_backend()`
+  reading `attune.memory_backends`, and cross-provider transport
+  shipped in 10.6.x
+  ([cross-provider-memory-transport](../cross-provider-memory-transport/requirements.md)).
+- **Extensions** — the trust-gated `attune.extensions` system ruled
+  in [release-16-manifest](../release-16-manifest/decisions.md)
+  D1/D2 (passenger 4), not yet on disk. Chair ruling D1b of this spec
+  makes it the seam through which providers, backends and seats
+  arrive.
+
+## Problem
+
+The 2026-09-01 host release (Claude Fable 5.1; the Cowork and Claude
+Code surfaces around it) ships first-party versions of things Attune
+built as portable, verified, multi-provider systems: a structured
+question widget (`AskUserQuestion`), desktop-persistent project
+memory (`MEMORY.md` + typed topic files), a skill-proposal card, a
+multi-agent workflow runner, typed review findings, hosted artifacts
+with runtime state, scheduled tasks, and a file monitor.
+
+Two failure modes follow, and they pull in opposite directions:
+
+1. **Ignore the host** and Attune's lowest rendering tier looks worse
+   than the native widget sitting next to it; memory reads as a
+   duplicate of a feature the host now has by the same name.
+2. **Chase the host** and Claude surfaces become privileged: a rich
+   Cowork path with a neglected Codex / Antigravity path, which is
+   exactly the power-user sacrifice the chair has ruled out.
+
+The requirements below resolve the tension with one rule: **every
+host-specific capability ships with its portable twin, receipted,
+in the same change** — and the multi-provider roster becomes data
+so a vendor change is a config edit, not a PR.
+
+## Hypotheses
+
+- **H1 — tier 0 is a render target, not a rival.** A single-question
+  form projected onto the host's native widget returns the same
+  validated answer as the widget-HTML and headless tiers. Richer
+  constructs (decision, pushback, ranking, triage, assumption
+  review, progress) keep their own renderers and are not degraded
+  to fit the host.
+- **H2 — parity can be mechanical.** "The receipt beats the promise"
+  is listed as *aspirational* in the collaboration contract. For
+  surfaces it can be an enforcer: a drift guard that fails when a
+  RICH-tier renderer or host hook lacks PORTABLE and HEADLESS twins
+  with receipts.
+- **H3 — the host remembers; Attune recalls.** Projecting the
+  promoted-lesson index into each host's native memory surface makes
+  a plain host session benefit from the corpus, while recall
+  (relevance-ranked, at prompt time) remains the product. Memory
+  stays the single source of truth; every projection is
+  regenerable and never hand-edited.
+- **H4 — local models earn a role before a seat.** Under D1a, a
+  local model's first job is the set of low-stakes, high-volume
+  roles where cost and privacy dominate — recall re-ranking, lesson
+  classification, triage pre-sort, skeptic/countersign at low
+  stakes, fact-check probes — not deliberation. Under D1b these
+  arrive as extensions under the two ruled capability contracts,
+  which makes an Ollama-backed reranker the first real second
+  implementer that release-16-manifest D2 named as its falsifier.
+- **H5 — roster by role, not vendor.** The three seats are harness
+  recipes with role properties (`PLAN_ONLY_SEATS`), not providers.
+  Expressing the roster as role slots with a vendor binding keeps
+  the fixed three as the default while making "Google changed tiers
+  again" or "add a fourth seat" a data change gated by the extension
+  system.
+
+## Requirements
+
+**R1 — Host tier 0 renderer** *(seat: proposed; chair: not yet ruled)*
+`attune-forms` gains a renderer that projects a single-question form
+onto the host's structured question contract: at most four options,
+each with label and description, optional multi-select, a
+"(Recommended)" suffix on the first option when the form carries a
+recommendation, and the host-supplied "Other" free-text escape.
+Forms that exceed the contract (more than four options, bounded
+numbers, path pickers, multi-question) fall through to the existing
+PORTABLE tier — never truncated. The answer is validated on the way
+back exactly as on every other tier.
+
+**R2 — Surface parity gate** *(seat: proposed; chair: not yet ruled)*
+A drift-guard test enumerates every RICH-tier renderer and every
+host-specific hook or template in the tree and fails when any lacks
+(a) a PORTABLE twin, (b) a HEADLESS twin, and (c) a receipt entry
+naming the three renders of one form with identical validated
+output. The gate is mechanical; it implements collaboration-contract
+principle 1 for surfaces and is listed there as its enforcer.
+
+**R3 — Memory index projection** *(seat: proposed; chair: not yet ruled)*
+The collaboration projector gains a second master — the
+promoted-lesson index — and projects it to every host memory
+surface: the Cowork project-memory `MEMORY.md` index (one line per
+lesson, pointing at the Attune store), the memory block of
+`.claude/CLAUDE.md`, `AGENTS.md`, and `.agents/AGENTS.md`. Promotion
+triggers regeneration; a line budget is drift-guarded; the projector
+refuses hand edits exactly as it does for the contract block.
+Recall is unchanged.
+
+**R4 — MCP Apps round-trip receipt** *(seat: proposed; chair: not yet ruled)*
+A recorded receipt of the Fix preview workspace rendered by the
+Cowork host through the standard `ui://` profile, with
+`fix_workspace_collect_action` returning revision, nonce and
+contract hash intact, a replayed action failing closed, and — if the
+host does not advertise the profile — the Markdown fallback rendering
+correctly. No production change unless the receipt fails.
+
+**R5 — Scheduled and monitored delivery, twinned** *(seat: proposed; chair: not yet ruled)*
+Templates that run `discovery-sweep`, `bug-predict`, and
+`release-prep` as host scheduled tasks and wake on a file monitor,
+each shipped with its portable twin (`cron` + `attune` CLI) and
+subject to the spend gate. The first monitored path is
+`~/.attune/telemetry/context_fit.jsonl`, which also settles the
+fit_source budget clock in `TASKS.md`.
+
+**R6 — Local-model roles via extensions** *(chair-ruled D1a, D1b; mechanics proposed)*
+Local models (Ollama first) enter as extensions under the two ruled
+capability contracts: a **memory-backend** extension advertising an
+optional `rerank` capability (Phase A of release-16-manifest D3), and
+**workflow** extensions for classification, triage pre-sort,
+skeptic/countersign at low stakes, and fact-check probes (Phase B).
+A `LOCAL` tier is added to the tier contract for routing these roles;
+the mechanics are D2 in decisions.md. No change to `ModelProvider`;
+no third capability contract (D3).
+
+**R7 — Roster as data** *(seat: proposed; chair: not yet ruled)*
+`CANONICAL_SEATS`, `SEAT_RECIPES` and `PLAN_ONLY_SEATS` become a
+roster document of role slots — one plan-only reviewer, one
+code-native proposer, one moderator with receipts — each bound to a
+harness recipe. The default roster is the current three, byte-for-byte
+in behavior. Workspace gates check roster size from the roster, not
+the literal three. A fourth slot is legal only when supplied by an
+enabled extension.
+
+**R8 — Asks-per-outcome** *(seat: proposed; chair: not yet ruled)*
+The session ledger records structured asks per completed outcome
+(receipt), so "demanding" is measured as structure per result rather
+than interruptions per session. `friction_gate` reads the figure; no
+new telemetry store.
+
+## Non-goals
+
+- No fourth round-table seat in this spec. A seat arrives through
+  R7 plus an enabled extension, in a later cycle, behind its own
+  chair go.
+- No general Ollama provider for all workflows. `ModelProvider` stays
+  Claude-native; local models serve the roles in R6 only. A
+  provider-level capability contract would be a third contract and
+  is deferred to the chair (decisions.md D3).
+- No change to recall ranking, the promote gate, or the memory
+  store's schema. R3 projects; it does not move truth.
+- No new renderer. R1 is a projection inside `attune-forms`; R4 is a
+  receipt.
+- No auto-promotion, no auto-advance. R4 in
+  [spec-lifecycle-gates](../spec-lifecycle-gates/requirements.md)
+  applies unchanged.
+
+## Public compatibility constraints
+
+- `attune fix` CLI behavior and exit contract are unchanged
+  ([outcome-first-fix](../outcome-first-fix/requirements.md)).
+- The `attune.memory_backends` entry-point group keeps working
+  through the compatibility adapter ruled in release-16-manifest D1.
+- The tier enum is duplicated by design in four places
+  (`src/attune/models/registry.py`, `src/attune/config/agent_config.py`,
+  `src/attune/workflows/compat.py`, `src/attune/workflows/progressive/core.py`)
+  and mirrored in `attune-rag`, with
+  `tests/unit/test_model_tiers_drift.py` as the alarm. Adding `LOCAL`
+  is a change to all copies and to the mirror in the same release;
+  the drift guard is the receipt.
+- R7 must not change the brief preamble's observable behavior for
+  the default roster; the "three-model round table" wording becomes
+  templated from the roster.
+- The brand-drift gate (G5) applies to every file in this spec.
+
+## Dissent register
+
+- The Claude seat's own earlier candidate (bridge to Cowork
+  `MEMORY.md` only) is withdrawn in favor of R3, which projects to
+  every host memory surface. Reason: a Claude-only bridge would make
+  memory the one place Attune quietly picks a vendor.
+- Anticipated pushback to weigh at the table: whether R3 dilutes
+  "Attune recalls" positioning by making the host notebook good
+  enough. The seat's answer: a corpus with no recall is the demo;
+  recall is the product.
+- Anticipated pushback: whether `LOCAL` belongs in the tier enum at
+  all versus a role-routing label. Recorded as D2 (proposed) with
+  both options.
+
+## Open questions for the chair
+
+1. Convene `q-fable-51-surface-overlap-001` before ruling R1–R8, or
+   rule from this brief? (Antigravity and Codex have not spoken.)
+2. Coverage floor for this initiative: the repository's 85% or the
+   90% the chair set for shared-command-workspaces (D4 there)?
+3. D2 mechanics for `LOCAL` (enum member vs. routing label).
+4. Whether R6's workflow extensions wait for release-16-manifest
+   Phase B, or Phase A ships the reranker alone first.

--- a/docs/specs/host-surface-parity/requirements.md
+++ b/docs/specs/host-surface-parity/requirements.md
@@ -1,16 +1,21 @@
 # Host Surface Parity — Requirements
 
-**Status:** draft (2026-09-03) — requirements proposed by the Claude
-seat; chair rulings D1a–D1c recorded in [decisions.md](decisions.md).
-No implementation authority is granted by this document; every task
-in [tasks.md](tasks.md) executes only behind its own chair go.
+**Status:** approved (2026-09-02) — round 1 of
+`q-fable-51-surface-overlap-001` deliberated R1–R8 (3/3 seats);
+the chair promoted the round in decisions.md **D5**: R4 adopted as
+written, R1/R2/R3/R5/R7/R8 adopted as amended (binding amendment
+text lives in D5), R6 adopted with D2's routing-label mechanics,
+R9 (capability-descriptor/conformance layer) adopted as the 16.3
+foundation. D6 (R2 enforcement locus) and the coverage floor remain
+open. No implementation authority is granted by this document; every
+task in [tasks.md](tasks.md) executes only behind its own chair go.
 **Slug:** `host-surface-parity`
 **Provenance:** Cowork session with the Claude seat, 2026-09-03,
 chair Patrick Roebuck. Companion brief: the artifact "Fable 5.1 and
 the Attune Surface" (Claude seat opening position, thread slug
 `q-fable-51-surface-overlap-001` proposed, not yet opened on the
-board). Antigravity and Codex have not deliberated this; the chair
-may convene the table before ruling any task.
+board). *(Update: the table was convened 2026-09-02 — all three
+seats deliberated; the round was promoted in decisions.md D5.)*
 
 ## Position in the existing stack
 
@@ -96,7 +101,7 @@ so a vendor change is a config edit, not a PR.
 
 ## Requirements
 
-**R1 — Host tier 0 renderer** *(seat: proposed; chair: not yet ruled)*
+**R1 — Host tier 0 renderer** *(chair-ruled 2026-09-02 — ADOPT as amended, D5: host-profile record, not a hardcoded vendor shape)*
 `attune-forms` gains a renderer that projects a single-question form
 onto the host's structured question contract: at most four options,
 each with label and description, optional multi-select, a
@@ -107,7 +112,7 @@ numbers, path pickers, multi-question) fall through to the existing
 PORTABLE tier — never truncated. The answer is validated on the way
 back exactly as on every other tier.
 
-**R2 — Surface parity gate** *(seat: proposed; chair: not yet ruled)*
+**R2 — Surface parity gate** *(chair-ruled 2026-09-02 — ADOPT as amended, D4/D5: expiring experiments allowlist, schema-identical payload receipts, lifecycle parity; locus open, D6)*
 A drift-guard test enumerates every RICH-tier renderer and every
 host-specific hook or template in the tree and fails when any lacks
 (a) a PORTABLE twin, (b) a HEADLESS twin, and (c) a receipt entry
@@ -115,7 +120,7 @@ naming the three renders of one form with identical validated
 output. The gate is mechanical; it implements collaboration-contract
 principle 1 for surfaces and is listed there as its enforcer.
 
-**R3 — Memory index projection** *(seat: proposed; chair: not yet ruled)*
+**R3 — Memory index projection** *(chair-ruled 2026-09-02 — ADOPT as amended, D5: bounded top-K sentinel-bracketed digest, per-host budgets)*
 The collaboration projector gains a second master — the
 promoted-lesson index — and projects it to every host memory
 surface: the Cowork project-memory `MEMORY.md` index (one line per
@@ -125,7 +130,7 @@ triggers regeneration; a line budget is drift-guarded; the projector
 refuses hand edits exactly as it does for the contract block.
 Recall is unchanged.
 
-**R4 — MCP Apps round-trip receipt** *(seat: proposed; chair: not yet ruled)*
+**R4 — MCP Apps round-trip receipt** *(chair-ruled 2026-09-02 — ADOPT as written, first among the eight, D5)*
 A recorded receipt of the Fix preview workspace rendered by the
 Cowork host through the standard `ui://` profile, with
 `fix_workspace_collect_action` returning revision, nonce and
@@ -133,7 +138,7 @@ contract hash intact, a replayed action failing closed, and — if the
 host does not advertise the profile — the Markdown fallback rendering
 correctly. No production change unless the receipt fails.
 
-**R5 — Scheduled and monitored delivery, twinned** *(seat: proposed; chair: not yet ruled)*
+**R5 — Scheduled and monitored delivery, twinned** *(chair-ruled 2026-09-02 — ADOPT as amended, D5: one master definition, generated bindings, sweep guards)*
 Templates that run `discovery-sweep`, `bug-predict`, and
 `release-prep` as host scheduled tasks and wake on a file monitor,
 each shipped with its portable twin (`cron` + `attune` CLI) and
@@ -141,17 +146,20 @@ subject to the spend gate. The first monitored path is
 `~/.attune/telemetry/context_fit.jsonl`, which also settles the
 fit_source budget clock in `TASKS.md`.
 
-**R6 — Local-model roles via extensions** *(chair-ruled D1a, D1b; mechanics proposed)*
+**R6 — Local-model roles via extensions** *(chair-ruled D1a, D1b; D2 mechanics ruled 2026-09-02 — routing label)*
 Local models (Ollama first) enter as extensions under the two ruled
 capability contracts: a **memory-backend** extension advertising an
 optional `rerank` capability (Phase A of release-16-manifest D3), and
 **workflow** extensions for classification, triage pre-sort,
 skeptic/countersign at low stakes, and fact-check probes (Phase B).
-A `LOCAL` tier is added to the tier contract for routing these roles;
-the mechanics are D2 in decisions.md. No change to `ModelProvider`;
-no third capability contract (D3).
+Local routing uses a `placement: local` **routing label** on the
+role's routing record — the tier enum stays `CHEAP / CAPABLE /
+PREMIUM` and no copy or mirror changes (D2, ruled: the label lets a
+role say "CHEAP, prefer local, fall back hosted"). No change to
+`ModelProvider`; no third capability contract (D3, ruled with the
+second-implementer tripwire).
 
-**R7 — Roster as data** *(seat: proposed; chair: not yet ruled)*
+**R7 — Roster as data** *(chair-ruled 2026-09-02 — ADOPT as amended, D5: typed slots, golden-roster receipt, loader-enforced fourth-slot gate)*
 `CANONICAL_SEATS`, `SEAT_RECIPES` and `PLAN_ONLY_SEATS` become a
 roster document of role slots — one plan-only reviewer, one
 code-native proposer, one moderator with receipts — each bound to a
@@ -160,11 +168,33 @@ in behavior. Workspace gates check roster size from the roster, not
 the literal three. A fourth slot is legal only when supplied by an
 enabled extension.
 
-**R8 — Asks-per-outcome** *(seat: proposed; chair: not yet ruled)*
+**R8 — Asks-per-outcome** *(chair-ruled 2026-09-02 — ADOPT as amended, D5: terminal outcomes, raw counts, floor)*
 The session ledger records structured asks per completed outcome
 (receipt), so "demanding" is measured as structure per result rather
 than interruptions per session. `friction_gate` reads the figure; no
 new telemetry store.
+
+**R9 — Host capability descriptor and conformance layer** *(chair-adopted 2026-09-02 at promotion, D5 — the 16.3 foundation item)*
+Every host adapter and extension publishes a machine-readable
+**capability descriptor** (structured-question shape, memory
+surfaces, `ui://` profiles, scheduling/monitoring support, action
+round-trip guarantees, receipt schema versions). An
+`attune surfaces doctor` probe records which contracts the current
+host actually advertises and writes a capability receipt; from
+accumulated receipts a generated, drift-guarded **hosts ×
+capabilities matrix** (each cell native / fallback-receipted /
+absent) lives in tree, so "no privileged surface" is a visible red
+cell rather than a vibe. A shared conformance suite runs canonical
+transcripts against each adapter and proves: unsupported
+capabilities degrade deliberately; semantic outputs stay
+equivalent; receipts keep provenance and replay protection;
+removing any host adapter leaves PORTABLE and HEADLESS execution
+usable; no workflow silently selects a privileged host. The matrix
+must be assertable in CI with **no host present** (all-fallback
+column green), or HEADLESS parity is a promise again. Renderers
+consult the probe instead of sniffing per call. *(Provenance: all
+three seats proposed this layer independently in round 1 — Codex
+R9, Claude R9, Antigravity's R1 capability descriptor.)*
 
 ## Non-goals
 
@@ -193,9 +223,10 @@ new telemetry store.
   (`src/attune/models/registry.py`, `src/attune/config/agent_config.py`,
   `src/attune/workflows/compat.py`, `src/attune/workflows/progressive/core.py`)
   and mirrored in `attune-rag`, with
-  `tests/unit/test_model_tiers_drift.py` as the alarm. Adding `LOCAL`
-  is a change to all copies and to the mirror in the same release;
-  the drift guard is the receipt.
+  `tests/unit/test_model_tiers_drift.py` as the alarm. Under the D2
+  ruling the enum does not change: `LOCAL` is a routing label, all
+  copies and the mirror stay three-member, and the drift guard
+  continues to assert exactly that.
 - R7 must not change the brief preamble's observable behavior for
   the default roster; the "three-model round table" wording becomes
   templated from the roster.
@@ -217,10 +248,13 @@ new telemetry store.
 
 ## Open questions for the chair
 
-1. Convene `q-fable-51-surface-overlap-001` before ruling R1–R8, or
-   rule from this brief? (Antigravity and Codex have not spoken.)
+1. ~~Convene before ruling R1–R8?~~ Resolved: convened 2026-09-02,
+   round 1 promoted (D5).
 2. Coverage floor for this initiative: the repository's 85% or the
    90% the chair set for shared-command-workspaces (D4 there)?
-3. D2 mechanics for `LOCAL` (enum member vs. routing label).
-4. Whether R6's workflow extensions wait for release-16-manifest
-   Phase B, or Phase A ships the reranker alone first.
+   **Still open.**
+3. ~~D2 mechanics~~ Ruled: routing label (D2).
+4. ~~Task 7 phasing~~ Ruled: the reranker ships alone on Phase A
+   (D5).
+5. D6 — R2 enforcement locus (registry vs. enumeration); rule
+   before Task 1.

--- a/docs/specs/host-surface-parity/requirements.md
+++ b/docs/specs/host-surface-parity/requirements.md
@@ -112,7 +112,7 @@ numbers, path pickers, multi-question) fall through to the existing
 PORTABLE tier — never truncated. The answer is validated on the way
 back exactly as on every other tier.
 
-**R2 — Surface parity gate** *(chair-ruled 2026-09-02 — ADOPT as amended, D4/D5: expiring experiments allowlist, schema-identical payload receipts, lifecycle parity; locus open, D6)*
+**R2 — Surface parity gate** *(chair-ruled — ADOPT as amended, D4/D5; locus ruled 2026-09-03, D6: hybrid — registry for renderers, enumeration for in-tree hooks)*
 A drift-guard test enumerates every RICH-tier renderer and every
 host-specific hook or template in the tree and fails when any lacks
 (a) a PORTABLE twin, (b) a HEADLESS twin, and (c) a receipt entry
@@ -256,5 +256,5 @@ R9, Claude R9, Antigravity's R1 capability descriptor.)*
 3. ~~D2 mechanics~~ Ruled: routing label (D2).
 4. ~~Task 7 phasing~~ Ruled: the reranker ships alone on Phase A
    (D5).
-5. D6 — R2 enforcement locus (registry vs. enumeration); rule
-   before Task 1.
+5. ~~D6 — R2 enforcement locus~~ Ruled 2026-09-03: hybrid,
+   subject-local (D6).

--- a/docs/specs/host-surface-parity/roundtable-question.md
+++ b/docs/specs/host-surface-parity/roundtable-question.md
@@ -1,0 +1,79 @@
+# Round-table question — `q-fable-51-surface-overlap-001`
+
+**Chair:** Patrick Roebuck · **Moderator:** Claude · **Roster:** Claude,
+Antigravity, Codex (fixed) · **Rounds:** 1 expected, 2 if the steelman
+provision fires (chair lean is recorded below), ceiling 3 (D3).
+**Spend gate (chair-ruled 2026-09-03):** 3 seat invocations, 1 round;
+a second round needs a fresh chair go.
+**Prepared:** 2026-09-03 by the Claude seat in a Cowork session.
+**Transcript:** the moderator writes the machine-local transcript to
+`~/.attune/reports/roundtable/q-fable-51-surface-overlap-001.md`; please
+also copy it to `docs/reports/roundtable/` so the Cowork seat (which
+sees only the repo) can read it and draft the promotion triage.
+
+## The question
+
+The 2026-09-01 host release (Claude Fable 5.1; Cowork and Claude Code)
+ships first-party versions of things attune-ai built as portable,
+verified, multi-provider systems: a structured question widget
+(`AskUserQuestion`), desktop-persistent project memory (`MEMORY.md` +
+typed topic files), a skill-proposal card, a multi-agent workflow
+runner, typed review findings, hosted artifacts with runtime state,
+scheduled tasks, and a file monitor.
+
+**Which of Attune's human↔AI communication and capability features
+does this release overlap, and where should the next two minors
+spend effort so the release is a tailwind rather than a headwind —
+without any host becoming the privileged surface, and without
+power users on Codex or Antigravity sacrificing anything?**
+
+## What each seat is asked to return
+
+Independently, text only, no tools (R1):
+
+1. A ruling on each proposed requirement R1–R8 in
+   `docs/specs/host-surface-parity/requirements.md`: **adopt / amend
+   (say how) / decline (say why)**.
+2. At least one requirement the Claude seat did **not** propose. The
+   chair has asked the table to be creative and not limited to the
+   brief.
+3. A position on the three open mechanics: D2 (`LOCAL` as enum member
+   vs routing label), D3 (no third capability contract), and whether
+   Task 7 (Ollama reranker as the Phase A example extension) should
+   wait for Phase B.
+4. Its own dissent register: where it disagrees with the Claude
+   seat's reading in the companion brief.
+
+## Facts taken as given (verified against the tree 2026-09-03)
+
+- attune-ai 16.2.0; attune-forms ≥ 0.12.2; `Surface.RICH / PORTABLE /
+  HEADLESS`; state-bound command workspaces shipped.
+- `CANONICAL_SEATS` is a literal three-tuple; `SEAT_RECIPES` fixed
+  argv; `PLAN_ONLY_SEATS = {"antigravity"}`; workspace gates require
+  exactly the fixed roster.
+- `ModelProvider` has one member (`ANTHROPIC`); tiers are
+  `CHEAP / CAPABLE / PREMIUM` in four copies plus the attune-rag
+  mirror with a drift guard.
+- `attune.extensions` (release-16-manifest passenger 4) is **not on
+  disk**; D1/D2 ruled; D3 phasing proposed, not ruled.
+- Chair rulings already made (this spec's D1, 2026-09-03): local
+  models start as a `LOCAL` tier for low-stakes roles, not a seat;
+  extensions are the seam for providers/backends/seats; the
+  deliverable is this spec.
+
+## Chair's lean (recorded so the steelman provision can fire)
+
+The chair leans toward adopting the parity rule (every host-specific
+capability ships with PORTABLE and HEADLESS twins, receipted, in the
+same change) and toward roster-as-data. Seats that agree should
+steelman the opposite; seats that disagree should say what the
+parity rule costs.
+
+## Companion material
+
+- Brief (Claude seat opening position): artifact
+  "Fable 5.1 and the Attune Surface", 2026-09-03.
+- Spec: `docs/specs/host-surface-parity/` (requirements, design,
+  tasks, decisions).
+- Discipline: attune-ai.dev/discipline, §2 (contract), §5 (memory),
+  §7 (verification), §9 (context budgeting).

--- a/docs/specs/host-surface-parity/tasks.md
+++ b/docs/specs/host-surface-parity/tasks.md
@@ -1,0 +1,291 @@
+# Host Surface Parity — Tasks
+
+**Status:** draft (2026-09-03) — no task authorized. Each task
+executes only behind its own chair go; a go on one task is not a go
+on the next. Tasks 7 and 8 are additionally gated on
+release-16-manifest Phases A and B.
+
+## Task 0 — Characterize the surfaces, roster and projector as they are
+
+```xml
+<task id="0" name="characterize-baseline">
+  <objective>
+    Pin current behavior before any change: which forms reach which
+    Surface tier, the exact roster gates, and the projector's
+    targets and refusal of hand edits.
+  </objective>
+  <files-to-create>
+    <file path="tests/unit/elicitation/test_surface_tiers_characterization.py">
+      One demo form rendered on RICH, PORTABLE, HEADLESS; identical
+      validated output asserted.
+    </file>
+    <file path="tests/unit/roundtable/test_roster_characterization.py">
+      CANONICAL_SEATS, SEAT_RECIPES, PLAN_ONLY_SEATS and the
+      workspace round_complete roster check pinned byte-for-byte.
+    </file>
+  </files-to-create>
+  <validation>
+    <check>Both suites green on main with no production change.</check>
+    <check>The projector's existing tests still refuse a hand edit inside the marked block.</check>
+  </validation>
+</task>
+```
+
+## Task 1 — Surface parity gate (R2)
+
+```xml
+<task id="1" name="surface-parity-gate">
+  <depends-on>0</depends-on>
+  <objective>
+    Add the drift guard that fails when any RICH-tier renderer or
+    host-specific hook/template lacks PORTABLE and HEADLESS twins
+    and a three-render receipt. Land it green against the current
+    tree, then it gates every later task.
+  </objective>
+  <files-to-create>
+    <file path="tests/unit/gates/test_surface_parity.py" />
+    <file path="docs/specs/host-surface-parity/receipts.md">
+      Receipt ledger: one line per (form, RICH render, PORTABLE
+      render, HEADLESS render, identical validated output).
+    </file>
+  </files-to-create>
+  <files-to-modify>
+    <file path="content/collaboration/contract.md">
+      Principle 1 gains "Enforcer (surfaces): tests/unit/gates/test_surface_parity.py"; re-run scripts/project_collaboration_contract.py.
+    </file>
+  </files-to-modify>
+  <validation>
+    <check>Gate green on main before any new renderer exists.</check>
+    <check>Deleting one PORTABLE twin in a scratch branch makes the gate fail with the exact shortfall named.</check>
+    <check>Projected contract blocks in AGENTS.md, .claude/CLAUDE.md and .agents/AGENTS.md are byte-identical to the master.</check>
+  </validation>
+</task>
+```
+
+## Task 2 — Host tier 0 renderer (R1)
+
+```xml
+<task id="2" name="host-tier-zero-renderer">
+  <depends-on>1</depends-on>
+  <objective>
+    In attune-forms, project a single-question choice form onto the
+    host's structured question contract; fall through to PORTABLE
+    for anything richer; validate the answer on the same path as
+    every other tier.
+  </objective>
+  <files-to-create>
+    <file path="attune-forms: src/attune_forms/host_question.py" />
+    <file path="attune-forms: tests/test_host_question.py" />
+  </files-to-create>
+  <files-to-modify>
+    <file path="scripts/render_demo_forms.py">
+      Add the tier-0 render of the existing audit demo form.
+    </file>
+    <file path="pyproject.toml">
+      Bump the attune-forms floor to the release that ships host_question.
+    </file>
+  </files-to-modify>
+  <validation>
+    <check>A 5-option form returns None from render_host_question and renders on PORTABLE unchanged.</check>
+    <check>A recommended option is first and suffixed " (Recommended)"; a form with no recommendation has no suffix.</check>
+    <check>A malformed host answer is re-asked on PORTABLE, never accepted.</check>
+    <check>Parity gate green with the new receipt line.</check>
+  </validation>
+</task>
+```
+
+## Task 3 — Memory index projection (R3)
+
+```xml
+<task id="3" name="lesson-index-projection">
+  <depends-on>1</depends-on>
+  <objective>
+    Generate a promoted-lesson index from the store and project it
+    to MEMORY.md, .claude/CLAUDE.md, AGENTS.md and .agents/AGENTS.md
+    through the existing projector; regenerate on promote.
+  </objective>
+  <files-to-create>
+    <file path="scripts/project_lesson_index.py" />
+    <file path="content/collaboration/lesson-index.md">
+      Generated; header states it is generated and names the script.
+    </file>
+    <file path="tests/unit/memory/test_lesson_index_projection.py" />
+  </files-to-create>
+  <files-to-modify>
+    <file path="scripts/project_collaboration_contract.py">
+      Second master + target set; MEMORY.md added as a target.
+    </file>
+    <file path="src/attune/memory/promotion.py">
+      promote() triggers regeneration; failure to regenerate is reported, never swallowed.
+    </file>
+  </files-to-modify>
+  <validation>
+    <check>A promotion in a scratch store produces the same index line in all four targets.</check>
+    <check>Exceeding the line budget fails the drift guard with the count.</check>
+    <check>A hand edit inside any projected block is refused exactly as the contract block is today.</check>
+    <check>Recall eval numbers are unchanged (the index is not consulted by recall).</check>
+  </validation>
+</task>
+```
+
+## Task 4 — MCP Apps round-trip receipt (R4)
+
+```xml
+<task id="4" name="mcp-apps-roundtrip-receipt">
+  <depends-on>1</depends-on>
+  <objective>
+    Record whether the Cowork host renders the Fix preview through
+    the ui:// profile and returns a bound action intact; record the
+    Markdown fallback if it does not. No production change unless
+    the receipt fails.
+  </objective>
+  <files-to-modify>
+    <file path="docs/specs/host-surface-parity/receipts.md">
+      R4 block: profile advertised (yes/no), render captured, action response with revision/nonce/hash, replay refused.
+    </file>
+  </files-to-modify>
+  <validation>
+    <check>Replayed action fails closed on the server with the existing fix_workspace error.</check>
+    <check>If the profile is absent, the Markdown preview matches the terminal preview argv exactly.</check>
+  </validation>
+</task>
+```
+
+## Task 5 — Scheduled and monitored delivery, twinned (R5)
+
+```xml
+<task id="5" name="scheduled-delivery-twinned">
+  <depends-on>1</depends-on>
+  <objective>
+    Ship host scheduled-task and monitor templates for sweep,
+    bug-predict, release-prep and the context_fit.jsonl watch, each
+    beside its cron + attune CLI twin, both under the spend gate.
+  </objective>
+  <files-to-create>
+    <file path="plugin/templates/scheduled/README.md" />
+    <file path="plugin/templates/scheduled/discovery-sweep.md" />
+    <file path="plugin/templates/scheduled/bug-predict.md" />
+    <file path="plugin/templates/scheduled/release-prep.md" />
+    <file path="plugin/templates/scheduled/context-fit-monitor.md" />
+    <file path="plugin/templates/scheduled/crontab.example" />
+  </files-to-create>
+  <files-to-modify>
+    <file path="src/attune/workflows/base.py">
+      Run receipts carry origin: scheduled | monitor | interactive.
+    </file>
+  </files-to-modify>
+  <validation>
+    <check>One scheduled run and its cron twin produce receipts in .attune/workflow_runs.jsonl differing only in origin.</check>
+    <check>The spend gate refuses a scheduled run whose prompt omits a cap.</check>
+    <check>Parity gate green: every host template has its twin.</check>
+    <check>The context_fit.jsonl monitor either fires on the first row or the task records that the writer path is not exercised (closing the TASKS.md item either way).</check>
+  </validation>
+</task>
+```
+
+## Task 6 — Roster as data (R7)
+
+```xml
+<task id="6" name="roster-as-data">
+  <depends-on>0</depends-on>
+  <objective>
+    Move the roster to a role-slot document with the current three
+    as the embedded default; derive CANONICAL_SEATS, SEAT_RECIPES and
+    PLAN_ONLY_SEATS from it; gate workspace roster checks on the
+    roster's length; template the brief preamble.
+  </objective>
+  <files-to-create>
+    <file path="src/attune/roundtable/roster.py" />
+    <file path="src/attune/roundtable/roster.default.yaml" />
+    <file path="tests/unit/roundtable/test_roster.py" />
+  </files-to-create>
+  <files-to-modify>
+    <file path="src/attune/roundtable/rotation.py" />
+    <file path="src/attune/roundtable/routine.py" />
+    <file path="src/attune/roundtable/workspace.py" />
+    <file path="src/attune/roundtable/skeptic.py" />
+    <file path="src/attune/roundtable/countersign.py" />
+  </files-to-modify>
+  <validation>
+    <check>Task 0's roster characterization suite passes unchanged against the derived views.</check>
+    <check>A roster naming a fourth seat with no enabled extension fails to load with the exact shortfall.</check>
+    <check>A roster swapping the plan_reviewer's vendor changes the recipe and nothing else.</check>
+  </validation>
+</task>
+```
+
+## Task 7 — Local reranker extension (R6a) — gated on Phase A
+
+```xml
+<task id="7" name="local-rerank-extension">
+  <depends-on>3</depends-on>
+  <gated-on>release-16-manifest Phase A shipped (attune.extensions on disk, enable CLI live)</gated-on>
+  <objective>
+    Ship the Phase A example extension as an Ollama-backed reranker
+    under the memory-backend contract's optional rerank capability,
+    with fail-open fallback to store ranking.
+  </objective>
+  <files-to-create>
+    <file path="extensions/attune-ext-local-rerank/" />
+    <file path="tests/unit/extensions/test_local_rerank.py" />
+  </files-to-create>
+  <validation>
+    <check>attune extension enable local-rerank loads and constructs the backend in-process (D1 receipt 2 wording).</check>
+    <check>With Ollama stopped, recall returns store ranking and the doctor reports the degradation.</check>
+    <check>memory-recall-eval reports P@3 with and without the reranker on the frozen benchmark; both numbers in receipts.md.</check>
+  </validation>
+</task>
+```
+
+## Task 8 — Local role workflows and LOCAL tier (R6b) — gated on Phase B
+
+```xml
+<task id="8" name="local-role-workflows">
+  <depends-on>6,7</depends-on>
+  <gated-on>release-16-manifest Phase B shipped (workflow contract); decisions.md D2 ruled</gated-on>
+  <objective>
+    Add the LOCAL tier per D2 and ship workflow extensions for
+    classification, triage pre-sort, low-stakes skeptic/countersign
+    and fact-check probes, each with a PREMIUM fallback above a
+    chair-set stakes threshold.
+  </objective>
+  <files-to-modify>
+    <file path="src/attune/models/registry.py" />
+    <file path="src/attune/config/agent_config.py" />
+    <file path="src/attune/workflows/compat.py" />
+    <file path="src/attune/workflows/progressive/core.py" />
+    <file path="tests/unit/test_model_tiers_drift.py">
+      Mirror check extended to LOCAL; attune-rag mirror bumped in the same release.
+    </file>
+  </files-to-modify>
+  <files-to-create>
+    <file path="extensions/attune-ext-local-roles/" />
+  </files-to-create>
+  <validation>
+    <check>Tier drift guard green with LOCAL present in all copies and the mirror.</check>
+    <check>A low-stakes skeptic pass routed to LOCAL produces a parseable verdict; above threshold it routes to PREMIUM and the ledger shows both.</check>
+    <check>No change to ModelProvider.</check>
+  </validation>
+</task>
+```
+
+## Task 9 — Asks-per-outcome (R8)
+
+```xml
+<task id="9" name="asks-per-outcome">
+  <depends-on>1</depends-on>
+  <objective>
+    Count structured asks and receipted outcomes in the session
+    ledger and surface the ratio through friction_gate at session end.
+  </objective>
+  <files-to-modify>
+    <file path="src/attune/gates/session_ledger.py" />
+    <file path="plugin/hooks/friction_gate.py" />
+    <file path="tests/unit/gates/test_session_ledger.py" />
+  </files-to-modify>
+  <validation>
+    <check>A session with three asks and one Fix receipt reports 3.0; a headless run with zero asks reports 0.0, not an error.</check>
+    <check>No new file or store; fields live in the existing ledger JSONL.</check>
+  </validation>
+</task>
+```

--- a/docs/specs/host-surface-parity/tasks.md
+++ b/docs/specs/host-surface-parity/tasks.md
@@ -214,7 +214,7 @@ release-16-manifest Phases A and B.
 </task>
 ```
 
-## Task 7 — Local reranker extension (R6a) — gated on Phase A
+## Task 7 — Local reranker extension (R6a) — gated on Phase A; ships alone, first (D5, unanimous)
 
 ```xml
 <task id="7" name="local-rerank-extension">
@@ -237,33 +237,40 @@ release-16-manifest Phases A and B.
 </task>
 ```
 
-## Task 8 — Local role workflows and LOCAL tier (R6b) — gated on Phase B
+## Task 8 — Local role workflows via placement label (R6b) — gated on Phase B
+
+*(Amended 2026-09-02 per the D2 ruling: routing label, not enum
+member. The tier enum, its four copies, and the attune-rag mirror do
+not change; the original enum-edit mechanics are superseded.)*
 
 ```xml
 <task id="8" name="local-role-workflows">
   <depends-on>6,7</depends-on>
-  <gated-on>release-16-manifest Phase B shipped (workflow contract); decisions.md D2 ruled</gated-on>
+  <gated-on>release-16-manifest Phase B shipped (workflow contract)</gated-on>
   <objective>
-    Add the LOCAL tier per D2 and ship workflow extensions for
-    classification, triage pre-sort, low-stakes skeptic/countersign
-    and fact-check probes, each with a PREMIUM fallback above a
-    chair-set stakes threshold.
+    Add a placement routing label (placement: local) on the role
+    routing record per the D2 ruling, and ship workflow extensions
+    for classification, triage pre-sort, low-stakes
+    skeptic/countersign and fact-check probes, each advisory-labeled
+    with a PREMIUM fallback above a chair-set stakes threshold
+    (fact-check probes additionally hosted-model countersigned per
+    D5's H4 ruling).
   </objective>
   <files-to-modify>
-    <file path="src/attune/models/registry.py" />
-    <file path="src/attune/config/agent_config.py" />
-    <file path="src/attune/workflows/compat.py" />
-    <file path="src/attune/workflows/progressive/core.py" />
+    <file path="src/attune/config/agent_config.py">
+      Role routing record gains the placement label; tier enum untouched.
+    </file>
     <file path="tests/unit/test_model_tiers_drift.py">
-      Mirror check extended to LOCAL; attune-rag mirror bumped in the same release.
+      Unchanged three-member assertion stands as the D2 receipt.
     </file>
   </files-to-modify>
   <files-to-create>
     <file path="extensions/attune-ext-local-roles/" />
   </files-to-create>
   <validation>
-    <check>Tier drift guard green with LOCAL present in all copies and the mirror.</check>
-    <check>A low-stakes skeptic pass routed to LOCAL produces a parseable verdict; above threshold it routes to PREMIUM and the ledger shows both.</check>
+    <check>Tier drift guard green with the enum unchanged in all copies and the mirror (no LOCAL member anywhere).</check>
+    <check>A role routed "CHEAP, prefer local" runs on the local extension when present and falls back hosted when absent; the ledger shows placement.</check>
+    <check>A low-stakes skeptic pass routed local produces a parseable advisory verdict; above threshold it routes to PREMIUM and the ledger shows both.</check>
     <check>No change to ModelProvider.</check>
   </validation>
 </task>


### PR DESCRIPTION
## What

Three commits that make the `q-fable-51-surface-overlap-001` round table durable and record its promotion:

1. **Round-1 transcript** (`docs/reports/roundtable/`) — all three seats, synthesis, spend-gate halt (was already on the branch).
2. **Track the spec** — `docs/specs/host-surface-parity/` (954 lines) previously existed only as untracked files in the main checkout; the transcript ruled on text with no git history.
3. **Promotion** — chair ruled the reviewing session's recommended triage in full: D2 RULED (routing label, unanimous), D3 RULED (confirmed + second-implementer tripwire), D4 RULED (parity gate as amended), new D5 (per-item record R1–R9, round 2 deferred), new D6 (R2 enforcement locus — open). requirements.md draft → approved with R9 added; Task 8 amended off the enum mechanics; transcript promotion status flipped.

## Still open

D6 (R2 enforcement locus) and the coverage floor. Every task still executes only behind its own chair go.

## After merge

Remove the now-redundant untracked spec copy in the main checkout (`~/attune-ai/docs/specs/host-surface-parity/`) or `git pull` there will refuse.

Docs-only; no production code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
