### PR TITLE
fix(release): enforce the dict contract in _parse_response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Release-gate parser can no longer return a non-dict**: `_parse_response`
+  strategies for XML-wrapped and markdown-fenced JSON now fall through to the
+  next strategy when the payload parses to an array or scalar, instead of
+  escaping a `-> dict` contract and surfacing as a spurious release-gate
+  failure (`quality_score 0.0`) inside `quality_agent` / `security_agent`.
+
 ## [16.2.0] - 2026-09-02
 
 This release brings state-bound dynamic workspaces to the command cohort and

--- a/src/attune/agents/release/release_parsing.py
+++ b/src/attune/agents/release/release_parsing.py
@@ -22,7 +22,9 @@ def _parse_response(text: str) -> dict[str, Any]:
     3. Raw JSON (starts with {)
     4. Regex metric extraction (last resort)
 
-    Never returns None — always returns a dict with at least empty defaults.
+    Never returns None, and never returns a non-dict: a strategy whose
+    JSON parses to an array or scalar falls through to the next one
+    rather than violating the return type (see the isinstance guards).
 
     Args:
         text: Raw response text from LLM or tool output
@@ -40,24 +42,41 @@ def _parse_response(text: str) -> dict[str, Any]:
     xml_match = re.search(r"<analysis>([\s\S]*?)</analysis>", text)
     if xml_match:
         try:
-            return json.loads(xml_match.group(1).strip())
+            parsed = json.loads(xml_match.group(1).strip())
         except json.JSONDecodeError:
             pass
+        else:
+            # A valid JSON ARRAY or scalar parses fine here and would be
+            # returned from a function typed -> dict, TypeErroring in
+            # consumers (quality_agent, security_agent) where the error is
+            # swallowed and reported as a spurious release-gate failure.
+            # Fall through to the next strategy instead.
+            if isinstance(parsed, dict):
+                return parsed
 
     # Strategy 2: Markdown-fenced JSON
     md_match = re.search(r"```(?:json)?\s*([\s\S]*?)```", text)
     if md_match:
         try:
-            return json.loads(md_match.group(1).strip())
+            parsed = json.loads(md_match.group(1).strip())
         except json.JSONDecodeError:
             pass
+        else:
+            if isinstance(parsed, dict):
+                return parsed
 
     # Strategy 3: Raw JSON
     if text.startswith("{"):
         try:
-            return json.loads(text)
+            parsed = json.loads(text)
         except json.JSONDecodeError:
             pass
+        else:
+            # Reachable only behind `text.startswith("{")`, so this guard is
+            # belt-and-braces — kept so the dict contract is enforced at
+            # EVERY return, not just the ones currently reachable otherwise.
+            if isinstance(parsed, dict):
+                return parsed
 
     # Strategy 4: Regex metric extraction (last resort)
     result: dict[str, Any] = {}

--- a/tests/unit/agents/release/test_release_parsing_contract.py
+++ b/tests/unit/agents/release/test_release_parsing_contract.py
@@ -1,0 +1,78 @@
+"""`_parse_response` returns a dict or nothing — never an array or scalar.
+
+Found by the 15.1.0 post-release self-review (`bug-predict` run
+`ca0c52c6c121`, HIGH). Strategies 1 and 2 returned `json.loads` output
+directly from a function typed `-> dict` and documented "never returns
+None". A model emitting a fenced JSON ARRAY parses fine, returns a list,
+and TypeErrors in `quality_agent.py` / `security_agent.py` — where the
+error is swallowed and surfaces as a spurious release-gate failure with
+`quality_score 0.0`. The failure mode fires DURING a release, which is
+the worst place for it.
+
+Strategy 3 was already safe behind `text.startswith("{")`; it carries a
+guard anyway so the contract holds at every return, not only where it
+currently must.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under the Apache License, Version 2.0
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from attune.agents.release.release_parsing import _parse_response
+
+# Payloads that are VALID JSON but not objects, in each delimiter shape.
+NON_DICT_BODIES = ["[1, 2, 3]", '"a bare string"', "42", "true", "null"]
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("body", NON_DICT_BODIES)
+@pytest.mark.parametrize(
+    "wrap",
+    [
+        lambda b: f"<analysis>{b}</analysis>",  # strategy 1
+        lambda b: f"```json\n{b}\n```",  # strategy 2
+        lambda b: f"```\n{b}\n```",  # strategy 2, unlabelled
+    ],
+    ids=["xml", "fenced-json", "fenced-bare"],
+)
+def test_non_dict_json_never_escapes_as_the_return_value(wrap, body) -> None:
+    """A parsable non-dict must fall through, not be returned."""
+    result = _parse_response(wrap(body))
+    assert isinstance(result, dict), f"{type(result).__name__} escaped the dict contract"
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "text",
+    [
+        '<analysis>{"score": 91}</analysis>',
+        '```json\n{"score": 91}\n```',
+        '{"score": 91}',
+    ],
+    ids=["xml", "fenced", "raw"],
+)
+def test_dict_payloads_still_parse_through_every_strategy(text: str) -> None:
+    """The guard must not break the happy path it wraps."""
+    assert _parse_response(text)["score"] == 91
+
+
+@pytest.mark.unit
+def test_array_in_xml_falls_through_to_a_later_strategy() -> None:
+    """Falling through is the point — a later strategy may still succeed.
+
+    An array inside <analysis> with a regex-extractable metric in the
+    surrounding prose should yield the regex result, not the array.
+    """
+    result = _parse_response("<analysis>[1,2,3]</analysis>\nQuality score: 77")
+    assert isinstance(result, dict)
+    assert result.get("score") == 77.0
+
+
+@pytest.mark.unit
+def test_unparseable_input_still_returns_a_dict() -> None:
+    """The documented floor: never None, always a dict."""
+    assert isinstance(_parse_response("no json here at all"), dict)
+    assert isinstance(_parse_response(""), dict)


### PR DESCRIPTION
## What

`_parse_response` is typed `-> dict` and documented "never returns None", but strategies 1 (XML) and 2 (markdown-fenced) returned raw `json.loads` output. A model emitting a fenced JSON **array** or bare scalar parses fine, escapes as a non-dict, and TypeErrors in `quality_agent.py` / `security_agent.py` — where a broad `except Exception` swallows it and reports a spurious release-gate failure (`quality_score 0.0`). The failure fires **during a release**.

Each strategy now falls through to the next unless its parse yields a dict; strategy 3 carries the guard belt-and-braces so the contract holds at every return.

## Receipts

- Found by the 15.1.0 post-release self-review (bug-predict run `ca0c52c6c121`, HIGH), verified in source before acting.
- 20 new contract tests: 5 non-dict JSON shapes × 3 delimiter shapes, fall-through, happy paths.
- **Mutation-verified twice**: at parking (reverting strategy 1 → 6 red) and again at unparking review (2026-09-02, full unguarded module → **16/20 red**; note the PYTHONPATH-override trap — pytest's rootdir config re-routes imports, so the red run needs `-o pythonpath=`).
- Premise re-verified on current main before rebase: `release_parsing.py` untouched since the branch point; guards absent on main.
- Rebased onto origin/main (clean, re-signed `G`); full release suite: **176 passed**.

## Provenance

Parked 2026-08-26 per retro ruling (queue, not do-now); unparked by chair 2026-09-02 in the catch-up plan (in-session review: correct, minimal, tests bite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
