### PR TITLE
fix(elicitation): omit null intake field payloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   escaping a `-> dict` contract and surfacing as a spurious release-gate
   failure (`quality_score 0.0`) inside `quality_agent` / `security_agent`.
 
+- Guided Fix and Spec intake payloads now omit absent optional fields instead
+  of serializing them as JSON `null`, so strict native MCP form schemas accept
+  the generated payload unchanged and render the dynamic UI.
+
 ## [16.2.0] - 2026-09-02
 
 This release brings state-bound dynamic workspaces to the command cohort and

--- a/docs/handoffs/codex-fix-dynamic-form-payload.md
+++ b/docs/handoffs/codex-fix-dynamic-form-payload.md
@@ -1,0 +1,52 @@
+# Agent work handoff
+
+## Goal
+
+Make Fix and Spec intake CLI payloads render on strict native MCP form schemas by omitting absent optional field properties instead of serializing them as JSON `null`.
+
+## Acceptance criteria
+
+- The Fix intake CLI payload validates unchanged against the `elicitation_ask` form schema.
+- The Spec intake CLI payload validates unchanged against the same schema.
+- The real local renderer accepts the generated Fix payload and returns a successful widget render receipt.
+- Focused lint and tests pass with no Anthropic spend.
+
+## Scope and assumptions
+
+- Branch/worktree: `codex/fix-dynamic-form-payload` at `/private/tmp/attune-ai-fix-dynamic-form`
+- Provider/session: Codex local session, Thursday, September 3, 2026
+- Assumptions:
+  - This branch stays scoped to the dynamic-form payload fix and its direct receipts.
+  - The original checkout at `/Users/patrickroebuck/attune-ai` keeps its unrelated untracked plan file and is not touched.
+
+## Current state
+
+- Status: ready for review, commit, push, and PR creation.
+- Changed files:
+  - `CHANGELOG.md`
+  - `src/attune/elicitation/fix_intake.py`
+  - `src/attune/elicitation/spec_intake.py`
+  - `tests/unit/elicitation/test_fix_intake.py`
+  - `tests/unit/elicitation/test_spec_intake.py`
+- Decisions:
+  - Preserve valid falsey values such as `required: false` and empty option lists; drop only keys whose value is `None`.
+  - Keep the fix symmetric between Fix and Spec intake serialization paths.
+  - Record the user-visible effect in `CHANGELOG.md` under `[Unreleased]`.
+- Risks or open questions:
+  - None known in the local branch after focused tests and renderer receipt.
+
+## Verification
+
+| Claim | Failure-sensitive probe | Result |
+| --- | --- | --- |
+| Focused files are the only branch changes. | `git status --short && git diff --stat` | Pass: only the five intended files are modified before commit. |
+| The branch is current with `origin/main`. | `git fetch origin` then `git rev-list --left-right --count origin/main...HEAD` | Pass: `0 0`. |
+| The payload fix keeps the diff syntactically clean. | `git diff --check` | Pass. |
+| Pinned formatting and lint are clean on the changed files. | `uv run --with pre-commit pre-commit run black --files CHANGELOG.md src/attune/elicitation/fix_intake.py src/attune/elicitation/spec_intake.py tests/unit/elicitation/test_fix_intake.py tests/unit/elicitation/test_spec_intake.py` and `uv run ruff check src/attune/elicitation/fix_intake.py src/attune/elicitation/spec_intake.py tests/unit/elicitation/test_fix_intake.py tests/unit/elicitation/test_spec_intake.py` | Pass. |
+| The changed surfaces pass focused tests without Anthropic spend. | `unset ANTHROPIC_API_KEY` then `uv run --frozen pytest tests/unit/elicitation/test_fix_intake.py tests/unit/elicitation/test_spec_intake.py tests/unit/mcp/test_tool_schemas.py tests/unit/mcp/handlers/test_elicitation_ask.py tests/unit/scripts/test_sync_form_design_tokens.py -q` | Pass: `94 passed`. |
+| Changed-code coverage stays above the project floor. | `uv run --frozen pytest tests/unit/elicitation/test_fix_intake.py tests/unit/elicitation/test_spec_intake.py --cov=attune.elicitation.fix_intake --cov=attune.elicitation.spec_intake --cov-report=term-missing --cov-fail-under=85 -q` | Pass: total `91.87%`, `fix_intake` `92.76%`, `spec_intake` `88.61%`. |
+| The real renderer accepts the generated Fix payload unchanged. | Local MCP call to `elicitation_render_widget` using the generated fixed payload | Pass: `success=true`, `html_present=true`, fields `request`, `scope`, `probes`. |
+
+## Next action
+
+Stage the six branch files including this handoff, create the conventional commit, push `codex/fix-dynamic-form-payload`, and open the PR against `main`.

--- a/src/attune/elicitation/fix_intake.py
+++ b/src/attune/elicitation/fix_intake.py
@@ -408,15 +408,19 @@ def _main(argv: list[str]) -> int:
             "description": form.description,
             "fields": [
                 {
-                    "id": q.id,
-                    "text": q.text,
-                    "type": q.type.value,
-                    "options": list(q.options),
-                    "default": q.default,
-                    "help_text": q.help_text,
-                    "required": q.required,
-                    "path_kind": q.path_kind,
-                    "path_options": list(q.path_options),
+                    key: value
+                    for key, value in {
+                        "id": q.id,
+                        "text": q.text,
+                        "type": q.type.value,
+                        "options": list(q.options),
+                        "default": q.default,
+                        "help_text": q.help_text,
+                        "required": q.required,
+                        "path_kind": q.path_kind,
+                        "path_options": list(q.path_options),
+                    }.items()
+                    if value is not None
                 }
                 for q in form.questions
             ],

--- a/src/attune/elicitation/spec_intake.py
+++ b/src/attune/elicitation/spec_intake.py
@@ -203,13 +203,17 @@ def _main(argv: list[str]) -> int:
             "description": form.description,
             "fields": [
                 {
-                    "id": q.id,
-                    "text": q.text,
-                    "type": q.type.value,
-                    "options": list(q.options),
-                    "default": q.default,
-                    "help_text": q.help_text,
-                    "required": q.required,
+                    key: value
+                    for key, value in {
+                        "id": q.id,
+                        "text": q.text,
+                        "type": q.type.value,
+                        "options": list(q.options),
+                        "default": q.default,
+                        "help_text": q.help_text,
+                        "required": q.required,
+                    }.items()
+                    if value is not None
                 }
                 for q in form.questions
             ],

--- a/tests/unit/elicitation/test_fix_intake.py
+++ b/tests/unit/elicitation/test_fix_intake.py
@@ -315,6 +315,16 @@ def test_main_default_prints_form_payload(tmp_path, monkeypatch, capsys) -> None
     request_field = payload["form"]["fields"][0]
     assert request_field["required"] is True
     assert request_field["type"] == "textarea"
+    assert all(
+        value is not None for field in payload["form"]["fields"] for value in field.values()
+    ), "CLI form payload must be accepted unchanged by strict MCP tool schemas"
+
+    import jsonschema
+
+    from attune.mcp.tool_schemas import get_elicitation_tools
+
+    schema = get_elicitation_tools()["elicitation_ask"]["input_schema"]["properties"]["form"]
+    jsonschema.validate(payload["form"], schema)
 
 
 def test_main_compose_reads_answers_from_stdin(monkeypatch, capsys) -> None:

--- a/tests/unit/elicitation/test_spec_intake.py
+++ b/tests/unit/elicitation/test_spec_intake.py
@@ -107,6 +107,16 @@ def test_main_default_prints_form_and_areas_payload(tmp_path: Path, monkeypatch,
     outcome_field = payload["form"]["fields"][0]
     assert outcome_field["required"] is True
     assert outcome_field["type"] == "textarea"
+    assert all(
+        value is not None for field in payload["form"]["fields"] for value in field.values()
+    ), "CLI form payload must be accepted unchanged by strict MCP tool schemas"
+
+    import jsonschema
+
+    from attune.mcp.tool_schemas import get_elicitation_tools
+
+    schema = get_elicitation_tools()["elicitation_ask"]["input_schema"]["properties"]["form"]
+    jsonschema.validate(payload["form"], schema)
 
 
 def test_main_default_degrades_without_areas(tmp_path: Path, monkeypatch, capsys) -> None:


### PR DESCRIPTION
## Summary

Fix the Fix and Spec intake CLI payloads so optional field properties are omitted when absent instead of serialized as JSON `null`.

This keeps the generated payload compatible with the strict native `elicitation_ask` form schema and restores dynamic UI rendering without changing the shape of valid falsey values such as `required: false` or empty option lists.

## Changes

- omit `None`-valued optional field properties in `fix_intake.py`
- omit `None`-valued optional field properties in `spec_intake.py`
- add schema-validation assertions for both CLI payloads
- record the user-visible fix in `CHANGELOG.md`
- add a tracked branch handoff with probes/results

## Verification

- `git rev-list --left-right --count origin/main...HEAD` -> `0 0` before commit
- `git diff --check`
- `uv run --with pre-commit pre-commit run black --files CHANGELOG.md src/attune/elicitation/fix_intake.py src/attune/elicitation/spec_intake.py tests/unit/elicitation/test_fix_intake.py tests/unit/elicitation/test_spec_intake.py`
- `uv run ruff check src/attune/elicitation/fix_intake.py src/attune/elicitation/spec_intake.py tests/unit/elicitation/test_fix_intake.py tests/unit/elicitation/test_spec_intake.py`
- `unset ANTHROPIC_API_KEY`
- `uv run --frozen pytest tests/unit/elicitation/test_fix_intake.py tests/unit/elicitation/test_spec_intake.py tests/unit/mcp/test_tool_schemas.py tests/unit/mcp/handlers/test_elicitation_ask.py tests/unit/scripts/test_sync_form_design_tokens.py -q` -> `94 passed`
- `uv run --frozen pytest tests/unit/elicitation/test_fix_intake.py tests/unit/elicitation/test_spec_intake.py --cov=attune.elicitation.fix_intake --cov=attune.elicitation.spec_intake --cov-report=term-missing --cov-fail-under=85 -q` -> total `91.87%`
- local renderer receipt: fixed Fix payload accepted by `elicitation_render_widget` with `success=true` and `html_present=true`

## Notes

- Checked open PR overlap before opening; only `#2375` was open and it does not overlap this surface.
