### PR TITLE
chore(release): prepare v16.2.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "Persistent memory and receipt-verified workflows for Claude Code. Spec-driven development with an approval loop, plus 28 auto-triggering skills: security audits, code review, test generation, release prep.",
-    "version": "16.2.0"
+    "version": "16.2.1"
   },
   "plugins": [
     {
       "name": "attune-ai",
       "description": "Persistent memory and receipt-verified workflows for Claude Code. /spec carries an idea through brainstorm, requirements, design, and task execution with quality gates and your approval at each stage. Backed by 28 auto-triggering skills — security audits, code reviews, test generation, bug prediction, and release preparation.",
       "source": "./plugin",
-      "version": "16.2.0",
+      "version": "16.2.1",
       "author": {
         "name": "Smart AI Memory",
         "email": "patrick.roebuck@smartaimemory.com"

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,4 +1,4 @@
-# Attune AI Framework v16.2.0
+# Attune AI Framework v16.2.1
 
 AI-powered developer workflows with cost optimization and multi-agent orchestration.
 
@@ -601,7 +601,7 @@ attune_redis/          # Redis plugin — BUNDLED, ships in the attune-ai
 
 ---
 
-**Version:** 16.2.0 | **License:** Apache 2.0 | **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)
+**Version:** 16.2.1 | **License:** Apache 2.0 | **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)
 
 ## Lessons — core
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [16.2.1] - 2026-09-03
+
+This patch restores strict native rendering for the guided Fix and Spec forms
+and prevents non-object model responses from escaping the release-gate parser.
+
 ### Fixed
 
 - **Release-gate parser can no longer return a non-dict**: `_parse_response`

--- a/README.md
+++ b/README.md
@@ -136,20 +136,16 @@ memory storage and recall, and every local transform.
      release with the headline feature; the displaced content moves to
      a permanent section below. Don't stack a second "New in" here. -->
 
-## New in 16.2.0 — shared workspaces, fewer ruling steps
+## New in 16.2.1 — strict dynamic forms render again
 
-Roundtable, Spec, Release Prep, Bug Predict, and the broader command cohort
-now use one state-bound dynamic workspace renderer. The same canonical action
-contract reaches rich widgets, Markdown/text fallbacks, and terminal receipts;
-stale or replayed actions fail closed instead of relying on presentation state.
+Guided Fix and Spec intake now omit optional field properties when they are
+absent instead of serializing them as JSON `null`. Strict native MCP hosts can
+accept the generated payload unchanged, so the dynamic form, scope picker, and
+probe suggestions render instead of failing client-side schema validation.
 
-Roundtable's seven-item promotion review now completes in atomic `3 + 3 + 1`
-batches: three submissions instead of seven, with the same terminal rulings.
-That is 57.143% fewer ruling submissions and 66.667% fewer added navigation
-rounds in the measured portable/headless path. These are interaction-mechanics
-figures, not claims about human dwell or provider execution time. Consequential
-actions use `attune-forms 0.12.2`'s visible inline two-click confirmation, so a
-host-blocked native browser dialog cannot make the button appear inert.
+The release-gate parser also rejects arrays and scalar values where an object
+is required, allowing its remaining response strategies to recover instead of
+reporting a misleading `quality_score 0.0` failure.
 
 <details>
 <summary>Previously new in 16.1.0 — harness-lite lands</summary>
@@ -384,6 +380,21 @@ works everywhere and degrades gracefully. The full construct vocabulary
 ships via `attune-forms` 0.7.0 (new in 13.0.0). Chart specs render
 through the same sealed SVG kernel (`chart_render_widget`, nine chart
 types).
+
+### State-bound command workspaces
+
+Roundtable, Spec, Release Prep, Bug Predict, and the broader command cohort
+use one state-bound dynamic workspace renderer. The same canonical action
+contract reaches rich widgets, Markdown/text fallbacks, and terminal receipts;
+stale or replayed actions fail closed instead of relying on presentation state.
+
+Roundtable's seven-item promotion review completes in atomic `3 + 3 + 1`
+batches: three submissions instead of seven, with the same terminal rulings.
+That is 57.143% fewer ruling submissions and 66.667% fewer added navigation
+rounds in the measured portable/headless path. These are interaction-mechanics
+figures, not claims about human dwell or provider execution time. Consequential
+actions use `attune-forms 0.12.2`'s visible inline two-click confirmation, so a
+host-blocked native browser dialog cannot make the button appear inert.
 
 ---
 

--- a/docs/handoffs/codex-release-16.2.1.md
+++ b/docs/handoffs/codex-release-16.2.1.md
@@ -1,0 +1,80 @@
+# Agent work handoff
+
+## Goal
+
+Publish attune-ai 16.2.1 from the main-branch merge of the strict dynamic-form
+payload fix and the release-gate parser fix.
+
+## Acceptance criteria
+
+- Every governed source version site and `uv.lock` agree on 16.2.1.
+- The existing post-merge docs-sync job updates the served framework-docs
+  artifact to 16.2.1, and the deployed page is checked before tagging.
+- The changelog promotes the two fixes from `[Unreleased]` into 16.2.1.
+- The release-prep PR passes all required CI checks and merges.
+- The final tag targets the verified full post-sync `main` SHA that contains
+  both the release-prep merge and the generated docs-sync commit.
+- PyPI's simple index exposes both the 16.2.1 wheel and source distribution.
+
+## Scope and assumptions
+
+- Branch/worktree: `codex/release-16.2.1` at
+  `/private/tmp/attune-ai-release-16.2.1`
+- Provider/session: Codex local session, 2026-09-03
+- Assumptions:
+  - The release is a patch because `[Unreleased]` contains fixes only.
+  - Patrick's zero-spend instruction remains active: do not call paid model
+    APIs or run AI-backed release workflows until separately authorized.
+  - The dirty original `main` checkout is left untouched; all release work
+    stays in this isolated worktree.
+
+## Current state
+
+- Status: no-cost release preparation is locally complete; SDK-backed workflow
+  calls remain prohibited by the zero-spend instruction.
+- Changed files: governed version projections, `CHANGELOG.md`, `README.md`,
+  `uv.lock`, and this handoff.
+- Decisions:
+  - Target version is 16.2.1.
+  - PR #2394 merged at
+    `3fda0611429e83ad5defb6208398f26166a15b93` before this branch was created.
+  - The release commit was rebased onto the unrelated spec-only #2395 merge
+    before push.
+- Risks or open questions:
+  - `secure-release` and `release-notes` are SDK-backed and have not run. Their
+    deterministic substance is being reproduced locally and will be labeled
+    Codex/manual rather than reported as workflow execution.
+  - The first `release-prep` attempt reported 40% coverage after pytest stopped
+    before emitting `TOTAL`; that value was a heuristic, not a measurement, and
+    is invalidated by the complete coverage receipt below.
+  - PR #2375 overlaps only `CHANGELOG.md`; it remains intentionally outside this
+    release. Re-check the overlap immediately before opening the release PR.
+
+## Verification
+
+| Claim | Failure-sensitive probe | Result |
+| --- | --- | --- |
+| Fix PR is merged from a fully green required-check set. | `gh pr checks 2394 --required` and `gh pr view 2394 --json state,mergeCommit` | Pass: required checks green; merged at full SHA `3fda0611429e83ad5defb6208398f26166a15b93`. |
+| Release branch started from current main. | `git rev-parse HEAD origin/main` before edits | Pass: both were `3fda0611429e83ad5defb6208398f26166a15b93`. |
+| 16.2.1 is not already on PyPI. | Query `https://pypi.org/simple/attune-ai/` | Pass: latest artifact is 16.2.0. |
+| Lockfile refresh is scoped. | `git diff -- uv.lock` | Pass: only the editable attune-ai version changed. |
+| Version projections agree. | Focused plugin/website version consistency tests. | Pass: 5 tests. |
+| README's historical Roundtable measurements are reproducible. | The two named seven-candidate workspace tests plus independent arithmetic. | Pass: 7 items complete in 3 submissions (`3 + 3 + 1`); submissions reduce 57.143% (`7 -> 3`) and added navigation reduces 66.667% (`6 -> 2`). |
+| README rotating release slot is current. | `tests/unit/scripts/test_check_badge_freshness.py` | Pass: 5 tests. |
+| Full-suite coverage clears the release floor. | `ATTUNE_REDIS_MOCK=true uv run --frozen pytest --cov=attune --cov-report=term-missing -x -q --no-header --timeout=30` | Pass: 25,264 passed, 259 skipped, 3 xfailed; measured total 95.30%. |
+| Deterministic documentation projection is current. | `uv run --frozen python scripts/list_stale_help_features.py --help-dir .help --project-root .` | Pass: empty stdout, meaning no stale features. |
+| Deterministic release team approves. | `release-prep` in simulated mode, empty Anthropic key, zero budget. | Pass: 4/4 agents, high confidence, recorded cost $0.00. |
+| Separately named release gate approves. | `release-gate` in simulated mode, empty Anthropic key, zero budget. | Pass: 4/4 agents, high confidence, recorded cost $0.00. |
+| Security scan matches CI scope. | `uv run --frozen bandit -c .bandit -r src/ attune_software/ --severity-level medium --confidence-level medium` | Pass: 156,680 lines scanned; 0 medium and 0 high findings. |
+| Changed files satisfy local hooks. | Pinned `pre-commit run --files ...` over all changed files. | Pass: all applicable hooks. |
+| Final artifacts are valid. | Fresh `uv build`, then Twine-check wheel and sdist. | Pass: both artifacts; wheel SHA-256 `5b304f7f11650736a3d2cac115808251196e748f485f52a23b8d3cc0beb17f8b`, sdist SHA-256 `fde2fc27f6846c2144a298f37f9144c9eeeeda0b6b28bd801fbcc95f78f1708c`. |
+| Built metadata contains the corrected release surface. | Inspect the wheel's `METADATA`. | Pass: version 16.2.1 and the `New in 16.2.1` form-improvement section are embedded. |
+| Installed wheel exposes the intended behavior. | Install the final wheel in a fresh venv; run `attune version` and both intake modules from `/private/tmp`. | Pass: `attune-ai 16.2.1`; 2 valid payloads, 0 null values, 3 Fix fields and 4 Spec fields. |
+| Source documentation builds. | `uv run --frozen mkdocs build --strict` | Pass. A local sync exposed broad generated-asset churn, so that output was reverted and publication is gated on the repository's existing post-merge docs-sync job instead. |
+| A different model reviewed the release diff. | Read-only release-risk review plus disposition review. | One P1 found: the served API-reference artifact remains 16.2.0 until docs sync. Resolution accepted: wait for and verify the post-merge docs-sync deployment, then tag the full post-sync `main` SHA; do not commit a 283-file toolchain-churn rebuild into this patch PR. |
+
+## Next action
+
+Push and open the release-prep PR, then wait for required CI. After merge, wait
+for the docs-sync job and verify the served 16.2.1 page before tagging. Do not
+cross the SDK-backed workflow boundary.

--- a/docs/reference/API_REFERENCE.md
+++ b/docs/reference/API_REFERENCE.md
@@ -1,6 +1,6 @@
 # Attune AI API Reference
 
-**Version:** 16.2.0
+**Version:** 16.2.1
 **License:** Apache License 2.0
 **Copyright:** 2025-2026 Smart AI Memory, LLC
 
@@ -1133,5 +1133,5 @@ msg = format_error(
 
 ---
 
-**Version:** 16.2.0 | **License:** Apache 2.0
+**Version:** 16.2.1 | **License:** Apache 2.0
 **Repo:** [attune-ai](https://github.com/Smart-AI-Memory/attune-ai)

--- a/plugin/.claude-plugin/marketplace.json
+++ b/plugin/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
   },
   "metadata": {
     "description": "Spec-driven development for Claude Code — /spec plans, reviews, and executes with quality gates; plus security audits, code reviews, test generation, and release prep from /attune.",
-    "version": "16.2.0"
+    "version": "16.2.1"
   },
   "plugins": [
     {
       "name": "attune-ai",
       "description": "Spec-driven development for Claude Code — /spec plans, reviews, and executes with quality gates; plus security audits, code reviews, test generation, and release prep from /attune.",
       "source": "./",
-      "version": "16.2.0",
+      "version": "16.2.1",
       "author": {
         "name": "Smart AI Memory",
         "email": "patrick.roebuck@smartaimemory.com"

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "attune-ai",
-  "version": "16.2.0",
+  "version": "16.2.1",
   "description": "Persistent memory and receipt-verified workflows for Claude Code — /spec plans, reviews, and executes with quality gates; plus security audits, code reviews, test generation, and release prep from /attune.",
   "author": {
     "name": "Smart AI Memory",

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -5,7 +5,7 @@ Code. Your agent stops starting from zero, and its word stops
 being the evidence. <!-- cap:skill_count -->28 auto-triggering skills<!-- /cap -->, zero
 commands: say what you need and Claude picks the right skill.
 
-**Version:** 16.2.0 | **License:** Apache 2.0
+**Version:** 16.2.1 | **License:** Apache 2.0
 
 > **Fix Receipts** (`/fix`) — new in 11.2.0. Say `fix this and
 > prove it`.

--- a/plugin/core/__init__.py
+++ b/plugin/core/__init__.py
@@ -5,4 +5,4 @@ This module provides the core workflow functionality when the full
 attune-ai package is not installed via pip.
 """
 
-__version__ = "16.2.0"
+__version__ = "16.2.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "attune-ai"
-version = "16.2.0"
+version = "16.2.1"
 description = "Persistent memory and receipt-verified workflows for Claude Code — plugin, MCP server, and CLI."
 readme = {file = "README.md", content-type = "text/markdown"}
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -299,7 +299,7 @@ wheels = [
 
 [[package]]
 name = "attune-ai"
-version = "16.2.0"
+version = "16.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "agent-memory-client" },

--- a/website/app/page.tsx
+++ b/website/app/page.tsx
@@ -38,7 +38,7 @@ export default function Home() {
                 test_homepage_badge_includes_package_version guard scans
                 this file for vX.Y.Z and compares it to the package. */}
             <div className="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-[var(--surface-container-high)] text-[var(--primary)] text-xs font-bold tracking-widest mb-8 uppercase">
-              <span>v16.2.0</span>
+              <span>v16.2.1</span>
               <span className="w-1 h-1 rounded-full bg-[var(--primary)]" aria-hidden="true"></span>
               <span className="opacity-80">Persistent memory for AI coding agents</span>
             </div>

--- a/website/lib/features.ts
+++ b/website/lib/features.ts
@@ -100,7 +100,7 @@ export const PRODUCTS: Product[] = [
     id: "attune-ai",
     name: "Attune AI",
     pypiName: "attune-ai",
-    version: "16.2.0",
+    version: "16.2.1",
     tagline:
       "Persistent memory and receipt-verified workflows for Claude Code",
     installCommand: "pip install attune-ai",
@@ -147,7 +147,7 @@ export const PRODUCTS: Product[] = [
     id: "claude-code-plugin",
     name: "Claude Code Plugin",
     pypiName: "attune-ai",
-    version: "16.2.0",
+    version: "16.2.1",
     tagline: "Skills, hooks, and forms on your Claude subscription",
     installCommand:
       "claude plugin marketplace add Smart-AI-Memory/attune-ai",


### PR DESCRIPTION
## Summary

- bump attune-ai and all governed version projections from 16.2.0 to 16.2.1
- promote the two fixes from `[Unreleased]` into the 2026-09-03 patch release
- make the README's rotating release slot describe the strict Fix/Spec form fix
- preserve the prior state-bound workspace announcement in the permanent forms section
- record a portable release handoff with failure-sensitive receipts

## Verification

- local full suite: 25,264 passed, 259 skipped, 3 xfailed; 95.30%
  branch-aware coverage
- completed CI coverage lane: 25,296 passed, 228 skipped, 3 xfailed;
  96.68% coverage (85% release floor)
- focused parser/form/version/README suite: 103 passed
- historical Roundtable measurement receipts: 7 items in 3 submissions (`3 + 3 + 1`), reproducing 57.143% fewer submissions (`7 -> 3`) and 66.667% fewer added navigation steps (`6 -> 2`)
- strict MkDocs build: passed
- changed-file pre-commit hooks: passed
- Bandit CI scope: 156,680 lines scanned; 0 medium and 0 high findings
- fresh wheel + sdist: Twine passed both
- clean-installed wheel: `attune-ai 16.2.1`; Fix and Spec payloads valid with 0 null values

## Release workflow receipts

- `release-prep`: APPROVED, 4/4 deterministic agents, high confidence, $0.00
- `release-gate`: APPROVED, 4/4 deterministic agents, high confidence, $0.00
- `secure-release` and `release-notes` were not invoked because they are SDK-backed and the active instruction prohibits additional API spend. Their deterministic security, packaging, documentation, and notes work was reproduced manually and is labeled as such in the handoff.

## Sequencing requirement

The source API reference is 16.2.1. The served static copy is owned by the existing post-merge docs-sync job. Do not tag until that job lands, the deployed page reports 16.2.1, and the full post-sync `main` SHA is verified.

## Scope

Open PR #2375 overlaps only `CHANGELOG.md` and remains intentionally outside this release.
