### PR TITLE
feat(models): retarget the premium tier to Claude Fable 5.1

### DIFF
--- a/.agents/skills/bulk/SKILL.md
+++ b/.agents/skills/bulk/SKILL.md
@@ -60,7 +60,7 @@ analyze_batch(requests=[
 - `task_id` and `task_type` and `input_data` are required per
   request; `model_tier` is optional (`cheap` / `capable` /
   `premium`, default `capable`).
-- **Premium tier policy:** interactive premium = `claude-fable-5`
+- **Premium tier policy:** interactive premium = `claude-fable-5-1`
   (with server-side opus fallback); **batch premium =
   `claude-opus-4-8`** — the Batch API rejects the `fallbacks`
   param, so fable models are downgraded at request-build time.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Premium tier moves to Claude Fable 5.1** (`claude-fable-5-1`): the tier
+  default in `attune.model_tiers`, the registry premium entry, the cost
+  baseline, the spec runner default, and every projected doc that named
+  `claude-fable-5` now point at 5.1. Same $10/$50 per MTok; prompt-cache
+  reads drop to $0.25/MTok and `AnthropicProvider.calculate_actual_cost`
+  prices them from an explicit per-model rate instead of the 0.1x
+  derivation. `claude-fable-5` stays served: it is a known
+  `ATTUNE_MODEL_PREMIUM` override and remains priced by id in
+  `ADDITIONAL_MODELS`. The `attune.model_tiers` mirror is changed in step
+  with attune-rag's canonical copy — the drift guard stays green only
+  once attune-rag ships the same defaults.
+
+### Fixed
+
+- **Curator no longer forces `tool_choice` on fable models**: Fable 5.1
+  returns 400 on forced tool use (`type "tool" and "any" are not supported
+  for this model`), which would have broken every default-tier curator
+  briefing. Fable models now steer with `tool_choice: auto` (the prompt
+  already names `emit_curation`) and keep the schema guarantee through
+  strict tool use (`strict: true` plus `additionalProperties: false` on
+  every schema object); non-fable pins keep the forced call unchanged.
+
 ## [16.2.1] - 2026-09-03
 
 This patch restores strict native rendering for the guided Fix and Spec forms

--- a/content/blog/17-ai-workflows-every-developer-needs-2026.md
+++ b/content/blog/17-ai-workflows-every-developer-needs-2026.md
@@ -41,7 +41,7 @@ Not feeling ready to configure? Try [Wizards](/wizards/) instead—they're inter
 
 ### Cost Optimization: Up to 90% Savings
 
-All Attune workflows use **progressive tier escalation**. They start with Haiku (cheap, fast), perform the analysis, then only escalate to Sonnet or Claude Fable 5 (the premium tier, priced at 2× the former Opus rate) when deeper thinking is truly needed. Result: enterprise-grade analysis at a fraction of the cost — and the pricier the premium tier gets, the more that discipline matters.
+All Attune workflows use **progressive tier escalation**. They start with Haiku (cheap, fast), perform the analysis, then only escalate to Sonnet or Claude Fable 5.1 (the premium tier, priced at 2× the former Opus rate) when deeper thinking is truly needed. Result: enterprise-grade analysis at a fraction of the cost — and the pricier the premium tier gets, the more that discipline matters.
 
 All workflows are completely free and open source under Apache 2.0. Self-host them or run with your own API keys.
 

--- a/content/blog/attune-ai-vs-crewai-vs-langchain.md
+++ b/content/blog/attune-ai-vs-crewai-vs-langchain.md
@@ -96,7 +96,7 @@ Attune AI's progressive tier system is designed to minimize cost:
 
 - **Tier 1 (Haiku)**: $1 per 1M input tokens. Use for fast, simple tasks
 - **Tier 2 (Sonnet)**: $3 per 1M input tokens. Use when Haiku hits complexity limits
-- **Tier 3 (Claude Fable 5)**: $10 per 1M input tokens (2× the former Opus premium rate). Use only when Sonnet isn't smart enough
+- **Tier 3 (Claude Fable 5.1)**: $10 per 1M input tokens (2× the former Opus premium rate). Use only when Sonnet isn't smart enough
 
 A typical workflow starts with Haiku, and escalates only on demand. In practice, this cuts costs by up to 90% compared to always using the premium tier.
 

--- a/content/blog/claude-code-workflows-complete-guide-2026.md
+++ b/content/blog/claude-code-workflows-complete-guide-2026.md
@@ -19,7 +19,7 @@ Claude Code workflows are multi-stage automation pipelines that combine natural 
 
 - Starts with **Haiku** (fast, cheap) for triage and analysis
 - Escalates to **Sonnet** (capable) for implementation and complex reasoning
-- Escalates to **Claude Fable 5** (premium, priced at 2× the former Opus rate) for architectural decisions and synthesis
+- Escalates to **Claude Fable 5.1** (premium, priced at 2× the former Opus rate) for architectural decisions and synthesis
 - Delivers **up to 90% cost savings** compared to using premium models exclusively
 
 This intelligent tier escalation is the core innovation of Attune AI. Instead of paying for Opus on every task, you pay for what you actually need.

--- a/docs/handoffs/claude-attune-ai-fable-5-1-64d292.md
+++ b/docs/handoffs/claude-attune-ai-fable-5-1-64d292.md
@@ -48,9 +48,8 @@ changes (forced `tool_choice` is a 400; cache reads are $0.25/MTok).
   `clear_at` / `display: "updates"` not adopted.
 - Risks or open questions:
   - `attune.model_tiers` is a byte-mirror of `attune_rag.model_tiers`;
-    CI installs attune-rag from PyPI (1.1.0 = `claude-fable-5`). The
-    drift guard stays red until attune-rag ships the mirror
-    (`~/attune-rag` branch `feat/fable-5-1-premium-tier`).
+    CI installs attune-rag from PyPI. RESOLVED: attune-rag 1.2.0 shipped
+    the mirror 2026-09-03 (Smart-AI-Memory/attune-rag#220, #221).
   - attune-author carries its own mirror of the attune-rag contract
     with its own drift test — needs the same retarget when attune-rag
     ships (out of scope here).
@@ -70,5 +69,8 @@ changes (forced `tool_choice` is a 400; cache reads are $0.25/MTok).
 
 ## Next action
 
-Ship attune-rag `feat/fable-5-1-premium-tier` (release ≥1.2.0 to PyPI),
-then re-run this PR's CI so the drift lane goes green, then merge.
+attune-rag 1.2.0 is on PyPI (2026-09-03, tag `v1.2.0` at
+`25d2cf00bbe4a71daa7e8894402153ed6465d238`, publish run 33829729074
+completed after the chair's gate click). This push re-runs CI with
+the released mirror; when the drift lane is green, merge. Then retarget
+attune-author's mirror the same way.

--- a/docs/handoffs/claude-attune-ai-fable-5-1-64d292.md
+++ b/docs/handoffs/claude-attune-ai-fable-5-1-64d292.md
@@ -1,0 +1,74 @@
+# Agent work handoff
+
+## Goal
+
+attune-ai works well with Claude Fable 5.1: every Fable 5.0 model
+reference (`claude-fable-5`) that describes the *current* premium tier
+points at `claude-fable-5-1`, and the code absorbs 5.1's breaking
+changes (forced `tool_choice` is a 400; cache reads are $0.25/MTok).
+
+## Acceptance criteria
+
+- `attune.model_tiers._DEFAULTS["premium"] == "claude-fable-5-1"`, with
+  `claude-fable-5` kept as a known override and priced by id.
+- The curator (the one raw-SDK forced-`tool_choice` premium call) sends
+  `tool_choice: auto` + `strict: true` for fable models; other pins keep
+  the forced call.
+- `AnthropicProvider.calculate_actual_cost` prices Fable 5.1 cache reads
+  at $0.25/MTok; every other row keeps the 0.1x derivation.
+- Projected docs (bulk skill + `.agents` mirror, help concept page,
+  blog tier lines) name 5.1; CHANGELOG + spec decisions record it.
+- Full test tree green except the model-tiers drift guard, which is red
+  by design until attune-rag ships the mirrored defaults (see Risks).
+
+## Scope and assumptions
+
+- Branch/worktree: `claude/attune-ai-fable-5-1-64d292` at
+  `.claude/worktrees/attune-ai-fable-5-1-64d292`
+- Provider/session: Claude (lead), autonomous session 2026-09-03
+- Assumptions: historical documents (weekly reports, COVERAGE_BUG_LOG,
+  archived spec text, the dated blog cost post, CHANGELOG history) keep
+  their `claude-fable-5` mentions — they describe the past. Pricing is
+  unchanged ($10/$50), so no savings figures move.
+
+## Current state
+
+- Status: implemented and verified; PR open (see Next action).
+- Changed files: `src/attune/model_tiers.py`, `llm/fable_call.py`,
+  `llm/providers/anthropic.py`, `models/registry.py`,
+  `models/telemetry/analytics.py`, `cost_tracker.py`,
+  `authoring/spec_runner.py`, `workflows/config.py`,
+  `routing/model_router.py`, `curator/core.py`, `curator/schema.py`;
+  `plugin/skills/bulk/SKILL.md` (+ `.agents` mirror),
+  `plugin/help/generated/{concepts/tier-routing,tasks/use-bulk,references/skill-bulk}.md`,
+  `scripts/generate_concept_templates.py`, three `content/blog` guides,
+  `CHANGELOG.md`, `docs/specs/fable-premium-tier/decisions.md`, tests.
+- Decisions: recorded in `docs/specs/fable-premium-tier/decisions.md`
+  (2026-09-03 entry) — array-form `fallbacks` kept, per-message effort /
+  `clear_at` / `display: "updates"` not adopted.
+- Risks or open questions:
+  - `attune.model_tiers` is a byte-mirror of `attune_rag.model_tiers`;
+    CI installs attune-rag from PyPI (1.1.0 = `claude-fable-5`). The
+    drift guard stays red until attune-rag ships the mirror
+    (`~/attune-rag` branch `feat/fable-5-1-premium-tier`).
+  - attune-author carries its own mirror of the attune-rag contract
+    with its own drift test — needs the same retarget when attune-rag
+    ships (out of scope here).
+  - `plugin/help/generated/tasks/use-bulk.md` and
+    `references/skill-bulk.md` were hand-edited (their regeneration
+    path spends API budget, which is capped at zero).
+
+## Verification
+
+| Claim | Failure-sensitive probe | Result |
+| --- | --- | --- |
+| No live-code `claude-fable-5` default remains | `grep -rn 'claude-fable-5"' src/ plugin/skills scripts/` shows only the deliberate predecessor entries | pass |
+| Targeted suites green | `pytest tests/unit/test_model_tiers.py tests/unit/models tests/unit/curator tests/unit/config ... tests/unit/gates` (4500 passed, 15 skipped) | pass |
+| Drift guard compares constants to attune-rag | `pytest tests/unit/test_model_tiers_drift.py` against installed attune-rag 1.1.0 | fail (expected — predecessor default) |
+| Drift guard green against the attune-rag branch | `PYTHONPATH=~/attune-rag/.claude/worktrees/fable-5-1/src pytest tests/unit/test_model_tiers_drift.py` | pass (5 passed) |
+| Full tree | `pytest tests` (3 drift tests deselected) | pass (25268 passed, 258 skipped, 3 xfailed) |
+
+## Next action
+
+Ship attune-rag `feat/fable-5-1-premium-tier` (release ≥1.2.0 to PyPI),
+then re-run this PR's CI so the drift lane goes green, then merge.

--- a/docs/specs/fable-premium-tier/decisions.md
+++ b/docs/specs/fable-premium-tier/decisions.md
@@ -1,5 +1,54 @@
 # fable-premium-tier — decisions
 
+## 2026-09-03 — Premium tier retargeted to Claude Fable 5.1 (Patrick, in-session)
+
+**Ruling:** the PREMIUM tier default is `claude-fable-5-1`. Same
+$10/$50 per MTok as Fable 5, same 1M context / 128K output, same
+adaptive-only thinking, same server-side `fallbacks` opt-in via the
+beta namespace (`claude-opus-4-8` stays the fallback target). `fable_extras`
+keeps its `claude-fable` prefix test, so both generations ride the same
+call path; `claude-fable-5` stays a known `ATTUNE_MODEL_PREMIUM`
+override and is priced by id in `ADDITIONAL_MODELS` (still served,
+and pre-5.1 telemetry records reference it).
+
+**What 5.1 changes that this codebase had to absorb:**
+
+- **Forced `tool_choice` is a 400** on 5.1 (`type "tool" and "any" are
+  not supported for this model`). The curator was the only raw-SDK
+  forced-tool call on the premium path; it now uses `tool_choice: auto`
+  plus `strict: true` (schema objects gained `additionalProperties:
+  false`) for fable models, and keeps the forced call for every other
+  pin. Pinned by `tests/unit/curator/test_run_curator.py`.
+- **Cache reads are $0.25/MTok** (0.025x input, versus the 0.1x every
+  other model derives). `AnthropicProvider.get_model_info` carries an
+  explicit `cost_per_1m_cache_read` on the 5.1 row and
+  `calculate_actual_cost` honors it; rows without the key keep the 0.1x
+  derivation. Pinned by `tests/unit/models/test_fable_pricing_consistency.py`.
+- **Thinking blocks are bound to the producing model and to the
+  conversation prefix.** Inferred, not live-verified: no attune-ai call
+  site replays prior assistant turns with thinking blocks to the raw
+  SDK (the provider extracts text only; escalation/retry builds fresh
+  prompts; agent-factory adapters carry plain-text assistant turns), so
+  neither check bites. Revisit if a multi-turn raw-SDK path is added.
+- **Retention hint** in `attune.llm.fable_call` now reads
+  `claude-fable-* models require >=30-day org data retention` — the
+  requirement is unchanged on 5.1.
+
+**Mirror contract:** `attune.model_tiers` is a byte-mirror of
+`attune_rag.model_tiers` and CI installs attune-rag from PyPI for the
+drift guard (`tests/unit/test_model_tiers_drift.py`). The same
+`_DEFAULTS` / `_KNOWN_MODELS` change is carried to attune-rag in step;
+this repo's drift lane is red until that attune-rag release is on
+PyPI, by design — the guard is doing its job.
+
+**Not adopted (follow-ups, chair-callable):** `fallbacks: "default"`
+(the newer category-routed form under `server-side-fallback-2026-07-01`)
+— the array form still works on 5.1 and keeps the fallback target
+explicit for telemetry; per-message effort and turn-scoped system
+messages (no agent loop here builds long `messages` arrays);
+`thinking.display: "updates"` (no user watches a long tool-calling
+turn through the provider).
+
 ## 2026-07-29 — Editing model split from the premium tier (Patrick, in-session)
 
 **Ruling:** writing tasks draft on the CAPABLE tier

--- a/plugin/help/generated/concepts/tier-routing.md
+++ b/plugin/help/generated/concepts/tier-routing.md
@@ -9,11 +9,11 @@ source: src/attune/model_tiers.py
 
 ## What
 
-Tier routing automatically selects the right Claude model based on task complexity: CHEAP resolves to Haiku, CAPABLE to Sonnet, and PREMIUM to Claude Fable 5 (`claude-fable-5`). Simple tasks use cheap models; complex tasks escalate to premium.
+Tier routing automatically selects the right Claude model based on task complexity: CHEAP resolves to Haiku, CAPABLE to Sonnet, and PREMIUM to Claude Fable 5.1 (`claude-fable-5-1`). Simple tasks use cheap models; complex tasks escalate to premium.
 
 ## Why
 
-Reduces API costs without sacrificing quality — most workflow stages don't need the most expensive model. Note the premium tier runs `claude-fable-5` at 2x the former Opus pricing ($10 input / $50 output per MTok), so premium-tier stages cost twice what they did on Opus.
+Reduces API costs without sacrificing quality — most workflow stages don't need the most expensive model. Note the premium tier runs `claude-fable-5-1` at 2x the former Opus pricing ($10 input / $50 output per MTok), so premium-tier stages cost twice what they did on Opus.
 
 ## How
 

--- a/plugin/help/generated/references/skill-bulk.md
+++ b/plugin/help/generated/references/skill-bulk.md
@@ -60,7 +60,7 @@ analyze_batch(requests=[
 - `task_id` and `task_type` and `input_data` are required per
   request; `model_tier` is optional (`cheap` / `capable` /
   `premium`, default `capable`).
-- **Premium tier policy:** interactive premium = `claude-fable-5`
+- **Premium tier policy:** interactive premium = `claude-fable-5-1`
   (with server-side opus fallback); **batch premium =
   `claude-opus-4-8`** — the Batch API rejects the `fallbacks`
   param, so fable models are downgraded at request-build time.

--- a/plugin/help/generated/tasks/use-bulk.md
+++ b/plugin/help/generated/tasks/use-bulk.md
@@ -54,7 +54,7 @@ Invoke with: `/bulk <what to batch>`
    - `task_id` and `task_type` and `input_data` are required per
      request; `model_tier` is optional (`cheap` / `capable` /
      `premium`, default `capable`).
-   - **Premium tier policy:** interactive premium = `claude-fable-5`
+   - **Premium tier policy:** interactive premium = `claude-fable-5-1`
      (with server-side opus fallback); **batch premium =
      `claude-opus-4-8`** — the Batch API rejects the `fallbacks`
      param, so fable models are downgraded at request-build time.

--- a/plugin/skills/bulk/SKILL.md
+++ b/plugin/skills/bulk/SKILL.md
@@ -62,7 +62,7 @@ analyze_batch(requests=[
 - `task_id` and `task_type` and `input_data` are required per
   request; `model_tier` is optional (`cheap` / `capable` /
   `premium`, default `capable`).
-- **Premium tier policy:** interactive premium = `claude-fable-5`
+- **Premium tier policy:** interactive premium = `claude-fable-5-1`
   (with server-side opus fallback); **batch premium =
   `claude-opus-4-8`** — the Batch API rejects the `fallbacks`
   param, so fable models are downgraded at request-build time.

--- a/scripts/generate_concept_templates.py
+++ b/scripts/generate_concept_templates.py
@@ -43,14 +43,14 @@ _CONCEPTS: list[dict] = [
         "what": (
             "Tier routing automatically selects the right Claude model "
             "based on task complexity: CHEAP resolves to Haiku, CAPABLE "
-            "to Sonnet, and PREMIUM to Claude Fable 5 "
-            "(`claude-fable-5`). Simple tasks use cheap models; complex "
+            "to Sonnet, and PREMIUM to Claude Fable 5.1 "
+            "(`claude-fable-5-1`). Simple tasks use cheap models; complex "
             "tasks escalate to premium."
         ),
         "why": (
             "Reduces API costs without sacrificing quality — most "
             "workflow stages don't need the most expensive model. Note "
-            "the premium tier runs `claude-fable-5` at 2x the former "
+            "the premium tier runs `claude-fable-5-1` at 2x the former "
             "Opus pricing ($10 input / $50 output per MTok), so "
             "premium-tier stages cost twice what they did on Opus."
         ),

--- a/src/attune/authoring/spec_runner.py
+++ b/src/attune/authoring/spec_runner.py
@@ -136,7 +136,7 @@ class SpecDraftRunner:
         self,
         client: Any,
         *,
-        model: str = "claude-fable-5",
+        model: str = "claude-fable-5-1",
         budgets: Budgets | None = None,
         on_progress: Callable[[str, float], None] | None = None,
     ) -> None:

--- a/src/attune/cost_tracker.py
+++ b/src/attune/cost_tracker.py
@@ -74,9 +74,11 @@ MODEL_PRICING = _build_model_pricing()
 # Moved opus-4-8 -> fable-5 (2026-07-10 amendment, docs/specs/
 # fable-premium-tier design §3): with fable premium at 2x opus pricing,
 # an opus baseline reports negative savings on every deliberate premium
-# call. Safe for history: baseline_cost is computed at log time and
-# stored per record (see log_request), so old records keep opus math.
-BASELINE_MODEL = "claude-fable-5"
+# call. Moved fable-5 -> fable-5-1 (2026-09-03, same $10/$50 — the
+# baseline math is unchanged). Safe for history: baseline_cost is
+# computed at log time and stored per record (see log_request), so old
+# records keep the math of their day.
+BASELINE_MODEL = "claude-fable-5-1"
 
 
 def _baseline_label() -> str:

--- a/src/attune/curator/core.py
+++ b/src/attune/curator/core.py
@@ -1,16 +1,20 @@
 """``run_curator`` orchestrator — the curator's headless public API.
 
-Reads every source, checks the TTL cache, invokes a single Opus call
-with forced tool-use for a guaranteed-schema briefing, validates the
-cited sources, and caches the result.
+Reads every source, checks the TTL cache, invokes a single premium-tier
+call that must answer through one ``emit_curation`` tool call for a
+guaranteed-schema briefing, validates the cited sources, and caches the
+result.
 
 The synthesis is one LLM call (no subagents, no agent loop, no file
-tools), so it uses the raw ``anthropic`` SDK with forced ``tool_choice``
-— the canonical CLAUDE.md "Forced Anthropic tool-use" pattern, the same
-one ``attune_rag``'s ``FaithfulnessJudge`` uses. (The agent SDK's
-``ClaudeAgentOptions`` has no ``tool_choice`` field and its ``tools`` is
-a name-allowlist, so it can't force a single guaranteed-schema call —
-see ``docs/specs/bulletin-curator/decisions.md``.)
+tools), so it uses the raw ``anthropic`` SDK — the canonical CLAUDE.md
+"Forced Anthropic tool-use" pattern, the same one ``attune_rag``'s
+``FaithfulnessJudge`` uses. (The agent SDK's ``ClaudeAgentOptions`` has
+no ``tool_choice`` field and its ``tools`` is a name-allowlist, so it
+can't force a single guaranteed-schema call — see
+``docs/specs/bulletin-curator/decisions.md``.) Fable 5.1 rejects forced
+``tool_choice`` (400), so fable models steer with ``auto`` — the prompt
+already names the tool — and keep the schema guarantee through strict
+tool use; every other model keeps the forced call.
 """
 
 from __future__ import annotations
@@ -48,6 +52,10 @@ from .sources import (
 
 if TYPE_CHECKING:
     from anthropic import AsyncAnthropic
+
+# Fable models (``claude-fable-*``) reject forced tool_choice on 5.1 —
+# same prefix test as attune.model_tiers.fable_extras.
+_FABLE_PREFIX = "claude-fable"
 
 logger = logging.getLogger(__name__)
 
@@ -133,10 +141,11 @@ def _compute_cost(model: str, usage: Any) -> float:
 
 
 def _extract_curation_payload(response: Any) -> dict[str, Any]:
-    """Pull the structured payload from a forced-tool-use response.
+    """Pull the structured payload from the synthesis response.
 
     Walks ``response.content``: a ``tool_use`` block's ``input`` is the
-    guaranteed-schema happy path. Forced ``tool_choice`` makes the text
+    guaranteed-schema happy path. Forced ``tool_choice`` (non-fable) or
+    the prompt's tool instruction (fable, ``auto``) makes the text
     fallback rare, but it's handled for robustness.
     """
     text_fallback: str | None = None
@@ -242,17 +251,28 @@ async def _query_opus(
     client: AsyncAnthropic,
     model: str,
 ) -> CuratorResult:
-    """Run the single forced-tool-use synthesis call.
+    """Run the single tool-use synthesis call.
 
     Returns a :class:`CuratorResult` with summary, items, cost, and
     model populated. ``sources_consulted`` and ``cached_at`` are set by
     the caller.
     """
-    tool = {
+    tool: dict[str, Any] = {
         "name": "emit_curation",
         "description": _CURATION_TOOL_DESCRIPTION,
         "input_schema": schema,
     }
+    # Fable 5.1 returns 400 on forced tool_choice (type "tool"/"any" are
+    # not supported for this model), so fable models steer with ``auto``
+    # — the prompt names emit_curation and says "exactly once" — and keep
+    # the schema-valid-arguments guarantee via strict tool use. Every
+    # other model keeps the forced call. Prefix check matches
+    # attune.model_tiers.fable_extras.
+    if model.startswith(_FABLE_PREFIX):
+        tool["strict"] = True
+        tool_choice: dict[str, Any] = {"type": "auto"}
+    else:
+        tool_choice = {"type": "tool", "name": "emit_curation"}
     # Build kwargs as a plain dict and splat — the raw-dict tool param
     # doesn't match the SDK's ToolParam TypedDict overloads, and the
     # splat sidesteps that (same approach as FaithfulnessJudge).
@@ -261,7 +281,7 @@ async def _query_opus(
         "max_tokens": _MAX_OUTPUT_TOKENS,
         "system": _CURATOR_SYSTEM_PROMPT,
         "tools": [tool],
-        "tool_choice": {"type": "tool", "name": "emit_curation"},
+        "tool_choice": tool_choice,
         "messages": [{"role": "user", "content": prompt}],
     }
     # Premium default is fable — the helper routes fable models via the

--- a/src/attune/curator/schema.py
+++ b/src/attune/curator/schema.py
@@ -1,10 +1,13 @@
-"""JSON schema for the curator's forced tool-use output.
+"""JSON schema for the curator's tool-use output.
 
-The orchestrator forces the model to call a single ``emit_curation``
-tool whose ``input`` is guaranteed to match :data:`_CURATION_SCHEMA`
-(per the CLAUDE.md lesson "Forced Anthropic tool-use is the cleanest
-path to guaranteed-schema JSON"). The schema is copied verbatim from
-``docs/specs/bulletin-curator/design.md`` "Output schema".
+The orchestrator has the model call a single ``emit_curation`` tool
+whose ``input`` is guaranteed to match :data:`_CURATION_SCHEMA` (per
+the CLAUDE.md lesson "Forced Anthropic tool-use is the cleanest path to
+guaranteed-schema JSON"; on Fable 5.1, which rejects forced
+``tool_choice``, the guarantee comes from strict tool use instead). The
+schema is the ``docs/specs/bulletin-curator/design.md`` "Output schema"
+plus ``additionalProperties: false`` on every object — strict tool use
+requires it.
 
 ``output_schema(max_items)`` returns the schema with the
 ``items.maxItems`` cap set dynamically so callers can bound how many
@@ -20,6 +23,7 @@ from typing import Any
 # safety ceiling; output_schema() overrides it per call.
 _CURATION_SCHEMA: dict[str, Any] = {
     "type": "object",
+    "additionalProperties": False,
     "required": ["summary", "items"],
     "properties": {
         "summary": {
@@ -35,6 +39,7 @@ _CURATION_SCHEMA: dict[str, Any] = {
             "maxItems": 10,
             "items": {
                 "type": "object",
+                "additionalProperties": False,
                 "required": ["id", "title", "severity", "rationale", "sources"],
                 "properties": {
                     "id": {"type": "string"},
@@ -48,6 +53,7 @@ _CURATION_SCHEMA: dict[str, Any] = {
                     },
                     "suggested_action": {
                         "type": "object",
+                        "additionalProperties": False,
                         "required": ["kind"],
                         "properties": {
                             "kind": {"enum": ["ask", "open", "run", "dismiss"]},

--- a/src/attune/llm/fable_call.py
+++ b/src/attune/llm/fable_call.py
@@ -34,7 +34,7 @@ from typing import Any
 from attune.model_tiers import ModelRefusalError, fable_extras
 
 _RETENTION_HINT = (
-    "claude-fable-5 requires >=30-day org data retention - check the "
+    "claude-fable-* models require >=30-day org data retention - check the "
     "org's retention configuration before debugging the payload."
 )
 

--- a/src/attune/llm/providers/anthropic.py
+++ b/src/attune/llm/providers/anthropic.py
@@ -463,18 +463,31 @@ class AnthropicProvider(BaseLLMProvider):
     def get_model_info(self) -> dict[str, Any]:
         """Get Claude model information with extended context capabilities."""
         model_info = {
-            "claude-fable-5": {
-                # 1M-token context window; cache write $12.50 / read $1
-                # per MTok fall out of the 1.25x / 0.1x input derivation
-                # in calculate_actual_cost.
+            "claude-fable-5-1": {
+                # 1M-token context window; cache write $12.50/MTok falls
+                # out of the 1.25x input derivation in
+                # calculate_actual_cost, but cache READS are $0.25/MTok
+                # (0.025x input — a quarter of the 0.1x other models
+                # derive), so the read price is carried explicitly.
                 "max_tokens": 1000000,
                 "cost_per_1m_input": 10.00,
                 "cost_per_1m_output": 50.00,
+                "cost_per_1m_cache_read": 0.25,
                 "supports_prompt_caching": True,
                 # Adaptive reasoning — explicit thinking config is
                 # stripped by _normalize_api_kwargs_for_model.
                 "supports_thinking": True,
                 "ideal_for": "Frontier reasoning, premium interactive work",
+            },
+            "claude-fable-5": {
+                # Predecessor, still served; same $10/$50 with the
+                # standard 0.1x cache-read derivation ($1/MTok).
+                "max_tokens": 1000000,
+                "cost_per_1m_input": 10.00,
+                "cost_per_1m_output": 50.00,
+                "supports_prompt_caching": True,
+                "supports_thinking": True,
+                "ideal_for": "Frontier reasoning (pre-5.1 pins)",
             },
             "claude-opus-4-8": {
                 "max_tokens": 200000,
@@ -546,7 +559,9 @@ class AnthropicProvider(BaseLLMProvider):
 
         Includes Anthropic prompt caching cost adjustments:
         - Cache writes: 25% markup over standard input pricing
-        - Cache reads: 90% discount from standard input pricing
+        - Cache reads: 90% discount from standard input pricing, unless
+          the model's ``get_model_info`` row carries an explicit
+          ``cost_per_1m_cache_read`` (Fable 5.1 reads at $0.25/MTok)
 
         Args:
             input_tokens: Regular input tokens (not cached)
@@ -586,8 +601,9 @@ class AnthropicProvider(BaseLLMProvider):
         cache_write_price = input_price_per_million * 1.25
         cache_write_cost = (cache_creation_tokens / 1_000_000) * cache_write_price
 
-        # Cache read cost (90% discount = 10% of input price)
-        cache_read_price = input_price_per_million * 0.1
+        # Cache read cost: 10% of input price unless the model row
+        # carries its own rate (Fable 5.1: $0.25/MTok = 2.5%).
+        cache_read_price = model_info.get("cost_per_1m_cache_read", input_price_per_million * 0.1)
         cache_read_cost = (cache_read_tokens / 1_000_000) * cache_read_price
 
         # Calculate savings from cache reads

--- a/src/attune/model_tiers.py
+++ b/src/attune/model_tiers.py
@@ -27,7 +27,7 @@ from typing import Any
 logger = logging.getLogger(__name__)
 
 _DEFAULTS = {
-    "premium": "claude-fable-5",
+    "premium": "claude-fable-5-1",
     "capable": "claude-sonnet-5",
     "cheap": "claude-haiku-4-5",
 }
@@ -37,11 +37,13 @@ _ENV = {
     "cheap": "ATTUNE_MODEL_CHEAP",
 }
 # Models we expect to see in overrides: the tier defaults, the fable
-# server-side fallback target, and the pre-tier defaults still pinned in
-# some environments. An override outside this set is honored but logged —
-# it usually means a typo, not a deliberate pin.
+# server-side fallback target, the still-served Fable 5 predecessor,
+# and the pre-tier defaults still pinned in some environments. An
+# override outside this set is honored but logged — it usually means a
+# typo, not a deliberate pin.
 _KNOWN_MODELS = frozenset(
     {
+        "claude-fable-5-1",
         "claude-fable-5",
         "claude-sonnet-5",
         "claude-haiku-4-5",

--- a/src/attune/models/registry.py
+++ b/src/attune/models/registry.py
@@ -125,7 +125,7 @@ class ModelInfo:
 MODEL_REGISTRY: dict[str, dict[str, ModelInfo]] = {
     # -------------------------------------------------------------------------
     # Anthropic Claude Models
-    # Premium tier is Fable 5 (server-side opus-4-8 fallback rides in the
+    # Premium tier is Fable 5.1 (server-side opus-4-8 fallback rides in the
     # request — see attune.model_tiers / llm.fable_call). Opus 4.8 stays
     # resolvable by id via ADDITIONAL_MODELS below (batch premium target).
     # -------------------------------------------------------------------------
@@ -151,11 +151,14 @@ MODEL_REGISTRY: dict[str, dict[str, ModelInfo]] = {
             supports_tools=True,
         ),
         "premium": ModelInfo(
-            id="claude-fable-5",
+            id="claude-fable-5-1",
             provider="anthropic",
             tier="premium",
-            # $10/$50 per MTok (prompt cache: $12.50/MTok write, $1/MTok
-            # read — derived as 1.25x / 0.1x input by cost calculators).
+            # $10/$50 per MTok, same as Fable 5. Prompt cache: $12.50/MTok
+            # write (1.25x input, derived by cost calculators); reads are
+            # $0.25/MTok — 0.025x input, a quarter of the 0.1x every other
+            # model derives — carried explicitly by
+            # AnthropicProvider.get_model_info (cost_per_1m_cache_read).
             # 1M-token context window; 128K max output tokens.
             input_cost_per_million=10.00,
             output_cost_per_million=50.00,
@@ -173,8 +176,19 @@ MODEL_REGISTRY: dict[str, dict[str, ModelInfo]] = {
 # while by-id lookups (get_model_by_id, get_pricing_for_model,
 # cost_tracker.MODEL_PRICING) still resolve them. opus-4-8 remains the
 # batch premium target (anthropic_batch._batch_premium_model) and the
-# pricing anchor for pre-fable telemetry records.
+# pricing anchor for pre-fable telemetry records; fable-5 (still served)
+# stays priced for pre-5.1 records and explicit ATTUNE_MODEL_PREMIUM pins.
 ADDITIONAL_MODELS: dict[str, ModelInfo] = {
+    "claude-fable-5": ModelInfo(
+        id="claude-fable-5",
+        provider="anthropic",
+        tier="premium",
+        input_cost_per_million=10.00,
+        output_cost_per_million=50.00,
+        max_tokens=128000,
+        supports_vision=True,
+        supports_tools=True,
+    ),
     "claude-opus-4-8": ModelInfo(
         id="claude-opus-4-8",
         provider="anthropic",
@@ -340,7 +354,7 @@ class ModelRegistry:
             >>> premium_models = registry.get_models_by_tier("premium")
             >>> for model in premium_models:
             ...     print(f"{model.provider}: {model.id}")
-            anthropic: claude-fable-5
+            anthropic: claude-fable-5-1
 
         """
         return self._tier_cache.get(tier.lower(), [])

--- a/src/attune/models/telemetry/analytics.py
+++ b/src/attune/models/telemetry/analytics.py
@@ -186,7 +186,7 @@ class TelemetryAnalytics:
         Tracks:
         - How often Sonnet succeeds vs needs a premium fallback
         - Cost savings vs always using the premium model (the baseline
-          is priced from the registry premium entry — fable-5 — so this
+          is priced from the registry premium entry — fable-5-1 — so this
           site cannot drift from the canonical pricing)
         - Return keys keep the legacy ``opus`` naming — they are a
           stable API consumed by the telemetry CLI and dashboards
@@ -207,7 +207,13 @@ class TelemetryAnalytics:
             for c in calls
             if c.provider == "anthropic"
             and c.model_id
-            in ["claude-sonnet-5", "claude-opus-4-6", "claude-opus-4-8", "claude-fable-5"]
+            in [
+                "claude-sonnet-5",
+                "claude-opus-4-6",
+                "claude-opus-4-8",
+                "claude-fable-5",
+                "claude-fable-5-1",
+            ]
         ]
 
         if not anthropic_calls:
@@ -234,7 +240,8 @@ class TelemetryAnalytics:
         opus_fallbacks = sum(
             1
             for c in anthropic_calls
-            if c.model_id in ("claude-opus-4-6", "claude-opus-4-8", "claude-fable-5")
+            if c.model_id
+            in ("claude-opus-4-6", "claude-opus-4-8", "claude-fable-5", "claude-fable-5-1")
             and c.fallback_used
         )
 
@@ -242,7 +249,7 @@ class TelemetryAnalytics:
         actual_cost = sum(c.estimated_cost for c in anthropic_calls)
 
         # Baseline: what it would cost if everything used the premium
-        # model. Priced from the registry premium entry (fable-5) so the
+        # model. Priced from the registry premium entry (fable-5-1) so the
         # baseline can't drift from the canonical pricing sites.
         from ..registry import MODEL_REGISTRY
 

--- a/src/attune/routing/model_router.py
+++ b/src/attune/routing/model_router.py
@@ -182,7 +182,7 @@ class ModelRouter:
             >>> router.route("fix_bug")
             'claude-sonnet-5'
             >>> router.route("coordinate")
-            'claude-fable-5'
+            'claude-fable-5-1'
 
         """
         provider = provider or self._default_provider

--- a/src/attune/workflows/config.py
+++ b/src/attune/workflows/config.py
@@ -578,7 +578,7 @@ custom_models:
   anthropic:
     cheap: claude-haiku-4-5
     capable: claude-sonnet-5
-    premium: claude-fable-5  # premium tier default — see attune.model_tiers
+    premium: claude-fable-5-1  # premium tier default — see attune.model_tiers
   openai:
     cheap: gpt-4o-mini
     capable: gpt-4o
@@ -591,7 +591,7 @@ custom_models:
   hybrid:
     cheap: gpt-4o-mini           # OpenAI - cheapest per token
     capable: claude-sonnet-5   # Anthropic - best code/reasoning
-    premium: claude-fable-5   # Anthropic - best overall (see attune.model_tiers)
+    premium: claude-fable-5-1   # Anthropic - best overall (see attune.model_tiers)
 
 # =============================================================================
 # CUSTOM PRICING (per million tokens)

--- a/tests/agents_md/test_registry.py
+++ b/tests/agents_md/test_registry.py
@@ -234,7 +234,7 @@ class TestUnifiedAgentConfigModelIds:
         for tier, expected in [
             (ModelTier.CHEAP, "claude-haiku-4-5"),
             (ModelTier.CAPABLE, "claude-sonnet-5"),
-            (ModelTier.PREMIUM, "claude-fable-5"),
+            (ModelTier.PREMIUM, "claude-fable-5-1"),
         ]:
             config = UnifiedAgentConfig(name="test", provider=Provider.ANTHROPIC, model_tier=tier)
             assert config.get_model_id() == expected

--- a/tests/llm/test_providers.py
+++ b/tests/llm/test_providers.py
@@ -621,7 +621,12 @@ class TestSamplingParamNormalization:
         """Live 400 on claude-sonnet-5 (integration-auth, 2026-07-06)."""
         from attune.llm.providers.anthropic import _normalize_api_kwargs_for_model
 
-        for model in ("claude-sonnet-5", "claude-fable-5", "claude-sonnet-5-20260301"):
+        for model in (
+            "claude-sonnet-5",
+            "claude-fable-5",
+            "claude-fable-5-1",
+            "claude-sonnet-5-20260301",
+        ):
             kw = {"model": model, "temperature": 0.7, "top_p": 0.9}
             _normalize_api_kwargs_for_model(kw)
             assert "temperature" not in kw and "top_p" not in kw, model

--- a/tests/routing/test_model_router.py
+++ b/tests/routing/test_model_router.py
@@ -89,7 +89,7 @@ class TestModelRouter:
     def test_route_premium_task(self, router):
         """Test routing premium task to premium model."""
         model = router.route("coordinate")
-        assert model == "claude-fable-5"  # Fable 5 (premium tier)
+        assert model == "claude-fable-5-1"  # Fable 5.1 (premium tier)
 
     # test_route_with_openai_provider deleted - OpenAI removed in v5.0.0 (Anthropic-only)
     # test_route_with_ollama_provider deleted - Ollama removed in v5.0.0 (Anthropic-only)
@@ -152,7 +152,7 @@ class TestModelRouter:
         assert tier == ModelTier.PREMIUM
 
         model = router.route("my_special_task")
-        assert model == "claude-fable-5"  # Fable 5 (premium tier)
+        assert model == "claude-fable-5-1"  # Fable 5.1 (premium tier)
 
     def test_add_task_routing(self, router):
         """Test adding custom routing dynamically."""

--- a/tests/unit/agents/release/test_release_models.py
+++ b/tests/unit/agents/release/test_release_models.py
@@ -396,7 +396,7 @@ class TestModuleConstants:
         # Prevent regression to deprecated model IDs
         assert config["cheap"] == "claude-haiku-4-5"
         assert config["capable"] == "claude-sonnet-5"
-        assert config["premium"] == "claude-fable-5"
+        assert config["premium"] == "claude-fable-5-1"
 
     def test_default_quality_gates_keys(self):
         """DEFAULT_QUALITY_GATES has expected keys."""

--- a/tests/unit/config/test_config_validation.py
+++ b/tests/unit/config/test_config_validation.py
@@ -280,14 +280,14 @@ class TestRoutingValidation:
         routing = RoutingConfig()
         assert routing.cheap_model == "claude-haiku-4-5"
         assert routing.capable_model == "claude-sonnet-5"
-        assert routing.premium_model == "claude-fable-5"
+        assert routing.premium_model == "claude-fable-5-1"
 
     def test_routing_config_from_empty_dict(self):
         """Test that from_dict with empty dict uses current defaults."""
         routing = RoutingConfig.from_dict({})
         assert routing.cheap_model == "claude-haiku-4-5"
         assert routing.capable_model == "claude-sonnet-5"
-        assert routing.premium_model == "claude-fable-5"
+        assert routing.premium_model == "claude-fable-5-1"
 
 
 class TestWorkflowsValidation:

--- a/tests/unit/curator/test_run_curator.py
+++ b/tests/unit/curator/test_run_curator.py
@@ -172,14 +172,34 @@ def test_happy_path_returns_validated_items(isolate):
     assert client.messages.calls  # SDK was invoked
 
 
-def test_forced_tool_use_options_passed(isolate):
+def test_fable_steers_with_auto_and_strict_tool(isolate, monkeypatch):
+    """Fable 5.1 rejects forced tool_choice (400): auto + strict keeps the schema."""
+    monkeypatch.delenv("ATTUNE_MODEL_PREMIUM", raising=False)
+    assert core._curator_model().startswith("claude-fable")
+    client = _FakeClient(_tool_response("ok", []))
+    asyncio.run(core.run_curator(project_root=isolate, client=client, max_items=7))
+    call = client.messages.calls[0]
+    assert call["tool_choice"] == {"type": "auto"}
+    assert call["tools"][0]["name"] == "emit_curation"
+    assert call["tools"][0]["strict"] is True
+    # strict tool use requires additionalProperties: false on every object
+    schema = call["tools"][0]["input_schema"]
+    assert schema["additionalProperties"] is False
+    assert schema["properties"]["items"]["items"]["additionalProperties"] is False
+    # max_items flows into the schema cap
+    assert schema["properties"]["items"]["maxItems"] == 7
+    # the fable path rides the beta namespace with the fallback opt-in
+    assert call["betas"] == ["server-side-fallback-2026-06-01"]
+
+
+def test_non_fable_keeps_forced_tool_use(isolate, monkeypatch):
+    monkeypatch.setenv("ATTUNE_MODEL_PREMIUM", "claude-opus-4-8")
     client = _FakeClient(_tool_response("ok", []))
     asyncio.run(core.run_curator(project_root=isolate, client=client, max_items=7))
     call = client.messages.calls[0]
     assert call["tool_choice"] == {"type": "tool", "name": "emit_curation"}
-    assert call["tools"][0]["name"] == "emit_curation"
-    # max_items flows into the schema cap
-    assert call["tools"][0]["input_schema"]["properties"]["items"]["maxItems"] == 7
+    assert "strict" not in call["tools"][0]
+    assert "betas" not in call
 
 
 def test_fabricated_source_item_dropped(isolate, caplog):

--- a/tests/unit/models/test_fable_pricing_consistency.py
+++ b/tests/unit/models/test_fable_pricing_consistency.py
@@ -1,4 +1,4 @@
-"""Fable-5 premium pricing + baseline consistency (task 7).
+"""Fable 5.1 premium pricing + baseline consistency (task 7; retargeted 2026-09-03).
 
 Per-tier pricing has historically drifted across three sites that must
 change together (twice-earned lesson): (1) the model registry —
@@ -8,8 +8,11 @@ ModelInfo entries and TIER_PRICING, (2) the AnthropicProvider
 same numbers so a future premium-price change can't land partially.
 
 Also covers the 2026-07-10 BASELINE_MODEL amendment: cost_tracker's
-baseline moves to claude-fable-5 (log-time storage keeps history at
-opus math) and the report label derives from BASELINE_MODEL.
+baseline moves to the fable premium (log-time storage keeps history at
+opus math) and the report label derives from BASELINE_MODEL. Fable 5.1
+keeps Fable 5's $10/$50 but reads prompt cache at $0.25/MTok (0.025x
+input, not the 0.1x every other model derives) — pinned below; the
+still-served claude-fable-5 stays priced by id.
 
 Mock-only — no live API calls.
 """
@@ -24,9 +27,11 @@ from attune.models.registry import (
     ModelRegistry,
 )
 
-FABLE = "claude-fable-5"
+FABLE = "claude-fable-5-1"
+FABLE_PREDECESSOR = "claude-fable-5"
 FABLE_INPUT = 10.00
 FABLE_OUTPUT = 50.00
+FABLE_CACHE_READ = 0.25
 
 
 class TestRegistryEntry:
@@ -54,19 +59,28 @@ class TestRegistryEntry:
         assert "claude-opus-4-8" in ADDITIONAL_MODELS
 
     def test_opus_not_tier_routed(self):
-        """Tier lookups see exactly one premium model: fable."""
+        """Tier lookups see exactly one premium model: fable 5.1."""
         registry = ModelRegistry()
         premium_models = registry.get_models_by_tier("premium")
         assert [m.id for m in premium_models] == [FABLE]
+
+    def test_fable_5_stays_resolvable_by_id(self):
+        """Fable 5 is still served (pins + pre-5.1 records) but not tier-routed."""
+        registry = ModelRegistry()
+        fable_5 = registry.get_model_by_id(FABLE_PREDECESSOR)
+        assert fable_5 is not None
+        assert fable_5.input_cost_per_million == FABLE_INPUT
+        assert fable_5.output_cost_per_million == FABLE_OUTPUT
+        assert FABLE_PREDECESSOR in ADDITIONAL_MODELS
 
 
 class TestProviderTable:
     """Site 2: AnthropicProvider.get_model_info pricing table."""
 
-    def _provider(self):
+    def _provider(self, model: str = FABLE):
         from attune.llm.providers import AnthropicProvider
 
-        return AnthropicProvider(api_key="test-key", model=FABLE)
+        return AnthropicProvider(api_key="test-key", model=model)
 
     def test_fable_row_matches_registry(self):
         info = self._provider().get_model_info()
@@ -75,8 +89,22 @@ class TestProviderTable:
         assert info["cost_per_1m_output"] == premium.output_cost_per_million
 
     def test_cache_pricing_derivation(self):
-        """Cache write $12.50 / read $1.00 per MTok (1.25x / 0.1x input)."""
+        """Fable 5.1: cache write $12.50 (1.25x input) / read $0.25 per MTok (explicit)."""
         cost = self._provider().calculate_actual_cost(
+            input_tokens=0,
+            output_tokens=0,
+            cache_creation_tokens=1_000_000,
+            cache_read_tokens=1_000_000,
+        )
+        assert cost["cache_write_cost"] == 12.50
+        assert cost["cache_read_cost"] == FABLE_CACHE_READ
+        # Savings are measured against full input price, so the cheaper
+        # read shows up as a bigger saving — not a silent no-op.
+        assert cost["savings"] == FABLE_INPUT - FABLE_CACHE_READ
+
+    def test_predecessor_keeps_standard_cache_read_derivation(self):
+        """Fable 5 (and every row without an explicit rate) still derives 0.1x."""
+        cost = self._provider(FABLE_PREDECESSOR).calculate_actual_cost(
             input_tokens=0,
             output_tokens=0,
             cache_creation_tokens=1_000_000,
@@ -176,8 +204,9 @@ class TestCostTrackerBaseline:
         assert "Baseline (Fable):" in report
         assert "Baseline (Opus)" not in report
 
-    def test_model_pricing_has_both_fable_and_opus(self):
+    def test_model_pricing_has_both_fable_generations_and_opus(self):
         from attune.cost_tracker import MODEL_PRICING
 
         assert MODEL_PRICING[FABLE] == {"input": FABLE_INPUT, "output": FABLE_OUTPUT}
+        assert MODEL_PRICING[FABLE_PREDECESSOR] == {"input": FABLE_INPUT, "output": FABLE_OUTPUT}
         assert MODEL_PRICING["claude-opus-4-8"] == {"input": 5.00, "output": 25.00}

--- a/tests/unit/progressive/test_workflow.py
+++ b/tests/unit/progressive/test_workflow.py
@@ -63,7 +63,7 @@ class TestLoadModelConfig:
 
         assert config["cheap"] == "gpt-4o-mini"
         assert config["capable"] == "claude-sonnet-5"
-        assert config["premium"] == "claude-fable-5"
+        assert config["premium"] == "claude-fable-5-1"
 
     def test_load_model_config_env_override(self, monkeypatch):
         """Test environment variable overrides."""
@@ -315,7 +315,7 @@ class TestProgressiveWorkflow:
 
         assert workflow._get_model_for_tier(Tier.CHEAP) == "gpt-4o-mini"
         assert workflow._get_model_for_tier(Tier.CAPABLE) == "claude-sonnet-5"
-        assert workflow._get_model_for_tier(Tier.PREMIUM) == "claude-fable-5"
+        assert workflow._get_model_for_tier(Tier.PREMIUM) == "claude-fable-5-1"
 
     def test_analyze_tier_result_empty(self):
         """Test analyzing empty tier result."""

--- a/tests/unit/progressive/test_workflow_integration.py
+++ b/tests/unit/progressive/test_workflow_integration.py
@@ -345,7 +345,7 @@ class TestProgressiveWorkflowModelSelection:
 
         assert cheap in ["gpt-4o-mini", "claude-haiku-4-5"]
         assert capable in ["claude-sonnet-5", "gpt-4o"]
-        assert premium in ["claude-fable-5", "o1"]
+        assert premium in ["claude-fable-5-1", "o1"]
 
 
 class TestEscalationEdgeCases:

--- a/tests/unit/test_model_tiers.py
+++ b/tests/unit/test_model_tiers.py
@@ -31,7 +31,7 @@ class TestResolveModel:
 
     def test_defaults_are_the_spec_tiers(self):
         assert _DEFAULTS == {
-            "premium": "claude-fable-5",
+            "premium": "claude-fable-5-1",
             "capable": "claude-sonnet-5",
             "cheap": "claude-haiku-4-5",
         }
@@ -78,6 +78,14 @@ class TestResolveModel:
     def test_defaults_are_known_models(self):
         assert set(_DEFAULTS.values()) <= _KNOWN_MODELS
 
+    def test_both_fable_generations_are_known_overrides(self, monkeypatch, caplog):
+        """Fable 5 is still served: pinning it must not trip the typo warning."""
+        assert {"claude-fable-5-1", "claude-fable-5"} <= _KNOWN_MODELS
+        monkeypatch.setenv(_ENV["premium"], "claude-fable-5")
+        with caplog.at_level(logging.WARNING, logger="attune.model_tiers"):
+            assert resolve_model("premium") == "claude-fable-5"
+        assert not [r for r in caplog.records if r.levelno == logging.WARNING]
+
 
 class TestFableExtras:
     def test_fable_gets_betas_and_fallbacks(self):
@@ -91,6 +99,9 @@ class TestFableExtras:
 
     def test_prefix_gating_covers_future_fable_ids(self):
         assert fable_extras("claude-fable-5-20260601") != {}
+
+    def test_fable_5_1_gets_the_same_extras(self):
+        assert fable_extras("claude-fable-5-1") == fable_extras("claude-fable-5")
 
     @pytest.mark.parametrize(
         "model",

--- a/tests/unit/test_model_tiers_drift.py
+++ b/tests/unit/test_model_tiers_drift.py
@@ -38,7 +38,7 @@ def test_known_models_match_canonical() -> None:
 
 
 def test_fable_extras_match_canonical() -> None:
-    for model in ("claude-fable-5", "claude-sonnet-5", "claude-haiku-4-5"):
+    for model in ("claude-fable-5-1", "claude-fable-5", "claude-sonnet-5", "claude-haiku-4-5"):
         assert ai_tiers.fable_extras(model) == rag_tiers.fable_extras(model)
 
 


### PR DESCRIPTION
## Summary

Retargets the premium tier from Claude Fable 5 to **Claude Fable 5.1** (`claude-fable-5-1`) and absorbs the two 5.1 breaking changes that touch this codebase.

**Retarget** (same $10/$50 per MTok, so no savings figures move): `attune.model_tiers._DEFAULTS`, registry premium entry, `cost_tracker.BASELINE_MODEL`, telemetry premium-id lists, `SpecRunner` default, config template, router docstring, the bulk skill (+ `.agents` mirror), the regenerated tier-routing help concept, the two bulk help projections (hand-edited — their regen path spends API budget), three blog guides' present-tense tier lines, CHANGELOG, and a new entry in `docs/specs/fable-premium-tier/decisions.md`. `claude-fable-5` stays served: known `ATTUNE_MODEL_PREMIUM` override, priced by id in `ADDITIONAL_MODELS`, still a `get_model_info` row. Historical docs (weekly reports, bug log, archived spec text, the dated cost blog post) keep their Fable 5 mentions on purpose.

**Fixed for 5.1:**
- **Curator forced `tool_choice`** — Fable 5.1 returns `400 tool_choice: type "tool" and "any" are not supported for this model`, which would have broken every default-tier briefing. Fable models now steer with `tool_choice: auto` (the prompt already says "call emit_curation exactly once") and keep the schema guarantee via strict tool use (`strict: true` + `additionalProperties: false` on every schema object). Non-fable pins keep the forced call. Pinned both ways in `tests/unit/curator/test_run_curator.py`.
- **Cache reads are $0.25/MTok on 5.1** (0.025x input; every other model derives 0.1x). `get_model_info` carries `cost_per_1m_cache_read` on the 5.1 row and `calculate_actual_cost` honors it; rows without the key keep the derivation. Pinned in `tests/unit/models/test_fable_pricing_consistency.py`.

**Checked, no change needed (inferred from grep, not live-verified):** 5.1 binds thinking blocks to the producing model and to the conversation prefix. No attune-ai call site replays prior assistant turns with thinking blocks through the raw SDK (the provider extracts text; escalation/retry rebuilds prompts; agent-factory adapters carry plain-text assistant turns).

**Not adopted, chair-callable:** `fallbacks: "default"` (array form still works and keeps the fallback target explicit for telemetry); per-message effort, `clear_at`, `thinking.display: "updates"`.

## ⚠ Merge order — drift guard is red by design

`attune.model_tiers` is a byte-mirror of `attune_rag.model_tiers`; CI installs attune-rag from PyPI (1.1.0 still says `claude-fable-5`), so `tests/unit/test_model_tiers_drift.py` fails on this PR until the canonical copy ships:

1. Merge + release Smart-AI-Memory/attune-rag#220 (≥1.2.0 to PyPI).
2. Re-run this PR's CI → drift lane green → merge.
3. attune-author carries the same mirror + drift test — needs the same retarget after (not in this PR).

## Receipts

| Claim | Probe | Result |
| --- | --- | --- |
| Full tree | `pytest tests` (3 drift tests deselected) | 25268 passed, 258 skipped, 3 xfailed |
| Drift guard vs installed attune-rag 1.1.0 | `pytest tests/unit/test_model_tiers_drift.py` | 1 failed (expected: predecessor default) |
| Drift guard vs attune-rag#220's branch | `PYTHONPATH=<rag-branch>/src pytest tests/unit/test_model_tiers_drift.py` | 5 passed |
| Mirror constants identical | `diff` of the `_DEFAULTS`…`_FABLE_FALLBACKS` block across both branches | identical |
| Gates | `tests/unit/gates`, skills-mirror + projection drift tests, in the full run | green |

No live API calls (budget cap is zero). Handoff: `docs/handoffs/claude-attune-ai-fable-5-1-64d292.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
