### PR TITLE
fix(lessons): curate the CRLF sub-lesson so the windows-crlf golden lands top-3; drop the strict xfail

### DIFF
--- a/.claude/lessons.md
+++ b/.claude/lessons.md
@@ -4169,10 +4169,12 @@ files.
   - **`Path.home()` reads `USERPROFILE`, not `HOME`** —
     `monkeypatch.setenv("HOME", ...)` silently no-ops on
     Windows; set BOTH env vars via a helper.
-  - **CRLF: the runner strips `\n` but leaves `\r`** —
-    `raw.decode(...).rstrip("\n")` leaves the CR, so exact
-    list-membership (`"text" in run.lines`, actual
-    `['text\r']`) fails while substring checks tolerate it.
+  - **CRLF: the runner strips `\n` but leaves a trailing
+    carriage return (`\r`) on every captured line** —
+    `raw.decode(...).rstrip("\n")` leaves the CR, so a test that
+    passes on macOS/Linux fails on Windows: exact list-membership
+    (`"text" in run.lines`, actual `['text\r']`) fails while
+    substring checks tolerate it.
     Fix: `[l.rstrip() for l in run.lines]` before the
     membership check. (PR #531; `run_meta_stdout.parse_line`
     already does `.rstrip("\r\n")`.)

--- a/tests/unit/lessons/test_lessons.py
+++ b/tests/unit/lessons/test_lessons.py
@@ -233,24 +233,7 @@ class TestGoldenSmoke:
     """Retrieval smoke against 3 frozen golden queries (real corpus)."""
 
     @pytest.mark.parametrize(
-        "query_id",
-        [
-            "pytest-cov-keyerror",
-            pytest.param(
-                "windows-crlf",
-                marks=pytest.mark.xfail(
-                    strict=True,
-                    reason=(
-                        "corpus dilution at the 2026-09-04 outbox sweep (#2404): "
-                        "the expected CRLF lesson scores 13.5 and sits at rank 4 "
-                        "behind a new backend-import-contexts lesson at 14.0; "
-                        "a keyword-precision fix should flip this back to XPASS "
-                        "(strict) — chair-ruled xfail, not a fixture edit"
-                    ),
-                ),
-            ),
-            "tag-before-squash",
-        ],
+        "query_id", ["pytest-cov-keyerror", "windows-crlf", "tag-before-squash"]
     )
     def test_golden_query_hits_top3(self, query_id):
         queries = json.loads(FIXTURE.read_text(encoding="utf-8"))["queries"]


### PR DESCRIPTION
## Summary

Restores the `windows-crlf` golden query (`tests/unit/lessons/test_lessons.py::TestGoldenSmoke::test_golden_query_hits_top3[windows-crlf]`) to a genuine pass and removes the `xfail(strict=True)` added by #2404. One PR, two files: a content curation of one sub-bullet in `.claude/lessons.md` and the marker revert. The golden fixture's expected list is untouched.

## Root cause (verified by scoring every entry of both expected lessons)

The query is "test passes on macOS but fails on Windows, the captured line has a trailing carriage return". The CRLF sub-lesson of the cross-platform mega-lesson said only "the runner strips `\n` but leaves `\r`". After tokenizing, `\r` is the token `r`; the words **carriage**, **return**, **trailing**, and **captured** appeared nowhere in that child doc or its parent. So the premise behind lever (a) in the brief — that the child doc "actually contains 'carriage return'" — was false: there was nothing for `split_atomic` to surface. The only tokens that matched were generic Windows-lesson tokens (`test`, `pass`, `fail`, `macos`, `windows`, `line`), which a dozen Windows-CI lessons share, so the new (genuine, non-duplicate) backend-import-contexts lesson from #2404 crowded the expected lesson out of the top 3.

## Fix: content curation, not a scorer change

The corpus's own ratified rule for this class (lesson "Corpus near-duplicates break retrieval-quality goldens by crowding — fix by CONSOLIDATING… the fix is content curation") applies. The sub-bullet head now states the symptom in the words a trap-moment query uses:

> **CRLF: the runner strips `\n` but leaves a trailing carriage return (`\r`) on every captured line** — … so a test that passes on macOS/Linux fails on Windows: exact list-membership … fails while substring checks tolerate it.

That is a factual description of PR #531's failure. No change to `LessonsIndex`, `split_atomic`, or attune-rag's `KeywordRetriever`: the child head already earns summary (1.5x) and content (1.0x) weight, so any code lever would have been tuning to this one query rather than fixing a mechanism.

## Rankings (merged corpus at 517925a77, `LessonsIndex(".claude/lessons.md").retrieve(q, k=10)`)

**Before** (`windows-crlf`):

| rank | score | lesson |
|---|---|---|
| 1 | 16.0 | all-windows-lanes-failing-on-your-pr-while-ubuntu-macos-are- |
| 2 | 15.0 | zsh-exists-only-on-the-macos-runners-ubuntu-and-windows-ci-l |
| 3 | 14.0 | backend-has-two-import-contexts-and-only-one-is-tested-by-de (new in #2404) |
| 4 | 13.5 | posix-file-mode-assertions-… **(expected)** |
| 10 | 11.5 | cross-platform-path-string-encoding-handling-… **(expected)** |

**After**:

| rank | score | lesson |
|---|---|---|
| 1 | 24.5 | cross-platform-path-string-encoding-handling-… **(expected)** |
| 2 | 16.0 | all-windows-lanes-failing-on-your-pr-while-ubuntu-macos-are- |
| 3 | 15.0 | zsh-exists-only-on-the-macos-runners-ubuntu-and-windows-ci-l |
| 4 | 14.0 | backend-has-two-import-contexts-and-only-one-is-tested-by-de |
| 5 | 13.5 | posix-file-mode-assertions-… (expected) |

Winning entry is the CRLF child doc: `path:2+summary:7+content:10`, an 8.5-point margin over rank 2.

**Other goldens, unchanged:** `pytest-cov-keyerror` rank 1 at 20.5; `tag-before-squash` rank 1 at 21.5 (identical top-10 before and after).

**Full 25-query golden set** (`docs/specs/archive/lessons-corpus-rag/golden_queries.json`, k=3, parent-collapsed):

| corpus | hit@1 | hit@3 | misses |
|---|---|---|---|
| origin/main before #2404 | 18/25 | 22/25 | pypi-env-gate, subscription-sdk-fail, codecov-patch-low |
| merged (#2404) before this PR | 18/25 | 21/25 | windows-crlf + the same three |
| merged + this PR | 19/25 | 22/25 | the same three pre-existing misses |

## Receipts

- `pytest tests/unit/lessons tests/unit/gates -q -rxX` → 448 passed, no xfail/xpass rows.
- `.claude/CLAUDE.md` does not mirror the cross-platform lesson (grep), so the core-mirror guard is unaffected.
- Pre-commit hooks ran on the commit (black, ruff, lessons-bulleted, brand-drift all passed); commit is GPG-signed.

## Not done / follow-ups

- The three pre-existing 25-query misses are untouched (out of scope).
- A general vocabulary bridge for escape notation (`\r` → "carriage return", `\n` → "newline") would live in attune-rag's tokenizer, a separate repo and release; not pursued because curation alone gives a wide margin.
- No D11 different-model review lane was run: the diff is a one-sub-bullet corpus curation plus a marker revert, the same class #2404 shipped under `auto-merge-when-green`. Chair's call whether to require one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
