### PR TITLE
fix(website): register the usage-digest cron on the trailing-slash path (Vercel Cron does not follow 308)

### DIFF
--- a/website/vercel.json
+++ b/website/vercel.json
@@ -3,7 +3,7 @@
   "trailingSlash": true,
   "crons": [
     {
-      "path": "/api/cron/usage-digest",
+      "path": "/api/cron/usage-digest/",
       "schedule": "0 12 * * *"
     }
   ],


### PR DESCRIPTION
## Summary

Follow-up to #2410. The site's `trailingSlash: true` makes `/api/cron/usage-digest` answer **308** → `/api/cron/usage-digest/`, and **Vercel Cron does not follow redirects**: per [Managing Cron Jobs → Cron jobs and redirects](https://vercel.com/docs/cron-jobs/manage-cron-jobs#cron-jobs-and-redirects), a 3xx is treated as the final response, and redirected invocations are not shown in the cron logs. The daily schedule would have fired and never reached the handler, silently.

One-line fix: the cron `path` now carries the trailing slash.

## Receipts (production, taken after #2410 deployed)

| Probe | Result |
|---|---|
| `GET /api/cron/usage-digest` (bare) | 308, `Location: /api/cron/usage-digest/` |
| `GET /api/cron/usage-digest/` no bearer | 401 `{"error":"Unauthorized"}` |
| `GET /api/cron/usage-digest/` wrong bearer | 401 |

So the handler runs and fails closed on the slash path, which is what the cron now targets.

## Also fixed out-of-band today

The first production deploy of #2410 **errored at build** because the `CRON_SECRET` I provisioned carried a trailing newline (`openssl rand -hex 32 | vercel env add` captured it; Vercel rejects whitespace in header values). Re-provisioned with `printf '%s'`, redeployed `ba24677`, now Ready and aliased. Value never displayed.

Website-only → no changelog entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
