### PR TITLE
fix(website): check each usage-digest auth header against its own secret

### DIFF
--- a/website/app/api/cron/usage-digest/route.ts
+++ b/website/app/api/cron/usage-digest/route.ts
@@ -2,9 +2,10 @@
  * `GET /api/cron/usage-digest` — daily usage digest email.
  *
  * Invoked by Vercel Cron (see `crons` in vercel.json), which sends
- * `Authorization: Bearer $CRON_SECRET`. Also callable by hand with the
- * same bearer token, or with `x-admin-secret: $ADMIN_SECRET`, so the
- * digest can be previewed or re-sent without waiting for the schedule.
+ * `Authorization: Bearer $CRON_SECRET`. Also callable by hand with
+ * `x-admin-secret: $ADMIN_SECRET` (each header is checked against its
+ * own secret), so the digest can be previewed or re-sent without
+ * waiting for the schedule.
  *
  * Behaviour:
  *   - No secret configured  → 500. Fails closed; never runs unauthenticated.
@@ -40,14 +41,19 @@ function secretsMatch(a: string, b: string): boolean {
  * nothing is authorized, so a misconfigured deploy cannot leak counts.
  */
 export function isAuthorized(req: NextRequest): boolean {
-  const secret = process.env.CRON_SECRET || process.env.ADMIN_SECRET;
-  if (!secret) return false;
+  // Each header is compared against ITS OWN secret. Picking one secret
+  // (`CRON_SECRET || ADMIN_SECRET`) and checking both headers against it
+  // meant that once CRON_SECRET existed, the admin header was compared
+  // against the cron secret and the manual path could never authorize.
+  const cron = process.env.CRON_SECRET;
+  const admin = process.env.ADMIN_SECRET;
+  if (!cron && !admin) return false;
 
   const auth = req.headers.get('authorization');
-  if (auth?.startsWith('Bearer ') && secretsMatch(auth.slice(7), secret)) return true;
+  if (cron && auth?.startsWith('Bearer ') && secretsMatch(auth.slice(7), cron)) return true;
 
   const header = req.headers.get('x-admin-secret');
-  if (header && secretsMatch(header, secret)) return true;
+  if (admin && header && secretsMatch(header, admin)) return true;
 
   return false;
 }

--- a/website/test/usage-digest.test.ts
+++ b/website/test/usage-digest.test.ts
@@ -152,6 +152,20 @@ describe('GET /api/cron/usage-digest', () => {
     expect(isAuthorized(req(undefined, { 'x-admin-secret': 'admin-secret' }))).toBe(true);
   });
 
+  it('checks each header against its own secret when BOTH are configured', () => {
+    // The production shape: CRON_SECRET for Vercel, ADMIN_SECRET for a human.
+    // A single `CRON_SECRET || ADMIN_SECRET` pick compared the admin header
+    // against the cron secret and locked the manual path out (found live
+    // 2026-09-04 with a real ADMIN_SECRET returning 401).
+    vi.stubEnv('CRON_SECRET', 'cron-secret');
+    vi.stubEnv('ADMIN_SECRET', 'admin-secret');
+    expect(isAuthorized(req(undefined, { 'x-admin-secret': 'admin-secret' }))).toBe(true);
+    expect(isAuthorized(req(undefined, { authorization: 'Bearer cron-secret' }))).toBe(true);
+    // Cross-use is not accepted: the admin value is not a bearer, and vice versa.
+    expect(isAuthorized(req(undefined, { 'x-admin-secret': 'cron-secret' }))).toBe(false);
+    expect(isAuthorized(req(undefined, { authorization: 'Bearer admin-secret' }))).toBe(false);
+  });
+
   it('sends the digest when there was activity', async () => {
     mockedCollect.mockResolvedValue(digest());
     const res = await GET(req(undefined, AUTH));


### PR DESCRIPTION
## Summary

Second follow-up to #2410, found by the chair running the manual path against production: `x-admin-secret: $ADMIN_SECRET` returned 401.

`isAuthorized` chose one secret, `CRON_SECRET || ADMIN_SECRET`, and compared **both** headers against it. With `CRON_SECRET` provisioned (which it now is), the admin header was compared against the cron secret, so the manual preview/re-send path could never authorize. The #2410 PR body's claim that the admin header works was wrong for the production configuration.

**Fix:** the bearer is checked against `CRON_SECRET` and `x-admin-secret` against `ADMIN_SECRET`, each only when its own secret is set. No cross-use.

**Why the suite was green:** the only admin-header test stubbed `CRON_SECRET` to empty, which is the one configuration where the bug cannot show. The new test sets both and pins all four directions (admin→admin ✓, bearer→cron ✓, admin value as bearer ✗, cron value as admin ✗).

## Receipts (worktree, own `npm ci`)

| Probe | Result |
|---|---|
| `vitest run test/usage-digest.test.ts` | 22 passed |
| `tsc --noEmit`, errors in touched files | 0 |
| `eslint` on both files | clean |

Post-merge receipt the chair can take, value never passing through the agent:

```bash
curl -s -H "x-admin-secret: $ADMIN_SECRET" 'https://smartaimemory.com/api/cron/usage-digest/?dry=1' | head -c 600
```

Website-only → no changelog entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
