### PR TITLE
fix(website): db/init fails closed on an unset or empty ADMIN_SECRET

### DIFF
--- a/website/.env.example
+++ b/website/.env.example
@@ -13,6 +13,9 @@ NEXT_PUBLIC_SITE_URL=https://smartaimemory.com
 DATABASE_URL=postgresql://user:password@host:5432/railway
 
 # Admin secret for database initialization (generate a random string)
+# Required for POST /api/db/init and the manual usage-digest path
+# (x-admin-secret header). Must be NON-EMPTY — a blank value is refused,
+# never treated as "no password". Generate one:  openssl rand -hex 32
 ADMIN_SECRET=your_random_admin_secret_here
 
 # ===========================================

--- a/website/app/api/db/init/route.ts
+++ b/website/app/api/db/init/route.ts
@@ -1,5 +1,26 @@
+import { timingSafeEqual } from 'node:crypto';
 import { NextRequest, NextResponse } from 'next/server';
 import { initializeDatabase } from '@/lib/db';
+
+/** Constant-time string compare that tolerates unequal lengths. */
+function secretsMatch(a: string, b: string): boolean {
+  const ab = Buffer.from(a, 'utf8');
+  const bb = Buffer.from(b, 'utf8');
+  if (ab.length !== bb.length) return false;
+  return timingSafeEqual(ab, bb);
+}
+
+/**
+ * Fails closed: with ADMIN_SECRET unset or EMPTY nothing is authorized.
+ * A plain `secret !== process.env.ADMIN_SECRET` let `{"secret": ""}`
+ * through whenever the variable existed with no value (found live
+ * 2026-09-04 — the production variable had been empty for 80 days).
+ */
+export function isAuthorized(secret: unknown): boolean {
+  const admin = process.env.ADMIN_SECRET;
+  if (!admin) return false;
+  return typeof secret === 'string' && secretsMatch(secret, admin);
+}
 
 // This endpoint initializes the database schema
 // Should only be called once during setup, protected by a secret
@@ -8,7 +29,7 @@ export async function POST(req: NextRequest) {
     // Check for admin secret
     const { secret } = await req.json();
 
-    if (secret !== process.env.ADMIN_SECRET) {
+    if (!isAuthorized(secret)) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 

--- a/website/test/db-init.test.ts
+++ b/website/test/db-init.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+vi.mock('@/lib/db', () => ({ initializeDatabase: vi.fn(async () => undefined) }));
+
+import { initializeDatabase } from '@/lib/db';
+import { POST, isAuthorized } from '@/app/api/db/init/route';
+import { NextRequest } from 'next/server';
+
+const mockedInit = vi.mocked(initializeDatabase);
+
+function post(body: unknown) {
+  return new NextRequest('https://smartaimemory.com/api/db/init', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  vi.unstubAllEnvs();
+  vi.stubEnv('DATABASE_URL', 'postgres://example');
+  mockedInit.mockClear();
+});
+
+describe('db/init isAuthorized', () => {
+  it('fails closed when ADMIN_SECRET is unset', () => {
+    vi.stubEnv('ADMIN_SECRET', '');
+    expect(isAuthorized('')).toBe(false);
+    expect(isAuthorized(undefined)).toBe(false);
+  });
+
+  it('refuses an EMPTY secret even when the variable exists but is blank', () => {
+    // The production variable sat blank for 80 days; `secret !== env` let
+    // `{"secret": ""}` through. Empty must never authorize.
+    vi.stubEnv('ADMIN_SECRET', '');
+    expect(isAuthorized('')).toBe(false);
+  });
+
+  it('accepts only the exact configured secret', () => {
+    vi.stubEnv('ADMIN_SECRET', 'admin-secret');
+    expect(isAuthorized('admin-secret')).toBe(true);
+    expect(isAuthorized('admin-secre')).toBe(false);
+    expect(isAuthorized('admin-secret ')).toBe(false);
+    expect(isAuthorized(42)).toBe(false);
+  });
+});
+
+describe('POST /api/db/init', () => {
+  it('returns 401 and does not touch the database with a blank secret and blank env', async () => {
+    vi.stubEnv('ADMIN_SECRET', '');
+    const res = await POST(post({ secret: '' }));
+    expect(res.status).toBe(401);
+    expect(mockedInit).not.toHaveBeenCalled();
+  });
+
+  it('initializes when the secret matches', async () => {
+    vi.stubEnv('ADMIN_SECRET', 'admin-secret');
+    const res = await POST(post({ secret: 'admin-secret' }));
+    expect(res.status).toBe(200);
+    expect(mockedInit).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
## Summary

Found while diagnosing the usage-digest manual path: production `ADMIN_SECRET` had existed for 80 days with an **empty** value. Two consequences, both fixed today.

**Code (this PR):** `POST /api/db/init` checked `secret !== process.env.ADMIN_SECRET`, so with a blank variable, `{"secret": ""}` authorized. `initializeDatabase` is `CREATE TABLE IF NOT EXISTS` throughout, so the exposure was an unauthenticated idempotent schema init rather than data loss. The route now fails closed on unset **or blank**, requires a string, and compares in constant time. Tests pin the blank/blank case, wrong and near-miss values, and the success path with `initializeDatabase` mocked. `.env.example` now says the value must be non-empty and how to generate it.

**Ops (done, not in the diff):** production `ADMIN_SECRET` rotated to a 32-byte random value and stored at `~/.attune/website.env` (0600) outside the repo, sourced by a guarded `.zshrc` line. Both sides verified equal by hash; the value never appeared in any transcript. Production redeployed so the new value is live.

## Receipts

| Probe | Result |
|---|---|
| `vitest run test/db-init.test.ts test/usage-digest.test.ts` | 27 passed |
| `tsc --noEmit`, errors in touched files | 0 |
| `eslint` on the route and test | clean |

Website-only → no changelog entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
