### PR TITLE
chore(website): finish the SendGrid retirement — env gates + privacy page

### DIFF
--- a/website/app/api/contact/route.ts
+++ b/website/app/api/contact/route.ts
@@ -56,7 +56,7 @@ export async function POST(request: NextRequest) {
       console.error('Database error (continuing anyway):', dbError);
     }
 
-    // Send email via SendGrid
+    // Send email via Resend
     const emailSent = await sendContactFormEmail({
       name,
       email,
@@ -65,7 +65,7 @@ export async function POST(request: NextRequest) {
       message,
     });
 
-    if (!emailSent && process.env.SENDGRID_API_KEY) {
+    if (!emailSent && process.env.RESEND_API_KEY) {
       console.warn('Failed to send contact form email, but returning success to user');
     }
 

--- a/website/app/api/newsletter/route.ts
+++ b/website/app/api/newsletter/route.ts
@@ -65,9 +65,9 @@ export async function POST(request: NextRequest) {
       console.warn('Mailchimp subscription failed:', mailchimpResult.error);
     }
 
-    // Send confirmation email via SendGrid
+    // Send confirmation email via Resend
     const emailSent = await sendNewsletterConfirmation(email);
-    if (!emailSent && process.env.SENDGRID_API_KEY) {
+    if (!emailSent && process.env.RESEND_API_KEY) {
       console.warn('Failed to send newsletter confirmation email');
     }
 

--- a/website/app/privacy/page.tsx
+++ b/website/app/privacy/page.tsx
@@ -82,7 +82,7 @@ export default function PrivacyPage() {
               <h2>4. Information Sharing and Disclosure</h2>
               <p>We do NOT sell your personal information. We may share information with:</p>
               <ul>
-                <li><strong>Service Providers:</strong> Email service providers (SendGrid), analytics (Plausible)</li>
+                <li><strong>Service Providers:</strong> Email service provider (Resend), analytics (Plausible)</li>
                 <li><strong>Legal Requirements:</strong> When required by law or to protect our rights</li>
                 <li><strong>Business Transfers:</strong> In connection with a merger, acquisition, or sale of assets</li>
               </ul>


### PR DESCRIPTION
Follow-up to #2414. Two `SENDGRID_API_KEY` gates in the contact and newsletter routes meant a failed send under Resend was never logged; they now key on `RESEND_API_KEY`. The privacy page named SendGrid as the email service provider; it now names Resend. Comments updated. Receipts: email + usage-digest vitest suites pass; eslint clean on the three files. Website-only, no changelog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)