### PR TITLE
fix(website): make a failed contact/newsletter send visible to the maintainer

### DIFF
--- a/website/app/api/contact/route.ts
+++ b/website/app/api/contact/route.ts
@@ -65,8 +65,11 @@ export async function POST(request: NextRequest) {
       message,
     });
 
-    if (!emailSent && process.env.RESEND_API_KEY) {
-      console.warn('Failed to send contact form email, but returning success to user');
+    if (!emailSent) {
+      // The visitor still gets a 200 (their submission is stored); the
+      // maintainer must be able to see the miss — at error level, and
+      // in the body so a production probe can read it.
+      console.error('contact form email NOT sent', { contactId, resendKeyPresent: Boolean(process.env.RESEND_API_KEY) });
     }
 
     // Log summary
@@ -80,6 +83,7 @@ export async function POST(request: NextRequest) {
       {
         success: true,
         message: 'Thank you! We will get back to you within 24-48 hours.',
+        emailSent,
       },
       { status: 200 }
     );

--- a/website/app/api/newsletter/route.ts
+++ b/website/app/api/newsletter/route.ts
@@ -67,8 +67,8 @@ export async function POST(request: NextRequest) {
 
     // Send confirmation email via Resend
     const emailSent = await sendNewsletterConfirmation(email);
-    if (!emailSent && process.env.RESEND_API_KEY) {
-      console.warn('Failed to send newsletter confirmation email');
+    if (!emailSent) {
+      console.error('newsletter confirmation email NOT sent', { resendKeyPresent: Boolean(process.env.RESEND_API_KEY) });
     }
 
     // Log summary
@@ -83,6 +83,7 @@ export async function POST(request: NextRequest) {
       {
         success: true,
         message: 'Successfully subscribed! Check your email for confirmation.',
+        emailSent,
       },
       { status: 200 }
     );


### PR DESCRIPTION
Retro 2026-09-04 item 3. Both routes returned `success: true` whether or not the email went out and warned only when a key existed, so two 'successful' test submissions produced no email while `RESEND_API_KEY` was blank. Visitor still gets 200; the miss is now an error-level log with the contact id and key presence, and the body carries `emailSent` so a production probe can read it. Receipts: eslint clean, tsc 0 errors in the routes, email + digest suites pass. Website-only, no changelog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)