### PR TITLE
feat(tooling): detached-HEAD push guard, worktree triage, Vercel probe (retro 09-04 items 1, 2, 4)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -73,6 +73,12 @@
             "command": "PY=$(command -v python3 || command -v python) && \"$PY\" \"$CLAUDE_PROJECT_DIR/src/attune/hooks/scripts/dirty_switch_guard.py\"",
             "timeout": 15,
             "statusMessage": "Dirty-tree switch check..."
+          },
+          {
+            "type": "command",
+            "command": "PY=$(command -v python3 || command -v python) && \"$PY\" \"$CLAUDE_PROJECT_DIR/src/attune/hooks/scripts/detached_head_push_guard.py\"",
+            "timeout": 10,
+            "statusMessage": "Detached-HEAD push check..."
           }
         ]
       }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Detached-HEAD push guard** (`src/attune/hooks/scripts/
+  detached_head_push_guard.py`, registered as a PreToolUse hook): refuses
+  `git push` while HEAD is detached, where the push moves the BRANCH ref
+  (unchanged) and reports "Everything up-to-date" with the remote a
+  commit behind — a foreign session's `checkout --detach` produced
+  exactly that on 2026-09-04. Explicit `HEAD:<ref>` and tag pushes
+  stay allowed; fail-open on unreadable git state;
+  `ATTUNE_ALLOW_DETACHED_PUSH=1` escape hatch.
+- **`scripts/worktree_triage.py`**: read-only worktree/branch triage
+  (cherry, plus whole-branch patch-id vs the PR merge commit to verify
+  squash merges) that emits a removal script for the chair to run. The
+  classifier behind the 2026-09-04 sweep (42 → 15 worktrees, 239 → 58
+  branches, nothing lost).
+- **`scripts/vercel_probe.py`**: read-only Vercel probe — env-var
+  NAMES with value length/prefix/digest (never values), `--expect` to
+  fail on blank secrets, `--domains` for per-project domain ATTACHMENT
+  via the API (the CLI's `domains inspect` reports ownership, which is
+  how a domain silently attached to a sibling project went unseen).
+
 ### Changed
 
 - **`attune-verify` cap widened `<0.6` → `<1.0`; `uv.lock` `0.2.2` → `0.5.0`.**

--- a/scripts/vercel_probe.py
+++ b/scripts/vercel_probe.py
@@ -115,24 +115,66 @@ def pull_env(env: str, cwd: Path) -> dict[str, str]:
         return out
 
 
-def env_report(env: str, cwd: Path, expect: list[str]) -> tuple[list[str], int]:
+#: Vercel env-var types whose values ``vercel env pull`` CAN return. A
+#: ``sensitive`` variable (integrations such as Neon set these) pulls back
+#: blank by design, and ``VERCEL_*`` system variables are injected at
+#: build time and never listed by the API — neither is "empty".
+PULLABLE_TYPES = {"encrypted", "plain"}
+
+
+def env_types(token: str, org: str, project_id: str) -> dict[str, str]:
+    """Map variable name -> Vercel type from the project env listing."""
+    if not (token and org and project_id):
+        return {}
+    try:
+        envs = _get(f"/v9/projects/{project_id}/env?teamId={org}", token).get("envs", [])
+    except (urllib.error.URLError, OSError, ValueError):
+        return {}
+    return {e.get("key", ""): e.get("type", "") for e in envs}
+
+
+def env_report(
+    env: str, cwd: Path, expect: list[str], types: dict[str, str] | None = None
+) -> tuple[list[str], int]:
+    """Describe every pulled variable; flag blanks only where a value was possible.
+
+    ``types`` (name -> Vercel type) comes from :func:`env_types`. Without
+    it every blank is flagged, which over-reports on projects with
+    integration-managed variables.
+    """
     values = pull_env(env, cwd)
+    types = types or {}
     lines = [f"env [{env}]: {len(values)} variables"]
     rc = 0
+
+    def pullable(name: str) -> bool:
+        if not types:
+            return True
+        return types.get(name, "system") in PULLABLE_TYPES
+
     for name in sorted(values):
         s = shape(values[name])
         flag = ""
         if s["len"] == 0:
-            flag = "  <-- EMPTY"
+            if not types or pullable(name):
+                flag = "  <-- EMPTY"
+            elif name in types:
+                flag = f"  ({types[name]}: not pullable)"
+            else:
+                flag = "  (system)"
         elif s["quoted"] or s["whitespace"]:
             flag = "  <-- quoted/whitespace"
         lines.append(
             f"  {name:<36} len={s['len']:<4} prefix={s['prefix']:<4} sha={s['sha12']}{flag}"
         )
     for name in expect:
-        if not shape(values.get(name, ""))["len"]:
-            lines.append(f"  MISSING OR EMPTY: {name}")
-            rc = 1
+        if shape(values.get(name, ""))["len"]:
+            continue
+        if types and not pullable(name) and name in types:
+            lines.append(f"  UNVERIFIABLE ({types[name]}): {name}")
+            continue
+        lines.append(f"  MISSING OR EMPTY: {name}")
+        rc = 1
     return lines, rc
 
 
@@ -145,7 +187,10 @@ def domains_report(token: str, org: str) -> list[str]:
             d["name"] + (f"(->{d['redirect']})" if d.get("redirect") else " [primary]")
             for d in doms
         )
-        lines.append(f"  {p['name']:<20} {rendered or '-'}")
+        # The API's ``name`` is the display name (it can differ from the
+        # CLI slug — attune-ai's "website" project is named after its
+        # domain), so the id is printed alongside for unambiguous matching.
+        lines.append(f"  {p['name']:<20} ({p['id'][:12]}) {rendered or '-'}")
     return lines
 
 
@@ -158,12 +203,12 @@ def main(argv: list[str]) -> int:
     args = ap.parse_args(argv[1:])
 
     cwd = Path(args.cwd).resolve()
-    lines, rc = env_report(args.env, cwd, args.expect)
+    token = _token()
+    org, project_id = _link(cwd)
+    lines, rc = env_report(args.env, cwd, args.expect, env_types(token, org, project_id))
     print("\n".join(lines))
 
     if args.domains:
-        token = _token()
-        org, _ = _link(cwd)
         if not token or not org:
             print("domains: no token or no .vercel/project.json link in cwd", file=sys.stderr)
             return max(rc, 1)

--- a/scripts/vercel_probe.py
+++ b/scripts/vercel_probe.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""Read-only Vercel probe: env-var SHAPES and domain ATTACHMENT, never values.
+
+Why this exists (retro 2026-09-04, item 1)
+------------------------------------------
+Three production faults that day were invisible to every green test and
+to ``vercel env ls``: ``ADMIN_SECRET`` had existed EMPTY for 80 days,
+``RESEND_API_KEY`` was pasted empty at the CLI prompt, and
+``smartaimemory.com`` had been silently ATTACHED to a sibling project.
+Each took ten-plus ad-hoc probes. ``vercel domains inspect`` reports
+domain OWNERSHIP, not attachment; only the project-domains API tells the
+truth. This script answers all three in one call and prints nothing a
+transcript could leak: for every env var it prints the name, targets,
+value LENGTH, a 3-char prefix, a quoted/whitespace flag, and a 12-hex
+digest; for every project it prints attached domains and redirects.
+
+Usage::
+
+    python scripts/vercel_probe.py [--project website] [--env production]
+                                   [--expect NAME ...] [--domains]
+
+``--expect`` names variables that MUST be non-empty in the chosen
+environment; the exit code is 1 when any is missing or blank, so the
+probe can gate a deploy step. ``--domains`` lists domain attachment
+for every project in the team.
+
+Credentials: the Vercel CLI's own token
+(``~/Library/Application Support/com.vercel.cli/auth.json`` or
+``$VERCEL_TOKEN``) and the ``.vercel/project.json`` link of the cwd.
+The token is sent in a header and never written anywhere.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under Apache 2.0
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+API = "https://api.vercel.com"
+
+
+def _token() -> str:
+    tok = os.environ.get("VERCEL_TOKEN")
+    if tok:
+        return tok
+    auth = Path.home() / "Library" / "Application Support" / "com.vercel.cli" / "auth.json"
+    if auth.exists():
+        return json.loads(auth.read_text()).get("token", "")
+    return ""
+
+
+def _link(cwd: Path) -> tuple[str, str]:
+    """Return (orgId, projectId) from the cwd's ``.vercel/project.json``."""
+    for d in (cwd, *cwd.parents):
+        p = d / ".vercel" / "project.json"
+        if p.exists():
+            j = json.loads(p.read_text())
+            return j.get("orgId", ""), j.get("projectId", "")
+    return "", ""
+
+
+def _get(path: str, token: str) -> dict:
+    req = urllib.request.Request(API + path, headers={"Authorization": f"Bearer {token}"})
+    with urllib.request.urlopen(req, timeout=30) as r:  # noqa: S310 - fixed https host
+        return json.load(r)
+
+
+def shape(value: str) -> dict:
+    """Describe a secret without revealing it."""
+    inner = value.strip().strip('"').strip("'")
+    return {
+        "len": len(inner),
+        "prefix": inner[:3] if inner else "",
+        "quoted": value[:1] in ('"', "'"),
+        "whitespace": value != value.strip(),
+        "sha12": hashlib.sha256(inner.encode()).hexdigest()[:12] if inner else "-",
+    }
+
+
+def pull_env(env: str, cwd: Path) -> dict[str, str]:
+    """``vercel env pull`` into a fresh 0600 temp file, parse, delete.
+
+    A path that already EXISTS makes the CLI block on an overwrite prompt
+    (``mktemp`` creates the file — so this uses a fresh name under a
+    private directory and passes ``--yes``).
+    """
+    with tempfile.TemporaryDirectory() as td:
+        target = Path(td) / f"vercel-{env}.env"
+        subprocess.run(
+            ["vercel", "env", "pull", "--yes", "--environment", env, str(target)],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            timeout=90,
+            check=False,
+        )
+        if not target.exists():
+            return {}
+        out: dict[str, str] = {}
+        for line in target.read_text().splitlines():
+            m = re.match(r"^([A-Za-z_][A-Za-z0-9_]*)=(.*)$", line)
+            if m:
+                out[m.group(1)] = m.group(2)
+        return out
+
+
+def env_report(env: str, cwd: Path, expect: list[str]) -> tuple[list[str], int]:
+    values = pull_env(env, cwd)
+    lines = [f"env [{env}]: {len(values)} variables"]
+    rc = 0
+    for name in sorted(values):
+        s = shape(values[name])
+        flag = ""
+        if s["len"] == 0:
+            flag = "  <-- EMPTY"
+        elif s["quoted"] or s["whitespace"]:
+            flag = "  <-- quoted/whitespace"
+        lines.append(
+            f"  {name:<36} len={s['len']:<4} prefix={s['prefix']:<4} sha={s['sha12']}{flag}"
+        )
+    for name in expect:
+        if not shape(values.get(name, ""))["len"]:
+            lines.append(f"  MISSING OR EMPTY: {name}")
+            rc = 1
+    return lines, rc
+
+
+def domains_report(token: str, org: str) -> list[str]:
+    lines = ["domain attachment (project -> domains):"]
+    projects = _get(f"/v9/projects?teamId={org}&limit=100", token).get("projects", [])
+    for p in projects:
+        doms = _get(f"/v9/projects/{p['id']}/domains?teamId={org}", token).get("domains", [])
+        rendered = ", ".join(
+            d["name"] + (f"(->{d['redirect']})" if d.get("redirect") else " [primary]")
+            for d in doms
+        )
+        lines.append(f"  {p['name']:<20} {rendered or '-'}")
+    return lines
+
+
+def main(argv: list[str]) -> int:
+    ap = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    ap.add_argument("--env", default="production")
+    ap.add_argument("--expect", nargs="*", default=[])
+    ap.add_argument("--domains", action="store_true")
+    ap.add_argument("--cwd", default=".")
+    args = ap.parse_args(argv[1:])
+
+    cwd = Path(args.cwd).resolve()
+    lines, rc = env_report(args.env, cwd, args.expect)
+    print("\n".join(lines))
+
+    if args.domains:
+        token = _token()
+        org, _ = _link(cwd)
+        if not token or not org:
+            print("domains: no token or no .vercel/project.json link in cwd", file=sys.stderr)
+            return max(rc, 1)
+        try:
+            print("\n".join(domains_report(token, org)))
+        except urllib.error.URLError as exc:
+            print(f"domains: API error {exc}", file=sys.stderr)
+            return max(rc, 1)
+    return rc
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/scripts/worktree_triage.py
+++ b/scripts/worktree_triage.py
@@ -1,0 +1,328 @@
+#!/usr/bin/env python3
+"""Worktree + branch triage: classify, then emit a removal script. Read-only.
+
+Why this exists (retro 2026-09-04, item 2)
+------------------------------------------
+The 2026-09-04 sweep took attune-ai from 42 worktrees / 239 branches to
+15 / 58 with zero content lost, using two scratch scripts. The
+classifier that made it safe is the part worth keeping:
+
+* ``git cherry -v origin/main <ref>`` marks single-commit branches
+  whose patch is on main with ``-`` — safe.
+* A SQUASH-merged multi-commit branch shows every commit as ``+``, so
+  cherry alone would hold it forever. The verifier: the whole branch's
+  patch-id (``git diff <merge-base> <branch> | git patch-id --stable``)
+  equals the PR merge commit's patch-id (``git show <merge-commit>
+  --format= | git patch-id --stable``) ⇒ fully merged, regardless of
+  commit count. Merge commits come from ``gh pr list --state all``.
+* A worktree with uncommitted changes is HELD, never removed, and its
+  dirty file NAMES are listed (never contents — filename smell test).
+* This session's own worktree and every branch with an OPEN PR are
+  excluded by construction.
+
+Nothing here mutates the repository. The ``script`` subcommand writes a
+shell script of ``git worktree remove`` / ``git branch -D`` lines for the
+chair to read and run — the auto-mode classifier blocks removals run
+by an agent even one at a time, and that is the correct boundary.
+
+Usage::
+
+    python scripts/worktree_triage.py worktrees [--repo PATH] [--self PATH]
+    python scripts/worktree_triage.py branches  [--repo PATH]
+    python scripts/worktree_triage.py script    [--repo PATH] [--self PATH] -o sweep.sh
+
+Copyright 2026 Smart-AI-Memory
+Licensed under Apache 2.0
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+BASE = "origin/main"
+
+
+# --------------------------------------------------------------------------
+# git / gh plumbing (thin, injectable for tests)
+# --------------------------------------------------------------------------
+
+
+def git(repo: Path, *args: str, inp: str | None = None) -> tuple[str, int]:
+    r = subprocess.run(
+        ["git", "-C", str(repo), *args], capture_output=True, text=True, input=inp, timeout=120
+    )
+    return r.stdout.strip(), r.returncode
+
+
+def patch_id(diff: str) -> str:
+    """Stable patch-id of a diff; ``(empty)`` when there is nothing to hash.
+
+    Two empties must never compare equal by accident — callers treat
+    ``(empty)`` as "no evidence", not "identical".
+    """
+    if not diff.strip():
+        return "(empty)"
+    out = subprocess.run(
+        ["git", "patch-id", "--stable"], capture_output=True, text=True, input=diff, timeout=60
+    ).stdout.split()
+    return out[0] if out else "(empty)"
+
+
+def merged_prs(repo: str) -> dict[str, list[tuple[int, str]]]:
+    """Map head branch -> [(pr number, merge commit oid)] for MERGED PRs."""
+    r = subprocess.run(
+        [
+            "gh",
+            "pr",
+            "list",
+            "--repo",
+            repo,
+            "--state",
+            "merged",
+            "--limit",
+            "1000",
+            "--json",
+            "number,headRefName,mergeCommit",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    out: dict[str, list[tuple[int, str]]] = {}
+    for p in json.loads(r.stdout or "[]"):
+        mc = p.get("mergeCommit") or {}
+        if mc.get("oid"):
+            out.setdefault(p["headRefName"], []).append((p["number"], mc["oid"]))
+    return out
+
+
+def open_pr_branches(repo: str) -> set[str]:
+    r = subprocess.run(
+        [
+            "gh",
+            "pr",
+            "list",
+            "--repo",
+            repo,
+            "--state",
+            "open",
+            "--limit",
+            "200",
+            "--json",
+            "headRefName",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    return {p["headRefName"] for p in json.loads(r.stdout or "[]")}
+
+
+# --------------------------------------------------------------------------
+# classification
+# --------------------------------------------------------------------------
+
+
+@dataclass
+class Row:
+    path: str
+    branch: str
+    head: str
+    dirty: list[str] = field(default_factory=list)
+    ahead: int = 0
+    cherry_minus: int = 0
+    cherry_plus: int = 0
+    squash_pr: int | None = None
+    is_self: bool = False
+    has_open_pr: bool = False
+    exists: bool = True
+    verdict: str = ""
+
+
+def squash_verified(repo: Path, ref: str, prs: list[tuple[int, str]]) -> int | None:
+    """Return the PR number whose merge commit's patch-id equals the branch's, else None."""
+    mb, rc = git(repo, "merge-base", BASE, ref)
+    if rc != 0:
+        return None
+    branch_pid = patch_id(git(repo, "diff", mb, ref)[0])
+    if branch_pid == "(empty)":
+        return None
+    for num, oid in prs:
+        merge_pid = patch_id(git(repo, "show", oid, "--format=")[0])
+        if merge_pid != "(empty)" and merge_pid == branch_pid:
+            return num
+    return None
+
+
+def classify(row: Row) -> str:
+    if row.is_self:
+        return "KEEP (this session)"
+    if not row.exists:
+        return "PRUNE-ENTRY (dir missing)"
+    if row.has_open_pr:
+        return "KEEP (open PR)"
+    if row.dirty:
+        return f"HOLD (dirty {len(row.dirty)})"
+    if row.ahead == 0:
+        return "REMOVE (nothing ahead)"
+    if row.cherry_plus == 0:
+        return "REMOVE (all patches on main)"
+    if row.squash_pr is not None:
+        return f"REMOVE (squash-verified #{row.squash_pr})"
+    return f"REVIEW (+{row.cherry_plus} unverified)"
+
+
+def fill(repo: Path, row: Row, merged: dict[str, list[tuple[int, str]]]) -> Row:
+    ref = row.head
+    ahead, _ = git(repo, "rev-list", "--count", f"{BASE}..{ref}")
+    row.ahead = int(ahead or 0)
+    ch, _ = git(repo, "cherry", BASE, ref)
+    row.cherry_minus = sum(1 for line in ch.splitlines() if line.startswith("-"))
+    row.cherry_plus = sum(1 for line in ch.splitlines() if line.startswith("+"))
+    if row.cherry_plus and row.branch in merged:
+        row.squash_pr = squash_verified(repo, ref, merged[row.branch])
+    row.verdict = classify(row)
+    return row
+
+
+def worktree_rows(repo: Path, self_path: Path | None, merged, open_prs) -> list[Row]:
+    porcelain, _ = git(repo, "worktree", "list", "--porcelain")
+    rows: list[Row] = []
+    cur: dict[str, str] = {}
+    for line in porcelain.splitlines() + [""]:
+        if not line:
+            if cur:
+                path = Path(cur["worktree"])
+                if path.resolve() != repo.resolve():
+                    branch = cur.get("branch", "").replace("refs/heads/", "") or "(detached)"
+                    row = Row(
+                        path=str(path),
+                        branch=branch,
+                        head=cur.get("HEAD", ""),
+                        is_self=(self_path is not None and path.resolve() == self_path.resolve()),
+                        has_open_pr=branch in open_prs,
+                        exists=path.exists(),
+                    )
+                    if row.exists:
+                        st, _ = git(path, "status", "--porcelain")
+                        row.dirty = [line[3:] for line in st.splitlines() if line.strip()]
+                        fill(repo, row, merged)
+                    else:
+                        row.verdict = classify(row)
+                    rows.append(row)
+            cur = {}
+            continue
+        k, _, v = line.partition(" ")
+        cur[k] = v
+    return rows
+
+
+def branch_rows(repo: Path, merged, open_prs) -> list[Row]:
+    """Local branches not checked out anywhere, with a gone or absent upstream."""
+    checked_out = {r.branch for r in worktree_rows(repo, None, {}, set())}
+    fmt = "%(refname:short)|%(upstream:short)|%(upstream:track)"
+    out, _ = git(repo, "for-each-ref", f"--format={fmt}", "refs/heads/")
+    rows: list[Row] = []
+    for line in out.splitlines():
+        br, up, track = line.split("|")
+        if br == "main" or br in checked_out:
+            continue
+        if up and track != "[gone]":
+            continue  # live upstream: not ours to judge
+        head, _ = git(repo, "rev-parse", br)
+        row = Row(path="", branch=br, head=head, has_open_pr=br in open_prs)
+        fill(repo, row, merged)
+        rows.append(row)
+    return rows
+
+
+# --------------------------------------------------------------------------
+# rendering
+# --------------------------------------------------------------------------
+
+
+def render_table(rows: list[Row]) -> str:
+    lines = [
+        "| verdict | path/branch | dirty | ahead | cherry | squash PR |",
+        "|---|---|---|---|---|---|",
+    ]
+    for r in sorted(rows, key=lambda r: (r.verdict, r.path or r.branch)):
+        where = r.path or r.branch
+        if r.path:
+            where = f"{r.path} [{r.branch}]"
+        lines.append(
+            f"| {r.verdict} | {where} | {len(r.dirty)} | {r.ahead} | -{r.cherry_minus}/+{r.cherry_plus} | {r.squash_pr or '-'} |"
+        )
+    return "\n".join(lines)
+
+
+def render_script(repo: Path, wt_rows: list[Row], br_rows: list[Row]) -> str:
+    lines = [
+        "#!/bin/zsh",
+        "# Generated by scripts/worktree_triage.py — read every line before running.",
+        "# Only REMOVE verdicts appear here; HOLD/REVIEW/KEEP rows are deliberately absent.",
+        f'R="{repo}"',
+        "",
+    ]
+    freed: list[str] = []
+    for r in wt_rows:
+        if r.verdict.startswith("REMOVE"):
+            lines.append(f'git -C "$R" worktree remove "{r.path}" || echo "FAILED: {r.path}"')
+            if r.branch != "(detached)":
+                freed.append(r.branch)
+    lines += ["", 'git -C "$R" worktree prune', ""]
+    for b in freed:
+        lines.append(f'git -C "$R" branch -D "{b}" || echo "FAILED: {b}"')
+    lines.append("")
+    for r in br_rows:
+        if r.verdict.startswith("REMOVE"):
+            lines.append(f'git -C "$R" branch -D "{r.branch}"  # {r.verdict}')
+    lines += [
+        "",
+        'echo "remaining worktrees:"; git -C "$R" worktree list',
+        'echo "remaining local branches: $(git -C "$R" branch --list | wc -l | tr -d \' \')"',
+    ]
+    return "\n".join(lines) + "\n"
+
+
+def main(argv: list[str]) -> int:
+    ap = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    ap.add_argument("cmd", choices=["worktrees", "branches", "script"])
+    ap.add_argument("--repo", default=".")
+    ap.add_argument(
+        "--self", dest="self_path", default=None, help="this session's worktree (never removed)"
+    )
+    ap.add_argument("--gh-repo", default="Smart-AI-Memory/attune-ai")
+    ap.add_argument("-o", "--out", default=None)
+    args = ap.parse_args(argv[1:])
+
+    repo = Path(args.repo).resolve()
+    self_path = Path(args.self_path).resolve() if args.self_path else None
+    merged = merged_prs(args.gh_repo)
+    open_prs = open_pr_branches(args.gh_repo)
+
+    if args.cmd == "worktrees":
+        print(render_table(worktree_rows(repo, self_path, merged, open_prs)))
+    elif args.cmd == "branches":
+        print(render_table(branch_rows(repo, merged, open_prs)))
+    else:
+        text = render_script(
+            repo,
+            worktree_rows(repo, self_path, merged, open_prs),
+            branch_rows(repo, merged, open_prs),
+        )
+        if args.out:
+            Path(args.out).write_text(text)
+            print(f"wrote {args.out}")
+        else:
+            print(text, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/src/attune/hooks/scripts/detached_head_push_guard.py
+++ b/src/attune/hooks/scripts/detached_head_push_guard.py
@@ -168,10 +168,37 @@ def main(ctx: dict[str, Any]) -> int:
     return 2
 
 
-if __name__ == "__main__":
+def _read_stdin_context() -> dict[str, Any]:
+    """Parse the hook context from stdin; empty dict when unavailable."""
     try:
         raw = sys.stdin.read()
-        payload = json.loads(raw) if raw.strip() else {}
     except (OSError, ValueError):
-        payload = {}
-    raise SystemExit(main(payload))
+        return {}
+    if not raw.strip():
+        return {}
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError:
+        return {}
+    return parsed if isinstance(parsed, dict) else {}
+
+
+if __name__ == "__main__":
+    from _bootstrap import ensure_utf8_stdio
+
+    ensure_utf8_stdio()
+    from _sdk_gate import exit_if_sdk_subprocess
+
+    exit_if_sdk_subprocess()
+    ctx = _read_stdin_context()
+    if not ctx:
+        sys.exit(0)
+    try:
+        sys.exit(main(ctx))
+    except Exception as exc:  # noqa: BLE001
+        # INTENTIONAL: a hook bug must never block real work.
+        print(
+            f"[{ENFORCEMENT_NAME}] hook error (allowing): {type(exc).__name__}: {exc}",
+            file=sys.stderr,
+        )
+        sys.exit(0)

--- a/src/attune/hooks/scripts/detached_head_push_guard.py
+++ b/src/attune/hooks/scripts/detached_head_push_guard.py
@@ -1,0 +1,177 @@
+"""PreToolUse hook: refuse ``git push`` while HEAD is detached.
+
+The bug class (2026-09-04, retro item 4): a concurrent session ran
+``git checkout --detach`` in this worktree between two of my commits (the
+corpus itself recommends that to free a branch). The next commit landed on
+the detached HEAD, and ``git push`` then printed ``Everything up-to-date``
+— a true statement about the BRANCH ref, which had not moved — while the
+remote was one commit behind. The PR was reviewed on stale content until
+``git ls-remote`` was compared with ``git rev-parse HEAD`` by hand.
+
+The check is mechanical: ``git symbolic-ref -q HEAD`` fails exactly when
+HEAD is detached. When it does, the push is refused with the recovery
+that re-attaches by fast-forward.
+
+What is NOT blocked, deliberately:
+- Any command that is not a ``git push``.
+- Pushes with an explicit ``HEAD:<ref>`` refspec — the operator is
+  pushing the detached commit on purpose.
+- Pushing tags (``--tags`` / ``refs/tags/...``) — unaffected by HEAD.
+- Anything when git state cannot be read (fail open — a hook bug must
+  never block work).
+
+Escape hatch: ``ATTUNE_ALLOW_DETACHED_PUSH=1``.
+
+Claude Code Protocol:
+    stdin: JSON with tool_name and tool_input
+    exit 0: allow tool call
+    exit 2: block tool call (stderr printed to user)
+
+Metrics: one line per fire in ~/.attune/enforcement-metrics.jsonl, the
+same ledger the other guards use.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under Apache 2.0
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+ENFORCEMENT_NAME = "detached-head-push-guard"
+METRICS_LOG = Path.home() / ".attune" / "enforcement-metrics.jsonl"
+ALLOW_ENV = "ATTUNE_ALLOW_DETACHED_PUSH"
+
+_HERE = Path(__file__).resolve().parent
+
+
+def _load_git_invocations():
+    """Reuse the sibling guard's shell-aware git tokenizer."""
+    spec = importlib.util.spec_from_file_location("_dsg", _HERE / "dirty_switch_guard.py")
+    if spec is None or spec.loader is None:  # pragma: no cover - packaging fault
+        return None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod.git_invocations
+
+
+def _log_metric(outcome: str, detail: str | None = None) -> None:
+    try:
+        METRICS_LOG.parent.mkdir(parents=True, exist_ok=True)
+        record = {
+            "ts": datetime.now(timezone.utc).isoformat(),
+            "enforcement": ENFORCEMENT_NAME,
+            "outcome": outcome,
+            "detail": detail,
+        }
+        with METRICS_LOG.open("a", encoding="utf-8") as f:
+            f.write(json.dumps(record) + "\n")
+    except OSError:
+        # INTENTIONAL: metrics are best-effort; never block on them.
+        pass
+
+
+def is_branch_push(args: list[str]) -> bool:
+    """True if ``args`` is a ``git push`` whose target depends on HEAD.
+
+    Explicit ``HEAD:<ref>`` refspecs and tag pushes are the operator
+    stating intent that does not need an attached HEAD.
+    """
+    if not args or args[0] != "push":
+        return False
+    rest = args[1:]
+    if "--tags" in rest:
+        return False
+    for token in rest:
+        if token.startswith("HEAD:") or token.startswith("refs/tags/"):
+            return False
+    return True
+
+
+def detached_head(cwd: Path | None = None) -> bool | None:
+    """True if HEAD is detached, False if on a branch, None if unreadable."""
+    try:
+        result = subprocess.run(
+            ["git", "symbolic-ref", "-q", "HEAD"],
+            cwd=str(cwd) if cwd else None,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=10,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if result.returncode == 0:
+        return False
+    if result.returncode == 1 and not result.stderr.strip():
+        return True  # detached: symbolic-ref -q exits 1 silently
+    return None  # not a git repo, or some other failure
+
+
+def block_message(cwd: Path | None = None) -> str:
+    head = "?"
+    try:
+        head = (
+            subprocess.run(
+                ["git", "rev-parse", "--short", "HEAD"],
+                cwd=str(cwd) if cwd else None,
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=10,
+            ).stdout.strip()
+            or "?"
+        )
+    except (OSError, subprocess.SubprocessError):
+        pass
+    return (
+        f"BLOCKED: HEAD is detached at {head} — a `git push` here pushes the BRANCH ref, "
+        "not this commit, and reports 'Everything up-to-date' while the remote stays behind.\n"
+        "  Something moved HEAD off the branch (another session's `checkout --detach`, "
+        "a rebase, a hook). Re-attach by fast-forward, then push:\n"
+        "    git branch --show-current            # prints nothing when detached\n"
+        "    git merge-base --is-ancestor <branch> HEAD && git checkout -B <branch> HEAD\n"
+        "  Or push the commit explicitly: git push origin HEAD:<branch>\n"
+        f"  Escape hatch for a deliberate detached push: {ALLOW_ENV}=1"
+    )
+
+
+def main(ctx: dict[str, Any]) -> int:
+    if os.environ.get(ALLOW_ENV) == "1":
+        return 0
+    if ctx.get("tool_name") != "Bash":
+        return 0
+    command = (ctx.get("tool_input") or {}).get("command", "")
+    if "push" not in command:
+        return 0
+    git_invocations = _load_git_invocations()
+    if git_invocations is None:
+        return 0
+    if not any(is_branch_push(args) for args in git_invocations(command)):
+        return 0
+    state = detached_head()
+    if state is None:
+        _log_metric("unknown", "git state unreadable")
+        return 0
+    if not state:
+        _log_metric("allowed")
+        return 0
+    _log_metric("fired", command[:200])
+    print(block_message(), file=sys.stderr)
+    return 2
+
+
+if __name__ == "__main__":
+    try:
+        raw = sys.stdin.read()
+        payload = json.loads(raw) if raw.strip() else {}
+    except (OSError, ValueError):
+        payload = {}
+    raise SystemExit(main(payload))

--- a/tests/unit/gates/test_broad_except_ratchet.py
+++ b/tests/unit/gates/test_broad_except_ratchet.py
@@ -140,6 +140,9 @@ _BASELINE: dict[str, int] = {
     # so a bug in the guard can never block real work — a guard that
     # crashes must fail OPEN (exit 0), matching every sibling hook here.
     "src/attune/hooks/scripts/dirty_switch_guard.py": 1,
+    # detached_head_push_guard: same fail-open __main__ block as its
+    # sibling above — a guard that crashes must exit 0, never block.
+    "src/attune/hooks/scripts/detached_head_push_guard.py": 1,
     "src/attune/hooks/scripts/evaluate_session.py": 3,
     # format_on_save added 1 for library-review L3 (PR #2117): the
     # PostToolUse exit-0-always contract must survive wrong-typed

--- a/tests/unit/gates/test_path_validation_gate.py
+++ b/tests/unit/gates/test_path_validation_gate.py
@@ -83,6 +83,9 @@ ALLOWLIST = frozenset(
         # user- or LLM-supplied component. Same shape and same path as
         # worktree_path_guard below.
         "src/attune/hooks/scripts/dirty_switch_guard.py",
+        # detached_head_push_guard: identical shape — appends only to the
+        # constant enforcement-metrics log, no interpolated component.
+        "src/attune/hooks/scripts/detached_head_push_guard.py",
         "src/attune/hooks/scripts/worktree_path_guard.py",
         "src/attune/help/feedback.py",
         "src/attune/help/generator.py",

--- a/tests/unit/hooks/test_detached_head_push_guard.py
+++ b/tests/unit/hooks/test_detached_head_push_guard.py
@@ -11,6 +11,7 @@ Licensed under the Apache License, Version 2.0
 from __future__ import annotations
 
 import importlib.util
+import json
 import os
 import subprocess
 import sys
@@ -135,3 +136,97 @@ class TestFailOpen:
     def test_unparseable_command_allows(self, mod, repo):
         _git(repo, "checkout", "-q", "--detach")
         assert mod.main(_ctx('git push "unbalanced')) == 0
+
+
+class TestStdinAndEntrypoint:
+    def test_read_stdin_context_shapes(self, mod, monkeypatch):
+        import io
+
+        for raw, expect in (
+            ("", {}),
+            ("   ", {}),
+            ("not json", {}),
+            ("[1,2]", {}),
+            ('{"a": 1}', {"a": 1}),
+        ):
+            monkeypatch.setattr(sys, "stdin", io.StringIO(raw))
+            assert mod._read_stdin_context() == expect
+
+    def test_script_round_trip_blocks_on_detached_head(self, repo):
+        """The real entrypoint: stdin JSON -> exit 2 + recovery text on stderr."""
+        _git(repo, "checkout", "-q", "--detach")
+        payload = json.dumps(
+            {"tool_name": "Bash", "tool_input": {"command": "git push origin main"}}
+        )
+        r = subprocess.run(
+            [sys.executable, str(SCRIPT_PATH)],
+            input=payload,
+            capture_output=True,
+            text=True,
+            cwd=repo,
+            timeout=30,
+        )
+        assert r.returncode == 2
+        assert "HEAD is detached" in r.stderr
+
+    def test_script_round_trip_allows_on_branch(self, repo):
+        payload = json.dumps(
+            {"tool_name": "Bash", "tool_input": {"command": "git push origin main"}}
+        )
+        r = subprocess.run(
+            [sys.executable, str(SCRIPT_PATH)],
+            input=payload,
+            capture_output=True,
+            text=True,
+            cwd=repo,
+            timeout=30,
+        )
+        assert r.returncode == 0
+
+    def test_script_round_trip_empty_stdin_allows(self, repo):
+        r = subprocess.run(
+            [sys.executable, str(SCRIPT_PATH)],
+            input="",
+            capture_output=True,
+            text=True,
+            cwd=repo,
+            timeout=30,
+        )
+        assert r.returncode == 0
+
+
+class TestFailOpenBranches:
+    """Every path where the guard cannot know must ALLOW, and never raise."""
+
+    def test_metrics_log_unwritable_is_swallowed(self, mod, tmp_path, monkeypatch):
+        blocker = tmp_path / "not-a-dir"
+        blocker.write_text("file, not a directory")
+        monkeypatch.setattr(mod, "METRICS_LOG", blocker / "metrics.jsonl")
+        mod._log_metric("fired", "x")  # OSError inside -> swallowed
+
+    def test_detached_head_unreadable_git(self, mod, monkeypatch):
+        def boom(*a, **k):
+            raise OSError("no git")
+
+        monkeypatch.setattr(mod.subprocess, "run", boom)
+        assert mod.detached_head() is None
+
+    def test_block_message_survives_unreadable_git(self, mod, monkeypatch):
+        def boom(*a, **k):
+            raise OSError("no git")
+
+        monkeypatch.setattr(mod.subprocess, "run", boom)
+        assert "HEAD is detached at ?" in mod.block_message()
+
+    def test_main_allows_when_tokenizer_unavailable(self, mod, monkeypatch, repo):
+        _git(repo, "checkout", "-q", "--detach")
+        monkeypatch.setattr(mod, "_load_git_invocations", lambda: None)
+        assert mod.main(_ctx("git push origin main")) == 0
+
+    def test_main_allows_on_unknown_state(self, mod, monkeypatch, repo):
+        monkeypatch.setattr(mod, "detached_head", lambda cwd=None: None)
+        assert mod.main(_ctx("git push origin main")) == 0
+
+    def test_main_ignores_commands_without_push_word(self, mod, repo):
+        _git(repo, "checkout", "-q", "--detach")
+        assert mod.main(_ctx("git status")) == 0

--- a/tests/unit/hooks/test_detached_head_push_guard.py
+++ b/tests/unit/hooks/test_detached_head_push_guard.py
@@ -1,0 +1,137 @@
+"""Tests for the detached-HEAD push guard PreToolUse hook.
+
+Covers the push classification, the block decision against a REAL git
+repository in both states, the explicit-refspec and tag carve-outs, and
+the fail-open paths.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under the Apache License, Version 2.0
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCRIPT_PATH = REPO_ROOT / "src" / "attune" / "hooks" / "scripts" / "detached_head_push_guard.py"
+
+
+@pytest.fixture(scope="module")
+def mod():
+    spec = importlib.util.spec_from_file_location("_detached_head_push_guard", SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None
+    m = importlib.util.module_from_spec(spec)
+    sys.modules["_detached_head_push_guard"] = m
+    spec.loader.exec_module(m)
+    return m
+
+
+def _ctx(command: str) -> dict:
+    return {"tool_name": "Bash", "tool_input": {"command": command}}
+
+
+def _git(repo: Path, *args: str) -> None:
+    env = {
+        **os.environ,
+        "GIT_AUTHOR_NAME": "t",
+        "GIT_AUTHOR_EMAIL": "t@x",
+        "GIT_COMMITTER_NAME": "t",
+        "GIT_COMMITTER_EMAIL": "t@x",
+        "HOME": str(repo),
+    }
+    subprocess.run(
+        ["git", "-C", str(repo), "-c", "commit.gpgsign=false", *args],
+        check=True,
+        capture_output=True,
+        env=env,
+        timeout=30,
+    )
+
+
+@pytest.fixture()
+def repo(tmp_path, monkeypatch):
+    r = tmp_path / "repo"
+    r.mkdir()
+    _git(r, "init", "-q", "-b", "main")
+    _git(r, "commit", "--allow-empty", "-q", "-m", "one")
+    _git(r, "commit", "--allow-empty", "-q", "-m", "two")
+    monkeypatch.chdir(r)
+    monkeypatch.delenv("ATTUNE_ALLOW_DETACHED_PUSH", raising=False)
+    return r
+
+
+class TestClassification:
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            "git push",
+            "git push origin main",
+            "git push -u origin feat/x",
+            "git push --force-with-lease origin feat/x",
+        ],
+    )
+    def test_branch_pushes(self, mod, cmd):
+        assert mod.is_branch_push(mod._load_git_invocations()(cmd)[0]) is True
+
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            "git push origin HEAD:feat/x",
+            "git push --tags",
+            "git push origin refs/tags/v1.0.0",
+            "git status",
+            "git pull",
+        ],
+    )
+    def test_carve_outs_and_non_pushes(self, mod, cmd):
+        invs = mod._load_git_invocations()(cmd)
+        assert not any(mod.is_branch_push(a) for a in invs)
+
+    def test_push_behind_a_harmless_command_is_still_seen(self, mod):
+        invs = mod._load_git_invocations()("git status && git push origin main")
+        assert any(mod.is_branch_push(a) for a in invs)
+
+
+class TestDecision:
+    def test_attached_head_allows(self, mod, repo):
+        assert mod.detached_head(repo) is False
+        assert mod.main(_ctx("git push origin main")) == 0
+
+    def test_detached_head_blocks(self, mod, repo, capsys):
+        _git(repo, "checkout", "-q", "--detach")
+        assert mod.detached_head(repo) is True
+        assert mod.main(_ctx("git push origin main")) == 2
+        err = capsys.readouterr().err
+        assert "HEAD is detached" in err and "checkout -B" in err
+
+    def test_detached_head_allows_explicit_refspec(self, mod, repo):
+        _git(repo, "checkout", "-q", "--detach")
+        assert mod.main(_ctx("git push origin HEAD:main")) == 0
+
+    def test_escape_hatch(self, mod, repo, monkeypatch):
+        _git(repo, "checkout", "-q", "--detach")
+        monkeypatch.setenv("ATTUNE_ALLOW_DETACHED_PUSH", "1")
+        assert mod.main(_ctx("git push origin main")) == 0
+
+    def test_non_bash_tool_is_ignored(self, mod, repo):
+        _git(repo, "checkout", "-q", "--detach")
+        assert mod.main({"tool_name": "Edit", "tool_input": {}}) == 0
+
+
+class TestFailOpen:
+    def test_outside_a_repo_allows(self, mod, tmp_path, monkeypatch):
+        plain = tmp_path / "plain"
+        plain.mkdir()
+        monkeypatch.chdir(plain)
+        assert mod.detached_head(plain) is None
+        assert mod.main(_ctx("git push origin main")) == 0
+
+    def test_unparseable_command_allows(self, mod, repo):
+        _git(repo, "checkout", "-q", "--detach")
+        assert mod.main(_ctx('git push "unbalanced')) == 0

--- a/tests/unit/scripts/test_vercel_probe.py
+++ b/tests/unit/scripts/test_vercel_probe.py
@@ -144,3 +144,58 @@ class TestDomainsReport:
         assert any(
             "/v9/projects/p1/domains" in c for c in calls
         )  # attachment endpoint, not /v4/domains
+
+
+class TestMain:
+    def test_main_prints_env_and_domains_and_exit_code(self, mod, monkeypatch, tmp_path, capsys):
+        monkeypatch.setattr(
+            mod, "pull_env", lambda env, cwd: {"RESEND_API_KEY": "re_" + "x" * 33, "PGHOST": ""}
+        )
+        monkeypatch.setattr(mod, "_token", lambda: "tok")
+        monkeypatch.setattr(mod, "_link", lambda cwd: ("org", "prj"))
+        monkeypatch.setattr(
+            mod, "env_types", lambda t, o, p: {"RESEND_API_KEY": "encrypted", "PGHOST": "sensitive"}
+        )
+        monkeypatch.setattr(
+            mod,
+            "domains_report",
+            lambda t, o: [
+                "domain attachment (project -> domains):",
+                "  website (prj) x.com [primary]",
+            ],
+        )
+        rc = mod.main(["x", "--cwd", str(tmp_path), "--expect", "RESEND_API_KEY", "--domains"])
+        out = capsys.readouterr().out
+        assert (
+            rc == 0 and "prefix=re_" in out and "not pullable" in out and "x.com [primary]" in out
+        )
+        assert "x" * 20 not in out
+
+    def test_main_without_link_reports_and_fails_domains(self, mod, monkeypatch, tmp_path, capsys):
+        monkeypatch.setattr(mod, "pull_env", lambda env, cwd: {})
+        monkeypatch.setattr(mod, "_token", lambda: "")
+        monkeypatch.setattr(mod, "_link", lambda cwd: ("", ""))
+        rc = mod.main(["x", "--cwd", str(tmp_path), "--domains"])
+        assert rc == 1 and "no token" in capsys.readouterr().err
+
+    def test_env_types_degrades_to_empty_on_api_error(self, mod, monkeypatch):
+        import urllib.error
+
+        def boom(path, token):
+            raise urllib.error.URLError("down")
+
+        monkeypatch.setattr(mod, "_get", boom)
+        assert mod.env_types("tok", "org", "prj") == {}
+        assert mod.env_types("", "org", "prj") == {}
+
+    def test_link_and_token_readers(self, mod, tmp_path, monkeypatch):
+        (tmp_path / ".vercel").mkdir()
+        (tmp_path / ".vercel" / "project.json").write_text(
+            '{"orgId": "team_1", "projectId": "prj_1"}'
+        )
+        sub = tmp_path / "website" / "app"
+        sub.mkdir(parents=True)
+        assert mod._link(sub) == ("team_1", "prj_1")
+        assert mod._link(Path("/")) == ("", "")
+        monkeypatch.setenv("VERCEL_TOKEN", "env-token")
+        assert mod._token() == "env-token"

--- a/tests/unit/scripts/test_vercel_probe.py
+++ b/tests/unit/scripts/test_vercel_probe.py
@@ -68,6 +68,22 @@ class TestEnvReport:
         _, rc = mod.env_report("production", tmp_path, ["RESEND_API_KEY"])
         assert rc == 1
 
+    def test_sensitive_blank_is_not_flagged_and_expect_is_unverifiable(
+        self, mod, monkeypatch, tmp_path
+    ):
+        # Neon-managed vars are `sensitive`: `env pull` leaves them blank by
+        # design, and VERCEL_* system vars are never in the API listing.
+        self._fake_pull(monkeypatch, mod, {"PGHOST": "", "VERCEL_URL": "", "ADMIN_SECRET": ""})
+        types = {"PGHOST": "sensitive", "ADMIN_SECRET": "encrypted"}
+        lines, rc = mod.env_report("production", tmp_path, ["PGHOST", "ADMIN_SECRET"], types)
+        joined = "\n".join(lines)
+        assert "PGHOST" in joined and "sensitive: not pullable" in joined
+        assert "VERCEL_URL" in joined and "(system)" in joined
+        assert "ADMIN_SECRET" in joined and "EMPTY" in joined
+        assert "UNVERIFIABLE (sensitive): PGHOST" in joined
+        assert "MISSING OR EMPTY: ADMIN_SECRET" in joined
+        assert rc == 1
+
 
 class TestPullEnvParsing:
     def test_parses_the_file_vercel_writes(self, mod, monkeypatch, tmp_path):
@@ -122,7 +138,7 @@ class TestDomainsReport:
         monkeypatch.setattr(mod, "_get", fake_get)
         lines = mod.domains_report("tok", "org")
         joined = "\n".join(lines)
-        assert "website" in joined and "smartaimemory.com [primary]" in joined
+        assert "website" in joined and "(p1)" in joined and "smartaimemory.com [primary]" in joined
         assert "www.smartaimemory.com(->smartaimemory.com)" in joined
         assert "shsc-ryan" in joined
         assert any(

--- a/tests/unit/scripts/test_vercel_probe.py
+++ b/tests/unit/scripts/test_vercel_probe.py
@@ -1,0 +1,130 @@
+"""Unit tests for scripts/vercel_probe.py — shapes, never values.
+
+The probe exists because two blank secrets and one silently re-attached
+domain each took ten-plus ad-hoc probes on 2026-09-04. These tests pin
+that (1) a value is described by length/prefix/digest only, (2) an empty
+value is flagged and fails ``--expect``, (3) the env file is parsed the
+way ``vercel env pull`` writes it, and (4) the domain report reads the
+project-domains endpoint (attachment), not the account domain record.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[3]
+SCRIPT = REPO / "scripts" / "vercel_probe.py"
+
+
+@pytest.fixture(scope="module")
+def mod():
+    spec = importlib.util.spec_from_file_location("_vercel_probe", SCRIPT)
+    assert spec is not None and spec.loader is not None
+    m = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(m)
+    return m
+
+
+class TestShape:
+    def test_never_contains_the_value(self, mod):
+        s = mod.shape('"re_abcdefghijklmnopqrstuvwxyz0123456789"')
+        rendered = repr(s)
+        assert "abcdefghijklmnop" not in rendered
+        assert s["len"] == 39 and s["prefix"] == "re_" and s["quoted"] is True
+        assert len(s["sha12"]) == 12
+
+    def test_empty_value(self, mod):
+        s = mod.shape("")
+        assert s["len"] == 0 and s["prefix"] == "" and s["sha12"] == "-"
+
+    def test_trailing_newline_is_whitespace(self, mod):
+        assert mod.shape("abc\n")["whitespace"] is True
+        assert mod.shape("abc")["whitespace"] is False
+
+
+class TestEnvReport:
+    def _fake_pull(self, monkeypatch, mod, values):
+        monkeypatch.setattr(mod, "pull_env", lambda env, cwd: values)
+
+    def test_flags_empty_and_fails_expect(self, mod, monkeypatch, tmp_path):
+        self._fake_pull(monkeypatch, mod, {"ADMIN_SECRET": "", "CRON_SECRET": "x" * 64})
+        lines, rc = mod.env_report("production", tmp_path, ["ADMIN_SECRET"])
+        joined = "\n".join(lines)
+        assert "ADMIN_SECRET" in joined and "EMPTY" in joined
+        assert "MISSING OR EMPTY: ADMIN_SECRET" in joined
+        assert rc == 1
+        assert "x" * 10 not in joined  # values never rendered
+
+    def test_expect_satisfied_exits_zero(self, mod, monkeypatch, tmp_path):
+        self._fake_pull(monkeypatch, mod, {"RESEND_API_KEY": "re_" + "a" * 33})
+        lines, rc = mod.env_report("production", tmp_path, ["RESEND_API_KEY"])
+        assert rc == 0 and "prefix=re_" in "\n".join(lines)
+
+    def test_missing_variable_fails_expect(self, mod, monkeypatch, tmp_path):
+        self._fake_pull(monkeypatch, mod, {})
+        _, rc = mod.env_report("production", tmp_path, ["RESEND_API_KEY"])
+        assert rc == 1
+
+
+class TestPullEnvParsing:
+    def test_parses_the_file_vercel_writes(self, mod, monkeypatch, tmp_path):
+        def fake_run(cmd, **kw):
+            target = Path(cmd[-1])
+            target.write_text('# Created by Vercel CLI\nA="1"\nB=""\nnot a var\nC=plain\n')
+
+            class R:
+                returncode = 0
+
+            return R()
+
+        monkeypatch.setattr(mod.subprocess, "run", fake_run)
+        values = mod.pull_env("production", tmp_path)
+        assert values == {"A": '"1"', "B": '""', "C": "plain"}
+
+    def test_pull_uses_yes_and_a_fresh_path(self, mod, monkeypatch, tmp_path):
+        seen = {}
+
+        def fake_run(cmd, **kw):
+            seen["cmd"] = cmd
+
+            class R:
+                returncode = 0
+
+            return R()
+
+        monkeypatch.setattr(mod.subprocess, "run", fake_run)
+        mod.pull_env("preview", tmp_path)
+        assert "--yes" in seen["cmd"] and not Path(seen["cmd"][-1]).exists()
+
+
+class TestDomainsReport:
+    def test_reads_attachment_per_project(self, mod, monkeypatch):
+        calls = []
+
+        def fake_get(path, token):
+            calls.append(path)
+            if path.startswith("/v9/projects?"):
+                return {
+                    "projects": [{"id": "p1", "name": "website"}, {"id": "p2", "name": "shsc-ryan"}]
+                }
+            if "/p1/domains" in path:
+                return {
+                    "domains": [
+                        {"name": "smartaimemory.com"},
+                        {"name": "www.smartaimemory.com", "redirect": "smartaimemory.com"},
+                    ]
+                }
+            return {"domains": []}
+
+        monkeypatch.setattr(mod, "_get", fake_get)
+        lines = mod.domains_report("tok", "org")
+        joined = "\n".join(lines)
+        assert "website" in joined and "smartaimemory.com [primary]" in joined
+        assert "www.smartaimemory.com(->smartaimemory.com)" in joined
+        assert "shsc-ryan" in joined
+        assert any(
+            "/v9/projects/p1/domains" in c for c in calls
+        )  # attachment endpoint, not /v4/domains

--- a/tests/unit/scripts/test_worktree_triage.py
+++ b/tests/unit/scripts/test_worktree_triage.py
@@ -148,3 +148,52 @@ class TestRenderScript:
         assert 'worktree remove "/w/go"' in text and "/w/keep" not in text
         assert 'branch -D "g"' in text and 'branch -D "stale"' in text and "unsure" not in text
         assert "worktree prune" in text
+
+
+class TestWorktreeRowsAndMain:
+    def test_worktree_rows_classify_a_real_worktree(self, mod, repo, tmp_path):
+        r, squash = repo
+        wt = tmp_path / "wt-feat"
+        _git(r, "worktree", "add", "-q", str(wt), "feat/two")
+        rows = mod.worktree_rows(r, None, {"feat/two": [(7, squash)]}, set())
+        by = {row.branch: row for row in rows}
+        assert by["feat/two"].verdict == "REMOVE (squash-verified #7)"
+        # dirty the worktree: it must flip to HOLD and list the NAME only
+        (wt / "scratch.txt").write_text("secret-looking content\n")
+        rows = mod.worktree_rows(r, None, {"feat/two": [(7, squash)]}, set())
+        row = {x.branch: x for x in rows}["feat/two"]
+        assert row.verdict == "HOLD (dirty 1)" and row.dirty == ["scratch.txt"]
+        # self-path and open-PR exclusions
+        rows = mod.worktree_rows(r, wt, {}, set())
+        assert {x.branch: x for x in rows}["feat/two"].verdict.startswith("KEEP (this session)")
+        rows = mod.worktree_rows(r, None, {}, {"feat/two"})
+        assert {x.branch: x for x in rows}["feat/two"].verdict.startswith("KEEP (open PR)")
+
+    def test_main_script_subcommand_writes_only_remove_lines(
+        self, mod, repo, tmp_path, monkeypatch, capsys
+    ):
+        r, squash = repo
+        monkeypatch.setattr(mod, "merged_prs", lambda gh: {"feat/two": [(7, squash)]})
+        monkeypatch.setattr(mod, "open_pr_branches", lambda gh: set())
+        out = tmp_path / "sweep.sh"
+        assert mod.main(["x", "script", "--repo", str(r), "-o", str(out)]) == 0
+        text = out.read_text()
+        assert 'branch -D "feat/two"' in text and "REMOVE (squash-verified #7)" in text
+        assert mod.main(["x", "branches", "--repo", str(r)]) == 0
+        assert "feat/two" in capsys.readouterr().out
+
+    def test_gh_readers_parse_json(self, mod, monkeypatch):
+        class R:
+            def __init__(self, stdout):
+                self.stdout = stdout
+
+        def fake_run(cmd, **kw):
+            if "merged" in cmd:
+                return R(
+                    '[{"number": 5, "headRefName": "b", "mergeCommit": {"oid": "abc"}}, {"number": 6, "headRefName": "c", "mergeCommit": null}]'
+                )
+            return R('[{"headRefName": "open-one"}]')
+
+        monkeypatch.setattr(mod.subprocess, "run", fake_run)
+        assert mod.merged_prs("o/r") == {"b": [(5, "abc")]}
+        assert mod.open_pr_branches("o/r") == {"open-one"}

--- a/tests/unit/scripts/test_worktree_triage.py
+++ b/tests/unit/scripts/test_worktree_triage.py
@@ -1,0 +1,150 @@
+"""Unit tests for scripts/worktree_triage.py.
+
+Pins the verdict matrix, the "(empty) is never identical" rule for
+patch-ids, squash-merge verification against a REAL temp repository, and
+that the emitted removal script carries only REMOVE verdicts.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[3]
+SCRIPT = REPO / "scripts" / "worktree_triage.py"
+
+
+@pytest.fixture(scope="module")
+def mod():
+    spec = importlib.util.spec_from_file_location("_worktree_triage", SCRIPT)
+    assert spec is not None and spec.loader is not None
+    m = importlib.util.module_from_spec(spec)
+    sys.modules["_worktree_triage"] = m  # dataclasses resolve annotations via sys.modules
+    spec.loader.exec_module(m)
+    return m
+
+
+def _git(repo: Path, *args: str) -> str:
+    env = {
+        **os.environ,
+        "GIT_AUTHOR_NAME": "t",
+        "GIT_AUTHOR_EMAIL": "t@x",
+        "GIT_COMMITTER_NAME": "t",
+        "GIT_COMMITTER_EMAIL": "t@x",
+        "HOME": str(repo),
+    }
+    r = subprocess.run(
+        ["git", "-C", str(repo), "-c", "commit.gpgsign=false", *args],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=30,
+    )
+    return r.stdout.strip()
+
+
+@pytest.fixture()
+def repo(tmp_path):
+    """main with one file; a 2-commit feature branch; a squash merge of it on main."""
+    r = tmp_path / "repo"
+    r.mkdir()
+    _git(r, "init", "-q", "-b", "main")
+    (r / "a.txt").write_text("base\n")
+    _git(r, "add", "a.txt")
+    _git(r, "commit", "-q", "-m", "base")
+    _git(r, "checkout", "-q", "-b", "feat/two")
+    (r / "b.txt").write_text("one\n")
+    _git(r, "add", "b.txt")
+    _git(r, "commit", "-q", "-m", "one")
+    (r / "b.txt").write_text("one\ntwo\n")
+    _git(r, "add", "b.txt")
+    _git(r, "commit", "-q", "-m", "two")
+    _git(r, "checkout", "-q", "main")
+    _git(r, "merge", "--squash", "-q", "feat/two")
+    _git(r, "commit", "-q", "-m", "feat: two (squash)")
+    squash = _git(r, "rev-parse", "HEAD")
+    _git(r, "update-ref", "refs/remotes/origin/main", "HEAD")
+    return r, squash
+
+
+class TestClassify:
+    def _row(self, mod, **kw):
+        base = {"path": "/wt", "branch": "b", "head": "abc"}
+        base.update(kw)
+        return mod.Row(**base)
+
+    def test_matrix(self, mod):
+        R = lambda **kw: mod.classify(self._row(mod, **kw))  # noqa: E731
+        assert R(is_self=True).startswith("KEEP (this session)")
+        assert R(exists=False).startswith("PRUNE-ENTRY")
+        assert R(has_open_pr=True).startswith("KEEP (open PR)")
+        assert R(dirty=["x"]).startswith("HOLD")
+        assert R(ahead=0).startswith("REMOVE (nothing ahead)")
+        assert R(ahead=1, cherry_plus=0).startswith("REMOVE (all patches")
+        assert R(ahead=2, cherry_plus=2, squash_pr=42) == "REMOVE (squash-verified #42)"
+        assert R(ahead=2, cherry_plus=2).startswith("REVIEW")
+
+    def test_self_beats_everything(self, mod):
+        assert mod.classify(self._row(mod, is_self=True, dirty=["x"], ahead=5)).startswith(
+            "KEEP (this session)"
+        )
+
+
+class TestPatchId:
+    def test_empty_diff_is_never_identical(self, mod):
+        assert mod.patch_id("") == "(empty)"
+        assert mod.patch_id("   \n") == "(empty)"
+
+    def test_same_diff_same_id(self, mod, repo):
+        r, squash = repo
+        d = subprocess.run(
+            ["git", "-C", str(r), "show", squash, "--format="], capture_output=True, text=True
+        ).stdout
+        assert mod.patch_id(d) == mod.patch_id(d) != "(empty)"
+
+
+class TestSquashVerified:
+    def test_squash_merged_branch_is_verified(self, mod, repo):
+        r, squash = repo
+        # cherry sees both feature commits as '+' (patch-ids differ per commit)...
+        ch = subprocess.run(
+            ["git", "-C", str(r), "cherry", "origin/main", "feat/two"],
+            capture_output=True,
+            text=True,
+        ).stdout
+        assert ch.count("+") == 2
+        # ...but the whole-branch patch-id equals the squash commit's.
+        assert mod.squash_verified(r, "feat/two", [(7, squash)]) == 7
+
+    def test_unrelated_merge_commit_does_not_verify(self, mod, repo):
+        r, _ = repo
+        base = _git(r, "rev-list", "--max-parents=0", "HEAD")
+        assert mod.squash_verified(r, "feat/two", [(9, base)]) is None
+
+    def test_branch_rows_end_to_end(self, mod, repo):
+        r, squash = repo
+        rows = mod.branch_rows(r, {"feat/two": [(7, squash)]}, set())
+        by = {row.branch: row for row in rows}
+        assert by["feat/two"].verdict == "REMOVE (squash-verified #7)"
+
+
+class TestRenderScript:
+    def test_only_remove_rows_are_emitted(self, mod):
+        wt = [
+            mod.Row(path="/w/keep", branch="k", head="1", verdict="HOLD (dirty 2)"),
+            mod.Row(path="/w/go", branch="g", head="2", verdict="REMOVE (all patches on main)"),
+        ]
+        br = [
+            mod.Row(path="", branch="stale", head="3", verdict="REMOVE (squash-verified #5)"),
+            mod.Row(path="", branch="unsure", head="4", verdict="REVIEW (+3 unverified)"),
+        ]
+        text = mod.render_script(Path("/repo"), wt, br)
+        assert 'worktree remove "/w/go"' in text and "/w/keep" not in text
+        assert 'branch -D "g"' in text and 'branch -D "stale"' in text and "unsure" not in text
+        assert "worktree prune" in text


### PR DESCRIPTION
## Summary

Retro 2026-09-04, items 1, 2 and 4 (chair: "implement"). Three mechanizations of the day's friction; nothing here mutates a repo or a deployment.

| Item | What | Tests |
|---|---|---|
| 4 | **`detached_head_push_guard.py`** — PreToolUse hook (registered in `.claude/settings.json`) refusing `git push` while HEAD is detached. A concurrent session's `checkout --detach` produced a commit on a detached HEAD; `git push` then said "Everything up-to-date" while the remote was one commit behind. Carve-outs: `HEAD:<ref>` refspecs and tag pushes; fail-open; `ATTUNE_ALLOW_DETACHED_PUSH=1`. | 17, real temp repo |
| 2 | **`scripts/worktree_triage.py`** — the classifier behind today's sweep (42 → 15 worktrees, 239 → 58 branches, zero content lost): cherry, plus whole-branch patch-id vs the PR merge commit to verify squash merges; HOLD on dirty, KEEP on open PR or self; `(empty)` patch-ids never compare equal. Emits a removal script for the chair to read and run. | 8, incl. a real squash-merge repo |
| 1 | **`scripts/vercel_probe.py`** — env-var NAMES with length/prefix/digest (never values), `--expect` fails on blank secrets, `--domains` reads per-project ATTACHMENT via the API. Today's two blank secrets and the domain attached to a sibling project each took ten-plus probes; this answers all three in one call. | 9 |

## Receipts (serial, keyless)

| Probe | Result |
|---|---|
| `tests/unit/{gates,quality,hooks,scripts,ci}` | 2254 passed, 1 skipped (after the path-validation allowlist entry, mirroring `dirty_switch_guard`) |
| pinned black + ruff on all six new files | clean |
| `settings.json` still valid JSON with the new hook registered | yes |
| **live-fire** `worktree_triage.py worktrees` on the real repo (16 worktrees) | table matches the hand-built one from the morning sweep: 9 HOLD (dirty, names only), 4 KEEP (self + open PRs), 3 REVIEW, 0 REMOVE |
| **live-fire** `vercel_probe.py --expect … --domains` on the real project | first run over-reported 33 blanks (`sensitive` + system types); fixed in `75d3beebc` to read types from the API — now 0 false EMPTY, 3 real secrets shown by length/prefix only, `website`'s domains listed as primary+redirect |

## CI corrections after opening

- `63be2f275`: the hook-gate drift guard (`tests/unit/plugins/test_sdk_subprocess_gate.py`) failed every lane — the hook lacked `exit_if_sdk_subprocess`. Entrypoint now mirrors `dirty_switch_guard` exactly (UTF-8 stdio, SDK gate, stdin reader, fail-open catch with a ratchet baseline entry). Caught by CI because that guard lives outside the gates/hooks/scripts suites I ran; the full tree now passes locally (25,334).
- `2e97daac4`: codecov/patch read 76% (it measures the hook alone; `scripts/` sit outside the coverage source). Added entrypoint round-trips, the five fail-open branches, and readers. **Measured with the repo coverage config: hook at 98.28%, two lines left (175–176).** The commit message says 100%; that overclaims by two lines and this body is the correction.

## Review notes

- Touches `src/` (the hook) → CHANGELOG "Added" entries included.
- Touches `.claude/settings.json` and a gate allowlist → enforcement surface; D11 lane available on request.
- The push guard reuses `dirty_switch_guard.git_invocations` by loading the sibling file, so the two guards stay on one shell tokenizer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
