### PR TITLE
feat(tooling): zsh argument-list word-split recall rule + API-based Vercel deploy waiter (retro 09-04 items 6, 9)

### DIFF
--- a/plugin/hooks/_recall_map.py
+++ b/plugin/hooks/_recall_map.py
@@ -159,6 +159,24 @@ RECALL_MAP: dict[str, list[dict[str, str]]] = {
                 "explicit word list. (`$(...)` output still splits.)"
             ),
         },
+        # zsh no-word-split, ARGUMENT-LIST shapes (retro 2026-09-04 item
+        # 6): the `for` rule above did not fire on `set -- $pair` (the
+        # whole "branch 2373" string became $1, both patch-ids went
+        # empty, and a squash-merge check printed IDENTICAL for ten
+        # branches) nor on `pre-commit run black --files $F` (one
+        # mangled path linted). Same trap, different syntax.
+        {
+            "rule_id": "zsh-no-word-split-args",
+            "match_regex": r"(?:\bset\s+--|--files|--paths|--include)\s+\$\{?[A-Za-z_]\w*\}?(?:\s|$)",
+            "text": (
+                "zsh does NOT word-split unquoted `$var` — `set -- $pair` "
+                "makes the WHOLE string $1 and `--files $F` passes ONE "
+                "mangled path. A downstream compare of two empty results "
+                "then reads IDENTICAL. Use `${=var}`, an array "
+                '(`"${F[@]}"`), `read -r a b <<<"$pair"`, or move the '
+                "loop to Python."
+            ),
+        },
         {
             "rule_id": "zsh-status-readonly",
             "match_substring": "status=",

--- a/plugin/hooks/_recall_map.py
+++ b/plugin/hooks/_recall_map.py
@@ -167,7 +167,7 @@ RECALL_MAP: dict[str, list[dict[str, str]]] = {
         # mangled path linted). Same trap, different syntax.
         {
             "rule_id": "zsh-no-word-split-args",
-            "match_regex": r"(?:\bset\s+--|--files|--paths|--include)\s+\$\{?[A-Za-z_]\w*\}?(?:\s|$)",
+            "match_regex": r"(?:\bset\s+--|--files|--paths|--include)\s+\$\{?[A-Za-z_]\w*\}?(?:[\s;|&)]|$)",
             "text": (
                 "zsh does NOT word-split unquoted `$var` — `set -- $pair` "
                 "makes the WHOLE string $1 and `--files $F` passes ONE "

--- a/scripts/vercel_wait_deploy.py
+++ b/scripts/vercel_wait_deploy.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""Wait for a Vercel production deployment of a given commit — via the API.
+
+Why this exists (retro 2026-09-04, item 9)
+------------------------------------------
+Every ad-hoc deploy-waiter loop that day parsed ``vercel ls`` / ``vercel
+inspect`` text with a regex that silently never matched, so each ran to
+its timeout and printed only a final probe — indistinguishable from
+"still building". A parser that can fail to match looks exactly like
+waiting. This script asks the deployments API for the state field
+directly, prints every transition, and exits by outcome:
+
+    0  READY (and, with ``--probe``, the URL answered ``--expect``)
+    1  ERROR or CANCELED (build log error lines are printed)
+    2  timeout, or no deployment for that commit appeared
+
+Usage::
+
+    python scripts/vercel_wait_deploy.py --commit <sha-prefix>
+        [--cwd website] [--timeout 900] [--interval 20]
+        [--probe https://smartaimemory.com/api/cron/usage-digest/ --expect 401]
+
+Credentials: the Vercel CLI's stored token (or ``$VERCEL_TOKEN``) and the
+cwd's ``.vercel/project.json`` link. The token goes in a header only.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under Apache 2.0
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+API = "https://api.vercel.com"
+TERMINAL_OK = {"READY"}
+TERMINAL_BAD = {"ERROR", "CANCELED"}
+
+
+def _token() -> str:
+    tok = os.environ.get("VERCEL_TOKEN")
+    if tok:
+        return tok
+    auth = Path.home() / "Library" / "Application Support" / "com.vercel.cli" / "auth.json"
+    if auth.exists():
+        return json.loads(auth.read_text()).get("token", "")
+    return ""
+
+
+def _link(cwd: Path) -> tuple[str, str]:
+    for d in (cwd, *cwd.parents):
+        p = d / ".vercel" / "project.json"
+        if p.exists():
+            j = json.loads(p.read_text())
+            return j.get("orgId", ""), j.get("projectId", "")
+    return "", ""
+
+
+def _get(path: str, token: str) -> dict:
+    req = urllib.request.Request(API + path, headers={"Authorization": f"Bearer {token}"})
+    with urllib.request.urlopen(req, timeout=30) as r:  # noqa: S310 - fixed https host
+        return json.load(r)
+
+
+def find_deployment(token: str, org: str, project_id: str, commit: str) -> dict | None:
+    """Newest production deployment whose git commit starts with ``commit``."""
+    data = _get(
+        f"/v6/deployments?projectId={project_id}&teamId={org}&target=production&limit=20",
+        token,
+    )
+    for d in data.get("deployments", []):
+        sha = (d.get("meta") or {}).get("githubCommitSha", "")
+        if sha.startswith(commit):
+            return d
+    return None
+
+
+def http_status(url: str) -> int:
+    """GET ``url`` without following redirects; return the status code."""
+
+    class _NoRedirect(urllib.request.HTTPRedirectHandler):
+        def redirect_request(self, *a, **k):  # noqa: D401 - protocol
+            return None
+
+    opener = urllib.request.build_opener(_NoRedirect)
+    try:
+        with opener.open(url, timeout=30) as r:
+            return r.status
+    except urllib.error.HTTPError as e:
+        return e.code
+
+
+def wait(
+    token: str,
+    org: str,
+    project_id: str,
+    commit: str,
+    timeout: float,
+    interval: float,
+    sleep=time.sleep,
+    clock=time.monotonic,
+    out=print,
+) -> tuple[int, dict | None]:
+    """Poll until the commit's deployment reaches a terminal state.
+
+    Returns ``(exit_code, deployment)``. Every state change is printed
+    once, so a hung build shows as a stalled BUILDING line, not silence.
+    """
+    start = clock()
+    last_state = None
+    while True:
+        dep = find_deployment(token, org, project_id, commit)
+        state = (dep or {}).get("readyState") or (dep or {}).get("state") or "NOT-FOUND"
+        if state != last_state:
+            url = (dep or {}).get("url", "")
+            out(
+                f"[{int(clock() - start):4d}s] {commit[:9]} -> {state}{'  https://' + url if url else ''}"
+            )
+            last_state = state
+        if state in TERMINAL_OK:
+            return 0, dep
+        if state in TERMINAL_BAD:
+            return 1, dep
+        if clock() - start > timeout:
+            out(f"timeout after {int(timeout)}s in state {state}")
+            return 2, dep
+        sleep(interval)
+
+
+def main(argv: list[str]) -> int:
+    ap = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    ap.add_argument("--commit", required=True, help="git SHA or prefix of the merge commit")
+    ap.add_argument("--cwd", default=".", help="a directory linked with .vercel/project.json")
+    ap.add_argument("--timeout", type=float, default=900)
+    ap.add_argument("--interval", type=float, default=20)
+    ap.add_argument("--probe", default=None, help="URL to GET once READY (no redirects followed)")
+    ap.add_argument("--expect", type=int, default=None, help="status the probe must return")
+    args = ap.parse_args(argv[1:])
+
+    token = _token()
+    org, project_id = _link(Path(args.cwd).resolve())
+    if not (token and org and project_id):
+        print("no Vercel token or no .vercel/project.json link in --cwd", file=sys.stderr)
+        return 2
+
+    try:
+        rc, dep = wait(token, org, project_id, args.commit, args.timeout, args.interval)
+    except urllib.error.URLError as exc:
+        print(f"API error: {exc}", file=sys.stderr)
+        return 2
+    if rc == 1 and dep:
+        err = (dep.get("errorMessage") or "").strip()
+        if err:
+            print(f"build error: {err}")
+    if rc != 0 or not args.probe:
+        return rc
+
+    code = http_status(args.probe)
+    if args.expect is not None and code != args.expect:
+        print(f"probe {args.probe} -> {code} (expected {args.expect})")
+        return 1
+    print(f"probe {args.probe} -> {code}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/tests/unit/hooks/test_jit_recall.py
+++ b/tests/unit/hooks/test_jit_recall.py
@@ -168,6 +168,39 @@ def test_zsh_word_split_fires_on_braced_var(jit_mod, monkeypatch, capsys):
     assert "word-split" in out
 
 
+def test_zsh_word_split_args_fires_on_set_dashdash(jit_mod, monkeypatch, capsys):
+    # The 2026-09-04 shape: `set -- $pair` handed "branch 2373" to $1.
+    rc, out = _run(
+        jit_mod,
+        monkeypatch,
+        capsys,
+        _bash_payload('for pair in "a 1" "b 2"; do set -- $pair; echo $1; done'),
+    )
+    assert rc == 0
+    assert "WHOLE string $1" in out
+
+
+def test_zsh_word_split_args_fires_on_files_flag(jit_mod, monkeypatch, capsys):
+    rc, out = _run(jit_mod, monkeypatch, capsys, _bash_payload("pre-commit run black --files $F"))
+    assert rc == 0
+    assert "mangled path" in out
+
+
+def test_zsh_word_split_args_silent_on_quoted_and_arrays(jit_mod, monkeypatch, capsys):
+    # Quoted scalar, array expansion, literal words, and ${=var} are fine.
+    rc, out = _run(
+        jit_mod,
+        monkeypatch,
+        capsys,
+        _bash_payload(
+            'set -- "$pair"; pre-commit run black --files "${F[@]}"; '
+            "set -- a b c; set -- ${=pair}; grep --files-with-matches x"
+        ),
+    )
+    assert rc == 0
+    assert "WHOLE string $1" not in out and "mangled path" not in out
+
+
 def test_zsh_word_split_silent_on_safe_shapes(jit_mod, monkeypatch, capsys):
     # Command substitution DOES split in zsh; explicit word lists and
     # array expansions are fine — none of these may trip the rule.

--- a/tests/unit/scripts/test_vercel_wait_deploy.py
+++ b/tests/unit/scripts/test_vercel_wait_deploy.py
@@ -1,0 +1,163 @@
+"""Unit tests for scripts/vercel_wait_deploy.py.
+
+Pins: the deployment is matched by commit prefix on the API's state
+field (no text parsing), every transition is printed once, outcomes map
+to exit codes, and the probe never follows redirects — a 308 must be
+reported as 308, because Vercel Cron treats it as final.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[3]
+SCRIPT = REPO / "scripts" / "vercel_wait_deploy.py"
+
+
+@pytest.fixture(scope="module")
+def mod():
+    spec = importlib.util.spec_from_file_location("_vercel_wait_deploy", SCRIPT)
+    assert spec is not None and spec.loader is not None
+    m = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(m)
+    return m
+
+
+def _dep(sha: str, state: str, url: str = "x.vercel.app", err: str | None = None) -> dict:
+    d = {"meta": {"githubCommitSha": sha}, "readyState": state, "url": url}
+    if err:
+        d["errorMessage"] = err
+    return d
+
+
+class TestFindDeployment:
+    def test_matches_by_commit_prefix_newest_first(self, mod, monkeypatch):
+        monkeypatch.setattr(
+            mod,
+            "_get",
+            lambda p, t: {"deployments": [_dep("abc123def", "READY"), _dep("abc999", "BUILDING")]},
+        )
+        d = mod.find_deployment("t", "o", "p", "abc123")
+        assert d and d["readyState"] == "READY"
+        assert mod.find_deployment("t", "o", "p", "zzz") is None
+
+
+class TestWait:
+    def _run(self, mod, monkeypatch, states, timeout=100):
+        seq = iter(states)
+        monkeypatch.setattr(mod, "find_deployment", lambda *a: next(seq))
+        lines = []
+        t = [0.0]
+
+        def clock():
+            return t[0]
+
+        def sleep(s):
+            t[0] += s
+
+        return (
+            mod.wait(
+                "t", "o", "p", "abc123def", timeout, 10, sleep=sleep, clock=clock, out=lines.append
+            ),
+            lines,
+        )
+
+    def test_transitions_printed_once_and_ready_exits_zero(self, mod, monkeypatch):
+        states = [
+            None,
+            _dep("abc123def", "QUEUED"),
+            _dep("abc123def", "BUILDING"),
+            _dep("abc123def", "BUILDING"),
+            _dep("abc123def", "READY"),
+        ]
+        (rc, dep), lines = self._run(mod, monkeypatch, states)
+        assert rc == 0 and dep["readyState"] == "READY"
+        joined = "\n".join(lines)
+        assert joined.count("BUILDING") == 1  # repeated state is not re-printed
+        assert "NOT-FOUND" in joined and "QUEUED" in joined and "READY" in joined
+
+    def test_error_exits_one(self, mod, monkeypatch):
+        (rc, dep), _ = self._run(
+            mod,
+            monkeypatch,
+            [_dep("abc123def", "BUILDING"), _dep("abc123def", "ERROR", err="bad env")],
+        )
+        assert rc == 1 and dep["errorMessage"] == "bad env"
+
+    def test_timeout_exits_two_and_says_the_stalled_state(self, mod, monkeypatch):
+        (rc, _), lines = self._run(
+            mod, monkeypatch, [_dep("abc123def", "BUILDING")] * 50, timeout=25
+        )
+        assert rc == 2 and any("timeout" in line and "BUILDING" in line for line in lines)
+
+
+class TestProbe:
+    def test_probe_does_not_follow_redirects(self, mod, monkeypatch):
+        import io
+        import urllib.error
+
+        class FakeOpener:
+            def open(self, url, timeout=30):
+                raise urllib.error.HTTPError(url, 308, "Permanent Redirect", {}, io.BytesIO(b""))
+
+        monkeypatch.setattr(mod.urllib.request, "build_opener", lambda *h: FakeOpener())
+        assert mod.http_status("https://example.com/api/x") == 308
+
+
+class TestMain:
+    def test_main_ready_then_probe_mismatch_fails(self, mod, monkeypatch, tmp_path):
+        monkeypatch.setattr(mod, "_token", lambda: "t")
+        monkeypatch.setattr(mod, "_link", lambda cwd: ("o", "p"))
+        monkeypatch.setattr(mod, "wait", lambda *a, **k: (0, _dep("abc", "READY")))
+        monkeypatch.setattr(mod, "http_status", lambda url: 308)
+        assert (
+            mod.main(
+                [
+                    "x",
+                    "--commit",
+                    "abc",
+                    "--cwd",
+                    str(tmp_path),
+                    "--probe",
+                    "https://e/x/",
+                    "--expect",
+                    "401",
+                ]
+            )
+            == 1
+        )
+        monkeypatch.setattr(mod, "http_status", lambda url: 401)
+        assert (
+            mod.main(
+                [
+                    "x",
+                    "--commit",
+                    "abc",
+                    "--cwd",
+                    str(tmp_path),
+                    "--probe",
+                    "https://e/x/",
+                    "--expect",
+                    "401",
+                ]
+            )
+            == 0
+        )
+
+    def test_main_without_link_exits_two(self, mod, monkeypatch, tmp_path, capsys):
+        monkeypatch.setattr(mod, "_token", lambda: "")
+        monkeypatch.setattr(mod, "_link", lambda cwd: ("", ""))
+        assert mod.main(["x", "--commit", "abc", "--cwd", str(tmp_path)]) == 2
+        assert "no Vercel token" in capsys.readouterr().err
+
+    def test_main_build_error_prints_message(self, mod, monkeypatch, tmp_path, capsys):
+        monkeypatch.setattr(mod, "_token", lambda: "t")
+        monkeypatch.setattr(mod, "_link", lambda cwd: ("o", "p"))
+        monkeypatch.setattr(
+            mod, "wait", lambda *a, **k: (1, _dep("abc", "ERROR", err="CRON_SECRET has whitespace"))
+        )
+        assert mod.main(["x", "--commit", "abc", "--cwd", str(tmp_path)]) == 1
+        assert "CRON_SECRET has whitespace" in capsys.readouterr().out


### PR DESCRIPTION
Retro 2026-09-04 items 6 and 9 (chair: implement).

**6 — `zsh-no-word-split-args`** joins the existing `for`-loop rule in `plugin/hooks/_recall_map.py`. Today's two misses were `set -- $pair` (the whole string became $1, both patch-ids went empty, a squash check printed IDENTICAL for ten branches) and `pre-commit run black --files $F` (one mangled path). Keyed on `set --` / `--files` / `--paths` / `--include` + an unquoted scalar; silent on quoted scalars, arrays, `${=var}`, literals. 3 tests.

**9 — `scripts/vercel_wait_deploy.py`** replaces the regex-on-CLI-text waiter loops that ran to timeout all day without matching. Reads `readyState` from the deployments API for the commit's production deployment, prints each transition once, exits 0/1/2 for READY / ERROR-or-CANCELED / timeout, prints the build error, and can probe a URL **without following redirects** (a 308 is reported as 308 — Vercel Cron treats it as final). 8 tests with a fake API and injected clock.

Receipts: jit-recall + waiter + gates + hook-gate drift guard suites pass serially; pinned black + ruff clean. No `src/` change → no changelog entry. Item 10 (secrets entry convention) landed as a memory edit, not code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)