### PR TITLE
feat(tooling): vercel_admin.py — one allowlistable Vercel mutation per call (retro 09-04 item 8)

### DIFF
--- a/scripts/vercel_admin.py
+++ b/scripts/vercel_admin.py
@@ -1,0 +1,283 @@
+#!/usr/bin/env python3
+"""One Vercel mutation per invocation, through the API, token never printed.
+
+Why this exists (retro 2026-09-04, item 8)
+------------------------------------------
+The auto-mode classifier blocks bare ``curl``/``vercel`` mutations of
+domains and env vars — bundled or one at a time — so a 25-minute domain
+outage was fixed by handing the chair curl chains to paste. Allowlisting
+``curl`` would be far too broad. This wrapper is the narrow, auditable
+entrypoint that CAN be allowlisted: each subcommand performs exactly one
+mutation, prints what it will do, supports ``--dry-run``, and reads the
+token only into a request header.
+
+Subcommands (one mutation each)::
+
+    env-set NAME (--from-file PATH | --generate) [--env production] [--store PATH]
+    env-rm NAME [--env production]
+    domain-attach DOMAIN [--redirect TARGET] [--project-id ID]
+    domain-detach DOMAIN [--project-id ID]
+    domain-redirect DOMAIN (--to TARGET | --clear) [--project-id ID]
+    redeploy [--url https://<latest-prod>.vercel.app]
+
+``env-set --generate`` mints ``openssl rand``-equivalent 32 random bytes
+(hex) and, with ``--store``, also writes ``NAME=<value>`` to a 0600 file
+outside the repo — the generate-once/write-both recipe. Values are never
+echoed; the receipt is ``len=`` and ``sha256[:12]``.
+
+Credentials: ``$VERCEL_TOKEN`` or the Vercel CLI's stored token; the
+project/team ids come from ``.vercel/project.json`` under ``--cwd``.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under Apache 2.0
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import secrets
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+API = "https://api.vercel.com"
+
+
+def _token() -> str:
+    tok = os.environ.get("VERCEL_TOKEN")
+    if tok:
+        return tok
+    auth = Path.home() / "Library" / "Application Support" / "com.vercel.cli" / "auth.json"
+    if auth.exists():
+        return json.loads(auth.read_text()).get("token", "")
+    return ""
+
+
+def _link(cwd: Path) -> tuple[str, str]:
+    for d in (cwd, *cwd.parents):
+        p = d / ".vercel" / "project.json"
+        if p.exists():
+            j = json.loads(p.read_text())
+            return j.get("orgId", ""), j.get("projectId", "")
+    return "", ""
+
+
+def _request(method: str, path: str, token: str, body: dict | None = None) -> dict:
+    data = json.dumps(body).encode() if body is not None else None
+    req = urllib.request.Request(
+        API + path,
+        data=data,
+        method=method,
+        headers={"Authorization": f"Bearer {token}", "content-type": "application/json"},
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=30) as r:  # noqa: S310 - fixed https host
+            raw = r.read()
+    except urllib.error.HTTPError as e:
+        raw = e.read()
+        try:
+            err = json.loads(raw)
+        except ValueError:
+            err = {"error": {"message": raw.decode(errors="replace")[:200]}}
+        return {"error": err.get("error", err), "status": e.code}
+    return json.loads(raw) if raw else {}
+
+
+def digest(value: str) -> str:
+    return hashlib.sha256(value.encode()).hexdigest()[:12]
+
+
+# --------------------------------------------------------------------------
+# operations — each returns (description, method, path, body)
+# --------------------------------------------------------------------------
+
+
+def op_env_set(org: str, pid: str, name: str, value: str, env: str):
+    return (
+        f"env-set {name} [{env}] len={len(value)} sha={digest(value)}",
+        "POST",
+        f"/v10/projects/{pid}/env?teamId={org}&upsert=true",
+        {"key": name, "value": value, "type": "encrypted", "target": [env]},
+    )
+
+
+def op_env_rm(org: str, pid: str, env_id: str, name: str, env: str):
+    return (
+        f"env-rm {name} [{env}] id={env_id}",
+        "DELETE",
+        f"/v9/projects/{pid}/env/{env_id}?teamId={org}",
+        None,
+    )
+
+
+def op_domain_attach(org: str, pid: str, domain: str, redirect: str | None):
+    body: dict = {"name": domain}
+    if redirect:
+        body.update({"redirect": redirect, "redirectStatusCode": 308})
+    return (
+        f"domain-attach {domain} -> project {pid}"
+        + (f" (redirect->{redirect})" if redirect else ""),
+        "POST",
+        f"/v10/projects/{pid}/domains?teamId={org}",
+        body,
+    )
+
+
+def op_domain_detach(org: str, pid: str, domain: str):
+    return (
+        f"domain-detach {domain} from project {pid}",
+        "DELETE",
+        f"/v9/projects/{pid}/domains/{domain}?teamId={org}",
+        None,
+    )
+
+
+def op_domain_redirect(org: str, pid: str, domain: str, target: str | None):
+    body = {"redirect": target, "redirectStatusCode": 308} if target else {"redirect": None}
+    return (
+        f"domain-redirect {domain} -> {target or '(none: primary)'}",
+        "PATCH",
+        f"/v9/projects/{pid}/domains/{domain}?teamId={org}",
+        body,
+    )
+
+
+# --------------------------------------------------------------------------
+
+
+def find_env_id(token: str, org: str, pid: str, name: str, env: str) -> str | None:
+    envs = _request("GET", f"/v9/projects/{pid}/env?teamId={org}", token).get("envs", [])
+    for e in envs:
+        if e.get("key") == name and env in (e.get("target") or []):
+            return e.get("id")
+    return None
+
+
+def store_locally(path: Path, name: str, value: str) -> None:
+    """Write ``NAME=value`` to ``path`` with 0600, replacing an existing NAME line."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lines = []
+    if path.exists():
+        lines = [line for line in path.read_text().splitlines() if not line.startswith(name + "=")]
+    lines.append(f"{name}={value}")
+    fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    with os.fdopen(fd, "w") as f:
+        f.write("\n".join(lines) + "\n")
+    os.chmod(path, 0o600)
+
+
+def main(argv: list[str]) -> int:
+    ap = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    ap.add_argument("--cwd", default=".", help="a directory linked with .vercel/project.json")
+    ap.add_argument("--project-id", default=None, help="override the linked projectId")
+    ap.add_argument("--dry-run", action="store_true", help="print the call, perform nothing")
+    sub = ap.add_subparsers(dest="cmd", required=True)
+
+    p = sub.add_parser("env-set")
+    p.add_argument("name")
+    g = p.add_mutually_exclusive_group(required=True)
+    g.add_argument("--from-file", help="0600 file holding the raw value (first line)")
+    g.add_argument("--generate", action="store_true", help="mint 32 random bytes as hex")
+    p.add_argument("--env", default="production")
+    p.add_argument("--store", help="also write NAME=value to this 0600 file (outside the repo)")
+
+    p = sub.add_parser("env-rm")
+    p.add_argument("name")
+    p.add_argument("--env", default="production")
+
+    p = sub.add_parser("domain-attach")
+    p.add_argument("domain")
+    p.add_argument("--redirect", default=None)
+
+    p = sub.add_parser("domain-detach")
+    p.add_argument("domain")
+
+    p = sub.add_parser("domain-redirect")
+    p.add_argument("domain")
+    g = p.add_mutually_exclusive_group(required=True)
+    g.add_argument("--to")
+    g.add_argument("--clear", action="store_true")
+
+    p = sub.add_parser("redeploy")
+    p.add_argument(
+        "--url", default=None, help="deployment URL; default: newest production deployment"
+    )
+
+    args = ap.parse_args(argv[1:])
+    cwd = Path(args.cwd).resolve()
+    token = _token()
+    org, linked_pid = _link(cwd)
+    pid = args.project_id or linked_pid
+    if not (token and org and pid):
+        print("no Vercel token or no .vercel/project.json link in --cwd", file=sys.stderr)
+        return 2
+
+    if args.cmd == "redeploy":
+        # The CLI's redeploy is the one mutation here; it reuses the source build.
+        url = args.url
+        if not url:
+            deps = _request(
+                "GET",
+                f"/v6/deployments?projectId={pid}&teamId={org}&target=production&limit=1",
+                token,
+            )
+            url = "https://" + (deps.get("deployments") or [{}])[0].get("url", "")
+        print(f"redeploy {url}")
+        if args.dry_run:
+            return 0
+        r = subprocess.run(
+            ["vercel", "redeploy", url], cwd=cwd, capture_output=True, text=True, timeout=900
+        )
+        print((r.stdout + r.stderr).strip()[-400:])
+        return 0 if r.returncode == 0 else 1
+
+    if args.cmd == "env-set":
+        if args.generate:
+            value = secrets.token_hex(32)
+        else:
+            value = Path(args.from_file).read_text().splitlines()[0].strip()
+        if not value:
+            print("refusing to set an EMPTY value", file=sys.stderr)
+            return 1
+        desc, method, path, body = op_env_set(org, pid, args.name, value, args.env)
+    elif args.cmd == "env-rm":
+        env_id = find_env_id(token, org, pid, args.name, args.env)
+        if not env_id:
+            print(f"no {args.name} in [{args.env}]", file=sys.stderr)
+            return 1
+        desc, method, path, body = op_env_rm(org, pid, env_id, args.name, args.env)
+    elif args.cmd == "domain-attach":
+        desc, method, path, body = op_domain_attach(org, pid, args.domain, args.redirect)
+    elif args.cmd == "domain-detach":
+        desc, method, path, body = op_domain_detach(org, pid, args.domain)
+    else:
+        desc, method, path, body = op_domain_redirect(
+            org, pid, args.domain, None if args.clear else args.to
+        )
+
+    print(f"{'DRY-RUN ' if args.dry_run else ''}{desc}")
+    print(f"  {method} {path}")
+    if args.dry_run:
+        return 0
+
+    result = _request(method, path, token, body)
+    if result.get("error"):
+        msg = (
+            result["error"].get("message") if isinstance(result["error"], dict) else result["error"]
+        )
+        print(f"  FAILED ({result.get('status')}): {msg}", file=sys.stderr)
+        return 1
+    print("  ok")
+    if args.cmd == "env-set" and args.store:
+        store_locally(Path(args.store).expanduser(), args.name, value)
+        print(f"  stored {args.name} in {args.store} (0600)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/tests/unit/scripts/test_vercel_admin.py
+++ b/tests/unit/scripts/test_vercel_admin.py
@@ -112,7 +112,8 @@ class TestMain:
         out = capsys.readouterr().out
         assert value not in out and "len=64" in out and "sha=" in out
         assert store.read_text() == f"K={value}\n"
-        assert stat.S_IMODE(os.stat(store).st_mode) == 0o600
+        if os.name != "nt":  # Windows has no POSIX mode bits (reports 0o666)
+            assert stat.S_IMODE(os.stat(store).st_mode) == 0o600
 
     def test_store_replaces_existing_line(self, mod, tmp_path):
         p = tmp_path / "x.env"

--- a/tests/unit/scripts/test_vercel_admin.py
+++ b/tests/unit/scripts/test_vercel_admin.py
@@ -1,0 +1,137 @@
+"""Unit tests for scripts/vercel_admin.py — one mutation per call, no leaks.
+
+Pins: each subcommand maps to exactly one API call with the right
+method/path/body; dry-run performs nothing; an empty value is refused;
+generate+store writes a 0600 file and prints only length/digest; API
+errors surface as exit 1 with the message.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import stat
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[3]
+SCRIPT = REPO / "scripts" / "vercel_admin.py"
+
+
+@pytest.fixture(scope="module")
+def mod():
+    spec = importlib.util.spec_from_file_location("_vercel_admin", SCRIPT)
+    assert spec is not None and spec.loader is not None
+    m = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(m)
+    return m
+
+
+@pytest.fixture()
+def linked(mod, monkeypatch, tmp_path):
+    """A linked cwd, a token, and a recorder in place of the network."""
+    monkeypatch.setattr(mod, "_token", lambda: "tok")
+    monkeypatch.setattr(mod, "_link", lambda cwd: ("org_1", "prj_1"))
+    calls = []
+
+    def fake_request(method, path, token, body=None):
+        calls.append((method, path, body))
+        assert token == "tok"
+        if method == "GET" and "/env?" in path:
+            return {"envs": [{"id": "env_9", "key": "ADMIN_SECRET", "target": ["production"]}]}
+        return {"ok": True}
+
+    monkeypatch.setattr(mod, "_request", fake_request)
+    return calls, tmp_path
+
+
+class TestOps:
+    def test_env_set_upserts_encrypted_for_target(self, mod):
+        desc, method, path, body = mod.op_env_set("o", "p", "K", "v" * 10, "production")
+        assert method == "POST" and "/v10/projects/p/env?" in path and "upsert=true" in path
+        assert body == {
+            "key": "K",
+            "value": "v" * 10,
+            "type": "encrypted",
+            "target": ["production"],
+        }
+        assert "v" * 10 not in desc and "len=10" in desc
+
+    def test_domain_attach_with_redirect(self, mod):
+        _, method, path, body = mod.op_domain_attach("o", "p", "www.x.com", "x.com")
+        assert method == "POST" and path.startswith("/v10/projects/p/domains")
+        assert body == {"name": "www.x.com", "redirect": "x.com", "redirectStatusCode": 308}
+
+    def test_domain_redirect_clear_makes_primary(self, mod):
+        _, method, _, body = mod.op_domain_redirect("o", "p", "x.com", None)
+        assert method == "PATCH" and body == {"redirect": None}
+
+
+class TestMain:
+    def test_dry_run_performs_nothing(self, mod, linked, capsys):
+        calls, tmp = linked
+        rc = mod.main(["x", "--cwd", str(tmp), "--dry-run", "domain-detach", "x.com"])
+        assert rc == 0 and calls == []
+        assert "DRY-RUN domain-detach x.com" in capsys.readouterr().out
+
+    def test_domain_detach_is_one_delete(self, mod, linked):
+        calls, tmp = linked
+        assert mod.main(["x", "--cwd", str(tmp), "domain-detach", "x.com"]) == 0
+        assert calls == [("DELETE", "/v9/projects/prj_1/domains/x.com?teamId=org_1", None)]
+
+    def test_env_rm_resolves_id_then_deletes(self, mod, linked):
+        calls, tmp = linked
+        assert mod.main(["x", "--cwd", str(tmp), "env-rm", "ADMIN_SECRET"]) == 0
+        assert [c[0] for c in calls] == ["GET", "DELETE"]
+        assert calls[1][1] == "/v9/projects/prj_1/env/env_9?teamId=org_1"
+
+    def test_env_rm_missing_name_fails_without_mutation(self, mod, linked, capsys):
+        calls, tmp = linked
+        assert mod.main(["x", "--cwd", str(tmp), "env-rm", "NOPE"]) == 1
+        assert [c[0] for c in calls] == ["GET"]
+        assert "no NOPE" in capsys.readouterr().err
+
+    def test_env_set_refuses_empty(self, mod, linked, capsys):
+        calls, tmp = linked
+        f = tmp / "empty"
+        f.write_text("\n")
+        assert mod.main(["x", "--cwd", str(tmp), "env-set", "K", "--from-file", str(f)]) == 1
+        assert calls == [] and "EMPTY" in capsys.readouterr().err
+
+    def test_env_set_generate_and_store_never_prints_value(self, mod, linked, capsys):
+        calls, tmp = linked
+        store = tmp / "secrets" / "site.env"
+        assert (
+            mod.main(["x", "--cwd", str(tmp), "env-set", "K", "--generate", "--store", str(store)])
+            == 0
+        )
+        body = calls[0][2]
+        value = body["value"]
+        assert len(value) == 64 and body["type"] == "encrypted"
+        out = capsys.readouterr().out
+        assert value not in out and "len=64" in out and "sha=" in out
+        assert store.read_text() == f"K={value}\n"
+        assert stat.S_IMODE(os.stat(store).st_mode) == 0o600
+
+    def test_store_replaces_existing_line(self, mod, tmp_path):
+        p = tmp_path / "x.env"
+        p.write_text("A=1\nK=old\n")
+        mod.store_locally(p, "K", "new")
+        assert p.read_text() == "A=1\nK=new\n"
+
+    def test_api_error_exits_one_with_message(self, mod, monkeypatch, tmp_path, capsys):
+        monkeypatch.setattr(mod, "_token", lambda: "tok")
+        monkeypatch.setattr(mod, "_link", lambda cwd: ("o", "p"))
+        monkeypatch.setattr(
+            mod,
+            "_request",
+            lambda *a, **k: {"error": {"message": "domain is in use"}, "status": 409},
+        )
+        assert mod.main(["x", "--cwd", str(tmp_path), "domain-attach", "x.com"]) == 1
+        assert "domain is in use" in capsys.readouterr().err
+
+    def test_no_link_exits_two(self, mod, monkeypatch, tmp_path):
+        monkeypatch.setattr(mod, "_token", lambda: "")
+        monkeypatch.setattr(mod, "_link", lambda cwd: ("", ""))
+        assert mod.main(["x", "--cwd", str(tmp_path), "domain-detach", "x.com"]) == 2


### PR DESCRIPTION
Retro 2026-09-04 item 8 (chair: implement).

The auto-mode classifier blocks bare `curl`/`vercel` mutations of domains and env vars, bundled or one at a time — today's domain outage was fixed by handing the chair curl chains. Allowlisting `curl` would be far too broad. **`scripts/vercel_admin.py`** is the narrow, auditable entrypoint that can be allowlisted instead.

| Subcommand | Mutation |
|---|---|
| `env-set NAME (--from-file P \| --generate) [--store 0600-file]` | one upsert; generate-once/write-both recipe built in |
| `env-rm NAME` | resolve id, one delete |
| `domain-attach D [--redirect T]` / `domain-detach D` | one POST / one DELETE |
| `domain-redirect D (--to T \| --clear)` | one PATCH (`--clear` = make primary) |
| `redeploy [--url]` | the CLI redeploy of the newest prod deployment |

Every call: `--dry-run` prints the exact API call and performs nothing; the token goes only in a header; values are never printed (receipt = `len` + `sha256[:12]`); empty values are refused; API errors exit 1 with the message.

**Receipts:** 12 unit tests against a recorded fake API; three live dry-runs on the real project resolved the link, an env-var id, and the newest production deployment without mutating anything; black + ruff clean. No `src/` change → no changelog. The allow rules go in the user-level settings (machine-local; the repo's `settings.local.json` is gitignored and absent from worktrees, so it would not cover worktree sessions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)