### PR TITLE
test(telemetry): keep main compatible with the forms correlation release

### DIFF
--- a/tests/unit/elicitation/test_widget.py
+++ b/tests/unit/elicitation/test_widget.py
@@ -7,6 +7,8 @@ sentinel postback payload, and the sendPrompt wiring.
 
 from __future__ import annotations
 
+import re
+
 from attune.elicitation import (
     WIDGET_RESPONSE_MARKER,
     form_from_dict,
@@ -52,7 +54,11 @@ class TestStructure:
         assert 'id="ae-submit-beat2"' in html
         assert 'id="ae-error-beat2"' in html
         assert "getElementById('attune-elicit-form-beat2')" in html
-        assert html == form_to_widget_html(form, instance_id="beat-2!")
+        other = form_to_widget_html(form, instance_id="beat-2!")
+        # Newer forms wheels add a per-display telemetry token even with fixed DOM ids.
+        assert re.sub(r'instance_id: "[a-f0-9]{32}"', 'instance_id: "TOKEN"', html) == re.sub(
+            r'instance_id: "[a-f0-9]{32}"', 'instance_id: "TOKEN"', other
+        )
         # The scoped CSS must follow the suffixed id.
         assert "#attune-elicit-form-beat2 {" in html
         assert "#attune-elicit-form " not in html

--- a/tests/unit/telemetry/test_form_events.py
+++ b/tests/unit/telemetry/test_form_events.py
@@ -10,6 +10,7 @@ per the issue's guidance and the "non-mocked round-trip" lesson.
 
 from __future__ import annotations
 
+import inspect
 import json
 import os
 import sys
@@ -247,9 +248,19 @@ _STAGE_EVENTS = pytest.mark.skipif(
 @_STAGE_EVENTS
 class TestStageEventsThroughAlias:
     def test_stage_loggers_and_latency_round_trip(self, _isolated_home: Path) -> None:
+        # The open dependency range covers both legacy and instance-aware forms.
+        # Exercise each installed logger's real join contract through the alias.
+        instance = (
+            {"instance_id": "a" * 32}
+            if all(
+                "instance_id" in inspect.signature(logger).parameters
+                for logger in (form_events_module.log_form_rendered, log_submission)
+            )
+            else {}
+        )
         form_events_module.log_form_build("f1", source="dict", question_count=2)
-        form_events_module.log_form_rendered("f1", duration_ms=3.0, html_bytes=1024)
-        form_events_module.log_submission(form_id="f1")
+        form_events_module.log_form_rendered("f1", duration_ms=3.0, html_bytes=1024, **instance)
+        form_events_module.log_submission(form_id="f1", **instance)
 
         events = [
             json.loads(line)


### PR DESCRIPTION
The telemetry alias round-trip test assumes that form identity alone joins a render and submission. The forthcoming attune-forms 0.12.3 correctly requires a display-instance token, so AI's open dependency range would make fresh main builds fail immediately after publication.

Pass one shared token when both installed logger signatures support it. Keep the strict `joined == 1` assertion and the real filesystem round trip for both supported call shapes. The fixed-DOM widget test also normalizes only the optional per-display telemetry token before checking exact HTML equality. All remaining UI bytes stay pinned. This is a test-only prerequisite to the forms release and [AI integration #2421](https://github.com/Smart-AI-Memory/attune-ai/pull/2421).

Validation: the 45 telemetry/widget tests pass with published forms 0.12.2. Against the installed candidate 0.12.3 wheel, all 45 changed-area tests and 1,988 forms/workspace consumer tests pass (36 consumer skips). Pinned pre-commit passes. `scripts/sync_forms_mirrors.py --check` confirms that all three projected forms test files are already in sync; neither changed file is a projected mirror.
