### PR TITLE
fix(scripts): vercel wrappers stop inheriting a parent's stale link and check token expiry

### DIFF
--- a/scripts/vercel_admin.py
+++ b/scripts/vercel_admin.py
@@ -25,8 +25,11 @@ Subcommands (one mutation each)::
 outside the repo — the generate-once/write-both recipe. Values are never
 echoed; the receipt is ``len=`` and ``sha256[:12]``.
 
-Credentials: ``$VERCEL_TOKEN`` or the Vercel CLI's stored token; the
-project/team ids come from ``.vercel/project.json`` under ``--cwd``.
+Credentials: ``$VERCEL_TOKEN`` or the Vercel CLI's stored token (expiry
+checked, refreshed via ``vercel whoami``); the project/team ids come from
+``.vercel/project.json`` in ``--cwd`` ITSELF — parents are never searched,
+because a worktree's parent walk once resolved to a deleted project (see
+``vercel_common.py``). Every output line names ``projectName/projectId``.
 
 Copyright 2026 Smart-AI-Memory
 Licensed under Apache 2.0
@@ -38,6 +41,7 @@ import argparse
 import hashlib
 import json
 import os
+import re
 import secrets
 import subprocess
 import sys
@@ -45,26 +49,11 @@ import urllib.error
 import urllib.request
 from pathlib import Path
 
+from vercel_common import VercelSetupError, resolve
+
 API = "https://api.vercel.com"
-
-
-def _token() -> str:
-    tok = os.environ.get("VERCEL_TOKEN")
-    if tok:
-        return tok
-    auth = Path.home() / "Library" / "Application Support" / "com.vercel.cli" / "auth.json"
-    if auth.exists():
-        return json.loads(auth.read_text()).get("token", "")
-    return ""
-
-
-def _link(cwd: Path) -> tuple[str, str]:
-    for d in (cwd, *cwd.parents):
-        p = d / ".vercel" / "project.json"
-        if p.exists():
-            j = json.loads(p.read_text())
-            return j.get("orgId", ""), j.get("projectId", "")
-    return "", ""
+#: A deployment URL the CLI can redeploy: https scheme, a dotted host, nothing else.
+DEPLOY_URL = re.compile(r"^https://[A-Za-z0-9-]+(\.[A-Za-z0-9-]+)+$")
 
 
 def _request(method: str, path: str, token: str, body: dict | None = None) -> dict:
@@ -210,12 +199,13 @@ def main(argv: list[str]) -> int:
 
     args = ap.parse_args(argv[1:])
     cwd = Path(args.cwd).resolve()
-    token = _token()
-    org, linked_pid = _link(cwd)
-    pid = args.project_id or linked_pid
-    if not (token and org and pid):
-        print("no Vercel token or no .vercel/project.json link in --cwd", file=sys.stderr)
+    try:
+        lk = resolve(cwd, args.project_id)
+    except VercelSetupError as exc:
+        print(f"vercel_admin: {exc}", file=sys.stderr)
         return 2
+    token, org, pid = lk.token, lk.org, lk.project_id
+    label = f"[{lk.label}]"
 
     if args.cmd == "redeploy":
         # The CLI's redeploy is the one mutation here; it reuses the source build.
@@ -226,8 +216,17 @@ def main(argv: list[str]) -> int:
                 f"/v6/deployments?projectId={pid}&teamId={org}&target=production&limit=1",
                 token,
             )
-            url = "https://" + (deps.get("deployments") or [{}])[0].get("url", "")
-        print(f"redeploy {url}")
+            if deps.get("error"):
+                print(f"{label} deployments lookup FAILED: {_err_msg(deps)}", file=sys.stderr)
+                return 1
+            host = (deps.get("deployments") or [{}])[0].get("url") or ""
+            url = f"https://{host}" if host else ""
+        if not DEPLOY_URL.match(url or ""):
+            print(
+                f"{label} refusing redeploy: no/malformed deployment URL {url!r}", file=sys.stderr
+            )
+            return 1
+        print(f"{'DRY-RUN ' if args.dry_run else ''}{label} redeploy {url}")
         if args.dry_run:
             return 0
         r = subprocess.run(
@@ -260,23 +259,26 @@ def main(argv: list[str]) -> int:
             org, pid, args.domain, None if args.clear else args.to
         )
 
-    print(f"{'DRY-RUN ' if args.dry_run else ''}{desc}")
+    print(f"{'DRY-RUN ' if args.dry_run else ''}{label} {desc}")
     print(f"  {method} {path}")
     if args.dry_run:
         return 0
 
     result = _request(method, path, token, body)
     if result.get("error"):
-        msg = (
-            result["error"].get("message") if isinstance(result["error"], dict) else result["error"]
-        )
-        print(f"  FAILED ({result.get('status')}): {msg}", file=sys.stderr)
+        print(f"  {label} FAILED ({result.get('status')}): {_err_msg(result)}", file=sys.stderr)
         return 1
-    print("  ok")
+    print(f"  {label} ok")
     if args.cmd == "env-set" and args.store:
         store_locally(Path(args.store).expanduser(), args.name, value)
         print(f"  stored {args.name} in {args.store} (0600)")
     return 0
+
+
+def _err_msg(result: dict) -> str:
+    """The API's error message from a :func:`_request` result (never the token)."""
+    err = result.get("error")
+    return str(err.get("message") if isinstance(err, dict) else err)
 
 
 if __name__ == "__main__":

--- a/scripts/vercel_common.py
+++ b/scripts/vercel_common.py
@@ -1,0 +1,158 @@
+"""Shared credential + project-link resolution for the ``vercel_*`` scripts.
+
+Two hazards found 2026-09-05 while dry-running from a git worktree
+(``.claude/worktrees/<slug>/``) motivate every rule below:
+
+1. **No parent walk.** ``website/.vercel/project.json`` is gitignored, so a
+   fresh worktree has none. The old helpers walked every parent directory
+   and landed on the MAIN checkout's ``.vercel/project.json``, which links
+   a project that no longer exists on the team. The wrapper then printed
+   ``redeploy https://`` (empty URL) with exit 0. Now only
+   ``<cwd>/.vercel/project.json`` is honored, the resolved
+   ``projectName/projectId`` is returned for every output line, and an
+   unlinked cwd raises :class:`VercelSetupError` (exit non-zero).
+
+2. **Token expiry.** ``~/Library/Application Support/com.vercel.cli/auth.json``
+   holds an OAuth access token with ``expiresAt`` (seconds) and a
+   ``refreshToken``. An expired token turns every API call into a 403
+   that the callers used to swallow. Now ``expiresAt`` is checked before
+   use; an expired token is refreshed by running ``vercel whoami`` (the
+   CLI rewrites the file), and if it is still expired afterwards the
+   caller gets a clear error. The token value is never printed.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under Apache 2.0
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+AUTH_FILE = Path.home() / "Library" / "Application Support" / "com.vercel.cli" / "auth.json"
+#: Treat a token that expires within this many seconds as already expired,
+#: so a 900 s redeploy does not start on a token that dies mid-call.
+EXPIRY_SKEW_S = 120
+
+
+class VercelSetupError(RuntimeError):
+    """A credential or project-link problem the user must fix; safe to print."""
+
+
+@dataclass(frozen=True)
+class Link:
+    """One resolved ``.vercel/project.json`` plus a usable token."""
+
+    token: str
+    org: str
+    project_id: str
+    project_name: str
+
+    @property
+    def label(self) -> str:
+        """``projectName/projectId`` for output lines — never the token."""
+        return f"{self.project_name or '?'}/{self.project_id}"
+
+
+def _read_auth(path: Path = AUTH_FILE) -> dict:
+    if not path.exists():
+        return {}
+    try:
+        data = json.loads(path.read_text())
+    except (OSError, ValueError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _expired(auth: dict, now: float | None = None) -> bool:
+    """True when ``auth`` carries an ``expiresAt`` at or before now (+skew).
+
+    ``expiresAt`` is seconds since the epoch in the current CLI; a value
+    that looks like milliseconds is normalized. No ``expiresAt`` (an older
+    static token) means "not expiring".
+    """
+    exp = auth.get("expiresAt")
+    if not isinstance(exp, (int, float)):
+        return False
+    if exp > 1e12:  # milliseconds
+        exp /= 1000
+    return exp <= (time.time() if now is None else now) + EXPIRY_SKEW_S
+
+
+def refresh_cli_token(timeout: float = 60) -> bool:
+    """Ask the Vercel CLI to refresh its stored token; True when it ran.
+
+    ``vercel whoami`` is read-only and rewrites ``auth.json`` with a fresh
+    access token when the refresh token is still valid. Its output is
+    discarded — nothing from this call is printed.
+    """
+    try:
+        r = subprocess.run(
+            ["vercel", "whoami"], capture_output=True, text=True, timeout=timeout, check=False
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+    return r.returncode == 0
+
+
+def token(auth_file: Path = AUTH_FILE) -> str:
+    """Return a usable token or raise :class:`VercelSetupError`.
+
+    ``$VERCEL_TOKEN`` wins and is never expiry-checked (it is the user's
+    own static token). Otherwise the CLI's stored token is used, refreshed
+    once via :func:`refresh_cli_token` when expired.
+    """
+    env_tok = os.environ.get("VERCEL_TOKEN")
+    if env_tok:
+        return env_tok
+    auth = _read_auth(auth_file)
+    if _expired(auth):
+        refresh_cli_token()
+        auth = _read_auth(auth_file)
+        if _expired(auth):
+            raise VercelSetupError(
+                "Vercel CLI token is expired and could not be refreshed; "
+                "run `vercel whoami` (or `vercel login`) and retry"
+            )
+    tok = auth.get("token", "")
+    if not isinstance(tok, str) or not tok:
+        raise VercelSetupError(
+            f"no Vercel token: set $VERCEL_TOKEN or run `vercel login` (looked in {auth_file})"
+        )
+    return tok
+
+
+def link(cwd: Path, project_id: str | None = None) -> tuple[str, str, str]:
+    """Return ``(orgId, projectId, projectName)`` from ``cwd/.vercel/project.json`` ONLY.
+
+    Parents are deliberately NOT searched (see module docstring). A
+    ``project_id`` override replaces the linked id but keeps the team.
+    """
+    path = cwd / ".vercel" / "project.json"
+    if not path.exists():
+        raise VercelSetupError(
+            f"{cwd} is not linked (no {path.relative_to(cwd)}); parents are not searched. "
+            f"Pass --cwd <linked dir> or run `vercel link --cwd {cwd}`"
+        )
+    try:
+        j = json.loads(path.read_text())
+    except (OSError, ValueError) as exc:
+        raise VercelSetupError(f"unreadable {path}: {exc}") from exc
+    org = str(j.get("orgId") or "")
+    pid = str(project_id or j.get("projectId") or "")
+    if not (org and pid):
+        raise VercelSetupError(f"{path} lacks orgId/projectId")
+    name = str(j.get("projectName") or "")
+    if project_id and project_id != j.get("projectId"):
+        name = ""  # the override is not the linked project; do not mislabel it
+    return org, pid, name
+
+
+def resolve(cwd: Path, project_id: str | None = None) -> Link:
+    """Token + link in one call; raises :class:`VercelSetupError` on either."""
+    org, pid, name = link(cwd, project_id)
+    return Link(token=token(), org=org, project_id=pid, project_name=name)

--- a/scripts/vercel_common.py
+++ b/scripts/vercel_common.py
@@ -135,7 +135,7 @@ def link(cwd: Path, project_id: str | None = None) -> tuple[str, str, str]:
     path = cwd / ".vercel" / "project.json"
     if not path.exists():
         raise VercelSetupError(
-            f"{cwd} is not linked (no {path.relative_to(cwd)}); parents are not searched. "
+            f"{cwd} is not linked (no .vercel/project.json); parents are not searched. "
             f"Pass --cwd <linked dir> or run `vercel link --cwd {cwd}`"
         )
     try:

--- a/scripts/vercel_probe.py
+++ b/scripts/vercel_probe.py
@@ -26,8 +26,10 @@ for every project in the team.
 
 Credentials: the Vercel CLI's own token
 (``~/Library/Application Support/com.vercel.cli/auth.json`` or
-``$VERCEL_TOKEN``) and the ``.vercel/project.json`` link of the cwd.
-The token is sent in a header and never written anywhere.
+``$VERCEL_TOKEN``; expiry checked, refreshed via ``vercel whoami``) and the
+``.vercel/project.json`` link of ``--cwd`` ITSELF — parents are never
+searched (see ``vercel_common.py``). The token is sent in a header and
+never written anywhere.
 
 Copyright 2026 Smart-AI-Memory
 Licensed under Apache 2.0
@@ -38,7 +40,6 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
-import os
 import re
 import subprocess
 import sys
@@ -47,27 +48,9 @@ import urllib.error
 import urllib.request
 from pathlib import Path
 
+from vercel_common import VercelSetupError, resolve
+
 API = "https://api.vercel.com"
-
-
-def _token() -> str:
-    tok = os.environ.get("VERCEL_TOKEN")
-    if tok:
-        return tok
-    auth = Path.home() / "Library" / "Application Support" / "com.vercel.cli" / "auth.json"
-    if auth.exists():
-        return json.loads(auth.read_text()).get("token", "")
-    return ""
-
-
-def _link(cwd: Path) -> tuple[str, str]:
-    """Return (orgId, projectId) from the cwd's ``.vercel/project.json``."""
-    for d in (cwd, *cwd.parents):
-        p = d / ".vercel" / "project.json"
-        if p.exists():
-            j = json.loads(p.read_text())
-            return j.get("orgId", ""), j.get("projectId", "")
-    return "", ""
 
 
 def _get(path: str, token: str) -> dict:
@@ -203,15 +186,17 @@ def main(argv: list[str]) -> int:
     args = ap.parse_args(argv[1:])
 
     cwd = Path(args.cwd).resolve()
-    token = _token()
-    org, project_id = _link(cwd)
+    try:
+        lk = resolve(cwd)
+    except VercelSetupError as exc:
+        print(f"vercel_probe: {exc}", file=sys.stderr)
+        return 2
+    token, org, project_id = lk.token, lk.org, lk.project_id
+    print(f"project [{lk.label}] team {org}")
     lines, rc = env_report(args.env, cwd, args.expect, env_types(token, org, project_id))
     print("\n".join(lines))
 
     if args.domains:
-        if not token or not org:
-            print("domains: no token or no .vercel/project.json link in cwd", file=sys.stderr)
-            return max(rc, 1)
         try:
             print("\n".join(domains_report(token, org)))
         except urllib.error.URLError as exc:

--- a/scripts/vercel_wait_deploy.py
+++ b/scripts/vercel_wait_deploy.py
@@ -20,8 +20,10 @@ Usage::
         [--cwd website] [--timeout 900] [--interval 20]
         [--probe https://smartaimemory.com/api/cron/usage-digest/ --expect 401]
 
-Credentials: the Vercel CLI's stored token (or ``$VERCEL_TOKEN``) and the
-cwd's ``.vercel/project.json`` link. The token goes in a header only.
+Credentials: the Vercel CLI's stored token (or ``$VERCEL_TOKEN``; expiry
+checked, refreshed via ``vercel whoami``) and the ``.vercel/project.json``
+link of ``--cwd`` ITSELF — parents are never searched (see
+``vercel_common.py``). The token goes in a header only.
 
 Copyright 2026 Smart-AI-Memory
 Licensed under Apache 2.0
@@ -31,35 +33,17 @@ from __future__ import annotations
 
 import argparse
 import json
-import os
 import sys
 import time
 import urllib.error
 import urllib.request
 from pathlib import Path
 
+from vercel_common import VercelSetupError, resolve
+
 API = "https://api.vercel.com"
 TERMINAL_OK = {"READY"}
 TERMINAL_BAD = {"ERROR", "CANCELED"}
-
-
-def _token() -> str:
-    tok = os.environ.get("VERCEL_TOKEN")
-    if tok:
-        return tok
-    auth = Path.home() / "Library" / "Application Support" / "com.vercel.cli" / "auth.json"
-    if auth.exists():
-        return json.loads(auth.read_text()).get("token", "")
-    return ""
-
-
-def _link(cwd: Path) -> tuple[str, str]:
-    for d in (cwd, *cwd.parents):
-        p = d / ".vercel" / "project.json"
-        if p.exists():
-            j = json.loads(p.read_text())
-            return j.get("orgId", ""), j.get("projectId", "")
-    return "", ""
 
 
 def _get(path: str, token: str) -> dict:
@@ -143,11 +127,13 @@ def main(argv: list[str]) -> int:
     ap.add_argument("--expect", type=int, default=None, help="status the probe must return")
     args = ap.parse_args(argv[1:])
 
-    token = _token()
-    org, project_id = _link(Path(args.cwd).resolve())
-    if not (token and org and project_id):
-        print("no Vercel token or no .vercel/project.json link in --cwd", file=sys.stderr)
+    try:
+        lk = resolve(Path(args.cwd).resolve())
+    except VercelSetupError as exc:
+        print(f"vercel_wait_deploy: {exc}", file=sys.stderr)
         return 2
+    token, org, project_id = lk.token, lk.org, lk.project_id
+    print(f"project [{lk.label}] commit {args.commit}")
 
     try:
         rc, dep = wait(token, org, project_id, args.commit, args.timeout, args.interval)

--- a/tests/unit/scripts/test_vercel_admin.py
+++ b/tests/unit/scripts/test_vercel_admin.py
@@ -3,7 +3,10 @@
 Pins: each subcommand maps to exactly one API call with the right
 method/path/body; dry-run performs nothing; an empty value is refused;
 generate+store writes a 0600 file and prints only length/digest; API
-errors surface as exit 1 with the message.
+errors surface as exit 1 with the message; an UNLINKED cwd exits 2 (no
+parent walk — the 2026-09-05 worktree hazard); ``redeploy`` refuses an
+empty or malformed URL and surfaces a failed deployments lookup instead
+of running ``vercel redeploy https://``.
 """
 
 from __future__ import annotations
@@ -11,12 +14,16 @@ from __future__ import annotations
 import importlib.util
 import os
 import stat
+import sys
 from pathlib import Path
 
 import pytest
 
 REPO = Path(__file__).resolve().parents[3]
-SCRIPT = REPO / "scripts" / "vercel_admin.py"
+SCRIPTS = REPO / "scripts"
+SCRIPT = SCRIPTS / "vercel_admin.py"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
 
 
 @pytest.fixture(scope="module")
@@ -28,11 +35,16 @@ def mod():
     return m
 
 
+def _fake_resolve(mod, token="tok", org="org_1", pid="prj_1", name="website"):
+    from vercel_common import Link
+
+    return lambda cwd, project_id=None: Link(token, org, project_id or pid, name)
+
+
 @pytest.fixture()
 def linked(mod, monkeypatch, tmp_path):
     """A linked cwd, a token, and a recorder in place of the network."""
-    monkeypatch.setattr(mod, "_token", lambda: "tok")
-    monkeypatch.setattr(mod, "_link", lambda cwd: ("org_1", "prj_1"))
+    monkeypatch.setattr(mod, "resolve", _fake_resolve(mod))
     calls = []
 
     def fake_request(method, path, token, body=None):
@@ -73,7 +85,7 @@ class TestMain:
         calls, tmp = linked
         rc = mod.main(["x", "--cwd", str(tmp), "--dry-run", "domain-detach", "x.com"])
         assert rc == 0 and calls == []
-        assert "DRY-RUN domain-detach x.com" in capsys.readouterr().out
+        assert "DRY-RUN [website/prj_1] domain-detach x.com" in capsys.readouterr().out
 
     def test_domain_detach_is_one_delete(self, mod, linked):
         calls, tmp = linked
@@ -122,17 +134,95 @@ class TestMain:
         assert p.read_text() == "A=1\nK=new\n"
 
     def test_api_error_exits_one_with_message(self, mod, monkeypatch, tmp_path, capsys):
-        monkeypatch.setattr(mod, "_token", lambda: "tok")
-        monkeypatch.setattr(mod, "_link", lambda cwd: ("o", "p"))
+        monkeypatch.setattr(mod, "resolve", _fake_resolve(mod))
         monkeypatch.setattr(
             mod,
             "_request",
             lambda *a, **k: {"error": {"message": "domain is in use"}, "status": 409},
         )
         assert mod.main(["x", "--cwd", str(tmp_path), "domain-attach", "x.com"]) == 1
-        assert "domain is in use" in capsys.readouterr().err
+        err = capsys.readouterr().err
+        assert "domain is in use" in err and "[website/prj_1]" in err
 
-    def test_no_link_exits_two(self, mod, monkeypatch, tmp_path):
-        monkeypatch.setattr(mod, "_token", lambda: "")
-        monkeypatch.setattr(mod, "_link", lambda cwd: ("", ""))
-        assert mod.main(["x", "--cwd", str(tmp_path), "domain-detach", "x.com"]) == 2
+    def test_every_output_line_names_the_project(self, mod, linked, capsys):
+        calls, tmp = linked
+        assert mod.main(["x", "--cwd", str(tmp), "domain-detach", "x.com"]) == 0
+        out = capsys.readouterr().out
+        assert out.startswith("[website/prj_1] domain-detach") and "[website/prj_1] ok" in out
+        assert "tok" not in out.replace("[website/prj_1]", "")
+
+
+class TestLinkResolution:
+    """No parent walk: the real resolver runs against a tmp tree."""
+
+    def test_unlinked_cwd_exits_two_with_a_clear_message(self, mod, monkeypatch, tmp_path, capsys):
+        monkeypatch.setenv("VERCEL_TOKEN", "env-token")
+        calls = []
+        monkeypatch.setattr(mod, "_request", lambda *a, **k: calls.append(a) or {})
+        rc = mod.main(["x", "--cwd", str(tmp_path), "--dry-run", "redeploy"])
+        err = capsys.readouterr().err
+        assert rc == 2 and calls == []
+        assert "not linked" in err and "parents are not searched" in err
+        assert "env-token" not in err
+
+    def test_parent_link_is_not_inherited(self, mod, monkeypatch, tmp_path, capsys):
+        (tmp_path / ".vercel").mkdir()
+        (tmp_path / ".vercel" / "project.json").write_text(
+            '{"projectId": "prj_STALE", "orgId": "team_1", "projectName": "attune-ai"}'
+        )
+        worktree = tmp_path / ".claude" / "worktrees" / "slug"
+        worktree.mkdir(parents=True)
+        monkeypatch.setenv("VERCEL_TOKEN", "env-token")
+        monkeypatch.setattr(mod, "_request", lambda *a, **k: pytest.fail("network touched"))
+        rc = mod.main(["x", "--cwd", str(worktree), "--dry-run", "domain-detach", "x.com"])
+        assert rc == 2 and "prj_STALE" not in capsys.readouterr().err
+
+    def test_linked_cwd_labels_output(self, mod, monkeypatch, tmp_path, capsys):
+        (tmp_path / ".vercel").mkdir()
+        (tmp_path / ".vercel" / "project.json").write_text(
+            '{"projectId": "prj_W", "orgId": "team_1", "projectName": "website"}'
+        )
+        monkeypatch.setenv("VERCEL_TOKEN", "env-token")
+        rc = mod.main(["x", "--cwd", str(tmp_path), "--dry-run", "domain-detach", "x.com"])
+        out = capsys.readouterr().out
+        assert rc == 0 and "DRY-RUN [website/prj_W] domain-detach x.com" in out
+        assert "teamId=team_1" in out and "env-token" not in out
+
+
+class TestRedeploy:
+    def _lookup(self, mod, monkeypatch, response):
+        monkeypatch.setattr(mod, "resolve", _fake_resolve(mod))
+        monkeypatch.setattr(mod, "_request", lambda *a, **k: response)
+        monkeypatch.setattr(mod.subprocess, "run", lambda *a, **k: pytest.fail("redeploy ran"))
+
+    def test_empty_lookup_url_is_refused(self, mod, monkeypatch, tmp_path, capsys):
+        self._lookup(mod, monkeypatch, {"deployments": [{}]})
+        rc = mod.main(["x", "--cwd", str(tmp_path), "redeploy"])
+        err = capsys.readouterr().err
+        assert rc == 1 and "refusing redeploy" in err and "'https://'" not in err.split("[")[0]
+
+    def test_forbidden_lookup_is_surfaced_not_swallowed(self, mod, monkeypatch, tmp_path, capsys):
+        self._lookup(mod, monkeypatch, {"error": {"message": "Not authorized"}, "status": 403})
+        rc = mod.main(["x", "--cwd", str(tmp_path), "redeploy"])
+        err = capsys.readouterr().err
+        assert rc == 1 and "deployments lookup FAILED: Not authorized" in err
+        assert "[website/prj_1]" in err
+
+    @pytest.mark.parametrize(
+        "bad", ["https://", "http://x.vercel.app", "x.vercel.app", "https://x y"]
+    )
+    def test_malformed_explicit_url_is_refused(self, mod, monkeypatch, tmp_path, bad, capsys):
+        self._lookup(mod, monkeypatch, {})
+        rc = mod.main(["x", "--cwd", str(tmp_path), "--dry-run", "redeploy", "--url", bad])
+        assert rc == 1 and "refusing redeploy" in capsys.readouterr().err
+
+    def test_good_lookup_url_dry_run_labels_and_performs_nothing(
+        self, mod, monkeypatch, tmp_path, capsys
+    ):
+        self._lookup(mod, monkeypatch, {"deployments": [{"url": "site-abc-team.vercel.app"}]})
+        rc = mod.main(["x", "--cwd", str(tmp_path), "--dry-run", "redeploy"])
+        assert rc == 0
+        assert (
+            "DRY-RUN [website/prj_1] redeploy https://site-abc-team.vercel.app"
+            in capsys.readouterr().out
+        )

--- a/tests/unit/scripts/test_vercel_common.py
+++ b/tests/unit/scripts/test_vercel_common.py
@@ -1,0 +1,171 @@
+"""Unit tests for scripts/vercel_common.py — link resolution and token expiry.
+
+Pins the two 2026-09-05 worktree hazards: (1) ``.vercel/project.json`` is
+honored in the cwd ONLY — a parent's link (the main checkout's stale,
+deleted project) is never picked up, and an unlinked cwd raises; (2) an
+expired CLI token triggers one ``vercel whoami`` refresh and raises when
+still expired, and the token value never appears in any message.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[3]
+SCRIPTS = REPO / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+
+@pytest.fixture(scope="module")
+def mod():
+    # A normal import (scripts/ is on sys.path), not spec_from_file_location:
+    # the module's dataclass needs itself registered in sys.modules under
+    # ``from __future__ import annotations``.
+    return importlib.import_module("vercel_common")
+
+
+def _write_link(d: Path, project_id="prj_1", name="website", org="team_1") -> Path:
+    (d / ".vercel").mkdir(parents=True, exist_ok=True)
+    p = d / ".vercel" / "project.json"
+    p.write_text(json.dumps({"projectId": project_id, "orgId": org, "projectName": name}))
+    return p
+
+
+class TestLink:
+    def test_reads_cwd_link_with_name(self, mod, tmp_path):
+        _write_link(tmp_path)
+        assert mod.link(tmp_path) == ("team_1", "prj_1", "website")
+
+    def test_no_parent_walk(self, mod, tmp_path):
+        """A worktree under a linked main checkout must NOT inherit main's link."""
+        _write_link(tmp_path, project_id="prj_STALE", name="attune-ai")
+        worktree = tmp_path / ".claude" / "worktrees" / "slug"
+        worktree.mkdir(parents=True)
+        with pytest.raises(mod.VercelSetupError) as ei:
+            mod.link(worktree)
+        msg = str(ei.value)
+        assert "not linked" in msg and "parents are not searched" in msg
+        assert "prj_STALE" not in msg
+
+    def test_unlinked_names_the_fix(self, mod, tmp_path):
+        with pytest.raises(mod.VercelSetupError) as ei:
+            mod.link(tmp_path)
+        assert "vercel link --cwd" in str(ei.value) and ".vercel/project.json" in str(ei.value)
+
+    def test_project_id_override_keeps_team_and_drops_name(self, mod, tmp_path):
+        _write_link(tmp_path)
+        assert mod.link(tmp_path, "prj_other") == ("team_1", "prj_other", "")
+        assert mod.link(tmp_path, "prj_1") == ("team_1", "prj_1", "website")
+
+    def test_malformed_link_raises(self, mod, tmp_path):
+        p = _write_link(tmp_path)
+        p.write_text("{not json")
+        with pytest.raises(mod.VercelSetupError, match="unreadable"):
+            mod.link(tmp_path)
+        p.write_text(json.dumps({"projectName": "x"}))
+        with pytest.raises(mod.VercelSetupError, match="lacks orgId/projectId"):
+            mod.link(tmp_path)
+
+
+class TestToken:
+    def _auth(self, tmp_path, expires_at, token="tok_secret_value_123"):
+        f = tmp_path / "auth.json"
+        f.write_text(
+            json.dumps({"token": token, "refreshToken": "rt_secret", "expiresAt": expires_at})
+        )
+        return f
+
+    def test_env_token_wins_and_skips_expiry(self, mod, monkeypatch, tmp_path):
+        monkeypatch.setenv("VERCEL_TOKEN", "env-token")
+        assert mod.token(tmp_path / "missing.json") == "env-token"
+
+    def test_valid_token_is_returned_without_refresh(self, mod, monkeypatch, tmp_path):
+        monkeypatch.delenv("VERCEL_TOKEN", raising=False)
+        calls = []
+        monkeypatch.setattr(mod, "refresh_cli_token", lambda **kw: calls.append(1) or True)
+        f = self._auth(tmp_path, expires_at=int(mod.time.time()) + 3600)
+        assert mod.token(f) == "tok_secret_value_123" and calls == []
+
+    def test_expired_token_refreshes_once_then_uses_new_file(self, mod, monkeypatch, tmp_path):
+        monkeypatch.delenv("VERCEL_TOKEN", raising=False)
+        f = self._auth(tmp_path, expires_at=int(mod.time.time()) - 10)
+        calls = []
+
+        def fake_refresh(**kw):
+            calls.append(1)
+            self._auth(tmp_path, expires_at=int(mod.time.time()) + 3600, token="tok_fresh")
+            return True
+
+        monkeypatch.setattr(mod, "refresh_cli_token", fake_refresh)
+        assert mod.token(f) == "tok_fresh" and calls == [1]
+
+    def test_still_expired_after_refresh_raises_without_leaking(self, mod, monkeypatch, tmp_path):
+        monkeypatch.delenv("VERCEL_TOKEN", raising=False)
+        f = self._auth(tmp_path, expires_at=int(mod.time.time()) - 10)
+        monkeypatch.setattr(mod, "refresh_cli_token", lambda **kw: False)
+        with pytest.raises(mod.VercelSetupError) as ei:
+            mod.token(f)
+        msg = str(ei.value)
+        assert "expired" in msg and "vercel whoami" in msg
+        assert "tok_secret_value_123" not in msg and "rt_secret" not in msg
+
+    def test_skew_counts_as_expired(self, mod, tmp_path):
+        assert mod._expired({"expiresAt": 1000 + mod.EXPIRY_SKEW_S - 1}, now=1000)
+        assert not mod._expired({"expiresAt": 1000 + mod.EXPIRY_SKEW_S + 1}, now=1000)
+
+    def test_millisecond_expiry_is_normalized_and_missing_means_static(self, mod):
+        # 2_000_000_000_000 ms == 2_000_000_000 s: later than now -> valid
+        assert not mod._expired({"expiresAt": 2_000_000_000_000}, now=1_000_000_000)
+        # 1_500_000_000_000 ms == 1_500_000_000 s: earlier than now -> expired
+        assert mod._expired({"expiresAt": 1_500_000_000_000}, now=2_000_000_000)
+        assert not mod._expired({"token": "static"}, now=1_000_000_000)
+
+    def test_missing_file_raises_naming_the_path(self, mod, monkeypatch, tmp_path):
+        monkeypatch.delenv("VERCEL_TOKEN", raising=False)
+        f = tmp_path / "auth.json"
+        with pytest.raises(mod.VercelSetupError, match="no Vercel token"):
+            mod.token(f)
+
+    def test_refresh_runs_whoami_and_discards_output(self, mod, monkeypatch):
+        seen = {}
+
+        def fake_run(cmd, **kw):
+            seen["cmd"] = cmd
+            seen["capture"] = kw.get("capture_output")
+
+            class R:
+                returncode = 0
+                stdout = "someone@example.com"
+
+            return R()
+
+        monkeypatch.setattr(mod.subprocess, "run", fake_run)
+        assert mod.refresh_cli_token() is True
+        assert seen["cmd"] == ["vercel", "whoami"] and seen["capture"] is True
+
+    def test_refresh_survives_missing_cli(self, mod, monkeypatch):
+        def boom(cmd, **kw):
+            raise FileNotFoundError("vercel")
+
+        monkeypatch.setattr(mod.subprocess, "run", boom)
+        assert mod.refresh_cli_token() is False
+
+
+class TestResolve:
+    def test_resolve_combines_link_and_token(self, mod, monkeypatch, tmp_path):
+        _write_link(tmp_path)
+        monkeypatch.setenv("VERCEL_TOKEN", "env-token")
+        lk = mod.resolve(tmp_path)
+        assert (lk.token, lk.org, lk.project_id, lk.project_name) == (
+            "env-token",
+            "team_1",
+            "prj_1",
+            "website",
+        )
+        assert lk.label == "website/prj_1" and "env-token" not in lk.label

--- a/tests/unit/scripts/test_vercel_probe.py
+++ b/tests/unit/scripts/test_vercel_probe.py
@@ -11,12 +11,22 @@ project-domains endpoint (attachment), not the account domain record.
 from __future__ import annotations
 
 import importlib.util
+import sys
 from pathlib import Path
 
 import pytest
 
 REPO = Path(__file__).resolve().parents[3]
-SCRIPT = REPO / "scripts" / "vercel_probe.py"
+SCRIPTS = REPO / "scripts"
+SCRIPT = SCRIPTS / "vercel_probe.py"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+
+def _fake_resolve(token="tok", org="org", pid="prj", name="website"):
+    from vercel_common import Link
+
+    return lambda cwd, project_id=None: Link(token, org, project_id or pid, name)
 
 
 @pytest.fixture(scope="module")
@@ -151,8 +161,7 @@ class TestMain:
         monkeypatch.setattr(
             mod, "pull_env", lambda env, cwd: {"RESEND_API_KEY": "re_" + "x" * 33, "PGHOST": ""}
         )
-        monkeypatch.setattr(mod, "_token", lambda: "tok")
-        monkeypatch.setattr(mod, "_link", lambda cwd: ("org", "prj"))
+        monkeypatch.setattr(mod, "resolve", _fake_resolve())
         monkeypatch.setattr(
             mod, "env_types", lambda t, o, p: {"RESEND_API_KEY": "encrypted", "PGHOST": "sensitive"}
         )
@@ -170,13 +179,15 @@ class TestMain:
             rc == 0 and "prefix=re_" in out and "not pullable" in out and "x.com [primary]" in out
         )
         assert "x" * 20 not in out
+        assert out.startswith("project [website/prj] team org") and "tok" not in out
 
-    def test_main_without_link_reports_and_fails_domains(self, mod, monkeypatch, tmp_path, capsys):
-        monkeypatch.setattr(mod, "pull_env", lambda env, cwd: {})
-        monkeypatch.setattr(mod, "_token", lambda: "")
-        monkeypatch.setattr(mod, "_link", lambda cwd: ("", ""))
+    def test_main_unlinked_cwd_exits_two_without_pulling(self, mod, monkeypatch, tmp_path, capsys):
+        """The real resolver runs: no ``.vercel/project.json`` in cwd, no parent walk."""
+        monkeypatch.setenv("VERCEL_TOKEN", "env-token")
+        monkeypatch.setattr(mod, "pull_env", lambda env, cwd: pytest.fail("env pull ran"))
         rc = mod.main(["x", "--cwd", str(tmp_path), "--domains"])
-        assert rc == 1 and "no token" in capsys.readouterr().err
+        err = capsys.readouterr().err
+        assert rc == 2 and "not linked" in err and "env-token" not in err
 
     def test_env_types_degrades_to_empty_on_api_error(self, mod, monkeypatch):
         import urllib.error
@@ -188,14 +199,15 @@ class TestMain:
         assert mod.env_types("tok", "org", "prj") == {}
         assert mod.env_types("", "org", "prj") == {}
 
-    def test_link_and_token_readers(self, mod, tmp_path, monkeypatch):
+    def test_link_is_cwd_only(self, mod, tmp_path, monkeypatch):
         (tmp_path / ".vercel").mkdir()
         (tmp_path / ".vercel" / "project.json").write_text(
-            '{"orgId": "team_1", "projectId": "prj_1"}'
+            '{"orgId": "team_1", "projectId": "prj_1", "projectName": "website"}'
         )
+        monkeypatch.setenv("VERCEL_TOKEN", "env-token")
+        lk = mod.resolve(tmp_path)
+        assert (lk.org, lk.project_id, lk.label) == ("team_1", "prj_1", "website/prj_1")
         sub = tmp_path / "website" / "app"
         sub.mkdir(parents=True)
-        assert mod._link(sub) == ("team_1", "prj_1")
-        assert mod._link(Path("/")) == ("", "")
-        monkeypatch.setenv("VERCEL_TOKEN", "env-token")
-        assert mod._token() == "env-token"
+        with pytest.raises(mod.VercelSetupError):  # a parent's link is NOT inherited
+            mod.resolve(sub)

--- a/tests/unit/scripts/test_vercel_wait_deploy.py
+++ b/tests/unit/scripts/test_vercel_wait_deploy.py
@@ -9,12 +9,22 @@ reported as 308, because Vercel Cron treats it as final.
 from __future__ import annotations
 
 import importlib.util
+import sys
 from pathlib import Path
 
 import pytest
 
 REPO = Path(__file__).resolve().parents[3]
-SCRIPT = REPO / "scripts" / "vercel_wait_deploy.py"
+SCRIPTS = REPO / "scripts"
+SCRIPT = SCRIPTS / "vercel_wait_deploy.py"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+
+def _fake_resolve(token="t", org="o", pid="p", name="website"):
+    from vercel_common import Link
+
+    return lambda cwd, project_id=None: Link(token, org, project_id or pid, name)
 
 
 @pytest.fixture(scope="module")
@@ -109,8 +119,7 @@ class TestProbe:
 
 class TestMain:
     def test_main_ready_then_probe_mismatch_fails(self, mod, monkeypatch, tmp_path):
-        monkeypatch.setattr(mod, "_token", lambda: "t")
-        monkeypatch.setattr(mod, "_link", lambda cwd: ("o", "p"))
+        monkeypatch.setattr(mod, "resolve", _fake_resolve())
         monkeypatch.setattr(mod, "wait", lambda *a, **k: (0, _dep("abc", "READY")))
         monkeypatch.setattr(mod, "http_status", lambda url: 308)
         assert (
@@ -148,14 +157,15 @@ class TestMain:
         )
 
     def test_main_without_link_exits_two(self, mod, monkeypatch, tmp_path, capsys):
-        monkeypatch.setattr(mod, "_token", lambda: "")
-        monkeypatch.setattr(mod, "_link", lambda cwd: ("", ""))
+        """The real resolver runs: an unlinked cwd fails before any API call."""
+        monkeypatch.setenv("VERCEL_TOKEN", "env-token")
+        monkeypatch.setattr(mod, "wait", lambda *a, **k: pytest.fail("API touched"))
         assert mod.main(["x", "--commit", "abc", "--cwd", str(tmp_path)]) == 2
-        assert "no Vercel token" in capsys.readouterr().err
+        err = capsys.readouterr().err
+        assert "not linked" in err and "env-token" not in err
 
     def test_main_build_error_prints_message(self, mod, monkeypatch, tmp_path, capsys):
-        monkeypatch.setattr(mod, "_token", lambda: "t")
-        monkeypatch.setattr(mod, "_link", lambda cwd: ("o", "p"))
+        monkeypatch.setattr(mod, "resolve", _fake_resolve())
         monkeypatch.setattr(
             mod, "wait", lambda *a, **k: (1, _dep("abc", "ERROR", err="CRON_SECRET has whitespace"))
         )


### PR DESCRIPTION
## Summary

Two hazards found 2026-09-05 while dry-running `scripts/vercel_admin.py` from a git worktree (`.claude/worktrees/<slug>/`):

1. **Parent walk landed on a stale link.** `_link()` searched every parent for `.vercel/project.json`. A worktree has none (gitignored), so it picked up the main checkout's root link to `prj_FmwGiRfVg6vYDKTd9V6DKiDW0THW` ("attune-ai") — a project that no longer exists on the team. The wrapper printed `redeploy https://` (empty URL) with exit 0; a non-dry-run would have executed `vercel redeploy https://`.
2. **Expired OAuth token swallowed into the same empty URL.** `_token()` read the CLI's `auth.json` without looking at `expiresAt`; once expired every API call was a 403 the redeploy lookup turned into an empty URL.

## Changes

New `scripts/vercel_common.py`, shared by `vercel_admin`, `vercel_probe`, and `vercel_wait_deploy` (all three carried the same copied helpers — one source now):

- `link()` honors `<cwd>/.vercel/project.json` **only**. No parent walk. Returns `projectName` too. An unlinked cwd raises `VercelSetupError`; each script turns that into exit 2 with the fix named (`vercel link --cwd …`).
- `token()`: `$VERCEL_TOKEN` wins. Otherwise `expiresAt` is checked (seconds; ms normalized; 120 s skew), the CLI token is refreshed once via `vercel whoami` with its output discarded, and a still-expired token raises. The token value never appears in any message.
- Every output line of all three scripts is prefixed `[projectName/projectId]`.
- `redeploy`: a failed deployments lookup is surfaced (exit 1) instead of swallowed; an empty or malformed URL is refused before the CLI runs (`DEPLOY_URL` regex).
- One mutation per invocation and never-print-secret-values are unchanged.

## Receipts

Live, read-only dry-runs on this machine:

| `--cwd` | Result |
|---|---|
| the worktree | exit 2 — `not linked (no .vercel/project.json); parents are not searched` |
| `~/attune-ai` (stale root link) | exit 1 — `[attune-ai/prj_FmwG…] deployments lookup FAILED: Project not found` |
| `~/attune-ai/website` | exit 0 — `DRY-RUN [website/prj_WX8P…] redeploy https://smartaimemory-…vercel.app` |
| `website` + `--url https://` | exit 1 — `refusing redeploy: no/malformed deployment URL 'https://'` |

Tests (serial): `tests/unit/scripts/test_vercel_{common,admin,probe,wait_deploy}.py` — 59 passed. `tests/unit/gates` — 423 passed. Coverage on `vercel_common.py`: 97% (codecov excludes `scripts/**`).

## Not done here

- The stale `~/attune-ai/.vercel/project.json` (machine-local, untracked) is still on disk. Deleting or re-linking it is the chair's call.
- D11: this diff touches credential handling, so a different-model review lane is owed before the chair reads the recommendation. Not launched here (spend gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
