### PR TITLE
docs(spec): adaptive-session-interactions T4 — preregistered protocol, open record, T5 conditional go (chair-read)

### DIFF
--- a/.agents/skills/spec/SKILL.md
+++ b/.agents/skills/spec/SKILL.md
@@ -144,6 +144,14 @@ next step needs. Rules, in precedence order:
 If any of these cannot be honored on the current host, say which and
 fall back to the returned Markdown; do not invent a surface.
 
+**T4 collection is open (adaptive-session-interactions D10).** On a real
+review stage on the named host, read the next unfilled slot in
+`docs/specs/adaptive-session-interactions/t4-record.md` and serve the
+choice under that slot's condition (A = widget; B = set
+`interaction_preference` to `conversation`, then the Markdown lane), then
+append the row per `t4-protocol.md` before continuing. Synthetic reviews
+and other hosts are exclusions, not slots.
+
 ## How It Works
 
 Five stages, one flow:

--- a/docs/specs/adaptive-session-interactions/decisions.md
+++ b/docs/specs/adaptive-session-interactions/decisions.md
@@ -183,3 +183,25 @@ sense / pushback?" Recorded by the lead the same evening.
   Nothing in T4 executes until the protocol is frozen per ASI-6 and any
   user participation or paid operation has its own authorization.
 - A go on T4 is not a go on T5.
+
+## D10 — T4 runs as a preregistered live collection, not a manufactured session (2026-09-05, chair via pushback card)
+
+The lead pushed back on running T4 as a session of manufactured
+spec-review moments (usefulness metrics read zero by construction on a
+decision nobody cares about; ASI-5 forbids creating consequential work
+to test an approval). The chair adopted the alternative:
+
+- **T4's exercise today is the protocol freeze** —
+  [`t4-protocol.md`](t4-protocol.md), preregistered per ASI-6 before any
+  occurrence is collected, with its SHA-256 recorded at freeze.
+- **Collection rides on real `/spec` review-stage choices** on the named
+  host, one occurrence at a time, in the preregistered ABBA order, until
+  the preregistered count is reached. Each occurrence is appended to
+  [`t4-record.md`](t4-record.md) — counts and outcomes only, never raw
+  answers or action nonces.
+- **The two conditions** are the automatic default (T2 guidance, widget
+  where the host renders it) and the session preference `conversation`
+  (Markdown lane, spoken answer transcribed). Latency is descriptive
+  (D8). No provider call is involved; no paid operation.
+- **T5 opens when the record reaches the count** or the falsification
+  rule trips, whichever first. A go on T4 is not a go on T5.

--- a/docs/specs/adaptive-session-interactions/decisions.md
+++ b/docs/specs/adaptive-session-interactions/decisions.md
@@ -205,3 +205,23 @@ to test an approval). The chair adopted the alternative:
   (D8). No provider call is involved; no paid operation.
 - **T5 opens when the record reaches the count** or the falsification
   rule trips, whichever first. A go on T4 is not a go on T5.
+
+## D11 — T5 holds a standing conditional go that opens on the T4 record (2026-09-05, chair via pushback card)
+
+The chair leaned toward a T5 go tonight; the lead pushed back (the T4
+record is empty, and ASI-6 forbids promoting a default without
+behavioral receipts of usefulness). The chair adopted the alternative:
+
+- **T5's go is granted now and fires on the preregistered condition**,
+  not on a date: the moment [`t4-record.md`](t4-record.md) holds eight
+  completed occurrences, or the T4 protocol's falsification rule trips.
+- **The session that fills the triggering row runs T5 in that session**:
+  it reads the record, applies the preregistered promotion criteria,
+  writes the T5 evidence (findings and the strongest counter-case), and
+  presents the promotion decision to the chair. No further "go on T5" is
+  needed; no session may run T5 before the trigger.
+- **Promotion itself stays a chair ruling** (ASI-6, ASI-7). T5 recommends;
+  the chair promotes or declines; the decision is a decisions entry.
+- The frozen T4 protocol is not amended by this entry; its operating
+  instruction already stops collection on the trigger. This entry supplies
+  the authority for what happens next.

--- a/docs/specs/adaptive-session-interactions/evidence.md
+++ b/docs/specs/adaptive-session-interactions/evidence.md
@@ -207,3 +207,14 @@ Paint timing on any host; usefulness of the automatic default (T4); any
 host other than the one named above; native-dialog rendering on this host
 (observed: auto-decline). Telemetry rows written by these probes live in
 the local `form_events.jsonl`; they are receipts, not measurements.
+
+## T4 preregistration (2026-09-05, decisions D10)
+
+[`t4-protocol.md`](t4-protocol.md) frozen before any occurrence was
+collected. SHA-256 of the file at freeze: `9ecc2b95148aa469a2ee9d2daad6f03587f8a0c67e2a6ed8578fac7f709dc2c9`.
+Record opened at [`t4-record.md`](t4-record.md) with the eight slots and
+their preregistered conditions (A B B A B A A B) and T3's two synthetic
+receipts listed as exclusions. The spec skill's review-choice section
+carries the collection instruction (master + tracked mirror + both help
+projections regenerated). No occurrence has been collected. Chair go for
+T5 is separate and waits on the record.

--- a/docs/specs/adaptive-session-interactions/t4-protocol.md
+++ b/docs/specs/adaptive-session-interactions/t4-protocol.md
@@ -1,0 +1,146 @@
+# Adaptive session interactions — T4 protocol (preregistered)
+
+**Status:** FROZEN 2026-09-05 (decisions D10). Amending this file after
+freeze requires a new decisions entry naming what changed and why;
+occurrences collected under the earlier text stay attributed to it.
+**Freeze identity:** the SHA-256 of this file at the freezing commit is
+recorded in [`evidence.md`](evidence.md) under "T4 preregistration".
+
+This is the ASI-6 preregistration for the bounded comparative trial
+(ladder T4). It fixes the scenarios, conditions, order, sample, host,
+outcomes, exclusions, missing-data rules, and falsification rule BEFORE
+the first occurrence is collected. It authorizes no provider call and no
+paid operation; every occurrence is a real interaction that would have
+happened anyway.
+
+## Question
+
+On the named host, is the automatic default presentation for the `spec`
+review choice (widget, per the T2 guidance) more useful than the
+session-preference alternative (`conversation`, Markdown lane), measured
+by what the user does, not by how fast anything paints?
+
+## Unit of analysis
+
+One **occurrence** = one real `/spec` run reaching the `review` stage
+(the `spec` adapter's `redo_plan` / `approve_plan` choice) on the named
+host, whose choice is answered and accepted through
+`command_workspace_collect_action`. Not a session, not a spec. A spec
+that returns to review after `redo_plan` yields a new occurrence.
+
+## Conditions
+
+| Code | Condition | What the agent does |
+| --- | --- | --- |
+| **A** | Automatic default | Present the returned widget HTML through the host's `show_widget`; the user answers by clicking; the posted payload is submitted unchanged. |
+| **B** | Session preference `conversation` | Set `interaction_preference = conversation` for the session (`context_set`); present the returned Markdown verbatim; the user answers in words; the agent transcribes into the bound payload and submits it. |
+
+Both conditions use the same canonical collector, binding grammar, and
+acceptance semantics (established by T3). Nothing else about the review
+stage changes. The condition governs presentation only.
+
+## Order (counterbalanced, fixed in advance)
+
+Occurrences are assigned in this order and no other:
+
+| Occurrence | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| Condition | A | B | B | A | B | A | A | B |
+
+The next unfilled slot in [`t4-record.md`](t4-record.md) is the assigned
+condition. An occurrence cannot be skipped to reach a preferred
+condition; a skipped occurrence is recorded as an exclusion with its
+reason.
+
+## Sample
+
+Eight occurrences, four per condition. This is a **within-user pilot on
+one host** (ASI-6: supports a local default decision, not a population
+claim). Collection closes at eight or on the falsification rule below,
+whichever comes first.
+
+## Host and runtime (recorded per occurrence)
+
+Named host: Claude desktop app, Code tab, with the attune-ai plugin MCP
+server. Each row records the attune-ai source or distribution the
+serving MCP process imports, the attune-forms version it loads, and the
+Python version — read from the serving process's environment, never
+inferred from a ref (T1's method). An occurrence on any other host is
+recorded and excluded.
+
+## Primary outcomes (per occurrence, all recorded; none may be dropped)
+
+| Outcome | Definition | Source |
+| --- | --- | --- |
+| Completed | the choice was accepted canonically (revision advanced) | `workspace_accepted` telemetry row joined on workspace, revision, instance |
+| Corrections | count of collector rejections before acceptance (stale, invalid, mismatched payloads) | `command_workspace_collect_action` results |
+| Clarification turns | count of agent-to-user turns between render and acceptance that asked something about the choice itself | transcript, counted by the agent at record time |
+| Override | the user asked for the OTHER lane after the assigned one was presented (either direction) | transcript |
+| Authority failure | any acceptance that did not match the rendered view, or any double execution | collector + telemetry; **any occurrence suspends collection (ASI-6)** |
+
+## Secondary (descriptive only; never a criterion — D8)
+
+Render-to-acceptance dwell in seconds from the telemetry join. Paint
+timing is **unmeasured on this host** and recorded as `null`, never
+estimated from tool-return or arrival times.
+
+## Exclusions (recorded, then excluded from the comparison)
+
+- Synthetic or manufactured review moments, including T3's two receipts.
+- An occurrence where the user named the alternative in words BEFORE
+  the presentation was rendered (ASI-5: no control is presented; record
+  as "pre-chosen" and do not count against the slot).
+- An occurrence on a host other than the named host.
+- An occurrence where the assigned condition could not be honored (for
+  example the host failed to render the widget under A) — record the
+  reason; the slot stays open.
+
+## Missing data
+
+A missing value is `null`, reported as such. No zero is imputed. An
+occurrence with a missing primary outcome still counts as an occurrence
+but is flagged in the record.
+
+## Falsification rule (preregistered)
+
+The automatic default is judged NOT useful, and T5 opens early to record
+that, if either holds before the eighth occurrence:
+
+- overrides away from A in two or more of A's occurrences, or
+- corrections plus clarification turns summed over A's occurrences exceed
+  the same sum over B's occurrences by three or more at any point where
+  both conditions have at least two occurrences.
+
+An authority failure in either condition suspends collection immediately
+regardless of counts (ASI-6) and returns the pilot to a verified
+fallback pending review.
+
+## Promotion criteria (what T5 needs to see to keep the default)
+
+All of: eight completed occurrences; zero authority failures; at most one
+override away from A; A's corrections-plus-clarifications not greater
+than B's. Anything less is reported as-is; there is no post-hoc metric
+selection.
+
+## Where the record lives
+
+[`t4-record.md`](t4-record.md), one row per occurrence, appended by the
+agent that served it, in the same session, before any other spec work
+continues. Rows carry counts, labels, and telemetry identifiers only —
+never the user's answers, never action nonces, never contract hashes.
+
+## Operating instruction (how an occurrence is collected)
+
+At a real `/spec` review stage on the named host:
+
+1. Read the next unfilled slot in `t4-record.md`; that is the condition.
+2. Apply it (A: widget; B: `context_set interaction_preference
+   conversation`, then the Markdown lane). Do not tell the user which
+   slot it is before they answer; do tell them, if asked, that the
+   review presentation is under the T4 trial.
+3. Serve the choice exactly as the T2 guidance says for that lane.
+4. After acceptance, append the row from the telemetry join and the
+   transcript. Reset the session preference to `default` after a B
+   occurrence unless the user set it themselves.
+5. Check the falsification rule. If it trips, stop collecting and open
+   T5 with the record as it stands.

--- a/docs/specs/adaptive-session-interactions/t4-record.md
+++ b/docs/specs/adaptive-session-interactions/t4-record.md
@@ -1,0 +1,37 @@
+# Adaptive session interactions — T4 record
+
+Append-only. One row per real `/spec` review-stage occurrence on the
+named host, served under [`t4-protocol.md`](t4-protocol.md) (frozen
+2026-09-05, decisions D10). The next row with an empty **Date** is the
+next assigned slot. Rows carry counts, labels, and telemetry identifiers
+only — never answers, nonces, or contract hashes.
+
+Columns: Completed = choice accepted canonically; Corr = collector
+rejections before acceptance; Clar = clarification turns about the choice
+between render and acceptance; Override = user asked for the other lane;
+Auth fail = any acceptance not matching the rendered view or any double
+execution; Dwell = render-to-acceptance seconds from the telemetry join
+(descriptive); Paint = always `null` on this host.
+
+| # | Cond | Date (UTC) | Spec slug | Workspace id | Runtime (attune-ai src / forms / py) | Completed | Corr | Clar | Override | Auth fail | Dwell s | Paint | Notes |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| 1 | A | | | | | | | | | | | null | |
+| 2 | B | | | | | | | | | | | null | |
+| 3 | B | | | | | | | | | | | null | |
+| 4 | A | | | | | | | | | | | null | |
+| 5 | B | | | | | | | | | | | null | |
+| 6 | A | | | | | | | | | | | null | |
+| 7 | A | | | | | | | | | | | null | |
+| 8 | B | | | | | | | | | | | null | |
+
+## Exclusions (recorded, not counted)
+
+| Date (UTC) | Spec slug | Reason | Notes |
+| --- | --- | --- | --- |
+| 2026-09-05 | asi-t3-widget-lane | synthetic (T3 receipt) | widget lane; accepted rev 3 → 4 |
+| 2026-09-05 | asi-t3-markdown-lane | synthetic (T3 receipt) | Markdown lane; accepted rev 3 → 4 |
+
+## Falsification / suspension log
+
+| Date (UTC) | Rule | Tripped? | Action |
+| --- | --- | --- | --- |

--- a/docs/specs/adaptive-session-interactions/t4-record.md
+++ b/docs/specs/adaptive-session-interactions/t4-record.md
@@ -6,6 +6,11 @@ named host, served under [`t4-protocol.md`](t4-protocol.md) (frozen
 next assigned slot. Rows carry counts, labels, and telemetry identifiers
 only — never answers, nonces, or contract hashes.
 
+**Trigger (decisions D11):** when row 8 is filled, or the falsification
+rule trips, the session that did it runs T5 immediately under the
+standing conditional go — no new go is needed — and presents the
+promotion decision to the chair. Before that, T5 may not run.
+
 Columns: Completed = choice accepted canonically; Corr = collector
 rejections before acceptance; Clar = clarification turns about the choice
 between render and acceptance; Override = user asked for the other lane;

--- a/docs/specs/adaptive-session-interactions/tasks.md
+++ b/docs/specs/adaptive-session-interactions/tasks.md
@@ -1,9 +1,9 @@
 # Adaptive session interactions — Tasks
 
 **Status:** active (2026-09-05) — resumed by the chair the same day
-(decisions D6–D9): T1, T2, T3 accepted; T4 holds a conditional go
-(D9, "when it makes sense") and has not started; T5 not started; no
-auto-run authority.
+(decisions D6–D10): T1, T2, T3 accepted; T4 in progress as a
+preregistered live collection (D10 — protocol frozen, record open, count
+not yet reached); T5 not started; no auto-run authority.
 
 Resume-Trigger (historical, fired 2026-09-05): Patrick explicitly resumed
 this feature for execution after coordination with Claude's active
@@ -91,4 +91,4 @@ empty list. No runtime or API invocation is needed to load this plan.
 </task>
 ```
 
-<!-- spec-state: {"schema_version": 1, "completed": ["1", "2", "3"], "current": null, "auto_run": false, "last_updated": "2026-09-05T20:55:45.647429+00:00"} -->
+<!-- spec-state: {"schema_version": 1, "completed": ["1", "2", "3"], "current": "4", "auto_run": false, "last_updated": "2026-09-05T20:57:58.222437+00:00"} -->

--- a/docs/specs/adaptive-session-interactions/tasks.md
+++ b/docs/specs/adaptive-session-interactions/tasks.md
@@ -3,7 +3,8 @@
 **Status:** active (2026-09-05) — resumed by the chair the same day
 (decisions D6–D10): T1, T2, T3 accepted; T4 in progress as a
 preregistered live collection (D10 — protocol frozen, record open, count
-not yet reached); T5 not started; no auto-run authority.
+not yet reached); T5 holds a standing conditional go that opens on the
+record's trigger (D11) and has not started; no auto-run authority.
 
 Resume-Trigger (historical, fired 2026-09-05): Patrick explicitly resumed
 this feature for execution after coordination with Claude's active

--- a/plugin/help/generated/references/skill-spec.md
+++ b/plugin/help/generated/references/skill-spec.md
@@ -133,6 +133,14 @@ next step needs. Rules, in precedence order:
 If any of these cannot be honored on the current host, say which and
 fall back to the returned Markdown; do not invent a surface.
 
+**T4 collection is open (adaptive-session-interactions D10).** On a real
+review stage on the named host, read the next unfilled slot in
+`docs/specs/adaptive-session-interactions/t4-record.md` and serve the
+choice under that slot's condition (A = widget; B = set
+`interaction_preference` to `conversation`, then the Markdown lane), then
+append the row per `t4-protocol.md` before continuing. Synthetic reviews
+and other hosts are exclusions, not slots.
+
 ## How It Works
 
 Five stages, one flow:

--- a/plugin/help/generated/tasks/use-spec.md
+++ b/plugin/help/generated/tasks/use-spec.md
@@ -27,7 +27,13 @@ Invoke with: `/spec <what to build, or 'resume'>`
 
 5. **Define presentation never changes authority.**
    Widget and Markdown carry the same binding; only the canonical collector's acceptance advances the revision. A capability change, a preference change, or a progress event grants nothing. If any of these cannot be honored on the current host, say which and
-   fall back to the returned Markdown; do not invent a surface.
+   fall back to the returned Markdown; do not invent a surface. **T4 collection is open (adaptive-session-interactions D10).** On a real
+   review stage on the named host, read the next unfilled slot in
+   `docs/specs/adaptive-session-interactions/t4-record.md` and serve the
+   choice under that slot's condition (A = widget; B = set
+   `interaction_preference` to `conversation`, then the Markdown lane), then
+   append the row per `t4-protocol.md` before continuing. Synthetic reviews
+   and other hosts are exclusions, not slots.
 
 
 ## Related Topics

--- a/plugin/skills/spec/SKILL.md
+++ b/plugin/skills/spec/SKILL.md
@@ -146,6 +146,14 @@ next step needs. Rules, in precedence order:
 If any of these cannot be honored on the current host, say which and
 fall back to the returned Markdown; do not invent a surface.
 
+**T4 collection is open (adaptive-session-interactions D10).** On a real
+review stage on the named host, read the next unfilled slot in
+`docs/specs/adaptive-session-interactions/t4-record.md` and serve the
+choice under that slot's condition (A = widget; B = set
+`interaction_preference` to `conversation`, then the Markdown lane), then
+append the row per `t4-protocol.md` before continuing. Synthetic reviews
+and other hosts are exclusions, not slots.
+
 ## How It Works
 
 Five stages, one flow:


### PR DESCRIPTION
## Summary

**T4 (bounded comparative trial), preregistered** — the half of T4 that runs today — plus decisions **D10** (T4 runs as a preregistered live collection, never a manufactured session) and **D11** (T5 holds a standing conditional go that fires on the record's trigger). **Chair-read: do not auto-merge.** Stacked on #2432 (merged `be0bf9fe2`), rebased onto its squash.

**Authority basis:** D9 ("go on t4 when it makes sense"), resolved by D10 via pushback card (`resp-20260905-165746-eda0b108`), and D11 via pushback card (`resp-20260905-170413-8e04b9df`).

## What lands

- `docs/specs/adaptive-session-interactions/t4-protocol.md` — the ASI-6 preregistration, **frozen** at SHA-256 `9ecc2b95148aa469a2ee9d2daad6f03587f8a0c67e2a6ed8578fac7f709dc2c9` (recorded in `evidence.md`): one occurrence = one real `/spec` review-stage choice on the named host; conditions A (automatic default, widget) and B (session preference `conversation`, Markdown lane, spoken answer transcribed); order A B B A B A A B; eight occurrences; primary outcomes completion / corrections / clarification turns / override / authority failure; paint `null` (unmeasured on this host); exclusions; missing-data rule; a preregistered falsification rule; promotion criteria for T5. No provider call, no paid operation, no synthetic occurrences.
- `t4-record.md` — the append-only record with the eight assigned slots, T3's two synthetic receipts listed as exclusions, and the D11 trigger in its header.
- `plugin/skills/spec/SKILL.md` — the review-choice section now tells the serving session how to collect one occurrence (read the next empty row, serve that condition, append the row). **All three projections regenerated** this time: `.agents/skills` mirror, `plugin/help/generated/references/skill-spec.md`, `plugin/help/generated/tasks/use-spec.md`.
- `decisions.md` D10 + D11; `tasks.md` status (T1–T3 accepted, T4 in progress, T5 conditional) and spec-state `completed ["1","2","3"], current "4"`; `evidence.md` T4 preregistration.

## Receipts

- `tests/unit/help` + mirror sync + plugin-reference validation + `test_adaptive_review_guidance.py` + status-line gate + doc-import drift: **591 passed** (serial, keyless).
- Pinned pre-commit over every changed file: passed. Commits GPG `G` after rebase.

## What this does not do

No occurrence is collected here. Every real `/spec` review on the Claude desktop host from now on is a T4 slot. T5 runs only when row 8 fills or the falsification rule trips, in the session that does it; promotion stays a chair ruling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
