### PR TITLE
docs(spec): host-surface-parity D10 — per-host attune-forms work ruled, Task 4b authored

### DIFF
--- a/docs/specs/host-surface-parity/decisions.md
+++ b/docs/specs/host-surface-parity/decisions.md
@@ -322,9 +322,52 @@ is covered by D8's go. Execution: Task 10 (R9) holds D8's 16.3
 execution go; Task 11 (R10) executes only behind its own chair go.
 Both report against D7's 90% floor and D8's zero-spend constraint.
 
+## D10 — Per-host attune-forms work: all three moves, in the recommended order (RULED 2026-09-06, chair, decision form + chat amendment)
+
+**Context.** The chair asked (2026-09-06) that Codex and other LLMs be
+able to use attune-forms. The lead's first pushback card mis-framed
+that goal as "build per-host adapters" (a position the chair never
+stated — the construct's `user_position` slot was filled by
+inference, the fabricated-disagreement failure D11d(4) names) and
+cited this spec's failure mode 2 backwards: failure mode 2 is a
+privileged Claude path beside a neglected Codex path, so building the
+Codex path is its remedy. Card withdrawn and corrected: **per-host
+work in this spec means host-profile records (R1/R9), thin per-host
+wrappers (siblings of the existing Claude plugin), and a per-host
+receipt — never renderer forks.** What survived the correction: the
+receipt comes first (Task 4 names the Cowork host only; nothing
+receipts Codex's native rendering), and "other LLMs" is bound to the
+roster carried as data (R7/R9).
+
+**Ruling.** Decision form `resp-20260905-211725-a9fb1618` returned
+option 3 ("Hold until R9 descriptors land"); the chair amended in
+chat to "all 3, in the recommended order". All three moves are
+authorized, nothing is held, sequence:
+
+1. **Codex native-host round-trip receipt** — authored below as
+   **Task 4b** beside Task 4. Falsifier: a `form_submitted` event
+   without the widget's `instance_id` means the answer was typed,
+   not rendered (`~/.attune/telemetry/form_events.jsonl` joins
+   `form_rendered` → `form_submitted` on `instance_id`).
+2. **Codex / Antigravity wrapper in the attune-forms repo** — install
+   lines for non-Claude hosts (the README documents only the Claude
+   plugin), an AGENTS-readable guidance twin of
+   `plugin/skills/forms/SKILL.md` with a drift guard, and the Codex
+   launcher pin lifted off `==0.12.3`.
+3. **Task 10 (R9)** under its existing D8 go.
+
+Zero spend throughout (D8). **Dependency, not ruled here:** Tasks 4,
+4b and 10 declare `depends-on 1`, and Task 1 (the parity gate) is not
+on main — it sits unpushed in Codex's worktree
+(`codex/host-surface-parity-task1` @ `4df9d848f`, ~3.5k lines,
+Codex absent until ~2026-09-09). Whether Claude lands it in Codex's
+absence is the chair's call (Open, below).
+
 ## Open
 
-- None. Every proposed decision in this spec is ruled.
+- **Task 1 landing while Codex is absent** (raised in D10): Claude
+  drives Codex's unpushed `codex/host-surface-parity-task1` to a PR, or
+  Tasks 4/4b/10 wait for Codex's return. Chair's call.
 
 Resolved 2026-09-02/03: the table was convened (round 1 complete,
 promoted in D5); D2 ruled (routing label); Task 7 ships alone on

--- a/docs/specs/host-surface-parity/tasks.md
+++ b/docs/specs/host-surface-parity/tasks.md
@@ -1,6 +1,6 @@
 # Host Surface Parity — Tasks
 
-**Status:** active (2026-09-03) — Tasks 0–12 authored; each task
+**Status:** active (2026-09-03) — Tasks 0–12 authored (+ Task 4b, D10 2026-09-06); each task
 executes only behind its own chair go; a go on one task is not a
 go on the next. D8 (2026-09-03) granted the 16.3 execution gos for
 the ungated items: Task 2 (R1 tier 0), Task 4 (R4 receipt), Task
@@ -150,6 +150,41 @@ are additionally gated on release-16-manifest Phases A and B.
   <validation>
     <check>Replayed action fails closed on the server with the existing fix_workspace error.</check>
     <check>If the profile is absent, the Markdown preview matches the terminal preview argv exactly.</check>
+  </validation>
+</task>
+```
+
+## Task 4b — Codex native-host round-trip receipt (D10)
+
+*(Authored 2026-09-06 under D10. Task 4 names the Cowork host only;
+the 2026-09-05 Codex preflight (`docs/probes/latency/merged-2026-09-05/
+native-host-blocker.md`) could not observe the native paint and its
+one validated result carried no instance id, so "Codex renders the
+rich surface" is unverified. Falsifier from the telemetry schema:
+`form_rendered` and `form_submitted` both carry `instance_id`; the
+widget's post-back includes it, a typed answer does not.)*
+
+```xml
+<task id="4b" name="codex-native-roundtrip-receipt">
+  <depends-on>1</depends-on>
+  <objective>
+    Record whether the Codex native app renders the attune-forms
+    ui:// surface and returns the widget's instance_id through
+    elicitation_collect_response; record the Markdown fallback if
+    it does not. No production change unless the receipt fails.
+  </objective>
+  <files-to-modify>
+    <file path="docs/specs/host-surface-parity/receipts.md">
+      R4b block: forms version loaded by the Codex-launched server,
+      form_rendered/form_submitted pair joined on instance_id from
+      ~/.attune/telemetry/form_events.jsonl, the collect receipt id,
+      and the chair's paint observation (yes/no/unobserved).
+    </file>
+  </files-to-modify>
+  <validation>
+    <check>A form_submitted event from the Codex-launched server carries the instance_id of a preceding form_rendered event — the answer came through the widget, not typed.</check>
+    <check>If no such pair exists, the Markdown fallback is recorded and the Codex host profile (R1) is written as PORTABLE-tier with the rich claim left open.</check>
+    <check>Zero spend: the interaction runs on the chair's Codex subscription surface; no API-billed call.</check>
   </validation>
 </task>
 ```


### PR DESCRIPTION
## Summary

Docs-only. Records chair ruling **D10** in `docs/specs/host-surface-parity/decisions.md` and authors **Task 4b** in `tasks.md`.

- **D10** (2026-09-06, decision form `resp-20260905-211725-a9fb1618` + chat amendment "all 3, in the recommended order"): per-host attune-forms work = host-profile records (R1/R9), thin per-host wrappers, a per-host receipt — never renderer forks. Sequence: Codex native-host receipt → Codex/Antigravity wrapper in the attune-forms repo → Task 10 (R9). Zero spend (D8).
- Records the lead's withdrawn pushback card and its two errors (fabricated `user_position`; failure mode 2 cited backwards).
- **Task 4b** — Codex native-host round-trip receipt, beside Task 4 (which names Cowork only). Falsifier: `form_submitted` without the widget's `instance_id` = typed, not rendered.
- **Open item raised, not ruled:** Tasks 4/4b/10 depend on Task 1, which is unpushed in Codex's worktree (`codex/host-surface-parity-task1` @ `4df9d848f`).

Sibling: attune-forms PR (wrapper + docs, D10 step 2).

## Test plan

- [x] Markdown only; no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
