### PR TITLE
fix(tests): prevent live inference in ordinary test runs

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -34,6 +34,8 @@ jobs:
   integration:
     name: integration (no-auth)
     runs-on: ubuntu-latest
+    env:
+      TIKTOKEN_CACHE_DIR: ${{ runner.temp }}/tiktoken-cache
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -51,6 +53,17 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -e .[dev]
+
+      # Download tokenizer data during setup; pytest stays inference-blocked.
+      - name: Cache tiktoken encodings
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ${{ runner.temp }}/tiktoken-cache
+          key: tiktoken-cl100k_base-${{ runner.os }}
+
+      - name: Warm tiktoken encoding
+        shell: bash
+        run: python -c "import tiktoken; tiktoken.get_encoding('cl100k_base')"
 
       - name: Run no-auth integration suite (keyless)
         # Empty ANTHROPIC_API_KEY → exercises the integration wiring

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -35,7 +35,7 @@ jobs:
     name: integration (no-auth)
     runs-on: ubuntu-latest
     env:
-      TIKTOKEN_CACHE_DIR: ${{ runner.temp }}/tiktoken-cache
+      TIKTOKEN_CACHE_DIR: ${{ github.workspace }}/../tiktoken-cache
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -58,7 +58,7 @@ jobs:
       - name: Cache tiktoken encodings
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
-          path: ${{ runner.temp }}/tiktoken-cache
+          path: ${{ github.workspace }}/../tiktoken-cache
           key: tiktoken-cl100k_base-${{ runner.os }}
 
       - name: Warm tiktoken encoding

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -110,7 +110,7 @@ jobs:
     # memory pressure, so the headroom would not fix it.
     runs-on: ${{ matrix.os }}
     env:
-      TIKTOKEN_CACHE_DIR: ${{ runner.temp }}/tiktoken-cache
+      TIKTOKEN_CACHE_DIR: ${{ github.workspace }}/../tiktoken-cache
     # ci-runner-hang spec: tightened from 75 so a wedged pytest step fails
     # in bounded time (and is rerun-recoverable) instead of stalling for
     # over an hour. A flat int (not a per-OS ${{ }} expression) keeps the
@@ -151,7 +151,7 @@ jobs:
       if: needs.changes.outputs.website_only != 'true'
       uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
-        path: ${{ runner.temp }}/tiktoken-cache
+        path: ${{ github.workspace }}/../tiktoken-cache
         key: tiktoken-cl100k_base-${{ runner.os }}
 
     - name: Warm tiktoken encoding
@@ -251,7 +251,7 @@ jobs:
     needs: changes
     runs-on: ubuntu-latest
     env:
-      TIKTOKEN_CACHE_DIR: ${{ runner.temp }}/tiktoken-cache
+      TIKTOKEN_CACHE_DIR: ${{ github.workspace }}/../tiktoken-cache
     timeout-minutes: 30
     strategy:
       fail-fast: false
@@ -285,7 +285,7 @@ jobs:
       if: needs.changes.outputs.website_only != 'true'
       uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
-        path: ${{ runner.temp }}/tiktoken-cache
+        path: ${{ github.workspace }}/../tiktoken-cache
         key: tiktoken-cl100k_base-${{ runner.os }}
 
     - name: Warm tiktoken encoding
@@ -313,7 +313,7 @@ jobs:
     # matrix tests.
     runs-on: ubuntu-latest
     env:
-      TIKTOKEN_CACHE_DIR: ${{ runner.temp }}/tiktoken-cache
+      TIKTOKEN_CACHE_DIR: ${{ github.workspace }}/../tiktoken-cache
     # ci-gating-lane-isolation Layer A: the job timeout is now the FINAL
     # backstop (both auto-retry attempts hung), not the first line of
     # defence — the 14m step-level `timeout` below kills a single wedged
@@ -350,7 +350,7 @@ jobs:
       if: needs.changes.outputs.website_only != 'true'
       uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
-        path: ${{ runner.temp }}/tiktoken-cache
+        path: ${{ github.workspace }}/../tiktoken-cache
         key: tiktoken-cl100k_base-${{ runner.os }}
 
     - name: Warm tiktoken encoding

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -109,6 +109,8 @@ jobs:
     # runner-hang it might have helped is an xdist finalize-deadlock, not
     # memory pressure, so the headroom would not fix it.
     runs-on: ${{ matrix.os }}
+    env:
+      TIKTOKEN_CACHE_DIR: ${{ runner.temp }}/tiktoken-cache
     # ci-runner-hang spec: tightened from 75 so a wedged pytest step fails
     # in bounded time (and is rerun-recoverable) instead of stalling for
     # over an hour. A flat int (not a per-OS ${{ }} expression) keeps the
@@ -144,10 +146,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install -e .[dev]
 
-    # Retro 2026-09-06 (R2): tiktoken fetches cl100k_base over HTTPS on first
-    # use. Warm it once, OUTSIDE pytest, into a cached dir so the suite never
-    # touches the network for it — the test-time inference guard blocks that
-    # download, and 40 tests went red for the same one file.
+    # Download tokenizer data during setup; pytest stays inference-blocked.
     - name: Cache tiktoken encodings
       if: needs.changes.outputs.website_only != 'true'
       uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
@@ -158,9 +157,7 @@ jobs:
     - name: Warm tiktoken encoding
       if: needs.changes.outputs.website_only != 'true'
       shell: bash
-      run: python -c "import tiktoken; tiktoken.get_encoding('cl100k_base')" || echo "::warning::tiktoken warm-up failed; encoding tests will try the network"
-      env:
-        TIKTOKEN_CACHE_DIR: ${{ runner.temp }}/tiktoken-cache
+      run: python -c "import tiktoken; tiktoken.get_encoding('cl100k_base')"
 
     - name: Run tests
       if: needs.changes.outputs.website_only != 'true'
@@ -193,7 +190,6 @@ jobs:
       run: |
         pytest -n auto --timeout=60 --timeout-method=thread -m "not network and not integration"
       env:
-        TIKTOKEN_CACHE_DIR: ${{ runner.temp }}/tiktoken-cache  # warmed above; keeps the suite offline for cl100k_base
         ANTHROPIC_API_KEY: ""  # keyless by design — live-key CI burned $1200+ on 2026-06-10 (mismarked tests make real API calls when keyed); the real secret is for integration-auth.yml + deliberate dispatches ONLY
 
     - name: Run security and workflow tests
@@ -254,6 +250,8 @@ jobs:
     # separately, deliberately out of scope for this PR).
     needs: changes
     runs-on: ubuntu-latest
+    env:
+      TIKTOKEN_CACHE_DIR: ${{ runner.temp }}/tiktoken-cache
     timeout-minutes: 30
     strategy:
       fail-fast: false
@@ -282,10 +280,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install -e .[dev]
 
-    # Retro 2026-09-06 (R2): tiktoken fetches cl100k_base over HTTPS on first
-    # use. Warm it once, OUTSIDE pytest, into a cached dir so the suite never
-    # touches the network for it — the test-time inference guard blocks that
-    # download, and 40 tests went red for the same one file.
+    # Download tokenizer data during setup; pytest stays inference-blocked.
     - name: Cache tiktoken encodings
       if: needs.changes.outputs.website_only != 'true'
       uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
@@ -296,9 +291,7 @@ jobs:
     - name: Warm tiktoken encoding
       if: needs.changes.outputs.website_only != 'true'
       shell: bash
-      run: python -c "import tiktoken; tiktoken.get_encoding('cl100k_base')" || echo "::warning::tiktoken warm-up failed; encoding tests will try the network"
-      env:
-        TIKTOKEN_CACHE_DIR: ${{ runner.temp }}/tiktoken-cache
+      run: python -c "import tiktoken; tiktoken.get_encoding('cl100k_base')"
 
     - name: Run unit suite under ${{ matrix.tz }}
       if: needs.changes.outputs.website_only != 'true'
@@ -308,7 +301,6 @@ jobs:
         pytest -n auto --timeout=60 --timeout-method=thread -m "not network and not integration"
       env:
         TZ: ${{ matrix.tz }}
-        TIKTOKEN_CACHE_DIR: ${{ runner.temp }}/tiktoken-cache  # warmed above; keeps the suite offline for cl100k_base
         ANTHROPIC_API_KEY: ""  # keyless by design — see the `test` job note
 
   coverage:
@@ -320,6 +312,8 @@ jobs:
     # and `-n auto` restored, this job runs in parallel like the
     # matrix tests.
     runs-on: ubuntu-latest
+    env:
+      TIKTOKEN_CACHE_DIR: ${{ runner.temp }}/tiktoken-cache
     # ci-gating-lane-isolation Layer A: the job timeout is now the FINAL
     # backstop (both auto-retry attempts hung), not the first line of
     # defence — the 14m step-level `timeout` below kills a single wedged
@@ -351,10 +345,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install -e .[dev]
 
-    # Retro 2026-09-06 (R2): tiktoken fetches cl100k_base over HTTPS on first
-    # use. Warm it once, OUTSIDE pytest, into a cached dir so the suite never
-    # touches the network for it — the test-time inference guard blocks that
-    # download, and 40 tests went red for the same one file.
+    # Download tokenizer data during setup; pytest stays inference-blocked.
     - name: Cache tiktoken encodings
       if: needs.changes.outputs.website_only != 'true'
       uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
@@ -365,9 +356,7 @@ jobs:
     - name: Warm tiktoken encoding
       if: needs.changes.outputs.website_only != 'true'
       shell: bash
-      run: python -c "import tiktoken; tiktoken.get_encoding('cl100k_base')" || echo "::warning::tiktoken warm-up failed; encoding tests will try the network"
-      env:
-        TIKTOKEN_CACHE_DIR: ${{ runner.temp }}/tiktoken-cache
+      run: python -c "import tiktoken; tiktoken.get_encoding('cl100k_base')"
 
     # Catch README badge rot: fails if the tests-count floor over-claims or
     # drifts far below the real collected count, or if coverage regressed to a
@@ -419,7 +408,6 @@ jobs:
         # uploads hang-dumps/) remain as the backstop.
         pytest -n auto --cov=src/attune --cov-report=xml --cov-fail-under=94 --timeout=60 --timeout-method=thread -m "not network and not integration"
       env:
-        TIKTOKEN_CACHE_DIR: ${{ runner.temp }}/tiktoken-cache  # warmed above; keeps the suite offline for cl100k_base
         ANTHROPIC_API_KEY: ""  # keyless by design — live-key CI burned $1200+ on 2026-06-10 (mismarked tests make real API calls when keyed); the real secret is for integration-auth.yml + deliberate dispatches ONLY
 
     - name: Track per-file test results

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Test inference isolation: pytest now blocks real provider HTTP calls and
+  Claude/Agent SDK inference launches before dispatch, scrubs child credentials,
+  and gives subprocesses a separate Claude profile. Fake transports and
+  non-inference CLI diagnostics remain usable; the local Ollama unit receipt
+  now uses a fixture-owned HTTP server. Interactive authentication is unchanged.
+  Windows audit events retain command checks when no executable override
+  is supplied. CI prepares tokenizer data before pytest, and no-auth
+  integration tests retain HTTP and MCP receipts through local fixtures.
+
 ### Added
 
 - **Worktree-add guard hook** (`src/attune/hooks/scripts/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Windows audit events retain command checks when no executable override
   is supplied. CI prepares tokenizer data before pytest, and no-auth
   integration tests retain HTTP and MCP receipts through local fixtures.
+  Windows command decoding preserves quoted Python programs and still blocks
+  quoted inference wrappers.
 
 ### Added
 

--- a/docs/COVERAGE_BUG_LOG.md
+++ b/docs/COVERAGE_BUG_LOG.md
@@ -1977,3 +1977,15 @@ before test jobs existed; local YAML parsing could not catch expression
 context validity. Use `github.workspace` with a sibling cache directory and
 reject runner-context expressions in job environments with a schema test.
 The same shared path still covers setup and every pytest step on all OSes.
+
+### 2026-09-06 — #2445 unlocked SDK transport upgrade (mocked)
+
+CI installs Anthropic 1.4.0/httpx2 2.12.0; the lockfile validation environment
+used Anthropic 0.125.0/httpx 0.28.1. The invalid-key fixture passed the older
+HTTP client to the new SDK and failed before the mocked 401. More seriously,
+the test guard only wrapped httpx: httpx2 could bypass the HTTP endpoint rule
+for a local proxy (external Python sockets were still denied). No live probe
+was used. Guard both installed transport generations, intercept both core
+pools in regression tests, and match SDK fixtures to the SDK's HTTP backend.
+Validation now includes a disposable environment resolved like CI and the
+locked legacy environment; no production authentication is changed.

--- a/docs/COVERAGE_BUG_LOG.md
+++ b/docs/COVERAGE_BUG_LOG.md
@@ -1989,3 +1989,18 @@ was used. Guard both installed transport generations, intercept both core
 pools in regression tests, and match SDK fixtures to the SDK's HTTP backend.
 Validation now includes a disposable environment resolved like CI and the
 locked legacy environment; no production authentication is changed.
+
+### 2026-09-06 — #2445 Windows command-line decoding (crash / mocked)
+
+Windows Popen audits a serialized command string even when its caller passes
+argv. Non-POSIX shlex does not decode the CRT quoting used by list2cmdline:
+14 Windows tests crashed on quoted multiline Python programs. The same
+parser also missed a quoted inference executable inside a serialized cmd
+wrapper. Regression tests fail against the old guard for both cases without
+launching a process. The guard now decodes backslash/quote parity before
+applying the existing inference checks, including nested wrappers.
+
+One nested pytest controller/worker probe additionally exhausted its 15s
+startup timeout on Windows 3.12. That probe alone gets 60s; its assertions
+that inference is blocked before process creation are unchanged. No live
+provider calls, broad skips, or interactive-auth changes are involved.

--- a/docs/COVERAGE_BUG_LOG.md
+++ b/docs/COVERAGE_BUG_LOG.md
@@ -2004,3 +2004,33 @@ One nested pytest controller/worker probe additionally exhausted its 15s
 startup timeout on Windows 3.12. That probe alone gets 60s; its assertions
 that inference is blocked before process creation are unchanged. No live
 provider calls, broad skips, or interactive-auth changes are involved.
+
+### 2026-09-06 — #2445 cold-child fixture boundaries (crash)
+
+After the quoting repair, Windows 3.11/3.12/3.14 passed. Windows 3.10 and
+3.13 exposed a race in the cold pytest probe: the checkout and fixture live
+on different drives, so pytest's ancestor traversal visits shared temporary
+siblings; another worker removes a guard folder before pytest's Windows
+same-file comparison stats it. Explicit fixture-local `--confcutdir` bounds
+collection while `-p tests.conftest` still loads the real guard. A collector
+assertion reproduces the over-broad traversal deterministically (2 failures
+without the boundary; all 3 controller/worker cases pass with it).
+
+Two Windows 3.10 probes also replaced their process environment without
+SystemRoot, preventing Python hash-randomization startup before the guard
+could run. The test fixtures retain only that required Windows runtime
+variable alongside their declared fake credentials. The credential-scrubbing
+and blocked-inference assertions remain unchanged.
+
+### 2026-09-06 — spec drift probe depends on runner scheduling (mocked)
+
+#2444 run 34025993709 reported one Windows 3.12 failure: the real-Git dirty
+spec test returned no findings. The scanner intentionally stops after a
+2.5s overall budget; the test previously required both worktrees to be
+visited within that wall-clock budget. A loaded runner can exhaust it
+without violating scanner behavior. The exact cutoff was not logged in
+that failed run, so timing is the diagnosed failure mechanism, not a
+measured duration receipt. Behavioral probes now use a module-local steady
+clock while retaining real Git/filesystem calls and their subprocess
+timeouts. A separate deterministic test exhausts the budget before the
+dirty worktree and requires no finding. Production limits are unchanged.

--- a/docs/COVERAGE_BUG_LOG.md
+++ b/docs/COVERAGE_BUG_LOG.md
@@ -1968,3 +1968,12 @@ queued for 24-72h post-tag.
   data before pytest; the no-auth integration lane uses fixture-owned AMS
   HTTP readback, explicit file-backend MCP dispatch, and an intercepted SDK
   401. The inference guard remains active through these tests.
+
+### 2026-09-06 — #2445 cache path rejected before CI jobs start (crash)
+
+The CI repair used `runner.temp` in job-level `env`, a context GitHub does
+not allow there. Runs 34021720623 and 34021720221 failed workflow validation
+before test jobs existed; local YAML parsing could not catch expression
+context validity. Use `github.workspace` with a sibling cache directory and
+reject runner-context expressions in job environments with a schema test.
+The same shared path still covers setup and every pytest step on all OSes.

--- a/docs/COVERAGE_BUG_LOG.md
+++ b/docs/COVERAGE_BUG_LOG.md
@@ -1955,3 +1955,16 @@ kind single-sourcing) drew no findings at all.
 
 No substitute was captured at tag time, per US-4. The AFTER snapshot is
 queued for 24-72h post-tag.
+
+## 2026-09-06 — inference-isolation CI repair (#2445)
+
+- **Crash:** `tests/_inference_guard.py` decoded the Windows Popen
+  audit event's absent executable as a filesystem path, aborting pytest.
+  The guard now checks the command even when the override is absent and
+  handles quoted Windows executable paths; simulated Windows audit events
+  retain inference and Python-bootstrap rejection checks.
+- **Mocked:** local warm tokenizer caches and the default integration
+  exclusion hid CI-only network attempts. CI now prepares static tokenizer
+  data before pytest; the no-auth integration lane uses fixture-owned AMS
+  HTTP readback, explicit file-backend MCP dispatch, and an intercepted SDK
+  401. The inference guard remains active through these tests.

--- a/docs/handoffs/codex-test-inference-isolation.md
+++ b/docs/handoffs/codex-test-inference-isolation.md
@@ -179,6 +179,40 @@ A disposable Python 3.12 environment was resolved with `uv pip install -e
   isolated credentials and disposable Redis were active. Normal interactive
   auth is unchanged. Windows still requires its own remote receipt.
 
+## Windows matrix repair (2026-09-06)
+
+Run 34022420737 at `4ceb65c015b334e0f23420928717c2b1eefbf0b9` passed
+Linux, macOS, no-auth integration and the Windows hook lanes, but failed
+all five Windows full-tree lanes. Downloaded Windows 3.12 job 101457398511
+reported 15 failures; Windows 3.14 job 101457398486 reported 14 failures.
+Fourteen were `ValueError: No closing quotation` from non-POSIX shlex
+parsing Windows Popen's serialized audit command. One additional Windows
+3.12 failure was a cold nested pytest/xdist process exceeding 15 seconds.
+
+The guard now decodes Windows CRT backslash/quote rules before its existing
+command checks. The new regressions fail against the prior guard for the
+multiline Python program and a quoted cmd wrapper that evaded the old check
+(2 failed, 5 passed in the targeted pre-fix run). No executable or provider
+is launched by those probes. Additional tests preserve CLI diagnostics,
+reject quoted inference/bootstrap bypasses, and round-trip 781 argument
+combinations through Python's actual list2cmdline serializer. Only the cold
+pytest controller/worker probe receives a 60-second startup allowance; its
+block-before-process-creation assertions remain unchanged.
+
+Local repair receipts (isolated credentials, committed guard, disposable
+loopback Redis, prepared static tokenizer cache):
+
+- Guard + affected subprocess suites + gates + quality + CI checks:
+  **1,048 passed, 1 existing skip in 72.92s**, **99.03%** guard
+  statement/branch coverage. All **33/33** executable lines changed in
+  this repair are covered. `/private/tmp/2445-windows-focused.log`;
+  `/private/tmp/2445-windows-focused-coverage.json`.
+- Separate no-auth integration selection: **234 passed, 41 existing skips**
+  in 8.36s. `/private/tmp/2445-windows-integration.log`.
+- Whole configured tree: **25,736 passed, 242 existing skips, 3 xfailed**
+  in 81.57s. `/private/tmp/2445-windows-whole.log`.
+- Pinned pre-commit checks: passed; `/private/tmp/2445-windows-hooks.log`.
+
 ## Next action
 
 Publish the signed repair and verify the fresh CI matrix, including Windows.

--- a/docs/handoffs/codex-test-inference-isolation.md
+++ b/docs/handoffs/codex-test-inference-isolation.md
@@ -151,6 +151,34 @@ the repair, not an inference-boundary failure.
 - The inference guard is unchanged from its 99.21% coverage receipt above.
   Fresh GitHub workflow acceptance and Windows results remain required.
 
+## Unlocked SDK transport compatibility
+
+CI's fresh dependency resolution installed Anthropic 1.4.0 with httpx2 2.12.0;
+the lockfile environment used Anthropic 0.125.0 with httpx 0.28.1. Integration
+job 101456121361 and Linux job 101456163089 failed because SDK mock clients
+used the old HTTP type, and the real-SDK guard probes reached the lower socket
+barrier instead of the expected HTTP barrier. The endpoint guard now wraps
+both installed HTTPX generations. Regressions intercept both httpcore pools,
+including arbitrary loopback proxy paths; no live provider probe was used.
+Mocked SDK responses use the HTTP module the SDK itself imports.
+
+A disposable Python 3.12 environment was resolved with `uv pip install -e
+'.[dev]'` to match CI's installation strategy before publishing again.
+
+- Fresh SDK guard + workflow checks: 434 passed, 1 existing skip; **98.85%**
+  guard statement/branch coverage. `/private/tmp/2445-httpx2-focused.log` and
+  `/private/tmp/2445-httpx2-coverage.json`.
+- Fresh SDK no-auth integration: 234 passed, 41 existing skips in 8.05s.
+  `/private/tmp/2445-httpx2-integration.log`.
+- Fresh SDK whole tree: **25,726 passed, 242 existing skips, 3 xfailed** in
+  91.43s. `/private/tmp/2445-httpx2-whole.log`.
+- Locked legacy SDK guard + workflow checks: 424 passed, 1 existing skip;
+  **98.09%** guard statement/branch coverage, including the optional-library
+  absence path. `/private/tmp/2445-legacy-httpx-focused.log`.
+- Static tokenizer data was prepared before pytest; the committed barrier,
+  isolated credentials and disposable Redis were active. Normal interactive
+  auth is unchanged. Windows still requires its own remote receipt.
+
 ## Next action
 
 Publish the signed repair and verify the fresh CI matrix, including Windows.

--- a/docs/handoffs/codex-test-inference-isolation.md
+++ b/docs/handoffs/codex-test-inference-isolation.md
@@ -135,6 +135,22 @@ rejects duplicate cache/warm steps.
 - Both suite runs used the committed guard, isolated credentials, the prepared
   static tokenizer cache and disposable Redis. No live inference was attempted.
 
+## CI expression-context correction
+
+GitHub rejected runs 34021720623 and 34021720221 before jobs started: the
+repair referenced `runner.temp` in job-level env, where runner context is
+unavailable. Use `github.workspace` with a sibling cache directory instead.
+The shared path still covers setup and every test step; a schema regression
+rejects runner-context references in job environments. This was a defect in
+the repair, not an inference-boundary failure.
+
+- Workflow checks: 344 passed, 1 existing skip.
+  `/private/tmp/2445-context-fix-tests.log`.
+- Whole configured tree before push: 25,716 passed, 242 existing skips,
+  3 xfailed in 77.73s. `/private/tmp/2445-context-fix-whole.log`.
+- The inference guard is unchanged from its 99.21% coverage receipt above.
+  Fresh GitHub workflow acceptance and Windows results remain required.
+
 ## Next action
 
 Publish the signed repair and verify the fresh CI matrix, including Windows.

--- a/docs/handoffs/codex-test-inference-isolation.md
+++ b/docs/handoffs/codex-test-inference-isolation.md
@@ -213,6 +213,58 @@ loopback Redis, prepared static tokenizer cache):
   in 81.57s. `/private/tmp/2445-windows-whole.log`.
 - Pinned pre-commit checks: passed; `/private/tmp/2445-windows-hooks.log`.
 
+## Cold-child fixture follow-up (2026-09-06)
+
+Run 34025913808 at `2dd9e4538e64f996d0c38a18b90cd29cb4825eef` verified
+the quoting repair: all 14 former quoting failures are gone. Windows
+3.11/3.12/3.14 passed, alongside Linux/macOS/coverage. Windows 3.10
+(job 101466758262) had three remaining failures; Windows 3.13
+(job 101466758208) had one.
+
+The cold pytest fixture traversed shared temp ancestors, racing with another
+worker's bootstrap cleanup during Windows same-file comparisons. It now
+sets `--confcutdir` to its own fixture directory while explicitly loading
+the real `tests.conftest` with `-p`. The test deliberately places rootdir
+above the fixture and asserts that directory collection stays inside the
+fixture. Removing the boundary gives 2 deterministic failures; adding it
+passes all 3 controller/worker cases (6.20s). Logs:
+`/private/tmp/2445-collection-boundary-before.log` and
+`/private/tmp/2445-collection-boundary-after.log`.
+
+The two other Windows 3.10 failures were Python startup failures in test
+fixtures that supplied minimal environments without SystemRoot. Those
+fixtures now retain that required runtime variable. They still prove
+credential scrubbing and inference rejection; no production barrier or
+assertion was removed.
+
+#2444's concurrent run 34025993709 also exposed a timing-dependent spec
+drift test on Windows 3.12. The behavioral tests required two real Git
+worktrees to be visited within the production 2.5s scan budget. Their clock
+is now steady and local to the module; Git/filesystem calls and subprocess
+timeouts remain real. A separate test requires budget exhaustion to stop
+before the dirty worktree. The permanent test isolation fix lives in this
+PR; production scanner code and limits are unchanged.
+
+Fresh fixture-repair receipts:
+
+- Guard + gates + quality + CI checks: **959 passed, 1 existing skip** in
+  68.91s; guard coverage **99.03%**. The guard implementation itself is
+  unchanged from the quoted-command repair.
+  `/private/tmp/2445-fixtures-focused.log`;
+  `/private/tmp/2445-fixtures-focused-coverage.json`.
+- Spec audit + inference isolation tests: **268 passed** in 18.76s.
+  `/private/tmp/2445-fixtures-spec-focused.log`.
+- Removing the effective scan deadline makes the new budget test fail with
+  an unwanted dirty-worktree finding (1 failed in 0.33s). This mutation runs
+  only in a disposable pytest process; repository production code is not
+  edited. `/private/tmp/2445-scan-budget-mutant.log`.
+
+- Final whole configured tree, including the scanner budget regression:
+  **25,737 passed, 242 existing skips, 3 xfailed** in 83.71s.
+  `/private/tmp/2445-fixtures-final-whole.log`.
+- All pinned pre-commit checks passed.
+  `/private/tmp/2445-fixtures-final-hooks.log`.
+
 ## Next action
 
 Publish the signed repair and verify the fresh CI matrix, including Windows.

--- a/docs/handoffs/codex-test-inference-isolation.md
+++ b/docs/handoffs/codex-test-inference-isolation.md
@@ -1,0 +1,144 @@
+# Agent work handoff
+
+## Goal
+
+Make ordinary attune-ai tests fail before real inference, without changing
+interactive authentication. Prepare this focused fix for Claude review.
+
+## Acceptance criteria
+
+- Direct API and Agent SDK/Claude CLI inference boundaries fail closed.
+- Fake credentials and intercepted calls prove the guard without provider probes.
+- Legitimate mocked tests and non-inference CLI diagnostics remain usable.
+- At least 90% coverage on the guard; full configured test tree passes under
+  isolated credentials before pushing.
+- Preserve PR #2444; no auto-merge, no host-surface-parity increment 3.
+
+## Scope and assumptions
+
+- Branch: `codex/test-inference-isolation`, separate worktree created from
+  `origin/main` at `db4e9ffb1a0eb1e9f62cbbd3e9dfd5ceb7a06de4`; rebased for the CI repair onto `3ff6b5a2677e47e9631868a4f80c77bcd11fd489` (#2447).
+- Local worktree: `/private/tmp/attune-test-inference-isolation-20260906`.
+- Provider: Codex executes; Claude requested changes on the original head. The CI repair needs a fresh Claude review.
+- Original parity worktree and PR #2444 remain separate and unchanged.
+- The September 6 usage estimate remains unattributed. Dates/models are not
+  evidence identifying an initiating session.
+
+## Current state
+
+- Read-only preflight and Git/PR inspection preceded edits. Preflight reported
+  no failures and warnings about the separate main checkout; that checkout was
+  left untouched. #2444 was confirmed open before work and before publication.
+- The previous conftest had no inference barrier. The security-audit workflow's
+  Agent SDK path can launch Claude with authentication independent of empty
+  parent API keys. The new regression exercises that real SDK transport with
+  an inert executable and fake saved authentication, and stops before launch.
+- The exact historical test node that initiated the reported live audits has
+  not been established. The previously fixed MCP path-containment test already
+  mocks its workflow correctly; this change does not relabel it as the culprit.
+- The guard installs before application imports/collection, checks real HTTP
+  transports and external Python sockets, checks subprocess launch paths,
+  scrubs credentials and supplies private Claude configuration to children,
+  and propagates into ordinary Python children. No production auth code changes.
+- Initial validation exposed ambient local AMS access as a gap in endpoint-name
+  filtering. Real HTTP now requires a fixture-owned endpoint, including local
+  proxies. Six existing live AMS tests are correctly marked integration/network;
+  their assertions remain intact and availability probing no longer happens
+  during collection. No broad test skip was introduced.
+- The Ollama unit test now retains a real HTTP request/parse round trip against
+  a deterministic fixture. Saved admin-key lookup is isolated in dashboard tests.
+  Environment-construction tests inspect intercepted subprocess arguments.
+  Hook and chart tests now inject their memory dependencies; webhook tests
+  still assert pinned socket destinations and original TLS SNI with intercepted
+  connection factories.
+- See `docs/testing/inference-isolation.md` for scope, authoring instructions,
+  and limitations. This is a test guard, not a hostile-code OS sandbox; opaque
+  native wrappers and plugins imported before conftest remain outside its scope.
+
+## Verification
+
+| Claim | Failure-sensitive probe | Result |
+| --- | --- | --- |
+| Guard behavior, cold collection, controller/workers, SDK and direct HTTP boundaries | `.venv/bin/python -m pytest tests/unit/test_inference_isolation.py -q -n0 --cov=tests._inference_guard --cov-config=tests/inference-coverage.ini` | 74 passed; 99.20% statement/branch coverage |
+| Whole configured tree under isolated credentials | `.venv/bin/python /private/tmp/run_parity_suite.py` | 25,618 passed, 242 skipped, 3 xfailed; 78.91s |
+| Pinned repository hooks | `uv run --frozen --with pre-commit pre-commit run --files <changed files>` | All pinned hooks passed |
+
+The whole-tree wrapper starts disposable loopback Redis with persistence off,
+sets empty provider API keys and a private Claude profile, and invokes
+`pytest -p parity_isolated_redis tests -n auto`. Its temporary pytest plugin
+restores the disposable Redis URL after the existing env-scrub fixtures only
+for `tests/memory/test_redis_integration.py`, with one DB per xdist worker.
+The committed inference guard enforces inference isolation independently of
+that wrapper. No API-backed workflow or live-provider probe is a validation
+step. Earlier diagnostic runs reached the existing local AMS service; no
+billing attribution is inferred from those accesses.
+
+## CI repair after Claude review (2026-09-06)
+
+The earlier whole-tree receipt was macOS/Python 3.11 with a warm tokenizer
+cache and the default integration exclusion. It did not certify the Windows
+matrix or the no-auth integration lane. Downloaded CI logs independently
+confirmed the Windows missing-executable crash, cold tokenizer downloads,
+unisolated AMS paths, live invalid-key request and orphan documentation.
+
+- Windows Popen audit events check argv when the executable override is
+  absent. Quoted Windows command strings still reject inference and Python
+  bootstrap bypass flags. No guard exception is swallowed in production.
+- Cold pytest children scrub parent PYTEST_ADDOPTS/PYTEST_PLUGINS.
+- Test, timezone, coverage and no-auth integration jobs prepare static
+  cl100k_base data before pytest. Setup failure fails the step; no test skip
+  or HTTP exemption was introduced. The job-wide cache path covers every
+  pytest step. The rebase reconciles #2447's tokenizer setup into one strict warm-up
+  per job and the shared cache environment, without duplicate setup steps.
+- AMS readback tests use real HTTP with a fixture-owned service: successful
+  create/readback and an acknowledged-but-unpersisted write returning 404.
+  They make no claim to test a deployed AMS server or its embedding model.
+- MCP and doctor tests select the fixture-local file backend for unrelated
+  memory diagnostics. Redis endpoint tests still use real RESP sockets;
+  dispatch/sanitization and stdout JSON-RPC frames remain production paths.
+- Invalid-key handling uses the real SDK through MockTransport with a 401,
+  asserting status, request count, path and the fake key sent.
+- The documentation now has a Contributing navigation entry.
+
+Verified receipts for this repair:
+
+- Focused guard + workflow checks: 423 passed, 1 existing skip; guard
+  statement/branch coverage 99.21%. Log: `/private/tmp/2445-round2-focused.log`.
+- Exact no-auth integration selection: 234 passed, 41 existing skips in
+  6.32s, guarded with disposable Redis and a freshly prepared tokenizer
+  cache. Log: `/private/tmp/2445-round2-integration.log`.
+- Doctor boundary rerun: 51 passed. The initial post-rebase whole tree
+  exposed 16 doctor tests reaching the newly merged AMS diagnostic; the
+  fixture-local file preference repairs that dependency without changing
+  their assertions. Log: `/private/tmp/2445-round2-doctor.log`.
+- Whole configured tree after the doctor repair: 25,685 passed, 242 existing
+  skips, 3 xfailed in 75.25s. Log:
+  `/private/tmp/2445-round2-whole-tree-final.log`. Inference guard active,
+  isolated credentials, freshly prepared tokenizer cache and disposable Redis.
+- Documentation wiring audit: no findings. Pinned hooks passed on the repair
+  files, including the doctor fixtures; they run again at commit.
+
+## Post-#2447 rebase receipts
+
+Base `3ff6b5a2677e47e9631868a4f80c77bcd11fd489`; the sole conflict was
+`.github/workflows/tests.yml`. The resolved file retains one strict warm-up
+per job and the job-wide cache environment. The workflow regression also
+rejects duplicate cache/warm steps.
+
+- Guard + workflow checks: 423 passed, 1 existing skip, 99.21% guard
+  statement/branch coverage. `/private/tmp/2445-post2447-focused.log` and
+  `/private/tmp/2445-post2447-coverage.json`.
+- Whole configured tree: 25,715 passed, 242 existing skips, 3 xfailed in
+  81.69s. `/private/tmp/2445-post2447-whole.log`.
+- No-auth integration: 234 passed, 41 existing skips in 6.05s.
+  `/private/tmp/2445-post2447-integration.log`.
+- Both suite runs used the committed guard, isolated credentials, the prepared
+  static tokenizer cache and disposable Redis. No live inference was attempted.
+
+## Next action
+
+Publish the signed repair and verify the fresh CI matrix, including Windows.
+Claude reviews the repaired head; the chair merges. Do not auto-merge or
+launch a review agent. The parity work is preserved in its separate #2444
+worktree and resumes after the required upstream merges. Do not start
+increment 3. The September 6 usage estimate remains unattributed.

--- a/docs/testing/inference-isolation.md
+++ b/docs/testing/inference-isolation.md
@@ -22,7 +22,7 @@ remains unattributed. These changes do not reconstruct that billing history.
 
 ## Enforced boundaries
 
-- Real `httpx`, `http.client`, and `urllib3` HTTP requests require a
+- Real `httpx`, installed `httpx2`, `http.client`, and `urllib3` HTTP requests require a
   fixture-owned endpoint. This also blocks arbitrary local proxies that could
   perform remote inference behind an ordinary-looking URL. External Python socket
   connections, datagrams, and DNS lookups are rejected before network access.
@@ -47,7 +47,8 @@ fixture directory.
 
 ## Writing tests
 
-Patch the workflow/SDK boundary or inject `httpx.MockTransport`/ASGI transports.
+Patch the workflow/SDK boundary or inject the matching HTTP library's
+`MockTransport`/ASGI transport (`httpx` or `httpx2`).
 These continue exercising real application and client behavior without network
 inference. Environment-construction tests assert the environment passed to an
 intercepted launch; the isolation regressions separately prove real child
@@ -79,7 +80,11 @@ selection. Its AMS readback tests use a fixture-owned HTTP service, including
 a real 404 for an acknowledged but unpersisted write. MCP stdout tests select
 the fixture-local file backend explicitly; dispatch, sanitization and JSON-RPC
 frames still run through production code. The invalid-key test exercises the
-real SDK's 401 handling through `httpx.MockTransport`. These tests never need
+real SDK's 401 handling through its matching `MockTransport`. Anthropic 0.125
+uses `httpx`; Anthropic 1.4 uses `httpx2`. The guard protects both installed
+transport generations, and the regression suite intercepts their underlying
+`httpcore`/`httpcore2` pools so a broken guard still cannot reach a provider.
+These tests never need
 an ambient AMS service or a provider response.
 
 The dedicated coverage configuration includes the test-support implementation,

--- a/docs/testing/inference-isolation.md
+++ b/docs/testing/inference-isolation.md
@@ -1,0 +1,109 @@
+# Inference isolation in tests
+
+Ordinary pytest runs install `tests/_inference_guard.py` from
+`tests/conftest.py` before application imports or test collection. This applies
+to the controller and xdist workers. No API key, pytest marker, or saved login
+opts a test into inference. Production imports do not install the guard.
+
+## Why empty keys were insufficient
+
+The suite previously isolated Attune/Redis settings but had no inference
+barrier. `SecurityAuditWorkflow._run_agent_audit` calls the Agent SDK, whose
+subprocess transport starts Claude with its own environment and authentication.
+A missing or empty API key cannot prove that this child lacks a saved login.
+An application fallback can also catch an ordinary connection exception and
+continue through another provider. Tests must stop at the inference boundary,
+independently of the credentials available there.
+
+The September 6 daily usage export does not identify an initiating session.
+Matching dates/models do not establish attribution or authorization for paid
+inference. The usage estimate
+remains unattributed. These changes do not reconstruct that billing history.
+
+## Enforced boundaries
+
+- Real `httpx`, `http.client`, and `urllib3` HTTP requests require a
+  fixture-owned endpoint. This also blocks arbitrary local proxies that could
+  perform remote inference behind an ordinary-looking URL. External Python socket
+  connections, datagrams, and DNS lookups are rejected before network access.
+- Claude/Agent SDK inference, the repository's other provider CLIs, and network
+  CLI calls are rejected before process creation. Shell/env/node wrappers,
+  executable overrides, and the SDK's streaming command shape are checked.
+  Exact non-inference checks such as `--version`, `--help`, `auth status`, and
+  `plugin list` remain available.
+- Every real `Popen` child gets scrubbed provider credentials, an isolated
+  `CLAUDE_CONFIG_DIR`, and a Python startup guard, including when the caller
+  supplies a replacement environment. Python flags that disable that startup
+  guard are rejected. Bootstrap failure exits the child rather than continuing.
+- `InferenceBlocked` derives from `BaseException` so normal application
+  `except Exception` fallback/degradation handlers cannot turn an attempted
+  inference into a passing test. Mock the boundary the test is meant to use;
+  do not catch this exception in application code.
+
+All environment changes are local to test processes and restored on teardown.
+No normal interactive authentication file, login, or shell configuration is
+changed. Dashboard tests also redirect their saved admin-key lookup into the
+fixture directory.
+
+## Writing tests
+
+Patch the workflow/SDK boundary or inject `httpx.MockTransport`/ASGI transports.
+These continue exercising real application and client behavior without network
+inference. Environment-construction tests assert the environment passed to an
+intercepted launch; the isolation regressions separately prove real child
+credentials are scrubbed.
+
+For a real local HTTP round trip, bind a fixture-owned socket on loopback port
+zero, then use `loopback_http_fixture(server.socket)` while it remains open.
+Only that bound endpoint is permitted; other model endpoints remain blocked.
+For a real connection-refusal receipt, keep a bound socket open without calling
+`listen`. Do not assume a fixed local port is empty. Fixture servers must close
+and join their threads on teardown.
+
+```bash
+.venv/bin/python -c "import tiktoken; tiktoken.get_encoding('cl100k_base')"
+.venv/bin/python -m pytest tests/unit/test_inference_isolation.py -n 0 \
+  --cov=tests._inference_guard --cov-config=tests/inference-coverage.ini
+.venv/bin/python -m pytest tests
+```
+
+The first command prepares static tokenizer vocabulary data outside pytest;
+it makes no inference request. CI caches this data in `TIKTOKEN_CACHE_DIR`
+and requires preparation to succeed before the matrix, coverage, timezone
+and no-auth integration suites. The same cache directory is inherited by
+every step in those jobs. A cold test process must not download it through
+the inference guard, and a failed setup does not skip tokenizer assertions.
+
+The no-auth integration lane runs separately from the default coverage
+selection. Its AMS readback tests use a fixture-owned HTTP service, including
+a real 404 for an acknowledged but unpersisted write. MCP stdout tests select
+the fixture-local file backend explicitly; dispatch, sanitization and JSON-RPC
+frames still run through production code. The invalid-key test exercises the
+real SDK's 401 handling through `httpx.MockTransport`. These tests never need
+an ambient AMS service or a provider response.
+
+The dedicated coverage configuration includes the test-support implementation,
+which the normal production coverage configuration deliberately omits.
+Regression probes use fake credentials, inert CLI fixtures, intercepted network
+transports, and nested pytest runs. They must fail without making a provider
+request even if a guard regresses.
+
+## Limits
+
+This is protection against accidental inference through the suite's Python
+transports and recognized CLI launch paths, not an operating-system sandbox for
+hostile tests. Arbitrary native programs, opaque shell scripts, direct native
+network bindings, or deliberate removal of the guard need an OS-level network
+sandbox before they can be treated as untrusted. Python plugins imported before
+`tests/conftest.py` are also outside its collection-time installation boundary.
+Do not add a new provider/transport without extending the guarded-boundary
+regressions. There is no live-inference opt-out in this pytest setup; separately
+authorized live-provider work needs a separate runner and spend approval.
+
+The full-tree receipt uses the repository's existing default marker exclusions.
+The six existing live AMS tests now carry integration/network markers and defer
+availability probing until fixture setup. Their assertions are unchanged;
+collection no longer auto-discovers a running model-backed memory service.
+Its legacy Redis integration module additionally needs an isolated Redis
+instance/database; this inference guard does not make destructive Redis tests
+safe against a user's shared database.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -285,6 +285,7 @@ nav:
   - Contributing:
       - contributing.md
       - Developer Guide: DEVELOPER_GUIDE.md
+      - Test Inference Isolation: testing/inference-isolation.md
 
   # Book section (separate from main docs)
   - Book:

--- a/tests/_inference_guard.py
+++ b/tests/_inference_guard.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import atexit
 import functools
 import http.client
+import importlib.util
 import ipaddress
 import os
 import shlex
@@ -274,23 +275,30 @@ def install() -> None:
         return original_urlopen(self, method, url, *args, **kwargs)
 
     patch(urllib3.HTTPConnectionPool, "urlopen", guarded_urlopen)
-    # MockTransport stays untouched. Both real httpx transports are blocked at
-    # dispatch, before even a loopback model or API proxy can receive a request.
+
+    def patch_httpx_transports(httpx: Any) -> None:
+        """Guard each HTTPX generation while leaving MockTransport untouched."""
+        original_sync = httpx.HTTPTransport.handle_request
+        original_async = httpx.AsyncHTTPTransport.handle_async_request
+
+        def guarded_sync(self: Any, request: Any) -> Any:
+            check_http_url(str(request.url))
+            return original_sync(self, request)
+
+        async def guarded_async(self: Any, request: Any) -> Any:
+            check_http_url(str(request.url))
+            return await original_async(self, request)
+
+        patch(httpx.HTTPTransport, "handle_request", guarded_sync)
+        patch(httpx.AsyncHTTPTransport, "handle_async_request", guarded_async)
+
     import httpx
 
-    original_sync = httpx.HTTPTransport.handle_request
-    original_async = httpx.AsyncHTTPTransport.handle_async_request
+    patch_httpx_transports(httpx)
+    if importlib.util.find_spec("httpx2") is not None:
+        import httpx2
 
-    def guarded_sync(self: Any, request: Any) -> Any:
-        check_http_url(str(request.url))
-        return original_sync(self, request)
-
-    async def guarded_async(self: Any, request: Any) -> Any:
-        check_http_url(str(request.url))
-        return await original_async(self, request)
-
-    patch(httpx.HTTPTransport, "handle_request", guarded_sync)
-    patch(httpx.AsyncHTTPTransport, "handle_async_request", guarded_async)
+        patch_httpx_transports(httpx2)
     atexit.register(uninstall)
 
 

--- a/tests/_inference_guard.py
+++ b/tests/_inference_guard.py
@@ -1,0 +1,310 @@
+"""Process-local pytest barriers against accidental live inference.
+
+Installed before application imports, inherited by ordinary Python children,
+and never installed by production code. This is not a sandbox for hostile tests.
+"""
+
+from __future__ import annotations
+
+import atexit
+import functools
+import http.client
+import ipaddress
+import os
+import shlex
+import subprocess
+import sys
+import tempfile
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlsplit
+
+
+class InferenceBlocked(BaseException):
+    """Escape application error/fallback handlers when a test attempts inference."""
+
+
+_CREDENTIALS = frozenset(
+    {
+        "ANTHROPIC_API_KEY",
+        "ANTHROPIC_ADMIN_API_KEY",
+        "ANTHROPIC_AUTH_TOKEN",
+        "CLAUDE_CODE_OAUTH_TOKEN",
+        "OPENAI_API_KEY",
+        "AZURE_OPENAI_API_KEY",
+        "GEMINI_API_KEY",
+        "GOOGLE_API_KEY",
+        "COHERE_API_KEY",
+        "MISTRAL_API_KEY",
+        "GROQ_API_KEY",
+        "HF_TOKEN",
+        "HUGGINGFACEHUB_API_TOKEN",
+        "ANTHROPIC_PROFILE",
+        "ANTHROPIC_IDENTITY_TOKEN_FILE",
+        "ANTHROPIC_FEDERATION_RULE_ID",
+        "ANTHROPIC_ORGANIZATION_ID",
+        "AWS_ACCESS_KEY_ID",
+        "AWS_SECRET_ACCESS_KEY",
+        "AWS_SESSION_TOKEN",
+        "AWS_PROFILE",
+        "GOOGLE_APPLICATION_CREDENTIALS",
+        "AZURE_CLIENT_SECRET",
+    }
+)
+_INFERENCE_CLI = frozenset(
+    {
+        "claude",
+        "claude.exe",
+        "claude-code",
+        "codex",
+        "codex.exe",
+        "gemini",
+        "ollama",
+        "llm",
+        "agy",
+        "antigravity",
+    }
+)
+_HTTP_TOOLS = frozenset({"curl", "curl.exe", "wget", "wget.exe", "http", "https"})
+_READ_ONLY = {("--version",), ("-v",), ("--help",), ("-h",), ("auth", "status"), ("plugin", "list")}
+_state: dict[str, Any] | None = None
+_http_fixtures: set[tuple[str, int]] = set()
+
+
+@contextmanager
+def loopback_http_fixture(sock: Any):
+    """Permit HTTP only to a loopback socket bound and owned by this test.
+
+    Keep the socket open for the entire context, even for refusal tests.
+    This cannot authorize an already-running model's occupied port.
+    """
+    address = sock.getsockname()[:2]
+    check_address(address)
+    if not address[1]:
+        raise ValueError("Fixture socket must already be bound")
+    _http_fixtures.add(address)
+    try:
+        yield
+    finally:
+        _http_fixtures.remove(address)
+
+
+def check_command(command: Any) -> None:
+    """Reject inference executables, including shell/env/node/SDK wrappers."""
+    if isinstance(command, str | bytes):
+        parts = shlex.split(os.fsdecode(command), posix=os.name != "nt")
+        # Non-POSIX splitting retains Windows command-line quotes.
+        parts = [p[1:-1] if len(p) > 1 and p[0] == p[-1] and p[0] in "\"'" else p for p in parts]
+    else:
+        parts = [os.fsdecode(p) for p in command]
+    if "--print" in parts and "stream-json" in parts:
+        raise InferenceBlocked("Live inference blocked: mock the Agent SDK transport")
+    for index, part in enumerate(parts):
+        name = part.replace("\\", "/").rsplit("/", 1)[-1].lower()
+        if name.startswith("python"):
+            for flag in parts[index + 1 :]:
+                if not flag.startswith("-") or flag in {"-c", "-m"}:
+                    break
+                if not flag.startswith("--") and set(flag[1:]) & {"I", "S", "E"}:
+                    raise InferenceBlocked("Unguarded Python child blocked: retain test isolation")
+        if (
+            name in _INFERENCE_CLI
+            or "@anthropic-ai/claude-code" in part
+            or (name == "cli.js" and "claude" in part.lower())
+        ):
+            if tuple(parts[index + 1 :]) not in _READ_ONLY:
+                raise InferenceBlocked(
+                    "Live inference blocked: mock the LLM/CLI boundary in this test"
+                )
+        if name in _HTTP_TOOLS:
+            if tuple(parts[index + 1 :]) not in {("--version",), ("--help",)}:
+                raise InferenceBlocked(
+                    "Network CLI blocked: use an intercepted HTTP client in tests"
+                )
+        if name == "env" and "-S" in parts[index + 1 :]:
+            check_command(parts[parts.index("-S", index + 1) + 1])
+        # A shell's command string is one argv item; inspect its contents too.
+        if name in {"sh", "bash", "zsh", "cmd", "cmd.exe", "powershell", "pwsh"}:
+            tail = parts[index + 1 :]
+            for flag in ("-c", "-lc", "/c", "-Command"):
+                if flag in tail and tail.index(flag) + 1 < len(tail):
+                    check_command(tail[tail.index(flag) + 1])
+
+
+def check_address(address: Any) -> None:
+    """Permit local test services; block real external sockets before connection."""
+    if not isinstance(address, tuple):
+        return  # Unix-domain sockets, including subprocess/xdist pipes.
+    host = os.fsdecode(address[0])
+    if host.lower() == "localhost":
+        return
+    try:
+        allowed = ipaddress.ip_address(host.split("%", 1)[0]).is_loopback
+    except ValueError:
+        allowed = False
+    if not allowed:
+        raise InferenceBlocked("External network blocked: mock the provider transport in this test")
+
+
+def check_http_url(url: str) -> None:
+    """Deny unregistered real HTTP: a local proxy can invoke remote inference."""
+    parsed = urlsplit(str(url))
+    if (parsed.hostname, parsed.port) in _http_fixtures:
+        return
+    raise InferenceBlocked(
+        "Inference HTTP endpoint blocked: use a mock transport or owned HTTP fixture"
+    )
+
+
+def _audit(event: str, args: tuple) -> None:
+    if _state is None:
+        return
+    if event in {"subprocess.Popen", "os.posix_spawn", "os.exec"}:
+        check_command(args[1])
+        if args[0] is not None:  # Windows Popen can omit the executable override.
+            command = args[1]
+            tail = [command] if isinstance(command, str | bytes) else command[1:]
+            check_command([args[0], *tail])
+    elif event == "os.spawn":
+        check_command(args[2])
+    elif event == "os.system":
+        check_command(args[0])
+    elif event in {"socket.connect", "socket.sendto"}:
+        check_address(args[-1])
+    elif event == "socket.getaddrinfo":
+        if args[0] is not None:  # Passive bind lookup does not connect anywhere.
+            check_address((args[0], args[1]))
+
+
+# CPython otherwise hides audit callback bodies from coverage's tracing hook.
+_audit.__cantrace__ = True
+
+
+def _child_env(env: Any, state: dict) -> dict:
+    result = {
+        os.fsdecode(k): os.fsdecode(v) for k, v in (os.environ if env is None else env).items()
+    }
+    for name in list(result):
+        if name.upper() in _CREDENTIALS:
+            del result[name]
+    result["ANTHROPIC_API_KEY"] = ""
+    result["OPENAI_API_KEY"] = ""
+    result["CLAUDE_CONFIG_DIR"] = state["profile"]
+    existing = result.get("PYTHONPATH", "")
+    result["PYTHONPATH"] = os.pathsep.join(filter(None, [state["bootstrap"], existing]))
+    return result
+
+
+def install() -> None:
+    """Install barriers in this test interpreter without editing user auth files."""
+    global _state
+    if _state is not None:
+        return
+    scratch = tempfile.TemporaryDirectory(prefix="attune-inference-guard-")
+    root = Path(scratch.name).resolve()
+    bootstrap = root / "sitecustomize.py"
+    if bootstrap.resolve().parent != root:
+        raise RuntimeError("Unsafe test bootstrap path")
+    source = Path(__file__).resolve()
+    bootstrap.write_text(
+        "import importlib.util, os, sys\n"
+        "try:\n"
+        f"    s = importlib.util.spec_from_file_location('tests._inference_guard', {str(source)!r})\n"
+        "    m = importlib.util.module_from_spec(s)\n"
+        "    sys.modules[s.name] = m\n"
+        "    s.loader.exec_module(m)\n"
+        "    m.install()\n"
+        "except BaseException:\n"
+        "    sys.stderr.write('Test inference isolation bootstrap failed\\n')\n"
+        "    os._exit(86)\n",
+        encoding="utf-8",
+    )
+    managed = _CREDENTIALS | {"CLAUDE_CONFIG_DIR", "PYTHONPATH"}
+    state = {
+        "scratch": scratch,
+        "bootstrap": str(root),
+        "profile": str(root / "claude"),
+        "environment": {k: os.environ.get(k) for k in managed},
+        "patches": [],
+    }
+    _state = state
+    os.environ.update(_child_env(None, state))
+    for key in _CREDENTIALS - {"ANTHROPIC_API_KEY", "OPENAI_API_KEY"}:
+        os.environ.pop(key, None)
+    sys.addaudithook(_audit)
+
+    def patch(owner: Any, name: str, replacement: Any) -> None:
+        state["patches"].append((owner, name, getattr(owner, name)))
+        setattr(owner, name, replacement)
+
+    original_init = subprocess.Popen.__init__
+
+    @functools.wraps(original_init)
+    def guarded_init(self: Any, args: Any, *pos: Any, **kwargs: Any) -> None:
+        check_command(args)
+        executable = kwargs.get("executable") or (pos[1] if len(pos) > 1 else None)
+        if executable:
+            check_command([executable, *([args] if isinstance(args, str) else args[1:])])
+        # env is positional argument 10 in Popen; preserve both calling styles.
+        if len(pos) > 9:
+            mutable = list(pos)
+            mutable[9] = _child_env(mutable[9], state)
+            pos = tuple(mutable)
+        else:
+            kwargs["env"] = _child_env(kwargs.get("env"), state)
+        original_init(self, args, *pos, **kwargs)
+
+    patch(subprocess.Popen, "__init__", guarded_init)
+    original_request = http.client.HTTPConnection.request
+
+    @functools.wraps(original_request)
+    def guarded_request(self: Any, method: str, url: str, *args: Any, **kwargs: Any) -> Any:
+        check_http_url(f"http://{self.host}:{self.port}{url}" if url.startswith("/") else url)
+        return original_request(self, method, url, *args, **kwargs)
+
+    patch(http.client.HTTPConnection, "request", guarded_request)
+    import urllib3
+
+    original_urlopen = urllib3.HTTPConnectionPool.urlopen
+
+    @functools.wraps(original_urlopen)
+    def guarded_urlopen(self: Any, method: str, url: str, *args: Any, **kwargs: Any) -> Any:
+        check_http_url(f"http://{self.host}:{self.port}{url}" if url.startswith("/") else url)
+        return original_urlopen(self, method, url, *args, **kwargs)
+
+    patch(urllib3.HTTPConnectionPool, "urlopen", guarded_urlopen)
+    # MockTransport stays untouched. Both real httpx transports are blocked at
+    # dispatch, before even a loopback model or API proxy can receive a request.
+    import httpx
+
+    original_sync = httpx.HTTPTransport.handle_request
+    original_async = httpx.AsyncHTTPTransport.handle_async_request
+
+    def guarded_sync(self: Any, request: Any) -> Any:
+        check_http_url(str(request.url))
+        return original_sync(self, request)
+
+    async def guarded_async(self: Any, request: Any) -> Any:
+        check_http_url(str(request.url))
+        return await original_async(self, request)
+
+    patch(httpx.HTTPTransport, "handle_request", guarded_sync)
+    patch(httpx.AsyncHTTPTransport, "handle_async_request", guarded_async)
+    atexit.register(uninstall)
+
+
+def uninstall() -> None:
+    """Restore only this interpreter's settings after pytest finishes."""
+    global _state
+    state, _state = _state, None
+    if state is None:
+        return
+    for owner, name, original in reversed(state["patches"]):
+        setattr(owner, name, original)
+    for key, value in state["environment"].items():
+        if value is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = value
+    state["scratch"].cleanup()

--- a/tests/_inference_guard.py
+++ b/tests/_inference_guard.py
@@ -91,12 +91,50 @@ def loopback_http_fixture(sock: Any):
         _http_fixtures.remove(address)
 
 
+def _split_windows_command(command: str) -> list[str]:
+    """Decode the CRT quoting used by Windows Popen's list2cmdline audit.
+
+    shlex is a shell parser: its non-POSIX mode cannot decode escaped quotes
+    in Python -c programs. Backslashes escape only quotes in this format.
+    """
+    parts = []
+    index = 0
+    while index < len(command):
+        if command[index] in " \t":
+            index += 1
+            continue
+        argument = []
+        quoted = False
+        while index < len(command):
+            slashes = 0
+            while index < len(command) and command[index] == "\\":
+                slashes += 1
+                index += 1
+            if index < len(command) and command[index] == '"':
+                argument.extend("\\" * (slashes // 2))
+                if slashes % 2:
+                    argument.append('"')
+                elif quoted and command[index : index + 2] == '""':
+                    argument.append('"')
+                    index += 1
+                else:
+                    quoted = not quoted
+                index += 1
+                continue
+            argument.extend("\\" * slashes)
+            if index == len(command) or (not quoted and command[index] in " \t"):
+                break
+            argument.append(command[index])
+            index += 1
+        parts.append("".join(argument))
+    return parts
+
+
 def check_command(command: Any) -> None:
     """Reject inference executables, including shell/env/node/SDK wrappers."""
     if isinstance(command, str | bytes):
-        parts = shlex.split(os.fsdecode(command), posix=os.name != "nt")
-        # Non-POSIX splitting retains Windows command-line quotes.
-        parts = [p[1:-1] if len(p) > 1 and p[0] == p[-1] and p[0] in "\"'" else p for p in parts]
+        text = os.fsdecode(command)
+        parts = _split_windows_command(text) if os.name == "nt" else shlex.split(text)
     else:
         parts = [os.fsdecode(p) for p in command]
     if "--print" in parts and "stream-json" in parts:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,6 +28,12 @@ from pathlib import Path
 import pydantic.root_model  # noqa: F401  (import for side effect: sys.modules warm-up)
 import pytest
 
+from tests._inference_guard import install as _install_inference_guard
+from tests._inference_guard import uninstall as _uninstall_inference_guard
+
+# Before workflow imports and collection, in the controller and every worker.
+_install_inference_guard()
+
 #: ``ATTUNE_*`` vars owned by the autouse fixtures further down, which
 #: set them per-test (tmp ``ATTUNE_HOME``, telemetry off). ``_scrub_attune_env``
 #: must not touch these — see its docstring for the failure it caused.
@@ -999,3 +1005,8 @@ def fake_module(monkeypatch):
         return module
 
     return register
+
+
+def pytest_unconfigure(config):
+    """Restore process-local isolation after all test workers finish."""
+    _uninstall_inference_guard()

--- a/tests/inference-coverage.ini
+++ b/tests/inference-coverage.ini
@@ -1,0 +1,6 @@
+[run]
+branch = true
+source = tests._inference_guard
+[report]
+fail_under = 90
+show_missing = true

--- a/tests/integration/test_ams_remember_readback_live.py
+++ b/tests/integration/test_ams_remember_readback_live.py
@@ -1,61 +1,113 @@
-"""Non-mocked boundary test: ``remember`` is a receipt, not an ack.
+"""AMS readback boundary receipts against a fixture-owned HTTP service.
 
-Runs only when a real Agent Memory Server answers ``/v1/health`` (skips in
-CI). Positive: a write reads back and the record is visible by id over the
-real transport. Negative: with the create call neutralised, the REAL readback
-404s and ``remember`` must return False — the shape of the 2026-08-23 silent
-stash loss, where AMS acked every create while persisting nothing.
+The real client serializes writes and reads records back over HTTP. A write
+acknowledgment without persistence must fail the backend's readback check.
+No running AMS, embedding model, credentials or availability probe is needed.
 """
 
 from __future__ import annotations
 
-import os
-import urllib.request
+import json
+import threading
 import uuid
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from urllib.parse import parse_qs, urlsplit
 
 import pytest
 
-AMS_URL = os.environ.get("ATTUNE_AMS_URL", "http://localhost:8000")
+from tests._inference_guard import loopback_http_fixture
 
-
-def _ams_up() -> bool:
-    try:
-        with urllib.request.urlopen(f"{AMS_URL}/v1/health", timeout=2) as r:  # noqa: S310
-            return r.status == 200
-    except Exception:  # noqa: BLE001
-        return False
-
-
-pytestmark = pytest.mark.skipif(not _ams_up(), reason="no live AMS at ATTUNE_AMS_URL")
+pytestmark = pytest.mark.integration
 
 
 @pytest.fixture
 def backend():
+    from attune_redis.config import RedisPluginConfig
     from attune_redis.memory import AMSMemoryBackend
 
-    be = AMSMemoryBackend()
+    records = {}
+    calls = []
+
+    class Handler(BaseHTTPRequestHandler):
+        def log_message(self, *args):
+            pass
+
+        def reply(self, code, body):
+            payload = json.dumps(body).encode("utf-8")
+            self.send_response(code)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(payload)))
+            self.end_headers()
+            self.wfile.write(payload)
+
+        def do_POST(self):
+            calls.append(("POST", self.path))
+            if self.path != "/v1/long-term-memory/":
+                self.reply(404, {"detail": "unknown fixture endpoint"})
+                return
+            payload = json.loads(self.rfile.read(int(self.headers["Content-Length"])))
+            assert payload["deduplicate"] is False
+            for record in payload["memories"]:
+                records[record["id"]] = record
+            self.reply(200, {"status": "ok"})
+
+        def do_GET(self):
+            calls.append(("GET", self.path))
+            record = records.get(self.path.removeprefix("/v1/long-term-memory/"))
+            self.reply(200 if record else 404, record or {"detail": "Memory not found"})
+
+        def do_DELETE(self):
+            calls.append(("DELETE", self.path))
+            for mid in parse_qs(urlsplit(self.path).query).get("memory_ids", []):
+                records.pop(mid, None)
+            self.reply(200, {"status": "ok"})
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    config = RedisPluginConfig(ams_base_url=f"http://127.0.0.1:{server.server_port}")
+    be = AMSMemoryBackend(config)
     be._namespace = f"itest-readback-{uuid.uuid4().hex[:8]}"
-    yield be
-    be.close()
+    try:
+        with loopback_http_fixture(server.socket):
+            yield be, records, calls
+    finally:
+        be.close()
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+        assert not thread.is_alive()
 
 
 def test_live_write_reads_back(backend):
     from attune_redis.memory import _run_sync
 
+    be, records, calls = backend
     mid = f"itest-{uuid.uuid4().hex}"
     try:
-        assert backend.remember("live readback receipt", memory_id=mid) is True
-        rec = _run_sync(backend._client.get_long_term_memory(mid))
+        assert be.remember("HTTP readback receipt", memory_id=mid) is True
+        rec = _run_sync(be._client.get_long_term_memory(mid))
         assert rec.id == mid
+        assert rec.text == records[mid]["text"] == "HTTP readback receipt"
+        assert calls == [
+            ("POST", "/v1/long-term-memory/"),
+            ("GET", f"/v1/long-term-memory/{mid}"),
+            ("GET", f"/v1/long-term-memory/{mid}"),
+        ]
     finally:
-        backend.forget([mid])
+        be.forget([mid])
+    assert mid not in records
 
 
 def test_live_unpersisted_write_is_not_a_success(backend, monkeypatch):
-    """Real transport, real 404: an acked-but-absent record returns False."""
+    """An acked-but-absent record produces a real HTTP 404 and returns False."""
+    be, records, calls = backend
 
     async def _ack_without_write(*args, **kwargs):
         return None
 
-    monkeypatch.setattr(backend._client, "create_long_term_memory", _ack_without_write)
-    assert backend.remember("never persisted", memory_id=f"itest-{uuid.uuid4().hex}") is False
+    monkeypatch.setattr(be._client, "create_long_term_memory", _ack_without_write)
+    mid = f"itest-{uuid.uuid4().hex}"
+    assert be.remember("never persisted", memory_id=mid) is False
+    assert mid not in records
+    assert calls == [("GET", f"/v1/long-term-memory/{mid}")] * 3

--- a/tests/integration/test_llm_integration.py
+++ b/tests/integration/test_llm_integration.py
@@ -14,6 +14,7 @@ Licensed under the Apache License, Version 2.0
 
 import os
 
+import httpx
 import pytest
 from dotenv import load_dotenv
 
@@ -309,11 +310,34 @@ class TestLLMErrorHandling:
     @pytest.mark.asyncio
     @pytest.mark.skipif(anthropic is None, reason="anthropic package not installed")
     async def test_invalid_api_key(self):
-        """Test handling of invalid API key"""
-        expected_exceptions = (ValueError, RuntimeError, anthropic.AuthenticationError)
-        with pytest.raises(expected_exceptions):
-            provider = AnthropicProvider(api_key="invalid-key-12345")
-            await provider.generate(messages=[{"role": "user", "content": "Hello"}], max_tokens=50)
+        """Exercise the real SDK/provider error path with an intercepted 401."""
+        requests = []
+
+        def unauthorized(request):
+            requests.append(request)
+            return httpx.Response(
+                401,
+                json={
+                    "type": "error",
+                    "error": {"type": "authentication_error", "message": "Invalid API key"},
+                },
+            )
+
+        async with httpx.AsyncClient(transport=httpx.MockTransport(unauthorized)) as http:
+            async with anthropic.AsyncAnthropic(
+                api_key="invalid-key-12345", http_client=http, max_retries=0
+            ) as client:
+                provider = AnthropicProvider(api_key="invalid-key-12345")
+                await provider.client.close()
+                provider.client = client
+                with pytest.raises(anthropic.AuthenticationError) as caught:
+                    await provider.generate(
+                        messages=[{"role": "user", "content": "Hello"}], max_tokens=50
+                    )
+        assert caught.value.status_code == 401
+        assert len(requests) == 1
+        assert requests[0].url.path == "/v1/messages"
+        assert requests[0].headers["x-api-key"] == "invalid-key-12345"
 
     @pytest.mark.llm
     @pytest.mark.asyncio

--- a/tests/integration/test_llm_integration.py
+++ b/tests/integration/test_llm_integration.py
@@ -311,11 +311,12 @@ class TestLLMErrorHandling:
     @pytest.mark.skipif(anthropic is None, reason="anthropic package not installed")
     async def test_invalid_api_key(self):
         """Exercise the real SDK/provider error path with an intercepted 401."""
+        sdk_http = getattr(anthropic._base_client, "httpx2", httpx)
         requests = []
 
         def unauthorized(request):
             requests.append(request)
-            return httpx.Response(
+            return sdk_http.Response(
                 401,
                 json={
                     "type": "error",
@@ -323,7 +324,7 @@ class TestLLMErrorHandling:
                 },
             )
 
-        async with httpx.AsyncClient(transport=httpx.MockTransport(unauthorized)) as http:
+        async with sdk_http.AsyncClient(transport=sdk_http.MockTransport(unauthorized)) as http:
             async with anthropic.AsyncAnthropic(
                 api_key="invalid-key-12345", http_client=http, max_retries=0
             ) as client:

--- a/tests/integration/test_mcp_dispatch.py
+++ b/tests/integration/test_mcp_dispatch.py
@@ -179,11 +179,14 @@ class _InMemorySearchableBackend:
 
 
 @pytest.fixture
-def session_server(server):
+def session_server(server, monkeypatch):
     """Real server with the attune_redis plugin tools actually registered
     (the base fixture suppresses plugin auto-registration)."""
     from attune_redis.mcp_tools import register_tools
 
+    # The real status/degradation path uses the fixture-local file tier;
+    # lifecycle tests below inject their searchable backend explicitly.
+    monkeypatch.setenv("ATTUNE_MEMORY_BACKEND", "file")
     register_tools(server)
     return server
 

--- a/tests/integration/test_mcp_stdout_purity.py
+++ b/tests/integration/test_mcp_stdout_purity.py
@@ -61,8 +61,9 @@ class _LineReader:
 def test_session_memory_capture_keeps_stdout_json_only(tmp_path):
     env = dict(os.environ)
     env["ATTUNE_REDIS_REQUIRED"] = "false"
+    env["ATTUNE_MEMORY_BACKEND"] = "file"
     # Keep the stash inside the test sandbox: HOME redirects the file
-    # fallback, and the dead AMS/Redis endpoints force that fallback even
+    # fallback, and the explicit file preference avoids probing AMS/Redis
     # on machines where a real local Redis is running (otherwise the
     # canary lands in the developer's live store — observed 2026-07-27).
     env["HOME"] = str(tmp_path)
@@ -116,6 +117,8 @@ def test_session_memory_capture_keeps_stdout_json_only(tmp_path):
         proc.stdin.flush()
         response = reader.wait_for_id(2, 60)
         assert response is not None, "no tools/call response"
+        assert "error" not in response, response
+        assert not response["result"].get("isError", False), response
 
         non_json = [line for line in reader.lines if line and not _parses(line)]
         assert non_json == [], (

--- a/tests/memory/test_ams_backend_integration.py
+++ b/tests/memory/test_ams_backend_integration.py
@@ -20,7 +20,10 @@ Prerequisites (skipped cleanly when absent):
       (default ``http://localhost:8000``)
 
 Run locally with AMS up:
-    pytest tests/memory/test_ams_backend_integration.py -v
+    This live-service module is integration/network scoped. Ordinary tests
+    must not discover and use an ambient server just because it is running.
+    A separately isolated live-service runner is required; the default pytest
+    inference guard rejects unregistered HTTP endpoints even when selected.
 """
 
 from __future__ import annotations
@@ -47,10 +50,14 @@ def _ams_running() -> bool:
         return False
 
 
-pytestmark = pytest.mark.skipif(
-    not _ams_running(),
-    reason=f"No Agent Memory Server reachable at {_AMS_BASE_URL}",
-)
+pytestmark = [pytest.mark.integration, pytest.mark.network]
+
+
+@pytest.fixture(autouse=True)
+def require_ams():
+    # Probe only after test selection, never during ordinary collection.
+    if not _ams_running():
+        pytest.skip(f"No Agent Memory Server reachable at {_AMS_BASE_URL}")
 
 
 @pytest.fixture

--- a/tests/unit/ci/test_workflow_yaml.py
+++ b/tests/unit/ci/test_workflow_yaml.py
@@ -85,6 +85,32 @@ PIP_CACHE_EXCEPTIONS = {
 SHA_PATTERN = re.compile(r"[0-9a-f]{40}")
 
 
+@pytest.mark.parametrize(
+    "filename,job_id",
+    [
+        ("tests.yml", "test"),
+        ("tests.yml", "clock-tz"),
+        ("tests.yml", "coverage"),
+        ("integration-tests.yml", "integration"),
+    ],
+)
+def test_tokenizer_data_is_prepared_before_isolated_pytest(filename, job_id):
+    job = ALL_WORKFLOWS[filename]["jobs"][job_id]
+    cache_dir = "${{ runner.temp }}/tiktoken-cache"
+    assert job["env"]["TIKTOKEN_CACHE_DIR"] == cache_dir
+    steps = job["steps"]
+    caches = [step for step in steps if step.get("name") == "Cache tiktoken encodings"]
+    warmups = [step for step in steps if step.get("name") == "Warm tiktoken encoding"]
+    assert len(caches) == len(warmups) == 1
+    cache, warm = caches[0], warmups[0]
+    assert cache["with"]["path"] == cache_dir
+    assert "tiktoken.get_encoding('cl100k_base')" in warm["run"]
+    assert "||" not in warm["run"] and not warm.get("continue-on-error", False)
+    pytest_steps = [i for i, step in enumerate(steps) if "pytest " in step.get("run", "")]
+    assert pytest_steps
+    assert steps.index(cache) < steps.index(warm) < min(pytest_steps)
+
+
 # ===========================================================================
 # 1. Schema Validation
 # ===========================================================================

--- a/tests/unit/ci/test_workflow_yaml.py
+++ b/tests/unit/ci/test_workflow_yaml.py
@@ -96,7 +96,7 @@ SHA_PATTERN = re.compile(r"[0-9a-f]{40}")
 )
 def test_tokenizer_data_is_prepared_before_isolated_pytest(filename, job_id):
     job = ALL_WORKFLOWS[filename]["jobs"][job_id]
-    cache_dir = "${{ runner.temp }}/tiktoken-cache"
+    cache_dir = "${{ github.workspace }}/../tiktoken-cache"
     assert job["env"]["TIKTOKEN_CACHE_DIR"] == cache_dir
     steps = job["steps"]
     caches = [step for step in steps if step.get("name") == "Cache tiktoken encodings"]
@@ -118,6 +118,16 @@ def test_tokenizer_data_is_prepared_before_isolated_pytest(filename, job_id):
 
 class TestSchemaValidation:
     """Every workflow file must be valid YAML with required top-level keys."""
+
+    def test_job_environment_does_not_use_runner_context(self):
+        """Runner context exists in steps, but GitHub rejects it in job env."""
+        for filename, workflow in ALL_WORKFLOWS.items():
+            for job_id, job in workflow.get("jobs", {}).items():
+                for name, value in job.get("env", {}).items():
+                    for expression in re.findall(r"\$\{\{(.*?)\}\}", str(value), re.S):
+                        assert not re.search(
+                            r"\brunner\.", expression
+                        ), f"{filename}:{job_id}:env:{name}: runner context unavailable"
 
     def test_all_workflow_files_are_valid_yaml(self):
         """Every .yml file in .github/workflows/ must parse as valid YAML."""

--- a/tests/unit/cli/test_doctor_redis_endpoint.py
+++ b/tests/unit/cli/test_doctor_redis_endpoint.py
@@ -60,6 +60,9 @@ def _run_doctor(monkeypatch: pytest.MonkeyPatch, url: str, capsys) -> str:
     for name in _REDIS_ENV:
         monkeypatch.delenv(name, raising=False)
     monkeypatch.setenv("REDIS_URL", url)
+    # Keep the independent memory-backend diagnostic off ambient AMS;
+    # the Redis endpoint above still performs the real RESP round trip.
+    monkeypatch.setenv("ATTUNE_MEMORY_BACKEND", "file")
     cmd_doctor(Namespace())
     return capsys.readouterr().out
 

--- a/tests/unit/cli_commands/test_utility_commands.py
+++ b/tests/unit/cli_commands/test_utility_commands.py
@@ -997,6 +997,13 @@ class TestCmdFeatures:
 # ---------------------------------------------------------------------------
 
 
+@pytest.fixture
+def doctor_file_backend(monkeypatch):
+    """Doctor's unrelated memory diagnostic uses the fixture-local file tier."""
+    monkeypatch.setenv("ATTUNE_MEMORY_BACKEND", "file")
+
+
+@pytest.mark.usefixtures("doctor_file_backend")
 class TestCmdDoctor:
     """Tests for cmd_doctor."""
 
@@ -1126,6 +1133,7 @@ class TestCmdDoctor:
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.usefixtures("doctor_file_backend")
 class TestCmdDoctorInstallDiagnostics:
     """Tests for the related-package and Claude plugin doctor checks."""
 

--- a/tests/unit/hooks/test_memory_telemetry.py
+++ b/tests/unit/hooks/test_memory_telemetry.py
@@ -289,6 +289,8 @@ def test_lesson_recall_no_match_logs_nothing(tmp_path, monkeypatch, capsys):
 
 
 def test_session_stash_logs_counts_and_extractor(tmp_path, monkeypatch, capsys):
+    monkeypatch.setattr("attune.memory.session_stash.resolve_backend", lambda backend=None: backend)
+    monkeypatch.setattr("attune.memory.session_stash.backend_status", lambda: {})
     monkeypatch.setenv("ATTUNE_HOME", str(tmp_path / ".attune"))
     monkeypatch.setenv("ATTUNE_AI_SENTINEL_DIR", str(tmp_path / "sentinels"))
     _load_module("_state")

--- a/tests/unit/hooks/test_memory_verdicts.py
+++ b/tests/unit/hooks/test_memory_verdicts.py
@@ -18,12 +18,15 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import socket
 import sys
 import threading
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
 
 import pytest
+
+from tests._inference_guard import loopback_http_fixture
 
 _HOOKS_DIR = Path(__file__).resolve().parents[3] / "plugin" / "hooks"
 
@@ -79,10 +82,15 @@ class TestReceipt1KeylessRoundTrip:
     """MI-6a: real write → real scorer (Ollama absent) → real reader."""
 
     def test_unscored_end_to_end(self, isolated_home, verdicts_mod, telemetry_mod, monkeypatch):
-        # Dead loopback port: connection refused == Ollama unavailable.
-        monkeypatch.setenv("ATTUNE_MEMORY_OLLAMA_URL", "http://127.0.0.1:9")
+        # Own a bound, non-listening socket: deterministic refusal, no model.
         _write_surfacing(telemetry_mod)
-        written = verdicts_mod.score_session("s1", "some transcript tail text")
+        with socket.socket() as refused:
+            refused.bind(("127.0.0.1", 0))
+            monkeypatch.setenv(
+                "ATTUNE_MEMORY_OLLAMA_URL", f"http://127.0.0.1:{refused.getsockname()[1]}"
+            )
+            with loopback_http_fixture(refused):
+                written = verdicts_mod.score_session("s1", "some transcript tail text")
         assert written == 2
 
         records = [e for e in _read_events(isolated_home) if e["event"] == "memory_signal"]
@@ -133,8 +141,13 @@ def fake_ollama(monkeypatch):
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()
     monkeypatch.setenv("ATTUNE_MEMORY_OLLAMA_URL", f"http://127.0.0.1:{server.server_port}")
-    yield _FakeOllama
-    server.shutdown()
+    try:
+        with loopback_http_fixture(server.socket):
+            yield _FakeOllama
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
 
 
 class TestReceipt2HermeticScoredLabels:

--- a/tests/unit/hooks/test_refs_binding.py
+++ b/tests/unit/hooks/test_refs_binding.py
@@ -32,7 +32,10 @@ def _load_module(name: str):
 
 
 @pytest.fixture
-def stash_mod():
+def stash_mod(monkeypatch):
+    # Hook logic is independent of discovering the user's live AMS service.
+    monkeypatch.setattr("attune.memory.session_stash.resolve_backend", lambda backend=None: backend)
+    monkeypatch.setattr("attune.memory.session_stash.backend_status", lambda: {})
     return _load_module("session_stash")
 
 

--- a/tests/unit/hooks/test_session_memory_hooks.py
+++ b/tests/unit/hooks/test_session_memory_hooks.py
@@ -15,11 +15,16 @@ import importlib.util
 import io
 import json
 import os
+import socket
 import sys
+import threading
 import urllib.request
+from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
 
 import pytest
+
+from tests._inference_guard import loopback_http_fixture
 
 _HOOKS_DIR = Path(__file__).resolve().parents[3] / "plugin" / "hooks"
 
@@ -37,7 +42,10 @@ def _load_module(name: str):
 
 
 @pytest.fixture
-def stash_mod():
+def stash_mod(monkeypatch):
+    # Hook logic is independent of discovering the user's live AMS service.
+    monkeypatch.setattr("attune.memory.session_stash.resolve_backend", lambda backend=None: backend)
+    monkeypatch.setattr("attune.memory.session_stash.backend_status", lambda: {})
     return _load_module("session_stash")
 
 
@@ -375,37 +383,59 @@ def test_stash_findings_maps_extras_to_tags(stash_mod, monkeypatch):
 # ==========================================================================
 
 
-def _ollama_available() -> bool:
-    """True when Ollama answers and the configured extraction model is pulled."""
-    base = os.environ.get("ATTUNE_MEMORY_OLLAMA_URL", "http://localhost:11434").rstrip("/")
-    model = os.environ.get("ATTUNE_MEMORY_OLLAMA_MODEL", "llama3.1:8b")
-    try:
-        with urllib.request.urlopen(f"{base}/api/tags", timeout=2) as resp:
-            tags = json.loads(resp.read().decode("utf-8"))
-    except Exception:  # noqa: BLE001 — any failure means "no Ollama" -> skip
-        return False
-    names = {m.get("name", "") for m in tags.get("models", [])}
-    family = model.split(":")[0]
-    return any(n == model or n.startswith(family) for n in names)
+def test_extract_via_ollama_http_round_trip(stash_mod, monkeypatch):
+    """Real HTTP serialization and parsing against a fixture-owned server."""
+    requests = []
 
+    class Handler(BaseHTTPRequestHandler):
+        def do_POST(self):  # noqa: N802
+            requests.append(
+                (self.path, json.loads(self.rfile.read(int(self.headers["Content-Length"]))))
+            )
+            body = json.dumps(
+                {
+                    "response": json.dumps(
+                        {
+                            "findings": [
+                                {
+                                    "type": "bug",
+                                    "content": "Idempotency key omitted on retries",
+                                    "confidence": 0.9,
+                                }
+                            ]
+                        }
+                    )
+                }
+            ).encode()
+            self.send_response(200)
+            self.end_headers()
+            self.wfile.write(body)
 
-@pytest.mark.skipif(not _ollama_available(), reason="Ollama + extraction model not available")
-def test_extract_via_ollama_real_round_trip(stash_mod):
-    """NON-MOCKED: a real Ollama call returns parseable typed findings.
+        def log_message(self, *args):
+            pass
 
-    The mocked test above proves parsing of a *canned* response; this proves
-    the real ``/api/generate`` request shape + real model output parse
-    end-to-end — the boundary a mock cannot exercise. Model output is
-    non-deterministic, so assert STRUCTURE, not content.
-    """
+    server = HTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    monkeypatch.setenv("ATTUNE_MEMORY_OLLAMA_URL", f"http://127.0.0.1:{server.server_port}")
     transcript = (
         "user: We kept getting double charges on Stripe webhooks.\n"
         "assistant: Root cause was the idempotency key being omitted on retries; "
         "adding it fixed the double charge. We also decided to standardize on "
         "Redis AMS for cross-session memory.\n"
     )
-    findings = stash_mod._extract_via_ollama(transcript)
-    assert findings is not None, "real Ollama returned no parseable findings for a clear transcript"
+    try:
+        with loopback_http_fixture(server.socket):
+            findings = stash_mod._extract_via_ollama(transcript)
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+    assert len(requests) == 1
+    assert requests[0][0] == "/api/generate"
+    assert transcript in requests[0][1]["prompt"]
+    assert requests[0][1]["stream"] is False
+    assert findings is not None, "fixture HTTP response was not parsed"
     assert isinstance(findings, list) and findings
     for f in findings:
         assert isinstance(f, dict)
@@ -421,9 +451,14 @@ def test_extract_via_ollama_real_unreachable_returns_none(stash_mod, monkeypatch
     heuristic. Complements the mocked-exception test with urllib's actual
     error path against a port where nothing listens.
     """
-    monkeypatch.setenv("ATTUNE_MEMORY_OLLAMA_URL", "http://127.0.0.1:1")
     monkeypatch.setenv("ATTUNE_MEMORY_STASH_TIMEOUT", "2")
-    assert stash_mod._extract_via_ollama("a session where we fixed a real bug") is None
+    with socket.socket() as refused:
+        refused.bind(("127.0.0.1", 0))
+        monkeypatch.setenv(
+            "ATTUNE_MEMORY_OLLAMA_URL", f"http://127.0.0.1:{refused.getsockname()[1]}"
+        )
+        with loopback_http_fixture(refused):
+            assert stash_mod._extract_via_ollama("a session where we fixed a real bug") is None
 
 
 # ==========================================================================

--- a/tests/unit/hooks/test_spec_audit.py
+++ b/tests/unit/hooks/test_spec_audit.py
@@ -2,9 +2,9 @@
 
 Covers ``deliverables_for_spec`` — the machine-readable
 ``## Deliverables`` contract a spec declares so the staleness
-classifier can check whether its work has shipped. Mock-free /
-filesystem-only per testing-conventions.md (no ``live`` marker, no
-API key).
+classifier can check whether its work has shipped. Filesystem and Git
+boundaries remain real; scan-clock tests separate content behavior from
+elapsed-budget checks (no ``live`` marker or API key).
 
 The hook module is loaded via ``spec_from_file_location`` to match the
 existing plugin-hook test convention (see
@@ -1200,6 +1200,14 @@ def _age(path: Path, days: float) -> None:
 
 
 class TestScanWorktreeSpecDrift:
+    @pytest.fixture(autouse=True)
+    def scan_clock(self, state_mod, monkeypatch):
+        # These tests check real Git/file behavior, not runner scheduling.
+        # Keep subprocess timeouts and the process-wide clock untouched.
+        clock = _types.SimpleNamespace(**vars(_time))
+        clock.monotonic = lambda: 0.0
+        monkeypatch.setattr(state_mod, "time", clock)
+
     def test_flags_week_old_untracked_spec_content(self, state_mod, repo_with_worktree) -> None:
         repo, worktree = repo_with_worktree
         stale = worktree / "specs" / "orphan" / "requirements.md"
@@ -1228,6 +1236,17 @@ class TestScanWorktreeSpecDrift:
         fresh = worktree / "specs" / "new" / "requirements.md"
         fresh.parent.mkdir(parents=True)
         fresh.write_text("**Status**: draft\n", encoding="utf-8")
+        assert state_mod.scan_worktree_spec_drift(repo) == []
+
+    def test_budget_exhaustion_stops_before_the_dirty_worktree(
+        self, state_mod, repo_with_worktree
+    ) -> None:
+        repo, worktree = repo_with_worktree
+        tracked = worktree / "specs" / "seed" / "requirements.md"
+        tracked.write_text("**Status**: approved\n", encoding="utf-8")
+        _age(tracked, days=9)
+        ticks = iter([0.0, 0.0, 3.0])
+        state_mod.time.monotonic = lambda: next(ticks)
         assert state_mod.scan_worktree_spec_drift(repo) == []
 
     def test_old_non_spec_files_do_not_alarm(self, state_mod, repo_with_worktree) -> None:

--- a/tests/unit/hooks/test_trap_stash_hook.py
+++ b/tests/unit/hooks/test_trap_stash_hook.py
@@ -1,4 +1,4 @@
-"""Tests for the trap_stash PostToolUse hook (non-mocked stdin round trips).
+"""Tests for trap_stash stdin round trips with real file persistence.
 
 HOME is redirected to a tmp dir so the subprocess's backend resolution
 (FileStashBackend under ~/.attune/session_stash) and the dedupe
@@ -29,13 +29,18 @@ def _run_hook(payload: object, home: Path, extra_env: dict[str, str] | None = No
     env["HOME"] = str(home)
     env["USERPROFILE"] = str(home)  # Windows Path.home()
     env.pop("ATTUNE_TRAP_STASH", None)
-    # Force the file fallback: an unreachable AMS keeps the subprocess's
-    # backend resolution out of any live Redis/AMS instance.
-    env["AMS_BASE_URL"] = "http://127.0.0.1:9"
+    # Inject a real file backend; a presumed-dead AMS port is not isolation.
     env.pop("REDIS_URL", None)
     env.update(extra_env or {})
+    runner = (
+        "import runpy\n"
+        "from unittest.mock import patch\n"
+        "from attune.memory.file_stash import FileStashBackend\n"
+        "with patch('attune.memory.session_stash.resolve_backend', return_value=FileStashBackend()):\n"
+        f"    runpy.run_path({str(HOOK)!r}, run_name='__main__')\n"
+    )
     return subprocess.run(
-        [sys.executable, str(HOOK)],
+        [sys.executable, "-c", runner],
         input=payload if isinstance(payload, str) else json.dumps(payload),
         capture_output=True,
         text=True,

--- a/tests/unit/mcp/test_server_chart_widget.py
+++ b/tests/unit/mcp/test_server_chart_widget.py
@@ -23,6 +23,7 @@ def stub_kernel(tmp_path, monkeypatch):
         encoding="utf-8",
     )
     monkeypatch.setattr(chart_widget_tool, "_KERNEL_PATH", stub)
+    monkeypatch.setattr(chart_widget_tool, "_resolve_backend", lambda: None)
 
 
 def _make_server(tmp_path):

--- a/tests/unit/mcp/test_version_check_resilience.py
+++ b/tests/unit/mcp/test_version_check_resilience.py
@@ -30,6 +30,7 @@ from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 import pytest
 
 from attune.mcp import version_check
+from tests._inference_guard import loopback_http_fixture
 
 # All tests here drive a real localhost socket; isolate them from the
 # parallel xdist lane (see module docstring).
@@ -89,7 +90,8 @@ def stub_server():
     thread.start()
     host, port = server.server_address
     try:
-        yield f"http://{host}:{port}"
+        with loopback_http_fixture(server.socket):
+            yield f"http://{host}:{port}"
     finally:
         server.shutdown()
         server.server_close()

--- a/tests/unit/monitoring/test_notifications.py
+++ b/tests/unit/monitoring/test_notifications.py
@@ -376,9 +376,11 @@ class TestPinnedDelivery:
             raise OSError("stop before real network I/O")
 
         monkeypatch.setattr(socket_mod, "create_connection", fake_create_connection)
-        opener = urlreq.build_opener(_PinnedHTTPHandler("8.8.8.8"))
-        with pytest.raises(urllib.error.URLError):
-            opener.open("http://webhook.example/hook", timeout=1)
+        handler = _PinnedHTTPHandler("8.8.8.8")
+        # Exercise the real connection factory at the intercepted socket seam.
+        monkeypatch.setattr(handler, "do_open", lambda factory, req: factory(req.host).connect())
+        with pytest.raises(OSError, match="stop before real network"):
+            handler.http_open(urlreq.Request("http://webhook.example/hook"))
 
         assert connected == [("8.8.8.8", 80)]
 
@@ -409,9 +411,12 @@ class TestPinnedDelivery:
         monkeypatch.setattr(socket_mod, "create_connection", fake_create_connection)
         monkeypatch.setattr(ssl.SSLContext, "wrap_socket", fake_wrap_socket)
 
-        opener = urlreq.build_opener(_PinnedHTTPSHandler("8.8.8.8"))
-        with pytest.raises(urllib.error.URLError):
-            opener.open("https://webhook.example/hook", timeout=1)
+        handler = _PinnedHTTPSHandler("8.8.8.8")
+        monkeypatch.setattr(
+            handler, "do_open", lambda factory, req, **kwargs: factory(req.host, **kwargs).connect()
+        )
+        with pytest.raises(OSError, match="stop before real TLS"):
+            handler.https_open(urlreq.Request("https://webhook.example/hook"))
 
         assert connected == [("8.8.8.8", 443)]
         # SNI/cert verification target is the hostname, NOT the pinned IP.

--- a/tests/unit/ops/conftest.py
+++ b/tests/unit/ops/conftest.py
@@ -34,3 +34,10 @@ def _no_memory_telemetry_pollution(monkeypatch):
     # Setting the module's opt-out env var makes log_memory_event no-op
     # for the duration of every test in this directory.
     monkeypatch.setenv("ATTUNE_MEMORY_TELEMETRY", "0")
+
+
+@pytest.fixture(autouse=True)
+def _isolate_admin_credentials(tmp_path, monkeypatch):
+    # Dashboard smoke tests must not read the user's saved billing credential.
+    # Credential-resolution tests can override this with their own fixture file.
+    monkeypatch.setattr("attune.ops.anthropic_cost.ADMIN_KEY_PATH", tmp_path / "admin.env")

--- a/tests/unit/ops/test_health_snapshot.py
+++ b/tests/unit/ops/test_health_snapshot.py
@@ -482,9 +482,13 @@ class TestCollectSnapshot:
     def test_shape_and_schema_version(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        # Every individual signal is unmocked here and will fail for
-        # trivial reasons (no src/, no network, no gh) — the point of
-        # this test is that collect_snapshot NEVER raises regardless.
+        # Exercise local collectors and their failures; external boundaries
+        # fail deterministically without relying on absent network/gh auth.
+        def unavailable(*args, **kwargs):
+            raise OSError("fixture service unavailable")
+
+        monkeypatch.setattr("requests.get", unavailable)
+        monkeypatch.setattr(subprocess, "run", unavailable)
         snapshot = hs.collect_snapshot(tmp_path, timeout=1)
         assert snapshot["schema_version"] == 1
         assert "collected_at" in snapshot

--- a/tests/unit/roundtable/test_routine.py
+++ b/tests/unit/roundtable/test_routine.py
@@ -8,7 +8,9 @@ non-mocked receipt; tests skip when Redis is unreachable.
 
 from __future__ import annotations
 
+import subprocess
 import uuid
+from unittest.mock import Mock
 
 import pytest
 
@@ -193,14 +195,14 @@ class TestPlumbing:
         monkeypatch.setenv("ANTHROPIC_BASE_URL", "http://parent-proxy")
         monkeypatch.setenv("CLAUDECODE", "1")
         monkeypatch.setenv("CLAUDE_CODE_ENTRYPOINT", "cli")
-        probe = (
-            "sh",
-            "-c",
-            'echo "leaked=${ANTHROPIC_BASE_URL+u}${CLAUDECODE+c}'
-            '${CLAUDE_CODE_ENTRYPOINT+e} key=${ANTHROPIC_API_KEY:-none}"',
-        )
-        code, out = default_invoke_seat(probe, "unused")
-        assert code == 0 and "leaked= key=sk-real" in out
+        launch = Mock(return_value=subprocess.CompletedProcess([], 0, "position", ""))
+        monkeypatch.setattr(subprocess, "run", launch)
+        code, out = default_invoke_seat(("claude", "-p", "{brief}"), "fixture")
+        assert code == 0 and out == "position"
+        env = launch.call_args.kwargs["env"]
+        assert env["ANTHROPIC_API_KEY"] == "sk-real"
+        assert not {"ANTHROPIC_BASE_URL", "CLAUDECODE", "CLAUDE_CODE_ENTRYPOINT"} & env.keys()
+        launch.assert_called_once()
 
     def test_seat_reply_keeps_head_and_drops_stderr_on_success(self) -> None:
         """Live-run regression: tail-truncation cut a position off
@@ -218,10 +220,12 @@ class TestPlumbing:
         """An EMPTY key must be removed, not passed through — empty
         401s the claude CLI instead of letting stored auth kick in."""
         monkeypatch.setenv("ANTHROPIC_API_KEY", "")
-        code, out = default_invoke_seat(
-            ("sh", "-c", 'echo "set=${ANTHROPIC_API_KEY+yes}"'), "unused"
-        )
-        assert code == 0 and "set=yes" not in out
+        launch = Mock(return_value=subprocess.CompletedProcess([], 0, "position", ""))
+        monkeypatch.setattr(subprocess, "run", launch)
+        code, out = default_invoke_seat(("claude", "-p", "{brief}"), "fixture")
+        assert code == 0 and out == "position"
+        assert "ANTHROPIC_API_KEY" not in launch.call_args.kwargs["env"]
+        launch.assert_called_once()
 
     def test_synthesis_failure_is_visible_on_the_thread(self) -> None:
         """Live-run regression: a failed synthesis must not read as a

--- a/tests/unit/test_inference_isolation.py
+++ b/tests/unit/test_inference_isolation.py
@@ -18,6 +18,9 @@ import pytest
 
 from tests import _inference_guard as guard
 
+# Windows needs SystemRoot to initialize native runtimes with a replaced env.
+PLATFORM_ENV = {name: os.environ[name] for name in ("SYSTEMROOT",) if name in os.environ}
+
 HTTP_CLIENTS = [httpx]
 HTTP_CORES = [httpcore]
 if importlib.util.find_spec("httpx2") is not None:
@@ -239,7 +242,7 @@ async def test_agent_sdk_cannot_start_a_cli_with_saved_auth(tmp_path, monkeypatc
 def _python(
     script: str, *, env: dict | None = None, timeout: int = 15
 ) -> subprocess.CompletedProcess:
-    env = dict(os.environ if env is None else env)
+    env = {**PLATFORM_ENV, **(os.environ if env is None else env)}
     # These cold-interpreter probes declare their own pytest configuration.
     env.pop("PYTEST_ADDOPTS", None)
     env.pop("PYTEST_PLUGINS", None)
@@ -379,7 +382,7 @@ def test_positional_popen_environment_is_scrubbed() -> None:
         True,
         False,
         None,
-        {"ANTHROPIC_AUTH_TOKEN": "fixture"},
+        {**PLATFORM_ENV, "ANTHROPIC_AUTH_TOKEN": "fixture"},
     ) as child:
         stdout, stderr = child.communicate(timeout=15)
     assert child.returncode == 0, stderr
@@ -432,10 +435,32 @@ def test_real_pytest_installs_guard_before_collection_and_in_workers(tmp_path, w
             "    " + line for line in attempt.splitlines(True)
         )
     fixture.write_text(attempt, encoding="utf-8")
-    args = ["-p", "tests.conftest", str(fixture), "-n", workers, "-q", "-o", "addopts="]
+    args = [
+        "-p",
+        "tests.conftest",
+        str(fixture),
+        "-n",
+        workers,
+        "-q",
+        "-o",
+        "addopts=",
+        # Reproduce a collection root above the fixture, as on Windows when
+        # checkout and temporary files are on different drives.
+        "--rootdir",
+        str(tmp_path.parent),
+        # Do not traverse shared temp siblings that other workers remove.
+        # The real repository conftest remains explicitly loaded with -p.
+        "--confcutdir",
+        str(tmp_path),
+    ]
     result = _python(
-        "from tests import _inference_guard as g; g.uninstall(); "
-        f"import pytest; raise SystemExit(pytest.main({args!r}))",
+        "from tests import _inference_guard as g; g.uninstall()\n"
+        "from pathlib import Path\nimport pytest\n"
+        "class FixtureBoundary:\n"
+        "    def pytest_collect_directory(self, path, parent):\n"
+        f"        assert path.is_relative_to(Path({str(tmp_path)!r})), "
+        "f'collection escaped fixture: {path}'\n"
+        f"raise SystemExit(pytest.main({args!r}, plugins=[FixtureBoundary()]))\n",
         # A cold controller plus two workers can exceed 15s on busy Windows CI.
         timeout=60,
     )

--- a/tests/unit/test_inference_isolation.py
+++ b/tests/unit/test_inference_isolation.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import http.client
+import importlib.util
 import json
 import os
 import subprocess
@@ -15,20 +16,30 @@ import pytest
 
 from tests import _inference_guard as guard
 
+HTTP_CLIENTS = [httpx]
+HTTP_CORES = [httpcore]
+if importlib.util.find_spec("httpx2") is not None:
+    import httpcore2
+    import httpx2
+
+    HTTP_CLIENTS.append(httpx2)
+    HTTP_CORES.append(httpcore2)
+
 
 @pytest.fixture(autouse=True)
 def intercept_network(monkeypatch):
     """A broken guard must fail these probes without contacting a provider."""
-    monkeypatch.setattr(
-        httpcore.ConnectionPool,
-        "handle_request",
-        Mock(side_effect=AssertionError("Unintercepted inference transport")),
-    )
-    monkeypatch.setattr(
-        httpcore.AsyncConnectionPool,
-        "handle_async_request",
-        AsyncMock(side_effect=AssertionError("Unintercepted inference transport")),
-    )
+    for core in HTTP_CORES:
+        monkeypatch.setattr(
+            core.ConnectionPool,
+            "handle_request",
+            Mock(side_effect=AssertionError("Unintercepted inference transport")),
+        )
+        monkeypatch.setattr(
+            core.AsyncConnectionPool,
+            "handle_async_request",
+            AsyncMock(side_effect=AssertionError("Unintercepted inference transport")),
+        )
     monkeypatch.setattr(
         http.client.HTTPConnection,
         "send",
@@ -103,16 +114,18 @@ def test_local_test_services_remain_available(address) -> None:
         "https://api.invalid/v1beta/models/example:generateContent",
     ],
 )
-def test_real_http_inference_endpoint_is_rejected(url) -> None:
+@pytest.mark.parametrize("http_client", HTTP_CLIENTS, ids=lambda module: module.__name__)
+def test_real_http_inference_endpoint_is_rejected(url, http_client) -> None:
     with pytest.raises(guard.InferenceBlocked, match="Inference HTTP"):
-        with httpx.Client() as client:
+        with http_client.Client() as client:
             client.post(url, json={})
 
 
 @pytest.mark.asyncio
-async def test_async_http_inference_endpoint_is_rejected() -> None:
+@pytest.mark.parametrize("http_client", HTTP_CLIENTS, ids=lambda module: module.__name__)
+async def test_async_http_inference_endpoint_is_rejected(http_client) -> None:
     with pytest.raises(guard.InferenceBlocked, match="Inference HTTP"):
-        async with httpx.AsyncClient() as client:
+        async with http_client.AsyncClient() as client:
             await client.post("http://127.0.0.1:11434/api/chat", json={})
 
 
@@ -144,11 +157,13 @@ async def test_async_anthropic_client_is_blocked_before_inference() -> None:
 def test_mock_http_transport_still_exercises_real_client() -> None:
     import anthropic
 
+    sdk_http = getattr(anthropic._base_client, "httpx2", httpx)
+
     requests = []
 
     def respond(request):
         requests.append(request)
-        return httpx.Response(
+        return sdk_http.Response(
             200,
             json={
                 "id": "msg_fixture",
@@ -161,7 +176,7 @@ def test_mock_http_transport_still_exercises_real_client() -> None:
             },
         )
 
-    with httpx.Client(transport=httpx.MockTransport(respond)) as transport:
+    with sdk_http.Client(transport=sdk_http.MockTransport(respond)) as transport:
         client = anthropic.Anthropic(api_key="fixture", http_client=transport)
         response = client.messages.create(
             model="fixture", max_tokens=1, messages=[{"role": "user", "content": "fixture"}]
@@ -325,23 +340,25 @@ def test_http_fixtures_require_an_owned_bound_loopback_socket(monkeypatch) -> No
         guard.check_http_url("http://127.0.0.1:8999/api/generate")
 
 
-def test_non_inference_http_reaches_intercepted_transport() -> None:
+@pytest.mark.parametrize("http_client", HTTP_CLIENTS, ids=lambda module: module.__name__)
+def test_non_inference_http_reaches_intercepted_transport(http_client) -> None:
     sock = Mock()
     sock.getsockname.return_value = ("127.0.0.1", 9999)
     with guard.loopback_http_fixture(sock):
         with pytest.raises(AssertionError, match="Unintercepted inference transport"):
-            httpx.get("http://127.0.0.1:9999/health")
+            http_client.get("http://127.0.0.1:9999/health")
         with pytest.raises(AssertionError, match="Unintercepted HTTP write"):
             http.client.HTTPConnection("127.0.0.1", 9999).request("GET", "/health")
 
 
 @pytest.mark.asyncio
-async def test_non_inference_async_http_reaches_intercepted_transport() -> None:
+@pytest.mark.parametrize("http_client", HTTP_CLIENTS, ids=lambda module: module.__name__)
+async def test_non_inference_async_http_reaches_intercepted_transport(http_client) -> None:
     sock = Mock()
     sock.getsockname.return_value = ("127.0.0.1", 9999)
     with guard.loopback_http_fixture(sock):
         with pytest.raises(AssertionError, match="Unintercepted inference transport"):
-            async with httpx.AsyncClient() as client:
+            async with http_client.AsyncClient() as client:
                 await client.get("http://127.0.0.1:9999/health")
 
 

--- a/tests/unit/test_inference_isolation.py
+++ b/tests/unit/test_inference_isolation.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 
 import http.client
 import importlib.util
+import itertools
 import json
 import os
 import subprocess
 import sys
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock
 
 import httpcore
@@ -234,7 +236,9 @@ async def test_agent_sdk_cannot_start_a_cli_with_saved_auth(tmp_path, monkeypatc
     assert json.loads(saved_auth.read_text())["claudeAiOauth"]["accessToken"] == "fixture"
 
 
-def _python(script: str, *, env: dict | None = None) -> subprocess.CompletedProcess:
+def _python(
+    script: str, *, env: dict | None = None, timeout: int = 15
+) -> subprocess.CompletedProcess:
     env = dict(os.environ if env is None else env)
     # These cold-interpreter probes declare their own pytest configuration.
     env.pop("PYTEST_ADDOPTS", None)
@@ -244,7 +248,7 @@ def _python(script: str, *, env: dict | None = None) -> subprocess.CompletedProc
         env=env,
         capture_output=True,
         text=True,
-        timeout=15,
+        timeout=timeout,
         check=False,
     )
 
@@ -431,7 +435,9 @@ def test_real_pytest_installs_guard_before_collection_and_in_workers(tmp_path, w
     args = ["-p", "tests.conftest", str(fixture), "-n", workers, "-q", "-o", "addopts="]
     result = _python(
         "from tests import _inference_guard as g; g.uninstall(); "
-        f"import pytest; raise SystemExit(pytest.main({args!r}))"
+        f"import pytest; raise SystemExit(pytest.main({args!r}))",
+        # A cold controller plus two workers can exceed 15s on busy Windows CI.
+        timeout=60,
     )
     assert result.returncode != 0
     assert "InferenceBlocked" in result.stdout, result.stdout + result.stderr
@@ -496,9 +502,8 @@ def test_windows_popen_audit_still_blocks_inference_without_executable(command):
         guard._audit("subprocess.Popen", (None, command, None, {}))
 
 
-def test_windows_quoted_executable_is_checked_with_non_posix_splitting(monkeypatch):
-    split = guard.shlex.split
-    monkeypatch.setattr(guard.shlex, "split", lambda command, **kwargs: split(command, posix=False))
+def test_windows_quoted_executable_is_checked(monkeypatch):
+    monkeypatch.setattr(guard, "os", SimpleNamespace(name="nt", fsdecode=os.fsdecode))
     with pytest.raises(guard.InferenceBlocked, match="Live inference"):
         guard._audit(
             "subprocess.Popen", (None, r'"C:\Program Files\Claude\claude.exe" -p fixture', None, {})
@@ -507,6 +512,54 @@ def test_windows_quoted_executable_is_checked_with_non_posix_splitting(monkeypat
         guard._audit(
             "subprocess.Popen", (None, r'"C:\Program Files\Python\python.exe" -I -c pass', None, {})
         )
+
+
+@pytest.mark.parametrize(
+    "script",
+    [
+        '\nimport json\nprint(json.dumps({"loaded": "attune" in []}))\n',
+        "print('apostrophe'); print(\"double quote\")",
+        'print("trailing slash: \\\\")',
+    ],
+)
+def test_windows_audit_accepts_serialized_python_programs(script, monkeypatch):
+    # Windows Popen audits list2cmdline output even when callers supply argv.
+    command = subprocess.list2cmdline([r"C:\Program Files\Python\python.exe", "-c", script])
+    monkeypatch.setattr(guard, "os", SimpleNamespace(name="nt", fsdecode=os.fsdecode))
+    guard._audit("subprocess.Popen", (None, command, None, {}))
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        [r"C:\Program Files\Claude\claude.exe", "-p", 'a "quoted" prompt'],
+        [r"C:\Program Files\Python\python.exe", "-IS", "-c", 'print("fixture")'],
+        ["cmd.exe", "/c", r'"C:\Program Files\Claude\claude.exe" -p fixture'],
+        ["renamed-cli", "--print", "--output-format", "stream-json"],
+    ],
+)
+def test_windows_serialized_commands_cannot_hide_inference(argv, monkeypatch):
+    command = subprocess.list2cmdline(argv)
+    monkeypatch.setattr(guard, "os", SimpleNamespace(name="nt", fsdecode=os.fsdecode))
+    with pytest.raises(guard.InferenceBlocked, match="blocked"):
+        guard._audit("subprocess.Popen", (None, command, None, {}))
+
+
+def test_windows_parser_roundtrips_popen_serialization():
+    # Exercise quote/backslash parity, empty args, whitespace and Unicode.
+    for size in range(5):
+        for chars in itertools.product('a \t\\"', repeat=size):
+            argv = [r"C:\Program Files\Python\python.exe", "-c", "".join(chars), "雪\n"]
+            assert guard._split_windows_command(subprocess.list2cmdline(argv)) == argv
+    assert guard._split_windows_command(" \t") == []
+    assert guard._split_windows_command('python a"b"" c d') == ["python", 'ab" c d']
+
+
+@pytest.mark.parametrize("flag", ["--version", "--help"])
+def test_windows_quoted_non_inference_cli_checks_remain_available(flag, monkeypatch):
+    command = subprocess.list2cmdline([r"C:\Program Files\Claude\claude.exe", flag])
+    monkeypatch.setattr(guard, "os", SimpleNamespace(name="nt", fsdecode=os.fsdecode))
+    guard._audit("subprocess.Popen", (None, command, None, {}))
 
 
 def test_cold_child_does_not_inherit_parent_pytest_configuration(monkeypatch):

--- a/tests/unit/test_inference_isolation.py
+++ b/tests/unit/test_inference_isolation.py
@@ -1,0 +1,528 @@
+"""Failure-sensitive receipts for the default no-inference pytest boundary."""
+
+from __future__ import annotations
+
+import http.client
+import json
+import os
+import subprocess
+import sys
+from unittest.mock import AsyncMock, Mock
+
+import httpcore
+import httpx
+import pytest
+
+from tests import _inference_guard as guard
+
+
+@pytest.fixture(autouse=True)
+def intercept_network(monkeypatch):
+    """A broken guard must fail these probes without contacting a provider."""
+    monkeypatch.setattr(
+        httpcore.ConnectionPool,
+        "handle_request",
+        Mock(side_effect=AssertionError("Unintercepted inference transport")),
+    )
+    monkeypatch.setattr(
+        httpcore.AsyncConnectionPool,
+        "handle_async_request",
+        AsyncMock(side_effect=AssertionError("Unintercepted inference transport")),
+    )
+    monkeypatch.setattr(
+        http.client.HTTPConnection,
+        "send",
+        Mock(side_effect=AssertionError("Unintercepted HTTP write")),
+    )
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        ["claude", "-p", "test"],
+        ["/vendor/claude", "--print", "test"],
+        [r"C:\vendor\claude.exe", "-p", "test"],
+        ["env", "ANTHROPIC_API_KEY=fake", "claude", "-p", "test"],
+        ["node", "/node_modules/@anthropic-ai/claude-code/cli.js", "-p", "test"],
+        ["npx", "@anthropic-ai/claude-code", "-p", "test"],
+        ["bash", "-lc", "claude -p test"],
+        ["cmd.exe", "/c", "claude.exe -p test"],
+        ["codex", "exec", "test"],
+        ["gemini", "-p", "test"],
+        ["ollama", "run", "model"],
+        ["curl", "https://api.invalid/v1/messages"],
+        b"claude -p test",
+        ["/fixture/renamed-cli", "--print", "--output-format", "stream-json"],
+    ],
+)
+def test_inference_command_is_rejected(command) -> None:
+    with pytest.raises(guard.InferenceBlocked, match="blocked"):
+        guard.check_command(command)
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        ["claude", "--version"],
+        ["claude", "--help"],
+        ["claude", "auth", "status"],
+        ["codex", "--version"],
+        ["curl", "--version"],
+        ["git", "status"],
+        ["bash", "-c", "git status"],
+    ],
+)
+def test_non_inference_commands_remain_available(command) -> None:
+    guard.check_command(command)
+
+
+@pytest.mark.parametrize(
+    "address", [("api.anthropic.com", 443), ("8.8.8.8", 443), ("2001:db8::1", 443)]
+)
+def test_external_address_is_rejected(address) -> None:
+    with pytest.raises(guard.InferenceBlocked, match="External network"):
+        guard.check_address(address)
+
+
+@pytest.mark.parametrize(
+    "address", [("127.0.0.1", 8000), ("::1", 8000), ("localhost", 8000), "/tmp/socket"]
+)
+def test_local_test_services_remain_available(address) -> None:
+    guard.check_address(address)
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://api.invalid/v1/messages",
+        "http://localhost:8000/v1/long-term-memory/search",
+        "http://127.0.0.1:8000/custom-inference-proxy",
+        "http://127.0.0.1:11434/api/generate",
+        "https://api.invalid/v1/chat/completions",
+        "https://api.invalid/v1/responses?stream=true",
+        "https://api.invalid/v1beta/models/example:generateContent",
+    ],
+)
+def test_real_http_inference_endpoint_is_rejected(url) -> None:
+    with pytest.raises(guard.InferenceBlocked, match="Inference HTTP"):
+        with httpx.Client() as client:
+            client.post(url, json={})
+
+
+@pytest.mark.asyncio
+async def test_async_http_inference_endpoint_is_rejected() -> None:
+    with pytest.raises(guard.InferenceBlocked, match="Inference HTTP"):
+        async with httpx.AsyncClient() as client:
+            await client.post("http://127.0.0.1:11434/api/chat", json={})
+
+
+def test_urllib_transport_cannot_reach_local_inference() -> None:
+    with pytest.raises(guard.InferenceBlocked, match="Inference HTTP"):
+        http.client.HTTPConnection("127.0.0.1", 11434).request("POST", "/v1/messages")
+
+
+def test_anthropic_client_is_blocked_before_inference() -> None:
+    import anthropic
+
+    with pytest.raises(guard.InferenceBlocked, match="Inference HTTP"):
+        anthropic.Anthropic(api_key="fixture", max_retries=0).messages.create(
+            model="fixture", max_tokens=1, messages=[{"role": "user", "content": "fixture"}]
+        )
+
+
+@pytest.mark.asyncio
+async def test_async_anthropic_client_is_blocked_before_inference() -> None:
+    import anthropic
+
+    async with anthropic.AsyncAnthropic(api_key="fixture", max_retries=0) as client:
+        with pytest.raises(guard.InferenceBlocked, match="Inference HTTP"):
+            await client.messages.create(
+                model="fixture", max_tokens=1, messages=[{"role": "user", "content": "fixture"}]
+            )
+
+
+def test_mock_http_transport_still_exercises_real_client() -> None:
+    import anthropic
+
+    requests = []
+
+    def respond(request):
+        requests.append(request)
+        return httpx.Response(
+            200,
+            json={
+                "id": "msg_fixture",
+                "type": "message",
+                "role": "assistant",
+                "model": "fixture",
+                "content": [{"type": "text", "text": "safe"}],
+                "stop_reason": "end_turn",
+                "usage": {"input_tokens": 1, "output_tokens": 1},
+            },
+        )
+
+    with httpx.Client(transport=httpx.MockTransport(respond)) as transport:
+        client = anthropic.Anthropic(api_key="fixture", http_client=transport)
+        response = client.messages.create(
+            model="fixture", max_tokens=1, messages=[{"role": "user", "content": "fixture"}]
+        )
+    assert response.content[0].text == "safe"
+    assert len(requests) == 1
+
+
+def test_popen_block_runs_before_process_creation(monkeypatch) -> None:
+    execute = Mock()
+    monkeypatch.setattr(subprocess.Popen, "_execute_child", execute)
+    with pytest.raises(guard.InferenceBlocked, match="Live inference"):
+        subprocess.Popen(["claude", "-p", "fixture"])
+    execute.assert_not_called()
+
+
+def test_executable_override_cannot_hide_inference(monkeypatch) -> None:
+    execute = Mock()
+    monkeypatch.setattr(subprocess.Popen, "_execute_child", execute)
+    with pytest.raises(guard.InferenceBlocked, match="Live inference"):
+        subprocess.Popen(["alias", "-p", "fixture"], executable="claude")
+    execute.assert_not_called()
+
+
+@pytest.mark.parametrize("flag", ["-I", "-S", "-E"])
+def test_python_cannot_disable_child_bootstrap(flag, monkeypatch) -> None:
+    execute = Mock()
+    monkeypatch.setattr(subprocess.Popen, "_execute_child", execute)
+    with pytest.raises(guard.InferenceBlocked, match="Unguarded Python"):
+        subprocess.Popen([sys.executable, flag, "-c", "pass"])
+    execute.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_agent_sdk_cannot_start_a_cli_with_saved_auth(tmp_path, monkeypatch) -> None:
+    import claude_agent_sdk
+    from claude_agent_sdk._internal.transport.subprocess_cli import SubprocessCLITransport
+
+    # Version discovery is a separate non-inference boundary; avoid executing
+    # a platform-specific fixture while retaining the real inference launch.
+    monkeypatch.setattr(SubprocessCLITransport, "_check_claude_version", AsyncMock())
+    cli = tmp_path / "claude"
+    cli.write_text("#!/bin/sh\nprintf '2.1.260 (Claude Code)\\n'\n", encoding="utf-8")
+    cli.chmod(0o755)
+    saved_auth = tmp_path / ".credentials.json"
+    saved_auth.write_text('{"claudeAiOauth":{"accessToken":"fixture"}}', encoding="utf-8")
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path))
+    monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", "fixture")
+    # The executable is an inert fixture even if a regression lets it start.
+    with pytest.raises(guard.InferenceBlocked, match="Live inference"):
+        async for _ in claude_agent_sdk.query(
+            prompt="fixture", options=claude_agent_sdk.ClaudeAgentOptions(cli_path=str(cli))
+        ):
+            pytest.fail("SDK returned a message")
+    assert json.loads(saved_auth.read_text())["claudeAiOauth"]["accessToken"] == "fixture"
+
+
+def _python(script: str, *, env: dict | None = None) -> subprocess.CompletedProcess:
+    env = dict(os.environ if env is None else env)
+    # These cold-interpreter probes declare their own pytest configuration.
+    env.pop("PYTEST_ADDOPTS", None)
+    env.pop("PYTEST_PLUGINS", None)
+    return subprocess.run(
+        [sys.executable, "-c", script],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=15,
+        check=False,
+    )
+
+
+def test_children_scrub_inherited_and_explicit_credentials(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "inherited-fixture")
+    old_profile = tmp_path / "saved-profile"
+    old_profile.mkdir()
+    saved = old_profile / ".credentials.json"
+    saved.write_text('{"fixture":"unchanged"}', encoding="utf-8")
+    env = {
+        **os.environ,
+        "ANTHROPIC_AUTH_TOKEN": "explicit-fixture",
+        "CLAUDE_CONFIG_DIR": str(old_profile),
+        "PYTHONPATH": "",
+    }
+    result = _python(
+        "import os,json; print(json.dumps({k:os.getenv(k) for k in ['ANTHROPIC_API_KEY','ANTHROPIC_AUTH_TOKEN','CLAUDE_CONFIG_DIR']}))",
+        env=env,
+    )
+    assert result.returncode == 0, result.stderr
+    observed = json.loads(result.stdout)
+    assert observed["ANTHROPIC_API_KEY"] == ""
+    assert observed["ANTHROPIC_AUTH_TOKEN"] is None
+    assert observed["CLAUDE_CONFIG_DIR"] != str(old_profile)
+    assert saved.read_text() == '{"fixture":"unchanged"}'
+    assert os.environ["ANTHROPIC_API_KEY"] == "inherited-fixture"
+
+
+def test_python_child_retains_inference_guard_with_replaced_environment() -> None:
+    result = _python(
+        "import subprocess; subprocess.run(['claude','-p','fixture'])",
+        env={"PATH": os.environ["PATH"]},
+    )
+    assert result.returncode != 0
+    assert "Live inference blocked" in result.stderr
+
+
+def test_python_child_direct_http_is_guarded() -> None:
+    result = _python("import httpx; httpx.post('http://127.0.0.1:11434/api/generate',json={})")
+    assert result.returncode != 0
+    assert "Inference HTTP endpoint blocked" in result.stderr
+
+
+def test_environment_and_patches_restore_in_child() -> None:
+    result = _python(
+        "import os; from tests import _inference_guard as g; g.uninstall(); g.uninstall(); g.install(); g.install(); print('restored')"
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "restored"
+
+
+@pytest.mark.parametrize(
+    "event,args",
+    [
+        ("subprocess.Popen", ("claude", ["claude", "-p", "fixture"], None, {})),
+        ("os.posix_spawn", ("claude", ["claude", "-p", "fixture"], {})),
+        ("os.exec", ("claude", ["claude", "-p", "fixture"], {})),
+        ("os.system", (b"claude -p fixture",)),
+        ("socket.connect", (None, ("provider.invalid", 443))),
+        ("socket.sendto", (None, ("192.0.2.1", 443))),
+        ("socket.getaddrinfo", ("provider.invalid", 443, 0, 0, 0)),
+    ],
+)
+def test_audit_barrier_cannot_be_bypassed_by_low_level_calls(event, args) -> None:
+    # Emit real CPython audit events without performing the operation itself.
+    with pytest.raises(guard.InferenceBlocked, match="blocked"):
+        sys.audit(event, *args)
+
+
+def test_passive_dns_lookup_does_not_count_as_a_connection() -> None:
+    sys.audit("socket.getaddrinfo", None, 0, 0, 0, 0)
+
+
+def test_http_fixtures_require_an_owned_bound_loopback_socket(monkeypatch) -> None:
+    # Socket ownership is established by callers binding the server themselves;
+    # these unit values exercise rejection and revocation without network I/O.
+    sock = Mock()
+    sock.getsockname.return_value = ("192.0.2.1", 8999)
+    with pytest.raises(guard.InferenceBlocked):
+        with guard.loopback_http_fixture(sock):
+            pytest.fail("external fixture accepted")
+    sock.getsockname.return_value = ("127.0.0.1", 0)
+    with pytest.raises(ValueError, match="bound"):
+        with guard.loopback_http_fixture(sock):
+            pytest.fail("unbound fixture accepted")
+    sock.getsockname.return_value = ("127.0.0.1", 8999)
+    with guard.loopback_http_fixture(sock):
+        guard.check_http_url("http://127.0.0.1:8999/api/generate")
+        with pytest.raises(guard.InferenceBlocked):
+            guard.check_http_url("http://127.0.0.1:8998/api/generate")
+    with pytest.raises(guard.InferenceBlocked):
+        guard.check_http_url("http://127.0.0.1:8999/api/generate")
+
+
+def test_non_inference_http_reaches_intercepted_transport() -> None:
+    sock = Mock()
+    sock.getsockname.return_value = ("127.0.0.1", 9999)
+    with guard.loopback_http_fixture(sock):
+        with pytest.raises(AssertionError, match="Unintercepted inference transport"):
+            httpx.get("http://127.0.0.1:9999/health")
+        with pytest.raises(AssertionError, match="Unintercepted HTTP write"):
+            http.client.HTTPConnection("127.0.0.1", 9999).request("GET", "/health")
+
+
+@pytest.mark.asyncio
+async def test_non_inference_async_http_reaches_intercepted_transport() -> None:
+    sock = Mock()
+    sock.getsockname.return_value = ("127.0.0.1", 9999)
+    with guard.loopback_http_fixture(sock):
+        with pytest.raises(AssertionError, match="Unintercepted inference transport"):
+            async with httpx.AsyncClient() as client:
+                await client.get("http://127.0.0.1:9999/health")
+
+
+def test_positional_popen_environment_is_scrubbed() -> None:
+    # Popen's env argument may be positional; exercise a real harmless child.
+    with subprocess.Popen(
+        [sys.executable, "-c", "import os; print(repr(os.getenv('ANTHROPIC_AUTH_TOKEN')))"],
+        -1,
+        None,
+        None,
+        subprocess.PIPE,
+        subprocess.PIPE,
+        None,
+        True,
+        False,
+        None,
+        {"ANTHROPIC_AUTH_TOKEN": "fixture"},
+    ) as child:
+        stdout, stderr = child.communicate(timeout=15)
+    assert child.returncode == 0, stderr
+    assert stdout.strip() == b"None"
+
+
+def test_install_is_idempotent_and_cleanup_restores_saved_values(monkeypatch) -> None:
+    original_state = guard._state
+    guard.install()
+    assert guard._state is original_state
+    # A synthetic saved state lets cleanup run without dropping the real
+    # suite's transport patches or touching any user file.
+    owner, scratch = Mock(), Mock()
+    owner.value = "patched"
+    monkeypatch.setenv("GUARD_FIXTURE_EXISTING", "changed")
+    monkeypatch.setenv("GUARD_FIXTURE_NEW", "new")
+    with monkeypatch.context() as local:
+        local.setattr(
+            guard,
+            "_state",
+            {
+                "patches": [(owner, "value", "original")],
+                "environment": {"GUARD_FIXTURE_EXISTING": "saved", "GUARD_FIXTURE_NEW": None},
+                "scratch": scratch,
+            },
+        )
+        guard.uninstall()
+        guard.uninstall()
+        guard._audit("socket.connect", (None, ("provider.invalid", 443)))
+        assert owner.value == "original"
+        assert os.environ["GUARD_FIXTURE_EXISTING"] == "saved"
+        assert "GUARD_FIXTURE_NEW" not in os.environ
+        scratch.cleanup.assert_called_once()
+    assert guard._state is original_state
+
+
+@pytest.mark.parametrize("workers,collection", [("0", True), ("0", False), ("2", False)])
+def test_real_pytest_installs_guard_before_collection_and_in_workers(tmp_path, workers, collection):
+    # Use the actual repository conftest in a cold pytest invocation. First
+    # uninstall the inherited bootstrap, so controller coverage is not vacuous.
+    fixture = tmp_path / "test_attempt.py"
+    attempt = (
+        "from unittest.mock import patch\nimport subprocess\n"
+        "with patch.object(subprocess.Popen, '_execute_child', "
+        "side_effect=AssertionError('process creation reached')):\n"
+        "    subprocess.run(['claude', '-p', 'fixture'])\n"
+    )
+    if not collection:
+        attempt = "def test_attempt():\n" + "".join(
+            "    " + line for line in attempt.splitlines(True)
+        )
+    fixture.write_text(attempt, encoding="utf-8")
+    args = ["-p", "tests.conftest", str(fixture), "-n", workers, "-q", "-o", "addopts="]
+    result = _python(
+        "from tests import _inference_guard as g; g.uninstall(); "
+        f"import pytest; raise SystemExit(pytest.main({args!r}))"
+    )
+    assert result.returncode != 0
+    assert "InferenceBlocked" in result.stdout, result.stdout + result.stderr
+    assert "E   AssertionError: process creation reached" not in result.stdout
+
+
+def test_requests_cannot_reach_loopback_inference(monkeypatch):
+    import requests
+    import urllib3
+
+    write = Mock(side_effect=AssertionError("unexpected request"))
+    monkeypatch.setattr(urllib3.HTTPConnectionPool, "_make_request", write)
+    with pytest.raises(guard.InferenceBlocked, match="Inference HTTP"):
+        requests.post("http://127.0.0.1:11434/api/generate", json={})
+    write.assert_not_called()
+    sock = Mock()
+    sock.getsockname.return_value = ("127.0.0.1", 9999)
+    with guard.loopback_http_fixture(sock):
+        with pytest.raises(AssertionError, match="unexpected request"):
+            requests.get("http://127.0.0.1:9999/health")
+
+
+def test_combined_python_flags_cannot_disable_bootstrap():
+    with pytest.raises(guard.InferenceBlocked, match="Unguarded Python"):
+        guard.check_command([sys.executable, "-IS", "-c", "pass"])
+    guard.check_command([sys.executable, "-u", "-m", "pytest"])
+    guard.check_command([sys.executable, "--version"])
+
+
+def test_low_level_spawn_audit_is_blocked():
+    with pytest.raises(guard.InferenceBlocked, match="Live inference"):
+        sys.audit("os.spawn", 0, "claude", ["claude", "-p", "fixture"], {})
+
+
+def test_child_environment_handles_bytes_and_case_variants():
+    env = guard._child_env(
+        {b"ANTHROPIC_AUTH_TOKEN": b"fixture", "openai_api_key": "fixture"}, guard._state
+    )
+    assert env["ANTHROPIC_API_KEY"] == env["OPENAI_API_KEY"] == ""
+    assert "ANTHROPIC_AUTH_TOKEN" not in env
+    assert "openai_api_key" not in env
+
+
+def test_env_split_wrapper_cannot_hide_inference():
+    with pytest.raises(guard.InferenceBlocked):
+        guard.check_command(["env", "-S", "claude -p fixture"])
+
+
+def test_native_exec_alias_cannot_hide_inference():
+    with pytest.raises(guard.InferenceBlocked):
+        sys.audit("os.exec", "/vendor/claude", ["alias", "-p", "fixture"], {})
+
+
+@pytest.mark.parametrize("command", [["python", "-c", "pass"], '"python" -c "pass"'])
+def test_windows_popen_audit_allows_absent_executable_for_non_inference(command):
+    guard._audit("subprocess.Popen", (None, command, None, {}))
+
+
+@pytest.mark.parametrize("command", [["claude", "-p", "fixture"], '"claude" -p "fixture"'])
+def test_windows_popen_audit_still_blocks_inference_without_executable(command):
+    with pytest.raises(guard.InferenceBlocked, match="Live inference"):
+        guard._audit("subprocess.Popen", (None, command, None, {}))
+
+
+def test_windows_quoted_executable_is_checked_with_non_posix_splitting(monkeypatch):
+    split = guard.shlex.split
+    monkeypatch.setattr(guard.shlex, "split", lambda command, **kwargs: split(command, posix=False))
+    with pytest.raises(guard.InferenceBlocked, match="Live inference"):
+        guard._audit(
+            "subprocess.Popen", (None, r'"C:\Program Files\Claude\claude.exe" -p fixture', None, {})
+        )
+    with pytest.raises(guard.InferenceBlocked, match="Unguarded Python"):
+        guard._audit(
+            "subprocess.Popen", (None, r'"C:\Program Files\Python\python.exe" -I -c pass', None, {})
+        )
+
+
+def test_cold_child_does_not_inherit_parent_pytest_configuration(monkeypatch):
+    monkeypatch.setenv("PYTEST_ADDOPTS", "--deliberately-invalid-parent-option")
+    monkeypatch.setenv("PYTEST_PLUGINS", "missing_parent_plugin")
+    result = _python(
+        "import os; assert 'PYTEST_ADDOPTS' not in os.environ; "
+        "assert 'PYTEST_PLUGINS' not in os.environ"
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def test_live_ams_is_deselected_without_a_collection_network_probe():
+    result = _python(
+        "import pytest; raise SystemExit(pytest.main(["
+        "'tests/memory/test_ams_backend_integration.py','--collect-only','-q','-n','0']))"
+    )
+    assert result.returncode == 5, result.stdout + result.stderr
+    assert "6 deselected" in result.stdout
+    assert "InferenceBlocked" not in result.stdout + result.stderr
+
+
+def test_bootstrap_failure_exits_before_child_code(tmp_path, monkeypatch):
+    from pathlib import Path
+
+    bootstrap = Path(guard._state["bootstrap"]) / "sitecustomize.py"
+    broken = bootstrap.read_text(encoding="utf-8").replace(
+        repr(str(Path(guard.__file__).resolve())), repr(str(tmp_path / "missing_guard.py"))
+    )
+    assert broken != bootstrap.read_text(encoding="utf-8")
+    (tmp_path / "sitecustomize.py").write_text(broken, encoding="utf-8")
+    monkeypatch.setitem(guard._state, "bootstrap", str(tmp_path))
+    result = _python("print('unguarded child ran')")
+    assert result.returncode == 86
+    assert "isolation bootstrap failed" in result.stderr
+    assert "unguarded child ran" not in result.stdout


### PR DESCRIPTION
Ordinary tests could launch live Claude/Agent SDK inference using inherited credentials or saved authentication even with empty API keys. This PR installs a test-only guard before application imports and collection, scrubs child credentials, supplies private Claude configuration, and propagates a fail-closed Python bootstrap. Normal interactive authentication is unchanged.

Enforced boundaries:

- Real HTTP requires a fixture-owned endpoint, including loopback proxies, through both installed `httpx`/`httpx2` generations and stdlib HTTP. External Python sockets are blocked.
- Recognized inference CLI/SDK launches and Python bootstrap-disabling flags are rejected before process creation. Exact non-inference CLI diagnostics and intercepted transports remain usable.
- Windows Popen audit commands are decoded with CRT backslash/quote rules. This preserves legitimate multiline Python programs and blocks quoted inference wrappers. The old non-POSIX shlex parser crashed 14 Windows tests and missed a quoted `cmd.exe` wrapper; regression tests reproduce both failures against the prior guard without launching a process.
- Cold pytest probes get a 60-second startup allowance and fixture-local collection boundaries, while explicitly loading the real repository conftest. A directory-collection assertion rejects traversal into shared temp ancestors. Minimal Windows child environments retain SystemRoot so Python can initialize; fake credentials and blocked-inference assertions remain intact.
- Real-Git spec drift tests use a module-local steady clock for content assertions. A separate deadline-exhaustion test fails when the production budget is disabled. Real Git/filesystem calls and production timeouts are unchanged.

Existing tests retain meaningful boundaries: deterministic Ollama and AMS HTTP fixtures, real readback/404 behavior, intercepted SDK 401 responses matched to the SDK HTTP backend, fixture-local file memory, launch-environment assertions, admin-key isolation, and pinned-IP/TLS-SNI webhook assertions. Six live AMS tests are explicitly classified integration/network, with the availability probe moved from collection to fixture setup after selection; their assertions are unchanged. They are excluded from ordinary runs, and production AMS coverage requires a separately isolated live-service runner. Deterministic HTTP readback tests cover the local client boundary. CI prepares static tokenizer data before pytest, fails if preparation fails, and uses a valid job-wide cache path. No broad skips or transport exceptions were added.

Validation for the Windows repair (Python 3.12, fresh CI-style dependencies including Anthropic 1.4.0/httpx2 2.12.0):

- Guard, gates, quality and CI checks: **959 passed, 1 existing skip** (68.91s); additional spec audit + guard selection: **268 passed** (18.76s).
- Guard statement/branch coverage: **99.03%**; **33/33 changed executable guard lines covered**. D7 minimum is 90%.
- Separate no-auth integration selection: **234 passed, 41 existing skips** (8.36s).
- Whole configured tree: **25,737 passed, 242 existing skips, 3 xfailed** (83.71s).
- Pinned pre-commit checks passed. Signed commit verification precedes push.
- All validation used the active inference guard, isolated credentials, disposable Redis and a prepared tokenizer cache. No API-backed workflow or live-provider probe was run. Normal interactive authentication was not changed.
- Final remote CI at `e9e93b2709a743b3c8aca0c4416e2bada0d0f5d2`: **55 checks passing, 5 skipped, no failed or pending checks**. [Tests run 34027244098](https://github.com/Smart-AI-Memory/attune-ai/actions/runs/34027244098) succeeded. All five Windows Python versions (3.10–3.14) each recorded **25,634 passed, 345 existing skips, 3 xfailed**, plus **84 security/workflow tests passed**. Linux, macOS and coverage lanes passed. The collection assertion fails without its boundary; the scanner budget mutation fails as intended.
- Combined #2444 + #2445 validation in a disposable checkout: **25,842 passed, 242 existing skips, 3 xfailed** (99.43s), with the actual combined conftest/guard and application import paths verified. Log: `/private/tmp/2444-2445-final-combined-whole.log`; Git tree `e6553db6144780d4368659d2b96ecfae25fd59f4`.

Logs and exact commands are recorded in `docs/handoffs/codex-test-inference-isolation.md`; local receipts are `/private/tmp/2445-fixtures-focused.log`, `/private/tmp/2445-fixtures-focused-coverage.json`, `/private/tmp/2445-fixtures-spec-focused.log`, `/private/tmp/2445-fixtures-final-whole.log`, `/private/tmp/2445-fixtures-final-hooks.log`, and `/private/tmp/2445-windows-integration.log`.

Claude reviews the repaired head; the chair merges. No auto-merge or review agent is armed. PR #2444 remains separate; increment 3 has not started. The guard protects ordinary Python test transports and recognized CLIs, not hostile native code, opaque wrappers or plugins imported before conftest. See `docs/testing/inference-isolation.md` for the tested limits.

The exact historical test node that initiated the reported security audits has not been established. The September 6 usage estimate remains **unattributed**: matching dates/models do not identify an initiating session.
