### PR TITLE
feat(memory): Redis stays bundled + zero-config; first-run choice persisted and honored; memory status + doctor line (redis-config-truth D5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   "[redis] extra remains as an empty alias" comment is corrected: there
   is no `[redis]` extra; the client libraries are core and the bundled
   plugin degrades to the file tier.
+- **First-run memory-backend choice, persisted and honored**
+  (redis-config-truth D5, 2026-09-06). A SessionStart hook notice (once,
+  anti-nag, asks the assistant to collect the choice), a one-time notice on
+  the first interactive `attune` run, an interactive prompt in `attune
+  setup`, and `attune memory use <auto|file|redis>` record
+  `memory.backend` in `~/.attune/config.json` (`ATTUNE_MEMORY_BACKEND`
+  overrides per process; `ATTUNE_MEMORY_NOTICE=0` silences the notices).
+  The resolver honors it: `file` never probes the Redis upgrade and never
+  reports it dark; `redis` prefers the Agent Memory Server and degrades
+  loudly; `auto` is unchanged. Redis's role is stated in the chair's words
+  wherever it is offered: enhanced memory features using Redis's
+  open-source options.
 
 - **Surface-producer inventory (host-surface-parity Task 1B, increment 1
   of the task).** `attune.elicitation.surface_inventory` mechanically

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`attune memory status` and a doctor "Memory backend" line**
+  (redis-config-truth D5, 2026-09-06). Redis stays optional and
+  zero-config; the state stops being silent. `attune memory status`
+  names the resolved backend, transport and reachability and prints the
+  guidance for the three states a user can be in — zero-config file tier
+  (how to upgrade via `AMS_BASE_URL`), degraded with a dark upgrade, or
+  not usable with the reason — with `--json` for the raw mapping. `attune
+  doctor` reports the same line without ever failing on it. The stale
+  "[redis] extra remains as an empty alias" comment is corrected: there
+  is no `[redis]` extra; the client libraries are core and the bundled
+  plugin degrades to the file tier.
+
 - **Surface-producer inventory (host-surface-parity Task 1B, increment 1
   of the task).** `attune.elicitation.surface_inventory` mechanically
   discovers every in-tree producer of a host-presented surface — calls

--- a/README.md
+++ b/README.md
@@ -201,8 +201,12 @@ whole point: less API, and all of it real.
   prompt or tool call needs, budget-capped no matter how large the
   corpus grows.
 
-Memory is local-first — nothing leaves your machine, and without
-Redis everything degrades to the file backend with clear guidance.
+Memory is local-first — nothing leaves your machine. Redis is optional:
+its role here is to provide enhanced memory features using Redis's
+open-source options (semantic recall across sessions through the Agent
+Memory Server). A plain install runs on the local file tier; you choose
+once — a first-run notice asks, or `attune memory use auto|file|redis` —
+and `attune memory status` / `attune doctor` always say which tier is live.
 The economics are measured, not promised (2026-07-05 snapshot;
 ratios improve as the corpus grows):
 

--- a/docs/handoffs/claude-redis-state-visible.md
+++ b/docs/handoffs/claude-redis-state-visible.md
@@ -27,26 +27,30 @@ using Redis's open-source options").
 
 ## Current state
 
-- Branch `claude/redis-state-visible` (PR #2446). Landed earlier: `attune
-  memory status`, doctor line, pyproject comment, D5 v1, tests (66042b2e8).
-- This WIP commit: `src/attune/memory/preference.py` (new), resolver +
-  `backend_status` honoring the preference, `cmd_memory_use`,
-  `first_run_memory_notice` + `main()` call, `_memory_backend_setup_prompt`,
-  `memory use` parser/dispatch. All import cleanly. **Not yet:** the hook
-  (`plugin/hooks/memory_backend_notice.py` + `hooks.json` registration),
-  tests for all of the above, baseline regen, D5 rewrite, README/CHANGELOG,
-  suite runs.
+- Branch `claude/redis-state-visible` (PR #2446). Commits: 66042b2e8 (status
+  + doctor line + pyproject comment + D5 v1), 76b64072b (WIP), 6c67d31b6
+  (the rework: preference store, resolver, `memory use`, terminal notice,
+  setup prompt, SessionStart hook + registration, baseline regen, tests,
+  D5 rewritten in the chair's words, README, CHANGELOG).
+- Everything in the acceptance list is implemented and unit-tested; the
+  whole-tree run is the last receipt before push (see the PR body).
+- Coordination: `producer_baseline.json` changed (one hook). #2444 embeds
+  the baseline; whichever of #2444 / #2446 lands second regenerates it.
 
 ## Verification
 
 | Claim | Probe | Result |
 | --- | --- | --- |
-| Edited modules import | `python -c "import …"` under the worktree src | ok |
-| Everything else | not yet run | pending |
+| Preference store + resolver honoring it | `tests/unit/memory/test_backend_preference.py` (fake entry points; file never probes the upgrade) | 14 passed; `preference.py` 100% |
+| Hook | `tests/unit/hooks/test_memory_backend_notice.py` (consent-notice harness) | 9 passed |
+| CLI use / status / terminal notice / setup prompt | `tests/unit/cli/test_memory_backend_choice.py` + memory-command tests | 14 + 6 passed |
+| Ratchets + gates + touched suites | `tests/unit/gates tests/unit/quality tests/unit/cli tests/unit/cli_commands tests/unit/hooks tests/unit/memory` | 4045 passed |
+| Baseline regen reviewed | `git diff producer_baseline.json` | +1 registration, +1 context_stdout envelope, +1 helper edge, 0 problems |
+| Pinned hooks | pre-commit on every changed file | Passed |
+| Whole tree | `pytest tests -n auto`, captured (macOS, py3.11, warm caches, integration lane skipped by `--cov`) | 25579 passed, 266 skipped, 3 xfailed |
 
 ## Next action
 
-Write the hook + registration, the tests (preference, resolver, CLI use/status,
-setup prompt, first-run notice, hook), regenerate `producer_baseline.json`,
-rewrite D5 in the chair's words, README + CHANGELOG, run gates + whole tree,
-push, update the #2446 body. Chair reads D5, then merge word. Not armed.
+Push; rewrite the #2446 body to the rework; chair reads D5 (lead-authored
+spec text, D11 class), then merge word. Not armed. After merge: the
+install/config audit chip's findings land as follow-ups under D5.

--- a/docs/handoffs/claude-redis-state-visible.md
+++ b/docs/handoffs/claude-redis-state-visible.md
@@ -1,0 +1,52 @@
+# Agent work handoff
+
+## Goal
+
+Rework PR #2446 to the chair's corrected goal (redis-config-truth D5,
+assumption review 2026-09-06): Redis stays bundled and zero-config; the
+backend STATE is visible; **a first-run notice lets users choose**; the
+choice is a **persisted preference the resolver honors** (`auto|file|redis`);
+Redis's role is stated in the chair's words ("enhanced memory features
+using Redis's open-source options").
+
+## Acceptance criteria
+
+- `~/.attune/config.json` (or `$ATTUNE_HOME/config.json`) `memory.backend`
+  ∈ {auto, file, redis}; `ATTUNE_MEMORY_BACKEND` overrides per process.
+- `resolve_backend()`: `file` never probes the upgrade; `redis` prefers it
+  and degrades loudly; `auto` unchanged. `backend_status()` carries
+  `preference`; a chosen `file` tier never reports a dark upgrade.
+- Surfaces: SessionStart hook notice (consent-notice pattern: once, anti-nag,
+  "ACTION FOR CLAUDE: ask once, then `attune memory use`"); one-time
+  terminal notice on the first interactive `attune` run (informs, never
+  blocks); interactive prompt in `attune setup`; `attune memory use
+  <auto|file|redis>`; `attune memory status` shows the preference.
+- Changed code ≥ 90%; whole tree green; D5 rewritten in the chair's words;
+  producer_baseline regenerated for the new hook (coordination: #2444 embeds
+  the baseline — whichever of #2444/#2446 lands second regenerates).
+
+## Current state
+
+- Branch `claude/redis-state-visible` (PR #2446). Landed earlier: `attune
+  memory status`, doctor line, pyproject comment, D5 v1, tests (66042b2e8).
+- This WIP commit: `src/attune/memory/preference.py` (new), resolver +
+  `backend_status` honoring the preference, `cmd_memory_use`,
+  `first_run_memory_notice` + `main()` call, `_memory_backend_setup_prompt`,
+  `memory use` parser/dispatch. All import cleanly. **Not yet:** the hook
+  (`plugin/hooks/memory_backend_notice.py` + `hooks.json` registration),
+  tests for all of the above, baseline regen, D5 rewrite, README/CHANGELOG,
+  suite runs.
+
+## Verification
+
+| Claim | Probe | Result |
+| --- | --- | --- |
+| Edited modules import | `python -c "import …"` under the worktree src | ok |
+| Everything else | not yet run | pending |
+
+## Next action
+
+Write the hook + registration, the tests (preference, resolver, CLI use/status,
+setup prompt, first-run notice, hook), regenerate `producer_baseline.json`,
+rewrite D5 in the chair's words, README + CHANGELOG, run gates + whole tree,
+push, update the #2446 body. Chair reads D5, then merge word. Not armed.

--- a/docs/specs/host-surface-parity/producer_baseline.json
+++ b/docs/specs/host-surface-parity/producer_baseline.json
@@ -24,6 +24,10 @@
       "root_anchor": "plugin/hooks/macos_timeout_guard.py:<module>"
     },
     {
+      "helper_anchor": "plugin/hooks/memory_backend_notice.py:main",
+      "root_anchor": "plugin/hooks/memory_backend_notice.py:<module>"
+    },
+    {
       "helper_anchor": "plugin/hooks/session_recall.py:main",
       "root_anchor": "plugin/hooks/session_recall.py:<module>"
     },
@@ -103,6 +107,14 @@
       "event": "PreToolUse",
       "signature": "exit2_stderr",
       "sink": "print(file=sys.stderr)",
+      "subject_kind": "informational_delivery"
+    },
+    {
+      "anchor": "plugin/hooks/memory_backend_notice.py:main",
+      "destination": "model_context",
+      "event": "SessionStart",
+      "signature": "context_stdout",
+      "sink": "print",
       "subject_kind": "informational_delivery"
     },
     {
@@ -361,13 +373,23 @@
       "manifest_path": "plugin/hooks/hooks.json",
       "matcher": "",
       "ordinal": 0,
+      "raw_command": "PY=$(command -v python3 || command -v python) && \"$PY\" ${CLAUDE_PLUGIN_ROOT}/hooks/memory_backend_notice.py",
+      "resolved_repo_path": "plugin/hooks/memory_backend_notice.py"
+    },
+    {
+      "error": null,
+      "event": "SessionStart",
+      "json_pointer": "/hooks/SessionStart/3/hooks/0/command",
+      "manifest_path": "plugin/hooks/hooks.json",
+      "matcher": "",
+      "ordinal": 0,
       "raw_command": "PY=$(command -v python3 || command -v python) && \"$PY\" ${CLAUDE_PLUGIN_ROOT}/hooks/spec_orient.py",
       "resolved_repo_path": "plugin/hooks/spec_orient.py"
     },
     {
       "error": null,
       "event": "SessionStart",
-      "json_pointer": "/hooks/SessionStart/3/hooks/0/command",
+      "json_pointer": "/hooks/SessionStart/4/hooks/0/command",
       "manifest_path": "plugin/hooks/hooks.json",
       "matcher": "",
       "ordinal": 0,

--- a/docs/specs/redis-config-truth/decisions.md
+++ b/docs/specs/redis-config-truth/decisions.md
@@ -84,57 +84,79 @@ and surfaced; only malformed values raise). The spec-text-highest-
 yield pattern holds: third consecutive spec-text lane with a 100%
 real-finding rate.
 
-## D5 — Redis stays bundled and zero-config; the backend STATE becomes visible (RULED 2026-09-06, chair, via pushback card)
+## D5 — Redis stays bundled and zero-config; a first-run notice lets users choose; the choice is honored (RULED 2026-09-06, chair — pushback card, then assumption review)
 
-**Date:** 2026-09-06 · **Status:** ruled (chair pick on the lead's
-pushback card: "Keep bundled and zero-config; make the state visible and
-fix the friction")
+**Date:** 2026-09-06 · **Status:** ruled. First recorded from a card pick
+the same night; rewritten the same night after the chair's assumption
+review corrected the shape. The chair's own words are the record:
 
-**Question.** The chair asked whether Redis should become an optional
-install, or an option during the initial install, "without damaging
-performance to users", and invited pushback.
+> Redis's primary goal is to "provide enhanced memory features using
+> Redis's open source coding options."
 
-**Facts the ruling rests on (verified 2026-09-06).** The Redis SERVER is
-already optional at runtime: with the Agent Memory Server unreachable
+> I want there to be a first run notice that lets users choose if
+> possible.
+
+**What was asked.** Whether Redis should become an optional install, or
+an option during the initial install, "without damaging performance to
+users"; the chair invited pushback.
+
+**What is true (verified 2026-09-06).** The Redis SERVER was already
+optional at runtime: with the Agent Memory Server unreachable
 `resolve_backend()` returns `FileStashBackend` (`is_fallback=True`) in
 0.15 s; with the plugin absent, in 0.04 s. The two client libraries
-(`redis`, `agent-memory-client`) are core dependencies and the
-`attune_redis` plugin is bundled in the wheel; the `[redis]` extra was an
-empty alias never used. Performance is not at stake in either
-direction: recall digest 4.6 ms on files vs 0.6 ms on Redis; importing
-the client libraries costs ~131 ms once. The AMS URL comes from the
-plugin config (`AMS_BASE_URL`, default `http://localhost:8000`), not
-from the Redis URL variables. `backend_status()` already distinguishes
-live-upgrade / file-fallback / dark-upgrade; the SessionStart recall
-hook warns only in the dark case; `attune doctor` reported raw Redis
-reachability but never the memory backend, and `attune memory` had no
-`status`.
+(`redis`, `agent-memory-client`) are core dependencies and `attune_redis`
+is bundled in the wheel; the `[redis]` extra was an empty alias no one
+ever used. Performance in the sense the chair meant (runtime speed) is
+not at stake: recall digest 4.6 ms on files vs 0.6 ms on Redis; client
+import ~131 ms once. The AMS URL comes from the plugin config
+(`AMS_BASE_URL`, default `http://localhost:8000`). `backend_status()`
+already distinguished live-upgrade / file-fallback / dark-upgrade, but
+`attune doctor` never named the memory backend and `attune memory` had
+no `status`.
 
-**Positions.** (a) Optional install or install-time option (chair's
-opening approach): `pip` cannot prompt, so this is a first-run question
-plus a real extra — two install paths, and the decision lands at the
-moment users know least; the last interactive installer here is where
-the #1418 "installed nothing, printed a checkmark" bug lived. (b) Make
-the extra real: client libraries out of core, plugin degrades; lighter
-base install, but a user with Redis and no extra silently gets the file
-tier. (c) **Keep bundled and zero-config; make the state visible; fix
-the friction** — the lead's alternative, adopted. Counter-case to (c),
-stated to the chair before the pick: bundling drags two client
-libraries and their closure into every install for users who never run
-Redis, and the empty alias was a standing lie in `pyproject.toml`.
+**Ruling.**
+1. Redis stays **bundled and zero-config**. No optional install, no
+   install-time prompt in `pip` (it cannot prompt; the last interactive
+   installer here is where the #1418 "installed nothing, printed a
+   checkmark" bug lived). The strategy memory "leverage the Redis work,
+   don't decouple" stands.
+2. The backend **state is visible**: `attune memory status` (`--json`)
+   and a doctor "Memory backend" line that never contributes a FAIL.
+3. A **first-run notice lets users choose**, on every surface that can
+   carry it: a SessionStart hook notice (the consent-notice pattern —
+   once, anti-nag, "ACTION FOR CLAUDE: ask once"), a one-time notice on
+   the first interactive `attune` run (informs and points at the
+   choosing commands; never blocks a command with a prompt), an
+   interactive prompt in `attune setup`, and `attune memory use
+   <auto|file|redis>` for changing it later.
+4. The choice is a **persisted preference the resolver honors**
+   (`~/.attune/config.json` → `memory.backend`; `ATTUNE_MEMORY_BACKEND`
+   overrides per process): `auto` = a reachable upgrade wins, else the
+   file tier (today's behavior); `file` = the local tier only, the
+   upgrade is never probed or reported dark; `redis` = prefer the Agent
+   Memory Server, degrade to files when unreachable and say so loudly.
+   A choice that changed nothing would be theater.
+5. Redis's role is stated everywhere it is offered in the chair's words
+   (`attune.memory.preference.REDIS_ROLE`).
 
-**What (c) means in code.** `attune memory status` (with `--json`)
-names the resolved backend, transport and reachability and prints the
-guidance for each state (zero-config file tier + how to upgrade;
-degraded with a dark upgrade; not usable with the reason). `attune
-doctor` gains a "Memory backend" line that never contributes a FAIL —
-memory is optional. The empty-alias comment in `pyproject.toml` is
-corrected. The friction findings come from the Redis install/config
+**Positions considered.** (a) optional install / install-time option —
+the chair's opening approach, declined for the reasons in 1; (b) make
+the `[redis]` extra real — left **not ruled**: it is the honest answer
+only if base-install weight becomes the concern, and its one cost is
+the silent fallback for a user with Redis and no extra; (c) keep
+bundled, make the state visible — adopted, then widened by the chair's
+review to include the first-run choice (3) and its persistence (4).
+Counter-case to the adopted position, stated before the pick: bundling
+drags two client libraries and their closure into every install for
+users who never run Redis.
+
+**Process note.** The first D5 was written within minutes of the card
+pick and recorded my framing, not the chair's. The assumption review
+that followed found the shape wrong (item 3). Rulings are recorded in
+the chair's words; a card pick settles one dimension, not the framing
+around it (project memory
+`feedback_assumption_review_before_recording_a_pick`).
+
+**Friction.** The install/config friction list comes from the Redis
 audit the chair started the same night (chip `task_af6763f5`); fixes
-land under this ruling, not under a new install path. The standing
-strategy memory ("leverage the Redis work, don't decouple") is
-unchanged by this ruling.
-
-**Not ruled.** Whether the client libraries should ever move to a real
-extra. If the base-install weight becomes the concern the chair holds,
-(b) is the honest answer and its one cost is the silent fallback.
+land under this ruling.

--- a/docs/specs/redis-config-truth/decisions.md
+++ b/docs/specs/redis-config-truth/decisions.md
@@ -83,3 +83,58 @@ was undefined — R1 now carries an explicit conflict rule
 and surfaced; only malformed values raise). The spec-text-highest-
 yield pattern holds: third consecutive spec-text lane with a 100%
 real-finding rate.
+
+## D5 — Redis stays bundled and zero-config; the backend STATE becomes visible (RULED 2026-09-06, chair, via pushback card)
+
+**Date:** 2026-09-06 · **Status:** ruled (chair pick on the lead's
+pushback card: "Keep bundled and zero-config; make the state visible and
+fix the friction")
+
+**Question.** The chair asked whether Redis should become an optional
+install, or an option during the initial install, "without damaging
+performance to users", and invited pushback.
+
+**Facts the ruling rests on (verified 2026-09-06).** The Redis SERVER is
+already optional at runtime: with the Agent Memory Server unreachable
+`resolve_backend()` returns `FileStashBackend` (`is_fallback=True`) in
+0.15 s; with the plugin absent, in 0.04 s. The two client libraries
+(`redis`, `agent-memory-client`) are core dependencies and the
+`attune_redis` plugin is bundled in the wheel; the `[redis]` extra was an
+empty alias never used. Performance is not at stake in either
+direction: recall digest 4.6 ms on files vs 0.6 ms on Redis; importing
+the client libraries costs ~131 ms once. The AMS URL comes from the
+plugin config (`AMS_BASE_URL`, default `http://localhost:8000`), not
+from the Redis URL variables. `backend_status()` already distinguishes
+live-upgrade / file-fallback / dark-upgrade; the SessionStart recall
+hook warns only in the dark case; `attune doctor` reported raw Redis
+reachability but never the memory backend, and `attune memory` had no
+`status`.
+
+**Positions.** (a) Optional install or install-time option (chair's
+opening approach): `pip` cannot prompt, so this is a first-run question
+plus a real extra — two install paths, and the decision lands at the
+moment users know least; the last interactive installer here is where
+the #1418 "installed nothing, printed a checkmark" bug lived. (b) Make
+the extra real: client libraries out of core, plugin degrades; lighter
+base install, but a user with Redis and no extra silently gets the file
+tier. (c) **Keep bundled and zero-config; make the state visible; fix
+the friction** — the lead's alternative, adopted. Counter-case to (c),
+stated to the chair before the pick: bundling drags two client
+libraries and their closure into every install for users who never run
+Redis, and the empty alias was a standing lie in `pyproject.toml`.
+
+**What (c) means in code.** `attune memory status` (with `--json`)
+names the resolved backend, transport and reachability and prints the
+guidance for each state (zero-config file tier + how to upgrade;
+degraded with a dark upgrade; not usable with the reason). `attune
+doctor` gains a "Memory backend" line that never contributes a FAIL —
+memory is optional. The empty-alias comment in `pyproject.toml` is
+corrected. The friction findings come from the Redis install/config
+audit the chair started the same night (chip `task_af6763f5`); fixes
+land under this ruling, not under a new install path. The standing
+strategy memory ("leverage the Redis work, don't decouple") is
+unchanged by this ruling.
+
+**Not ruled.** Whether the client libraries should ever move to a real
+extra. If the base-install weight becomes the concern the chair holds,
+(b) is the honest answer and its one cost is the silent fallback.

--- a/plugin/hooks/hooks.json
+++ b/plugin/hooks/hooks.json
@@ -23,6 +23,15 @@
         "hooks": [
           {
             "type": "command",
+            "command": "PY=$(command -v python3 || command -v python) && \"$PY\" ${CLAUDE_PLUGIN_ROOT}/hooks/memory_backend_notice.py",
+            "timeout": 3
+          }
+        ]
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
             "command": "PY=$(command -v python3 || command -v python) && \"$PY\" ${CLAUDE_PLUGIN_ROOT}/hooks/spec_orient.py",
             "timeout": 4
           }

--- a/plugin/hooks/memory_backend_notice.py
+++ b/plugin/hooks/memory_backend_notice.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""SessionStart hook — surface the memory-backend choice once (redis-config-truth D5).
+
+Redis stays bundled and zero-config: a plain install runs on the local file
+tier and upgrades to the Redis Agent Memory Server automatically when one
+is reachable. Until the user records a preference, this notice explains
+what Redis is FOR here and asks the assistant to collect the choice once at
+a natural break; the answer is recorded with ``attune memory use``.
+
+Mirrors ``usage_consent_notice.py``: shows at most ``_MAX_SHOWS`` times, never
+on the post-compact SessionStart, never when a preference exists, silenced by
+``ATTUNE_MEMORY_NOTICE=0``, and never crashes the session.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import traceback
+from pathlib import Path
+
+_FALSEY = {"", "0", "false", "no", "off"}
+_VALUES = ("auto", "file", "redis")
+_MAX_SHOWS = 3
+
+_NOTICE = """\
+## Memory backend (one-time choice)
+
+attune-ai memory is running on the **local file tier** — zero-config,
+nothing to set up. Redis is optional. Redis's role in attune-ai is to
+provide **enhanced memory features using Redis's open-source options**:
+semantic recall across sessions through the Agent Memory Server.
+
+Choices (recorded in `~/.attune/config.json`, change any time):
+- `auto`  — a reachable Agent Memory Server wins, otherwise the file tier (default)
+- `file`  — the local tier only; the upgrade is never probed or warned about
+- `redis` — prefer the Agent Memory Server; degrade to files when unreachable, loudly
+
+ACTION FOR CLAUDE: At a natural break in this session, ask the user ONCE
+which memory backend they want (a decision card: auto / file / redis, with
+`auto` recommended for a plain install and `redis` when they run an Agent
+Memory Server). Then run `attune memory use <choice>`. Do not ask again
+this session; `attune memory status` shows the live state. Silence this
+notice with ATTUNE_MEMORY_NOTICE=0.
+"""
+
+
+def _attune_home() -> Path:
+    home = os.environ.get("ATTUNE_HOME")
+    return Path(home).expanduser() if home else Path("~/.attune").expanduser()
+
+
+def _config_path() -> Path:
+    return _attune_home() / "config.json"
+
+
+def _count_path() -> Path:
+    return _attune_home() / "telemetry" / ".memory_notice_count"
+
+
+def _enabled() -> bool:
+    return os.environ.get("ATTUNE_MEMORY_NOTICE", "1").strip().lower() not in _FALSEY
+
+
+def _preference_recorded() -> bool:
+    """True when the user (or the env override) already chose a backend."""
+    if os.environ.get("ATTUNE_MEMORY_BACKEND", "").strip().lower() in _VALUES:
+        return True
+    try:
+        data = json.loads(_config_path().read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError, ValueError):
+        return False
+    memory = data.get("memory") if isinstance(data, dict) else None
+    return bool(isinstance(memory, dict) and memory.get("backend") in _VALUES)
+
+
+def _show_count() -> int:
+    try:
+        return int(_count_path().read_text(encoding="utf-8").strip() or "0")
+    except (OSError, ValueError):
+        return 0
+
+
+def _bump_count(current: int) -> None:
+    try:
+        path = _count_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(str(current + 1), encoding="utf-8")
+    except OSError:
+        pass  # anti-nag is best-effort; a missed bump just shows once more
+
+
+def main() -> int:
+    try:
+        if not _enabled():
+            return 0
+        try:
+            payload = json.load(sys.stdin)
+        except (json.JSONDecodeError, ValueError):
+            payload = {}
+        if str(payload.get("source") or "startup").lower() == "compact":
+            return 0  # don't pile onto post-compact context
+        if _preference_recorded():
+            return 0
+        count = _show_count()
+        if count >= _MAX_SHOWS:
+            return 0
+        print(_NOTICE)
+        _bump_count(count)
+        return 0
+    except Exception:  # noqa: BLE001 — SessionStart hook must never crash a session
+        traceback.print_exc(file=sys.stderr)
+        return 0
+
+
+if __name__ == "__main__":
+    from _sdk_gate import exit_if_sdk_subprocess
+
+    exit_if_sdk_subprocess()
+    sys.exit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,7 +89,9 @@ dependencies = [
     # without one (see tests/unit/memory/test_no_server_degradation.py).
     # agent-memory-client is capped tightly — it moves fast and now
     # sits on every user's resolution path; raise the cap only after
-    # re-validating. The [redis] extra remains as an empty alias.
+    # re-validating. There is no [redis] extra: the client
+    # libraries are core and the bundled attune_redis plugin degrades to the
+    # local file tier when no server is reachable (redis-config-truth D5).
     "agent-memory-client>=0.14.0,<0.15",
     "redis>=5.0.0,<9.0.0",
     # NOTE: attune-author retired 2026-07-27 (author-consolidation T4,

--- a/src/attune/cli_commands/memory_commands.py
+++ b/src/attune/cli_commands/memory_commands.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import logging
 from argparse import Namespace
+from typing import Any
 
 logger = logging.getLogger(__name__)
 
@@ -256,6 +257,9 @@ def cmd_memory_status(args: Namespace) -> int:
     if getattr(args, "json", False):
         print(json.dumps(status, sort_keys=True))
         return 0 if status.get("ok") else 1
+    print(
+        f"Preference: {status.get('preference', 'auto')}  (change with: attune memory use auto|file|redis)"
+    )
     backend = status.get("backend") or "none"
     transport = status.get("transport") or "none"
     reach = status.get("reachability") or "unknown"
@@ -284,6 +288,76 @@ def cmd_memory_status(args: Namespace) -> int:
     print(f"Memory backend: {backend} ({transport}, {reach})")
     print(f"  Redis Agent Memory Server live at {url}; findings are searchable across sessions.")
     return 0
+
+
+def cmd_memory_use(args: Namespace) -> int:
+    """Record the memory backend preference: auto, file, or redis (D5).
+
+    Args:
+        args: ``backend`` is one of :data:`attune.memory.preference.VALUES`.
+
+    Returns:
+        0 on success, 1 on an invalid value or an unwritable config.
+    """
+    from attune.memory.preference import REDIS_ROLE, set_backend_preference
+
+    try:
+        path = set_backend_preference(args.backend)
+    except ValueError as e:
+        print(f"Error: {e}")
+        return 1
+    except OSError as e:
+        logger.error("Failed to write memory preference: %s", e)
+        print(f"Error writing {e.filename or 'config'}: {e}")
+        return 1
+    effects = {
+        "auto": "a reachable Redis Agent Memory Server wins, otherwise the local file tier.",
+        "file": "the local file tier only; the Redis upgrade is never probed or warned about.",
+        "redis": "prefer the Redis Agent Memory Server; degrade to files when unreachable, loudly.",
+    }
+    print(f"Memory backend preference: {args.backend} — {effects[args.backend]}")
+    if args.backend == "redis":
+        print(f"  {REDIS_ROLE}")
+    print(f"  Recorded in {path}")
+    return cmd_memory_status(Namespace(json=False))
+
+
+FIRST_RUN_NOTICE = """\
+Memory: running on the local file tier (zero-config; nothing to set up).
+  Redis is optional. {role}
+  Choose once — attune memory use auto|file|redis — or run: attune setup
+  (silence this notice: ATTUNE_MEMORY_NOTICE=0)"""
+
+
+def first_run_memory_notice(command: str | None, stream: Any = None) -> bool:
+    """Print the one-time terminal notice when a human has not yet chosen (D5).
+
+    Fires only on an interactive terminal, only until the user records a
+    preference, only once, and never for the ``memory``/``setup`` commands
+    that are themselves the way to choose. It informs and points at the
+    choosing commands; it never blocks a command with a prompt.
+
+    Returns:
+        True when the notice was printed.
+    """
+    import sys
+
+    from attune.memory import preference as pref
+
+    out = stream if stream is not None else sys.stdout
+    try:
+        if command in {"memory", "setup"} or not pref.notice_enabled():
+            return False
+        if not getattr(out, "isatty", lambda: False)():
+            return False
+        if pref.preference_recorded() or pref.notice_shown():
+            return False
+        print(FIRST_RUN_NOTICE.format(role=pref.REDIS_ROLE), file=out)
+        pref.mark_notice_shown()
+        return True
+    except OSError as e:  # unwritable home: inform once per process, never fail the command
+        logger.debug("first-run memory notice not recorded: %s", e)
+        return True
 
 
 def cmd_memory_forget_topic(args: Namespace) -> int:

--- a/src/attune/cli_commands/memory_commands.py
+++ b/src/attune/cli_commands/memory_commands.py
@@ -225,6 +225,67 @@ def cmd_memory_topics(args: Namespace) -> int:
         return 1
 
 
+def _ams_base_url() -> str:
+    """The Agent Memory Server URL the bundled plugin would use (AMS_BASE_URL)."""
+    try:
+        from attune_redis.config import RedisPluginConfig
+
+        return RedisPluginConfig.from_env().ams_base_url
+    except ImportError:
+        return "http://localhost:8000"
+
+
+def cmd_memory_status(args: Namespace) -> int:
+    """Say which memory backend recall resolves to, and why (redis-config-truth D5).
+
+    Redis is optional: the zero-config install runs on the local file tier and
+    upgrades to the Redis Agent Memory Server automatically when one is
+    reachable. This command makes that state visible instead of silent.
+
+    Args:
+        args: Parsed arguments; ``--json`` prints the raw status mapping.
+
+    Returns:
+        0 when a usable write/recall path exists, 1 otherwise.
+    """
+    import json
+
+    from attune.memory.session_stash import backend_status
+
+    status = backend_status()
+    if getattr(args, "json", False):
+        print(json.dumps(status, sort_keys=True))
+        return 0 if status.get("ok") else 1
+    backend = status.get("backend") or "none"
+    transport = status.get("transport") or "none"
+    reach = status.get("reachability") or "unknown"
+    dark = status.get("unreachable_upgrade")
+    url = _ams_base_url()
+    if not status.get("ok"):
+        print(f"Memory backend: {backend} ({transport}, {reach}) — NOT USABLE")
+        print(f"  reason: {status.get('reason') or 'unknown'}")
+        return 1
+    if dark:
+        print(f"Memory backend: {backend} (file tier, {reach}) — DEGRADED")
+        print(
+            f"  Registered upgrade '{dark}' is unreachable at {url}: findings stored there are"
+            " dark until it is back (e.g. restart the Agent Memory Server)."
+        )
+        print("  New findings go to the local file tier meanwhile.")
+        return 0
+    if status.get("fallback"):
+        print(f"Memory backend: {backend} (file tier, {reach}) — zero-config default")
+        print("  Redis is optional. Findings are stored locally and searched from files.")
+        print(
+            f"  To upgrade: run a Redis Agent Memory Server and point AMS_BASE_URL at it"
+            f" (currently {url}); attune switches automatically when it is reachable."
+        )
+        return 0
+    print(f"Memory backend: {backend} ({transport}, {reach})")
+    print(f"  Redis Agent Memory Server live at {url}; findings are searchable across sessions.")
+    return 0
+
+
 def cmd_memory_forget_topic(args: Namespace) -> int:
     """Delete a topic (or specific kind) from personal memory.
 

--- a/src/attune/cli_commands/utility_commands.py
+++ b/src/attune/cli_commands/utility_commands.py
@@ -102,6 +102,37 @@ def _install_config_files() -> int:
     return configs_copied
 
 
+def _memory_backend_setup_prompt() -> None:
+    """Ask once, on a terminal, which memory backend to use (redis-config-truth D5).
+
+    Non-interactive runs only print the pointer; a recorded preference is
+    never re-asked; EOF or an unwritable config never fails setup.
+    """
+    from attune.memory import preference as pref
+
+    if pref.preference_recorded():
+        return
+    print("\n  Memory backend:")
+    print("  The local file tier works with nothing to set up. Redis is optional.")
+    print(f"  {pref.REDIS_ROLE}")
+    if not (sys.stdin.isatty() and sys.stdout.isatty()):
+        print("  Choose later with: attune memory use auto|file|redis")
+        return
+    try:
+        answer = input("  Use which backend? [auto/file/redis] (auto): ").strip().lower() or "auto"
+    except EOFError:
+        return
+    if answer not in pref.VALUES:
+        print(f"  Not one of {', '.join(pref.VALUES)}; leaving it at auto (change any time).")
+        return
+    try:
+        path = pref.set_backend_preference(answer)
+    except OSError as e:
+        print(f"  Could not record the choice ({e}); use: attune memory use {answer}")
+        return
+    print(f"  ✅ Memory backend preference: {answer} (recorded in {path})")
+
+
 def cmd_setup(args: Namespace) -> int:
     """Install Attune slash commands for Claude Code."""
     source_dir = _find_source_dir()
@@ -147,6 +178,7 @@ def cmd_setup(args: Namespace) -> int:
         print("   Make sure you're running from the attune-ai directory.")
         return 1
 
+    _memory_backend_setup_prompt()
     total = copied + agents_copied + configs_copied
     print(
         f"\n✅ Installed {total} file(s)"

--- a/src/attune/cli_commands/utility_commands.py
+++ b/src/attune/cli_commands/utility_commands.py
@@ -17,6 +17,7 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from argparse import Namespace
+from collections.abc import Callable
 
 logger = logging.getLogger(__name__)
 
@@ -340,6 +341,34 @@ def cmd_features(args: Namespace) -> int:
     return 0
 
 
+def _report_memory_backend(ok: Callable[..., None], warn: Callable[..., None]) -> None:
+    """One doctor line naming the memory backend recall resolves to; never a FAIL.
+
+    Memory is optional (redis-config-truth D5): the zero-config file tier is
+    OK, a live upgrade is OK, a registered-but-dark upgrade is a warning
+    that names it, and an unusable path is a warning with its reason.
+    """
+    try:
+        from attune.memory.session_stash import backend_status
+    except ImportError as e:
+        warn("Memory backend status unavailable", str(e))
+        return
+    status = backend_status()
+    backend = status.get("backend") or "none"
+    dark = status.get("unreachable_upgrade")
+    if dark:
+        warn(
+            f"Memory backend: {backend} (file tier)",
+            f"registered upgrade '{dark}' unreachable — findings stored there are dark",
+        )
+    elif status.get("fallback"):
+        ok(f"Memory backend: {backend} (file tier)", "Redis Agent Memory Server optional")
+    elif status.get("ok"):
+        ok(f"Memory backend: {backend}", status.get("transport") or "direct")
+    else:
+        warn("Memory backend: none usable", status.get("reason") or "unknown")
+
+
 def cmd_doctor(args: Namespace) -> int:
     """Run comprehensive environment health check.
 
@@ -445,6 +474,10 @@ def cmd_doctor(args: Namespace) -> int:
     except Exception:  # noqa: BLE001
         # INTENTIONAL: Redis is optional
         _warn("Redis server not reachable", "optional")
+
+    # 6b. Memory backend — zero-config file tier; the Redis AMS upgrade is optional
+    # (redis-config-truth D5: make the state visible, never silent).
+    _report_memory_backend(_ok, _warn)
 
     # 7. Workflows
     try:

--- a/src/attune/cli_minimal.py
+++ b/src/attune/cli_minimal.py
@@ -79,7 +79,9 @@ from attune.cli_commands.memory_commands import (
     cmd_memory_recall,
     cmd_memory_status,
     cmd_memory_topics,
+    cmd_memory_use,
     cmd_remember,
+    first_run_memory_notice,
 )
 from attune.cli_commands.pattern_review import (
     cmd_patterns_promote,
@@ -656,6 +658,10 @@ def _add_misc_subparsers(subparsers: argparse._SubParsersAction) -> None:
         "status", help="Which memory backend is live (file tier or Redis AMS) and why"
     )
     status_p.add_argument("--json", action="store_true", help="Output the raw status mapping")
+    use_p = memory_sub.add_parser(
+        "use", help="Choose the memory backend: auto (default), file, or redis"
+    )
+    use_p.add_argument("backend", choices=["auto", "file", "redis"], help="Backend preference")
 
     forget_topic_p = memory_sub.add_parser("forget-topic", help="Delete a topic from memory")
     forget_topic_p.add_argument("topic", help="Topic slug to delete")
@@ -816,6 +822,7 @@ _SUBCOMMAND_DISPATCH: dict[str, dict[str, object]] = {
         "recall": cmd_memory_recall,
         "topics": cmd_memory_topics,
         "status": cmd_memory_status,
+        "use": cmd_memory_use,
         "forget-topic": cmd_memory_forget_topic,
     },
 }
@@ -916,6 +923,7 @@ def main(argv: list[str] | None = None) -> int:
     """Main entry point."""
     parser = create_parser()
     args = parser.parse_args(argv)
+    first_run_memory_notice(getattr(args, "command", None))
 
     # Configure logging (one-line records unless --verbose; see
     # _OneLineLogFormatter).

--- a/src/attune/cli_minimal.py
+++ b/src/attune/cli_minimal.py
@@ -77,6 +77,7 @@ from attune.cli_commands.memory_commands import (
     cmd_memory_capture,
     cmd_memory_forget_topic,
     cmd_memory_recall,
+    cmd_memory_status,
     cmd_memory_topics,
     cmd_remember,
 )
@@ -651,6 +652,10 @@ def _add_misc_subparsers(subparsers: argparse._SubParsersAction) -> None:
     recall_p.add_argument("--json", action="store_true", help="Output as JSON")
 
     memory_sub.add_parser("topics", help="List all personal memory topics")
+    status_p = memory_sub.add_parser(
+        "status", help="Which memory backend is live (file tier or Redis AMS) and why"
+    )
+    status_p.add_argument("--json", action="store_true", help="Output the raw status mapping")
 
     forget_topic_p = memory_sub.add_parser("forget-topic", help="Delete a topic from memory")
     forget_topic_p.add_argument("topic", help="Topic slug to delete")
@@ -810,6 +815,7 @@ _SUBCOMMAND_DISPATCH: dict[str, dict[str, object]] = {
         "capture": cmd_memory_capture,
         "recall": cmd_memory_recall,
         "topics": cmd_memory_topics,
+        "status": cmd_memory_status,
         "forget-topic": cmd_memory_forget_topic,
     },
 }

--- a/src/attune/memory/preference.py
+++ b/src/attune/memory/preference.py
@@ -1,0 +1,123 @@
+"""User preference for the memory backend (redis-config-truth D5).
+
+Redis stays bundled and zero-config: a plain install runs on the local
+file tier and upgrades to the Redis Agent Memory Server automatically when
+one is reachable. This module records the user's stated choice so the
+resolver can honor it and the first-run notice can stop asking:
+
+- ``auto``  — today's behavior: a reachable upgrade wins, else the file tier.
+- ``file``  — the local tier only; the upgrade is never probed, never warned.
+- ``redis`` — prefer the Agent Memory Server; degrade to files when it is
+  unreachable, but say so loudly.
+
+The preference lives in the user config (``~/.attune/config.json``, or
+``$ATTUNE_HOME/config.json``), never in a project-local file, under the
+``memory`` key beside the telemetry consent. ``ATTUNE_MEMORY_BACKEND``
+overrides it for one process (CI, tests, one-off runs).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+VALUES: tuple[str, ...] = ("auto", "file", "redis")
+ENV_VAR = "ATTUNE_MEMORY_BACKEND"
+#: Set to 0/false to silence the first-run notice (hook and terminal).
+NOTICE_ENV_VAR = "ATTUNE_MEMORY_NOTICE"
+_FALSEY = {"", "0", "false", "no", "off"}
+
+#: The chair's words for what Redis is FOR here (redis-config-truth D5).
+REDIS_ROLE = (
+    "Redis's role in attune-ai is to provide enhanced memory features using "
+    "Redis's open-source options: semantic recall across sessions through the "
+    "Agent Memory Server."
+)
+
+
+def config_path() -> Path:
+    """The user config file; honors ``ATTUNE_HOME`` so tests never touch ``~``."""
+    home = os.environ.get("ATTUNE_HOME")
+    base = Path(home).expanduser() if home else Path("~/.attune").expanduser()
+    return base / "config.json"
+
+
+def _read() -> dict[str, Any]:
+    try:
+        data = json.loads(config_path().read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError, ValueError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _memory_section(data: dict[str, Any]) -> dict[str, Any]:
+    section = data.get("memory")
+    return dict(section) if isinstance(section, dict) else {}
+
+
+def notice_enabled() -> bool:
+    """False when ``ATTUNE_MEMORY_NOTICE`` is set to a falsy value."""
+    return os.environ.get(NOTICE_ENV_VAR, "1").strip().lower() not in _FALSEY
+
+
+def get_backend_preference() -> str:
+    """``auto`` unless the user recorded a choice or the env var overrides it."""
+    env = os.environ.get(ENV_VAR, "").strip().lower()
+    if env in VALUES:
+        return env
+    value = _memory_section(_read()).get("backend")
+    return value if value in VALUES else "auto"
+
+
+def preference_recorded() -> bool:
+    """True once the user has chosen (the notices stop asking)."""
+    return _memory_section(_read()).get("backend") in VALUES
+
+
+def set_backend_preference(value: str) -> Path:
+    """Record ``value`` in the user config; returns the file written."""
+    if value not in VALUES:
+        raise ValueError(f"memory backend must be one of {', '.join(VALUES)}, got {value!r}")
+    return _write_memory_key("backend", value)
+
+
+def notice_shown() -> bool:
+    """True once the terminal first-run notice has been printed."""
+    return bool(_memory_section(_read()).get("notice_shown"))
+
+
+def mark_notice_shown() -> Path:
+    return _write_memory_key("notice_shown", True)
+
+
+def _write_memory_key(key: str, value: Any) -> Path:
+    from attune.security.path_validation import _validate_file_path
+
+    path = config_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    target = _validate_file_path(str(path), allowed_dir=str(path.parent))
+    data = _read()
+    section = _memory_section(data)
+    section[key] = value
+    data["memory"] = section
+    tmp = target.with_name(target.name + ".tmp")
+    tmp.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    os.replace(tmp, target)
+    return target
+
+
+__all__ = [
+    "ENV_VAR",
+    "NOTICE_ENV_VAR",
+    "REDIS_ROLE",
+    "VALUES",
+    "config_path",
+    "get_backend_preference",
+    "mark_notice_shown",
+    "notice_enabled",
+    "notice_shown",
+    "preference_recorded",
+    "set_backend_preference",
+]

--- a/src/attune/memory/session_stash.py
+++ b/src/attune/memory/session_stash.py
@@ -141,7 +141,10 @@ def resolve_backend(
         from attune.memory.backend import SearchableMemoryBackend as _Searchable
 
         fallback: SearchableMemoryBackend | None = None
+        preference = _backend_preference()
         for ep in entry_points(group=_BACKEND_GROUP):
+            if preference == "file" and ep.name != "file":
+                continue  # the user chose the local tier: never probe an upgrade (D5)
             try:
                 instance = ep.load()()
             except Exception as exc:  # noqa: BLE001
@@ -176,6 +179,16 @@ def resolve_backend(
         # INTENTIONAL: resolution is best-effort; never propagate.
         logger.debug("backend resolution failed: %s", exc)
     return None
+
+
+def _backend_preference() -> str:
+    """The user's recorded backend preference; ``auto`` when unavailable."""
+    try:
+        from attune.memory.preference import get_backend_preference
+
+        return get_backend_preference()
+    except ImportError:
+        return "auto"
 
 
 def backend_status() -> dict:
@@ -226,6 +239,7 @@ def backend_status() -> dict:
         "transport": "none",
         "reachability": "unknown",
         "reason": None,
+        "preference": _backend_preference(),
     }
     resolved = resolve_backend(None)
     if resolved is not None:
@@ -260,6 +274,8 @@ def backend_status() -> dict:
         from importlib.metadata import entry_points
 
         for ep in entry_points(group=_BACKEND_GROUP):
+            if status["preference"] == "file" and ep.name != "file":
+                continue  # chosen local tier: an unprobed upgrade is not "dark" (D5)
             try:
                 instance = ep.load()()
             except Exception:  # noqa: BLE001

--- a/tests/unit/cli/test_doctor_memory_backend.py
+++ b/tests/unit/cli/test_doctor_memory_backend.py
@@ -1,0 +1,108 @@
+"""``attune doctor`` names the live memory backend (redis-config-truth D5).
+
+Redis is optional: a zero-config install runs on the local file tier and
+upgrades to the Redis Agent Memory Server automatically when one is
+reachable. Before D5 the doctor reported raw Redis reachability but never
+which memory backend recall actually resolves to, so a dark upgrade
+(AMS registered but down) was invisible from the CLI. These tests pin the
+three states a user can be in, driven through the real command with
+``backend_status`` intercepted — no server, no network.
+"""
+
+from __future__ import annotations
+
+from argparse import Namespace
+
+import pytest
+
+from attune.cli_commands.utility_commands import cmd_doctor
+from attune.memory import session_stash
+
+
+def _doctor_line(monkeypatch: pytest.MonkeyPatch, status: dict, capsys) -> str:
+    monkeypatch.setattr(session_stash, "backend_status", lambda: status)
+    cmd_doctor(Namespace())
+    out = capsys.readouterr().out
+    lines = [line for line in out.splitlines() if "Memory backend" in line]
+    assert len(lines) == 1, f"doctor printed {len(lines)} memory-backend lines:\n{out}"
+    return lines[0]
+
+
+def test_live_upgrade_backend_is_ok(monkeypatch, capsys) -> None:
+    line = _doctor_line(
+        monkeypatch,
+        {
+            "backend": "AMSMemoryBackend",
+            "fallback": False,
+            "unreachable_upgrade": None,
+            "ok": True,
+            "transport": "direct",
+        },
+        capsys,
+    )
+    assert line.startswith("  [OK]") and "AMSMemoryBackend" in line and "direct" in line
+
+
+def test_zero_config_file_tier_is_ok_and_says_redis_is_optional(monkeypatch, capsys) -> None:
+    line = _doctor_line(
+        monkeypatch,
+        {
+            "backend": "FileStashBackend",
+            "fallback": True,
+            "unreachable_upgrade": None,
+            "ok": True,
+            "transport": "file",
+        },
+        capsys,
+    )
+    assert line.startswith("  [OK]") and "file tier" in line and "optional" in line
+
+
+def test_dark_upgrade_is_a_warning_naming_the_upgrade(monkeypatch, capsys) -> None:
+    line = _doctor_line(
+        monkeypatch,
+        {
+            "backend": "FileStashBackend",
+            "fallback": True,
+            "unreachable_upgrade": "redis",
+            "ok": True,
+            "transport": "file",
+        },
+        capsys,
+    )
+    assert line.startswith("  [--]") and "'redis' unreachable" in line and "dark" in line
+
+
+def test_no_usable_backend_is_a_warning_with_the_reason(monkeypatch, capsys) -> None:
+    line = _doctor_line(
+        monkeypatch,
+        {
+            "backend": None,
+            "fallback": False,
+            "unreachable_upgrade": None,
+            "ok": False,
+            "reason": "file_write_denied",
+        },
+        capsys,
+    )
+    assert line.startswith("  [--]") and "none usable" in line and "file_write_denied" in line
+
+
+def test_memory_line_never_fails_the_doctor(monkeypatch, capsys) -> None:
+    """Memory is optional; the doctor's exit code must not depend on it."""
+    monkeypatch.setattr(
+        session_stash,
+        "backend_status",
+        lambda: {
+            "backend": None,
+            "fallback": False,
+            "unreachable_upgrade": None,
+            "ok": False,
+            "reason": "no_backend",
+        },
+    )
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-fake-not-a-key")
+    code = cmd_doctor(Namespace())
+    out = capsys.readouterr().out
+    assert "[FAIL] Memory" not in out
+    assert code in (0, 1)  # other checks decide; this one never contributes a FAIL

--- a/tests/unit/cli/test_memory_backend_choice.py
+++ b/tests/unit/cli/test_memory_backend_choice.py
@@ -1,0 +1,207 @@
+"""The three choosing surfaces for the memory backend (redis-config-truth D5).
+
+- ``attune memory use <auto|file|redis>`` records the preference and shows the
+  live status; invalid values and unwritable configs fail with a message.
+- The one-time terminal notice fires only on an interactive terminal, only
+  before a choice, only once, never for the choosing commands, and never
+  blocks a command with a prompt.
+- ``attune setup`` asks once on a terminal, prints the pointer otherwise, and
+  never fails on EOF, an unknown answer, or an unwritable config.
+
+Everything runs against a temporary ``ATTUNE_HOME``; ``backend_status`` is
+intercepted so no backend, server, or network is touched.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+from argparse import Namespace
+
+import pytest
+
+from attune.cli_commands import memory_commands as mc
+from attune.cli_commands import utility_commands as uc
+from attune.memory import preference as pref
+from attune.memory import session_stash
+
+_FILE_STATUS = {
+    "backend": "FileStashBackend",
+    "fallback": True,
+    "unreachable_upgrade": None,
+    "ok": True,
+    "transport": "file",
+    "reachability": "reachable",
+    "reason": None,
+    "preference": "auto",
+}
+
+
+class _Tty(io.StringIO):
+    def isatty(self) -> bool:
+        return True
+
+
+@pytest.fixture(autouse=True)
+def _isolated(tmp_path, monkeypatch):
+    monkeypatch.setenv("ATTUNE_HOME", str(tmp_path))
+    monkeypatch.delenv(pref.ENV_VAR, raising=False)
+    monkeypatch.delenv(pref.NOTICE_ENV_VAR, raising=False)
+    monkeypatch.setattr(session_stash, "backend_status", lambda: dict(_FILE_STATUS))
+
+
+# --- attune memory use -------------------------------------------------------
+
+
+@pytest.mark.parametrize("backend", ["auto", "file", "redis"])
+def test_memory_use_records_and_shows_status(backend, capsys) -> None:
+    code = mc.cmd_memory_use(Namespace(backend=backend))
+    out = capsys.readouterr().out
+    assert code == 0
+    assert f"Memory backend preference: {backend}" in out
+    assert "Recorded in" in out and "Preference:" in out and "Memory backend:" in out
+    assert json.loads(pref.config_path().read_text())["memory"]["backend"] == backend
+    if backend == "redis":
+        assert "enhanced memory features using Redis's open-source options" in out
+
+
+def test_memory_use_rejects_an_invalid_value(capsys) -> None:
+    assert mc.cmd_memory_use(Namespace(backend="both")) == 1
+    assert "must be one of" in capsys.readouterr().out
+    assert pref.preference_recorded() is False
+
+
+def test_memory_use_reports_an_unwritable_config(monkeypatch, capsys) -> None:
+    def _boom(value: str):
+        raise OSError(13, "Permission denied", "config.json")
+
+    monkeypatch.setattr(pref, "set_backend_preference", _boom)
+    assert mc.cmd_memory_use(Namespace(backend="file")) == 1
+    assert "Permission denied" in capsys.readouterr().out
+
+
+def test_status_prints_the_preference_line(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(
+        session_stash, "backend_status", lambda: {**_FILE_STATUS, "preference": "file"}
+    )
+    assert mc.cmd_memory_status(Namespace(json=False)) == 0
+    out = capsys.readouterr().out
+    assert out.startswith("Preference: file")
+    assert "attune memory use auto|file|redis" in out
+
+
+# --- the one-time terminal notice --------------------------------------------
+
+
+def test_notice_fires_once_on_a_tty_before_any_choice() -> None:
+    first, second = _Tty(), _Tty()
+    assert mc.first_run_memory_notice("doctor", stream=first) is True
+    assert "local file tier" in first.getvalue()
+    assert "enhanced memory features using Redis's open-source options" in first.getvalue()
+    assert "attune memory use auto|file|redis" in first.getvalue()
+    assert pref.notice_shown() is True
+    assert mc.first_run_memory_notice("doctor", stream=second) is False
+    assert second.getvalue() == ""
+
+
+def test_notice_is_silent_off_a_tty_and_for_the_choosing_commands() -> None:
+    assert mc.first_run_memory_notice("doctor", stream=io.StringIO()) is False
+    for command in ("memory", "setup"):
+        assert mc.first_run_memory_notice(command, stream=_Tty()) is False
+    assert pref.notice_shown() is False
+
+
+def test_notice_is_silent_once_a_choice_exists_or_when_disabled(monkeypatch) -> None:
+    pref.set_backend_preference("auto")
+    assert mc.first_run_memory_notice("doctor", stream=_Tty()) is False
+    monkeypatch.setenv(pref.ENV_VAR, "")  # no env override; config choice stands
+    monkeypatch.setattr(pref, "preference_recorded", lambda: False)
+    monkeypatch.setenv(pref.NOTICE_ENV_VAR, "0")
+    assert mc.first_run_memory_notice("doctor", stream=_Tty()) is False
+
+
+def test_notice_survives_an_unwritable_home(monkeypatch) -> None:
+    def _boom():
+        raise OSError("read-only home")
+
+    monkeypatch.setattr(pref, "mark_notice_shown", _boom)
+    stream = _Tty()
+    assert mc.first_run_memory_notice("doctor", stream=stream) is True
+    assert "local file tier" in stream.getvalue()
+
+
+def test_cli_main_calls_the_notice(monkeypatch) -> None:
+    from attune import cli_minimal
+
+    seen: list = []
+    monkeypatch.setattr(
+        cli_minimal, "first_run_memory_notice", lambda command, stream=None: seen.append(command)
+    )
+    monkeypatch.setattr(cli_minimal, "_dispatch_subcommand", lambda args, command: 0, raising=False)
+    try:
+        cli_minimal.main(["memory", "status"])
+    except SystemExit:
+        pass
+    assert seen == ["memory"]
+
+
+# --- attune setup prompt -----------------------------------------------------
+
+
+def _tty_stdio(monkeypatch, answer: str | None) -> None:
+    monkeypatch.setattr(uc.sys, "stdin", _Tty())
+    monkeypatch.setattr(uc.sys, "stdout", _Tty())
+    if answer is None:
+        monkeypatch.setattr("builtins.input", lambda prompt="": (_ for _ in ()).throw(EOFError()))
+    else:
+        monkeypatch.setattr("builtins.input", lambda prompt="": answer)
+
+
+def test_setup_prompt_records_a_terminal_answer(monkeypatch) -> None:
+    _tty_stdio(monkeypatch, "redis")
+    uc._memory_backend_setup_prompt()
+    out = uc.sys.stdout.getvalue()
+    assert "Memory backend preference: redis" in out
+    assert pref.get_backend_preference() == "redis"
+
+
+def test_setup_prompt_defaults_to_auto_on_empty_answer(monkeypatch) -> None:
+    _tty_stdio(monkeypatch, "")
+    uc._memory_backend_setup_prompt()
+    assert pref.get_backend_preference() == "auto" and pref.preference_recorded() is True
+
+
+def test_setup_prompt_ignores_an_unknown_answer_and_eof(monkeypatch) -> None:
+    _tty_stdio(monkeypatch, "cloud")
+    uc._memory_backend_setup_prompt()
+    assert "leaving it at auto" in uc.sys.stdout.getvalue()
+    assert pref.preference_recorded() is False
+    _tty_stdio(monkeypatch, None)
+    uc._memory_backend_setup_prompt()
+    assert pref.preference_recorded() is False
+
+
+def test_setup_prompt_prints_pointer_off_a_tty(monkeypatch) -> None:
+    monkeypatch.setattr(uc.sys, "stdin", io.StringIO())
+    monkeypatch.setattr(uc.sys, "stdout", io.StringIO())
+    uc._memory_backend_setup_prompt()
+    out = uc.sys.stdout.getvalue()
+    assert "Choose later with: attune memory use" in out
+    assert pref.preference_recorded() is False
+
+
+def test_setup_prompt_is_silent_once_chosen(monkeypatch) -> None:
+    pref.set_backend_preference("file")
+    _tty_stdio(monkeypatch, "redis")
+    uc._memory_backend_setup_prompt()
+    assert uc.sys.stdout.getvalue() == ""
+    assert pref.get_backend_preference() == "file"
+
+
+def test_setup_prompt_reports_an_unwritable_config(monkeypatch) -> None:
+    _tty_stdio(monkeypatch, "file")
+    monkeypatch.setattr(
+        pref, "set_backend_preference", lambda v: (_ for _ in ()).throw(OSError("read-only"))
+    )
+    uc._memory_backend_setup_prompt()
+    assert "Could not record the choice" in uc.sys.stdout.getvalue()

--- a/tests/unit/hooks/test_memory_backend_notice.py
+++ b/tests/unit/hooks/test_memory_backend_notice.py
@@ -1,0 +1,108 @@
+"""Tests for memory_backend_notice.py SessionStart hook (redis-config-truth D5).
+
+Mirrors the usage-consent notice tests:
+- Emits the notice when no preference is recorded and the hook is enabled
+- No-op once a preference exists (config or ATTUNE_MEMORY_BACKEND)
+- No-op when disabled via ATTUNE_MEMORY_NOTICE=0
+- No-op on the post-compact SessionStart source
+- Anti-nag cap: stops after _MAX_SHOWS and bumps the count each emit
+- Unreadable config counts as "no choice yet"
+- Hook never raises (script-level catch-all)
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+_HOOKS_DIR = Path(__file__).resolve().parents[3] / "plugin" / "hooks"
+
+
+def _load_module(name: str):
+    if str(_HOOKS_DIR) not in sys.path:
+        sys.path.insert(0, str(_HOOKS_DIR))
+    if name in sys.modules:
+        del sys.modules[name]
+    spec = importlib.util.spec_from_file_location(name, _HOOKS_DIR / f"{name}.py")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def hook(tmp_path, monkeypatch):
+    monkeypatch.setenv("ATTUNE_HOME", str(tmp_path))
+    monkeypatch.delenv("ATTUNE_MEMORY_NOTICE", raising=False)
+    monkeypatch.delenv("ATTUNE_MEMORY_BACKEND", raising=False)
+    return _load_module("memory_backend_notice")
+
+
+def _run(hook, monkeypatch, capsys, payload: dict | None = None) -> str:
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(payload or {"source": "startup"})))
+    assert hook.main() == 0
+    return capsys.readouterr().out
+
+
+def _record(tmp_path: Path, backend: str) -> None:
+    (tmp_path / "config.json").write_text(json.dumps({"memory": {"backend": backend}}))
+
+
+def test_emits_notice_with_the_choice_and_the_action_for_claude(
+    hook, monkeypatch, capsys, tmp_path
+) -> None:
+    out = _run(hook, monkeypatch, capsys)
+    assert "Memory backend (one-time choice)" in out
+    assert "enhanced memory features using Redis's open-source options" in out
+    assert "attune memory use" in out and "ACTION FOR CLAUDE" in out
+    assert (tmp_path / "telemetry" / ".memory_notice_count").read_text() == "1"
+
+
+def test_silent_once_a_preference_is_recorded(hook, monkeypatch, capsys, tmp_path) -> None:
+    _record(tmp_path, "file")
+    assert _run(hook, monkeypatch, capsys) == ""
+
+
+def test_env_override_counts_as_a_choice(hook, monkeypatch, capsys) -> None:
+    monkeypatch.setenv("ATTUNE_MEMORY_BACKEND", "redis")
+    assert _run(hook, monkeypatch, capsys) == ""
+
+
+def test_disabled_by_env(hook, monkeypatch, capsys) -> None:
+    monkeypatch.setenv("ATTUNE_MEMORY_NOTICE", "0")
+    assert _run(hook, monkeypatch, capsys) == ""
+
+
+def test_silent_on_post_compact_source(hook, monkeypatch, capsys) -> None:
+    assert _run(hook, monkeypatch, capsys, {"source": "compact"}) == ""
+
+
+def test_anti_nag_cap_stops_after_max_shows(hook, monkeypatch, capsys) -> None:
+    for _ in range(hook._MAX_SHOWS):
+        assert "Memory backend" in _run(hook, monkeypatch, capsys)
+    assert _run(hook, monkeypatch, capsys) == ""
+
+
+def test_unreadable_config_means_no_choice_yet(hook, monkeypatch, capsys, tmp_path) -> None:
+    (tmp_path / "config.json").write_text("{not json")
+    assert "Memory backend" in _run(hook, monkeypatch, capsys)
+
+
+def test_non_json_stdin_is_treated_as_startup(hook, monkeypatch, capsys) -> None:
+    monkeypatch.setattr(sys, "stdin", io.StringIO("not json"))
+    assert hook.main() == 0
+    assert "Memory backend" in capsys.readouterr().out
+
+
+def test_hook_never_raises(hook, monkeypatch, capsys) -> None:
+    monkeypatch.setattr(
+        hook, "_preference_recorded", lambda: (_ for _ in ()).throw(RuntimeError("boom"))
+    )
+    monkeypatch.setattr(sys, "stdin", io.StringIO("{}"))
+    assert hook.main() == 0
+    assert "boom" in capsys.readouterr().err

--- a/tests/unit/memory/test_backend_preference.py
+++ b/tests/unit/memory/test_backend_preference.py
@@ -1,0 +1,165 @@
+"""Memory backend preference and the resolver honoring it (redis-config-truth D5).
+
+Redis stays bundled and zero-config; the user's recorded choice —
+``auto`` / ``file`` / ``redis`` — is persisted in the user config and
+honored by ``resolve_backend`` and ``backend_status``. Every test here
+runs against a temporary ``ATTUNE_HOME`` and fake entry points: no real
+backend, no server, no network.
+"""
+
+from __future__ import annotations
+
+import importlib.metadata as md
+import json
+
+import pytest
+
+from attune.memory import preference as pref
+from attune.memory import session_stash as ss
+
+
+@pytest.fixture(autouse=True)
+def _isolated_home(tmp_path, monkeypatch):
+    monkeypatch.setenv("ATTUNE_HOME", str(tmp_path))
+    monkeypatch.delenv(pref.ENV_VAR, raising=False)
+    monkeypatch.delenv(pref.NOTICE_ENV_VAR, raising=False)
+
+
+class _Backend:
+    """Duck-typed searchable backend; records whether it was probed."""
+
+    def __init__(self, name: str, *, fallback: bool = False, connected: bool = True):
+        self.name = name
+        self.is_fallback = fallback
+        self._connected = connected
+        self.probed = 0
+
+    def is_connected(self) -> bool:
+        self.probed += 1
+        return self._connected
+
+    def search(self, *a, **k):  # pragma: no cover - duck typing only
+        return []
+
+    def stash(self, *a, **k):  # pragma: no cover - duck typing only
+        return None
+
+
+class _EP:
+    def __init__(self, name: str, instance: _Backend):
+        self.name = name
+        self._instance = instance
+
+    def load(self):
+        return lambda: self._instance
+
+
+def _install(monkeypatch, *backends: _Backend) -> None:
+    eps = [_EP(b.name, b) for b in backends]
+    monkeypatch.setattr(md, "entry_points", lambda group=None: eps)
+
+
+# --- the store ---------------------------------------------------------------
+
+
+def test_default_is_auto_and_nothing_recorded() -> None:
+    assert pref.get_backend_preference() == "auto"
+    assert pref.preference_recorded() is False
+    assert pref.notice_shown() is False
+
+
+def test_set_round_trips_and_preserves_other_config_keys(tmp_path) -> None:
+    path = pref.config_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps({"telemetry": {"usage_ping_consented": True}}), encoding="utf-8")
+    written = pref.set_backend_preference("file")
+    assert written.resolve() == path.resolve()
+    data = json.loads(path.read_text(encoding="utf-8"))
+    assert data["memory"]["backend"] == "file"
+    assert data["telemetry"] == {"usage_ping_consented": True}, "sibling keys must survive"
+    assert pref.get_backend_preference() == "file"
+    assert pref.preference_recorded() is True
+    assert not list(path.parent.glob("*.tmp")), "atomic write leaves no temp file"
+
+
+@pytest.mark.parametrize("bad", ["", "redis-please", "FILE", "both"])
+def test_invalid_values_are_rejected(bad) -> None:
+    with pytest.raises(ValueError, match="must be one of"):
+        pref.set_backend_preference(bad)
+
+
+def test_env_override_wins_but_does_not_count_as_recorded(monkeypatch) -> None:
+    pref.set_backend_preference("file")
+    monkeypatch.setenv(pref.ENV_VAR, "redis")
+    assert pref.get_backend_preference() == "redis"
+    monkeypatch.setenv(pref.ENV_VAR, "nonsense")
+    assert pref.get_backend_preference() == "file", "an invalid override is ignored"
+
+
+def test_unreadable_or_non_object_config_means_no_choice() -> None:
+    path = pref.config_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("[]", encoding="utf-8")
+    assert pref.get_backend_preference() == "auto"
+    path.write_text("{not json", encoding="utf-8")
+    assert pref.preference_recorded() is False
+
+
+def test_notice_shown_flag_round_trips() -> None:
+    pref.mark_notice_shown()
+    assert pref.notice_shown() is True
+    assert pref.preference_recorded() is False, "the notice flag is not a choice"
+
+
+def test_notice_enabled_honors_env(monkeypatch) -> None:
+    assert pref.notice_enabled() is True
+    for value in ("0", "false", "off", "no", ""):
+        monkeypatch.setenv(pref.NOTICE_ENV_VAR, value)
+        assert pref.notice_enabled() is False
+
+
+# --- the resolver ------------------------------------------------------------
+
+
+def test_auto_prefers_a_connected_upgrade(monkeypatch) -> None:
+    file_tier, upgrade = _Backend("file", fallback=True), _Backend("redis")
+    _install(monkeypatch, file_tier, upgrade)
+    assert ss.resolve_backend() is upgrade
+
+
+def test_file_preference_never_probes_the_upgrade(monkeypatch) -> None:
+    pref.set_backend_preference("file")
+    file_tier, upgrade = _Backend("file", fallback=True), _Backend("redis")
+    _install(monkeypatch, file_tier, upgrade)
+    assert ss.resolve_backend() is file_tier
+    assert upgrade.probed == 0, "a chosen file tier must not cost a connectivity probe"
+    status = ss.backend_status()
+    assert status["preference"] == "file"
+    assert status["unreachable_upgrade"] is None, "an unprobed upgrade is not 'dark'"
+    assert status["fallback"] is True
+
+
+def test_redis_preference_degrades_to_file_and_reports_the_dark_upgrade(monkeypatch) -> None:
+    pref.set_backend_preference("redis")
+    file_tier, upgrade = _Backend("file", fallback=True), _Backend("redis", connected=False)
+    _install(monkeypatch, file_tier, upgrade)
+    assert ss.resolve_backend() is file_tier
+    status = ss.backend_status()
+    assert status["preference"] == "redis"
+    assert status["unreachable_upgrade"] == "redis"
+
+
+def test_redis_preference_uses_the_upgrade_when_reachable(monkeypatch) -> None:
+    pref.set_backend_preference("redis")
+    file_tier, upgrade = _Backend("file", fallback=True), _Backend("redis")
+    _install(monkeypatch, file_tier, upgrade)
+    assert ss.resolve_backend() is upgrade
+    assert ss.backend_status()["backend"] == "_Backend"
+
+
+def test_env_override_reaches_the_resolver(monkeypatch) -> None:
+    monkeypatch.setenv(pref.ENV_VAR, "file")
+    file_tier, upgrade = _Backend("file", fallback=True), _Backend("redis")
+    _install(monkeypatch, file_tier, upgrade)
+    assert ss.resolve_backend() is file_tier
+    assert upgrade.probed == 0

--- a/tests/unit/memory/test_session_stash.py
+++ b/tests/unit/memory/test_session_stash.py
@@ -569,6 +569,7 @@ def test_backend_status_no_backends():
         "transport": "none",
         "reachability": "unknown",
         "reason": "no_backend",
+        "preference": "auto",
     }
 
 

--- a/tests/unit/test_cli_memory_commands.py
+++ b/tests/unit/test_cli_memory_commands.py
@@ -9,6 +9,7 @@ Licensed under Apache 2.0
 
 from __future__ import annotations
 
+from argparse import Namespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -532,3 +533,125 @@ class TestCmdMemoryForgetTopic:
 
         assert result == 1
         assert "Error:" in capsys.readouterr().out
+
+
+class TestMemoryStatus:
+    """``attune memory status`` makes the backend state visible (redis-config-truth D5)."""
+
+    @staticmethod
+    def _status(monkeypatch, status: dict) -> None:
+        from attune.memory import session_stash
+
+        monkeypatch.setattr(session_stash, "backend_status", lambda: status)
+
+    def test_zero_config_file_tier_says_redis_is_optional(self, monkeypatch, capsys) -> None:
+        from attune.cli_commands.memory_commands import cmd_memory_status
+
+        self._status(
+            monkeypatch,
+            {
+                "backend": "FileStashBackend",
+                "fallback": True,
+                "unreachable_upgrade": None,
+                "ok": True,
+                "transport": "file",
+                "reachability": "reachable",
+                "reason": None,
+            },
+        )
+        code = cmd_memory_status(Namespace(json=False))
+        out = capsys.readouterr().out
+        assert code == 0
+        assert "zero-config default" in out and "Redis is optional" in out
+        assert "AMS_BASE_URL" in out
+
+    def test_dark_upgrade_is_reported_as_degraded(self, monkeypatch, capsys) -> None:
+        from attune.cli_commands.memory_commands import cmd_memory_status
+
+        self._status(
+            monkeypatch,
+            {
+                "backend": "FileStashBackend",
+                "fallback": True,
+                "unreachable_upgrade": "redis",
+                "ok": True,
+                "transport": "file",
+                "reachability": "reachable",
+                "reason": None,
+            },
+        )
+        code = cmd_memory_status(Namespace(json=False))
+        out = capsys.readouterr().out
+        assert code == 0
+        assert "DEGRADED" in out and "'redis' is unreachable" in out and "dark" in out
+
+    def test_live_upgrade_backend(self, monkeypatch, capsys) -> None:
+        from attune.cli_commands.memory_commands import cmd_memory_status
+
+        self._status(
+            monkeypatch,
+            {
+                "backend": "AMSMemoryBackend",
+                "fallback": False,
+                "unreachable_upgrade": None,
+                "ok": True,
+                "transport": "direct",
+                "reachability": "reachable",
+                "reason": None,
+            },
+        )
+        code = cmd_memory_status(Namespace(json=False))
+        out = capsys.readouterr().out
+        assert code == 0
+        assert "AMSMemoryBackend (direct, reachable)" in out and "live at" in out
+
+    def test_unusable_backend_exits_one_with_reason(self, monkeypatch, capsys) -> None:
+        from attune.cli_commands.memory_commands import cmd_memory_status
+
+        self._status(
+            monkeypatch,
+            {
+                "backend": None,
+                "fallback": False,
+                "unreachable_upgrade": None,
+                "ok": False,
+                "transport": "none",
+                "reachability": "unreachable_local",
+                "reason": "file_write_denied",
+            },
+        )
+        code = cmd_memory_status(Namespace(json=False))
+        out = capsys.readouterr().out
+        assert code == 1 and "NOT USABLE" in out and "file_write_denied" in out
+
+    def test_json_prints_the_raw_mapping(self, monkeypatch, capsys) -> None:
+        import json
+
+        from attune.cli_commands.memory_commands import cmd_memory_status
+
+        status = {
+            "backend": "FileStashBackend",
+            "fallback": True,
+            "unreachable_upgrade": None,
+            "ok": True,
+            "transport": "file",
+            "reachability": "reachable",
+            "reason": None,
+        }
+        self._status(monkeypatch, status)
+        code = cmd_memory_status(Namespace(json=True))
+        assert code == 0
+        assert json.loads(capsys.readouterr().out) == status
+
+    def test_ams_url_falls_back_when_plugin_absent(self, monkeypatch) -> None:
+        import sys
+
+        from attune.cli_commands.memory_commands import _ams_base_url
+
+        monkeypatch.setitem(sys.modules, "attune_redis", None)
+        monkeypatch.setitem(sys.modules, "attune_redis.config", None)
+        assert _ams_base_url() == "http://localhost:8000"
+        monkeypatch.setenv("AMS_BASE_URL", "http://10.0.0.5:8000")
+        monkeypatch.delitem(sys.modules, "attune_redis", raising=False)
+        monkeypatch.delitem(sys.modules, "attune_redis.config", raising=False)
+        assert _ams_base_url() == "http://10.0.0.5:8000"


### PR DESCRIPTION
## Summary

**redis-config-truth D5, reworked to the chair's corrected goal** (assumption review 2026-09-06; D5 is now recorded in the chair's own words). Redis stays **bundled and zero-config**; the backend **state is visible**; **a first-run notice lets users choose**; the choice is a **persisted preference the resolver honors**.

> Redis's primary goal is to "provide enhanced memory features using Redis's open source coding options." — the chair; stated wherever the choice is offered (`attune.memory.preference.REDIS_ROLE`).

### What lands

- **Preference store** — `attune.memory.preference`: `memory.backend = auto | file | redis` in the user config (`~/.attune/config.json`, `ATTUNE_HOME`-aware, atomic write, sibling keys preserved). `ATTUNE_MEMORY_BACKEND` overrides per process; `ATTUNE_MEMORY_NOTICE=0` silences the notices.
- **Resolver honors it** — `resolve_backend` / `backend_status`: `file` never probes the Redis upgrade and never reports it dark; `redis` prefers the Agent Memory Server and degrades to files loudly; `auto` is unchanged (a reachable upgrade wins). `backend_status` carries `preference` (additive key).
- **Four choosing surfaces** — a SessionStart hook `plugin/hooks/memory_backend_notice.py` (the consent-notice pattern: once, anti-nag ×3, never post-compact, "ACTION FOR CLAUDE: ask once, then `attune memory use`"), registered in `hooks.json`; a one-time notice on the first interactive `attune` run (informs and points at the choosing commands — it never blocks a command with a prompt, which is the one deliberate narrowing of "first terminal run"); an interactive prompt at the end of `attune setup` (terminal only; EOF, unknown answers and unwritable configs never fail setup); `attune memory use <auto|file|redis>`.
- **Visible state** (from v1 of this PR) — `attune memory status` (`--json`) now leads with the preference; `attune doctor`'s "Memory backend" line never contributes a FAIL.
- **Records** — D5 rewritten in the chair's words with the positions, the counter-case and a process note; README memory paragraph; CHANGELOG; the empty-alias comment in `pyproject.toml` corrected.
- **Producer baseline regenerated** for the new hook: +1 registration, +1 `context_stdout` envelope, +1 helper edge, 0 problems (reviewed). **Coordination:** #2444 embeds the baseline — whichever of #2444 / #2446 lands second regenerates it.

## Receipts

| Claim | Probe | Result |
| --- | --- | --- |
| Store + resolver: `file` never probes the upgrade; `redis` degrades and reports dark; env override reaches the resolver | `tests/unit/memory/test_backend_preference.py` (fake entry points) | 14 passed; `preference.py` 100% |
| Hook: emits once, silent after a choice / env override / disable / post-compact, anti-nag cap, never raises | `tests/unit/hooks/test_memory_backend_notice.py` | 9 passed |
| `memory use`, status preference line, terminal notice (tty-only, once, never for the choosing commands, survives read-only home), setup prompt (answer / default / unknown / EOF / non-tty / unwritable) | `tests/unit/cli/test_memory_backend_choice.py` + memory-command tests | 14 + 6 passed |
| Changed modules ≥ 90% | `--cov` on `preference` 100%, `session_stash` 96.2%, `memory_commands` 92.8%; `utility_commands` module total 85.0% (pre-existing setup file-copy paths; the new helper is fully covered) | pass |
| Ratchets + gates + touched suites | `tests/unit/gates tests/unit/quality tests/unit/cli tests/unit/cli_commands tests/unit/hooks tests/unit/memory` | 4045 passed (parity gate green on the regenerated baseline) |
| Whole tree | `pytest tests -n auto`, captured — macOS, py3.11, warm caches, integration lane skipped by `--cov` | 25579 passed, 266 skipped, 3 xfailed |
| Pinned hooks | pre-commit on every changed file | Passed |
| Live | `attune memory status` on this machine | `Preference: auto` + `AMSMemoryBackend (direct, reachable)` |

Not armed. D5 is lead-authored spec text (D11 class): the chair reads it before the merge word. Handoff: `docs/handoffs/claude-redis-state-visible.md`. Friction fixes follow the running Redis audit chip (`task_af6763f5`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
