### PR TITLE
chore(retro): 2026-09-06 do-now batch — tiktoken CI cache, ci_failures triage, worktree-add guard, quality ratchet in preflight, D13 + D5-R5

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -50,6 +50,12 @@
             "command": "PY=$(command -v python3 || command -v python) && \"$PY\" \"$CLAUDE_PROJECT_DIR/src/attune/hooks/scripts/security_guard.py\"",
             "timeout": 5,
             "statusMessage": "Security check..."
+          },
+          {
+            "type": "command",
+            "command": "PY=$(command -v python3 || command -v python) && \"$PY\" \"$CLAUDE_PROJECT_DIR/src/attune/hooks/scripts/worktree_add_guard.py\"",
+            "timeout": 5,
+            "statusMessage": "Worktree-add check..."
           }
         ]
       },

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -144,6 +144,24 @@ jobs:
         python -m pip install --upgrade pip
         pip install -e .[dev]
 
+    # Retro 2026-09-06 (R2): tiktoken fetches cl100k_base over HTTPS on first
+    # use. Warm it once, OUTSIDE pytest, into a cached dir so the suite never
+    # touches the network for it — the test-time inference guard blocks that
+    # download, and 40 tests went red for the same one file.
+    - name: Cache tiktoken encodings
+      if: needs.changes.outputs.website_only != 'true'
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: ${{ runner.temp }}/tiktoken-cache
+        key: tiktoken-cl100k_base-${{ runner.os }}
+
+    - name: Warm tiktoken encoding
+      if: needs.changes.outputs.website_only != 'true'
+      shell: bash
+      run: python -c "import tiktoken; tiktoken.get_encoding('cl100k_base')" || echo "::warning::tiktoken warm-up failed; encoding tests will try the network"
+      env:
+        TIKTOKEN_CACHE_DIR: ${{ runner.temp }}/tiktoken-cache
+
     - name: Run tests
       if: needs.changes.outputs.website_only != 'true'
       # --timeout=60 + --timeout-method=thread: names a hanging test (with a
@@ -175,6 +193,7 @@ jobs:
       run: |
         pytest -n auto --timeout=60 --timeout-method=thread -m "not network and not integration"
       env:
+        TIKTOKEN_CACHE_DIR: ${{ runner.temp }}/tiktoken-cache  # warmed above; keeps the suite offline for cl100k_base
         ANTHROPIC_API_KEY: ""  # keyless by design — live-key CI burned $1200+ on 2026-06-10 (mismarked tests make real API calls when keyed); the real secret is for integration-auth.yml + deliberate dispatches ONLY
 
     - name: Run security and workflow tests
@@ -263,6 +282,24 @@ jobs:
         python -m pip install --upgrade pip
         pip install -e .[dev]
 
+    # Retro 2026-09-06 (R2): tiktoken fetches cl100k_base over HTTPS on first
+    # use. Warm it once, OUTSIDE pytest, into a cached dir so the suite never
+    # touches the network for it — the test-time inference guard blocks that
+    # download, and 40 tests went red for the same one file.
+    - name: Cache tiktoken encodings
+      if: needs.changes.outputs.website_only != 'true'
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: ${{ runner.temp }}/tiktoken-cache
+        key: tiktoken-cl100k_base-${{ runner.os }}
+
+    - name: Warm tiktoken encoding
+      if: needs.changes.outputs.website_only != 'true'
+      shell: bash
+      run: python -c "import tiktoken; tiktoken.get_encoding('cl100k_base')" || echo "::warning::tiktoken warm-up failed; encoding tests will try the network"
+      env:
+        TIKTOKEN_CACHE_DIR: ${{ runner.temp }}/tiktoken-cache
+
     - name: Run unit suite under ${{ matrix.tz }}
       if: needs.changes.outputs.website_only != 'true'
       shell: bash
@@ -271,6 +308,7 @@ jobs:
         pytest -n auto --timeout=60 --timeout-method=thread -m "not network and not integration"
       env:
         TZ: ${{ matrix.tz }}
+        TIKTOKEN_CACHE_DIR: ${{ runner.temp }}/tiktoken-cache  # warmed above; keeps the suite offline for cl100k_base
         ANTHROPIC_API_KEY: ""  # keyless by design — see the `test` job note
 
   coverage:
@@ -312,6 +350,24 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -e .[dev]
+
+    # Retro 2026-09-06 (R2): tiktoken fetches cl100k_base over HTTPS on first
+    # use. Warm it once, OUTSIDE pytest, into a cached dir so the suite never
+    # touches the network for it — the test-time inference guard blocks that
+    # download, and 40 tests went red for the same one file.
+    - name: Cache tiktoken encodings
+      if: needs.changes.outputs.website_only != 'true'
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: ${{ runner.temp }}/tiktoken-cache
+        key: tiktoken-cl100k_base-${{ runner.os }}
+
+    - name: Warm tiktoken encoding
+      if: needs.changes.outputs.website_only != 'true'
+      shell: bash
+      run: python -c "import tiktoken; tiktoken.get_encoding('cl100k_base')" || echo "::warning::tiktoken warm-up failed; encoding tests will try the network"
+      env:
+        TIKTOKEN_CACHE_DIR: ${{ runner.temp }}/tiktoken-cache
 
     # Catch README badge rot: fails if the tests-count floor over-claims or
     # drifts far below the real collected count, or if coverage regressed to a
@@ -363,6 +419,7 @@ jobs:
         # uploads hang-dumps/) remain as the backstop.
         pytest -n auto --cov=src/attune --cov-report=xml --cov-fail-under=94 --timeout=60 --timeout-method=thread -m "not network and not integration"
       env:
+        TIKTOKEN_CACHE_DIR: ${{ runner.temp }}/tiktoken-cache  # warmed above; keeps the suite offline for cl100k_base
         ANTHROPIC_API_KEY: ""  # keyless by design — live-key CI burned $1200+ on 2026-06-10 (mismarked tests make real API calls when keyed); the real secret is for integration-auth.yml + deliberate dispatches ONLY
 
     - name: Track per-file test results

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Worktree-add guard hook** (`src/attune/hooks/scripts/
+  worktree_add_guard.py`, retro 2026-09-06 R8). A PreToolUse Bash hook
+  that refuses `git worktree add` from a session already running inside
+  `.claude/worktrees/` — a sibling worktree created there is unwritable
+  (the worktree path guard refuses every Edit/Write into it), so the
+  refusal names the fix at creation time: switch branches in place.
+  `git worktree list/remove/prune` and creation from the main checkout
+  stay allowed; `ATTUNE_ALLOW_NESTED_WORKTREE=1` is the escape hatch.
+  Registered in the repo's `.claude/settings.json` alongside the
+  sibling guards; fires to the enforcement-metrics log like them.
+- **`scripts/ci_failures.py`** — per-job CI failure extraction that
+  anchors on pytest's own `FAILED`/`ERROR`/summary/`INTERNALERROR`
+  lines (retro R4), so a test NAME containing "failed" can never be
+  reported as a failure. `python scripts/ci_failures.py <run-id>` or
+  `--log job.log`; exit 1 when any job is red.
+
 - **`attune memory status` and a doctor "Memory backend" line**
   (redis-config-truth D5, 2026-09-06). Redis stays optional and
   zero-config; the state stops being silent. `attune memory status`

--- a/docs/specs/host-surface-parity/decisions.md
+++ b/docs/specs/host-surface-parity/decisions.md
@@ -711,70 +711,79 @@ and the lead reported success unverified until the chair said "I don't
 see it". Three `form_rendered` telemetry rows from this session never
 reached a screen: a live R10 tier-provenance data point.
 
-## D13 — The parity registry's binding to the producer baseline: digest pin by default, bare reference only if Codex concurs (PROPOSED 2026-09-06; chair's conditional recorded; the chair rules after Codex answers on #2444)
+## D13 — The parity registry binds to the producer baseline by DIGEST PIN (PROPOSED 2026-09-06 with the chair's conditional satisfied by Codex's hearing; awaiting the chair's ruling word)
 
 **Status and provenance.** First written by the lead as "RULED, chair"
 straight from the retro's `do now` on R3, without the assumption review
 or the counter-case it owed (D11d). The chair flagged it: "re 2447 D13
-needs discussion." The discussion put three shapes side by side; the
-chair's lean, verbatim: *"a digest pin that preserves the forcing
-function with a one-line diff instead of a 650-line copy. This sounds
-like a better option."* A form answer that crossed with that message
-picked bare reference and "rewrite as RULED"; asked which stood, the
-chair answered, verbatim: *"1 y, 2y if Codex concurs , 3 y"* — decoded
-with the three numbered options as put: (1) the digest pin stands as
-the default shape; (2) bare reference is acceptable ONLY if Codex
-concurs that it loses nothing its obligations or gates rely on; (3)
-D13 stays PROPOSED until Codex answers the hearing request on #2444,
-and the chair rules then, from the shapes below. This entry may merge
-as PROPOSED; a merge word on #2447 does not promote it.
+needs discussion." Three shapes were put side by side; the chair's lean,
+verbatim: *"a digest pin that preserves the forcing function with a
+one-line diff instead of a 650-line copy. This sounds like a better
+option."* A crossed form answer picked bare reference; asked which stood,
+the chair answered, verbatim: *"1 y, 2y if Codex concurs , 3 y"* — (1)
+the digest pin stands as the default; (2) bare reference only if Codex
+concurs it loses nothing; (3) PROPOSED until Codex answers, then the
+chair rules. Codex was heard (read-only, against #2444 head `f959377dd`,
+2026-09-06 ~07:40Z, relayed by the chair); its closing line, verbatim:
+*"Recommendation: digest pin — preserve the complete reviewed-baseline
+binding with one stored canonical digest, retain the existing semantic
+checks, and pass verified baseline content to experiment validation; I
+do not concur that a bare reference loses nothing."* Under the chair's
+conditional, (2) is closed and (1) is the shape. The chair's ruling word
+promotes this entry; nothing else does.
 
-**The three shapes, and why the middle one.**
+**The three shapes.**
 
 1. *Embedded copy* (#2444 as opened): `parity-registry.json` carries a
-   full copy of `producer_baseline.json` and the gate asserts equality.
-   Forcing function: ANY fixture change breaks the gate and someone
-   re-derives the obligations. Cost: a ~650-line twin of a reviewed
-   fixture (principle 3 tension) and a 650-line diff on every regen.
-2. *Bare reference* (D13 as first written): the registry names the
-   fixture path and schema version; the gate loads the fixture at test
-   time. Cost the counter-case exposed: Codex's 152 obligations are
-   DERIVED from the baseline, and by reference only a root add/remove
-   forces a registry edit — an existing subject's producer set can change
-   (a hook growing a `pretooluse_deny` producer beside its
-   `exit2_stderr` one) and pass with no re-derivation.
-3. *Digest pin* (the lean): the registry records the fixture's path,
-   schema version, and a content digest. Any fixture change breaks the
-   gate, so re-derivation stays forced exactly as with the copy; the diff
-   on regen is one line; it is the idiom #2444 already uses for every
-   other pin (`fixture_digest`, `registry_digest`).
+   full copy of `producer_baseline.json`; `validate_inventory` rejects an
+   unequal copy before validating producers. Codex: the copy is a
+   snapshot, not extra parity semantics; its one real advantage is local
+   readability of the snapshot inside the registry. Cost: a ~650-line
+   twin of a reviewed fixture (principle 3) and a 650-line diff per regen.
+2. *Bare reference*: path + schema version, fixture loaded at test time.
+   What it loses (Codex, confirmed by the lead's re-run): the mandatory
+   registry acknowledgment of baseline changes that the semantic
+   validators do not consume — e.g. a renderer call's recorded `syntax`
+   (`direct | reexport | qualified`) is stored in the baseline and read by
+   nothing in `surface_registry.py`; copy equality or a content digest
+   still surfaces that change, a bare reference does not.
+3. *Digest pin*: `producer_baseline: {path, schema_version, digest}`
+   with `digest = canonical_digest(fixture)` (the SHA-256 over canonical
+   JSON #2444 already ships at `surface_registry.py:59-62`). Same
+   complete-baseline binding as the copy, one stored line, same regen
+   forcing function.
 
-**What the lead is assuming (for the chair's read to check).**
+**Correction to the lead's counter-case (Codex, verified).** The lead
+claimed that by reference "only a root add/remove forces a registry
+edit" and that a hook growing a `pretooluse_deny` producer beside its
+`exit2_stderr` one would pass unreviewed. Both wrong: `validate_producers`
+requires each subject's exact `producer_anchors` list (helper provenance
+included) and exactly one subject per root, and `_validate_hook_routes`
+compares the full set of `(event, matcher, signature, sink, destination)`
+tuples against declared delivery routes — so both changes already fail
+without any copy or pin. "Unreviewed" was also too strong: the
+scan-vs-fixture gate still forces a fixture diff. The real gap is the
+one in shape 2 above. Neither copy nor pin proves a human re-derived the
+obligations rather than refreshing a value.
 
-- A1. "Digest" is the content digest of the reviewed fixture file
-  (canonical JSON, same `canonical_digest` helper #2444 ships), distinct
-  from `registry_digest`.
-- A2. The pin lives in `parity-registry.json` under `producer_baseline`
-  as `{path, schema_version, digest}`, replacing the copy; the check
-  lives beside the existing subject-vs-root validation in the gate.
-- A3. The failure names both digests and the regen command, so the
-  message is "registry derived from a baseline that no longer exists —
-  regenerate, re-derive, review", never a bare mismatch.
-- A4. "One-line diff" describes the pin. Obligations derived from a NEW
-  subject still need their own registry entries; that is the forcing
-  function, not a cost to remove.
-- A5. Codex applies this on #2444's rebase onto main (which already
-  regenerates the fixture for the #2446 hook subject and the retro PR's
-  `worktree_add_guard` producer). #2447 changes no registry code.
+**Migration scope (Codex, verified — not a one-line code change).**
+`validate_experiments` reads `registry["producer_baseline"]["shipped_roots"]`
+directly; with a pin it must receive the validated, resolved baseline (or
+its shipped roots), and the synthetic tests that supply the embedded
+shape (`test_surface_parity.py` ~729, ~922, ~1372) migrate with it.
+`InventoryReport.registry_digest` hashes the whole registry and stays
+transitive through the pin: validate the resolved fixture against the pin
+before issuing a report. `surface_evidence.py` has no producer-baseline
+dependency. The mismatch diagnostic — today only "reviewed baseline
+drift" — names expected and actual digests plus the regenerate /
+re-derive / review command. The JSON diff on regen is one line; the code
+migration is small and bounded to the above.
 
-**Application (on the ruling).** Codex applies the ruled shape in
-#2444's rebase — the digest pin unless the chair rules bare reference on
-Codex's concurrence; the lead lifts the hold posted on #2444 and quotes
-the ruling there. The bare-reference instruction the lead posted on
-#2444 earlier that day is withdrawn; the hearing request posted after
-it (three read-only questions: what the copy catches that a pin would
-not, whether a bare reference loses anything, whether any code binds to
-the copy's content) is the input the ruling waits on.
+**Application (on the ruling).** Codex applies the pin in #2444's
+rebase onto main (which already regenerates the fixture for the #2446
+hook subject and the retro PR's `worktree_add_guard` producer); the lead
+lifts the hold on #2444 and quotes the ruling there. The bare-reference
+instruction the lead posted on #2444 earlier that day is withdrawn.
 
 ## Open
 

--- a/docs/specs/host-surface-parity/decisions.md
+++ b/docs/specs/host-surface-parity/decisions.md
@@ -711,6 +711,30 @@ and the lead reported success unverified until the chair said "I don't
 see it". Three `form_rendered` telemetry rows from this session never
 reached a screen: a live R10 tier-provenance data point.
 
+## D13 — The parity registry reads the reviewed producer baseline at test time; it does not embed a copy (RULED 2026-09-06, chair, retro R3)
+
+**Why.** Increment 2 (#2444) embeds `producer_baseline.json` inside
+`parity-registry.json` and its gate asserts the embedded copy equals the
+fixture. The first hook added after that (#2446, one SessionStart hook)
+changes the fixture and breaks #2444's gate on main; every later hook or
+renderer call would do the same, and two PRs now regenerate one fixture.
+Embedding buys nothing the fixture does not already provide: the fixture
+IS the reviewed evidence, and the gate reads it.
+
+**Ruling.** `parity-registry.json` drops the `producer_baseline` copy.
+The registry keeps what it owns — subjects, renderers, receipts, pending
+obligations, experiments, schemas — and binds to the baseline by
+reference (the fixture path plus the baseline's `schema_version`); the
+gate loads `producer_baseline.json` at test time and validates subjects
+against it exactly as now. A subject missing for a baseline root still
+fails with the root named; a baseline change still requires a registry
+change when it adds or removes a root, and nothing else.
+
+**Application.** Codex applies this in #2444's rebase onto `cd15ca05f`
+(which already requires regenerating for the new hook); the digest
+contract is unchanged because `registry_digest` never covered the
+embedded copy's content beyond equality.
+
 ## Open
 
 - None. Every proposed decision in this spec is ruled.

--- a/docs/specs/host-surface-parity/decisions.md
+++ b/docs/specs/host-surface-parity/decisions.md
@@ -711,29 +711,59 @@ and the lead reported success unverified until the chair said "I don't
 see it". Three `form_rendered` telemetry rows from this session never
 reached a screen: a live R10 tier-provenance data point.
 
-## D13 — The parity registry reads the reviewed producer baseline at test time; it does not embed a copy (RULED 2026-09-06, chair, retro R3)
+## D13 — The parity registry binds to the producer baseline by DIGEST PIN, not by embedded copy and not by bare reference (PROPOSED 2026-09-06; chair's lean recorded; promoted to RULED by the chair's merge word on #2447)
 
-**Why.** Increment 2 (#2444) embeds `producer_baseline.json` inside
-`parity-registry.json` and its gate asserts the embedded copy equals the
-fixture. The first hook added after that (#2446, one SessionStart hook)
-changes the fixture and breaks #2444's gate on main; every later hook or
-renderer call would do the same, and two PRs now regenerate one fixture.
-Embedding buys nothing the fixture does not already provide: the fixture
-IS the reviewed evidence, and the gate reads it.
+**Status and provenance.** First written by the lead as "RULED, chair"
+straight from the retro's `do now` on R3, without the assumption review
+or the counter-case it owed (D11d). The chair flagged it: "re 2447 D13
+needs discussion." The discussion put three shapes side by side; the
+chair's lean, verbatim: *"a digest pin that preserves the forcing
+function with a one-line diff instead of a 650-line copy. This sounds
+like a better option."* This entry records that lean. It becomes a
+ruling when the chair's merge word lands on #2447, not before.
 
-**Ruling.** `parity-registry.json` drops the `producer_baseline` copy.
-The registry keeps what it owns — subjects, renderers, receipts, pending
-obligations, experiments, schemas — and binds to the baseline by
-reference (the fixture path plus the baseline's `schema_version`); the
-gate loads `producer_baseline.json` at test time and validates subjects
-against it exactly as now. A subject missing for a baseline root still
-fails with the root named; a baseline change still requires a registry
-change when it adds or removes a root, and nothing else.
+**The three shapes, and why the middle one.**
 
-**Application.** Codex applies this in #2444's rebase onto `cd15ca05f`
-(which already requires regenerating for the new hook); the digest
-contract is unchanged because `registry_digest` never covered the
-embedded copy's content beyond equality.
+1. *Embedded copy* (#2444 as opened): `parity-registry.json` carries a
+   full copy of `producer_baseline.json` and the gate asserts equality.
+   Forcing function: ANY fixture change breaks the gate and someone
+   re-derives the obligations. Cost: a ~650-line twin of a reviewed
+   fixture (principle 3 tension) and a 650-line diff on every regen.
+2. *Bare reference* (D13 as first written): the registry names the
+   fixture path and schema version; the gate loads the fixture at test
+   time. Cost the counter-case exposed: Codex's 152 obligations are
+   DERIVED from the baseline, and by reference only a root add/remove
+   forces a registry edit — an existing subject's producer set can change
+   (a hook growing a `pretooluse_deny` producer beside its
+   `exit2_stderr` one) and pass with no re-derivation.
+3. *Digest pin* (the lean): the registry records the fixture's path,
+   schema version, and a content digest. Any fixture change breaks the
+   gate, so re-derivation stays forced exactly as with the copy; the diff
+   on regen is one line; it is the idiom #2444 already uses for every
+   other pin (`fixture_digest`, `registry_digest`).
+
+**What the lead is assuming (for the chair's read to check).**
+
+- A1. "Digest" is the content digest of the reviewed fixture file
+  (canonical JSON, same `canonical_digest` helper #2444 ships), distinct
+  from `registry_digest`.
+- A2. The pin lives in `parity-registry.json` under `producer_baseline`
+  as `{path, schema_version, digest}`, replacing the copy; the check
+  lives beside the existing subject-vs-root validation in the gate.
+- A3. The failure names both digests and the regen command, so the
+  message is "registry derived from a baseline that no longer exists —
+  regenerate, re-derive, review", never a bare mismatch.
+- A4. "One-line diff" describes the pin. Obligations derived from a NEW
+  subject still need their own registry entries; that is the forcing
+  function, not a cost to remove.
+- A5. Codex applies this on #2444's rebase onto main (which already
+  regenerates the fixture for the #2446 hook subject and the retro PR's
+  `worktree_add_guard` producer). #2447 changes no registry code.
+
+**Application (on the ruling).** Codex replaces the embedded copy with
+the digest pin in #2444's rebase; the lead lifts the hold posted on
+#2444 and quotes this entry there. The bare-reference instruction the
+lead posted on #2444 earlier that day is withdrawn.
 
 ## Open
 

--- a/docs/specs/host-surface-parity/decisions.md
+++ b/docs/specs/host-surface-parity/decisions.md
@@ -711,7 +711,7 @@ and the lead reported success unverified until the chair said "I don't
 see it". Three `form_rendered` telemetry rows from this session never
 reached a screen: a live R10 tier-provenance data point.
 
-## D13 — The parity registry binds to the producer baseline by DIGEST PIN (PROPOSED 2026-09-06 with the chair's conditional satisfied by Codex's hearing; awaiting the chair's ruling word)
+## D13 — The parity registry binds to the producer baseline by DIGEST PIN (RULED 2026-09-06, chair: "rule D13 pin")
 
 **Status and provenance.** First written by the lead as "RULED, chair"
 straight from the retro's `do now` on R3, without the assumption review
@@ -729,8 +729,8 @@ chair rules. Codex was heard (read-only, against #2444 head `f959377dd`,
 binding with one stored canonical digest, retain the existing semantic
 checks, and pass verified baseline content to experiment validation; I
 do not concur that a bare reference loses nothing."* Under the chair's
-conditional, (2) is closed and (1) is the shape. The chair's ruling word
-promotes this entry; nothing else does.
+conditional, (2) was closed and (1) was the shape. The chair ruled, in
+their words, 2026-09-06: *"rule D13 pin"*.
 
 **The three shapes.**
 

--- a/docs/specs/host-surface-parity/decisions.md
+++ b/docs/specs/host-surface-parity/decisions.md
@@ -711,7 +711,7 @@ and the lead reported success unverified until the chair said "I don't
 see it". Three `form_rendered` telemetry rows from this session never
 reached a screen: a live R10 tier-provenance data point.
 
-## D13 — The parity registry binds to the producer baseline by DIGEST PIN, not by embedded copy and not by bare reference (PROPOSED 2026-09-06; chair's lean recorded; promoted to RULED by the chair's merge word on #2447)
+## D13 — The parity registry's binding to the producer baseline: digest pin by default, bare reference only if Codex concurs (PROPOSED 2026-09-06; chair's conditional recorded; the chair rules after Codex answers on #2444)
 
 **Status and provenance.** First written by the lead as "RULED, chair"
 straight from the retro's `do now` on R3, without the assumption review
@@ -719,8 +719,15 @@ or the counter-case it owed (D11d). The chair flagged it: "re 2447 D13
 needs discussion." The discussion put three shapes side by side; the
 chair's lean, verbatim: *"a digest pin that preserves the forcing
 function with a one-line diff instead of a 650-line copy. This sounds
-like a better option."* This entry records that lean. It becomes a
-ruling when the chair's merge word lands on #2447, not before.
+like a better option."* A form answer that crossed with that message
+picked bare reference and "rewrite as RULED"; asked which stood, the
+chair answered, verbatim: *"1 y, 2y if Codex concurs , 3 y"* — decoded
+with the three numbered options as put: (1) the digest pin stands as
+the default shape; (2) bare reference is acceptable ONLY if Codex
+concurs that it loses nothing its obligations or gates rely on; (3)
+D13 stays PROPOSED until Codex answers the hearing request on #2444,
+and the chair rules then, from the shapes below. This entry may merge
+as PROPOSED; a merge word on #2447 does not promote it.
 
 **The three shapes, and why the middle one.**
 
@@ -760,10 +767,14 @@ ruling when the chair's merge word lands on #2447, not before.
   regenerates the fixture for the #2446 hook subject and the retro PR's
   `worktree_add_guard` producer). #2447 changes no registry code.
 
-**Application (on the ruling).** Codex replaces the embedded copy with
-the digest pin in #2444's rebase; the lead lifts the hold posted on
-#2444 and quotes this entry there. The bare-reference instruction the
-lead posted on #2444 earlier that day is withdrawn.
+**Application (on the ruling).** Codex applies the ruled shape in
+#2444's rebase — the digest pin unless the chair rules bare reference on
+Codex's concurrence; the lead lifts the hold posted on #2444 and quotes
+the ruling there. The bare-reference instruction the lead posted on
+#2444 earlier that day is withdrawn; the hearing request posted after
+it (three read-only questions: what the copy catches that a pin would
+not, whether a bare reference loses anything, whether any code binds to
+the copy's content) is the input the ruling waits on.
 
 ## Open
 

--- a/docs/specs/host-surface-parity/producer_baseline.json
+++ b/docs/specs/host-surface-parity/producer_baseline.json
@@ -72,6 +72,10 @@
       "root_anchor": "src/attune/hooks/scripts/starter_reconciler.py:<module>"
     },
     {
+      "helper_anchor": "src/attune/hooks/scripts/worktree_add_guard.py:main",
+      "root_anchor": "src/attune/hooks/scripts/worktree_add_guard.py:<module>"
+    },
+    {
       "helper_anchor": "src/attune/hooks/scripts/worktree_path_guard.py:main",
       "root_anchor": "src/attune/hooks/scripts/worktree_path_guard.py:<module>"
     }
@@ -219,6 +223,14 @@
       "event": "SessionStart",
       "signature": "context_stdout",
       "sink": "print",
+      "subject_kind": "informational_delivery"
+    },
+    {
+      "anchor": "src/attune/hooks/scripts/worktree_add_guard.py:main",
+      "destination": "model_context",
+      "event": "PreToolUse",
+      "signature": "exit2_stderr",
+      "sink": "print(file=sys.stderr)",
       "subject_kind": "informational_delivery"
     },
     {
@@ -565,6 +577,16 @@
       "ordinal": 0,
       "raw_command": "PY=$(command -v python3 || command -v python) && \"$PY\" \"$CLAUDE_PROJECT_DIR/src/attune/hooks/scripts/security_guard.py\"",
       "resolved_repo_path": "src/attune/hooks/scripts/security_guard.py"
+    },
+    {
+      "error": null,
+      "event": "PreToolUse",
+      "json_pointer": "/hooks/PreToolUse/0/hooks/1/command",
+      "manifest_path": ".claude/settings.json",
+      "matcher": "Bash",
+      "ordinal": 1,
+      "raw_command": "PY=$(command -v python3 || command -v python) && \"$PY\" \"$CLAUDE_PROJECT_DIR/src/attune/hooks/scripts/worktree_add_guard.py\"",
+      "resolved_repo_path": "src/attune/hooks/scripts/worktree_add_guard.py"
     },
     {
       "error": null,

--- a/docs/specs/redis-config-truth/decisions.md
+++ b/docs/specs/redis-config-truth/decisions.md
@@ -157,6 +157,8 @@ the chair's words; a card pick settles one dimension, not the framing
 around it (project memory
 `feedback_assumption_review_before_recording_a_pick`).
 
+**Retro ruling (2026-09-06, R5).** The first-terminal-run surface is a NOTICE, not a blocking prompt: it informs and points at `attune memory use` / `attune setup`; the interactive question lives in `attune setup`. The lead's narrowing of "interactive prompt on first terminal run" stands — chair: "keep the notice-only shape".
+
 **Friction.** The install/config friction list comes from the Redis
 audit the chair started the same night (chip `task_af6763f5`); fixes
 land under this ruling.

--- a/scripts/ci_failures.py
+++ b/scripts/ci_failures.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""Extract the REAL failures from a GitHub Actions run — never regex raw logs.
+
+Retro ruling 2026-09-06 (R4): a loose ``grep -E 'passed|failed'`` over a
+job log matches TEST NAMES that contain those words and reports phantom
+failures (eight of them, that night). This script anchors on what pytest
+actually prints: the final ``=== N failed, M passed ... ===`` summary line
+and the ``FAILED``/``ERROR`` result lines, per job.
+
+Usage:
+    python scripts/ci_failures.py <run-id> [--repo OWNER/REPO]
+    python scripts/ci_failures.py --log job.log        # a saved job log
+
+Output, per job (or for the saved log): the summary line, then one line
+per failed/errored test node with its reason. Exit 0 when no job reports
+failures, 1 otherwise. Requires ``gh`` for the run-id form.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+#: GitHub job logs prefix every line with ``<job>\t<step>\t<timestamp> ``.
+_PREFIX = re.compile(r"^[^\t]*\t[^\t]*\t\d{4}-\d{2}-\d{2}T[^ ]+ ?")
+_SUMMARY = re.compile(r"^=+ .*\b(\d+) (passed|failed|error)s?\b.* in [\d.]+s.*=+$")
+_RESULT = re.compile(r"^(FAILED|ERROR) (\S+)(?: - (.*))?$")
+_INTERNAL = re.compile(r"^INTERNALERROR> ([A-Za-z]+Error.*)$")
+
+
+@dataclass
+class JobReport:
+    name: str
+    summary: str = ""
+    results: list[tuple[str, str, str]] = field(default_factory=list)  # kind, node, reason
+    internal_errors: list[str] = field(default_factory=list)
+
+    @property
+    def red(self) -> bool:
+        return bool(self.results or self.internal_errors) or " failed" in self.summary
+
+
+def parse_log(text: str, name: str = "log") -> JobReport:
+    """Anchor on pytest's own result and summary lines; ignore everything else."""
+    report = JobReport(name)
+    seen: set[str] = set()
+    for raw in text.splitlines():
+        line = _PREFIX.sub("", raw).rstrip()
+        if (m := _RESULT.match(line)) and m.group(2) not in seen:
+            seen.add(m.group(2))
+            report.results.append((m.group(1), m.group(2), (m.group(3) or "").strip()))
+        elif _SUMMARY.match(line):
+            report.summary = line.strip("= ").strip()
+        elif (m := _INTERNAL.match(line)) and m.group(1) not in report.internal_errors:
+            report.internal_errors.append(m.group(1))
+    return report
+
+
+def _gh(args: list[str]) -> str:
+    return subprocess.run(["gh", *args], check=True, capture_output=True, text=True).stdout
+
+
+def run_reports(run_id: str, repo: str | None) -> list[JobReport]:
+    """One report per job of the run, fetched through ``gh``."""
+    repo_args = ["-R", repo] if repo else []
+    jobs = json.loads(_gh(["run", "view", run_id, *repo_args, "--json", "jobs"]))["jobs"]
+    reports = []
+    for job in jobs:
+        if job.get("conclusion") not in {"failure", "cancelled", "timed_out"}:
+            continue
+        endpoint = f"repos/{repo}/actions/jobs/{job['databaseId']}/logs" if repo else None
+        if endpoint is None:
+            endpoint = f"{job['url'].split('github.com/')[-1]}/logs".replace(
+                "actions/runs", "repos"
+            )
+        try:
+            text = _gh(["api", endpoint])
+        except subprocess.CalledProcessError as exc:  # a log can expire or be pending
+            reports.append(
+                JobReport(job["name"], summary=f"(log unavailable: {exc.stderr.strip()[:80]})")
+            )
+            continue
+        reports.append(parse_log(text, job["name"]))
+    return reports
+
+
+def render(reports: list[JobReport]) -> str:
+    lines = []
+    for r in reports:
+        lines.append(f"## {r.name}")
+        lines.append(f"summary: {r.summary or '(no pytest summary line)'}")
+        for err in r.internal_errors:
+            lines.append(f"INTERNALERROR {err}")
+        for kind, node, reason in r.results:
+            lines.append(f"{kind} {node}" + (f" - {reason}" if reason else ""))
+        lines.append("")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    parser.add_argument("run_id", nargs="?", help="GitHub Actions run id")
+    parser.add_argument("--repo", help="OWNER/REPO (defaults to the current repository)")
+    parser.add_argument("--log", type=Path, help="parse a saved job log instead of a run")
+    args = parser.parse_args(argv)
+    if args.log:
+        reports = [parse_log(args.log.read_text(encoding="utf-8", errors="replace"), args.log.name)]
+    elif args.run_id:
+        reports = run_reports(args.run_id, args.repo)
+    else:
+        parser.error("give a run id or --log")
+    sys.stdout.write(render(reports))
+    return 1 if any(r.red for r in reports) else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/collaboration_preflight.py
+++ b/scripts/collaboration_preflight.py
@@ -30,6 +30,9 @@ FOCUSED_TESTS = (
     "tests/unit/scripts/test_collaboration_preflight.py",
     "tests/unit/scripts/test_project_collaboration_contract.py",
     "tests/unit/plugins/test_sync_agents_skills.py",
+    # Retro 2026-09-06 (R9): the complexity ratchet lives OUTSIDE tests/unit/gates,
+    # so a push that only ran the gates still went red in CI. ~3 s.
+    "tests/unit/quality",
 )
 MAIN_UPDATE_GUIDANCE = (
     "Inspect the existing main checkout first. Pull only when that checkout "

--- a/src/attune/hooks/scripts/worktree_add_guard.py
+++ b/src/attune/hooks/scripts/worktree_add_guard.py
@@ -1,0 +1,158 @@
+"""PreToolUse hook: refuse ``git worktree add`` from inside a worktree session.
+
+Origin (retro 2026-09-06, R8): a session running in
+``.claude/worktrees/<slug>/`` created a sibling worktree for a second
+branch, and every Edit/Write into it was then refused by
+``worktree_path_guard`` — the guard that exists precisely so a session
+cannot write into a tree it is not running in. The new worktree had to
+be removed and the branch switched in place. Two guards disagreed about
+one act; this one settles it at the moment of creation, before the
+~460 MB venv and the wasted round trip.
+
+Rule: a session whose cwd (or ``CLAUDE_PROJECT_DIR``) is inside
+``.claude/worktrees/`` does not spawn worktrees. Switch branches in
+place — ``dirty_switch_guard`` keeps that safe — or start the new lane
+from the main checkout, which is where worktrees come from.
+
+What is NOT blocked, deliberately:
+
+- ``git worktree list`` / ``remove`` / ``prune`` — reads and reaps.
+- ``git worktree add`` from the main checkout.
+- Anything when ``ATTUNE_ALLOW_NESTED_WORKTREE=1`` is set.
+
+Claude Code Protocol:
+    stdin: JSON with tool_name and tool_input
+    exit 0: allow tool call
+    exit 2: block tool call (stderr printed to user)
+
+Metrics: appends one line to ~/.attune/enforcement-metrics.jsonl per
+fire, like the sibling guards.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under Apache 2.0
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from dirty_switch_guard import git_invocations  # noqa: E402  (sibling hook script)
+
+ENFORCEMENT_NAME = "worktree-add-guard"
+METRICS_LOG = Path.home() / ".attune" / "enforcement-metrics.jsonl"
+ALLOW_ENV = "ATTUNE_ALLOW_NESTED_WORKTREE"
+PROJECT_DIR_ENV = "CLAUDE_PROJECT_DIR"
+
+
+def _log_metric(outcome: str, detail: str | None = None) -> None:
+    """Append one best-effort record to the enforcement metrics log."""
+    try:
+        METRICS_LOG.parent.mkdir(parents=True, exist_ok=True)
+        record = {
+            "ts": datetime.now(timezone.utc).isoformat(),
+            "enforcement": ENFORCEMENT_NAME,
+            "outcome": outcome,
+            "detail": detail,
+        }
+        with METRICS_LOG.open("a", encoding="utf-8") as f:
+            f.write(json.dumps(record) + "\n")
+    except OSError:
+        # INTENTIONAL: metrics are best-effort; never block on them.
+        pass
+
+
+def is_worktree_add(args: list[str]) -> bool:
+    """True if the git arg-list is ``[global opts] worktree add ...``."""
+    if "worktree" not in args:
+        return False
+    idx = args.index("worktree")
+    return len(args) > idx + 1 and args[idx + 1] == "add"
+
+
+def session_worktree_root(path: Path) -> Path | None:
+    """The ``.claude/worktrees/<slug>`` root containing ``path``, or None."""
+    parts = path.parts
+    for i in range(len(parts) - 2):
+        if parts[i] == ".claude" and parts[i + 1] == "worktrees":
+            return Path(*parts[: i + 3])
+    return None
+
+
+def block_message(root: Path) -> str:
+    """The refusal text: why, and the two ways forward."""
+    return (
+        f"[{ENFORCEMENT_NAME}] refusing `git worktree add`: this session runs "
+        f"inside a worktree\n    {root}\n"
+        "and a sibling worktree would be unwritable from here "
+        "(worktree_path_guard refuses Edit/Write into any tree but this one).\n\n"
+        "Switch branches in place instead — commit or stash first, then "
+        "`git checkout -b <branch> origin/main` (dirty_switch_guard keeps that "
+        "safe). Worktrees are created from the main checkout. "
+        f"To disable for this session: {ALLOW_ENV}=1"
+    )
+
+
+def main(context: dict[str, Any]) -> int:
+    """Block ``git worktree add`` inside a worktree session; 0 allow, 2 block."""
+    if context.get("tool_name") != "Bash":
+        return 0
+    command = context.get("tool_input", {}).get("command", "")
+    if not command or not any(is_worktree_add(args) for args in git_invocations(command)):
+        return 0
+    if os.environ.get(ALLOW_ENV) == "1":
+        _log_metric("allowed", "escape hatch set")
+        return 0
+
+    root = session_worktree_root(Path.cwd())
+    project_dir = os.environ.get(PROJECT_DIR_ENV, "")
+    if root is None and project_dir:
+        root = session_worktree_root(Path(project_dir))
+    if root is None:
+        _log_metric("allowed", "worktree add from a non-worktree checkout")
+        return 0
+
+    print(block_message(root), file=sys.stderr)
+    _log_metric("fired", str(root))
+    return 2
+
+
+def _read_stdin_context() -> dict[str, Any]:
+    """Parse the hook context from stdin; empty dict when unavailable."""
+    try:
+        raw = sys.stdin.read()
+    except (OSError, ValueError):
+        return {}
+    if not raw.strip():
+        return {}
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError:
+        return {}
+    return parsed if isinstance(parsed, dict) else {}
+
+
+if __name__ == "__main__":
+    from _bootstrap import ensure_utf8_stdio
+
+    ensure_utf8_stdio()
+    from _sdk_gate import exit_if_sdk_subprocess
+
+    exit_if_sdk_subprocess()
+    ctx = _read_stdin_context()
+    if not ctx:
+        sys.exit(0)
+    try:
+        sys.exit(main(ctx))
+    except Exception as exc:  # noqa: BLE001
+        # INTENTIONAL: a hook bug must never block real work.
+        print(
+            f"[{ENFORCEMENT_NAME}] hook error (allowing): {type(exc).__name__}: {exc}",
+            file=sys.stderr,
+        )
+        sys.exit(0)

--- a/tests/unit/gates/test_broad_except_ratchet.py
+++ b/tests/unit/gates/test_broad_except_ratchet.py
@@ -145,6 +145,9 @@ _BASELINE: dict[str, int] = {
     # detached_head_push_guard: same fail-open __main__ block as its
     # sibling above — a guard that crashes must exit 0, never block.
     "src/attune/hooks/scripts/detached_head_push_guard.py": 1,
+    # worktree_add_guard (retro 2026-09-06 R8): the same fail-open __main__
+    # block — a guard that crashes must exit 0, never block.
+    "src/attune/hooks/scripts/worktree_add_guard.py": 1,
     "src/attune/hooks/scripts/evaluate_session.py": 3,
     # format_on_save added 1 for library-review L3 (PR #2117): the
     # PostToolUse exit-0-always contract must survive wrong-typed

--- a/tests/unit/gates/test_path_validation_gate.py
+++ b/tests/unit/gates/test_path_validation_gate.py
@@ -86,6 +86,9 @@ ALLOWLIST = frozenset(
         # detached_head_push_guard: identical shape — appends only to the
         # constant enforcement-metrics log, no interpolated component.
         "src/attune/hooks/scripts/detached_head_push_guard.py",
+        # worktree_add_guard (retro 2026-09-06 R8): identical shape — appends
+        # only to the constant enforcement-metrics log, no interpolated component.
+        "src/attune/hooks/scripts/worktree_add_guard.py",
         "src/attune/hooks/scripts/worktree_path_guard.py",
         "src/attune/help/feedback.py",
         "src/attune/help/generator.py",

--- a/tests/unit/hooks/test_worktree_add_guard.py
+++ b/tests/unit/hooks/test_worktree_add_guard.py
@@ -1,0 +1,148 @@
+"""Tests for the worktree-add guard PreToolUse hook (retro 2026-09-06, R8).
+
+A session running inside ``.claude/worktrees/<slug>/`` must not spawn a
+sibling worktree — worktree_path_guard would refuse every write into it.
+Covers the command classification, the session-location check, the block
+decision, the escape hatch, and the fail-open paths.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under the Apache License, Version 2.0
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCRIPT_PATH = REPO_ROOT / "src" / "attune" / "hooks" / "scripts" / "worktree_add_guard.py"
+
+
+@pytest.fixture(scope="module")
+def mod():
+    spec = importlib.util.spec_from_file_location("_worktree_add_guard", SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None
+    m = importlib.util.module_from_spec(spec)
+    sys.modules["_worktree_add_guard"] = m
+    spec.loader.exec_module(m)
+    return m
+
+
+@pytest.fixture
+def metrics(mod, tmp_path, monkeypatch):
+    log = tmp_path / "metrics.jsonl"
+    monkeypatch.setattr(mod, "METRICS_LOG", log)
+    monkeypatch.delenv(mod.ALLOW_ENV, raising=False)
+    monkeypatch.delenv(mod.PROJECT_DIR_ENV, raising=False)
+    return log
+
+
+def _ctx(command: str, tool: str = "Bash") -> dict:
+    return {"tool_name": tool, "tool_input": {"command": command}}
+
+
+def _worktree(tmp_path: Path) -> Path:
+    root = tmp_path / ".claude" / "worktrees" / "some-slug"
+    root.mkdir(parents=True)
+    return root
+
+
+class TestClassification:
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "git worktree add ../other -b feature",
+            "git -C /repo worktree add /tmp/x main",
+            "echo hi; git worktree add x",
+            "cd /repo && git worktree add --detach x",
+        ],
+    )
+    def test_worktree_add_forms(self, mod, command):
+        assert any(mod.is_worktree_add(a) for a in mod.git_invocations(command))
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "git worktree list",
+            "git worktree remove ../other",
+            "git worktree prune",
+            "git add worktree.txt",
+            "git status",
+            "ls .claude/worktrees",
+        ],
+    )
+    def test_other_commands_are_not(self, mod, command):
+        assert not any(mod.is_worktree_add(a) for a in mod.git_invocations(command))
+
+
+class TestSessionLocation:
+    def test_inside_a_worktree_returns_its_root(self, mod):
+        p = Path("/home/u/repo/.claude/worktrees/slug/src/pkg")
+        assert mod.session_worktree_root(p) == Path("/home/u/repo/.claude/worktrees/slug")
+
+    @pytest.mark.parametrize(
+        "path",
+        ["/home/u/repo", "/home/u/repo/.claude/worktrees", "/home/u/.claude/other/worktrees/x"],
+    )
+    def test_outside_returns_none(self, mod, path):
+        assert mod.session_worktree_root(Path(path)) is None
+
+
+class TestDecision:
+    def test_blocks_from_inside_a_worktree(self, mod, metrics, tmp_path, monkeypatch, capsys):
+        root = _worktree(tmp_path)
+        monkeypatch.chdir(root)
+        assert mod.main(_ctx("git worktree add ../other -b feature")) == 2
+        err = capsys.readouterr().err
+        assert "switch branches in place" in err.lower()
+        assert str(root) in err
+        record = json.loads(metrics.read_text().splitlines()[-1])
+        assert record["enforcement"] == "worktree-add-guard" and record["outcome"] == "fired"
+
+    def test_blocks_when_project_dir_env_is_a_worktree(self, mod, metrics, tmp_path, monkeypatch):
+        root = _worktree(tmp_path)
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv(mod.PROJECT_DIR_ENV, str(root))
+        assert mod.main(_ctx("git worktree add x")) == 2
+
+    def test_allows_from_the_main_checkout(self, mod, metrics, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        assert mod.main(_ctx("git worktree add .claude/worktrees/new -b feature")) == 0
+        assert json.loads(metrics.read_text())["outcome"] == "allowed"
+
+    def test_escape_hatch(self, mod, metrics, tmp_path, monkeypatch):
+        monkeypatch.chdir(_worktree(tmp_path))
+        monkeypatch.setenv(mod.ALLOW_ENV, "1")
+        assert mod.main(_ctx("git worktree add x")) == 0
+
+    @pytest.mark.parametrize(
+        "ctx",
+        [
+            _ctx("git worktree add x", tool="Edit"),
+            _ctx(""),
+            _ctx("git worktree list"),
+            _ctx("git checkout -b feature origin/main"),
+            {"tool_name": "Bash"},
+        ],
+    )
+    def test_everything_else_passes_silently(self, mod, metrics, tmp_path, monkeypatch, ctx):
+        monkeypatch.chdir(_worktree(tmp_path))
+        assert mod.main(ctx) == 0
+        assert not metrics.exists()
+
+    def test_metrics_failure_never_blocks_the_decision(self, mod, metrics, tmp_path, monkeypatch):
+        monkeypatch.setattr(mod, "METRICS_LOG", tmp_path / "not-a-dir" / "x" / "m.jsonl")
+        (tmp_path / "not-a-dir").write_text("file, not a directory")
+        monkeypatch.chdir(_worktree(tmp_path))
+        assert mod.main(_ctx("git worktree add x")) == 2
+
+
+def test_registered_in_project_settings():
+    settings = json.loads((REPO_ROOT / ".claude" / "settings.json").read_text())
+    bash_groups = [g for g in settings["hooks"]["PreToolUse"] if g["matcher"] == "Bash"]
+    commands = [h["command"] for g in bash_groups for h in g["hooks"]]
+    assert any("worktree_add_guard.py" in c for c in commands)

--- a/tests/unit/scripts/test_ci_failures.py
+++ b/tests/unit/scripts/test_ci_failures.py
@@ -1,0 +1,106 @@
+"""scripts/ci_failures.py anchors on pytest's own result lines (retro 2026-09-06 R4).
+
+The failure it exists to prevent: a substring grep for ``passed|failed``
+over a job log matches test NAMES containing those words and reports
+phantom failures. Every fixture here contains such names and asserts they
+are never reported.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPT = Path(__file__).resolve().parents[3] / "scripts" / "ci_failures.py"
+
+
+@pytest.fixture(scope="module")
+def cf():
+    spec = importlib.util.spec_from_file_location("_ci_failures", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["_ci_failures"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+_PREFIX = "test (ubuntu-latest, 3.12)\tRun tests\t2026-09-06T05:28:22.9782634Z "
+
+_GREEN_LOG = "\n".join(
+    _PREFIX + line
+    for line in [
+        "tests/unit/x/test_a.py::test_prose_panel_failed_run_not_a_false_all_clear ",
+        "[gw3] [ 23%] PASSED tests/unit/x/test_a.py::test_prose_panel_failed_run_not_a_false_all_clear ",
+        "tests/unit/x/test_b.py::test_default_days_passed_to_tracker ",
+        "[gw1] [ 24%] PASSED tests/unit/x/test_b.py::test_default_days_passed_to_tracker ",
+        "====== 8885 passed, 46 skipped, 3 xfailed in 201.18s (0:03:21) ======",
+    ]
+)
+
+_RED_LOG = "\n".join(
+    _PREFIX + line
+    for line in [
+        "[gw0] [ 10%] PASSED tests/unit/x/test_a.py::test_status_probe_error_falls_back_to_write_failed ",
+        "FAILED tests/adaptive/test_task_complexity.py::test_complex_task_scoring - tests._inference_guard.InferenceBlocked: Inference HTTP endpoint blocked",
+        "FAILED tests/models/test_token_estimator.py::TestEstimateTokens::test_claude_model - tests._inference_guard.InferenceBlocked: Inference HTTP endpoint blocked",
+        "FAILED tests/adaptive/test_task_complexity.py::test_complex_task_scoring - duplicate line in the short summary",
+        "ERROR tests/integration/test_ams_remember_readback_live.py - tests._inference_guard.InferenceBlocked",
+        "====== 40 failed, 8885 passed, 46 skipped, 3 xfailed in 257.35s (0:04:17) ======",
+    ]
+)
+
+_INTERNAL_LOG = "\n".join(
+    _PREFIX + line
+    for line in [
+        'INTERNALERROR>   File "D:\\a\\attune-ai\\tests\\_inference_guard.py", line 98, in check_command',
+        "INTERNALERROR> TypeError: expected str, bytes or os.PathLike object, not NoneType",
+    ]
+)
+
+
+def test_green_log_with_failure_like_names_reports_nothing(cf) -> None:
+    report = cf.parse_log(_GREEN_LOG, "ubuntu")
+    assert report.results == []
+    assert report.red is False
+    assert report.summary.startswith("8885 passed")
+
+
+def test_red_log_lists_each_failed_node_once_with_its_reason(cf) -> None:
+    report = cf.parse_log(_RED_LOG, "ubuntu")
+    nodes = [node for _, node, _ in report.results]
+    assert nodes == [
+        "tests/adaptive/test_task_complexity.py::test_complex_task_scoring",
+        "tests/models/test_token_estimator.py::TestEstimateTokens::test_claude_model",
+        "tests/integration/test_ams_remember_readback_live.py",
+    ]
+    assert report.results[0][2].startswith("tests._inference_guard.InferenceBlocked")
+    assert report.results[2][0] == "ERROR"
+    assert "falls_back_to_write_failed" not in cf.render([report])
+    assert report.red is True and report.summary.startswith("40 failed")
+
+
+def test_internal_error_is_reported_even_without_a_summary(cf) -> None:
+    report = cf.parse_log(_INTERNAL_LOG, "windows")
+    assert report.results == []
+    assert report.internal_errors == [
+        "TypeError: expected str, bytes or os.PathLike object, not NoneType"
+    ]
+    assert report.red is True
+
+
+def test_render_and_exit_code_from_a_saved_log(cf, tmp_path, capsys) -> None:
+    log = tmp_path / "job.log"
+    log.write_text(_RED_LOG, encoding="utf-8")
+    assert cf.main(["--log", str(log)]) == 1
+    out = capsys.readouterr().out
+    assert out.startswith("## job.log\nsummary: 40 failed")
+    assert out.count("FAILED ") == 2 and out.count("ERROR ") == 1
+    log.write_text(_GREEN_LOG, encoding="utf-8")
+    assert cf.main(["--log", str(log)]) == 0
+
+
+def test_requires_a_run_id_or_a_log(cf) -> None:
+    with pytest.raises(SystemExit):
+        cf.main([])


### PR DESCRIPTION
## What

The 2026-09-06 retro's `do now` items (chair dispositions R2, R4, R8, R9) plus the two spec lines the retro recorded (R3 → host-surface-parity **D13**, R5 → redis-config-truth **D5 retro ruling**).

**Not armed for auto-merge — contains spec/decision text (D11d). Chair reads, then the merge word.**

| Item | Change | Why (the moment) |
|---|---|---|
| R2 | `tests.yml`: `actions/cache` (pinned v6.1.0) + warm step for tiktoken `cl100k_base` in the `test`, `clock-tz`, `coverage` jobs; `TIKTOKEN_CACHE_DIR` on the pytest steps | #2445's test-time inference guard blocks the download inside pytest → 40 red tests for one file |
| R4 | `scripts/ci_failures.py` + tests | a loose `passed\|failed` grep matched test NAMES and I reported 8 phantom failures to the chair; the script anchors on pytest's own `FAILED`/`ERROR`/summary/`INTERNALERROR` lines |
| R8 | `src/attune/hooks/scripts/worktree_add_guard.py` (PreToolUse Bash, exit 2, escape hatch `ATTUNE_ALLOW_NESTED_WORKTREE=1`) + registration + tests; `producer_baseline.json` regenerated | a worktree session spawned a sibling worktree, then `worktree_path_guard` refused every write into it; the branch had to be switched in place anyway |
| R9 | `collaboration_preflight.py`: `FOCUSED_TESTS` gains `tests/unit/quality` (~3 s) | the complexity ratchet lives outside `tests/unit/gates`, so a push that ran the gates still went red in CI |
| D13 | **PROPOSED, chair's lean recorded verbatim (2026-09-06):** the registry binds to the baseline by DIGEST PIN — path + schema version + content digest — not by embedded copy and not by bare reference. Five lead assumptions are on the page for the chair's read. Codex was heard (recommends the pin; does not concur that a bare reference loses nothing; corrected the lead's counter-case; one content dependency in the experiment validator). Eight cited claims re-run by the lead, all held. Still PROPOSED — the chair's ruling word promotes it; a merge word here does not. | first draft was written as RULED from the retro pick without its counter-case (a bare reference lets an existing subject's producer set change without re-derivation); the chair flagged it; the digest pin keeps the forcing function with a one-line diff |
| D5 | first-terminal-run surface is a NOTICE, not a blocking prompt | chair kept my alternative at retro (R5) |

## Baseline diff (reviewed)

Exactly three new entries, all for the new guard: one `.claude/settings.json` registration (`/hooks/PreToolUse/0/hooks/1`), one `exit2_stderr` producer at `worktree_add_guard.py:main`, one helper anchor. Nothing removed.

## Ratchets raised, with reasons at the site

- broad-except baseline: `worktree_add_guard.py: 1` — the fail-open `__main__` block, identical to every sibling guard.
- path-validation allowlist: same constant enforcement-metrics log as `dirty_switch_guard` / `detached_head_push_guard`, no interpolated component.

## Receipts

- Whole tree, keyless (`ANTHROPIC_API_KEY=""`): **25612 passed, 266 skipped, 3 xfailed** in 92.6 s.
- `tests/unit/gates` + `tests/unit/quality`: 483 passed.
- Hook, live stdin round trip from inside this worktree: `git worktree add ../second -b feature` → exit 2 with the "switch branches in place" message; `git worktree list` → exit 0.
- CI-policy tests (`tests/unit/ci`) green on the edited workflow: SHA pin + version comment present.
- Pinned pre-commit on the staged set: all hooks passed.

## Coordination

- #2444 (Codex, Task 1B registry) regenerates the baseline on rebase — it will pick up this guard's three entries and the #2446 hook subject together. A hold is posted there on the registry's baseline binding until D13 is ruled; on the merge word the lead lifts it and Codex applies the digest pin.
- `~/.attune/next_session_starter.md` rewritten with today's state and the retro queue (R15 still needs discussion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
