### PR TITLE
docs(reports): weekly modules-needing-work refresh

### DIFF
--- a/docs/reports/modules-needing-work.md
+++ b/docs/reports/modules-needing-work.md
@@ -1,12 +1,29 @@
 # Modules needing work
 
-**Generated:** 2026-08-17 13:09 UTC by `scripts/modules_needing_work.py` — regenerate in place, don't hand-edit (the dated 2026-07-30 report is the historical first edition).
+**Generated:** 2026-09-07 13:07 UTC by `scripts/modules_needing_work.py` — regenerate in place, don't hand-edit (the dated 2026-07-30 report is the historical first edition).
 
-**Source:** Codecov main — project total 96.16% across 717 files. Candidate list for coverage lanes (test-quality program #1569).
+**Source:** Codecov main — project total 95.84% across 742 files. Candidate list for coverage lanes (test-quality program #1569).
 
-## Tier 1 — measured below the 85% bar (0 modules)
+## Tier 1 — measured below the 85% bar (6 modules)
 
-Nothing below 85% — the floor is the ceiling today.
+### Clusters by miss volume
+
+| Cluster | Modules | Missed lines |
+|---|---|---|
+| `classes` | 4 | 74 |
+| `workflows` | 1 | 14 |
+| `hooks` | 1 | 11 |
+
+### Full list (ascending coverage)
+
+| Cover | Lines | Miss | Module |
+|---|---|---|---|
+| 75.96% | 104 | 22 | `src/attune/classes/teeth.py` |
+| 80.70% | 114 | 15 | `src/attune/classes/mock_worklist.py` |
+| 81.69% | 71 | 13 | `src/attune/classes/class_m.py` |
+| 82.58% | 155 | 24 | `src/attune/classes/register.py` |
+| 83.07% | 65 | 11 | `src/attune/hooks/scripts/worktree_add_guard.py` |
+| 84.82% | 112 | 14 | `src/attune/workflows/__init__.py` |
 
 ## Tier 2 — omitted from measurement (un-omit-audit candidates)
 
@@ -25,12 +42,6 @@ Production entries still in the `pyproject.toml` omit list. Every stated reason 
 - `*/monitoring/alerts_cli.py` — Monitoring CLI
 - `attune_software/cli/*.py` — Plugin CLI subcommands
 - `*/memory/control_panel_api.py` — FastAPI REST server
-- `*/hooks/scripts/evaluate_session.py` — Standalone hook
-- `*/hooks/scripts/first_time_init.py` — Standalone hook
-- `*/hooks/scripts/session_end.py` — Standalone hook
-- `*/hooks/scripts/session_start.py` — Standalone hook
-- `*/hooks/scripts/suggest_compact.py` — Standalone hook
-- `*/hooks/scripts/telemetry_hook.py` — Standalone hook
 - `*/core_modules/interaction.py` — Interaction stubs
 - `*/core_modules/short_term_memory.py` — Memory stubs
 - `*/mcp/__init__.py` — MCP package init
@@ -38,7 +49,6 @@ Production entries still in the `pyproject.toml` omit list. Every stated reason 
 - `*/memory/storage/__init__.py` — Storage package init
 - `*/core_modules/__init__.py` — Core modules init
 - `*/models/__main__.py` — Models CLI entry point
-- `*/hooks/scripts/help_freshness_nudge.py` — Standalone hook script (not importable via pytest)
 
 ## How lanes run (parallel delegation)
 


### PR DESCRIPTION
Scheduled weekly refresh of `docs/reports/modules-needing-work.md`, regenerated in place by `scripts/modules_needing_work.py` against Codecov's read-only public API for `main`. No API spend; report file only.

## What moved

Project total **96.16% -> 95.84%**, measured files **717 -> 742**.

**Tier 1 goes 0 -> 6 modules below the 85% bar.** Five of the six are newly-landed code that arrived under the bar, not regressions on existing work — the previous report generated 2026-08-17, and everything below except `workflows/__init__.py` was added after that date:

| Cover | Miss | Module | Added |
|---|---|---|---|
| 75.96% | 22 | `src/attune/classes/teeth.py` | 2026-08-22 |
| 80.70% | 15 | `src/attune/classes/mock_worklist.py` | 2026-08-22 |
| 81.69% | 13 | `src/attune/classes/class_m.py` | 2026-08-22 |
| 82.58% | 24 | `src/attune/classes/register.py` | 2026-08-22 |
| 83.07% | 11 | `src/attune/hooks/scripts/worktree_add_guard.py` | 2026-09-06 |
| 84.82% | 14 | `src/attune/workflows/__init__.py` | 2026-02-01 (regression) |

`workflows/__init__.py` is the one genuine regression on a long-lived module; its most recent change was the 16.0.0 entry-point-seam collapse (#2334, 2026-08-27).

**Tier 2 shrinks by seven entries**, all traceable to the 2026-08-25 omit-audit (#2294), which de-omitted the six standalone hook scripts plus `help_freshness_nudge.py`. Those modules are now measured rather than hidden — a real improvement, and part of why the project total ticked down: newly-measured code brings its own misses into the denominator.

## Top-3 lane candidates by missed-line volume

1. `src/attune/classes/register.py` — 24 missed lines
2. `src/attune/classes/teeth.py` — 22 missed lines
3. `src/attune/classes/mock_worklist.py` — 15 missed lines

All three sit in the same `classes` cluster (4 modules, 74 missed lines total), so a single lane scoped to `src/attune/classes/` would clear the bulk of Tier 1 in one pass rather than three separate delegations.

## Verification

- Codecov fetch succeeded; script reported `wrote docs/reports/modules-needing-work.md (6 modules below 85%)`.
- Diff is confined to that one file (21 insertions, 11 deletions).
- Module-age and omit-list attributions above were each verified with `git log` (`--diff-filter=A` for add dates; `-S` on `pyproject.toml` for the omit removals), not inferred from the report text.

Generated by the `modules-needing-work-weekly` scheduled task.
