### PR TITLE
docs(probes): Claude desktop trial prep — stale plugin cache, Fable widget render

### DIFF
--- a/docs/probes/host-surface-parity/host-native-trials-2026-09-07.md
+++ b/docs/probes/host-surface-parity/host-native-trials-2026-09-07.md
@@ -194,14 +194,18 @@ buttons plus an empty unranked pool, headed "Ranked 4/4 proposed"; the
 triage renders six radiogroups. Every control is a native element with a
 `:focus-visible` outline, so Tab reach is plausible and unobserved.
 
-Finding for the forms repo, stated as an observation and not a bug claim:
-`suggested` on the ranking pre-fills the ranked list, and `suggested` on
-the triage pre-checks one radio per row, so an untouched Submit posts the
-proposals as the answer. The schema text calls a suggestion "a visible
-proposal, never the answer". Whether the renderer should leave the answer
-empty until the user acts is a forms-repo question (thread 4 territory).
+Observation for the forms repo, not a bug claim: `suggested` on the
+ranking pre-fills the ranked list, and `suggested` on the triage pre-checks
+one radio per row, so an untouched Submit posts the proposals as the
+answer. The renderer's own docstring (`attune_forms/widget.py`, read this
+session) states this is D2-c by design: "submitting without touching it
+posts the proposal — that submit IS the confirmation, and the badge is
+what makes it visible rather than silent." The open question is narrower
+than a bug: whether a required field with a suggestion should demand a
+touch, or log an accepted-untouched flag for calibration. Filed as an
+attune-forms issue at Patrick's direction (card pick below).
 
-Pending, needs Patrick at the keyboard: paint of all five controls;
+Pending at 19:06Z, resolved in the result section below: paint of all five controls;
 keyboard-only operation of the ranking buttons, the radios, the number
 spinner, the date picker and the textarea; Submit; the
 `__elicitation_response__` post-back arriving in this session;
@@ -212,8 +216,130 @@ land, the D16 caveat on these constructs stands unchanged.
 
 ### Other state at write time
 
-- #2461 open; its Tests workflow was still in progress (Windows lane and
-  coverage pending, nothing failed).
+- #2461 was open with its Tests workflow in progress when this section
+  began; it merged at 19:15:09Z as 46816577b.
 - Codex Task 1B increment 2 exists as branch
   `codex/host-surface-parity-task1b-increment2` at 1efa08406 in worktree
   9c6c; no PR yet.
+
+### Trial (b) result — submitted and validated at 19:12Z
+
+Patrick submitted the widget from this session about six minutes after the
+render. Evidence chain, each row with its basis:
+
+| Step | Evidence |
+| --- | --- |
+| Post-back | The `__elicitation_response__` payload arrived as a user message carrying instance `10404e263dd242a2b3e4e9b63466fcf8`, the render's id; only the widget's own script writes that field |
+| Collect | `elicitation_collect_response` with that instance id returned success and `resp-20260907-151254-6baac98d` |
+| Telemetry | `form_submitted` for form cf43dd900008 with the same instance id at 19:12:54.379Z, the same second as the response id (15:12:54 US-Eastern) |
+| Render to submit | 6 min 35 s wall clock, which includes the lead writing this probe; not a UX latency |
+
+Answers as validated: the ranking came back reordered to Codex Task 1B
+review first, then desktop trials, the Socratic metric, and the forms
+flip, so the ranking control was operated and the suggestion was not
+simply accepted. The triage kept every suggestion (five observe today,
+discovery defer). Number 45. Date 2026-09-07. Attestation verbatim: "It
+worked and worked well."
+
+Attested by Patrick: paint and successful completion of all five controls
+and Submit on Fable 5.1 in the desktop Code tab. Not yet attested at this
+point: whether the operation was keyboard-only; that is asked next, on the
+trial (a) one-question card. Number bounds, date-picker behavior and
+textarea resizing were not separately reported.
+
+### Trial (a) live observations — same session, Patrick at the keyboard
+
+Patrick ruled five items "observe today" on the widget, so the lead ran
+them here with real questions. The host control itself is under test; the
+skill discovery item stays deferred until the plugin cache is refreshed.
+
+#### One-question card (19:14Z)
+
+- Call: one single-select question, three options, no `metadata`. The
+  operator-local `~/.claude/hooks/ask_question_format_guard.py` (99 lines,
+  read this session) blocked it because the first option did not end in
+  "(Recommended)". Its rules, read from the file: more than one question
+  needs `metadata.source` containing "form"; at most four questions; the
+  first option of every single-select question must end in
+  "(Recommended)"; multi-select questions are exempt. The call was retried
+  with the marker disclosed in the question text as hook-mandated.
+- Tool result, shape verbatim: `Your questions have been answered:
+  "<full question text>"="Keyboard only (Recommended)". You can now
+  continue with these answers in mind.` The answer is the option LABEL,
+  marker included, keyed by the full question text, wrapped in prose
+  rather than JSON.
+- Attested by Patrick's pick: keyboard-only operation of the widget,
+  ranking move buttons included (the option text he chose says so). The
+  card itself rendered, evidenced by the answer arriving; paint details
+  were not described. Whether this card was completed keyboard-only is
+  asked on the next card.
+- Finding, guard versus ruling: the local guard forces a recommended
+  option on every single-select question. D16 rules that a confirm gate
+  carries NO recommended option, and the elicit skill says to put a
+  recommendation first only when justified. On this host the guard wins
+  mechanically, so a confirm gate or a factual attestation cannot be
+  asked as ruled without either a multi-select workaround or a guard
+  change. Operator infrastructure, not a shipped hook; Patrick's call.
+
+#### Multi-question card with a deliberate blank (19:16Z)
+
+- Call: four questions in one call with `metadata.source` set to
+  `elicit-form`; three single-select (first option marked "(Recommended)"
+  to satisfy the guard) and one multi-select. Question 3 asked Patrick to
+  leave it unanswered and submit; question 4 asked for keyboard
+  attestation on the native cards themselves.
+- Tool result, shape verbatim: `The user answered: "<q1 text>"="<label>",
+  "<q2 text>"="<label>", "<q3 text>"="[No preference]", "<q4
+  text>"="Previous card: keyboard only,This card: keyboard only,Used the
+  mouse somewhere". Read the answers carefully — they may request
+  clarification, changes, or that you not proceed — and follow what they
+  actually say.` The prefix differs from the one-question shape. A
+  skipped question comes back as the literal string `[No preference]`.
+  Multi-select answers are the chosen labels joined by commas with no
+  spaces. Free text through "Other" was not exercised.
+- Observed: a partially answered call CAN be submitted on the desktop
+  Code tab, and the result names the skipped question with
+  `[No preference]` rather than omitting it. The elicit skill's "retain
+  valid prior answers and ask only the remainder" clause therefore has a
+  concrete trigger string on this host.
+- Rulings carried by the same card: Patrick runs the plugin refresh
+  after this session (so the discovery trial stays deferred today); the
+  suggested-prefill observation goes to an attune-forms issue.
+- Keyboard attestation for the native cards: Patrick selected all three
+  options, including "Used the mouse somewhere", so keyboard-only
+  completion of the native cards is NOT cleanly attested; where the mouse
+  came in was not localized. The widget's keyboard-only attestation from
+  the one-question card stands on its own.
+
+#### Dismissal card (19:18Z)
+
+- Call: one single-select question asking Patrick to dismiss the card
+  with Escape instead of answering.
+- Tool result on dismissal, verbatim: `The user doesn't want to proceed
+  with this tool use. The tool use was rejected (eg. if it was a file
+  edit, the new_string was NOT written to the file). STOP what you are
+  doing and wait for the user to tell you how to proceed.` The transcript
+  carried `[Request interrupted by user for tool use]`, the assistant turn
+  ended, and no answers were returned. The string is the host's generic
+  tool-rejection message, not question-specific; a rejected Edit produces
+  the same text.
+- Patrick then confirmed in prose that he pressed Escape as the script
+  asked. This matches the elicit skill's clause that an interrupted or
+  dismissed call supplies no answers and is the user's cancellation: the
+  lead stopped, did not re-post the card, and continued only on his next
+  message.
+
+#### Trial (a) status after the live cards
+
+| Item | Status | Basis |
+| --- | --- | --- |
+| One-question card renders | observed | answer returned; paint attested by use, not described |
+| Multi-question card renders | observed | four-question answer set returned |
+| Keyboard-only completion | attested for the widget; not clean for the native cards | Patrick's picks (see the two cards above) |
+| Partial call can be submitted | observed | skipped question returned as `[No preference]` |
+| Tool result on dismissal | observed | generic rejection text, turn ended, no answers |
+| Fresh flower-shop request discovers #2459 | deferred | plugin cache stale; Patrick refreshes after this session |
+
+Not observed: a terminal Claude Code rendering, free text through
+"Other", and the desktop card's paint details (layout, focus ring,
+option descriptions). These remain pending.

--- a/docs/probes/host-surface-parity/host-native-trials-2026-09-07.md
+++ b/docs/probes/host-surface-parity/host-native-trials-2026-09-07.md
@@ -202,10 +202,11 @@ session) states this is D2-c by design: "submitting without touching it
 posts the proposal — that submit IS the confirmation, and the badge is
 what makes it visible rather than silent." The open question is narrower
 than a bug: whether a required field with a suggestion should demand a
-touch, or log an accepted-untouched flag for calibration. Filed as an
-attune-forms issue at Patrick's direction (card pick below).
+touch, or log an accepted-untouched flag for calibration. Filed as
+attune-forms#90 at Patrick's direction (card pick below).
 
-Pending at 19:06Z, resolved in the result section below: paint of all five controls;
+Pending at 19:06Z, resolved in the result section below: paint of all
+five controls;
 keyboard-only operation of the ranking buttons, the radios, the number
 spinner, the date picker and the textarea; Submit; the
 `__elicitation_response__` post-back arriving in this session;
@@ -304,7 +305,8 @@ skill discovery item stays deferred until the plugin cache is refreshed.
   concrete trigger string on this host.
 - Rulings carried by the same card: Patrick runs the plugin refresh
   after this session (so the discovery trial stays deferred today); the
-  suggested-prefill observation goes to an attune-forms issue.
+  suggested-prefill observation goes to an attune-forms issue, filed the
+  same session as attune-forms#90.
 - Keyboard attestation for the native cards: Patrick selected all three
   options, including "Used the mouse somewhere", so keyboard-only
   completion of the native cards is NOT cleanly attested; where the mouse

--- a/docs/probes/host-surface-parity/host-native-trials-2026-09-07.md
+++ b/docs/probes/host-surface-parity/host-native-trials-2026-09-07.md
@@ -111,3 +111,109 @@ the constructs the native control cannot express (ranking, triage over
 four items, number, date, textarea) — render, submit, and keyboard
 operation. When these are run, record tool returns separately from
 visible UI and user attestation, as the Codex section above does.
+
+## Claude desktop trial prep — 2026-09-07, second session
+
+Recorded by the Claude lead from the desktop app's Code tab in an
+autonomous session. Patrick was not at the keyboard, so nothing below is a
+paint or keyboard observation. Every claim names its basis.
+
+### Trial (a): the receiving plugin is stale — refresh before recording
+
+- Desktop `plugin:attune-ai` resolves through
+  `~/.claude/plugins/installed_plugins.json` to
+  `~/.claude/plugins/cache/attune-ai/attune-ai/16.2.1`, git SHA f51a2dd6
+  (#2422, merged 2026-09-05), last updated 2026-09-05T03:23Z. Verified by
+  reading that file and by `git merge-base --is-ancestor`: the cache does
+  not contain 7bdf4112e (#2459).
+- Its `skills/elicit/SKILL.md` has no "Claude: native questions first"
+  heading. Its `skills/planning/SKILL.md` still says to gather Subject and
+  Scope "as one form via the elicit skill, preferring the rich widget
+  surface" — the D21 default that #2459 replaced. A fresh flower-shop
+  request on this desktop would therefore exercise the OLD guidance no
+  matter which checkout the session opens in, because these two skills are
+  plugin-sourced. The repository's own `.claude/skills/plan` and `attune`
+  skills call `AskUserQuestion` but are not the skills #2459 changed. This
+  session's own `attune-ai:elicit` listing came from the same stale cache;
+  the lead followed the worktree's SKILL.md text instead.
+- The marketplace clone at `~/.claude/plugins/marketplaces/attune-ai` is
+  also at f51a2dd6. The plugin version on origin/main is still 16.2.1, so
+  the cache path will not change on refresh.
+- Precondition, NOT run this session because it changes the operator's
+  global plugin install for every session on the machine:
+
+```bash
+claude plugin marketplace update attune-ai
+claude plugin update attune-ai@attune-ai
+```
+
+Then restart the desktop app (the CLI states a restart is required), then
+take the receipt:
+
+```bash
+grep -n "native questions first" ~/.claude/plugins/cache/attune-ai/attune-ai/16.2.1/skills/elicit/SKILL.md
+```
+
+A match on that path is the go signal for the recording. No match means do
+not record — the bakery lesson above.
+
+- Observation protocol once refreshed: a fresh desktop session, the
+  ordinary request "Help me plan a website for a flower shop", no mention
+  of forms. Record per item: which tool was called (`AskUserQuestion`,
+  `elicitation_render_widget`, or prose only); card and question counts;
+  keyboard-only completion (Tab, arrows, Space, Enter); whether a partial
+  answer set can be submitted and what the tool result then carries; what
+  the tool result carries on dismissal (Escape); and whether the
+  continuation uses the accepted answers. Tool returns in one column,
+  visible UI in a second, Patrick's attestation in a third.
+
+### Trial (b): Fable 5.1 widget — rendered; submit and keyboard pending
+
+Setup: one form built in this session with the five constructs the native
+control cannot express. Ranking of the four starter threads with the
+starter's order as the suggestion; triage over six items (the pending
+observations above; dispositions observe today / defer / drop; discovery
+suggested defer because of the stale cache); number (0–120 minutes); date;
+textarea for the attestation (2000 characters). The content is real: the
+answers are this thread's rulings.
+
+Tool returns, verified from the returns and not from the screen:
+
+| Step | Return |
+| --- | --- |
+| `elicitation_render_widget` | success; five field ids; 28,137 HTML bytes |
+| Serving process | project `.mcp.json` server, pid 26830, this worktree's venv; attune 16.2.1 imported from this worktree's `src` at f10baa3e1; attune-forms 0.14.0 |
+| Telemetry 19:06:19Z | `form_build` cf43dd900008; `form_surface` chose widget, reason `no_portable_control`; `form_rendered` instance `10404e263dd242a2b3e4e9b63466fcf8` |
+| `show_widget` | "Content rendered and shown to the user" — a host tool claim, not a paint observation |
+
+HTML inspection, from the returned string: number is
+`<input type="number" min="0" max="120" step="any">`; date is
+`<input type="date">`; the textarea has `rows="3" maxlength="2000"`; the
+ranking renders four ranked rows with move-up, move-down and remove
+buttons plus an empty unranked pool, headed "Ranked 4/4 proposed"; the
+triage renders six radiogroups. Every control is a native element with a
+`:focus-visible` outline, so Tab reach is plausible and unobserved.
+
+Finding for the forms repo, stated as an observation and not a bug claim:
+`suggested` on the ranking pre-fills the ranked list, and `suggested` on
+the triage pre-checks one radio per row, so an untouched Submit posts the
+proposals as the answer. The schema text calls a suggestion "a visible
+proposal, never the answer". Whether the renderer should leave the answer
+empty until the user acts is a forms-repo question (thread 4 territory).
+
+Pending, needs Patrick at the keyboard: paint of all five controls;
+keyboard-only operation of the ranking buttons, the radios, the number
+spinner, the date picker and the textarea; Submit; the
+`__elicitation_response__` post-back arriving in this session;
+`elicitation_collect_response` with the instance id; the `form_submitted`
+telemetry row (the falsifier from the Codex receipt: the submit carries
+the render's instance id); and the attestation text itself. Until those
+land, the D16 caveat on these constructs stands unchanged.
+
+### Other state at write time
+
+- #2461 open; its Tests workflow was still in progress (Windows lane and
+  coverage pending, nothing failed).
+- Codex Task 1B increment 2 exists as branch
+  `codex/host-surface-parity-task1b-increment2` at 1efa08406 in worktree
+  9c6c; no PR yet.


### PR DESCRIPTION
## What

Docs-only. Appends "Claude desktop trial prep" and the live results to
`docs/probes/host-surface-parity/host-native-trials-2026-09-07.md` for
thread 1 of the post-#2459 starter (desktop acceptance trials). Three
commits: autonomous prep, live observations with Patrick at the keyboard,
and a wording and line-length touch-up.

## Receipts

- **Trial (a) precondition:** the desktop `plugin:attune-ai` cache
  (`~/.claude/plugins/cache/attune-ai/attune-ai/16.2.1`) is at f51a2dd6
  (#2422, 2026-09-05) and does not contain #2459 (`git merge-base
  --is-ancestor` fails). Its elicit skill lacks the "Claude: native
  questions first" heading; its planning skill still prefers the widget
  surface. The probe records the refresh commands and the grep receipt that
  must match before any recording. Patrick chose to run the refresh after
  this session (card pick), so the discovery trial stays deferred.
- **Trial (b), Fable 5.1 widget, DONE:** `elicitation_render_widget`
  returned success, five field ids, 28,137 bytes; telemetry `form_surface`
  (widget, `no_portable_control`) and `form_rendered` (instance
  `10404e263dd242a2b3e4e9b63466fcf8`). Patrick submitted;
  `elicitation_collect_response` returned `resp-20260907-151254-6baac98d`;
  the `form_submitted` telemetry row landed the same second carrying the
  render's instance id. Keyboard-only widget operation attested on the
  follow-up card. Attestation: "It worked and worked well."
- **Trial (a) live cards:** one-question and four-question
  `AskUserQuestion` renders observed; a skipped question comes back as the
  literal `[No preference]`; Escape dismissal returns the host's generic
  tool-rejection text, ends the turn, and returns no answers. Result
  shapes recorded verbatim.
- **Finding:** the operator-local `ask_question_format_guard.py` forces a
  "(Recommended)" first option on every single-select question, which
  conflicts with D16's rule that confirm gates carry none. Recorded;
  Patrick's infrastructure, not a shipped hook.
- **Forms observation** filed as Smart-AI-Memory/attune-forms#90 at
  Patrick's direction, as a design question: the renderer's D2-c documents
  the pre-fill as intended.
- Lint: `pre-commit run --files <probe>` passed; no non-table line over 80
  characters after the touch-up.

## Still pending, not claimed

Fresh flower-shop discovery of #2459 (after the cache refresh and grep
receipt); a terminal Claude Code render; free text via "Other"; clean
keyboard-only completion of the native cards (Patrick's attestation was
mixed); desktop card paint details. The D16 caveat in decisions.md is left
for the chair to narrow.

## Notes

- No handoff file: the session starter carries the state. No labels
  applied; the chair merges.
- #2461 merged at 19:15Z as 46816577b during the session; this branch is
  docs-only off f10baa3e1 with no file overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
