### PR TITLE
docs(forms): D17 — the Claude ladder in the chair's words; widget for non-expressible constructs; rung 3 split (chair-read)

### DIFF
--- a/.agents/skills/elicit/SKILL.md
+++ b/.agents/skills/elicit/SKILL.md
@@ -112,36 +112,55 @@ A correction replaces the affected answer; it never restarts intake.
 Answers scope the work; they do not grant additional action authority.
 
 **Synchronous lifecycle:** `AskUserQuestion` blocks until the user
-submits, and its tool result carries the answers keyed by question text
-(a multi-select answer lists the chosen labels). Only that returned
-answer set is a reply; a rendered question, elapsed time, or a highlighted
-option is not. A call the user interrupts or dismisses supplies no
-answers and is the user's cancellation: stop dependent work, do not
-re-post the same questions automatically, and respond to what the user
-says next. A call that errors, or a tool that is absent or reported
-unsupported, is a tool failure, not a user decision: say so, keep any
-answers already returned, and ask a concise conversational question
-without claiming a control was shown. When the user answers some
+submits, and its tool result carries the answers keyed by question text.
+A multi-select answer lists the chosen labels joined by a bare comma; a
+question left blank comes back as the literal `[No preference]`; the
+recommended option's label comes back with its " (Recommended)" suffix,
+so match on the label you emitted. Only that returned answer set is a
+reply; a rendered question, elapsed time, or a highlighted option is not.
+A call the user interrupts or dismisses supplies no answers and is the
+user's cancellation — on the desktop it arrives either as a tool error
+that ends the turn or as a result whose every value is
+`[User dismissed — do not proceed, wait for next instruction]`; treat
+both alike: stop dependent work, do not re-post the same questions
+automatically, and respond to what the user says next. A call that
+errors, or a tool that is absent or reported unsupported, is a tool
+failure, not a user decision: say so, keep any answers already returned,
+and ask a concise conversational question without claiming a control was
+shown. When the user answers some
 questions in prose instead, retain those answers and ask only the
 remainder once.
 
-**Controls the schema cannot represent:** there is no number, date, or
-long-text control, and options cap at four. State the expected answer
-format and ask a concise typed question, or use a two-tier picker
-(category, then item) for more than four options; validate the typed reply
-against what you asked and never silently drop the field. Do not switch to
-an experimental renderer to represent it unless the user asked for a form.
+**Controls the schema cannot represent (D17 ladder):** options cap at
+four and there is no ordering, number, date, or long-text control, so
+`ranking`, `triage` over four items, `assumption_review` (its edit lane
+is a text question), `number`, `date`, and `textarea` do not fit. On a
+widget-capable Claude host (the desktop Code tab, Cowork) render the
+Attune widget: `elicitation_render_widget`, then pass its `html` to
+`show_widget` — the MCP Apps card does not paint on the Code tab, and
+`show_widget` is the path that does — and validate the post-back through
+`elicitation_collect_response` with the render's `instance_id`. Desktop
+acceptance was observed 2026-09-07: render, keyboard-only operation,
+submit, and a validated collect. Where no widget exists or the user is
+in keyboard mode: for a single `number`, `date`, or `textarea`, state
+the expected format and ask one typed question; for a ranking, a triage
+board, an assumption review, or any multi-field form, relay the
+`form_to_markdown` skeleton and parse the reply deterministically with
+`markdown_to_answers`. Never silently drop a field. For more than four
+options on an otherwise expressible question, use a two-tier picker
+(category, then item) on the native control.
 
-**Experimental on Claude for ordinary requests:** the Attune widget
-(`elicitation_render_widget` → `show_widget`, present only on
-widget-capable hosts such as the desktop Code tab and Cowork), the Attune
-server route (`elicitation_route_form`), and native MCP elicitation
-(`elicitation_ask`, which Claude Code has auto-declined without rendering;
-decisions D10). Use them only for an explicitly requested Attune-form
-interaction or trial, following the sections below; availability does not
-make them the default. Visible rendering, keyboard operation, partial
-submission, and dismissal behavior of `AskUserQuestion` on the desktop
-app are pending observation — do not claim them from the schema alone.
+**Still experimental on Claude:** the Attune server route
+(`elicitation_route_form`) and native MCP elicitation (`elicitation_ask`,
+which Claude Code has auto-declined without rendering; decisions D10).
+Use them only for an explicitly requested Attune-form interaction or
+trial, following the sections below; availability does not make them the
+default. Observed on the desktop Code tab 2026-09-07: one- and
+four-question `AskUserQuestion` cards render, a partially answered card
+submits, dismissal returns no answers, and the widget path above round
+trips. Still pending: discovery of this guidance on a fresh ordinary
+request, a terminal render, and free text through "Other" — do not claim
+those.
 
 ### Antigravity: enhanced prompts; native forms experimental
 

--- a/.agents/skills/planning/SKILL.md
+++ b/.agents/skills/planning/SKILL.md
@@ -81,9 +81,14 @@ the built-in "Other"). Read the `elicit` skill's **Host defaults** for the
 synchronous reply lifecycle, answer retention, corrections, cancellation,
 and the typed fallback for controls the schema cannot represent. Ask a
 subject or problem statement as a plain conversational question when it
-has no honest predefined choices. The Attune widget and server route are
-experimental on Claude; use them only when the user asks for a form.
-Desktop rendering and keyboard behavior remain pending observation.
+has no honest predefined choices. For a form the control cannot carry
+(ranking, triage over four, assumption review, number, date, textarea)
+follow the `elicit` skill's Claude ladder (D17): the Attune widget via
+`show_widget` on a widget-capable host, else one typed question for a
+single simple field or the markdown skeleton for a structured form. The
+server route stays experimental on Claude. Desktop rendering and keyboard
+operation of the native card and the widget were observed 2026-09-07;
+fresh-request discovery is still pending.
 
 **Antigravity:** use the `elicit` host default: enhanced conversational
 prompts, with native forms experimental.

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -563,16 +563,20 @@ The native control carries the decision-shaped constructs too:
 
 ### Constructs the native control cannot express
 
-`ranking` (no ordering control), `triage` over four items, and the
-`number` / `date` / `textarea` fields have no honest `AskUserQuestion`
-shape. For these, and only these, build the `FormSchema` via
-`attune.elicitation.form_from_dict` and render
-`form_to_widget_html(form)` on a widget-capable session. Where no
-widget exists, or the user is in keyboard mode, use the typed fallback
-(`form_to_markdown` skeleton, deterministic parse) and never silently
-drop the field. Otherwise the widget and Attune forms are experimental
-in this repository too: use them only when the user asks for a form or
-a trial.
+`ranking` (no ordering control), `triage` over four items, the
+`number` / `date` / `textarea` fields, and a library-routed
+`assumption_review` (its edit lane is a text question; an agent-composed
+card with accept / reject and one edit through "Other" stays legal) have
+no honest `AskUserQuestion` shape. For these, and only these, build the
+`FormSchema` via `attune.elicitation.form_from_dict` and render
+`form_to_widget_html(form)` through `show_widget` on a widget-capable
+session (D17; desktop acceptance observed 2026-09-07). Where no widget
+exists, or the user is in keyboard mode: one typed question for a single
+`number` / `date` / `textarea`; the `form_to_markdown` skeleton with a
+deterministic parse for a ranking, triage, assumption review, or any
+multi-field form. Never silently drop a field. Otherwise the widget and
+Attune forms are experimental in this repository too: use them only when
+the user asks for a form or a trial.
 
 ### Two grammars, two directions — not a ranking
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,10 +17,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Claude planning guidance now prefers the host's built-in `AskUserQuestion`
-  for ordinary scoping requests, asks schema-unrepresentable fields as typed
-  questions, and treats an interrupted call as cancellation. The Attune
-  widget and server route are experimental on Claude; desktop rendering and
-  keyboard acceptance remain pending observation.
+  for ordinary scoping requests, renders the Attune widget through
+  `show_widget` for the constructs the control cannot carry on widget-capable
+  hosts (desktop Code tab, Cowork; acceptance observed 2026-09-07), falls
+  back to one typed question for a single simple field or the markdown
+  skeleton for a structured form, and treats an interrupted or dismissed
+  call as cancellation (host-surface-parity D17). The Attune server route
+  and native MCP elicitation stay experimental on Claude.
 
 - Codex planning guidance now prefers built-in questions and handles pending
   asynchronous replies, corrections, and cancellation explicitly. Attune forms

--- a/docs/specs/host-surface-parity/decisions.md
+++ b/docs/specs/host-surface-parity/decisions.md
@@ -940,6 +940,62 @@ not been exercised on the current desktop model; until it is, those
 constructs carry the same unobserved-rendering caveat as the native
 control.
 
+## D17 — The Claude ladder, in the chair's words (2026-09-07 evening; recorded by the lead)
+
+Patrick, verbatim: "It uses native questions by default for claude you
+use askuserquestion using all controls, in claude's case, forms that
+handle widgets not covered by native questions (askuserquestions) are
+used. If they can't be used the would use enhanced prompts. Enhanced
+prompts are used by default by Antigravity btw." He then asked for
+pushback.
+
+The lead pushed back on rung 3 only, on the native control: the five
+non-expressible constructs exist to carry structure (an order, per-item
+rulings, a bounded number, a date, long text) and a conversational
+prompt drops the deterministic parse and R4 validation that the PORTABLE
+markdown form keeps. Counter-case carried with it: for one simple field
+a skeleton is ceremony, and the skill already says to state the format
+and ask a typed question. Patrick picked "Split rung 3 (Recommended)".
+
+Disclosures accepted with the pick: attune-forms admits nine types
+natively, not D16's ten — `assumption_review`'s edit lane expands to a
+text question in the library, so the library routes it to the widget
+(an agent-composed native card with accept / reject and a single edit
+through "Other" remains legal in dev sessions); and on the desktop Code
+tab the only painting widget path is `show_widget`, which the skills now
+name.
+
+Ruled:
+
+1. Rung 1 — native `AskUserQuestion` for every ask it can express,
+   decision-shaped asks included.
+2. Rung 2 — the Attune widget (`elicitation_render_widget` →
+   `show_widget`, validated through `elicitation_collect_response`) for
+   `ranking`, `triage` over four items, `assumption_review`, `number`,
+   `date`, and `textarea` on widget-capable Claude hosts. This narrows
+   D16's caveat: on the desktop Code tab the lead observed, with Patrick
+   at the keyboard on 2026-09-07, native one- and four-question renders,
+   partial submission (`[No preference]`), dismissal (a tool error on a
+   one-question card; the sentinel `[User dismissed — do not proceed,
+   wait for next instruction]` per question on a four-question card),
+   and the widget's render, keyboard-only operation, submit, and
+   validated collect (probe `host-native-trials-2026-09-07.md`).
+   Fresh-request discovery stays pending until the desktop plugin cache
+   carries #2459.
+3. Rung 3, split — where no widget exists or the user is in keyboard
+   mode: one typed question stating the expected format for a single
+   `number`, `date`, or `textarea`; the `form_to_markdown` skeleton with
+   `markdown_to_answers` for a ranking, triage, assumption review, or any
+   multi-field form. Never silently drop a field.
+4. Antigravity: enhanced conversational prompts by default (D15,
+   unchanged). Codex: built-in questions first (D15, unchanged).
+
+Shipped with this entry, same PR: the `elicit` and `planning` skills'
+Claude sections, the Socratic rule in `.claude/CLAUDE.md`, and the
+CHANGELOG line. attune-forms PR #91 (AF-2) encodes the same ladder in
+`select_form_surface` (host-native default; widget only when the
+installed host-question profile does not admit the form).
+
 ## Open decisions
 
 - None. Every proposed decision in this spec is ruled.

--- a/plugin/help/generated/references/skill-elicit.md
+++ b/plugin/help/generated/references/skill-elicit.md
@@ -108,36 +108,55 @@ A correction replaces the affected answer; it never restarts intake.
 Answers scope the work; they do not grant additional action authority.
 
 **Synchronous lifecycle:** `AskUserQuestion` blocks until the user
-submits, and its tool result carries the answers keyed by question text
-(a multi-select answer lists the chosen labels). Only that returned
-answer set is a reply; a rendered question, elapsed time, or a highlighted
-option is not. A call the user interrupts or dismisses supplies no
-answers and is the user's cancellation: stop dependent work, do not
-re-post the same questions automatically, and respond to what the user
-says next. A call that errors, or a tool that is absent or reported
-unsupported, is a tool failure, not a user decision: say so, keep any
-answers already returned, and ask a concise conversational question
-without claiming a control was shown. When the user answers some
+submits, and its tool result carries the answers keyed by question text.
+A multi-select answer lists the chosen labels joined by a bare comma; a
+question left blank comes back as the literal `[No preference]`; the
+recommended option's label comes back with its " (Recommended)" suffix,
+so match on the label you emitted. Only that returned answer set is a
+reply; a rendered question, elapsed time, or a highlighted option is not.
+A call the user interrupts or dismisses supplies no answers and is the
+user's cancellation — on the desktop it arrives either as a tool error
+that ends the turn or as a result whose every value is
+`[User dismissed — do not proceed, wait for next instruction]`; treat
+both alike: stop dependent work, do not re-post the same questions
+automatically, and respond to what the user says next. A call that
+errors, or a tool that is absent or reported unsupported, is a tool
+failure, not a user decision: say so, keep any answers already returned,
+and ask a concise conversational question without claiming a control was
+shown. When the user answers some
 questions in prose instead, retain those answers and ask only the
 remainder once.
 
-**Controls the schema cannot represent:** there is no number, date, or
-long-text control, and options cap at four. State the expected answer
-format and ask a concise typed question, or use a two-tier picker
-(category, then item) for more than four options; validate the typed reply
-against what you asked and never silently drop the field. Do not switch to
-an experimental renderer to represent it unless the user asked for a form.
+**Controls the schema cannot represent (D17 ladder):** options cap at
+four and there is no ordering, number, date, or long-text control, so
+`ranking`, `triage` over four items, `assumption_review` (its edit lane
+is a text question), `number`, `date`, and `textarea` do not fit. On a
+widget-capable Claude host (the desktop Code tab, Cowork) render the
+Attune widget: `elicitation_render_widget`, then pass its `html` to
+`show_widget` — the MCP Apps card does not paint on the Code tab, and
+`show_widget` is the path that does — and validate the post-back through
+`elicitation_collect_response` with the render's `instance_id`. Desktop
+acceptance was observed 2026-09-07: render, keyboard-only operation,
+submit, and a validated collect. Where no widget exists or the user is
+in keyboard mode: for a single `number`, `date`, or `textarea`, state
+the expected format and ask one typed question; for a ranking, a triage
+board, an assumption review, or any multi-field form, relay the
+`form_to_markdown` skeleton and parse the reply deterministically with
+`markdown_to_answers`. Never silently drop a field. For more than four
+options on an otherwise expressible question, use a two-tier picker
+(category, then item) on the native control.
 
-**Experimental on Claude for ordinary requests:** the Attune widget
-(`elicitation_render_widget` → `show_widget`, present only on
-widget-capable hosts such as the desktop Code tab and Cowork), the Attune
-server route (`elicitation_route_form`), and native MCP elicitation
-(`elicitation_ask`, which Claude Code has auto-declined without rendering;
-decisions D10). Use them only for an explicitly requested Attune-form
-interaction or trial, following the sections below; availability does not
-make them the default. Visible rendering, keyboard operation, partial
-submission, and dismissal behavior of `AskUserQuestion` on the desktop
-app are pending observation — do not claim them from the schema alone.
+**Still experimental on Claude:** the Attune server route
+(`elicitation_route_form`) and native MCP elicitation (`elicitation_ask`,
+which Claude Code has auto-declined without rendering; decisions D10).
+Use them only for an explicitly requested Attune-form interaction or
+trial, following the sections below; availability does not make them the
+default. Observed on the desktop Code tab 2026-09-07: one- and
+four-question `AskUserQuestion` cards render, a partially answered card
+submits, dismissal returns no answers, and the widget path above round
+trips. Still pending: discovery of this guidance on a fresh ordinary
+request, a terminal render, and free text through "Other" — do not claim
+those.
 
 ### Antigravity: enhanced prompts; native forms experimental
 

--- a/plugin/help/generated/references/skill-planning.md
+++ b/plugin/help/generated/references/skill-planning.md
@@ -90,9 +90,14 @@ the built-in "Other"). Read the `elicit` skill's **Host defaults** for the
 synchronous reply lifecycle, answer retention, corrections, cancellation,
 and the typed fallback for controls the schema cannot represent. Ask a
 subject or problem statement as a plain conversational question when it
-has no honest predefined choices. The Attune widget and server route are
-experimental on Claude; use them only when the user asks for a form.
-Desktop rendering and keyboard behavior remain pending observation.
+has no honest predefined choices. For a form the control cannot carry
+(ranking, triage over four, assumption review, number, date, textarea)
+follow the `elicit` skill's Claude ladder (D17): the Attune widget via
+`show_widget` on a widget-capable host, else one typed question for a
+single simple field or the markdown skeleton for a structured form. The
+server route stays experimental on Claude. Desktop rendering and keyboard
+operation of the native card and the widget were observed 2026-09-07;
+fresh-request discovery is still pending.
 
 **Antigravity:** use the `elicit` host default: enhanced conversational
 prompts, with native forms experimental.

--- a/plugin/skills/elicit/SKILL.md
+++ b/plugin/skills/elicit/SKILL.md
@@ -114,36 +114,55 @@ A correction replaces the affected answer; it never restarts intake.
 Answers scope the work; they do not grant additional action authority.
 
 **Synchronous lifecycle:** `AskUserQuestion` blocks until the user
-submits, and its tool result carries the answers keyed by question text
-(a multi-select answer lists the chosen labels). Only that returned
-answer set is a reply; a rendered question, elapsed time, or a highlighted
-option is not. A call the user interrupts or dismisses supplies no
-answers and is the user's cancellation: stop dependent work, do not
-re-post the same questions automatically, and respond to what the user
-says next. A call that errors, or a tool that is absent or reported
-unsupported, is a tool failure, not a user decision: say so, keep any
-answers already returned, and ask a concise conversational question
-without claiming a control was shown. When the user answers some
+submits, and its tool result carries the answers keyed by question text.
+A multi-select answer lists the chosen labels joined by a bare comma; a
+question left blank comes back as the literal `[No preference]`; the
+recommended option's label comes back with its " (Recommended)" suffix,
+so match on the label you emitted. Only that returned answer set is a
+reply; a rendered question, elapsed time, or a highlighted option is not.
+A call the user interrupts or dismisses supplies no answers and is the
+user's cancellation — on the desktop it arrives either as a tool error
+that ends the turn or as a result whose every value is
+`[User dismissed — do not proceed, wait for next instruction]`; treat
+both alike: stop dependent work, do not re-post the same questions
+automatically, and respond to what the user says next. A call that
+errors, or a tool that is absent or reported unsupported, is a tool
+failure, not a user decision: say so, keep any answers already returned,
+and ask a concise conversational question without claiming a control was
+shown. When the user answers some
 questions in prose instead, retain those answers and ask only the
 remainder once.
 
-**Controls the schema cannot represent:** there is no number, date, or
-long-text control, and options cap at four. State the expected answer
-format and ask a concise typed question, or use a two-tier picker
-(category, then item) for more than four options; validate the typed reply
-against what you asked and never silently drop the field. Do not switch to
-an experimental renderer to represent it unless the user asked for a form.
+**Controls the schema cannot represent (D17 ladder):** options cap at
+four and there is no ordering, number, date, or long-text control, so
+`ranking`, `triage` over four items, `assumption_review` (its edit lane
+is a text question), `number`, `date`, and `textarea` do not fit. On a
+widget-capable Claude host (the desktop Code tab, Cowork) render the
+Attune widget: `elicitation_render_widget`, then pass its `html` to
+`show_widget` — the MCP Apps card does not paint on the Code tab, and
+`show_widget` is the path that does — and validate the post-back through
+`elicitation_collect_response` with the render's `instance_id`. Desktop
+acceptance was observed 2026-09-07: render, keyboard-only operation,
+submit, and a validated collect. Where no widget exists or the user is
+in keyboard mode: for a single `number`, `date`, or `textarea`, state
+the expected format and ask one typed question; for a ranking, a triage
+board, an assumption review, or any multi-field form, relay the
+`form_to_markdown` skeleton and parse the reply deterministically with
+`markdown_to_answers`. Never silently drop a field. For more than four
+options on an otherwise expressible question, use a two-tier picker
+(category, then item) on the native control.
 
-**Experimental on Claude for ordinary requests:** the Attune widget
-(`elicitation_render_widget` → `show_widget`, present only on
-widget-capable hosts such as the desktop Code tab and Cowork), the Attune
-server route (`elicitation_route_form`), and native MCP elicitation
-(`elicitation_ask`, which Claude Code has auto-declined without rendering;
-decisions D10). Use them only for an explicitly requested Attune-form
-interaction or trial, following the sections below; availability does not
-make them the default. Visible rendering, keyboard operation, partial
-submission, and dismissal behavior of `AskUserQuestion` on the desktop
-app are pending observation — do not claim them from the schema alone.
+**Still experimental on Claude:** the Attune server route
+(`elicitation_route_form`) and native MCP elicitation (`elicitation_ask`,
+which Claude Code has auto-declined without rendering; decisions D10).
+Use them only for an explicitly requested Attune-form interaction or
+trial, following the sections below; availability does not make them the
+default. Observed on the desktop Code tab 2026-09-07: one- and
+four-question `AskUserQuestion` cards render, a partially answered card
+submits, dismissal returns no answers, and the widget path above round
+trips. Still pending: discovery of this guidance on a fresh ordinary
+request, a terminal render, and free text through "Other" — do not claim
+those.
 
 ### Antigravity: enhanced prompts; native forms experimental
 

--- a/plugin/skills/planning/SKILL.md
+++ b/plugin/skills/planning/SKILL.md
@@ -83,9 +83,14 @@ the built-in "Other"). Read the `elicit` skill's **Host defaults** for the
 synchronous reply lifecycle, answer retention, corrections, cancellation,
 and the typed fallback for controls the schema cannot represent. Ask a
 subject or problem statement as a plain conversational question when it
-has no honest predefined choices. The Attune widget and server route are
-experimental on Claude; use them only when the user asks for a form.
-Desktop rendering and keyboard behavior remain pending observation.
+has no honest predefined choices. For a form the control cannot carry
+(ranking, triage over four, assumption review, number, date, textarea)
+follow the `elicit` skill's Claude ladder (D17): the Attune widget via
+`show_widget` on a widget-capable host, else one typed question for a
+single simple field or the markdown skeleton for a structured form. The
+server route stays experimental on Claude. Desktop rendering and keyboard
+operation of the native card and the widget were observed 2026-09-07;
+fresh-request discovery is still pending.
 
 **Antigravity:** use the `elicit` host default: enhanced conversational
 prompts, with native forms experimental.


### PR DESCRIPTION
## What

Records **host-surface-parity D17** verbatim from Patrick (2026-09-07
evening) with his pushback pick, and ships the ladder it rules in the
shipped skills. Docs and skill text only. Chair-read: it touches the
Socratic rule in `.claude/CLAUDE.md` and a decisions record.

**The ladder on Claude (D17):**

1. Native `AskUserQuestion` for every ask it can express.
2. The Attune widget (`elicitation_render_widget` → `show_widget`,
   collected through `elicitation_collect_response` with the render's
   `instance_id`) for ranking, triage over four, assumption review,
   number, date and textarea on widget-capable hosts (desktop Code tab,
   Cowork).
3. Split rung 3 (Patrick picked the lead's alternative over "enhanced
   prompts always"): one typed question stating the format for a single
   number/date/textarea; the `form_to_markdown` skeleton with
   `markdown_to_answers` for a ranking, triage, assumption review or any
   multi-field form.

Antigravity keeps enhanced prompts by default and Codex keeps built-in
questions (D15, unchanged).

## Receipts

- Rung 2 rests on today's desktop observations with Patrick at the
  keyboard (probe `host-native-trials-2026-09-07.md`, merged in #2462):
  native one- and four-question renders, partial submit (`[No preference]`),
  dismissal (tool error on a one-question card; the sentinel
  `[User dismissed — do not proceed, wait for next instruction]` per
  question on a four-question card), and the widget's render, keyboard-only
  operation, submit and validated collect (`resp-20260907-151254-6baac98d`).
- `python scripts/sync_agents_skills.py --write` regenerated the mirrors;
  `tests/unit/plugins/test_sync_agents_skills.py` passes; preflight reports
  skills-projection and collaboration-projection in sync.
- Drift guards run locally: `tests/unit/plugins` (skill/reference/mirror
  selection), `tests/unit/lessons/test_core_mirror.py`, `tests/unit/rules`,
  brand and claim drift gates: all green. Pre-commit hooks pass on every
  changed file.
- Prompt refinement checked, not changed: `HOST_INSTRUCTIONS` in
  `src/attune/prompt_refinement.py` already defers to the elicit/form tools
  "when useful and supported", so detected questions inherit this ladder.

## Disclosures accepted with the pick

- attune-forms admits **nine** types natively, not D16's ten:
  `assumption_review`'s edit lane expands to a text question, so the
  library routes it to the widget. An agent-composed native card with
  accept / reject and one edit through "Other" stays legal in dev sessions.
- On the desktop Code tab the MCP Apps card does not paint; `show_widget`
  is the path that does, and the skills now say so.

## Still pending, not claimed

Fresh-request discovery of this guidance (needs the desktop plugin cache
refreshed past #2459 and the grep receipt), a terminal render, and free
text through "Other". Codex ladder observations are unchanged from D15.

## Related

- attune-forms#91 (AF-2) encodes the same ladder in `select_form_surface`
  and ships `HostQuestionProfile`; independent of this PR.
- This PR is also the truth-up named for the 16.3.0 cut: the CHANGELOG
  Unreleased line no longer says desktop rendering is pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
