### PR TITLE
docs(probes): host-native trials — correct the plugin refresh recipe (version-keyed cache; update is a no-op at 16.2.1)

### DIFF
--- a/docs/probes/host-surface-parity/host-native-trials-2026-09-07.md
+++ b/docs/probes/host-surface-parity/host-native-trials-2026-09-07.md
@@ -140,15 +140,28 @@ paint or keyboard observation. Every claim names its basis.
   also at f51a2dd6. The plugin version on origin/main is still 16.2.1, so
   the cache path will not change on refresh.
 - Precondition, NOT run this session because it changes the operator's
-  global plugin install for every session on the machine:
+  global plugin install for every session on the machine. **Corrected
+  2026-09-07 late (next-session-start session):** the two-command
+  refresh originally written here cannot deliver #2459. Patrick ran
+  `claude plugin marketplace update attune-ai` that evening and the
+  clone moved to d45019a0 (19:45Z, which contains 7bdf4112e), yet the
+  cache directory kept its 2026-09-04 mtime and `installed_plugins.json`
+  its f51a2dd6 SHA: `claude plugin update` is a no-op while the
+  declared plugin version is unchanged, because the cache is keyed by
+  version and the recorded commit SHA is not used for change detection.
+  Basis: the Claude Code plugin docs (via the guide agent) plus those
+  on-disk timestamps; not verified by running the update. Two ways the
+  cache can move:
 
 ```bash
-claude plugin marketplace update attune-ai
-claude plugin update attune-ai@attune-ai
+# interim, operator-run: drop the version-keyed cache and reinstall
+claude plugin uninstall attune-ai@attune-ai
+claude plugin install attune-ai@attune-ai
 ```
 
-Then restart the desktop app (the CLI states a restart is required), then
-take the receipt:
+or wait for the 16.3.0 release, whose version bump is what delivers
+#2459 to every installed user. Either way restart the desktop app (the
+CLI states a restart is required), then take the receipt:
 
 ```bash
 grep -n "native questions first" ~/.claude/plugins/cache/attune-ai/attune-ai/16.2.1/skills/elicit/SKILL.md
@@ -340,7 +353,7 @@ skill discovery item stays deferred until the plugin cache is refreshed.
 | Keyboard-only completion | attested for the widget; not clean for the native cards | Patrick's picks (see the two cards above) |
 | Partial call can be submitted | observed | skipped question returned as `[No preference]` |
 | Tool result on dismissal | observed | generic rejection text, turn ended, no answers |
-| Fresh flower-shop request discovers #2459 | deferred | plugin cache stale; Patrick refreshes after this session |
+| Fresh flower-shop request discovers #2459 | deferred | plugin cache stale by mechanism (version-keyed; `plugin update` is a no-op at 16.2.1); needs the 16.3.0 bump or uninstall + reinstall — corrected 2026-09-07 late |
 
 Not observed: a terminal Claude Code rendering, free text through
 "Other", and the desktop card's paint details (layout, focus ring,


### PR DESCRIPTION
## What this is

Docs-only, one file. The 2026-09-07 host-native trials probe told the operator to refresh the desktop plugin with `claude plugin marketplace update attune-ai` + `claude plugin update attune-ai@attune-ai` + restart before recording the discovery trial. That recipe cannot deliver #2459 and the probe now says so as a **dated correction** (the record itself is not rewritten).

## Why the recipe fails

- The marketplace clone did move to `d45019a0` (2026-09-07 19:45Z; contains `7bdf4112e` = #2459) after Patrick ran the marketplace update.
- The cache `~/.claude/plugins/cache/attune-ai/attune-ai/16.2.1` kept its Sep 4 mtime and `installed_plugins.json` its `f51a2dd6` SHA, and the receipt grep still matches nothing.
- `claude plugin update` is a no-op while the declared plugin version is unchanged: the cache is keyed by version, and the recorded commit SHA is not used for change detection.

**Basis:** Claude Code plugin docs via the guide agent, plus the on-disk timestamps above. Not verified by running the update (it changes the operator's global install for every session on the machine, the same reason the original session did not run it).

## What changed

- Precondition block: correction paragraph with the basis, interim recipe (`uninstall` + `install`), and the 16.3.0 bump named as the delivery vehicle.
- Results table: the deferred flower-shop row says "stale by mechanism" instead of "Patrick refreshes after this session".

Pinned pre-commit hooks passed on the file. Handed over by the sibling session that wrote the original recipe; the same finding is recorded in the calibration-spec PR's sibling thread and the session starters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
