### PR TITLE
fix(deps): pin attune-forms below 0.16 — 0.17.0 turned main red with no commit

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,12 @@ dependencies = [
     "typing-extensions>=4.0.0,<5.0.0",
     "python-dotenv>=1.0.0,<2.0.0",
     "structlog>=24.0.0,<27.0.0",
-    "attune-forms>=0.15.0,<1.0",  # AF-2: HostQuestionProfile, route-active host target, host-native router default (D15-D17)
+    # CEILING IS LOAD-BEARING: 0.16.0+ ships AF-2 registry changes this repo
+    # has not consumed yet, and the surface-parity gates fail against them
+    # (verified: 0.15.0 -> 238 passed, 0.17.0 -> 10 failed in
+    # tests/unit/gates/test_surface_parity.py). host-surface-parity Task 2
+    # lands the new receipt line and raises this to >=0.17.0 (D18).
+    "attune-forms>=0.15.0,<0.16",  # AF-2: HostQuestionProfile, route-active host target, host-native router default (D15-D17)
     "jsonschema>=4.26.0,<5.0.0",  # Direct use by surface-evidence HEADLESS contract validation
     "defusedxml>=0.7.0,<1.0.0",
     "rich>=13.0.0,<16.0.0",  # Beautiful CLI output

--- a/uv.lock
+++ b/uv.lock
@@ -532,7 +532,7 @@ requires-dist = [
     { name = "anthropic", marker = "extra == 'enterprise'", specifier = ">=0.40.0" },
     { name = "anthropic", marker = "extra == 'full'", specifier = ">=0.40.0" },
     { name = "anthropic", marker = "extra == 'llm'", specifier = ">=0.40.0" },
-    { name = "attune-forms", specifier = ">=0.15.0,<1.0" },
+    { name = "attune-forms", specifier = ">=0.15.0,<0.16" },
     { name = "attune-help", marker = "extra == 'dev'", specifier = ">=0.10.0" },
     { name = "attune-rag", specifier = ">=1.2.0,<2.0" },
     { name = "attune-rag", marker = "extra == 'dev'", specifier = ">=1.2.0,<2.0" },


### PR DESCRIPTION
## Main is red, and no commit caused it

Main has been failing since **2026-09-08 22:19 UTC** with nothing pushed to it. `pyproject.toml` floated `attune-forms>=0.15.0,<1.0`, and the CI test job installs `attune-ai==16.3.0` **resolving fresh rather than from `uv.lock`** — so it takes whatever satisfies the range at job time.

| Event | Time (UTC) |
|---|---|
| main's last tests.yml run — **green** | 2026-09-08 03:57 |
| attune-forms **0.16.0** published | 2026-09-08 22:19 |
| attune-forms **0.17.0** published | 2026-09-08 23:43 |
| first CI run after — **12 required checks red** | 2026-09-09 00:27 |

Main's last run predates both releases. That is the only reason it still *looks* green; the next push would have hit this cold.

## Why the gates fail

0.16.0+ ships AF-2 registry changes this repo has not consumed — the new route-active target has no receipt line here, so the registry raises:

```
SurfaceRegistryError: lifecycle:subject:surface-native-elicitation:abort:
stale/missing implementation_digest
```

Consuming those changes is `host-surface-parity` **Task 2**'s job, and Task 2 is blocked on Task 10 (`src/attune/surfaces/` does not exist yet).

## Reproduced with the version as the only variable

Released PyPI artifact shadowed onto an otherwise unchanged tree:

| attune-forms | `tests/unit/gates/test_surface_parity.py` |
|---|---|
| 0.15.0 | **238 passed** |
| 0.17.0 | **10 failed**, 228 passed — failing names match CI exactly |

## The change

Ceiling narrowed to `<0.16` and documented as load-bearing, matching the convention already used for the other ceilings in this file, with a pointer to the work that lifts it (Task 2 raises it to `>=0.17.0` under D18). `uv.lock` re-resolves to **0.15.0 unchanged** — only the recorded specifier moves.

`<0.16` rather than `<0.17` deliberately: 0.15.0 is verified green and 0.17.0 verified red; **0.16.0 was never tested**, so the conservative bound is the honest one.

## Receipt

Whole configured tree: **26,143 passed, 266 skipped, 3 xfailed** in 90.81s.

## Follow-up, not in this PR

The structural half — making CI install from `uv.lock` (`uv sync --locked`) so an upstream release can never again change what CI installs without a commit. This PR is the immediate restoration only.

Note for dependabot: the ceiling is deliberate, so a widening bump should be closed with `@dependabot ignore` per the documented-ceiling convention, not merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
