### PR TITLE
fix(ci): install tests.yml gate lanes from uv.lock, not a fresh resolve

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -142,9 +142,31 @@ jobs:
 
     - name: Install dependencies
       if: needs.changes.outputs.website_only != 'true'
+      # Install the versions in uv.lock, never a fresh resolve. A floating
+      # upper bound plus a fresh resolve let an upstream PUBLISH turn main
+      # red with no commit: attune-forms 0.17.0 shipped 2026-09-08 22:19Z
+      # and the next run installed it, failing 12 required checks, while
+      # main's last (older) run still read green. uv exports the locked
+      # versions as a pip constraints file, so the same tree installs the
+      # same dependencies until a commit changes uv.lock. `--locked` fails
+      # loudly when the lock is stale instead of silently re-resolving.
+      #
+      # The uv pin tracks whatever writes uv.lock; a newer lock revision
+      # fails this export loudly, and the fix is to bump both together.
+      #
+      # NOT locked, on purpose: the default-install-smoke lane still
+      # resolves fresh. That lane is the signal for "the published range is
+      # broken for users", and this change must not hide it.
+      #
+      # shell: bash forces Git Bash on Windows runners so $RUNNER_TEMP and
+      # the quoting below behave identically across the matrix.
+      shell: bash
       run: |
         python -m pip install --upgrade pip
-        pip install -e .[dev]
+        pip install 'uv==0.9.22'
+        uv export --locked --extra dev --no-emit-project --no-hashes \
+          -o "$RUNNER_TEMP/ci-constraints.txt"
+        pip install -e .[dev] -c "$RUNNER_TEMP/ci-constraints.txt"
 
     # Download tokenizer data during setup; pytest stays inference-blocked.
     - name: Cache tiktoken encodings
@@ -276,9 +298,31 @@ jobs:
 
     - name: Install dependencies
       if: needs.changes.outputs.website_only != 'true'
+      # Install the versions in uv.lock, never a fresh resolve. A floating
+      # upper bound plus a fresh resolve let an upstream PUBLISH turn main
+      # red with no commit: attune-forms 0.17.0 shipped 2026-09-08 22:19Z
+      # and the next run installed it, failing 12 required checks, while
+      # main's last (older) run still read green. uv exports the locked
+      # versions as a pip constraints file, so the same tree installs the
+      # same dependencies until a commit changes uv.lock. `--locked` fails
+      # loudly when the lock is stale instead of silently re-resolving.
+      #
+      # The uv pin tracks whatever writes uv.lock; a newer lock revision
+      # fails this export loudly, and the fix is to bump both together.
+      #
+      # NOT locked, on purpose: the default-install-smoke lane still
+      # resolves fresh. That lane is the signal for "the published range is
+      # broken for users", and this change must not hide it.
+      #
+      # shell: bash forces Git Bash on Windows runners so $RUNNER_TEMP and
+      # the quoting below behave identically across the matrix.
+      shell: bash
       run: |
         python -m pip install --upgrade pip
-        pip install -e .[dev]
+        pip install 'uv==0.9.22'
+        uv export --locked --extra dev --no-emit-project --no-hashes \
+          -o "$RUNNER_TEMP/ci-constraints.txt"
+        pip install -e .[dev] -c "$RUNNER_TEMP/ci-constraints.txt"
 
     # Download tokenizer data during setup; pytest stays inference-blocked.
     - name: Cache tiktoken encodings
@@ -341,9 +385,31 @@ jobs:
 
     - name: Install dependencies
       if: needs.changes.outputs.website_only != 'true'
+      # Install the versions in uv.lock, never a fresh resolve. A floating
+      # upper bound plus a fresh resolve let an upstream PUBLISH turn main
+      # red with no commit: attune-forms 0.17.0 shipped 2026-09-08 22:19Z
+      # and the next run installed it, failing 12 required checks, while
+      # main's last (older) run still read green. uv exports the locked
+      # versions as a pip constraints file, so the same tree installs the
+      # same dependencies until a commit changes uv.lock. `--locked` fails
+      # loudly when the lock is stale instead of silently re-resolving.
+      #
+      # The uv pin tracks whatever writes uv.lock; a newer lock revision
+      # fails this export loudly, and the fix is to bump both together.
+      #
+      # NOT locked, on purpose: the default-install-smoke lane still
+      # resolves fresh. That lane is the signal for "the published range is
+      # broken for users", and this change must not hide it.
+      #
+      # shell: bash forces Git Bash on Windows runners so $RUNNER_TEMP and
+      # the quoting below behave identically across the matrix.
+      shell: bash
       run: |
         python -m pip install --upgrade pip
-        pip install -e .[dev]
+        pip install 'uv==0.9.22'
+        uv export --locked --extra dev --no-emit-project --no-hashes \
+          -o "$RUNNER_TEMP/ci-constraints.txt"
+        pip install -e .[dev] -c "$RUNNER_TEMP/ci-constraints.txt"
 
     # Download tokenizer data during setup; pytest stays inference-blocked.
     - name: Cache tiktoken encodings


### PR DESCRIPTION
Structural half of the 0.17.0 incident. [#2476](https://github.com/Smart-AI-Memory/attune-ai/pull/2476) pinned the ceiling that broke; this removes the mechanism that let an upstream publish break anything at all.

## The mechanism

`tests.yml` ran `pip install -e .[dev]` in three jobs — `test`, `clock-tz`, `coverage` — which **resolves ranges fresh at job time**. A PyPI publish could therefore change what CI installed with no commit in this repo. On 2026-09-08 it did: attune-forms 0.17.0 shipped at 22:19Z, the next run installed it, 12 required checks went red, and main's last run still read green because it predated the release.

The workflow already listed `uv.lock` in its **pip cache key** while ignoring it for resolution — the lock was present, correct, and consulted by nothing.

## The change

Each of those three steps now exports the locked versions with `uv export --locked` and installs under them as a pip constraints file. The same tree installs the same dependencies until a commit changes `uv.lock`, and `--locked` fails **loudly** on a stale lock rather than silently re-resolving.

## Receipt that the constraints actually bind

Run against the real released artifacts, not a mock:

```
pip install --dry-run --ignore-installed attune-forms
  -> would install attune-forms-0.17.0    # what CI did
pip install --dry-run --ignore-installed attune-forms -c <export>
  -> would install attune-forms-0.15.0    # what uv.lock says
```

## Deliberately NOT locked

`default-install-smoke`, in this same workflow, **still resolves fresh**. That lane exists to answer *"is the published range broken for users"* — a real question this change must not hide. A fresh-resolving lane is what should have caught 0.17.0 as a **signal** rather than taking the whole merge gate down. The comment in the diff says so, so nobody "finishes the job" later by locking it.

## Scope

`tests.yml` only, by chair decision. The other dep-installing required lanes (`pre-commit`, `lint`, `code-quality`, `platform-compat`, `doc-import-audit`, `wiring-audit`, `changelog-entry`) still resolve fresh and follow in a second PR once this shape proves green across the matrix.

## Two details worth a reviewer's eye

- **`shell: bash`** is added to the three steps so `$RUNNER_TEMP` and the quoting behave identically on Windows. The same file already uses that pattern in four other steps, one carrying the comment *"shell: bash forces Git Bash on Windows runners"*.
- **The uv pin (`0.9.22`)** tracks whatever writes `uv.lock`. It is the version verified to export this lock. A newer lock revision fails the export loudly, and the fix is to bump both together — stated in the diff comment.

## Receipts

- `tests/unit/ci` + `tests/unit/gates`: **1,049 passed**, 1 skipped
- Whole configured tree: **26,143 passed**, 266 skipped, 3 xfailed in 87.10s

The real receipt is this PR's own matrix — it is the first run to install from the lock, and the Windows and macOS lanes are where a `shell: bash` or `$RUNNER_TEMP` mistake would surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
