### PR TITLE
fix(ci): install the remaining gate lanes from uv.lock

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -108,7 +108,13 @@ jobs:
       # same import graph mkdocs build sees.
       - name: Install package (mkdocstrings symbols must resolve)
         if: needs.changes.outputs.docs == 'true'
-        run: pip install -e ".[dev,developer]" pathspec pyyaml
+        shell: bash
+        run: |
+          pip install 'uv==0.9.22'
+          uv export --locked --all-extras --no-emit-project --no-hashes \
+            -o "$RUNNER_TEMP/ci-constraints.txt"
+          pip install -e ".[dev,developer]" pathspec pyyaml \
+            -c "$RUNNER_TEMP/ci-constraints.txt"
 
       - name: Run wiring audit
         if: needs.changes.outputs.docs == 'true'
@@ -147,7 +153,13 @@ jobs:
 
       - name: Install package (import graph must resolve)
         if: needs.changes.outputs.docs == 'true'
-        run: pip install -e ".[dev,developer]" pathspec
+        shell: bash
+        run: |
+          pip install 'uv==0.9.22'
+          uv export --locked --all-extras --no-emit-project --no-hashes \
+            -o "$RUNNER_TEMP/ci-constraints.txt"
+          pip install -e ".[dev,developer]" pathspec \
+            -c "$RUNNER_TEMP/ci-constraints.txt"
 
       - name: Run doc-import audit
         if: needs.changes.outputs.docs == 'true'

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -37,10 +37,17 @@ jobs:
         restore-keys: pre-commit-
 
     - name: Install dependencies
+      # Install from uv.lock, not a fresh resolve — an upstream publish must
+      # not be able to change what this gate installs without a commit.
+      # uv is installed first and pinned, since it produces the constraints.
+      shell: bash
       run: |
-        pip install pre-commit uv
+        pip install 'uv==0.9.22'
+        uv export --locked --all-extras --no-emit-project --no-hashes \
+          -o "$RUNNER_TEMP/ci-constraints.txt"
+        pip install pre-commit -c "$RUNNER_TEMP/ci-constraints.txt"
         # Install package for local hooks (pattern-summary, etc.)
-        pip install -e .[dev,software]
+        pip install -e .[dev,software] -c "$RUNNER_TEMP/ci-constraints.txt"
 
     - name: Run pre-commit hooks
       run: pre-commit run --all-files --show-diff-on-failure

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -164,7 +164,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install 'uv==0.9.22'
-        uv export --locked --extra dev --no-emit-project --no-hashes \
+        uv export --locked --all-extras --no-emit-project --no-hashes \
           -o "$RUNNER_TEMP/ci-constraints.txt"
         pip install -e .[dev] -c "$RUNNER_TEMP/ci-constraints.txt"
 
@@ -320,7 +320,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install 'uv==0.9.22'
-        uv export --locked --extra dev --no-emit-project --no-hashes \
+        uv export --locked --all-extras --no-emit-project --no-hashes \
           -o "$RUNNER_TEMP/ci-constraints.txt"
         pip install -e .[dev] -c "$RUNNER_TEMP/ci-constraints.txt"
 
@@ -407,7 +407,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install 'uv==0.9.22'
-        uv export --locked --extra dev --no-emit-project --no-hashes \
+        uv export --locked --all-extras --no-emit-project --no-hashes \
           -o "$RUNNER_TEMP/ci-constraints.txt"
         pip install -e .[dev] -c "$RUNNER_TEMP/ci-constraints.txt"
 
@@ -550,9 +550,21 @@ jobs:
           uv.lock
 
     - name: Install dependencies
+      # Package deps come from uv.lock (see the test job for why). The lint
+      # TOOLS deliberately do not: black is pinned to 24.10.0 to match
+      # .pre-commit-config.yaml, which is this repo's formatting contract.
+      # uv.lock resolves black to 26.5.1 for the dev extra, so constraining
+      # this line would force a different formatter and fail the gate.
+      # ruff and bandit are pinned to the lock's versions so a new release
+      # cannot change lint results without a commit.
+      shell: bash
       run: |
         python -m pip install --upgrade pip
-        pip install -e . 'black==24.10.0' ruff bandit[toml]
+        pip install 'uv==0.9.22'
+        uv export --locked --all-extras --no-emit-project --no-hashes \
+          -o "$RUNNER_TEMP/ci-constraints.txt"
+        pip install -e . -c "$RUNNER_TEMP/ci-constraints.txt"
+        pip install 'black==24.10.0' 'ruff==0.15.21' 'bandit[toml]==1.9.4'
 
     - name: Check formatting with Black
       run: black --check .
@@ -692,9 +704,13 @@ jobs:
           uv.lock
 
     - name: Install dependencies
+      shell: bash
       run: |
         python -m pip install --upgrade pip
-        pip install -e .[software]
+        pip install 'uv==0.9.22'
+        uv export --locked --all-extras --no-emit-project --no-hashes \
+          -o "$RUNNER_TEMP/ci-constraints.txt"
+        pip install -e .[software] -c "$RUNNER_TEMP/ci-constraints.txt"
 
     - name: Count tech debt markers
       id: debt


### PR DESCRIPTION
Completes what [#2483](https://github.com/Smart-AI-Memory/attune-ai/pull/2483) started. Five more required lanes installed dependencies with a **fresh resolve**, so an upstream publish could still change what they installed with no commit here.

**Locked now:** `lint`, `code-quality` (tests.yml) · `pre-commit` (pre-commit.yml) · `wiring-audit`, `doc-import-audit` (docs.yml).

## Two of the "seven" install nothing at all

I named seven remaining lanes earlier. Two were wrong — they were required checks, but neither installs a dependency, so neither can drift:

| Lane | Why it's out of scope |
|---|---|
| `platform-compat` | runs `scripts/check_platform_compat.py` with only `actions/setup-python` — no pip step, stdlib only |
| `changelog-entry` | `changelog-gate.yml` has no install step |

## `lint` is why this isn't a blanket sweep

`lint` installs `black==24.10.0`, matching `.pre-commit-config.yaml`'s `rev: 24.10.0` — **this repo's formatting contract**. `uv.lock` resolves black to **26.5.1** for the dev extra. Applying the constraints file to that line would have forced a different formatter and failed the gate on a diff that changed no Python.

So the package install is constrained; the lint **tools** are pinned explicitly instead. `ruff` and `bandit` move from *unpinned* to the lock's versions (`0.15.21`, `1.9.4`), verified equal to `uv.lock` by comparison rather than by eye — a new release of either can no longer change lint results without a commit.

## One idiom everywhere

The three steps #2483 landed move from `--extra dev` to `--all-extras`, so a single command covers every lane regardless of extras (`code-quality` needs `software`, the docs lanes need `developer`). A constraints file may pin packages that are never installed — unused constraints are ignored — so the wider export is safe everywhere.

`pre-commit` installs uv first and pinned, since uv produces the constraints it then installs under.

## Receipts

- `tests/unit/ci` + `tests/unit/gates`: **1,049 passed**, 1 skipped
- Whole configured tree: **26,143 passed**, 266 skipped, 3 xfailed
- Lint pins compared programmatically against `uv.lock`: `ruff` MATCH, `bandit` MATCH; black confirmed equal to the pre-commit rev

This PR's own run is the real receipt — it exercises every changed lane.

## Unrelated flake, recorded not fixed

`tests/unit/test_tier_recommender.py` failed once on a missing `patterns/debugging/workflow_*.json`, then passed in isolation and on a clean full-tree re-run. Tests writing into the repo working tree are a pollution source worth its own fix. Nothing in this diff can reach that module — it changes three YAML files, and the only test that reads them (`test_workflow_yaml.py`) passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
