### PR TITLE
fix(release-tooling): claim-freshness window in land_pr.sh, and quiet the worktree cleanup

### DIFF
--- a/scripts/land_pr.sh
+++ b/scripts/land_pr.sh
@@ -57,10 +57,43 @@ case "$HEAD" in
         ;;
 esac
 
+# CLAIM FRESHNESS. The head-SHA gate above answers "did the content
+# change since the chair read it". It cannot answer "is what this
+# content ASSERTS still true" — a sibling PR touching no file in common
+# can invalidate a claim, and the merge order is decided after both were
+# written. D18 landed 19 minutes after #2476 falsified a version bound it
+# stated in present tense; nothing conflicted, rebased or went red.
+if git rev-parse --verify --quiet "$AUTHORIZED_SHA^{commit}" >/dev/null; then
+    git fetch origin main --quiet 2>/dev/null || true
+    MB=$(git merge-base "$AUTHORIZED_SHA" origin/main 2>/dev/null || true)
+    if [ -n "$MB" ]; then
+        LANDED=$(git log --oneline "$MB..origin/main" 2>/dev/null)
+        if [ -n "$LANDED" ]; then
+            echo "[land_pr] landed on main since this branch forked:"
+            printf '%s\n' "$LANDED" | sed 's/^/    /'
+            echo "[land_pr] ^ did any of these change a fact this PR ASSERTS"
+            echo "          (a version bound, a count, a status, \"X is not implemented\")?"
+            echo "          Ctrl-C now if so; the head-SHA gate does not cover it."
+        fi
+    fi
+else
+    echo "[land_pr] note: $AUTHORIZED_SHA not resolvable locally —" >&2
+    echo "          claim-freshness window skipped, verify by hand." >&2
+fi
+
 echo "[land_pr] all checks green at authorized head — merging…"
 # Local post-merge steps (branch delete, checkout refresh) often fail
-# from a worktree even when the REMOTE merge succeeded; verify below.
-gh pr merge "$PR" --squash --delete-branch || true
+# from a worktree even when the REMOTE merge succeeded; the known
+# worktree case is reported calmly, anything else is surfaced.
+MERGE_ERR=$(gh pr merge "$PR" --squash --delete-branch 2>&1 >/dev/null) || true
+if [ -n "$MERGE_ERR" ]; then
+    case "$MERGE_ERR" in
+        *"already used by worktree"*|*"failed to run git"*)
+            echo "[land_pr] local branch cleanup skipped (running from a worktree); remote merge unaffected" ;;
+        *)
+            printf '%s\n' "$MERGE_ERR" >&2 ;;
+    esac
+fi
 
 STATE=$(gh pr view "$PR" --json state --jq '.state')
 if [ "$STATE" != "MERGED" ]; then


### PR DESCRIPTION
Retro items 1 + 7, folded because they touch the same file — doing them separately would burn two CI cycles for one script.

## Claim freshness

`land_pr.sh` gates on *zero failed checks* and *head still equals the authorized SHA*. Both are sound. **Neither can catch what actually happened this session.**

D18 ([#2475](https://github.com/Smart-AI-Memory/attune-ai/pull/2475)) asserted a version bound in present tense and merged **19 minutes after** [#2476](https://github.com/Smart-AI-Memory/attune-ai/pull/2476) falsified it. The two PRs shared no files — so nothing conflicted, the rebase was clean, both CIs were green, and the chair's word was correctly bound to an unmoved head. Every mechanism was silent *by construction*.

The head-SHA gate answers **"did the content change since it was read."** It cannot answer **"is what this content asserts still true"** — and merge order is decided after both PRs are written.

So before merging, the script now prints what landed on main since the branch forked, and asks one question:

```
[land_pr] landed on main since this branch forked:
    644827c66 chore(deps): bump nodemailer …
    9ab90a810 docs(spec): D19 …
[land_pr] ^ did any of these change a fact this PR ASSERTS
          (a version bound, a count, a status, "X is not implemented")?
          Ctrl-C now if so; the head-SHA gate does not cover it.
```

It does **not** parse assertions and does **not** block. It puts the window in front of a human at the moment the decision is made. In the D18 case, #2476 would have been in that list.

## Worktree cleanup noise

`gh pr merge --delete-branch` runs a local branch delete that fails from a worktree, printing `failed to run git: fatal: 'main' is already used by worktree …` **after a merge that succeeded**. The `|| true` swallowed the exit code, but the text still reads as failure — it appeared on three successful merges tonight and needed explaining each time.

Known worktree errors now get one calm line. **Every other error is still surfaced verbatim on stderr**, so this hides nothing else.

## Verification

| Case | Result |
|---|---|
| worktree error → filter | one calm line |
| HTTP 403 → filter | surfaced unchanged |
| nothing landed since fork | window silent (no false noise) |
| six-commit fork | all six listed |
| `bash -n` | passes |

Unchanged: still never uses `--admin`, still refuses on a red check or a moved head. There are no tests for `land_pr.sh` — that gap predates this PR and isn't closed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
