### PR TITLE
chore(usage-signals): reach snapshot 2026-09-09 (5/5)

### DIFF
--- a/docs/specs/usage-signals/snapshots/2026-09-09.json
+++ b/docs/specs/usage-signals/snapshots/2026-09-09.json
@@ -1,0 +1,69 @@
+{
+  "attempts": [
+    {
+      "at": "2026-09-09T11:30:01.324405+00:00",
+      "captured": 2,
+      "outcome": "rate-limited"
+    },
+    {
+      "at": "2026-09-09T13:22:53.087629+00:00",
+      "captured": 5,
+      "outcome": "complete"
+    }
+  ],
+  "date": "2026-09-09",
+  "github": {
+    "clones_14d": 21100,
+    "forks": 2,
+    "stars": 10,
+    "views_14d": 519
+  },
+  "manifest": {
+    "captured": [
+      "attune-ai",
+      "attune-rag",
+      "attune-help",
+      "attune-author",
+      "attune-verify"
+    ],
+    "complete": true,
+    "expected": [
+      "attune-ai",
+      "attune-rag",
+      "attune-help",
+      "attune-author",
+      "attune-verify"
+    ],
+    "missing": [],
+    "observed_at": "2026-09-09T13:22:53.087958+00:00",
+    "source": "pypistats.org/api/recent"
+  },
+  "pypi_recent": {
+    "attune-ai": {
+      "last_day": 171,
+      "last_month": 2451,
+      "last_week": 821
+    },
+    "attune-author": {
+      "last_day": 2,
+      "last_month": 279,
+      "last_week": 40
+    },
+    "attune-help": {
+      "last_day": 107,
+      "last_month": 9495,
+      "last_week": 1410
+    },
+    "attune-rag": {
+      "last_day": 38,
+      "last_month": 5950,
+      "last_week": 575
+    },
+    "attune-verify": {
+      "last_day": 38,
+      "last_month": 2612,
+      "last_week": 411
+    }
+  },
+  "taken_at": "2026-09-09T13:22:53.087958+00:00"
+}


### PR DESCRIPTION
Closes the 16.3.0 AFTER-window obligation, whose window opened today.

## Complete — 5/5 packages plus GitHub traffic

| Package | last_day | last_week | last_month |
|---|---|---|---|
| attune-ai | 171 | 821 | 2,451 |
| attune-help | 107 | 1,410 | 9,495 |
| attune-rag | 38 | 575 | 5,950 |
| attune-verify | 38 | 411 | 2,612 |
| attune-author | 2 | 40 | 279 |

GitHub: forks 2, stars 10, `clones_14d` 21,100, `views_14d` 519.

## Two attempts, both in the file's own ledger

```
11:30:01Z  captured=2  outcome=rate-limited
13:22:53Z  captured=5  outcome=complete
```

The resume seed carried the two already-captured packages forward, so the second attempt spent **three** pypistats requests rather than five. That is attempt 2 of the per-day budget of 3.

## Completeness read from the file, not the exit code

`reach_snapshot.py` **exits 0 on a rate-limit** — a documented trap where three attempts across ~90 minutes each reported "completed, exit code 0" while capturing nothing. So the receipt here is the written file: `pypi_recent` 5/5, a non-empty `github` block, `outcome=complete`.

## `2026-09-08.json` is deliberately untouched

It showed as modified in the main checkout, but that working copy is **byte-identical to `origin/main`** — the difference was against a local HEAD seven commits behind, i.e. an unpulled checkout, not a local edit. Reverting it would have undone what #2486 landed. `git diff origin/main` on this branch for that path is empty.

## Receipts

Whole configured tree, run **after** the last edit: **26,143 passed**, 266 skipped, 3 xfailed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
