### PR TITLE
docs(spec): Task 2 route-selection note — the adapter is necessary but not sufficient

### DIFF
--- a/docs/specs/host-surface-parity/tasks.md
+++ b/docs/specs/host-surface-parity/tasks.md
@@ -466,6 +466,30 @@ consumes only the verified released artifact.
 
 ## Task 2 — Consume the host tier 0 renderer (R1)
 
+*(Route-selection note, measured 2026-09-09 — read before increment 3.
+A registered HostQuestionAdapter is NECESSARY BUT NOT SUFFICIENT to
+make this route selectable, and nothing in this task can change that.
+Host-native routes are built as `f"host-native:{target_id}"`
+(`surface_registry.py:457`, `:811`). `CapabilitySnapshot.supports()`
+resolves `RICH` and `mcp-native:` prefixes from `negotiated`; every
+other route falls through to `host_static` then `cached_static`
+(`surface_policy.py:520-526`). Both are empty: `host_static` is
+declared at `:513` and read at `:522` — its only two references in
+`src/` — and the runtime builds the snapshot from the negotiated tuple
+alone (`surface_runtime.py:116-120`). The single call site is the
+selection loop at `surface_policy.py:577`, so a host-native candidate
+is rejected with reason `unsupported_capability` ONE CONDITION BEFORE
+the `missing_adapter` check on the next line. Task 10's doctor — or a
+narrower substitute writing that cell — is what lights this route
+(D20 ruling 3 and 4).
+
+TEST-DESIGN CONSEQUENCE, since the failure is invisible by default: a
+test asserting "PORTABLE was selected" PASSES FOR THE WRONG REASON
+here, because PORTABLE is what happens with or without the adapter.
+Increment-3 tests must read the disposition reason and distinguish
+`unsupported_capability` from `missing_adapter`, or they prove nothing
+about the adapter at all.)*
+
 ```xml
 <task id="2" name="host-tier-zero-consumer">
   <dependencies>


### PR DESCRIPTION
Measured while cutting Task 2 into increments. The question was whether a registered `HostQuestionAdapter` alone makes the host-native route selectable.

**It does not, and no part of Task 2 can change that.**

## The chain — each link read, not inferred

| Step | Evidence |
|---|---|
| Host-native routes are built as `f"host-native:{target_id}"` | `surface_registry.py:457`, `:811` |
| `supports()` sends `RICH` and `mcp-native:` to `negotiated`; **everything else** falls to `host_static` then `cached_static` | `surface_policy.py:520-526` |
| Both are empty — `host_static` is declared at `:513`, read at `:522`, its **only two references in `src/`**; the runtime builds the snapshot from the negotiated tuple alone | `surface_runtime.py:116-120` |
| The single call site is the selection loop, so a host-native candidate is rejected with `unsupported_capability` **one condition before** the `missing_adapter` check on the next line | `surface_policy.py:577` |

So Task 2 may land the consumer and the route still cannot fire. Task 10's doctor — or a narrower substitute writing that cell — is what lights it (D20 rulings 3 and 4).

## The test-design consequence, which is the part that bites

This failure is **invisible by default**. An increment-3 test asserting *"PORTABLE was selected"* **passes for the wrong reason**: PORTABLE is what happens with **or without** the adapter.

Such tests must read the disposition reason and distinguish `unsupported_capability` from `missing_adapter`, or they prove nothing about the adapter at all.

Same shape as the transport-migration case already in the lessons corpus, where emptiness assertions were satisfied by the very failure they should have caught. Worth having written down *before* the tests are written.

## Placement

A measured mechanism, not a ruling — so it goes in Task 2's prose note rather than `decisions.md`.

## Provenance

Originally committed on a branch stacked on #2492. That PR squash-merged, which made the stacked commit an orphan (`git merge-base --is-ancestor 794a6e11c origin/main` → false, verified). Recovered by cherry-picking onto a fresh branch off the new `origin/main` rather than pushing the dead branch.

## Receipts

- Diff against main is **only** the note: 1 file, 24 insertions
- Composes with D20's changes already on main — 0 `dep-10` declarations, Task 10 deferred line intact
- 14 tasks still parse through `attune.pipeline.spec_reader`, Task 2 present
- Whole configured tree, run after the last edit: **26,143 passed**, 266 skipped, 3 xfailed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
