### PR TITLE
docs(spec): Task 2 increment 1 — preconditions and characterization receipts

### DIFF
--- a/docs/specs/host-surface-parity/receipts.md
+++ b/docs/specs/host-surface-parity/receipts.md
@@ -322,3 +322,68 @@ the branch handoff. These answers are fixture-owned and do not prove host paint.
 
 Final whole-suite receipt for the bootstrap update: 26,056 passed, 242 skipped,
 3 xfailed in 73.04 seconds, with isolated Redis and the inference guard.
+
+## Task 2 increment 1 — preconditions and characterization (2026-09-09)
+
+Satisfies Task 2 validation checks 1 and 6. No production code; this
+increment's whole claim is that the evidence those checks demand exists
+and says what the task assumes. Probed against the artifact resolved by
+this repo's own pinned environment, not a checkout.
+
+### Check 1 — the installed released artifact
+
+| Property | Observed |
+|---|---|
+| version | `0.17.0` (`importlib.metadata`) |
+| loads from | `.venv/lib/python3.11/site-packages/attune_forms` |
+| dist-info | `attune_forms-0.17.0.dist-info` |
+| exports | `HostQuestionProfile`, `QuestionAnswerBinding`, `HostQuestionBatch`, `host_question_admissibility`, `form_to_host_question` — all present |
+| registry target | `form.host_question` · status `route_active` · profile `claude-askuserquestion` |
+| profile resolution | exactly ONE installed `InteractionProfile` carries the matching host-question facet |
+
+**Not an editable checkout**, established by asking the question about
+this package rather than about the environment: no
+`__editable__*attune_forms*` finder, no `*attune_forms*.pth`, no
+`direct_url.json` in the dist-info, and the module resolves inside
+site-packages. A first pass reported "editable = True" because it
+globbed for any `__editable__*` marker and matched
+`__editable__.attune_ai-16.3.0.pth` — THIS repo's own editable install,
+not attune-forms'. Recorded because the false positive is the more
+likely reading of a naive probe.
+
+The pin backing this is `attune-forms>=0.17.0,<0.18` (#2488), whose
+ceiling deliberately tracks the consumed minor rather than returning to
+`<1.0`.
+
+### Check 6 — characterization of the installed AskUserQuestion profile
+
+Read from the installed facet, and matching what D18 amended and D19
+corrected:
+
+| Field | Value |
+|---|---|
+| `max_header_chars` | 12 |
+| `response_correlation` | `emitted_text` |
+| multi-select | `comma_delimited`, delimiter `','` (bare comma, no space) |
+| escaping | `none`, `escaping_verified=True` |
+| `canonical_reencode` | `True` |
+| `freeform` | `separate_response` |
+| `other_label` / `unanswered_marker` | `Other` / `[No preference]` |
+| caps | 4 questions, 4 options, 3 validation attempts, 1800s deadline |
+| `inadmissible_types` | `('ranking',)` |
+
+Two of these carry history worth keeping attached. The delimiter is a
+BARE comma and the escaping is `none` — D18 struck the spec's
+"comma-space-delimited" and "JSON-string quoting" after a live host
+trial measured both false, so a delimiter- or quote-bearing multi-select
+label is PERMANENTLY inadmissible rather than pending evidence. And
+`freeform` is recorded here as DECLARED, not characterized: no trial has
+exercised free text through "Other", which is why D18 struck it from the
+pinned set. This receipt does not claim it was measured.
+
+### What this increment does NOT establish
+
+Nothing about routing. The host-native route remains unselectable
+regardless of this evidence — see the route-selection note on Task 2 and
+D20 rulings 3 and 4. No adapter exists, no production file changed, and
+no receipt here should be read as the route being live.


### PR DESCRIPTION
First increment of Task 2, cut at a claim boundary: **satisfies checks 1 and 6, and nothing else.** No production code. Its whole claim is that the evidence those checks demand exists and says what the task assumes.

## Check 1 — the installed released artifact

| Property | Observed |
|---|---|
| version | `0.17.0` |
| loads from | `.venv/…/site-packages/attune_forms` |
| dist-info | `attune_forms-0.17.0.dist-info` |
| exports | all five AF-2 symbols present |
| registry target | `form.host_question` · `route_active` · `claude-askuserquestion` |
| profile resolution | exactly **one** installed `InteractionProfile` with the host-question facet |

**The not-an-editable-checkout half comes with its own correction, recorded rather than quietly fixed.** A first pass reported `editable = True` — because it globbed for *any* `__editable__*` marker in site-packages and matched `__editable__.attune_ai-16.3.0.pth`, **this repo's** editable install, not attune-forms'.

Asking the question about the package instead: no `__editable__*attune_forms*` finder, no `*attune_forms*.pth`, no `direct_url.json`, module inside site-packages. The false positive is the likelier reading of a naive probe, so it belongs in the receipt.

## Check 6 — characterization of the installed profile

Header cap 12 · `emitted_text` correlation · **bare comma** delimiter · `escaping=none`, `escaping_verified=True` · canonical re-encode · 4 questions / 4 options / 3 attempts / 1800s · `inadmissible_types=('ranking',)`.

Two carry history worth keeping attached:

- **Delimiter and escaping** match what D18 amended after a live trial measured "comma-space" and "JSON-string quoting" both false. A delimiter- or quote-bearing multi-select label is **permanently** inadmissible, not pending evidence.
- **`freeform` is recorded as DECLARED, not characterized.** No trial has exercised free text through "Other" — which is exactly why D18 struck it from the pinned set. This receipt does not claim it was measured.

## What this increment does NOT establish

**Nothing about routing.** The host-native route remains unselectable regardless of this evidence — see the Task 2 route-selection note ([#2493](https://github.com/Smart-AI-Memory/attune-ai/pull/2493)) and D20 rulings 3 and 4. No adapter exists, no production file changed, and nothing here should be read as the route being live.

That boundary is the point of cutting here: this increment's gate asserts only what it proves.

## Receipts

Whole configured tree, run after the last edit: **26,143 passed**, 266 skipped, 3 xfailed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
