### PR TITLE
docs(spec): Task 2 text reconciled against the tree, + D21 ruling (chair-read)

### DIFF
--- a/docs/specs/host-surface-parity/decisions.md
+++ b/docs/specs/host-surface-parity/decisions.md
@@ -1217,6 +1217,78 @@ does not schedule it.
 No release, API-spend or automatic-merge authorization is granted or
 changed.
 
+## D21 — Increment 3 is built behind an unregistered profile; both open PRs take one combined review lane (RULED 2026-09-09, chair, via round table)
+
+Promoted from round-table thread `q-2496-2497-next-step-001` (board
+messages 2, 3, 6; full transcript machine-local at
+`~/.attune/reports/roundtable/q-2496-2497-next-step-001.md`, per D2). One
+round, fixed roster, 3/3 seats answered, no absent seat. The chair
+promoted items 3, 6 and 7; items 1, 2, 4 and 5 were presented and NOT
+ruled, and nothing was written for them.
+
+### Ruled
+
+1. **One combined review lane over both open PRs, before chair-read.**
+   #2496 (the host-question adapter boundary) and #2497 (this spec's
+   text reconciliation) are reviewed in a single different-model pass
+   rather than two. Two seats reached this independently; the reason
+   recorded here is the one only the Claude seat stated, because it is
+   the reason the combined shape beats two separate lanes: **the
+   highest-value finding available is cross-PR.** #2497 corrects the
+   task text to say the admissibility gate belongs in
+   `surface_runtime.py`, while #2496 declares the boundary that gate
+   will admit or refuse. A reviewer holding one diff cannot check that
+   the corrected text and the shipped adapter agree about where
+   enforcement lives — which is the entire point of reconciling text
+   against tree, and is invisible to a single-PR lane.
+
+2. **Increment 3 is built behind an UNREGISTERED profile.** The seam is
+   implemented and fully tested without adding the profile to
+   `host_profiles`; registration plus the parity-registry rows, the
+   receipts, the demo render and a green parity gate then land together
+   as one small final PR. This reuses the technique #2496 already proved
+   — the adapter is deliberately not exported from the package
+   `__init__` — and it splits a large diff **without splitting the
+   atomic obligation**, which is the constraint that makes the naive
+   split illegal.
+
+   The reason it is illegal to split the other way: **registration is a
+   one-way door.** Registering the profile is the act that CREATES the
+   parity obligation (`surface_registry.py:420`, pinned by
+   `tests/unit/gates/test_surface_parity.py:1253`), so the gate demands
+   satisfaction in the same PR that registers. There is no state in
+   which the profile is registered and the receipt is still owed.
+
+3. **The receipt shape for increment 3 is an OPEN question, recorded not
+   answered.** Raised by the Antigravity seat (board message 6): the
+   parity gate will demand a receipt for the newly-obligated host-native
+   target, while D20 ruling 3 forbids any Task 2 receipt from reporting
+   the host-native route as firing, because nothing writes the static
+   capability cell. Both constraints are settled and neither yields.
+   Increment 3 may not begin until this has an answer; producing one is
+   in scope for its planning, not for this entry.
+
+### Recorded, not ruled
+
+The table was **unanimous** that the D11 lane is owed on BOTH PRs, and
+that splitting the spec text into #2497 relocated the trigger rather
+than discharging it. The chair did not rule that question here; ruling 1
+authorizes the lane as an action without settling the doctrine, and the
+two precedent questions the table raised — whether a shrink-only
+ratchet's baseline entry is itself a D11 trigger (seats split 2/1), and
+whether a risk class that is DECLARED but not yet CROSSED fires the lane
+at the declaring or the wiring diff — remain open for a future ruling.
+
+One correction the table produced about this project's own reporting,
+kept because it outlives the thread: **100% statement and branch
+coverage on `host_question_adapter.py` was measured and is true, but it
+does not speak to the boundary contract, because the adapter under test
+is a fake.** Coverage over a cooperative fake proves the module's own
+control flow. This is the same shape as the MGET-migration lesson, where
+ten emptiness-asserting tests passed precisely because the logic never
+ran. The figure should not be cited as evidence about the trust
+boundary.
+
 ## Open decisions
 
 - None. Every proposed decision in this spec is ruled.

--- a/docs/specs/host-surface-parity/decisions.md
+++ b/docs/specs/host-surface-parity/decisions.md
@@ -1246,11 +1246,21 @@ ruled, and nothing was written for them.
    implemented and fully tested without adding the profile to
    `host_profiles`; registration plus the parity-registry rows, the
    receipts, the demo render and a green parity gate then land together
-   as one small final PR. This reuses the technique #2496 already proved
-   — the adapter is deliberately not exported from the package
-   `__init__` — and it splits a large diff **without splitting the
-   atomic obligation**, which is the constraint that makes the naive
-   split illegal.
+   as one small final PR. This reuses the shape #2496 already
+   proved — a complete, fully tested component with **no production
+   caller** — and it splits a large diff **without splitting the atomic
+   obligation**, which is the constraint that makes the naive split
+   illegal.
+
+   Corrected 2026-09-09, same day, by the review lane this ruling
+   authorized: the first wording credited that isolation to the adapter
+   being "not exported from the package `__init__`", which is not what
+   makes it inert. The module is directly importable — #2496's own tests
+   import it — so omitting a re-export hides nothing. What makes it inert
+   is that **nothing calls it**. The distinction is load-bearing for
+   increment 3: the property to maintain is "no caller", which an author
+   must hold deliberately, not "no re-export", which packaging could
+   satisfy while a caller quietly existed.
 
    The reason it is illegal to split the other way: **registration is a
    one-way door.** Registering the profile is the act that CREATES the
@@ -1291,7 +1301,24 @@ boundary.
 
 ## Open decisions
 
-- None. Every proposed decision in this spec is ruled.
+Three, all opened by D21 (2026-09-09). Recorded because an inventory
+reading "None" while a ruling in the same file leaves questions open is a
+claim the file itself disproves.
+
+- **Increment 3's receipt shape.** The parity gate will demand a receipt
+  for the newly-obligated host-native target the moment the profile is
+  registered, while D20 ruling 3 forbids any Task 2 receipt from reporting
+  the route as firing. Both constraints are settled and neither yields.
+  D21 ruling 3 makes answering this a precondition of starting increment 3.
+- **Does a shrink-only ratchet's baseline entry trigger a D11 lane?** The
+  round table split 2/1: two seats held that permitting one more broad
+  catch changes what the gate allows even with gate logic untouched; one
+  held the trigger weak, because the baseline GREW with an annotation
+  rather than shrinking, and treating every entry as a trigger makes the
+  ratchet's own escape hatch expensive to use honestly. Unruled.
+- **Declared versus crossed.** When a risk class is DECLARED but not yet
+  CROSSED — an unexported trust boundary with no caller — does the lane
+  fire at the declaring diff or at the wiring diff? Unruled.
 
 Resolved 2026-09-02/03/04: the table was convened (round 1 complete,
 promoted in D5); D2 ruled (routing label); Task 7 ships alone on

--- a/docs/specs/host-surface-parity/tasks.md
+++ b/docs/specs/host-surface-parity/tasks.md
@@ -5,12 +5,16 @@ characterization check amended 2026-09-08 (D18).
 Task 0 merged in #2442. Task 1B increment 1 merged in #2443;
 increment 2 merged in #2444; increment 3 merged in #2450
 (2026-09-07, 6934b177e). Full Task 1B remains incomplete.
+Task 2 increment 1 (checks 1 and 6, evidence only) merged in #2494;
+increment 2 added the trusted host-question presentation boundary
+(`host_question_adapter.py`) and touched no routing seam.
 AF-1 is available in the released, non-editable attune-forms 0.14.0
-artifact and AF-2 in 0.17.0; the locked consumer specifier is
->=0.15.0,<0.16 — the D12 floor, with the ceiling narrowed from <1.0 by
-#2476 because the AF-2 registry breaks the Task 1B parity gates —
-which Task 2 raises to >=0.17.0 with a ceiling it must establish
-(D18, corrected by D19).
+artifact and AF-2 in 0.17.0. The locked consumer specifier is
+`attune-forms>=0.17.0,<0.18` (`pyproject.toml:75`, `uv.lock:535`,
+verified 2026-09-09): #2488 landed BOTH halves of what D18 ruled and D19
+left open — the 0.17.0 floor, and a replacement ceiling at the consumed
+minor rather than a restored <1.0. Task 2's pyproject/uv.lock entries are
+therefore already satisfied; see their files-to-modify lines.
 
 D14 authorizes the bounded increment-3 Codex form interaction from the
 existing milestone brief. It lifts the prior increment-3 hold for that
@@ -488,7 +492,35 @@ test asserting "PORTABLE was selected" PASSES FOR THE WRONG REASON
 here, because PORTABLE is what happens with or without the adapter.
 Increment-3 tests must read the disposition reason and distinguish
 `unsupported_capability` from `missing_adapter`, or they prove nothing
-about the adapter at all.)*
+about the adapter at all.
+
+TWO CORRECTIONS to this note, measured 2026-09-09 during increment 2 and
+recorded because each moves work the note did not name.
+
+First, the note describes what happens to "a host-native candidate", and
+there is no such candidate to describe. The routing subject
+`surface-runtime-route-form` declares cold
+`[mcp-native:surface-native-elicitation, PORTABLE, HEADLESS]` and warm
+`[RICH, ...]`; the loop iterates that order, so no host-native row is
+produced and the disposition the note asks increment 3 to assert on does
+not exist yet. The note is not false — it is conditional on a candidate
+the registry does not offer. Adding the route to that subject's order (a
+`scripts/project_surface_runtime.py` projection) is a precondition of the
+receipt, not a detail of it.
+
+Second, and the reason increment 2 stopped short of the seam:
+REGISTERING THE PROFILE IS THE OBLIGATION-CREATING ACT.
+`surface_registry.py:420` states it — "Registering the profile in
+`host_profiles` is the act that makes the obligation exist" — and
+`tests/unit/gates/test_surface_parity.py:1253` pins the consequence:
+appending `claude-askuserquestion` to `host_profiles` turns
+`renderer:...:host-native:<target>` from ABSENT into a required parity
+obligation and adds `lifecycle:host_profile:...:abort`. `host_profiles`
+is `[]` today. So the seam is not separable from its receipt: whichever
+increment registers the profile must land `parity-registry.json`,
+`receipts.md`, the demo render and a green parity gate in the same PR —
+while D20 ruling 3 still forbids that receipt from reporting the route as
+firing.)*
 
 ```xml
 <task id="2" name="host-tier-zero-consumer">
@@ -517,7 +549,9 @@ about the adapter at all.)*
     <file path="tests/unit/elicitation/test_host_question_adapter.py">Profile/target identity binding, Task 1B challenge use, same-call collection, completion compare-and-consume, session-close race, absent-adapter fallback and fake-adapter interface receipts.</file>
   </files-to-create>
   <files-to-modify>
-    <file path="src/attune/elicitation/surface_policy.py">Register the released profile target as host-native only when a live matching HostQuestionAdapter object is installed; preserve selected-only rendering.</file>
+    <file path="src/attune/elicitation/surface_policy.py">Consume the host-native candidate in the selection loop and preserve selected-only rendering. NOTE (measured 2026-09-09): the ADMISSIBILITY GATE is not here. `deliverable_routes` is built by the caller and only read at `:579`; the name's three occurrences in this file are the parameter, a docstring line and that `not in` check. Nothing in this file registers an adapter.</file>
+    <file path="src/attune/elicitation/surface_runtime.py">ADDED 2026-09-09, absent from the authored list: `route_form` is where `deliverable_routes` is actually constructed (`:141`, currently `frozenset({NATIVE_ROUTE}) if native else frozenset()`), so "only when a live matching adapter is installed" is a change HERE. `resolve_host_adapter` returns None for an absent or mismatched adapter, which is the pre-render answer the loop needs.</file>
+    <file path="src/attune/elicitation/surface_runtime_registry.json">ADDED 2026-09-09, via `scripts/project_surface_runtime.py` (generated; do not hand-edit). The routing subject `surface-runtime-route-form` carries cold `[mcp-native:surface-native-elicitation, PORTABLE, HEADLESS]` and warm `[RICH, ...]` — NO host-native route. The selection loop iterates that order, so today no host-native candidate is produced and NO disposition row for it exists. Until the route joins this order, the `unsupported_capability` vs `missing_adapter` distinction the route-selection note requires cannot be observed at all, and a test claiming to prove it would be vacuous.</file>
     <file path="src/attune/elicitation/ask_payload.py">Add the raw host codec/correlation and Other/cancellation decoder from immutable QuestionAnswerBinding records into the common validator bridge for a same-call trusted HostQuestionCompletion; invoke the released renderer only with the trusted profile and preserve form_to_ask_payload unchanged.</file>
     <file path="src/attune/mcp/server.py">Register the immutable adapter outside request data; for the unified host-question arm call present_and_collect with an in-memory challenge and collect its completion without returning a relay payload.</file>
     <file path="src/attune/mcp/tool_schemas.py">Define host-question-completion as the unified response arm; expose no caller input for bindings, profile, tier, presentation challenge or completion attestation.</file>
@@ -528,9 +562,9 @@ about the adapter at all.)*
       Add the tier-0 render and profile-change fallback of the existing audit demo form.
     </file>
     <file path="pyproject.toml">
-      Raise the attune-forms floor to 0.17.0 in the same commit as the green parity receipt, and lift the 0.16 ceiling #2476 installed. ESTABLISH the replacement ceiling from that receipt; do not restore the former 1.0 bound. #2476 narrowed it because a fresh resolve picked up a minor this repo had not consumed, and that hazard recurs at every unconsumed minor. There is no 1.0 upper bound in the tree to "retain", and raising only the floor against the current pin yields an empty specifier (D19).
+      DONE — no action remains. #2488 landed `attune-forms>=0.17.0,<0.18` ahead of this task (`pyproject.toml:75`, verified 2026-09-09). That PR both raised the floor to D18's ruled 0.17.0 and lifted the `<0.16` ceiling #2476 installed, settling it at the consumed minor rather than restoring `<1.0` — which is the ceiling D19 ruling 4 explicitly left for "Task 2 to establish with its receipt or for a later ruling". It was established by receipt, one PR early. The former instruction to raise the floor here is retained in git history only; acting on it now would be a no-op at best.
     </file>
-    <file path="uv.lock">Lock that released package artifact.</file>
+    <file path="uv.lock">DONE — no action remains. `uv.lock:535` records the `>=0.17.0,<0.18` specifier and the locked 0.17.0 artifact (verified 2026-09-09).</file>
     <file path="docs/specs/host-surface-parity/parity-registry.json">Add the new profile target's machine receipt foreign keys.</file>
     <file path="docs/specs/host-surface-parity/receipts.md">Record the human evidence keyed to those receipt IDs.</file>
   </files-to-modify>


### PR DESCRIPTION
Text only, no code. Three corrections to Task 2 (host-surface-parity), each **measured before it was written**. None reopens a ruling; all of them move work the authored text did not name.

Split from its code sibling #2496 so that PR does not inherit this one's authored-spec-text D11 trigger.

## 1. `pyproject.toml` and `uv.lock` are DONE, not pending

#2488 landed `attune-forms>=0.17.0,<0.18` ahead of this task (`pyproject.toml:75`, `uv.lock:535`, verified 2026-09-09). That PR did both halves at once: D18's ruled 0.17.0 floor, **and** a replacement ceiling at the consumed minor rather than a restored `<1.0` — which is precisely what **D19 ruling 4** left for "Task 2 to establish with its receipt or for a later ruling."

It was established by receipt, one PR early. The old instruction now reads as a no-op at best, and the header's "a ceiling it must establish" is retired with it.

## 2. The admissibility gate is not in `surface_policy.py`

`deliverable_routes` is **built by the caller** at `surface_runtime.py:141` and only *read* at `surface_policy.py:579`. The name's three occurrences in `surface_policy.py` are the parameter, a docstring line, and the `not in` check — nothing there registers an adapter.

So "register the target as host-native only when a live matching adapter is installed" is a change to `surface_runtime.py`, which the authored `files-to-modify` never listed. Added, with the `surface_policy.py` line corrected to say what it actually owns.

## 3. No host-native candidate exists to observe

Subject `surface-runtime-route-form` declares cold `[mcp-native:surface-native-elicitation, PORTABLE, HEADLESS]` and warm `[RICH, ...]`. The selection loop iterates that order, so no host-native row is produced and the disposition the route-selection note tells increment 3 to assert on is not merely latent — **it does not exist**.

The note was not false; it was conditional on a candidate the registry does not offer. Adding the route to that order is a `scripts/project_surface_runtime.py` projection, also unlisted, and a precondition of the receipt rather than a detail of it.

## The finding that stopped increment 2 short of the seam

**Registering the profile is the obligation-creating act.** `surface_registry.py:420` says so in terms — *"Registering the profile in `host_profiles` is the act that makes the obligation exist"* — and `tests/unit/gates/test_surface_parity.py:1253` pins the consequence: appending `claude-askuserquestion` to `host_profiles` turns `renderer:…:host-native:<target>` from **absent** into a required parity obligation, plus a `lifecycle:host_profile:…:abort` obligation. `host_profiles` is `[]` today.

So the seam cannot be landed without its receipt in the same PR — `parity-registry.json`, `receipts.md`, the demo render and a green parity gate — while D20 ruling 3 still forbids that receipt from reporting the route as firing. **Whoever schedules increment 3 should price it as seam-plus-receipt, not seam.**

## Receipts

| Check | Result |
|---|---|
| `read_spec` on the edited file | 14 tasks; id 2 reads as `host-tier-zero-consumer` |
| Lifecycle + surface-parity + spec-reader gates | 285 passed |
| Pinned pre-commit | clean |

A strict-XML probe is the *wrong* check here and was discarded: it fails on Task 0's untouched prose, because these blocks were never strict XML. The real spec reader is lenient, so `read_spec` is the receipt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
