### PR TITLE
fix(hooks): starter reconciler names a PR-less branch as not landed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `<task>` block (a single-quoted attribute drops the whole task) or when a
   `<file>`/`<risk>` tag is present but yields no value (missing `path=` or
   `severity=`), instead of discarding the content in silence.
+- The session-start reconciler no longer reports a bare `exists` for a
+  handoff-named branch: an existing branch is qualified by its pull-request
+  state (`exists (PR #N MERGED|OPEN)`, `exists, NO PR — pushed, not landed`,
+  or `exists (PR unverified)` when `gh` cannot answer).
 
 ### Security
 

--- a/src/attune/hooks/scripts/starter_reconciler.py
+++ b/src/attune/hooks/scripts/starter_reconciler.py
@@ -417,11 +417,43 @@ def check_pr(num: int, cwd: Path | None, target: str | None = None) -> str:
 
 
 def check_branch(name: str, cwd: Path | None) -> str:
-    """Return ``exists`` / ``gone`` for a remote branch, or ``unverified``."""
+    """Return ``gone`` / ``unverified``, or ``exists`` qualified by PR state.
+
+    A branch that exists with NO pull request is the state a handoff most
+    often misreports as "landed": pushed, unmerged, unreviewed, untested
+    (2026-09-11, HANDOVER.md called a 3-commit PR-less branch "landed").
+    ``exists`` alone reads as reassurance; the qualifier is the verdict.
+    """
     result = _run(["git", "ls-remote", "--heads", "origin", name], cwd)
     if result is None or result.returncode != 0:
         return "unverified"
-    return "exists" if result.stdout.strip() else "gone"
+    if not result.stdout.strip():
+        return "gone"
+    pr = _run(
+        [
+            "gh",
+            "pr",
+            "list",
+            "--head",
+            name,
+            "--state",
+            "all",
+            "--limit",
+            "1",
+            "--json",
+            "number,state",
+        ],
+        cwd,
+    )
+    if pr is None or pr.returncode != 0:
+        return "exists (PR unverified)"
+    try:
+        found = json.loads(pr.stdout or "[]")
+    except ValueError:
+        return "exists (PR unverified)"
+    if not found:
+        return "exists, NO PR — pushed, not landed"
+    return f"exists (PR #{found[0].get('number')} {str(found[0].get('state', '')).upper()})"
 
 
 def merged_prs_on_main(cwd: Path | None, limit: int = MAIN_LOG_SCAN) -> list[int]:

--- a/tests/unit/hooks/test_starter_reconciler.py
+++ b/tests/unit/hooks/test_starter_reconciler.py
@@ -134,12 +134,36 @@ class TestCheckPr:
         assert hook_module.check_pr(1, None, "github.com/owner/repo") == "unverified"
 
 
+def _branch_runner(pr_stdout, pr_rc=0):
+    """Fake ``_run``: ls-remote says the branch exists; ``gh`` answers as given."""
+
+    def run(cmd, cwd=None, **_):
+        if cmd[0] == "git":
+            return _FakeProc("abc123\trefs/heads/x", 0)
+        return _FakeProc(pr_stdout, pr_rc)
+
+    return run
+
+
 class TestCheckBranch:
-    def test_exists_when_ls_remote_has_output(self, hook_module, monkeypatch):
+    def test_exists_with_merged_pr_names_the_pr(self, hook_module, monkeypatch):
         monkeypatch.setattr(
-            hook_module, "_run", lambda *a, **k: _FakeProc("abc123\trefs/heads/x", 0)
+            hook_module, "_run", _branch_runner('[{"number": 2508, "state": "MERGED"}]')
         )
-        assert hook_module.check_branch("x", None) == "exists"
+        assert hook_module.check_branch("x", None) == "exists (PR #2508 MERGED)"
+
+    def test_exists_without_pr_says_not_landed(self, hook_module, monkeypatch):
+        """The handoff-misreport case: pushed, no PR — never a bare 'exists'."""
+        monkeypatch.setattr(hook_module, "_run", _branch_runner("[]"))
+        assert hook_module.check_branch("x", None) == "exists, NO PR — pushed, not landed"
+
+    def test_exists_when_gh_fails_stays_unverified_on_pr(self, hook_module, monkeypatch):
+        monkeypatch.setattr(hook_module, "_run", _branch_runner("", pr_rc=1))
+        assert hook_module.check_branch("x", None) == "exists (PR unverified)"
+
+    def test_exists_when_gh_output_is_not_json(self, hook_module, monkeypatch):
+        monkeypatch.setattr(hook_module, "_run", _branch_runner("not json"))
+        assert hook_module.check_branch("x", None) == "exists (PR unverified)"
 
     def test_gone_when_ls_remote_empty(self, hook_module, monkeypatch):
         monkeypatch.setattr(hook_module, "_run", lambda *a, **k: _FakeProc("", 0))


### PR DESCRIPTION
## What

`starter_reconciler.check_branch` no longer reports a bare `exists`. An existing remote branch is qualified by its pull-request state:

- `exists (PR #2508 MERGED)` / `exists (PR #2509 OPEN)`
- `exists, NO PR — pushed, not landed` ← the case a handoff misreports as "landed"
- `exists (PR unverified)` when `gh` fails or answers non-JSON (degrades, never a bare `exists`)

## Why

2026-09-11: `HANDOVER.md` from a cloud session called a 3-commit, PR-less, test-less branch "landed". The reconciler already checks whether handoff-named branches are `gone`; the misleading state is the other one — present, pushed, and going nowhere. Retro 2026-09-11 item 1, chair ruled `do now`.

## Receipts (this machine, worktree `retro-item1-reconciler`, main venv + `PYTHONPATH`)

- `tests/unit/hooks/test_starter_reconciler.py`: **103 passed** serial (4 new: merged PR named, no-PR → not landed, `gh` failure → unverified, non-JSON → unverified).
- **Live probes** through the real hook module: `docs/socratic-confirm-gate-marker` → `exists (PR #2509 OPEN)`; this branch **before** its PR existed → `exists, NO PR — pushed, not landed`; a deleted branch → `gone`.
- Pinned `black`/`ruff --no-fix` clean (the first commit attempt was skipped by the pinned black hook; re-staged and re-committed — noted so the reflog reads right).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
