### PR TITLE
fix(scripts): land_pr.sh refuses CONFLICTING/DRAFT before the watch; remote state is the exit status

### DIFF
--- a/scripts/land_pr.sh
+++ b/scripts/land_pr.sh
@@ -6,6 +6,10 @@
 # Encodes the guarded-merge shape ratified from the 2026-08-12 retro
 # (#2059/#2061/#2063 were merged with this logic inline):
 #
+#   0. Probe mergeability FIRST. A PR that is CONFLICTING against main
+#      (or still a DRAFT) cannot merge no matter what the checks say, so
+#      it is refused with the rebase instruction BEFORE the long watch —
+#      #2513 (2026-09-11) watched a full matrix only to fail at merge time.
 #   1. Watch ALL checks to completion (full matrix — never --fail-fast,
 #      so non-required OS/version lanes are blocking too).
 #   2. Merge ONLY if zero checks failed AND the PR head still equals
@@ -13,11 +17,24 @@
 #      head the chair read; any later push invalidates it).
 #   3. Verify the merge REMOTELY (state/mergedAt) — the local
 #      --delete-branch step often errors harmlessly from a worktree.
+#      The remote state IS the exit status: anything but MERGED exits
+#      non-zero, so a background task's "exit 0" means the PR landed.
 #   4. --pull: fast-forward the main checkout afterward (autostash
 #      rebase; only when that checkout is on main).
 #
+# Exit status:   0  merged (remote state MERGED)
+#                1  refused — a red check, a moved head, or the merge
+#                   did not land
+#                2  refused — CONFLICTING (rebase first) or DRAFT
+#               64  usage
+#
+# Run it directly. Through `… | tee log` the shell reports tee's exit
+# status, not this script's — use `set -o pipefail` or read
+# `${PIPESTATUS[0]}`; that is how #2513's refusal surfaced as "exit 0".
+#
 # The script never uses --admin and never bypasses anything: a red
-# check, a moved head, or a blocked merge state all refuse loudly.
+# check, a moved head, a conflicting base, or a blocked merge state all
+# refuse loudly.
 set -euo pipefail
 
 REPO_MAIN="${LAND_PR_MAIN_CHECKOUT:-$HOME/attune-ai}"
@@ -29,6 +46,43 @@ fi
 PR="$1"
 AUTHORIZED_SHA="$2"
 DO_PULL="${3:-}"
+
+# Refuse (exit 2) when the PR cannot merge no matter what the checks
+# say — CONFLICTING against main, or still a DRAFT — and say what to do
+# instead. GitHub computes mergeability lazily, so right after a push
+# it reads UNKNOWN for a few seconds: re-probe before trusting that.
+# $1 names the moment for the message ("before watching"/"before merging").
+gate_mergeability() {
+    local probe tries=0
+    while :; do
+        probe=$(gh pr view "$PR" --json mergeable,mergeStateStatus \
+            --jq '"\(.mergeable) \(.mergeStateStatus)"')
+        tries=$((tries + 1))
+        if [ "${probe%% *}" != "UNKNOWN" ] || [ "$tries" -ge 3 ]; then
+            break
+        fi
+        sleep "${LAND_PR_PROBE_DELAY:-5}"
+    done
+    case "$probe" in
+        CONFLICTING*)
+            echo "[land_pr] REFUSING ($1): PR #$PR is CONFLICTING against main (mergeStateStatus: ${probe#* })" >&2
+            echo "  Rebase, then re-authorize at the NEW head (the merge word binds to the head the chair read):" >&2
+            echo "    git fetch origin main && git rebase -S origin/main" >&2
+            echo "    git log --format='%G? %h %s' origin/main..HEAD   # every row G — a rebase can replay unsigned" >&2
+            echo "    git push --force-with-lease" >&2
+            exit 2
+            ;;
+        *" DRAFT")
+            echo "[land_pr] REFUSING ($1): PR #$PR is a DRAFT — mark it ready first: gh pr ready $PR" >&2
+            exit 2
+            ;;
+        UNKNOWN*)
+            echo "[land_pr] note ($1): GitHub has not computed mergeability yet ($probe) — continuing"
+            ;;
+    esac
+}
+
+gate_mergeability "before watching"
 
 echo "[land_pr] watching PR #$PR checks (full matrix, no fail-fast)…"
 # --watch exit code is unreliable (cancelled-but-fail-tagged rows);
@@ -81,10 +135,17 @@ else
     echo "          claim-freshness window skipped, verify by hand." >&2
 fi
 
+# Main may have moved during the watch: re-probe so a conflict that
+# appeared mid-watch is reported as a rebase instruction, not as gh's
+# generic "the merge commit cannot be cleanly created".
+gate_mergeability "before merging"
+
 echo "[land_pr] all checks green at authorized head — merging…"
 # Local post-merge steps (branch delete, checkout refresh) often fail
 # from a worktree even when the REMOTE merge succeeded; the known
-# worktree case is reported calmly, anything else is surfaced.
+# worktree case is reported calmly, anything else is surfaced. The
+# merge command's own exit status is deliberately NOT the verdict —
+# the remote state re-read below is.
 MERGE_ERR=$(gh pr merge "$PR" --squash --delete-branch 2>&1 >/dev/null) || true
 if [ -n "$MERGE_ERR" ]; then
     case "$MERGE_ERR" in
@@ -95,9 +156,12 @@ if [ -n "$MERGE_ERR" ]; then
     esac
 fi
 
+# THE REMOTE STATE IS THE EXIT STATUS. Nothing after this check may
+# soften it: a caller judging by exit code (a background task, a CI
+# step, an && chain) must only ever see 0 when the PR is MERGED.
 STATE=$(gh pr view "$PR" --json state --jq '.state')
 if [ "$STATE" != "MERGED" ]; then
-    echo "[land_pr] merge did NOT land (state: $STATE) — investigate" >&2
+    echo "[land_pr] merge did NOT land (state: $STATE) — exit 1" >&2
     exit 1
 fi
 gh pr view "$PR" --json state,mergedAt,mergeCommit \

--- a/tests/unit/scripts/test_land_pr_exit_codes.py
+++ b/tests/unit/scripts/test_land_pr_exit_codes.py
@@ -1,0 +1,222 @@
+"""Exit-status receipts for ``scripts/land_pr.sh``.
+
+A background task reporting "completed (exit 0)" must mean the PR is
+MERGED — the same defect class as ``reach_snapshot.py`` exiting 0 on
+rate-limit (lesson, 2026-07-17), seen again on #2513 (2026-09-11) when a
+CONFLICTING PR was watched to green and then refused at merge time.
+
+Every path is driven through a fake ``gh`` on PATH that answers the
+script's exact queries from a JSON scenario and logs each call, so the
+tests can assert both the exit status and *which* gh calls happened
+(e.g. no ``checks --watch`` before a CONFLICTING refusal). Nothing here
+touches the network.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under the Apache License, Version 2.0
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCRIPT = REPO_ROOT / "scripts" / "land_pr.sh"
+HEAD = "dff8e5e03aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32" or shutil.which("bash") is None,
+    reason="land_pr.sh is a bash script driven through a POSIX fake gh",
+)
+
+FAKE_GH = '''#!{python}
+"""Fake gh: answers land_pr.sh's exact queries from a JSON scenario."""
+import json
+import os
+import sys
+from pathlib import Path
+
+argv = sys.argv[1:]
+log = Path(os.environ["FAKE_GH_LOG"])
+scenario = json.loads(Path(os.environ["FAKE_GH_SCENARIO"]).read_text())
+prior = [json.loads(line) for line in log.read_text().splitlines()] if log.exists() else []
+with log.open("a") as fh:
+    fh.write(json.dumps(argv) + "\\n")
+merged_marker = log.with_suffix(".merged")
+
+
+def opt(name):
+    return argv[argv.index(name) + 1] if name in argv else ""
+
+
+sub = argv[:2]
+if sub == ["pr", "checks"] and "--watch" in argv:
+    sys.exit(0)
+if sub == ["pr", "checks"]:
+    names = scenario.get("failed_checks", [])
+    if "length" in opt("--jq"):
+        print(len(names))
+    else:
+        print("\\n".join("  " + n for n in names))
+    sys.exit(0)
+if sub == ["pr", "merge"]:
+    if not scenario.get("merge_ok", False):
+        sys.stderr.write(
+            "X Pull request #%s is not mergeable: "
+            "the merge commit cannot be cleanly created.\\n" % argv[2]
+        )
+        sys.exit(1)
+    if scenario.get("merge_lands", True):
+        merged_marker.touch()
+    sys.exit(0)
+if sub == ["pr", "view"]:
+    fields = opt("--json")
+    state = "MERGED" if merged_marker.exists() else scenario.get("state", "OPEN")
+    if fields == "mergeable,mergeStateStatus":
+        seq = scenario["mergeability"]
+        n = sum(1 for call in prior if "mergeable,mergeStateStatus" in call)
+        print(seq[min(n, len(seq) - 1)])
+        sys.exit(0)
+    if fields == "headRefOid":
+        print(scenario["head"])
+        sys.exit(0)
+    if fields == "state":
+        print(state)
+        sys.exit(0)
+    if fields == "state,mergedAt,mergeCommit":
+        print("[land_pr] #%s: %s · mergedAt: t · sha: %s" % (argv[2], state, scenario["head"][:9]))
+        sys.exit(0)
+sys.stderr.write("fake gh: unexpected argv %r\\n" % (argv,))
+sys.exit(99)
+'''
+
+GREEN = {
+    "mergeability": ["MERGEABLE BLOCKED"],
+    "failed_checks": [],
+    "head": HEAD,
+    "merge_ok": True,
+}
+
+
+def _run(tmp_path: Path, scenario: dict, *args: str):
+    """Run land_pr.sh with a fake gh on PATH; return (proc, gh calls)."""
+    fakebin = tmp_path / "bin"
+    fakebin.mkdir(exist_ok=True)
+    gh = fakebin / "gh"
+    gh.write_text(FAKE_GH.format(python=sys.executable))
+    gh.chmod(0o755)
+    scenario_path = tmp_path / "scenario.json"
+    scenario_path.write_text(json.dumps(scenario))
+    log = tmp_path / "gh_calls.jsonl"
+    env = {
+        **os.environ,
+        "PATH": f"{fakebin}{os.pathsep}{os.environ['PATH']}",
+        "FAKE_GH_SCENARIO": str(scenario_path),
+        "FAKE_GH_LOG": str(log),
+        "LAND_PR_PROBE_DELAY": "0",
+    }
+    proc = subprocess.run(
+        ["bash", str(SCRIPT), *args],
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    calls = [json.loads(line) for line in log.read_text().splitlines()] if log.exists() else []
+    return proc, calls
+
+
+def _watched(calls) -> bool:
+    return any(c[:2] == ["pr", "checks"] and "--watch" in c for c in calls)
+
+
+def _merge_attempted(calls) -> bool:
+    return any(c[:2] == ["pr", "merge"] for c in calls)
+
+
+def test_script_parses():
+    assert subprocess.run(["bash", "-n", str(SCRIPT)], check=False).returncode == 0
+
+
+def test_green_at_authorized_head_merges_and_exits_0(tmp_path):
+    proc, calls = _run(tmp_path, GREEN, "2513", HEAD[:9])
+    assert proc.returncode == 0, proc.stderr
+    assert _watched(calls) and _merge_attempted(calls)
+    assert "#2513: MERGED" in proc.stdout
+
+
+def test_conflicting_refuses_before_watching(tmp_path):
+    proc, calls = _run(tmp_path, {**GREEN, "mergeability": ["CONFLICTING DIRTY"]}, "2513", HEAD[:9])
+    assert proc.returncode == 2
+    assert not _watched(calls) and not _merge_attempted(calls)
+    assert "CONFLICTING" in proc.stderr and "before watching" in proc.stderr
+    assert "git rebase -S origin/main" in proc.stderr
+    assert "git push --force-with-lease" in proc.stderr
+    assert "re-authorize at the NEW head" in proc.stderr
+
+
+def test_draft_refuses_before_watching(tmp_path):
+    proc, calls = _run(tmp_path, {**GREEN, "mergeability": ["MERGEABLE DRAFT"]}, "2513", HEAD[:9])
+    assert proc.returncode == 2
+    assert not _watched(calls)
+    assert "DRAFT" in proc.stderr and "gh pr ready 2513" in proc.stderr
+
+
+def test_conflict_appearing_during_watch_refuses_before_merging(tmp_path):
+    scenario = {**GREEN, "mergeability": ["MERGEABLE BLOCKED", "CONFLICTING DIRTY"]}
+    proc, calls = _run(tmp_path, scenario, "2513", HEAD[:9])
+    assert proc.returncode == 2
+    assert _watched(calls) and not _merge_attempted(calls)
+    assert "before merging" in proc.stderr and "git rebase -S origin/main" in proc.stderr
+
+
+def test_unknown_mergeability_is_reprobed_then_proceeds(tmp_path):
+    scenario = {**GREEN, "mergeability": ["UNKNOWN UNKNOWN", "MERGEABLE BLOCKED"]}
+    proc, calls = _run(tmp_path, scenario, "2513", HEAD[:9])
+    assert proc.returncode == 0, proc.stderr
+    probes = [c for c in calls if "mergeable,mergeStateStatus" in c]
+    assert len(probes) >= 3  # UNKNOWN, re-probe, and the pre-merge probe
+
+
+def test_merge_refused_by_gh_exits_1_not_0(tmp_path):
+    """The #2513 shape: everything green, gh pr merge refuses, state stays OPEN."""
+    proc, calls = _run(tmp_path, {**GREEN, "merge_ok": False}, "2513", HEAD[:9])
+    assert proc.returncode == 1
+    assert _merge_attempted(calls)
+    assert "merge commit cannot be cleanly created" in proc.stderr
+    assert "did NOT land (state: OPEN)" in proc.stderr
+
+
+def test_merge_command_exit_0_but_state_not_merged_exits_1(tmp_path):
+    """gh exiting 0 is not the receipt — the remote state re-read is."""
+    proc, _ = _run(tmp_path, {**GREEN, "merge_lands": False}, "2513", HEAD[:9])
+    assert proc.returncode == 1
+    assert "did NOT land (state: OPEN)" in proc.stderr
+
+
+def test_red_check_refuses_without_merging(tmp_path):
+    scenario = {**GREEN, "failed_checks": ["test (windows-latest, 3.13)"]}
+    proc, calls = _run(tmp_path, scenario, "2513", HEAD[:9])
+    assert proc.returncode == 1
+    assert not _merge_attempted(calls)
+    assert "1 check(s) failed" in proc.stderr and "windows-latest" in proc.stderr
+
+
+def test_moved_head_refuses_without_merging(tmp_path):
+    proc, calls = _run(tmp_path, GREEN, "2513", "0000000")
+    assert proc.returncode == 1
+    assert not _merge_attempted(calls)
+    assert "head moved since authorization" in proc.stderr
+
+
+def test_usage_exits_64(tmp_path):
+    proc, calls = _run(tmp_path, GREEN, "2513")
+    assert proc.returncode == 64
+    assert calls == []


### PR DESCRIPTION
## Why

On #2513 (2026-09-11, head dff8e5e03) `scripts/land_pr.sh` watched a full matrix to green, then `gh pr merge` refused ("the merge commit cannot be cleanly created" — the PR was CONFLICTING against main), and the caller's background task still reported "completed (exit 0)". Same defect class as `reach_snapshot.py` exiting 0 on rate-limit (lesson, 2026-07-17).

**Premise correction, verified:** both committed versions of the script (#2064, #2489) already `exit 1` on the did-not-land path; the other session's transcript shows the refusal line followed by the harness wrapper's `[exited with code 0]`. The invocation line was not recoverable, so the masking cause is *inferred, not checked*: most likely a `… | tee log` pipe, where the shell reports tee's status. The header now says so.

## What

- **Mergeability gate, twice.** `gate_mergeability` probes `mergeable,mergeStateStatus` before the watch and again right before the merge (main can move mid-watch). CONFLICTING → exit 2 with the rebase recipe (`rebase -S`, a `%G?` signature check, `--force-with-lease`, and the D10 reminder to re-authorize at the NEW head). DRAFT → exit 2 (same waste class; one case line — drop it if unwanted). UNKNOWN is re-probed up to three times, since GitHub computes mergeability lazily — confirmed live: #2507 read UNKNOWN in a list call and CONFLICTING three seconds later.
- **The remote state is the exit status.** The `gh pr view … state` re-read is marked as the sole determinant; the merge command's own exit status is explicitly not the verdict. Exit codes documented in the header (0 merged / 1 refused or not landed / 2 needs rebase or draft / 64 usage).
- **Unchanged:** head-SHA binding, remote verification, `--pull`.

## Receipts

- `tests/unit/scripts/test_land_pr_exit_codes.py` — 11 tests through a fake `gh` on PATH that answers the script's exact queries from a JSON scenario and logs every call, so each test asserts the exit status **and** which gh calls happened. Serial run: 11 passed.

| scenario | exit | also asserted |
|---|---|---|
| green, head matches, merged | 0 | watch + merge called |
| CONFLICTING up front | 2 | no watch call, rebase recipe printed |
| DRAFT up front | 2 | no watch call |
| conflict appears mid-watch | 2 | watch called, no merge call |
| UNKNOWN then MERGEABLE | 0 | ≥3 probes |
| gh merge refuses, state OPEN (the #2513 shape) | 1 | merge called, "did NOT land" |
| gh merge exits 0 but state OPEN | 1 | merge status is not the receipt |
| red check / moved head / usage | 1 / 1 / 64 | no merge call |

- **Real CLI, read-only by construction** (a bogus authorized head makes the merge unreachable): open CONFLICTING #2507 → exit 2 before watching; closed #2512 → exit 1 on the head gate.
- shellcheck 0.11.0 (`uvx --from shellcheck-py`, the repo does not run it in pre-commit): clean. Pre-commit on both files: clean. `tests/unit/gates` + `tests/unit/scripts`: 1262 passed.

## Review lane

Release tooling is a D11 risk class; a different-model lane is the chair's call before "merge N".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
