### PR TITLE
fix(doctor): optional extra raising a non-ImportError no longer crashes attune doctor; scope the metadata patch in its tests (salvaged from session 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Plugin metadata lookup now handles registered engine workflows without
   constructing them; bundled software workflow lookup no longer crashes on
   legacy analyzer-only fields.
+- `attune doctor` no longer crashes when an optional extra raises
+  something other than `ImportError` at import time (a missing native
+  library, a CUDA probe, an import-time metadata read); the package is
+  reported as `import failed`, distinct from `not installed`.
 
 - Class scans and class-register commands now return a non-zero exit code
   when a Python file cannot be parsed. The parse diagnostic remains in the

--- a/src/attune/cli_commands/utility_commands.py
+++ b/src/attune/cli_commands/utility_commands.py
@@ -471,6 +471,14 @@ def cmd_doctor(args: Namespace) -> int:
             _ok(f"{pkg_name} installed")
         except ImportError:
             _warn(f"{pkg_name} not installed", "optional")
+        except Exception as e:  # noqa: BLE001
+            # INTENTIONAL: a diagnostic must never crash on a broken extra.
+            # Import-time failures that are NOT ImportError are routine for
+            # this class of package — a missing native library, a metadata
+            # read, a torch/CUDA probe — and "installed but unimportable" is
+            # a different fact from "absent". Report which one, never
+            # collapse them and never let it propagate out of the doctor.
+            _warn(f"{pkg_name} import failed: {e}", "optional")
 
     # 5. Related attune packages (installed versions)
     from importlib.metadata import PackageNotFoundError

--- a/tests/unit/cli_commands/test_utility_commands.py
+++ b/tests/unit/cli_commands/test_utility_commands.py
@@ -1133,6 +1133,11 @@ class TestCmdDoctor:
 # ---------------------------------------------------------------------------
 
 
+#: The packages cmd_doctor's related-package section reports on. Kept in
+#: step with ``utility_commands.cmd_doctor`` section 5.
+_RELATED_PACKAGES = ("attune-rag", "attune-verify", "attune-forms")
+
+
 @pytest.mark.usefixtures("doctor_file_backend")
 class TestCmdDoctorInstallDiagnostics:
     """Tests for the related-package and Claude plugin doctor checks."""
@@ -1158,6 +1163,19 @@ class TestCmdDoctorInstallDiagnostics:
         mock attribute instead of the real module — 3.11+ uses
         pkgutil.resolve_name and is unaffected, so the miss is invisible
         on newer interpreters.
+
+        ``importlib.metadata.version`` is patched SCOPED to the three
+        attune-* packages under test, and ``sentence_transformers`` is
+        pinned absent. Both are load-bearing. cmd_doctor imports its
+        optional extras for real, and ``sentence_transformers`` pulls in
+        ``huggingface_hub``, which reads its own dependency metadata at
+        import time — so a blanket patch of ``metadata.version`` hands the
+        mock's ``side_effect`` to a third-party import and this class
+        would pass or fail on whether that package happens to be installed
+        in the interpreter running it: green in CI, where neither package
+        is in ``uv.lock``, and red on a machine that has them. Unlike
+        redis and jinja2, ``sentence_transformers`` is not a project
+        dependency, so its presence is genuinely environmental.
         """
         import shutil as shutil_module
         import subprocess as subprocess_module
@@ -1165,6 +1183,10 @@ class TestCmdDoctorInstallDiagnostics:
 
         monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
         args = types.SimpleNamespace()
+
+        # Pinned absent so the extras probe cannot import a real package
+        # that reads its own metadata at import time (see docstring).
+        fake_module("sentence_transformers")
 
         mock_version = MagicMock()
         mock_version.__version__ = "5.0.0"
@@ -1185,11 +1207,16 @@ class TestCmdDoctorInstallDiagnostics:
         elif run_result is not None:
             run_mock.return_value = run_result
 
-        monkeypatch.setattr(
-            metadata,
-            "version",
-            pkg_version if pkg_version is not None else MagicMock(return_value="0.0.0"),
-        )
+        probe = pkg_version if pkg_version is not None else MagicMock(return_value="0.0.0")
+        real_version = metadata.version
+
+        def scoped_version(name: str, *a, **kw):
+            """Answer only for the packages cmd_doctor's section 5 probes."""
+            if name in _RELATED_PACKAGES:
+                return probe(name, *a, **kw)
+            return real_version(name, *a, **kw)
+
+        monkeypatch.setattr(metadata, "version", scoped_version)
         monkeypatch.setattr(shutil_module, "which", MagicMock(return_value=which))
         monkeypatch.setattr(subprocess_module, "run", run_mock)
 
@@ -1252,6 +1279,43 @@ class TestCmdDoctorInstallDiagnostics:
         assert result == 0
         out = capsys.readouterr().out
         assert "[--]   attune-rag version unknown (optional)" in out
+
+    def test_optional_extra_import_raises_non_import_error(
+        self,
+        capsys: pytest.CaptureFixture[str],
+        monkeypatch: pytest.MonkeyPatch,
+        fake_module,
+    ) -> None:
+        """A broken optional extra degrades to a row, never crashes the doctor.
+
+        Regression guard. cmd_doctor's extras probe caught only
+        ``ImportError``, so anything else raised while EXECUTING an
+        extra's module body propagated out and killed the whole
+        diagnostic — reported as a hard traceback from the one command
+        whose entire job is telling the truth about the environment.
+        Real instances of this are ordinary: a missing native library, a
+        CUDA/driver probe, an import-time metadata read.
+        """
+        import builtins
+
+        real_import = builtins.__import__
+
+        def exploding_import(name: str, *a, **kw):
+            if name == "sentence_transformers":
+                raise RuntimeError("dlopen(libomp.dylib): image not found")
+            return real_import(name, *a, **kw)
+
+        monkeypatch.setattr(builtins, "__import__", exploding_import)
+
+        result = self._run_doctor(monkeypatch, fake_module)
+
+        assert result == 0
+        out = capsys.readouterr().out
+        assert "[--]   sentence-transformers import failed" in out
+        assert "dlopen(libomp.dylib): image not found" in out
+        # Distinct from the absent case — the doctor must not collapse
+        # "installed but unimportable" into "not installed".
+        assert "sentence-transformers not installed" not in out
 
     def test_claude_cli_not_found(
         self,

--- a/tests/unit/gates/test_broad_except_ratchet.py
+++ b/tests/unit/gates/test_broad_except_ratchet.py
@@ -116,7 +116,12 @@ _BASELINE: dict[str, int] = {
     "src/attune/cli_commands/telemetry_commands.py": 12,
     # utility_commands: 7th site is cmd_doctor's related-package version
     # probe — a diagnostic must never crash on broken package metadata.
-    "src/attune/cli_commands/utility_commands.py": 7,
+    # Raised 7 -> 8: cmd_doctor's optional-extras probe. `except ImportError`
+    # alone let a non-ImportError raised while IMPORTING an extra (a missing
+    # native library, an import-time metadata read) propagate out and crash
+    # the doctor — the same must-not-crash contract as the 7th site, one
+    # section earlier.
+    "src/attune/cli_commands/utility_commands.py": 8,
     "src/attune/cli_commands/workflow_commands.py": 1,
     "src/attune/cli_minimal.py": 3,
     "src/attune/cli_router.py": 1,


### PR DESCRIPTION
## What this is

Salvage of real, uncommitted work from CCD session "still open session 3" (worktree `objective-mahavira-cad2f1`, 2026-09-09), applied verbatim on a fresh branch off `origin/main`. That worktree's three dirty files are **left untouched** as the backup until this merges; nothing there was committed, reset, or reaped.

## Two separable defects, both fixed

**Product.** `attune doctor`'s optional-extra probe caught only `ImportError`. An extra whose import raises anything else at import time (a missing native library, a CUDA probe, an import-time `importlib.metadata` read) took the whole diagnostic down with a traceback. It now reports `[--] <pkg> import failed: <e>`, kept distinct from "not installed". The broad-except ratchet baseline moves 7 → 8 with the reason recorded in the test.

**Test.** `test_related_packages_broken_metadata` blanket-patched `importlib.metadata.version` for every package. `huggingface_hub` calls that function at import time, so on any interpreter with `sentence-transformers` installed the mock fired inside third-party code and the test crashed. CI never installs that extra (it is absent from `pyproject.toml` and `uv.lock`), so CI was green by accident of a leaner environment. The patch is now scoped to the three `attune-*` names and delegates everything else to the real function; `sentence_transformers` is pinned absent in the fixture; `test_optional_extra_import_raises_non_import_error` pins the new path.

## Receipts

| Probe | Result | Where |
| --- | --- | --- |
| Reproduction on pyenv 3.10.11 (has the extra) | identical traceback, `Error importing huggingface_hub.hf_api: boom` | session 3, relayed |
| Whole tree, pyenv 3.10.11 / `.venv` 3.11.14 | 26,163 passed / 26,144 passed, raw exit 0 | session 3, relayed |
| `tests/unit/cli_commands/test_utility_commands.py` + `tests/unit/gates/test_broad_except_ratchet.py` against THIS worktree's source (`PYTHONPATH` override, not main's editable mapping) | 51 passed | this head, re-run |
| Mutation: product fix reverted → new regression test | 1 failed (guard is real) | this head, re-run |
| Diff identity vs session 3's worktree (index lines aside) | identical | this head |
| Pinned pre-commit hooks on the three files | passed | this head |
| `tests/unit/gates` full run (worktree source) | 672 passed | this head, re-run |

## Disclosures

- The ratchet baseline is an enforcement surface; the bump is +1 with its reason in the same commit. Whether that needs a D11 lane or merges on receipts is the chair's call (09-06 waiver).
- Session 3 also found that `pytest … | tail` reports `tail`'s exit status, not pytest's; that and the blanket-patch class are one lesson now in the docs outbox (`20260911-2105-lesson-blanket-stdlib-patch-bleeds-into-third-party-imports.md`), not appended to `.claude/lessons.md` here.
- Authored by session 3 (Claude); landed by the next-session-start session; the salvage was claimed with "still open session 1", which had the same brief, before starting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
