### PR TITLE
fix(hooks): guard tokenizer splits on newlines and treats heredoc bodies as data; worktree-add guard matches the subcommand after git's global options (stranded-diff recovery 1/3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   when a Python file cannot be parsed. The parse diagnostic remains in the
   output, and scanning continues for other files; an incomplete scan can
   no longer silently pass the register's scan-error check.
+- The worktree-add, dirty-switch and detached-head-push guards split
+  multi-line Bash commands on newlines, treat here-document bodies as
+  data, and match `git worktree add` by position after git's global
+  options (`-C`, `-c`, `--git-dir` …): a `git -C <main> worktree add`
+  on the line after `set -e` is now refused, while `git commit -m
+  worktree add` and heredoc bodies are not.
 - `/cross-review` no longer briefs the authoring seat on its own diff
   when the moderator is not Claude. `run_review()` resolves an omitted
   `seat` against the moderating host: Claude-hosted and host-less runs

--- a/src/attune/hooks/scripts/dirty_switch_guard.py
+++ b/src/attune/hooks/scripts/dirty_switch_guard.py
@@ -53,6 +53,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import shlex
 import subprocess
 import sys
@@ -72,6 +73,23 @@ _FORCE_FLAGS = {"-f", "--force", "--discard-changes"}
 
 #: Shell operators that separate one command from the next.
 _SEPARATORS = {"&&", "||", ";", "|", "&"}
+
+#: ``<<EOF`` / ``<<-'EOF'`` — the start of a here-document.
+_HEREDOC = re.compile(r"<<-?\s*(['\"]?)([A-Za-z_][\w-]*)\1")
+
+
+def _strip_heredocs(command: str) -> str:
+    """Drop here-document bodies: they are data, not commands to inspect."""
+    kept: list[str] = []
+    pending: list[str] = []  # closing delimiters, in the order bash reads them
+    for line in command.split("\n"):
+        if pending:
+            if line.lstrip("\t") == pending[0]:
+                pending.pop(0)
+            continue
+        kept.append(line)
+        pending.extend(m.group(2) for m in _HEREDOC.finditer(line))
+    return "\n".join(kept)
 
 
 def _log_metric(outcome: str, detail: str | None = None) -> None:
@@ -125,9 +143,15 @@ def git_invocations(command: str) -> list[list[str]]:
     # punctuation_chars is required, not cosmetic: plain shlex.split
     # leaves "hi;" as one token, so `echo hi; git reset --hard` would
     # parse as a single harmless invocation and slip past the guard.
+    # A newline separates commands too: the 2026-09-11 escape was a
+    # `git -C … worktree add` on the line after `set -e`, merged into one
+    # non-git invocation. Here-document bodies are data, a backslash-newline
+    # is a continuation, and a trailing comment must not swallow the next line.
+    text = _strip_heredocs(command).replace("\\\n", " ").replace("\n", " ; ")
     try:
-        lexer = shlex.shlex(command, posix=True, punctuation_chars=True)
+        lexer = shlex.shlex(text, posix=True, punctuation_chars=True)
         lexer.whitespace_split = True
+        lexer.commenters = ""
         tokens = list(lexer)
     except ValueError:
         return []  # unbalanced quotes: cannot parse, so cannot judge

--- a/src/attune/hooks/scripts/worktree_add_guard.py
+++ b/src/attune/hooks/scripts/worktree_add_guard.py
@@ -67,12 +67,21 @@ def _log_metric(outcome: str, detail: str | None = None) -> None:
         pass
 
 
+#: Git global options that consume the next token as their value.
+_GLOBAL_OPTS_WITH_VALUE = {"-C", "-c", "--git-dir", "--work-tree", "--namespace", "--config-env"}
+
+
 def is_worktree_add(args: list[str]) -> bool:
-    """True if the git arg-list is ``[global opts] worktree add ...``."""
-    if "worktree" not in args:
-        return False
-    idx = args.index("worktree")
-    return len(args) > idx + 1 and args[idx + 1] == "add"
+    """True if the git arg-list is ``[global opts] worktree add ...``.
+
+    Global options (``-C <dir>``, ``-c k=v``, ``--git-dir=<x>``,
+    ``--no-pager`` …) are skipped so the subcommand is matched by
+    position — ``git commit -m worktree add`` is not a worktree add.
+    """
+    i = 0
+    while i < len(args) and args[i].startswith("-"):
+        i += 2 if args[i] in _GLOBAL_OPTS_WITH_VALUE else 1
+    return args[i : i + 2] == ["worktree", "add"]
 
 
 def session_worktree_root(path: Path) -> Path | None:

--- a/tests/unit/hooks/test_dirty_switch_guard.py
+++ b/tests/unit/hooks/test_dirty_switch_guard.py
@@ -111,6 +111,14 @@ class TestChainedCommands:
         invocations = mod.git_invocations("echo hi; git reset --hard HEAD~1")
         assert any(mod.is_hard_reset(a) for a in invocations)
 
+    def test_switch_on_the_next_line_is_still_seen(self, mod):
+        invocations = mod.git_invocations("set -e\ngit checkout main")
+        assert any(mod.is_branch_switch(a) for a in invocations)
+
+    def test_heredoc_body_is_data_not_commands(self, mod):
+        command = "cat > notes.md <<'EOF'\ngit checkout main\nEOF\ngit status"
+        assert [a[0] for a in mod.git_invocations(command)] == ["status"]
+
     def test_unparseable_command_degrades_to_no_invocations(self, mod):
         assert mod.git_invocations('git checkout "unbalanced') == []
 

--- a/tests/unit/hooks/test_worktree_add_guard.py
+++ b/tests/unit/hooks/test_worktree_add_guard.py
@@ -57,8 +57,15 @@ class TestClassification:
         [
             "git worktree add ../other -b feature",
             "git -C /repo worktree add /tmp/x main",
+            "git -c core.x=y -C /repo worktree add ../other",
+            "git --git-dir=/repo/.git --no-pager worktree add x",
+            "git --work-tree /repo worktree add x",
             "echo hi; git worktree add x",
             "cd /repo && git worktree add --detach x",
+            # the 2026-09-11 escape: global option AND a newline-separated script
+            'set -e\nW=/tmp/x\ngit -C /repo worktree add -q "$W" -b fix/y origin/main\ncd "$W"',
+            "git worktree \\\n  add x",
+            "echo start # note\ngit worktree add x",
         ],
     )
     def test_worktree_add_forms(self, mod, command):
@@ -71,6 +78,8 @@ class TestClassification:
             "git worktree remove ../other",
             "git worktree prune",
             "git add worktree.txt",
+            "git commit -m worktree add",
+            "cat > notes.md <<'EOF'\ngit worktree add ../other\nEOF",
             "git status",
             "ls .claude/worktrees",
         ],
@@ -103,6 +112,19 @@ class TestDecision:
         record = json.loads(metrics.read_text().splitlines()[-1])
         assert record["enforcement"] == "worktree-add-guard" and record["outcome"] == "fired"
 
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "git -C /repo worktree add ../other -b feature",
+            "git -c core.x=y -C /repo worktree add ../other -b feature",
+            'set -e\nW=/tmp/x\ngit -C /repo worktree add -q "$W" -b fix/y origin/main',
+        ],
+    )
+    def test_blocks_global_option_forms(self, mod, metrics, tmp_path, monkeypatch, command):
+        monkeypatch.chdir(_worktree(tmp_path))
+        assert mod.main(_ctx(command)) == 2
+        assert json.loads(metrics.read_text())["outcome"] == "fired"
+
     def test_blocks_when_project_dir_env_is_a_worktree(self, mod, metrics, tmp_path, monkeypatch):
         root = _worktree(tmp_path)
         monkeypatch.chdir(tmp_path)
@@ -114,10 +136,11 @@ class TestDecision:
         assert mod.main(_ctx("git worktree add .claude/worktrees/new -b feature")) == 0
         assert json.loads(metrics.read_text())["outcome"] == "allowed"
 
-    def test_escape_hatch(self, mod, metrics, tmp_path, monkeypatch):
+    @pytest.mark.parametrize("command", ["git worktree add x", "git -C /repo worktree add x"])
+    def test_escape_hatch(self, mod, metrics, tmp_path, monkeypatch, command):
         monkeypatch.chdir(_worktree(tmp_path))
         monkeypatch.setenv(mod.ALLOW_ENV, "1")
-        assert mod.main(_ctx("git worktree add x")) == 0
+        assert mod.main(_ctx(command)) == 0
 
     @pytest.mark.parametrize(
         "ctx",
@@ -125,6 +148,8 @@ class TestDecision:
             _ctx("git worktree add x", tool="Edit"),
             _ctx(""),
             _ctx("git worktree list"),
+            _ctx("git worktree remove ../other"),
+            _ctx("git -C /repo worktree list"),
             _ctx("git checkout -b feature origin/main"),
             {"tool_name": "Bash"},
         ],


### PR DESCRIPTION
## What this is

PR 1 of the stranded-diff recovery (Patrick, 2026-09-11: "recover the four stranded diffs as four PRs, one at a time on fresh branches from main in this worktree, tests run per PR, awesome-noether first; the owning worktrees stay untouched"). The doctor fix was #2516; this is the guards fix from worktree `awesome-noether-f81a8d` (CCD session "Make worktree_add_guard match the git -C form", tonight), applied verbatim on a fresh branch off `origin/main`. That worktree's four dirty files are **untouched** and remain the backup until this merges.

## The defect

The 2026-09-11 escape was a multi-line Bash script: `set -e`, two assignments, then `git -C <main> worktree add …` on its own line. The shared tokenizer split invocations only on `&&` `||` `;` `|` `&`, never on newlines, so the whole script became one invocation starting with `set`, which the git detector rejected. The single-line `-C` form was already refused and already pinned. Verified by the authoring session by replaying the exact command from the good-morning-247b52 transcript through the unmodified script from a worktree cwd: exit 0.

## The fix

- **`dirty_switch_guard.py`** (owner of the shared tokenizer): newline is a command separator; backslash-newline joins; `#` comment handling is disabled so a trailing comment cannot swallow the next line; here-document bodies are stripped first so a heredoc containing `git worktree add` or `git checkout main` is data, not a command. Without the heredoc step, the newline split would have made the dirty-switch guard block ordinary heredoc file writes from a dirty tree. Reaches all three consumers: worktree-add, dirty-switch, detached-head-push.
- **`worktree_add_guard.py`**: `is_worktree_add` skips git's global options (`-C`, `-c`, `--git-dir`, `--work-tree`, `--namespace`, `--config-env` with values; other leading flags without) and matches `worktree add` by position, so `git commit -m worktree add` is not a worktree add. Escape hatch and main-checkout allowance untouched.
- **Tests** pin the bare, `-C`, `-c … -C`, `--git-dir=… --no-pager`, `--work-tree`, exact 09-11 multi-line, continuation and trailing-comment forms as refused; `list`, `remove`, `-C … list`, `commit -m worktree add` and a heredoc body as allowed; the escape hatch over both forms; a next-line switch pin and a heredoc-is-data pin on the dirty guard. No new `except`; the broad-except baseline is unchanged.

## Receipts on this head (worktree source via `PYTHONPATH`, not main's editable mapping)

| Probe | Result |
| --- | --- |
| Both guard test modules, serial | 93 passed |
| Whole `tests/unit/hooks`, serial | 1152 passed |
| `tests/unit/gates` + `tests/unit/plugins/test_sdk_subprocess_gate.py` (every repo hook gated) | 715 passed |
| Live stdin, `HOME` redirected to a scratch dir: exact 09-11 multi-line, single-line `-C` | exit 2 (refused) |
| Live stdin: heredoc body only (both guards), `git worktree list`, `git commit -m worktree add` | exit 0 (allowed) |
| Diff identity vs the source worktree (index lines aside) | identical |
| `git apply --check` of the source diff against `origin/main` via a temp index | clean |
| Pinned pre-commit hooks on the four files | passed |

The authoring session's own receipts (93 / 1152 / 252, ruff on two versions, black, live probes) are in its transcript and were not relayed as this PR's evidence; everything above was re-run here.

## Disclosures

- **Enforcement surface.** These are the two PreToolUse guards that run on every Bash call in a session; a wrong fix blocks or unblocks git fleet-wide. Whether that warrants a D11 lane or merges on receipts is the chair's call.
- **Metrics log.** The authoring session's live probes appended ~7 "fired" and 2 "allowed" rows to `~/.attune/enforcement-metrics.jsonl` (2026-09-12T00:0x–00:14Z, detail = its worktree path) and was blocked from removing them; they will inflate the worktree-add-guard hit count at the next retirement review unless Patrick strips them. This PR's probes wrote to a scratch `HOME` instead.
- Landed by the next-session-start session; claimed with "still open session 1" (which found the diff) and announced to the authoring session before push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
