### PR TITLE
fix(ops): session_summary_cache validates session_id against the flat cache dir; drop its allowlist entry (stranded-diff recovery 2/3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   including the moderator's own; that run is stamped `self_review: True`
   rather than passed off as a cross-review. Saved board posts and ledger
   rows retain the host, self-review state, and resolved Claude auth route.
+- The ops session-summary cache validates its session id against the
+  flat cache directory before any write: an id that would escape or
+  nest raises `ValueError` and touches nothing. No shipping caller could
+  reach a traversal; this is defence in depth.
 - `claude_auth` defaults to `"auto"`, which selects the verified Pro/Max
   subscription route ONLY for a real `claude` seat briefed from a known
   non-Claude host. That cross-host case previously failed with

--- a/src/attune/ops/session_summary_cache.py
+++ b/src/attune/ops/session_summary_cache.py
@@ -29,6 +29,8 @@ from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 
+from attune.security.path_validation import _validate_file_path
+
 logger = logging.getLogger(__name__)
 
 # Bytes hashed from the JSONL tail to form the cache-key digest.
@@ -110,8 +112,32 @@ def cache_path_for(attune_home: Path, session_id: str) -> Path:
     The directory is created on first ``save()``; this function does
     not create it (callers may want to test "is there a cache for X?"
     without forcing the dir into existence).
+
+    Every shipping caller derives ``session_id`` from ``Path.stem`` of
+    a locally-globbed ``*.jsonl``, which cannot carry a separator — so
+    the containment check below is defence in depth for future callers,
+    not a fix for a live traversal.
+
+    Raises:
+        ValueError: If ``session_id`` composes to anything but a direct
+            child of ``<attune_home>/ops/session_summaries/`` — a
+            separator, a ``..`` component, an absolute path, or a null
+            byte.
     """
-    return attune_home / "ops" / "session_summaries" / f"{session_id}.json"
+    cache_dir = attune_home / "ops" / "session_summaries"
+    path = cache_dir / f"{session_id}.json"
+    # The cache is a FLAT directory of ``<session-id>.json`` files, so
+    # anything that lands elsewhere — escaping or merely nesting — is a
+    # bad id. Checked before the containment validator because the
+    # parent test is the stricter of the two.
+    if path.parent != cache_dir:
+        raise ValueError(f"session_id must be a single path component, got {session_id!r}")
+    # Belt-and-braces containment (null bytes, symlinked components).
+    # The validator's resolved return value is discarded so callers keep
+    # the unresolved path they composed — a symlinked ``attune_home``
+    # must not be rewritten under them. Creates nothing.
+    _validate_file_path(str(path), allowed_dir=str(cache_dir))
+    return path
 
 
 def load(attune_home: Path, session_id: str, expected: CacheKey) -> CachedSummary | None:
@@ -127,6 +153,10 @@ def load(attune_home: Path, session_id: str, expected: CacheKey) -> CachedSummar
     A returned :class:`CachedSummary` always has ``source == "cached"``
     so the caller can distinguish hits from fresh writes (which use
     ``source == "haiku"``). The cached text itself is unchanged.
+
+    Raises :class:`ValueError` for a ``session_id`` that would escape
+    the cache directory — see :func:`cache_path_for`. A traversal
+    attempt is a caller bug, not a cache miss, so it is not swallowed.
     """
     path = cache_path_for(attune_home, session_id)
     if not path.is_file():
@@ -186,9 +216,12 @@ def save(
     record was written to. Atomic via temp-file + rename so a
     concurrent reader never observes a half-written JSON.
 
-    Raises :class:`OSError` on filesystem errors. Callers that want
-    silent best-effort caching should wrap the call in a try/except
-    rather than burying the failure here.
+    Raises :class:`OSError` on filesystem errors, and
+    :class:`ValueError` for a ``session_id`` that would escape the
+    cache directory (see :func:`cache_path_for`) — the guard runs
+    before the directory is created or any temp file is opened.
+    Callers that want silent best-effort caching should wrap the call
+    in a try/except rather than burying the failure here.
     """
     path = cache_path_for(attune_home, session_id)
     path.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/unit/gates/test_path_validation_gate.py
+++ b/tests/unit/gates/test_path_validation_gate.py
@@ -107,10 +107,6 @@ ALLOWLIST = frozenset(
         "src/attune/ops/routes/specs.py",
         # Re-seeded 2026-08-21 when the scanner learned the atomic-write
         # idiom (tempfile.mkstemp + os.fdopen), previously invisible.
-        # Reviewed: writes <attune_home>/ops/session_summaries/<id>.json.
-        # NOTE: the <id> component is interpolated unvalidated — tracked
-        # separately as a traversal question, not waved through here.
-        "src/attune/ops/session_summary_cache.py",
         "src/attune/ops/sweep_results.py",
         "src/attune/orchestration/ghosts/worktree.py",
         "src/attune/pipeline_learner/decisions.py",

--- a/tests/unit/ops/test_session_summary_cache.py
+++ b/tests/unit/ops/test_session_summary_cache.py
@@ -215,3 +215,86 @@ def test_save_persisted_record_has_haiku_source_on_disk(attune_home):
     path = cache.cache_path_for(attune_home, "sid")
     data = json.loads(path.read_text(encoding="utf-8"))
     assert data["source"] == "haiku"
+
+
+# --- traversal containment (regression) ------------------------------
+#
+# ``cache_path_for`` interpolates ``session_id`` straight into a
+# filesystem path. Every shipping caller derives the id from
+# ``Path.stem`` of a locally-globbed ``*.jsonl``, so no traversing id
+# reaches it today — these lock the containment guard so a future
+# caller (a route, an MCP tool, a CLI flag) cannot reintroduce one.
+
+#: Ids that escape the cache dir, plus one that merely nests inside
+#: it — the cache is a flat directory, so both are bad ids.
+BAD_IDS = [
+    "../escaped",
+    "../../../../etc/passwd",
+    "a/../../escaped",
+    "sub/dir/escaped",
+]
+
+
+@pytest.mark.parametrize("session_id", BAD_IDS)
+def test_cache_path_for_rejects_escaping_or_nesting_session_id(attune_home, session_id):
+    with pytest.raises(ValueError):
+        cache.cache_path_for(attune_home, session_id)
+
+
+def test_cache_path_for_rejects_absolute_session_id(attune_home, tmp_path):
+    """An absolute id would win the ``/`` join outright."""
+    with pytest.raises(ValueError):
+        cache.cache_path_for(attune_home, str(tmp_path / "outside"))
+
+
+@pytest.mark.parametrize("session_id", BAD_IDS)
+def test_save_writes_nothing_outside_the_cache_dir(attune_home, tmp_path, session_id):
+    """The guard fires before mkdir, mkstemp, and the rename."""
+    before = set(tmp_path.rglob("*"))
+
+    with pytest.raises(ValueError):
+        cache.save(
+            attune_home,
+            session_id,
+            key=_make_key(),
+            summary="pwned",
+            tokens_in=1,
+            tokens_out=1,
+            cost_usd=0.0,
+        )
+
+    assert set(tmp_path.rglob("*")) == before, "save() touched the filesystem"
+    assert not (attune_home / "ops" / "session_summaries").exists()
+    assert not (tmp_path / "escaped.json").exists()
+
+
+def test_load_rejects_traversing_session_id_instead_of_missing(attune_home):
+    """A traversal attempt is a caller bug, not a cache miss."""
+    with pytest.raises(ValueError):
+        cache.load(attune_home, "../escaped", expected=_make_key())
+
+
+def test_uuid_shaped_session_id_still_round_trips(attune_home):
+    """The guard must not reject the real id shape (Claude Code UUIDs)."""
+    session_id = "76caa7c4-fa37-4d5d-b122-b36bdd52ca72"
+    key = _make_key()
+    path = cache.save(
+        attune_home,
+        session_id,
+        key=key,
+        summary="ok",
+        tokens_in=1,
+        tokens_out=1,
+        cost_usd=0.0,
+    )
+    assert path.parent == attune_home / "ops" / "session_summaries"
+    loaded = cache.load(attune_home, session_id, expected=key)
+    assert loaded is not None and loaded.summary == "ok"
+
+
+def test_dot_dot_stem_composes_to_an_ordinary_filename(attune_home):
+    """``Path("...jsonl").stem`` is ``".."`` — the ``.json`` suffix
+    makes it an ordinary in-dir filename, so it must not be rejected."""
+    path = cache.cache_path_for(attune_home, "..")
+    assert path.name == "...json"
+    assert path.parent == attune_home / "ops" / "session_summaries"


### PR DESCRIPTION
## What this is

PR 2 of the stranded-diff recovery (Patrick, 2026-09-11: "recover the four stranded diffs as four PRs, one at a time on fresh branches from main in this worktree, tests run per PR; the owning worktrees stay untouched"). #2516 was the doctor fix, #2517 the guards; this is the session-summary-cache traversal guard from worktree `morning-cleanup-review-1150e7` (CCD session "Validate session_id in ops session-summary cache path", 2026-08-21 — the chip filed by the 08-21 path-validation lesson), applied verbatim on a fresh branch off `origin/main`. That worktree's two dirty files are **untouched** and remain the backup until this merges.

## Reachability (the authoring session's trace, re-stated)

`cache_path_for()` is called only by `load()`/`save()` in the same module; those are called only from `session_summarizer.py`, where `session_id = jsonl_path.stem` of a locally globbed `*.jsonl`; `summarize_session()` has zero non-test callers in `src/` (the dashboard routes that once forwarded ids were deleted in #1545). A stem cannot carry a separator, so **no live traversal existed**. The guard is defence in depth for future callers of a public helper whose docstring already promised a flat `<id>.json` layout.

## The change

- `cache_path_for()` checks the flat-directory invariant first (the composed path's parent must be the cache dir, rejecting escaping **and** merely nesting ids), then routes through `_validate_file_path` for null bytes and resolution-based containment. The validator's resolved value is discarded so a symlinked `attune_home` is not rewritten under callers. Creates nothing.
- `save()` raises before `mkdir`, `mkstemp` and the rename, so a bad id touches nothing; `load()` raises rather than treating a traversal as a cache miss. Docstrings carry the `ValueError` contract.
- 9 regression tests: escaping ids, an absolute id, a nesting id (`sub/dir/x`), a no-filesystem-mutation assertion on `save()`, and pins that real UUID ids and the `..` stem still work.
- **Allowlist ratchet:** the module now references the validation helper, so `test_allowlist_entries_are_still_needed` failed on the applied diff (1 failed / 10 passed) until its entry and the NOTE that tracked exactly this question were removed from `tests/unit/gates/test_path_validation_gate.py`. The 08-21 re-seed group header stays because the other re-seeded modules remain listed. (The entry did not exist when the session wrote the diff; it was re-seeded later that day.)

## Receipts on this head (worktree source via `PYTHONPATH`)

| Probe | Result |
| --- | --- |
| `tests/unit/ops/test_session_summary_cache.py` | 26 passed |
| Whole `tests/unit/ops` | 1688 passed |
| `tests/unit/gates` (path-validation gate included, entry dropped) | 672 passed |
| Mutation: source guard reverted → new tests | 10 failed / 16 passed (the guard is real) |
| Diff identity vs the source worktree (index lines aside) | identical |
| `git apply --check` against `origin/main` via a temp index | clean |
| Pinned pre-commit hooks on the three files | passed |

The authoring session's own live-fire (a real `save()` with `../../../escaped` raising before any write under a temp home) is in its transcript and not relayed as evidence here.

## Disclosures

- Security-adjacent path handling plus a gate allowlist change: D11 risk classes. Lane or merge-on-receipts is the chair's call.
- The authoring session flagged a separate gap: about 12 modules use `mkstemp`/`NamedTemporaryFile` and were invisible to the scanner at the time. Main's scanner has since learned that idiom (the 08-21 re-seed), so that gap is closed; nothing rides along here.
- Landed by the next-session-start session; claimed with "still open session 1"; the authoring session is idle since 08-21 and was not messaged (absence, per the peer-driving protocol) — its worktree was read, never written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
