### PR TITLE
fix(llm): thread max_tokens through EmpathyLLM.interact and the level handlers; executor mixin and test-gen pass their caps (stranded-diff recovery 3/3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   raises `ReviewTargetError`. An unknown host still resolves to `"api"`,
   preserving the zero-cap refusal. Pass `claude_auth="api"` to force the
   billable route.
+- `EmpathyLLM.interact()` accepts `max_tokens`, threaded through all
+  five empathy levels; the workflow executor forwards a step's cap and
+  parallel test generation passes 16384, so long generated outputs are
+  no longer silently truncated at the level default.
 - The CI Ruff gate now runs `ruff check --no-fix .`. With `fix = true` in
   `pyproject.toml`, the bare `ruff check .` rewrote the runner's checkout and
   exited 0, so every auto-fixable violation passed the gate and merged

--- a/src/attune/llm/core.py
+++ b/src/attune/llm/core.py
@@ -310,6 +310,7 @@ class EmpathyLLM(SecurityMixin, InteractionMixin):
         context: dict[str, Any] | None = None,
         force_level: int | None = None,
         task_type: str | None = None,
+        max_tokens: int | None = None,
     ) -> dict[str, Any]:
         """Main interaction method.
 
@@ -334,6 +335,10 @@ class EmpathyLLM(SecurityMixin, InteractionMixin):
             force_level: Force specific level (for testing/demos)
             task_type: Type of task for model routing (e.g., "summarize", "fix_bug").
                 If not provided with routing enabled, defaults to "capable" tier.
+            max_tokens: Optional response-token cap. Overrides the
+                empathy level's recommendation (1024-4096) when set —
+                callers with long outputs (test/doc generation) MUST
+                pass this or the level default silently truncates.
 
         Returns:
             Dictionary with:
@@ -388,15 +393,25 @@ class EmpathyLLM(SecurityMixin, InteractionMixin):
         # Route to appropriate level handler using sanitized input
         # Pass routed_model for cost-optimized model selection
         if level == 1:
-            result = await self._level_1_reactive(sanitized_input, state, context, routed_model)
+            result = await self._level_1_reactive(
+                sanitized_input, state, context, routed_model, max_tokens
+            )
         elif level == 2:
-            result = await self._level_2_guided(sanitized_input, state, context, routed_model)
+            result = await self._level_2_guided(
+                sanitized_input, state, context, routed_model, max_tokens
+            )
         elif level == 3:
-            result = await self._level_3_proactive(sanitized_input, state, context, routed_model)
+            result = await self._level_3_proactive(
+                sanitized_input, state, context, routed_model, max_tokens
+            )
         elif level == 4:
-            result = await self._level_4_anticipatory(sanitized_input, state, context, routed_model)
+            result = await self._level_4_anticipatory(
+                sanitized_input, state, context, routed_model, max_tokens
+            )
         elif level == 5:
-            result = await self._level_5_systems(sanitized_input, state, context, routed_model)
+            result = await self._level_5_systems(
+                sanitized_input, state, context, routed_model, max_tokens
+            )
         else:
             raise ValueError(f"Invalid level: {level}")
 

--- a/src/attune/llm/interaction.py
+++ b/src/attune/llm/interaction.py
@@ -57,6 +57,7 @@ Follow the CLAUDE.md instructions above, then apply the Attune AI below.
         state: CollaborationState,
         context: dict[str, Any],
         model_override: str | None = None,
+        max_tokens: int | None = None,
     ) -> dict[str, Any]:
         """Level 1: Reactive - Simple Q&A
 
@@ -66,7 +67,7 @@ Follow the CLAUDE.md instructions above, then apply the Attune AI below.
             "messages": [{"role": "user", "content": user_input}],
             "system_prompt": self._build_system_prompt(1),
             "temperature": EmpathyLevel.get_temperature_recommendation(1),
-            "max_tokens": EmpathyLevel.get_max_tokens_recommendation(1),
+            "max_tokens": max_tokens or EmpathyLevel.get_max_tokens_recommendation(1),
         }
         if model_override:
             generate_kwargs["model"] = model_override
@@ -85,6 +86,7 @@ Follow the CLAUDE.md instructions above, then apply the Attune AI below.
         state: CollaborationState,
         context: dict[str, Any],
         model_override: str | None = None,
+        max_tokens: int | None = None,
     ) -> dict[str, Any]:
         """Level 2: Guided - Ask clarifying questions
 
@@ -98,7 +100,7 @@ Follow the CLAUDE.md instructions above, then apply the Attune AI below.
             "messages": messages,
             "system_prompt": self._build_system_prompt(2),
             "temperature": EmpathyLevel.get_temperature_recommendation(2),
-            "max_tokens": EmpathyLevel.get_max_tokens_recommendation(2),
+            "max_tokens": max_tokens or EmpathyLevel.get_max_tokens_recommendation(2),
         }
         if model_override:
             generate_kwargs["model"] = model_override
@@ -121,6 +123,7 @@ Follow the CLAUDE.md instructions above, then apply the Attune AI below.
         state: CollaborationState,
         context: dict[str, Any],
         model_override: str | None = None,
+        max_tokens: int | None = None,
     ) -> dict[str, Any]:
         """Level 3: Proactive - Act on detected patterns
 
@@ -165,7 +168,7 @@ Was this helpful? If not, I can adjust my pattern detection.
             "messages": messages,
             "system_prompt": self._build_system_prompt(3),
             "temperature": EmpathyLevel.get_temperature_recommendation(3),
-            "max_tokens": EmpathyLevel.get_max_tokens_recommendation(3),
+            "max_tokens": max_tokens or EmpathyLevel.get_max_tokens_recommendation(3),
         }
         if model_override:
             generate_kwargs["model"] = model_override
@@ -188,6 +191,7 @@ Was this helpful? If not, I can adjust my pattern detection.
         state: CollaborationState,
         context: dict[str, Any],
         model_override: str | None = None,
+        max_tokens: int | None = None,
     ) -> dict[str, Any]:
         """Level 4: Anticipatory - Predict future needs
 
@@ -224,7 +228,7 @@ Use anticipatory format:
             "messages": messages,
             "system_prompt": self._build_system_prompt(4),
             "temperature": EmpathyLevel.get_temperature_recommendation(4),
-            "max_tokens": EmpathyLevel.get_max_tokens_recommendation(4),
+            "max_tokens": max_tokens or EmpathyLevel.get_max_tokens_recommendation(4),
         }
         if model_override:
             generate_kwargs["model"] = model_override
@@ -248,6 +252,7 @@ Use anticipatory format:
         state: CollaborationState,
         context: dict[str, Any],
         model_override: str | None = None,
+        max_tokens: int | None = None,
     ) -> dict[str, Any]:
         """Level 5: Systems - Cross-domain pattern learning
 
@@ -277,7 +282,7 @@ TASK:
             "messages": messages,
             "system_prompt": self._build_system_prompt(5),
             "temperature": EmpathyLevel.get_temperature_recommendation(5),
-            "max_tokens": EmpathyLevel.get_max_tokens_recommendation(5),
+            "max_tokens": max_tokens or EmpathyLevel.get_max_tokens_recommendation(5),
         }
         if model_override:
             generate_kwargs["model"] = model_override

--- a/src/attune/workflows/executor_mixin.py
+++ b/src/attune/workflows/executor_mixin.py
@@ -216,6 +216,9 @@ class ExecutorMixin:
             task_type=step.task_type,
         )
 
+        if step.max_tokens is not None:
+            kwargs.setdefault("max_tokens", step.max_tokens)
+
         start_time = datetime.now()
         response = await executor.run(
             task_type=step.task_type,

--- a/src/attune/workflows/test_gen_parallel.py
+++ b/src/attune/workflows/test_gen_parallel.py
@@ -261,6 +261,7 @@ Output the COMPLETE test file, no TODOs remaining."""
             tier=ModelTier.CAPABLE,
             system="You are a test completion assistant. Output ONLY Python code.",
             user_message=prompt,
+            max_tokens=16384,
         )
 
         return content

--- a/tests/unit/workflows/test_llm_max_tokens_threading.py
+++ b/tests/unit/workflows/test_llm_max_tokens_threading.py
@@ -1,0 +1,106 @@
+"""max_tokens must reach the provider — regression for the dropped-parameter bug.
+
+Found 2026-08-18 by the fit_source budget A/B: ``_call_llm(max_tokens=...)``
+built a WorkflowStepConfig carrying the value, but
+``run_step_with_executor`` never forwarded it and ``EmpathyLLM.interact``
+could not accept it — so EVERY workflow LLM call ran at the empathy
+level's recommendation (1024-4096, typically 1536), which Claude 5's
+adaptive thinking can fully consume, yielding intermittently EMPTY
+outputs. These tests pin both halves of the thread-through.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from attune.workflows.step_config import WorkflowStepConfig
+
+
+class TestExecutorForwardsMaxTokens:
+    """run_step_with_executor forwards step.max_tokens to executor.run."""
+
+    @pytest.mark.asyncio
+    async def test_step_max_tokens_forwarded(self):
+        from attune.workflows.test_gen_parallel import ParallelTestGenerationWorkflow
+
+        wf = ParallelTestGenerationWorkflow.__new__(ParallelTestGenerationWorkflow)
+        executor = MagicMock()
+        response = MagicMock(
+            content="ok",
+            metadata={},
+            tier="capable",
+            model_id="m",
+            tokens_input=1,
+            tokens_output=1,
+            cost_estimate=0.0,
+        )
+        executor.run = AsyncMock(return_value=response)
+        with (
+            patch.object(type(wf), "_get_executor", lambda self: executor, create=True),
+            patch.object(
+                type(wf), "_create_execution_context", lambda self, **kw: None, create=True
+            ),
+            patch.object(type(wf), "_emit_call_telemetry", lambda self, **kw: None, create=True),
+        ):
+            step = WorkflowStepConfig(
+                name="s", task_type="general", tier_hint="capable", max_tokens=7777
+            )
+            await wf.run_step_with_executor(step=step, prompt="p", system="sys")
+        assert executor.run.call_args.kwargs["max_tokens"] == 7777
+
+    @pytest.mark.asyncio
+    async def test_absent_max_tokens_not_injected(self):
+        from attune.workflows.test_gen_parallel import ParallelTestGenerationWorkflow
+
+        wf = ParallelTestGenerationWorkflow.__new__(ParallelTestGenerationWorkflow)
+        executor = MagicMock()
+        response = MagicMock(
+            content="ok",
+            metadata={},
+            tier="capable",
+            model_id="m",
+            tokens_input=1,
+            tokens_output=1,
+            cost_estimate=0.0,
+        )
+        executor.run = AsyncMock(return_value=response)
+        with (
+            patch.object(type(wf), "_get_executor", lambda self: executor, create=True),
+            patch.object(
+                type(wf), "_create_execution_context", lambda self, **kw: None, create=True
+            ),
+            patch.object(type(wf), "_emit_call_telemetry", lambda self, **kw: None, create=True),
+        ):
+            step = WorkflowStepConfig(name="s", task_type="general", tier_hint="capable")
+            await wf.run_step_with_executor(step=step, prompt="p", system="sys")
+        assert "max_tokens" not in executor.run.call_args.kwargs
+
+
+class TestInteractHonorsMaxTokens:
+    """interact(max_tokens=...) overrides the level recommendation."""
+
+    def _llm_with_mock_provider(self):
+        from attune.llm.core import EmpathyLLM
+
+        llm = EmpathyLLM(provider="anthropic", api_key="fake")  # pragma: allowlist secret
+        llm.provider = MagicMock()
+        llm.provider.generate = AsyncMock(
+            return_value=MagicMock(content="ok", tokens_used=2, model="m")
+        )
+        return llm
+
+    @pytest.mark.asyncio
+    async def test_override_reaches_provider_generate(self):
+        llm = self._llm_with_mock_provider()
+        await llm.interact("u", "hello", force_level=2, max_tokens=9999)
+        assert llm.provider.generate.call_args.kwargs["max_tokens"] == 9999
+
+    @pytest.mark.asyncio
+    async def test_default_is_level_recommendation(self):
+        from attune.llm.levels import EmpathyLevel
+
+        llm = self._llm_with_mock_provider()
+        await llm.interact("u", "hello", force_level=2)
+        assert llm.provider.generate.call_args.kwargs[
+            "max_tokens"
+        ] == EmpathyLevel.get_max_tokens_recommendation(2)


### PR DESCRIPTION
## What this is

PR 3 of 3 of the stranded-diff recovery (Patrick, 2026-09-11: "recover the four stranded diffs as four PRs, one at a time on fresh branches from main in this worktree, tests run per PR; the owning worktrees stay untouched"). #2516 doctor, #2517 guards, #2518 traversal guard; this is the `max_tokens` threading from worktree `context-management-792e27` on `fix/llm-max-tokens-threading` (2026-08-19; its session is no longer listed), applied on a fresh branch off `origin/main`. That worktree's four dirty files and one untracked test are **untouched** and remain the backup until this merges.

## The defect

`EmpathyLLM.interact()` had no `max_tokens` parameter. Every level handler used `EmpathyLevel.get_max_tokens_recommendation(<level>)` unconditionally (1024–4096), so a caller with a long output, such as test or doc generation, was silently truncated at the level default with no way to raise it.

## The change

- `EmpathyLLM.interact(max_tokens: int | None = None)`: documented override, passed to `_level_1_reactive` … `_level_5_systems`; each handler takes `max_tokens` and uses it ahead of the level recommendation.
- `workflows/executor_mixin.py`: a step's `max_tokens` is forwarded into the call kwargs via `setdefault`, so an explicit kwarg still wins.
- `workflows/test_gen_parallel.py`: passes `max_tokens=16384` for its generation step.
- `tests/unit/workflows/test_llm_max_tokens_threading.py` (new): pins the threading at each seam.

## Fidelity to the source diff

- One hunk offset in `executor_mixin.py` (`@@ -216` vs `@@ -186`): the later #2314 refactor added 30 lines above the touched region. Content identical; `git apply --check` against `origin/main` via a temp index was clean.
- **Black (pinned) rewrapped seven long lines**: the five `_level_N(...)` calls in `llm/interaction.py` and two `patch.object(...)` lines in the new test. Formatting only; no token changed. The source worktree's copy predates the current pin.

## Receipts on this head (worktree source via `PYTHONPATH`)

| Probe | Result |
| --- | --- |
| New test + `tests/unit/llm` + `test_executor_mixin_hybrid.py` + `test_parallel_test_gen.py`, serial | 102 passed |
| `tests/unit/workflows` + `tests/unit/models`, xdist | 3708 passed, 1 skipped |
| Mutation: threading reverted in `llm/core.py` + `llm/interaction.py` → new test | 1 failed / 3 passed (the pin is real) |
| New `except` clauses | 0 |
| Pinned pre-commit hooks on the five files (after black's rewrap) | passed |

## Disclosures

- Touches the LLM call path (`attune.llm`), a models/workflows seam that #2314 was cleaning up; no import direction changes here, but a reviewer of that layering may want a look. Lane or merge-on-receipts is the chair's call.
- No API-key call was made; every run used `ANTHROPIC_API_KEY=""`.
- Landed by the next-session-start session; claimed with "still open session 1"; the authoring session is absent (not in the session list), so no owner was messaged; its worktree was read, never written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
