### PR TITLE
docs(contract): D11 amendment — a different-model lane is mandatory for hook-guard and gate-allowlist diffs (chair-read)

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -290,6 +290,10 @@ as pickable work.
   lanes on well-tested code and release diffs showed cost without
   yield there). Yield stays measured in the R5 ledger; a future
   chair ruling can revisit either direction.
+  Ruled 2026-09-12 (chair, retro pushback): diffs under
+  `src/attune/hooks/scripts/` or touching `tests/unit/gates/`
+  allowlists/baselines get the lane REGARDLESS OF SIZE — the
+  merge-on-receipts waiver does not cover them.
 
 ### Artifact selection
 

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -283,6 +283,10 @@ as pickable work.
   lanes on well-tested code and release diffs showed cost without
   yield there). Yield stays measured in the R5 ledger; a future
   chair ruling can revisit either direction.
+  Ruled 2026-09-12 (chair, retro pushback): diffs under
+  `src/attune/hooks/scripts/` or touching `tests/unit/gates/`
+  allowlists/baselines get the lane REGARDLESS OF SIZE — the
+  merge-on-receipts waiver does not cover them.
 
 ### Artifact selection
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -290,6 +290,10 @@ as pickable work.
   lanes on well-tested code and release diffs showed cost without
   yield there). Yield stays measured in the R5 ledger; a future
   chair ruling can revisit either direction.
+  Ruled 2026-09-12 (chair, retro pushback): diffs under
+  `src/attune/hooks/scripts/` or touching `tests/unit/gates/`
+  allowlists/baselines get the lane REGARDLESS OF SIZE — the
+  merge-on-receipts waiver does not cover them.
 
 ### Artifact selection
 

--- a/content/collaboration/contract.md
+++ b/content/collaboration/contract.md
@@ -262,6 +262,10 @@ as pickable work.
   lanes on well-tested code and release diffs showed cost without
   yield there). Yield stays measured in the R5 ledger; a future
   chair ruling can revisit either direction.
+  Ruled 2026-09-12 (chair, retro pushback): diffs under
+  `src/attune/hooks/scripts/` or touching `tests/unit/gates/`
+  allowlists/baselines get the lane REGARDLESS OF SIZE — the
+  merge-on-receipts waiver does not cover them.
 
 ### Artifact selection
 

--- a/docs/specs/feature-lead-governance/decisions.md
+++ b/docs/specs/feature-lead-governance/decisions.md
@@ -676,3 +676,39 @@ product gap).
 
 Register construction is a lead task; the ranked list and its
 scoring inputs land in this spec when built.
+
+## 2026-09-12 — D11 amendment — lane mandatory for hook-guard and gate-allowlist diffs (chair)
+
+Ruled by Patrick at the 2026-09-11 close-out retro, adopting the
+pushback card "make a different-model lane mandatory for hook-guard
+and gate-allowlist diffs regardless of size" (form response
+`resp-20260911-224927-0dd7c67b`; 2026-09-12 UTC): a lead-authored
+diff touching a hook-guard script under `src/attune/hooks/scripts/`
+or a gate allowlist or baseline under `tests/unit/gates/` requires
+the different-model review lane REGARDLESS OF SIZE, and the chair's
+merge-on-receipts waiver does not cover those paths.
+
+- **Origin:** that night #2517 (the dirty-switch and worktree-add
+  guard tokenizers) and #2518 (session-summary-cache path
+  validation plus the drop of its `test_path_validation_gate.py`
+  allowlist entry) merged on receipts under `auto-merge-when-green`
+  with no lane run and no R5 ledger row. Both sit inside risk
+  classes D11b already names — guards and gates — and both were
+  waived on size.
+- **Counter-case carried (D11d.2):** both diffs were small,
+  mutation-checked and live-probed, and the merge-on-receipts
+  waiver exists so that exactly that class of diff does not pay
+  for a lane. The pushback was adopted over it: size does not
+  bound what a guard admits or what a gate asserts about the
+  tree, so on these two path families the receipts table alone no
+  longer earns the merge word.
+- **In practice:** on those paths the lead runs the lane and
+  ledgers the row BEFORE asking for "merge N". Everywhere else
+  D11b's risk-triggered default and the merge-on-receipts waiver
+  stand unchanged; advisory posture, chair override in either
+  direction, and R8 are untouched.
+- **Encoded:** contract master D11 bullet
+  (`content/collaboration/contract.md`), projected to
+  `.claude/CLAUDE.md`, `AGENTS.md` and `.agents/AGENTS.md` via
+  `scripts/project_collaboration_contract.py` (the handoff
+  template does not carry the D11 bullet and was unchanged).


### PR DESCRIPTION
## Ruling (verbatim, as encoded in the contract master)

> Ruled 2026-09-12 (chair, retro pushback): diffs under
> `src/attune/hooks/scripts/` or touching `tests/unit/gates/`
> allowlists/baselines get the lane REGARDLESS OF SIZE — the
> merge-on-receipts waiver does not cover them.

Origin: the 2026-09-11 close-out retro pushback card, adopted by
Patrick (form response `resp-20260911-224927-0dd7c67b`). That
night #2517 (two `src/attune/hooks/scripts/` guard tokenizers) and
#2518 (path validation + drop of a `test_path_validation_gate.py`
allowlist entry) merged on receipts under `auto-merge-when-green`
with no lane and no R5 ledger row. The counter-case carried: both
diffs were small, mutation-checked and live-probed.

## Files

- `content/collaboration/contract.md` — MASTER; 4 lines appended
  to the D11 bullet (227 bytes).
- Projections regenerated by
  `scripts/project_collaboration_contract.py` (write mode):
  - `.claude/CLAUDE.md`
  - `AGENTS.md`
  - `.agents/AGENTS.md`
  - `templates/agent-handoff.md` — reported `unchanged` (it does
    not carry the D11 bullet).
- `docs/specs/feature-lead-governance/decisions.md` — the file
  that owns the original D11 ruling (2026-07-29 entry and the
  D11b/D11c/D11d follow-ons); new entry "2026-09-12 — D11
  amendment — lane mandatory for hook-guard and gate-allowlist
  diffs (chair)": ruling, origin, counter-case, in-practice
  change, encoding.

Docs-only. No code, no `.claude/lessons.md` change, no changelog
entry (docs-only; the changelog gate no-ops).

## Receipts

| Probe | Result |
|---|---|
| `git checkout -b docs/d11-lane-mandatory-hook-guards origin/main` | cut from `42ca938a8` (origin/main at fetch) |
| `scripts/project_collaboration_contract.py` (write) | wrote AGENTS.md, .claude/CLAUDE.md, .agents/AGENTS.md; handoff unchanged |
| `scripts/project_collaboration_contract.py --check` | all four surfaces `unchanged`, exit 0 |
| `pytest tests/unit/scripts/test_project_collaboration_contract.py tests/unit/rules/test_rules_residency_budget.py tests/unit/lessons/test_core_mirror.py tests/unit/gates/test_brand_drift.py -p no:xdist -o addopts=` (PYTHONPATH=worktree/src, `ANTHROPIC_API_KEY=""`) | 36 passed in 0.58s |
| `uv run --frozen --with pre-commit pre-commit run --files <5 files>` | every hook Passed or Skipped(no files); no reformatting; contract-projection and G5 brand-drift hooks Passed |
| `gh pr view 2517 --json files,mergedAt,labels` | files include `src/attune/hooks/scripts/dirty_switch_guard.py`, `worktree_add_guard.py`; merged 2026-09-12T01:54Z; `auto-merge-when-green` |
| `gh pr view 2518 --json files,mergedAt,labels` | files include `tests/unit/gates/test_path_validation_gate.py`; merged 2026-09-12T01:56Z; `auto-merge-when-green` |
| `grep -n "2517\|2518" docs/specs/cross-review/receipts.md` | no rows — neither PR has an R5 ledger entry |
| `git diff --stat` | 5 files, +52 / -0; the 4-line hunk is byte-identical in master and all three projections |

## Disclosures

- **Governance text (D11d.1 CHAIR-ARMS).** This diff edits the
  collaboration contract and a governance decisions record. The
  lead does not arm auto-merge on it and has not; Patrick reads
  and merges. The chair-read gate stands in for the D11 lane on
  governance text, so no lane was run before opening.
- **Ruling date.** Stamped `2026-09-12` per the task; the retro
  response id is `20260911-224927` (US Eastern), which is
  2026-09-12 UTC — consistent with this repo's UTC-stamp
  convention and with the #2517/#2518 merge timestamps.
- **Residency budget.** `test_rules_residency_budget.py` scopes
  `.claude/rules/attune/`, not `.claude/CLAUDE.md`; it was run as
  instructed and passes, but it is not the test that would bound
  this projection's byte growth (+227 bytes per surface).
- **Heading length.** The new decisions heading is 98 columns;
  the file's existing entry headings run to 110 and
  `.markdownlint.json` disables MD013. Body text is wrapped under
  80. Headings cannot wrap, so precedent was followed.
- **Not verified in-repo.** The form response id is not present
  in the tree (it lives in the retro's local form store); it is
  carried as given by the chair's task text.
- **Task wording.** The task suggested "two or three lines"; the
  sentence wrapped to four at the bullet's 66-column width
  without dropping either path family or the waiver clause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
