### PR TITLE
feat(scripts): salvage_worktree_diff.sh — read-only salvage of a stranded worktree diff onto a fresh branch (retro 2026-09-11 item 1)

### DIFF
--- a/scripts/salvage_worktree_diff.sh
+++ b/scripts/salvage_worktree_diff.sh
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+# salvage_worktree_diff.sh — read-only salvage of a stranded worktree's
+# uncommitted diff onto a fresh branch in the CURRENT checkout.
+#
+# Usage: scripts/salvage_worktree_diff.sh <source-worktree> <new-branch> \
+#            [--base <ref>]            (default base: origin/main)
+#
+# Mechanizes the recovery recipe that ran by hand four times on
+# 2026-09-11 (#2516–#2519): a session's worktree is left holding real,
+# uncommitted work. Rather than committing INTO that worktree (another
+# agent's, possibly still open), the diff is lifted verbatim onto a
+# fresh branch cut from current main, and the source worktree stays
+# untouched as the backup until the PR merges.
+#
+#   1. Refuse to run inside the source worktree, or from a dirty
+#      checkout. Everything about the source is READ-ONLY: the script
+#      never writes there (GIT_OPTIONAL_LOCKS=0 keeps git from even
+#      refreshing the source's index).
+#   2. Capture the tracked diff — `git diff --binary HEAD`, staged AND
+#      unstaged, so nothing a session `git add`ed is dropped — and the
+#      untracked file list. Nothing to salvage -> exit 2.
+#   3. Fetch the base's remote branch, then `git checkout -b <branch>
+#      <base>` here.
+#   4. `git apply --check`, then apply; copy each untracked file to the
+#      same relative path (never over a file that already exists here).
+#   5. Identity receipt: the diff here must equal the captured patch
+#      with `index` lines and `@@` hunk headers ignored. Then a receipt
+#      of files, +/- counts, untracked copies, and the next steps.
+#
+# Committed-but-unpushed work on the source branch is NOT salvaged —
+# this handles the uncommitted diff only; cherry-pick commits yourself.
+#
+# Exit status:   0  branch created, patch applied, identity held
+#                1  refused — inside the source, dirty checkout, base
+#                   fetch/checkout failed, patch does not apply, an
+#                   untracked file collides with a file here, or the
+#                   identity receipt differs
+#                2  nothing to salvage (no tracked diff, no untracked)
+#               64  usage
+set -euo pipefail
+
+usage() {
+    echo "usage: $0 <source-worktree> <new-branch> [--base <ref>]" >&2
+    exit 64
+}
+
+refuse() {
+    echo "refused: $*" >&2
+    exit 1
+}
+
+SRC=""
+BRANCH=""
+BASE="origin/main"
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --base)
+            [ $# -ge 2 ] || usage
+            BASE="$2"
+            shift 2
+            ;;
+        --base=*)
+            BASE="${1#--base=}"
+            shift
+            ;;
+        -*)
+            usage
+            ;;
+        *)
+            if [ -z "$SRC" ]; then
+                SRC="$1"
+            elif [ -z "$BRANCH" ]; then
+                BRANCH="$1"
+            else
+                usage
+            fi
+            shift
+            ;;
+    esac
+done
+[ -n "$SRC" ] && [ -n "$BRANCH" ] && [ -n "$BASE" ] || usage
+
+# --- 1. locate both checkouts; refuse the unsafe starting states -------
+if ! SRC_TOP=$(git -C "$SRC" rev-parse --show-toplevel); then
+    echo "not a git worktree: $SRC" >&2
+    exit 64
+fi
+if ! CUR_TOP=$(git rev-parse --show-toplevel); then
+    echo "run this from inside the checkout that receives the branch" >&2
+    exit 64
+fi
+# git apply from a subdirectory silently ignores paths outside it.
+cd "$CUR_TOP"
+[ "$SRC_TOP" != "$CUR_TOP" ] || refuse "the current checkout IS the" \
+    "source worktree ($SRC_TOP); run from the checkout that receives" \
+    "the branch, never inside the source"
+[ -z "$(git status --porcelain)" ] || refuse "the current checkout is" \
+    "dirty; commit, stash, or clean it before salvaging into it"
+
+# --- 2. read-only capture from the source ------------------------------
+PATCH=$(mktemp)
+HERE=$(mktemp)
+trap 'rm -f "$PATCH" "$HERE"' EXIT
+GIT_OPTIONAL_LOCKS=0 git -C "$SRC_TOP" diff --binary HEAD > "$PATCH"
+
+UNTRACKED=()
+while IFS= read -r -d '' entry; do
+    case "$entry" in
+        '?? '*) UNTRACKED+=("${entry:3}") ;;
+    esac
+done < <(GIT_OPTIONAL_LOCKS=0 git -C "$SRC_TOP" status --porcelain -z \
+    --untracked-files=all)
+
+if [ ! -s "$PATCH" ] && [ "${#UNTRACKED[@]}" -eq 0 ]; then
+    echo "nothing to salvage: $SRC_TOP has no tracked diff and no" \
+        "untracked files" >&2
+    exit 2
+fi
+# git emits worktree-relative paths; keep the copy inside this tree.
+for path in ${UNTRACKED[@]+"${UNTRACKED[@]}"}; do
+    case "$path" in
+        /* | ../* | */../* | */.. | ..)
+            refuse "untracked path escapes the worktree: $path"
+            ;;
+    esac
+done
+
+# --- 3. fresh branch from the (refreshed) base ---------------------------
+REMOTE="${BASE%%/*}"
+if [ "$REMOTE" != "$BASE" ] && git remote get-url "$REMOTE" >/dev/null 2>&1
+then
+    git fetch "$REMOTE" "${BASE#*/}" || refuse "fetch of $BASE failed"
+fi
+git checkout -b "$BRANCH" "$BASE" \
+    || refuse "could not create $BRANCH from $BASE"
+
+# --- 4. apply the patch; copy the untracked files ------------------------
+for path in ${UNTRACKED[@]+"${UNTRACKED[@]}"}; do
+    [ ! -e "$CUR_TOP/$path" ] || refuse "untracked file would overwrite" \
+        "an existing file here: $path ($BRANCH is at $BASE, nothing applied)"
+done
+if [ -s "$PATCH" ]; then
+    git apply --check "$PATCH" || refuse "the patch does not apply to" \
+        "$BASE ($BRANCH is at $BASE, nothing applied); if the source" \
+        "branch has commits ahead of $BASE, cherry-pick those first"
+    git apply "$PATCH"
+fi
+for path in ${UNTRACKED[@]+"${UNTRACKED[@]}"}; do
+    mkdir -p "$(dirname "$CUR_TOP/$path")"
+    cp -p "$SRC_TOP/$path" "$CUR_TOP/$path"
+done
+
+# --- 5. identity receipt ---------------------------------------------------
+normalize() {
+    grep -v -e '^index ' -e '^@@ ' "$1" || true
+}
+git diff --binary HEAD > "$HERE"
+if DELTA=$(diff <(normalize "$PATCH") <(normalize "$HERE")); then
+    echo "identity: IDENTICAL (index lines and @@ hunk headers ignored)"
+else
+    echo "identity: DIFFERS — the diff here is not the captured patch:" >&2
+    echo "$DELTA" >&2
+    exit 1
+fi
+
+echo
+echo "== salvage receipt =="
+echo "source:  $SRC_TOP (HEAD $(git -C "$SRC_TOP" rev-parse --short HEAD))"
+echo "         UNTOUCHED — it stays the backup until the PR merges"
+echo "branch:  $BRANCH from $BASE ($(git rev-parse --short HEAD))"
+echo "here:    $CUR_TOP"
+git diff --stat HEAD
+echo "untracked copied: ${#UNTRACKED[@]}"
+for path in ${UNTRACKED[@]+"${UNTRACKED[@]}"}; do
+    echo "  $path"
+done
+cat <<EOF
+next:
+  1. run the tests against THIS worktree's source, not main's mapping:
+     PYTHONPATH=$CUR_TOP/src ANTHROPIC_API_KEY="" \\
+       .venv/bin/python -m pytest <targets> -q
+  2. git add -A && git commit -F <message-file>
+  3. git push -u origin $BRANCH
+     gh pr create --base ${BASE#*/} --head $BRANCH --body-file <body-file>
+EOF

--- a/scripts/salvage_worktree_diff.sh
+++ b/scripts/salvage_worktree_diff.sh
@@ -21,7 +21,9 @@
 #      untracked file list. Nothing to salvage -> exit 2.
 #   3. Fetch the base's remote branch, then `git checkout -b <branch>
 #      <base>` here.
-#   4. `git apply --check`, then apply; copy each untracked file to the
+#   4. `git apply --check`, then `git apply --index` (applied changes
+#      arrive STAGED so new files and renames are visible to the
+#      receipt; `git reset` unstages); copy each untracked file to the
 #      same relative path (never over a file that already exists here).
 #   5. Identity receipt: the diff here must equal the captured patch
 #      with `index` lines and `@@` hunk headers ignored. Then a receipt
@@ -143,7 +145,10 @@ if [ -s "$PATCH" ]; then
     git apply --check "$PATCH" || refuse "the patch does not apply to" \
         "$BASE ($BRANCH is at $BASE, nothing applied); if the source" \
         "branch has commits ahead of $BASE, cherry-pick those first"
-    git apply "$PATCH"
+    # --index: new files and renames land STAGED, so the identity
+    # receipt (worktree vs HEAD) can see them; a plain apply leaves
+    # them untracked and the receipt reports DIFFERS for a good salvage.
+    git apply --index "$PATCH"
 fi
 for path in ${UNTRACKED[@]+"${UNTRACKED[@]}"}; do
     mkdir -p "$(dirname "$CUR_TOP/$path")"
@@ -160,6 +165,8 @@ if DELTA=$(diff <(normalize "$PATCH") <(normalize "$HERE")); then
 else
     echo "identity: DIFFERS — the diff here is not the captured patch:" >&2
     echo "$DELTA" >&2
+    echo "state: this checkout is now on $BRANCH with the applied files" \
+        "on disk (git status shows them); the source is untouched." >&2
     exit 1
 fi
 

--- a/tests/unit/scripts/test_salvage_worktree_diff.py
+++ b/tests/unit/scripts/test_salvage_worktree_diff.py
@@ -84,6 +84,8 @@ def repos(tmp_path: Path) -> Repos:
     _git(r, r.primary, "init", "-q", "-b", "main")
     (r.primary / "base.txt").write_text("one\ntwo\nthree\n", encoding="utf-8")
     (r.primary / "keep.txt").write_text("keep\n", encoding="utf-8")
+    (r.primary / "moveme.txt").write_text("to be renamed\n", encoding="utf-8")
+    (r.primary / "blob.bin").write_bytes(bytes(range(256)))
     _git(r, r.primary, "add", ".")
     _git(r, r.primary, "commit", "-q", "-m", "base")
     _git(r, r.primary, "remote", "add", "origin", str(origin))
@@ -97,6 +99,17 @@ def _dirty(source: Path) -> None:
     (source / "base.txt").write_text("one\ntwo-edited\nthree\nfour\n", encoding="utf-8")
     (source / "new_dir").mkdir()
     (source / "new_dir" / "new_file.txt").write_bytes(b"brand new\x00bytes\n")
+
+
+def _dirty_staged_and_binary(repos: Repos) -> None:
+    """The git-added class: a staged new file, a `git mv` rename, and a
+    tracked BINARY edit. Without `git apply --index` the first two land
+    untracked here and the identity receipt reports DIFFERS; without
+    `--binary` on both diffs the binary hunk cannot apply at all."""
+    (repos.source / "added.txt").write_text("staged new file\n", encoding="utf-8")
+    _git(repos, repos.source, "add", "added.txt")
+    _git(repos, repos.source, "mv", "moveme.txt", "renamed.txt")
+    (repos.source / "blob.bin").write_bytes(bytes(range(255, -1, -1)))
 
 
 def _run(repos: Repos, *args: str, cwd: Path | None = None) -> subprocess.CompletedProcess[str]:
@@ -126,16 +139,24 @@ def _source_snapshot(repos: Repos) -> tuple[str, str, dict[str, bytes]]:
 
 def test_happy_path_salvages_onto_fresh_branch_and_leaves_source_untouched(repos: Repos) -> None:
     _dirty(repos.source)
+    _dirty_staged_and_binary(repos)
     before = _source_snapshot(repos)
-    expected_patch = _git(repos, repos.source, "diff", "HEAD")
+    expected_patch = _git(repos, repos.source, "diff", "--binary", "HEAD")
 
     res = _run(repos, str(repos.source), "salvage/x")
 
     assert res.returncode == 0, res.stderr
     assert _git(repos, repos.primary, "branch", "--show-current").strip() == "salvage/x"
     # Tracked diff landed and is identical modulo index lines / hunk headers.
-    got_patch = _git(repos, repos.primary, "diff", "HEAD")
+    got_patch = _git(repos, repos.primary, "diff", "--binary", "HEAD")
     assert _normalize(got_patch) == _normalize(expected_patch)
+    # The git-added class arrived: staged new file, rename, binary edit.
+    assert (repos.primary / "added.txt").read_text(encoding="utf-8") == "staged new file\n"
+    assert (repos.primary / "renamed.txt").exists() and not (repos.primary / "moveme.txt").exists()
+    assert (repos.primary / "blob.bin").read_bytes() == bytes(range(255, -1, -1))
+    status_here = _git(repos, repos.primary, "status", "--porcelain")
+    assert "A  added.txt" in status_here
+    assert "R  moveme.txt -> renamed.txt" in status_here
     assert (repos.primary / "base.txt").read_text(encoding="utf-8") == (
         repos.source / "base.txt"
     ).read_text(encoding="utf-8")

--- a/tests/unit/scripts/test_salvage_worktree_diff.py
+++ b/tests/unit/scripts/test_salvage_worktree_diff.py
@@ -1,0 +1,214 @@
+"""Behavioral receipts for ``scripts/salvage_worktree_diff.sh``.
+
+The script lifts a stranded worktree's uncommitted diff onto a fresh
+branch in another checkout, read-only on the source. Every case here
+builds a throwaway repo (primary checkout + bare ``origin`` + a linked
+worktree), dirties the worktree, and drives the real script through
+``bash`` from the primary checkout — no mocks, no network.
+
+Fixture commits never invoke GPG: every git call carries
+``-c commit.gpgsign=false`` and runs against a scratch
+``GIT_CONFIG_GLOBAL`` / ``HOME`` (a signing fixture hangs on pinentry;
+lesson 2026-08-26).
+
+Copyright 2026 Smart-AI-Memory
+Licensed under the Apache License, Version 2.0
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCRIPT = REPO_ROOT / "scripts" / "salvage_worktree_diff.sh"
+
+# A POSIX/bash ops helper: on Windows runners a bare `bash` is the WSL
+# stub, which exits before the script runs. Same guard as land_pr.sh.
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32" or shutil.which("bash") is None,
+    reason="salvage_worktree_diff.sh is a POSIX/bash ops helper",
+)
+
+
+@dataclass
+class Repos:
+    env: dict[str, str]
+    primary: Path
+    source: Path
+
+
+def _hermetic_env(scratch: Path) -> dict[str, str]:
+    home = scratch / "home"
+    home.mkdir()
+    cfg = scratch / "gitconfig"
+    cfg.write_text(
+        "[user]\n\tname = t\n\temail = t@example.invalid\n"
+        "[commit]\n\tgpgsign = false\n[tag]\n\tgpgsign = false\n",
+        encoding="utf-8",
+    )
+    system = scratch / "gitconfig-system"
+    system.write_text("", encoding="utf-8")
+    return {
+        **os.environ,
+        "HOME": str(home),
+        "GIT_CONFIG_GLOBAL": str(cfg),
+        "GIT_CONFIG_SYSTEM": str(system),
+    }
+
+
+def _git(repos: Repos, cwd: Path, *args: str) -> str:
+    done = subprocess.run(
+        ["git", "-c", "commit.gpgsign=false", *args],
+        cwd=str(cwd),
+        env=repos.env,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return done.stdout
+
+
+@pytest.fixture
+def repos(tmp_path: Path) -> Repos:
+    r = Repos(env=_hermetic_env(tmp_path), primary=tmp_path / "primary", source=tmp_path / "src")
+    origin = tmp_path / "origin.git"
+    _git(r, tmp_path, "init", "-q", "--bare", "-b", "main", str(origin))
+    r.primary.mkdir()
+    _git(r, r.primary, "init", "-q", "-b", "main")
+    (r.primary / "base.txt").write_text("one\ntwo\nthree\n", encoding="utf-8")
+    (r.primary / "keep.txt").write_text("keep\n", encoding="utf-8")
+    _git(r, r.primary, "add", ".")
+    _git(r, r.primary, "commit", "-q", "-m", "base")
+    _git(r, r.primary, "remote", "add", "origin", str(origin))
+    _git(r, r.primary, "push", "-q", "-u", "origin", "main")
+    _git(r, r.primary, "worktree", "add", "-q", "-b", "stranded", str(r.source))
+    return r
+
+
+def _dirty(source: Path) -> None:
+    """A tracked edit plus a nested untracked file — the stranded shape."""
+    (source / "base.txt").write_text("one\ntwo-edited\nthree\nfour\n", encoding="utf-8")
+    (source / "new_dir").mkdir()
+    (source / "new_dir" / "new_file.txt").write_bytes(b"brand new\x00bytes\n")
+
+
+def _run(repos: Repos, *args: str, cwd: Path | None = None) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["bash", str(SCRIPT), *args],
+        cwd=str(cwd or repos.primary),
+        env=repos.env,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _normalize(patch: str) -> list[str]:
+    return [ln for ln in patch.splitlines() if not ln.startswith(("index ", "@@ "))]
+
+
+def _source_snapshot(repos: Repos) -> tuple[str, str, dict[str, bytes]]:
+    status = _git(repos, repos.source, "status", "--porcelain", "--untracked-files=all")
+    head = _git(repos, repos.source, "rev-parse", "HEAD")
+    files = {
+        str(p.relative_to(repos.source)): p.read_bytes()
+        for p in repos.source.rglob("*")
+        if p.is_file() and ".git" not in p.parts
+    }
+    return status, head, files
+
+
+def test_happy_path_salvages_onto_fresh_branch_and_leaves_source_untouched(repos: Repos) -> None:
+    _dirty(repos.source)
+    before = _source_snapshot(repos)
+    expected_patch = _git(repos, repos.source, "diff", "HEAD")
+
+    res = _run(repos, str(repos.source), "salvage/x")
+
+    assert res.returncode == 0, res.stderr
+    assert _git(repos, repos.primary, "branch", "--show-current").strip() == "salvage/x"
+    # Tracked diff landed and is identical modulo index lines / hunk headers.
+    got_patch = _git(repos, repos.primary, "diff", "HEAD")
+    assert _normalize(got_patch) == _normalize(expected_patch)
+    assert (repos.primary / "base.txt").read_text(encoding="utf-8") == (
+        repos.source / "base.txt"
+    ).read_text(encoding="utf-8")
+    # Untracked file copied byte-for-byte into the same relative path.
+    copied = repos.primary / "new_dir" / "new_file.txt"
+    assert copied.read_bytes() == (repos.source / "new_dir" / "new_file.txt").read_bytes()
+    assert "identity: IDENTICAL" in res.stdout
+    assert "new_dir/new_file.txt" in res.stdout
+    assert "UNTOUCHED" in res.stdout
+    # The source is the backup: status, HEAD, and every file byte unchanged.
+    assert _source_snapshot(repos) == before
+    assert _git(repos, repos.source, "branch", "--show-current").strip() == "stranded"
+
+
+def test_refuses_to_run_inside_the_source(repos: Repos) -> None:
+    _dirty(repos.source)
+
+    res = _run(repos, str(repos.source), "salvage/x", cwd=repos.source)
+
+    assert res.returncode == 1, res.stderr
+    assert "source worktree" in res.stderr
+    assert _git(repos, repos.source, "branch", "--show-current").strip() == "stranded"
+    assert _git(repos, repos.primary, "branch", "--list", "salvage/x").strip() == ""
+
+
+def test_refuses_dirty_current_checkout(repos: Repos) -> None:
+    _dirty(repos.source)
+    (repos.primary / "scratch.txt").write_text("unrelated\n", encoding="utf-8")
+
+    res = _run(repos, str(repos.source), "salvage/x")
+
+    assert res.returncode == 1, res.stderr
+    assert "dirty" in res.stderr
+    assert _git(repos, repos.primary, "branch", "--show-current").strip() == "main"
+
+
+def test_clean_source_is_nothing_to_salvage(repos: Repos) -> None:
+    res = _run(repos, str(repos.source), "salvage/x")
+
+    assert res.returncode == 2, res.stderr
+    assert "nothing to salvage" in res.stderr
+    assert _git(repos, repos.primary, "branch", "--show-current").strip() == "main"
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        (),
+        ("only-source",),
+        ("src", "branch", "extra-positional"),
+        ("src", "branch", "--bogus"),
+        ("src", "branch", "--base"),
+    ],
+)
+def test_usage_errors_exit_64(repos: Repos, argv: tuple[str, ...]) -> None:
+    args = tuple(str(repos.source) if a == "src" else a for a in argv)
+
+    res = _run(repos, *args)
+
+    assert res.returncode == 64, res.stderr
+    assert "usage:" in res.stderr
+
+
+def test_untracked_file_colliding_with_tracked_file_here_is_refused(repos: Repos) -> None:
+    # The stranded branch committed a deletion of keep.txt, then a fresh
+    # untracked keep.txt appeared. On the base, keep.txt is still tracked.
+    _git(repos, repos.source, "rm", "-q", "keep.txt")
+    _git(repos, repos.source, "commit", "-q", "-m", "drop keep")
+    (repos.source / "keep.txt").write_text("would clobber\n", encoding="utf-8")
+
+    res = _run(repos, str(repos.source), "salvage/x")
+
+    assert res.returncode == 1, res.stderr
+    assert "keep.txt" in res.stderr
+    assert (repos.primary / "keep.txt").read_text(encoding="utf-8") == "keep\n"
+    assert _git(repos, repos.primary, "status", "--porcelain") == ""


### PR DESCRIPTION
## What this is

Retro 2026-09-11 item 1 (chair-ruled do-now). Mechanizes the
stranded-diff salvage recipe that ran by hand 4/4 tonight
(#2516–#2519): lift a worktree's uncommitted diff verbatim onto a
fresh branch cut from current main, in the current checkout, and
leave the source worktree untouched as the backup until the PR merges.

```text
scripts/salvage_worktree_diff.sh <source-worktree> <new-branch> \
    [--base <ref>]            # default base: origin/main
```

Exit status: `0` branch created + patch applied + identity held;
`1` refused (inside the source, dirty checkout, fetch/checkout failed,
patch does not apply, untracked file collides with a file here,
identity differs); `2` nothing to salvage; `64` usage.

## Behavior, in order

1. Refuses to run inside the source worktree (toplevel comparison)
   or from a dirty checkout (`git status --porcelain` non-empty).
2. Read-only capture: `git diff --binary HEAD` (staged AND unstaged)
   into a temp patch, plus the `??` lines of
   `git status --porcelain -z --untracked-files=all`. Both empty
   -> exit 2. The source reads run under `GIT_OPTIONAL_LOCKS=0`, so
   git does not even refresh the source's index.
3. `git fetch <remote> <branch>` derived from `--base`, then
   `git checkout -b <new-branch> <base>` — after `cd` to the
   toplevel, because `git apply` from a subdirectory silently
   ignores paths outside it.
4. `git apply --check`, then apply; each untracked file is copied to
   the same relative path (dirs created, `cp -p`), refusing with the
   path if anything already exists there.
5. Identity receipt: `diff` of the two patches with `index` lines and
   `@@` hunk headers stripped — prints `IDENTICAL` or the differing
   lines (exit 1). Then the receipt: `--stat` (files, +/- counts),
   untracked copies, the untouched-backup reminder, next steps
   (tests against THIS worktree's src, commit via `-F`, push, PR).

bash-3.2 safe (no `mapfile`, empty arrays guarded) so `/bin/bash` on a
Mac without Homebrew bash runs it; shellcheck clean.

## Tests

`tests/unit/scripts/test_salvage_worktree_diff.py` builds a throwaway
repo (primary checkout + bare `origin` with `main` pushed + a linked
worktree), dirties the worktree with a tracked edit and a nested
untracked binary file, and drives the real script via `bash` from the
primary checkout. Cases: happy path (branch created, normalized diff
identical, untracked copied byte-for-byte, source status/HEAD/every
file byte unchanged, exit 0); inside the source -> 1; dirty current
checkout -> 1; clean source -> 2; five usage shapes -> 64; untracked
file colliding with a tracked file on the base -> 1 with the path and
nothing applied. Fixture git calls carry `-c commit.gpgsign=false`
under a scratch `GIT_CONFIG_GLOBAL`/`GIT_CONFIG_SYSTEM`/`HOME`.

## Receipts (what was actually run, this head)

| Probe | Result |
| --- | --- |
| `uvx --from shellcheck-py shellcheck scripts/salvage_worktree_diff.sh` | rc=0, no findings (ShellCheck 0.11.0) |
| `tests/unit/scripts/test_salvage_worktree_diff.py`, serial (`-p no:xdist -o addopts=`), `PYTHONPATH=<this worktree>/src`, main venv py3.10, `ANTHROPIC_API_KEY=""` | `10 passed in 2.67s` |
| Same file with `PATH=/usr/bin:/bin:/usr/sbin:/sbin` so `bash` is `/bin/bash` 3.2 | `10 passed in 3.75s` |
| `tests/unit/scripts`, serial, same env | `601 passed in 22.50s` |
| `uv run --frozen --with pre-commit pre-commit run --files <both>` | every hook Passed (black, ruff, bare-except, bandit, detect-secrets, whitespace, eof, line-ending, brand-drift); no reformat |
| `git log -1 --format='%G?'` / `git status --short` after commit | `G` / empty |

Basis note: the pytest counts are read from pytest's own summary line;
those runs were piped through `tail`, so the exit status observed was
`tail`'s, not pytest's.

## Disclosures

- **No lane owed.** `scripts/` is not an enforcement surface (not a
  gate, guard, ledger, or contract text); no `src/` or gate changes.
- **Recipe source:** the four recovery PRs tonight (#2516–#2519) —
  applied verbatim on a fresh branch off `origin/main`, identity
  "index lines aside", source worktree left untouched as the backup.
- **Deviation from the brief's literal `git diff`:** the capture is
  `git diff --binary HEAD` (staged AND unstaged). A bare `git diff`
  drops anything the stranded session had `git add`ed, and the salvage
  would still print IDENTICAL — a receipt that lies is the worst
  failure mode here. The identity check compares `git diff --binary
  HEAD` on both sides; with nothing staged on the new branch that is
  the brief's `git diff`.
- **Collision rule is stricter than "tracked":** the copy refuses if
  ANY file exists at the destination. The checkout was verified clean,
  so anything there is tracked or ignored; neither is clobbered.
- **Paths not exercised by tests:** `--base` with a non-remote ref,
  the apply-failure refusal, and the identity-DIFFERS branch (a
  successful `git apply` implies identity; no honest fixture reaches
  it). Stated, not checked.
- **Platform marker:** the module carries the repo's standing
  `skipif(win32 or no bash)` for bash helpers (Windows lanes' `bash`
  is the WSL stub). On macOS/Linux every case runs; nothing is marked
  skip or xfail.
- No CHANGELOG entry — `scripts/` is not shipped code.
- The pinned pre-commit run created this worktree's `.venv` via
  `uv run --frozen` (git-ignored). Nothing else on disk changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
