### PR TITLE
feat(hooks): changelog-entry guard — refuse a push of shipped code without a CHANGELOG entry (retro 2026-09-11 item 6)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -56,6 +56,12 @@
             "command": "PY=$(command -v python3 || command -v python) && \"$PY\" \"$CLAUDE_PROJECT_DIR/src/attune/hooks/scripts/worktree_add_guard.py\"",
             "timeout": 5,
             "statusMessage": "Worktree-add check..."
+          },
+          {
+            "type": "command",
+            "command": "PY=$(command -v python3 || command -v python) && \"$PY\" \"$CLAUDE_PROJECT_DIR/src/attune/hooks/scripts/changelog_entry_guard.py\"",
+            "timeout": 10,
+            "statusMessage": "Changelog-entry check..."
           }
         ]
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   challenge-bound completions, and explicit presentation failure handling.
   Host-native routing is not enabled by this change. Preventing repeated
   presentation of consumed or closed challenges remains deferred.
+- Added a changelog-entry PreToolUse guard
+  (`src/attune/hooks/scripts/changelog_entry_guard.py`, registered for
+  Bash in `.claude/settings.json`): a `git push` whose range changes
+  `src/` or `attune_redis/` without touching `CHANGELOG.md` is refused
+  at push time, naming the shipped paths and the two exits (add the
+  entry under `[Unreleased]`, or `ATTUNE_ALLOW_NO_CHANGELOG=1` plus the
+  `no-changelog` label). It mirrors the CI `changelog-entry` gate's
+  prefixes and loads at the next session start.
 
 ### Changed
 

--- a/docs/specs/host-surface-parity/parity-registry.json
+++ b/docs/specs/host-surface-parity/parity-registry.json
@@ -492,6 +492,24 @@
       "reason": "No replayable production-subject receipt exists yet; inventory declaration is not evidence."
     },
     {
+      "key": "delivery:src-changelog_entry_guard-module:c0b0046d68345b0b:content_schema",
+      "next_increment": 3,
+      "owner": "host-surface-parity",
+      "reason": "No replayable production-subject receipt exists yet; inventory declaration is not evidence."
+    },
+    {
+      "key": "delivery:src-changelog_entry_guard-module:c0b0046d68345b0b:delivery",
+      "next_increment": 3,
+      "owner": "host-surface-parity",
+      "reason": "No replayable production-subject receipt exists yet; inventory declaration is not evidence."
+    },
+    {
+      "key": "delivery:src-changelog_entry_guard-module:c0b0046d68345b0b:destination",
+      "next_increment": 3,
+      "owner": "host-surface-parity",
+      "reason": "No replayable production-subject receipt exists yet; inventory declaration is not evidence."
+    },
+    {
       "key": "delivery:src-worktree_add_guard-module:c0b0046d68345b0b:content_schema",
       "next_increment": 3,
       "owner": "host-surface-parity",
@@ -979,7 +997,7 @@
     }
   ],
   "producer_baseline": {
-    "digest": "edfcfa3656bc0b63019142c25b06a50c9113ae588edf826e569e9d8959abd308",
+    "digest": "91a202cb613753f811c20243c6b249be41aace9a297f075b59722e916a15204f",
     "path": "docs/specs/host-surface-parity/producer_baseline.json",
     "schema_version": "attune.surface-inventory.producer-baseline/1"
   },
@@ -2223,6 +2241,27 @@
         "src/attune/hooks/scripts/worktree_add_guard.py:main"
       ],
       "root_anchor": "src/attune/hooks/scripts/worktree_add_guard.py:<module>",
+      "subject_kind": "informational_delivery"
+    },
+    {
+      "delivery_routes": [
+        {
+          "destination": "model_context",
+          "event": "PreToolUse",
+          "id": "c0b0046d68345b0b",
+          "matcher": "Bash",
+          "signature": "exit2_stderr",
+          "sink": "print(file=sys.stderr)"
+        }
+      ],
+      "discovered": true,
+      "evidence_status": "pending-local-receipts",
+      "id": "src-changelog_entry_guard-module",
+      "normalization_paths": [],
+      "producer_anchors": [
+        "src/attune/hooks/scripts/changelog_entry_guard.py:main"
+      ],
+      "root_anchor": "src/attune/hooks/scripts/changelog_entry_guard.py:<module>",
       "subject_kind": "informational_delivery"
     },
     {

--- a/docs/specs/host-surface-parity/producer_baseline.json
+++ b/docs/specs/host-surface-parity/producer_baseline.json
@@ -48,6 +48,10 @@
       "root_anchor": "plugin/hooks/usage_consent_notice.py:<module>"
     },
     {
+      "helper_anchor": "src/attune/hooks/scripts/changelog_entry_guard.py:main",
+      "root_anchor": "src/attune/hooks/scripts/changelog_entry_guard.py:<module>"
+    },
+    {
       "helper_anchor": "src/attune/hooks/scripts/detached_head_push_guard.py:main",
       "root_anchor": "src/attune/hooks/scripts/detached_head_push_guard.py:<module>"
     },
@@ -171,6 +175,14 @@
       "event": "SessionStart",
       "signature": "context_stdout",
       "sink": "print",
+      "subject_kind": "informational_delivery"
+    },
+    {
+      "anchor": "src/attune/hooks/scripts/changelog_entry_guard.py:main",
+      "destination": "model_context",
+      "event": "PreToolUse",
+      "signature": "exit2_stderr",
+      "sink": "print(file=sys.stderr)",
       "subject_kind": "informational_delivery"
     },
     {
@@ -625,6 +637,16 @@
       "ordinal": 1,
       "raw_command": "PY=$(command -v python3 || command -v python) && \"$PY\" \"$CLAUDE_PROJECT_DIR/src/attune/hooks/scripts/worktree_add_guard.py\"",
       "resolved_repo_path": "src/attune/hooks/scripts/worktree_add_guard.py"
+    },
+    {
+      "error": null,
+      "event": "PreToolUse",
+      "json_pointer": "/hooks/PreToolUse/0/hooks/2/command",
+      "manifest_path": ".claude/settings.json",
+      "matcher": "Bash",
+      "ordinal": 2,
+      "raw_command": "PY=$(command -v python3 || command -v python) && \"$PY\" \"$CLAUDE_PROJECT_DIR/src/attune/hooks/scripts/changelog_entry_guard.py\"",
+      "resolved_repo_path": "src/attune/hooks/scripts/changelog_entry_guard.py"
     },
     {
       "error": null,

--- a/src/attune/elicitation/surface_runtime_baseline.json
+++ b/src/attune/elicitation/surface_runtime_baseline.json
@@ -48,6 +48,10 @@
       "root_anchor": "plugin/hooks/usage_consent_notice.py:<module>"
     },
     {
+      "helper_anchor": "src/attune/hooks/scripts/changelog_entry_guard.py:main",
+      "root_anchor": "src/attune/hooks/scripts/changelog_entry_guard.py:<module>"
+    },
+    {
       "helper_anchor": "src/attune/hooks/scripts/detached_head_push_guard.py:main",
       "root_anchor": "src/attune/hooks/scripts/detached_head_push_guard.py:<module>"
     },
@@ -171,6 +175,14 @@
       "event": "SessionStart",
       "signature": "context_stdout",
       "sink": "print",
+      "subject_kind": "informational_delivery"
+    },
+    {
+      "anchor": "src/attune/hooks/scripts/changelog_entry_guard.py:main",
+      "destination": "model_context",
+      "event": "PreToolUse",
+      "signature": "exit2_stderr",
+      "sink": "print(file=sys.stderr)",
       "subject_kind": "informational_delivery"
     },
     {
@@ -625,6 +637,16 @@
       "ordinal": 1,
       "raw_command": "PY=$(command -v python3 || command -v python) && \"$PY\" \"$CLAUDE_PROJECT_DIR/src/attune/hooks/scripts/worktree_add_guard.py\"",
       "resolved_repo_path": "src/attune/hooks/scripts/worktree_add_guard.py"
+    },
+    {
+      "error": null,
+      "event": "PreToolUse",
+      "json_pointer": "/hooks/PreToolUse/0/hooks/2/command",
+      "manifest_path": ".claude/settings.json",
+      "matcher": "Bash",
+      "ordinal": 2,
+      "raw_command": "PY=$(command -v python3 || command -v python) && \"$PY\" \"$CLAUDE_PROJECT_DIR/src/attune/hooks/scripts/changelog_entry_guard.py\"",
+      "resolved_repo_path": "src/attune/hooks/scripts/changelog_entry_guard.py"
     },
     {
       "error": null,

--- a/src/attune/elicitation/surface_runtime_registry.json
+++ b/src/attune/elicitation/surface_runtime_registry.json
@@ -492,6 +492,24 @@
       "reason": "No replayable production-subject receipt exists yet; inventory declaration is not evidence."
     },
     {
+      "key": "delivery:src-changelog_entry_guard-module:c0b0046d68345b0b:content_schema",
+      "next_increment": 3,
+      "owner": "host-surface-parity",
+      "reason": "No replayable production-subject receipt exists yet; inventory declaration is not evidence."
+    },
+    {
+      "key": "delivery:src-changelog_entry_guard-module:c0b0046d68345b0b:delivery",
+      "next_increment": 3,
+      "owner": "host-surface-parity",
+      "reason": "No replayable production-subject receipt exists yet; inventory declaration is not evidence."
+    },
+    {
+      "key": "delivery:src-changelog_entry_guard-module:c0b0046d68345b0b:destination",
+      "next_increment": 3,
+      "owner": "host-surface-parity",
+      "reason": "No replayable production-subject receipt exists yet; inventory declaration is not evidence."
+    },
+    {
       "key": "delivery:src-worktree_add_guard-module:c0b0046d68345b0b:content_schema",
       "next_increment": 3,
       "owner": "host-surface-parity",
@@ -979,7 +997,7 @@
     }
   ],
   "producer_baseline": {
-    "digest": "edfcfa3656bc0b63019142c25b06a50c9113ae588edf826e569e9d8959abd308",
+    "digest": "91a202cb613753f811c20243c6b249be41aace9a297f075b59722e916a15204f",
     "path": "docs/specs/host-surface-parity/producer_baseline.json",
     "schema_version": "attune.surface-inventory.producer-baseline/1"
   },
@@ -2223,6 +2241,27 @@
         "src/attune/hooks/scripts/worktree_add_guard.py:main"
       ],
       "root_anchor": "src/attune/hooks/scripts/worktree_add_guard.py:<module>",
+      "subject_kind": "informational_delivery"
+    },
+    {
+      "delivery_routes": [
+        {
+          "destination": "model_context",
+          "event": "PreToolUse",
+          "id": "c0b0046d68345b0b",
+          "matcher": "Bash",
+          "signature": "exit2_stderr",
+          "sink": "print(file=sys.stderr)"
+        }
+      ],
+      "discovered": true,
+      "evidence_status": "pending-local-receipts",
+      "id": "src-changelog_entry_guard-module",
+      "normalization_paths": [],
+      "producer_anchors": [
+        "src/attune/hooks/scripts/changelog_entry_guard.py:main"
+      ],
+      "root_anchor": "src/attune/hooks/scripts/changelog_entry_guard.py:<module>",
       "subject_kind": "informational_delivery"
     },
     {

--- a/src/attune/hooks/scripts/changelog_entry_guard.py
+++ b/src/attune/hooks/scripts/changelog_entry_guard.py
@@ -1,0 +1,213 @@
+"""PreToolUse hook: refuse a ``git push`` of shipped code with no CHANGELOG entry.
+
+The bug class (retro 2026-09-11, item 6): four ``src/``-touching PRs in
+one evening each cost a red round-trip on the CI ``changelog-entry`` gate
+(``.github/scripts/changelog_gate.py``) because the CHANGELOG entry was
+written AFTER the PR was opened. The gate is right to fail them; this
+guard asks the same question at push time, in the agent session, where
+the fix is one more commit instead of a CI cycle.
+
+The check is mechanical and mirrors the CI gate. The commits about to be
+pushed are ``git merge-base origin/main HEAD`` .. ``HEAD``; if any path
+changed in that range starts with a shipped prefix and ``CHANGELOG.md``
+is not among the changed paths, the push is refused.
+
+What is NOT blocked, deliberately:
+- Any command that is not a ``git push``.
+- A range that touches nothing under the shipped prefixes (docs, tests,
+  tooling, CI).
+- A range that already changes ``CHANGELOG.md``.
+- Anything when ``origin/main`` is unknown, HEAD has no commits, or git
+  cannot be read (fail open, one stderr line — a hook bug must never
+  block work). The range is read from the session's cwd; a ``-C <dir>``
+  on the push is not followed.
+
+Escape hatch: ``ATTUNE_ALLOW_NO_CHANGELOG=1`` for an internal-only
+change. Apply the ``no-changelog`` label after opening the PR — that
+label is the declaration the CI gate accepts.
+
+Claude Code Protocol:
+    stdin: JSON with tool_name and tool_input
+    exit 0: allow tool call
+    exit 2: block tool call (stderr printed to user)
+
+Metrics: one line per fire in ~/.attune/enforcement-metrics.jsonl, the
+same ledger the other guards use.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under Apache 2.0
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from dirty_switch_guard import git_invocations  # noqa: E402  (sibling hook script)
+
+ENFORCEMENT_NAME = "changelog-entry-guard"
+METRICS_LOG = Path.home() / ".attune" / "enforcement-metrics.jsonl"
+ALLOW_ENV = "ATTUNE_ALLOW_NO_CHANGELOG"
+
+#: Mirrors ``SHIPPED_PREFIXES`` in ``.github/scripts/changelog_gate.py``,
+#: the CI ``changelog-entry`` gate this guard front-runs. A drift test in
+#: tests/unit/hooks/test_changelog_entry_guard.py pins the two equal.
+SHIPPED_PREFIXES: tuple[str, ...] = ("src/", "attune_redis/")
+
+#: The file an entry must land in, and the label that declares "none needed".
+CHANGELOG = "CHANGELOG.md"
+OPT_OUT_LABEL = "no-changelog"
+
+#: Git global options that consume the next token as their value.
+_GLOBAL_OPTS_WITH_VALUE = {"-C", "-c", "--git-dir", "--work-tree", "--namespace", "--config-env"}
+
+
+def _log_metric(outcome: str, detail: str | None = None) -> None:
+    """Append one best-effort record to the enforcement metrics log."""
+    try:
+        METRICS_LOG.parent.mkdir(parents=True, exist_ok=True)
+        record = {
+            "ts": datetime.now(timezone.utc).isoformat(),
+            "enforcement": ENFORCEMENT_NAME,
+            "outcome": outcome,
+            "detail": detail,
+        }
+        with METRICS_LOG.open("a", encoding="utf-8") as f:
+            f.write(json.dumps(record) + "\n")
+    except OSError:
+        # INTENTIONAL: metrics are best-effort; never block on them.
+        pass
+
+
+def is_push(args: list[str]) -> bool:
+    """True if the git arg-list is ``[global opts] push ...``.
+
+    Global options (``-C <dir>``, ``-c k=v``, ``--no-pager`` ...) are
+    skipped so the subcommand is matched by position — ``git commit -m
+    push`` is not a push.
+    """
+    i = 0
+    while i < len(args) and args[i].startswith("-"):
+        i += 2 if args[i] in _GLOBAL_OPTS_WITH_VALUE else 1
+    return args[i : i + 1] == ["push"]
+
+
+def _git(args: list[str], cwd: Path | None = None) -> str | None:
+    """Stdout of a git command, or None when it fails for any reason."""
+    try:
+        result = subprocess.run(
+            ["git", *args],
+            cwd=str(cwd) if cwd else None,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=15,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if result.returncode != 0:
+        return None
+    return result.stdout
+
+
+def pushed_paths(cwd: Path | None = None) -> list[str] | None:
+    """Paths changed from the ``origin/main`` merge base to HEAD, or None if unknown."""
+    base = _git(["merge-base", "origin/main", "HEAD"], cwd)
+    if base is None:
+        return None
+    diff = _git(["diff", "--name-only", base.strip(), "HEAD"], cwd)
+    if diff is None:
+        return None
+    return [line for line in diff.splitlines() if line]
+
+
+def block_message(shipped: list[str]) -> str:
+    """The refusal text: the shipped paths, and the two ways forward."""
+    shown = shipped[:8]
+    listing = "\n".join(f"    {p}" for p in shown)
+    if len(shipped) > len(shown):
+        listing += f"\n    ... and {len(shipped) - len(shown)} more"
+    return (
+        f"[{ENFORCEMENT_NAME}] refusing: this push ships code with no "
+        f"{CHANGELOG} change in the pushed range, so the CI `changelog-entry` "
+        "gate would fail the PR.\n"
+        f"  Shipped paths:\n{listing}\n\n"
+        "  Two exits:\n"
+        f"    1. Add an entry under `## [Unreleased]` in {CHANGELOG}, inside the "
+        "EXISTING `### Added` / `### Changed` / `### Fixed` section for its "
+        "kind (never a second one), commit, and push again.\n"
+        f"    2. Internal-only change: {ALLOW_ENV}=1 <push command> for this "
+        f"push, then apply the `{OPT_OUT_LABEL}` label after opening the PR."
+    )
+
+
+def main(context: dict[str, Any]) -> int:
+    """Block a push of shipped code with no CHANGELOG entry; 0 allow, 2 block."""
+    if context.get("tool_name") != "Bash":
+        return 0
+    command = (context.get("tool_input") or {}).get("command", "")
+    if not command or not any(is_push(args) for args in git_invocations(command)):
+        return 0
+    if os.environ.get(ALLOW_ENV) == "1":
+        _log_metric("allowed", "escape hatch set")
+        return 0
+
+    paths = pushed_paths()
+    if paths is None:
+        print(
+            f"[{ENFORCEMENT_NAME}] cannot read the push range "
+            "(no origin/main, no commits, or not a git tree) — skipping",
+            file=sys.stderr,
+        )
+        _log_metric("unknown", "push range unreadable")
+        return 0
+    shipped = [p for p in paths if p.startswith(SHIPPED_PREFIXES)]
+    if not shipped or CHANGELOG in paths:
+        _log_metric("allowed", f"{len(shipped)} shipped path(s)")
+        return 0
+
+    print(block_message(shipped), file=sys.stderr)
+    _log_metric("fired", f"{len(shipped)} shipped path(s), no {CHANGELOG}")
+    return 2
+
+
+def _read_stdin_context() -> dict[str, Any]:
+    """Parse the hook context from stdin; empty dict when unavailable."""
+    try:
+        raw = sys.stdin.read()
+    except (OSError, ValueError):
+        return {}
+    if not raw.strip():
+        return {}
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError:
+        return {}
+    return parsed if isinstance(parsed, dict) else {}
+
+
+if __name__ == "__main__":
+    from _bootstrap import ensure_utf8_stdio
+
+    ensure_utf8_stdio()
+    from _sdk_gate import exit_if_sdk_subprocess
+
+    exit_if_sdk_subprocess()
+    ctx = _read_stdin_context()
+    if not ctx:
+        sys.exit(0)
+    try:
+        sys.exit(main(ctx))
+    except Exception as exc:  # noqa: BLE001
+        # INTENTIONAL: a hook bug must never block real work.
+        print(
+            f"[{ENFORCEMENT_NAME}] hook error (allowing): {type(exc).__name__}: {exc}",
+            file=sys.stderr,
+        )
+        sys.exit(0)

--- a/tests/unit/elicitation/test_surface_bootstrap.py
+++ b/tests/unit/elicitation/test_surface_bootstrap.py
@@ -32,7 +32,10 @@ async def test_packaged_evidence_enables_only_the_receipted_route(tmp_path):
     )
     assert route_evidence_missing(runtime._registry, runtime._report, native.SUBJECT_ID, "RICH")
     assert not runtime._report.complete
-    assert len(runtime._report.pending_keys) == 162
+    # Every pending_obligations row in the packaged registry; nothing beyond the
+    # eight receipts is verified. Each new hook delivery route adds three
+    # (content_schema, destination, delivery).
+    assert len(runtime._report.pending_keys) == 165
     assert (tmp_path / "surface-auth/receipt.key").is_file()
     assert not runtime.store._records  # Canonical fixture state never enters production.
 

--- a/tests/unit/gates/test_broad_except_ratchet.py
+++ b/tests/unit/gates/test_broad_except_ratchet.py
@@ -160,6 +160,9 @@ _BASELINE: dict[str, int] = {
     # worktree_add_guard (retro 2026-09-06 R8): the same fail-open __main__
     # block — a guard that crashes must exit 0, never block.
     "src/attune/hooks/scripts/worktree_add_guard.py": 1,
+    # changelog_entry_guard (retro 2026-09-11 item 6): the same fail-open
+    # __main__ block — a guard that crashes must exit 0, never block.
+    "src/attune/hooks/scripts/changelog_entry_guard.py": 1,
     "src/attune/hooks/scripts/evaluate_session.py": 3,
     # format_on_save added 1 for library-review L3 (PR #2117): the
     # PostToolUse exit-0-always contract must survive wrong-typed

--- a/tests/unit/gates/test_path_validation_gate.py
+++ b/tests/unit/gates/test_path_validation_gate.py
@@ -89,6 +89,10 @@ ALLOWLIST = frozenset(
         # worktree_add_guard (retro 2026-09-06 R8): identical shape — appends
         # only to the constant enforcement-metrics log, no interpolated component.
         "src/attune/hooks/scripts/worktree_add_guard.py",
+        # changelog_entry_guard (retro 2026-09-11 item 6): identical shape —
+        # appends only to the constant enforcement-metrics log, no
+        # interpolated component.
+        "src/attune/hooks/scripts/changelog_entry_guard.py",
         "src/attune/hooks/scripts/worktree_path_guard.py",
         "src/attune/help/feedback.py",
         "src/attune/help/generator.py",

--- a/tests/unit/gates/test_surface_parity.py
+++ b/tests/unit/gates/test_surface_parity.py
@@ -1818,6 +1818,13 @@ def test_experiment_uses_resolved_shipped_roots_and_rejects_stale_pin(small_regi
             "exit2_stderr",
             "print(file=sys.stderr)",
         ),
+        (
+            "src/attune/hooks/scripts/changelog_entry_guard.py",
+            "PreToolUse",
+            "Bash",
+            "exit2_stderr",
+            "print(file=sys.stderr)",
+        ),
     ],
 )
 def test_new_hook_subjects_have_qualified_delivery_obligations(

--- a/tests/unit/hooks/test_changelog_entry_guard.py
+++ b/tests/unit/hooks/test_changelog_entry_guard.py
@@ -1,0 +1,333 @@
+"""Tests for the changelog-entry guard PreToolUse hook (retro 2026-09-11, item 6).
+
+A ``git push`` whose range changes shipped code without touching
+``CHANGELOG.md`` is refused at push time, before the CI ``changelog-entry``
+gate can fail the PR. Covers the push classification, the block decision
+against a REAL repository with a bare origin, the escape hatch, the
+fail-open paths, the script entrypoint, and drift against the CI gate.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under the Apache License, Version 2.0
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import os
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCRIPT_PATH = REPO_ROOT / "src" / "attune" / "hooks" / "scripts" / "changelog_entry_guard.py"
+GATE_PATH = REPO_ROOT / ".github" / "scripts" / "changelog_gate.py"
+
+
+def _load(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    m = importlib.util.module_from_spec(spec)
+    sys.modules[name] = m
+    spec.loader.exec_module(m)
+    return m
+
+
+@pytest.fixture(scope="module")
+def mod():
+    return _load("_changelog_entry_guard", SCRIPT_PATH)
+
+
+@pytest.fixture(scope="module")
+def gate():
+    return _load("_changelog_gate_for_drift", GATE_PATH)
+
+
+def _ctx(command: str, tool: str = "Bash") -> dict:
+    return {"tool_name": tool, "tool_input": {"command": command}}
+
+
+def _git_env(home: Path) -> dict[str, str]:
+    """A scratch HOME so no global gitconfig, signing key, or hook is consulted."""
+    return {
+        **os.environ,
+        "HOME": str(home),
+        "GIT_CONFIG_NOSYSTEM": "1",
+        "GIT_AUTHOR_NAME": "t",
+        "GIT_AUTHOR_EMAIL": "t@x",
+        "GIT_COMMITTER_NAME": "t",
+        "GIT_COMMITTER_EMAIL": "t@x",
+    }
+
+
+@dataclass
+class Repo:
+    path: Path
+    home: Path
+
+    def git(self, *args: str) -> None:
+        subprocess.run(
+            ["git", "-C", str(self.path), "-c", "commit.gpgsign=false", *args],
+            check=True,
+            capture_output=True,
+            env=_git_env(self.home),
+            timeout=30,
+        )
+
+    def commit(self, rel: str, text: str, message: str) -> None:
+        target = self.path / rel
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(text, encoding="utf-8")
+        self.git("add", "-A")
+        self.git("commit", "-q", "-m", message)
+
+
+@pytest.fixture
+def metrics(mod, tmp_path, monkeypatch):
+    log = tmp_path / "metrics.jsonl"
+    monkeypatch.setattr(mod, "METRICS_LOG", log)
+    monkeypatch.delenv(mod.ALLOW_ENV, raising=False)
+    return log
+
+
+@pytest.fixture
+def repo(metrics, tmp_path, monkeypatch) -> Repo:
+    """A clone-shaped repo: bare origin, origin/main known, feature branch out."""
+    home = tmp_path / "home"
+    home.mkdir()
+    origin = tmp_path / "origin.git"
+    r = Repo(tmp_path / "repo", home)
+    r.path.mkdir()
+    subprocess.run(
+        ["git", "init", "-q", "--bare", "-b", "main", str(origin)],
+        check=True,
+        capture_output=True,
+        env=_git_env(home),
+        timeout=30,
+    )
+    r.git("init", "-q", "-b", "main")
+    r.git("remote", "add", "origin", str(origin))
+    (r.path / "CHANGELOG.md").write_text("# Changelog\n\n## [Unreleased]\n", encoding="utf-8")
+    r.commit("src/pkg/mod.py", "X = 1\n", "base")
+    r.git("push", "-q", "origin", "main")
+    r.git("checkout", "-q", "-b", "feat/x")
+    monkeypatch.chdir(r.path)
+    return r
+
+
+class TestPushClassification:
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "git push",
+            "git push origin main",
+            "git push -u origin feat/x",
+            "git push --force-with-lease origin feat/x",
+            "git -C /repo push origin feat/x",
+            "git -c core.x=y --no-pager push",
+            "echo hi; git push origin main",
+            "set -e\ngit push origin HEAD",
+        ],
+    )
+    def test_pushes_are_detected(self, mod, command):
+        assert any(mod.is_push(args) for args in mod.git_invocations(command))
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "git status",
+            "git commit -m push",
+            "git -C /repo commit -m 'push later'",
+            "echo git push",
+            "gh pr create --title push",
+        ],
+    )
+    def test_non_pushes_are_not_detected(self, mod, command):
+        assert not any(mod.is_push(args) for args in mod.git_invocations(command))
+
+
+class TestDecision:
+    def test_non_push_command_allows(self, mod, repo):
+        repo.commit("src/pkg/new.py", "Y = 2\n", "shipped, no entry")
+        assert mod.main(_ctx("git status")) == 0
+        assert mod.main(_ctx("pytest tests")) == 0
+
+    def test_docs_only_push_allows(self, mod, repo):
+        repo.commit("docs/guide.md", "# guide\n", "docs")
+        assert mod.main(_ctx("git push origin feat/x")) == 0
+
+    def test_tests_and_ci_paths_are_not_shipped(self, mod, repo):
+        repo.commit("tests/unit/test_x.py", "def test_x(): pass\n", "tests")
+        repo.commit(".github/workflows/x.yml", "name: x\n", "ci")
+        assert mod.main(_ctx("git push origin feat/x")) == 0
+
+    def test_src_push_without_changelog_blocks(self, mod, repo, capsys):
+        repo.commit("src/pkg/new.py", "Y = 2\n", "shipped, no entry")
+        assert mod.main(_ctx("git push origin feat/x")) == 2
+        err = capsys.readouterr().err
+        assert "src/pkg/new.py" in err
+        assert "[Unreleased]" in err
+        assert mod.ALLOW_ENV in err
+        assert mod.OPT_OUT_LABEL in err
+
+    def test_attune_redis_prefix_is_shipped(self, mod, repo):
+        repo.commit("attune_redis/x.py", "Z = 3\n", "shipped, no entry")
+        assert mod.main(_ctx("git push origin feat/x")) == 2
+
+    def test_changelog_in_range_allows(self, mod, repo):
+        repo.commit("src/pkg/new.py", "Y = 2\n", "shipped")
+        repo.commit("CHANGELOG.md", "# Changelog\n\n## [Unreleased]\n\n- new\n", "entry")
+        assert mod.main(_ctx("git push origin feat/x")) == 0
+
+    def test_changelog_in_an_earlier_commit_of_the_range_allows(self, mod, repo):
+        repo.commit("CHANGELOG.md", "# Changelog\n\n## [Unreleased]\n\n- new\n", "entry")
+        repo.commit("src/pkg/new.py", "Y = 2\n", "shipped")
+        assert mod.main(_ctx("git push origin feat/x")) == 0
+
+    def test_nothing_to_push_allows(self, mod, repo):
+        assert mod.pushed_paths() == []
+        assert mod.main(_ctx("git push origin feat/x")) == 0
+
+    def test_escape_hatch_allows(self, mod, repo, metrics, monkeypatch):
+        repo.commit("src/pkg/new.py", "Y = 2\n", "shipped, no entry")
+        monkeypatch.setenv(mod.ALLOW_ENV, "1")
+        assert mod.main(_ctx("git push origin feat/x")) == 0
+        assert "escape hatch" in metrics.read_text(encoding="utf-8")
+
+    def test_non_bash_tool_is_ignored(self, mod, repo):
+        repo.commit("src/pkg/new.py", "Y = 2\n", "shipped, no entry")
+        assert mod.main({"tool_name": "Edit", "tool_input": {"file_path": "x"}}) == 0
+
+    def test_fire_writes_a_metric_row(self, mod, repo, metrics):
+        repo.commit("src/pkg/new.py", "Y = 2\n", "shipped, no entry")
+        assert mod.main(_ctx("git push origin feat/x")) == 2
+        rows = [json.loads(line) for line in metrics.read_text(encoding="utf-8").splitlines()]
+        assert rows[-1]["enforcement"] == mod.ENFORCEMENT_NAME
+        assert rows[-1]["outcome"] == "fired"
+
+    def test_block_message_truncates_a_long_listing(self, mod):
+        message = mod.block_message([f"src/attune/m{i}.py" for i in range(12)])
+        assert "src/attune/m7.py" in message
+        assert "src/attune/m8.py" not in message
+        assert "and 4 more" in message
+
+
+class TestFailOpen:
+    """Every path where the guard cannot know must ALLOW, and never raise."""
+
+    def test_no_origin_main_allows(self, mod, metrics, tmp_path, monkeypatch, capsys):
+        home = tmp_path / "home"
+        home.mkdir()
+        r = Repo(tmp_path / "lonely", home)
+        r.path.mkdir()
+        r.git("init", "-q", "-b", "main")
+        r.commit("src/pkg/new.py", "Y = 2\n", "shipped, no remote at all")
+        monkeypatch.chdir(r.path)
+        assert mod.pushed_paths() is None
+        assert mod.main(_ctx("git push origin main")) == 0
+        assert "skipping" in capsys.readouterr().err
+
+    def test_outside_a_git_tree_allows(self, mod, metrics, tmp_path, monkeypatch):
+        plain = tmp_path / "plain"
+        plain.mkdir()
+        monkeypatch.chdir(plain)
+        assert mod.pushed_paths() is None
+        assert mod.main(_ctx("git push origin main")) == 0
+
+    def test_git_unreadable_yields_none(self, mod, monkeypatch):
+        def boom(*a, **k):
+            raise OSError("no git")
+
+        monkeypatch.setattr(mod.subprocess, "run", boom)
+        assert mod.pushed_paths() is None
+
+    def test_unparseable_command_allows(self, mod, repo):
+        repo.commit("src/pkg/new.py", "Y = 2\n", "shipped, no entry")
+        assert mod.main(_ctx('git push "unbalanced')) == 0
+
+    def test_empty_command_allows(self, mod, repo):
+        assert mod.main(_ctx("")) == 0
+
+    def test_metrics_log_unwritable_is_swallowed(self, mod, tmp_path, monkeypatch):
+        blocker = tmp_path / "not-a-dir"
+        blocker.write_text("file, not a directory", encoding="utf-8")
+        monkeypatch.setattr(mod, "METRICS_LOG", blocker / "metrics.jsonl")
+        mod._log_metric("fired", "x")  # OSError inside -> swallowed
+
+
+class TestStdinAndEntrypoint:
+    def test_read_stdin_context_shapes(self, mod, monkeypatch):
+        for raw, expect in (
+            ("", {}),
+            ("   ", {}),
+            ("not json", {}),
+            ("[1,2]", {}),
+            ('{"a": 1}', {"a": 1}),
+        ):
+            monkeypatch.setattr(sys, "stdin", io.StringIO(raw))
+            assert mod._read_stdin_context() == expect
+
+    @staticmethod
+    def _run(repo: Repo, payload: str) -> subprocess.CompletedProcess:
+        """The real entrypoint, as Claude Code runs it; SDK-gate signals scrubbed."""
+        env = _git_env(repo.home)  # HOME is scratch: metrics land there, not in ~
+        for signal in (
+            "ATTUNE_SDK_SUBPROCESS",
+            "CLAUDE_CODE_ENTRYPOINT",
+            "ATTUNE_ALLOW_NO_CHANGELOG",
+        ):
+            env.pop(signal, None)
+        return subprocess.run(
+            [sys.executable, str(SCRIPT_PATH)],
+            input=payload,
+            capture_output=True,
+            text=True,
+            cwd=repo.path,
+            env=env,
+            timeout=30,
+        )
+
+    def test_script_round_trip_blocks_shipped_code_without_entry(self, repo):
+        repo.commit("src/pkg/new.py", "Y = 2\n", "shipped, no entry")
+        r = self._run(repo, json.dumps(_ctx("git push origin feat/x")))
+        assert r.returncode == 2
+        assert "src/pkg/new.py" in r.stderr
+        assert "no-changelog" in r.stderr
+
+    def test_script_round_trip_allows_with_entry(self, repo):
+        repo.commit("src/pkg/new.py", "Y = 2\n", "shipped")
+        repo.commit("CHANGELOG.md", "# Changelog\n\n## [Unreleased]\n\n- new\n", "entry")
+        r = self._run(repo, json.dumps(_ctx("git push origin feat/x")))
+        assert r.returncode == 0
+
+    def test_script_round_trip_empty_stdin_allows(self, repo):
+        assert self._run(repo, "").returncode == 0
+
+    def test_script_round_trip_malformed_stdin_allows(self, repo):
+        assert self._run(repo, "{not json").returncode == 0
+
+
+class TestDriftAgainstCiGate:
+    """The guard front-runs .github/scripts/changelog_gate.py; the two must agree."""
+
+    def test_shipped_prefixes_match_the_ci_gate(self, mod, gate):
+        assert mod.SHIPPED_PREFIXES == gate.SHIPPED_PREFIXES
+
+    def test_changelog_path_and_label_match_the_ci_gate(self, mod, gate):
+        assert mod.CHANGELOG == gate.CHANGELOG
+        assert mod.OPT_OUT_LABEL == gate.OPT_OUT_LABEL
+
+    def test_verdict_agrees_with_the_gate_on_the_same_range(self, mod, gate, repo):
+        repo.commit("src/pkg/new.py", "Y = 2\n", "shipped, no entry")
+        paths = mod.pushed_paths()
+        assert gate.is_satisfied(paths, []) is False
+        assert mod.main(_ctx("git push origin feat/x")) == 2
+
+        repo.commit("CHANGELOG.md", "# Changelog\n\n## [Unreleased]\n\n- new\n", "entry")
+        paths = mod.pushed_paths()
+        assert gate.is_satisfied(paths, []) is True
+        assert mod.main(_ctx("git push origin feat/x")) == 0


### PR DESCRIPTION
## Summary

Retro 2026-09-11 item 6 (chair ruling, response
resp-20260911-224927-0dd7c67b). Four `src/`-touching PRs tonight each
cost a red round-trip on the CI `changelog-entry` gate because the
CHANGELOG entry was written after the PR was opened. This adds a repo
PreToolUse guard that asks the gate's question at push time, in the
agent session, where the fix is one more commit instead of a CI cycle.

**`src/attune/hooks/scripts/changelog_entry_guard.py`** (new)

- Acts only on `tool_name == "Bash"` whose command contains a `git push`
  invocation (shared tokenizer `git_invocations` from
  `dirty_switch_guard`; git global options `-C`/`-c`/`--no-pager` ...
  are skipped so `push` is matched by position). Anything else: exit 0.
- Range = `git merge-base origin/main HEAD` .. `HEAD`; changed paths =
  `git diff --name-only <mb> HEAD`.
- Exit 2 when any changed path starts with `SHIPPED_PREFIXES`
  (`("src/", "attune_redis/")`, mirrored from
  `.github/scripts/changelog_gate.py` with a drift test) AND
  `CHANGELOG.md` is not in the range AND `ATTUNE_ALLOW_NO_CHANGELOG` is
  unset. The message names the shipped paths and the two exits (entry
  under `[Unreleased]` in the EXISTING section for its kind, or the env
  override for this push + the `no-changelog` label after opening).
- Fail-open (exit 0, one stderr line) when `origin/main` is unknown,
  HEAD has no commits, the cwd is not a git tree, or any git call
  fails. `__main__` block is `dirty_switch_guard`'s verbatim
  (`ensure_utf8_stdio`, `exit_if_sdk_subprocess`, `_read_stdin_context`,
  fail-open broad except with the INTENTIONAL comment).
- Metrics: one row per decision in `~/.attune/enforcement-metrics.jsonl`,
  same ledger as the sibling guards.

**Registration and ledgers**

- `.claude/settings.json`: registered under the `Bash` PreToolUse
  matcher, after `worktree_add_guard`, same command shape, timeout 10.
- `tests/unit/gates/test_broad_except_ratchet.py`: baseline entry (1,
  the fail-open `__main__` block).
- `tests/unit/gates/test_path_validation_gate.py`: allowlist entry
  (appends only to the constant metrics log, no interpolated component).

**Surface parity** (the scanner discovers every registered hook with an
`exit2_stderr` envelope, so this is required for `tests/unit/gates` to
stay green)

- `docs/specs/host-surface-parity/producer_baseline.json` regenerated via
  `write_baseline`: exactly the three records a sibling guard carries
  (registration, `:main` envelope anchor, helper edge); no problems.
- `parity-registry.json`: subject `src-changelog_entry_guard-module`
  (route id `c0b0046d68345b0b` = first 16 hex of the canonical digest of
  the route fields, identical to `worktree_add_guard`'s because the
  fields are identical) + three `pending_obligations` rows
  (`content_schema`/`delivery`/`destination`, `next_increment: 3`, same
  owner/reason as the sibling); `producer_baseline.digest` re-pinned.
- `scripts/project_surface_runtime.py --write` re-projected
  `src/attune/elicitation/surface_runtime_{registry,baseline}.json`;
  check mode passes. Outside the new subject the only changed lines in
  all three JSON files are the digest.
- `tests/unit/gates/test_surface_parity.py`: the new hook added to the
  `test_new_hook_subjects_have_qualified_delivery_obligations`
  parametrization.

**Tests** — `tests/unit/hooks/test_changelog_entry_guard.py` (39): real
repo with a bare origin (commits with `-c commit.gpgsign=false` and a
scratch `HOME`), in-process `main()` and a subprocess round trip through
`__main__`; non-push → 0, docs-only → 0, tests/CI paths → 0, src commit
without CHANGELOG → 2 naming the path, `attune_redis/` → 2, CHANGELOG in
the range (later or earlier commit) → 0, override env → 0, no
`origin/main` → 0, cwd not a repo → 0, unparseable command → 0, metrics
row on fire, message truncation, stdin shapes, and drift pins against
the CI gate (`SHIPPED_PREFIXES`, `CHANGELOG`, `OPT_OUT_LABEL`, plus the
guard's verdict agreeing with `is_satisfied()` on the same range).

**CHANGELOG**: one bullet under the EXISTING `### Added` in
`## [Unreleased]`.

## Receipts

All test runs: `PYTHONPATH=<this worktree>/src ANTHROPIC_API_KEY=""
/Users/patrickroebuck/attune-ai/.venv/bin/python -m pytest <target> -q
-p no:xdist -o addopts=`, run serially from the worktree root.

| Probe | Result |
|---|---|
| `tests/unit/hooks/test_changelog_entry_guard.py` | 39 passed in 5.17s |
| `tests/unit/hooks` (whole) | 1191 passed in 48.57s |
| `tests/unit/gates` (whole, incl. surface parity, ratchets) | 673 passed in 42.76s |
| `tests/unit/plugins/test_sdk_subprocess_gate.py` | 43 passed in 2.70s |
| `tests/unit/quality` | 5 passed in 3.89s |
| `tests/unit/scripts/test_consolidate_changelog.py` | 20 passed in 0.13s |
| `write_baseline(Path('.'), <producer_baseline.json>)` | `problems: ()`; +22 lines, the three sibling-shaped records |
| `scripts/project_surface_runtime.py --write` then plain (check) | both exit 0 (`projection ok`, `check ok`); the "Native form transport failed: TimeoutError" lines are the native-evidence replay's own timeout receipt, printed identically on main |
| `uv run --frozen --no-sync --project /Users/patrickroebuck/attune-ai --with pre-commit pre-commit run --files <all 11 changed files>` | black, ruff, ruff-bare-exception-check, bandit, whitespace/EOF, check json, brand-drift gate: all Passed; nothing reformatted |
| `git log -1 --format='%G?'` | `G` (7eb21f6d5) |
| `git status --short` after commit | empty |
| `git ls-remote --heads origin feat/changelog-entry-guard` vs `git rev-parse HEAD` | both `7eb21f6d5d23a815e7b9119df16dfccbed072562` |

Live stdin probes of the script (scratch repo built with
`git init --bare -b main origin.git`, `git init -b main repo`,
`remote add origin`, one `base` commit with `CHANGELOG.md` +
`src/pkg/mod.py` pushed to `origin main`, then `checkout -b feat/x` and
a commit adding `src/pkg/new.py`; `repo2` = a clone with `src/pkg/new.py`
AND a `CHANGELOG.md` change on `feat/y`). Each probe:
`cd <repo> && <main venv python> <worktree>/src/attune/hooks/scripts/changelog_entry_guard.py < payload.json; echo $?`
with `payload_push.json` =
`{"tool_name": "Bash", "tool_input": {"command": "git push origin feat/x"}}`
and `payload_status.json` the same with `"git status"`.

| Probe | Result |
|---|---|
| 1. `repo`, push payload, `ATTUNE_ALLOW_NO_CHANGELOG` unset | exit **2**; stderr names `src/pkg/new.py`, `[Unreleased]`, `ATTUNE_ALLOW_NO_CHANGELOG=1`, `no-changelog` |
| 2. `repo`, push payload, `ATTUNE_ALLOW_NO_CHANGELOG=1` | exit **0** |
| 3. `repo`, `git status` payload | exit **0** (no output) |
| 4. `repo2`, push payload (CHANGELOG.md in range) | exit **0** |
| `tail ~/.attune/enforcement-metrics.jsonl` | rows `fired`, `allowed` (escape hatch), `allowed` (1 shipped path) from probes 1, 2, 4 |

## Disclosures

- **This PR adds a hook-guard script.** Under the 2026-09-12 ruling
  (retro pushback, adopted) a different-model review lane is
  **MANDATORY before merge regardless of size**. `lane_owed_before_merge
  = true`. **The PR is not armed** — no auto-merge label, no `gh pr
  merge`; Patrick merges after the lane.
- **The hook loads at the next session start**, not in the session that
  merges it (Claude Code reads `.claude/settings.json` at startup).
- **Sibling registrations, observed not changed:** `dirty_switch_guard`
  and `detached_head_push_guard` are registered under the `Edit|Write`
  PreToolUse matcher in `.claude/settings.json` (since #2302 / #2417),
  while both act only on `tool_name == "Bash"`. Verified by reading the
  file and both `main()`s. The enforcement ledger nonetheless shows
  `dirty-switch-guard` with 575 `fired` / 574 `allowed` rows, and
  neither `~/.claude/settings.json` nor either checkout's
  `settings.local.json` registers it (grep count 0) — so how it fires
  is NOT resolved here (inferred: some other loader). Out of scope for
  this PR: moving them changes their parity route ids and obligations
  and widens the hook-review lane. Flagged for a separate decision.
- **Three probe rows landed in the real `~/.attune/enforcement-metrics
  .jsonl`** (the sandbox refused a scratch `HOME` for the probe
  commands). They are the last three `changelog-entry-guard` rows
  timestamped 2026-09-12T03:10Z; discount them in any retirement review.
- **Pre-commit invocation deviates from the prescribed form:** this
  worktree has no `.venv`, so `uv run --frozen --with pre-commit ...`
  would have synced a fresh ~460 MB env here; I ran it with
  `--no-sync --project /Users/patrickroebuck/attune-ai` instead (main's
  env, untouched by `--no-sync`; the pinned hook envs come from
  `.pre-commit-config.yaml` regardless). The commit-time hook run
  (repo pre-commit) also passed.
- **A `-C <dir>` on the push is not followed** — the range is read from
  the session cwd, as the sibling push guard does; documented in the
  module docstring. Tag pushes and `--delete` pushes are not carved out
  (the range check still applies; the escape hatch covers them).
- **Surface parity evidence is declared pending, not receipted**
  (`pending-local-receipts`, increment 3), exactly like every other hook
  subject; inventory declaration is not evidence.
- No `.claude/lessons.md` append; no other worktree touched. Coverage
  for the new module is exercised in-process by the test file (all
  branches of `main`, `pushed_paths`, `is_push`, `block_message`,
  `_log_metric`, `_read_stdin_context`); the `__main__` block is covered
  by the subprocess round trips only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
