### PR TITLE
feat(roundtable): `python -m attune.roundtable ledger` renders and appends the R5 row for a captured cross-review (retro 2026-09-12 item 1)

### DIFF
--- a/.agents/skills/cross-review/SKILL.md
+++ b/.agents/skills/cross-review/SKILL.md
@@ -65,10 +65,22 @@ print(json.dumps(run_review('.', mode=os.environ['MODE'], board=b), ensure_ascii
    file was omitted (a partial review must say so). ABSENT and
    `format_noncompliant` results render as-is; never fabricate or
    repair findings.
-4. **Ledger row** (R5): append `review.ledger_row(result)` to
-   `docs/specs/cross-review/receipts.md`, offering the user the
-   disposition edit (`real` / `noise` / `not-triaged`). Only real
-   runs — no synthetic rows.
+4. **Ledger row** (R5): with the run captured as `> review.json`,
+   render and append the row in one command — it validates the
+   disposition against both ledger gates and exits 1 (appending
+   nothing) if it would fail:
+
+```bash
+python -m attune.roundtable ledger --result review.json \
+  --disposition "2 real — accepted and fixed in-branch (<sha>): ..." \
+  --append docs/specs/cross-review/receipts.md
+```
+
+   `--disposition-file <path>` takes a longer disposition from a file;
+   omit both to render the `not-triaged` placeholder (a `clean` lane
+   fills its own). Offer the user the disposition edit (`real` /
+   `noise` / `rejected — claim: "..." — reason: ...`). Only real runs —
+   no synthetic rows.
 5. **Promotion**: findings worth keeping go through the roundtable
    Step 6 promotion flow (`/roundtable promote <thread>`); the
    board thread is TTL'd, the ledger row is durable.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `python -m attune.roundtable ledger --result review.json [--disposition ... | --disposition-file ...] [--append docs/specs/cross-review/receipts.md]`: renders the R5 ledger row for a captured `/cross-review` run, validating the disposition against both ledger gates (exit 1, nothing appended, when it would fail); the skill's step 4 now points at it (retro 2026-09-12 item 1).
+
 - Added an internal host-question adapter boundary for presenting question
   batches and collecting responses in one call, with adapter identity checks,
   challenge-bound completions, and explicit presentation failure handling.

--- a/plugin/help/generated/references/skill-cross-review.md
+++ b/plugin/help/generated/references/skill-cross-review.md
@@ -69,10 +69,22 @@ print(json.dumps(run_review('.', mode=os.environ['MODE'], board=b), ensure_ascii
    file was omitted (a partial review must say so). ABSENT and
    `format_noncompliant` results render as-is; never fabricate or
    repair findings.
-4. **Ledger row** (R5): append `review.ledger_row(result)` to
-   `docs/specs/cross-review/receipts.md`, offering the user the
-   disposition edit (`real` / `noise` / `not-triaged`). Only real
-   runs — no synthetic rows.
+4. **Ledger row** (R5): with the run captured as `> review.json`,
+   render and append the row in one command — it validates the
+   disposition against both ledger gates and exits 1 (appending
+   nothing) if it would fail:
+
+```bash
+python -m attune.roundtable ledger --result review.json \
+  --disposition "2 real — accepted and fixed in-branch (<sha>): ..." \
+  --append docs/specs/cross-review/receipts.md
+```
+
+   `--disposition-file <path>` takes a longer disposition from a file;
+   omit both to render the `not-triaged` placeholder (a `clean` lane
+   fills its own). Offer the user the disposition edit (`real` /
+   `noise` / `rejected — claim: "..." — reason: ...`). Only real runs —
+   no synthetic rows.
 5. **Promotion**: findings worth keeping go through the roundtable
    Step 6 promotion flow (`/roundtable promote <thread>`); the
    board thread is TTL'd, the ledger row is durable.

--- a/plugin/skills/cross-review/SKILL.md
+++ b/plugin/skills/cross-review/SKILL.md
@@ -67,10 +67,22 @@ print(json.dumps(run_review('.', mode=os.environ['MODE'], board=b), ensure_ascii
    file was omitted (a partial review must say so). ABSENT and
    `format_noncompliant` results render as-is; never fabricate or
    repair findings.
-4. **Ledger row** (R5): append `review.ledger_row(result)` to
-   `docs/specs/cross-review/receipts.md`, offering the user the
-   disposition edit (`real` / `noise` / `not-triaged`). Only real
-   runs — no synthetic rows.
+4. **Ledger row** (R5): with the run captured as `> review.json`,
+   render and append the row in one command — it validates the
+   disposition against both ledger gates and exits 1 (appending
+   nothing) if it would fail:
+
+```bash
+python -m attune.roundtable ledger --result review.json \
+  --disposition "2 real — accepted and fixed in-branch (<sha>): ..." \
+  --append docs/specs/cross-review/receipts.md
+```
+
+   `--disposition-file <path>` takes a longer disposition from a file;
+   omit both to render the `not-triaged` placeholder (a `clean` lane
+   fills its own). Offer the user the disposition edit (`real` /
+   `noise` / `rejected — claim: "..." — reason: ...`). Only real runs —
+   no synthetic rows.
 5. **Promotion**: findings worth keeping go through the roundtable
    Step 6 promotion flow (`/roundtable promote <thread>`); the
    board thread is TTL'd, the ledger row is durable.

--- a/src/attune/roundtable/__main__.py
+++ b/src/attune/roundtable/__main__.py
@@ -1,0 +1,31 @@
+"""``python -m attune.roundtable`` — command-line entry points for the round table.
+
+Only ``ledger`` exists today: it renders (and optionally appends) the R5
+dogfood-ledger row for a captured ``/cross-review`` result. The
+mechanics stay in :mod:`attune.roundtable.review`.
+
+Copyright 2026 Smart-AI-Memory
+Licensed under Apache 2.0
+"""
+
+from __future__ import annotations
+
+import sys
+
+from attune.roundtable.review import ledger_cli
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Dispatch the subcommand; ``ledger`` is the only one."""
+    args = list(sys.argv[1:] if argv is None else argv)
+    if args[:1] == ["ledger"]:
+        return ledger_cli(args[1:])
+    print(
+        "usage: python -m attune.roundtable ledger --result <file> [--disposition TEXT | --disposition-file FILE] [--append RECEIPTS_MD]",
+        file=sys.stderr,
+    )
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/attune/roundtable/review.py
+++ b/src/attune/roundtable/review.py
@@ -19,6 +19,7 @@ import json
 import os
 import re
 import subprocess  # nosec B404 — fixed argv, read-only git, never shell=True
+import sys
 from collections.abc import Callable, Sequence
 from datetime import datetime, timezone
 from pathlib import Path, PurePath
@@ -675,3 +676,65 @@ def ledger_row(result: dict[str, Any], disposition: str = "not-triaged") -> str:
         f"{len(manifest['sent'])} sent / {len(manifest['omitted'])} omitted | "
         f"{len(result['findings'])} ({result['status']}) | {disposition} |"
     )
+
+
+def load_review_result(path: Path) -> dict[str, Any]:
+    """Parse a captured ``run_review`` stdout file.
+
+    The result is the LAST non-empty line: a capture made with the
+    pre-#2524 snippet carries structlog's digest line ahead of the JSON,
+    and the parse must not fail on it (retro 2026-09-11 item 1).
+    """
+    lines = [line for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
+    if not lines:
+        raise ValueError(f"{path}: no review result found (empty file)")
+    try:
+        result = json.loads(lines[-1])
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"{path}: last line is not a JSON review result: {exc}") from exc
+    if not isinstance(result, dict) or "manifest" not in result or "findings" not in result:
+        raise ValueError(f"{path}: last line is not a run_review result")
+    return result
+
+
+def ledger_cli(argv: list[str] | None = None) -> int:
+    """``python -m attune.roundtable ledger`` — render (and append) an R5 ledger row.
+
+    The skill's step 4 used to be "append ``review.ledger_row(result)``",
+    and every session hand-wrote the same dozen lines to load the
+    capture, pass the disposition and validate it (retro 2026-09-12
+    item 1). Exit 1 with the gate problems on stderr when the
+    disposition would fail the ledger gates; nothing is appended then.
+    """
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        prog="python -m attune.roundtable ledger",
+        description="Render the R5 dogfood-ledger row for a captured cross-review result.",
+    )
+    parser.add_argument("--result", required=True, type=Path, help="captured run_review stdout")
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument("--disposition", help="disposition text (validated against the gates)")
+    group.add_argument("--disposition-file", type=Path, help="file holding the disposition text")
+    parser.add_argument(
+        "--append",
+        type=Path,
+        metavar="RECEIPTS_MD",
+        help="append the row to this ledger file after printing it",
+    )
+    args = parser.parse_args(argv)
+    disposition = "not-triaged"
+    if args.disposition is not None:
+        disposition = args.disposition.strip()
+    elif args.disposition_file is not None:
+        disposition = args.disposition_file.read_text(encoding="utf-8").strip()
+    try:
+        row = ledger_row(load_review_result(args.result), disposition)
+    except ValueError as exc:
+        print(f"ledger: {exc}", file=sys.stderr)
+        return 1
+    print(row)
+    if args.append is not None:
+        with args.append.open("a", encoding="utf-8") as handle:
+            handle.write(row + "\n")
+    return 0

--- a/src/attune/roundtable/review.py
+++ b/src/attune/roundtable/review.py
@@ -29,6 +29,7 @@ import structlog
 
 from attune.roundtable.compiler import ROLE_REPLY_CHARS
 from attune.roundtable.routine import SEAT_RECIPES, default_invoke_seat
+from attune.security.path_validation import _validate_file_path
 
 logger = structlog.get_logger(__name__)
 
@@ -729,12 +730,16 @@ def ledger_cli(argv: list[str] | None = None) -> int:
     elif args.disposition_file is not None:
         disposition = args.disposition_file.read_text(encoding="utf-8").strip()
     try:
+        target = None
+        if args.append is not None:
+            # The ledger lives in the repo: refuse an append outside the cwd.
+            target = _validate_file_path(str(args.append), allowed_dir=str(Path.cwd()))
         row = ledger_row(load_review_result(args.result), disposition)
     except ValueError as exc:
         print(f"ledger: {exc}", file=sys.stderr)
         return 1
     print(row)
-    if args.append is not None:
-        with args.append.open("a", encoding="utf-8") as handle:
+    if target is not None:
+        with target.open("a", encoding="utf-8") as handle:
             handle.write(row + "\n")
     return 0

--- a/tests/unit/roundtable/test_review.py
+++ b/tests/unit/roundtable/test_review.py
@@ -779,7 +779,8 @@ class TestLedgerCli:
         with pytest.raises(ValueError):
             review.load_review_result(capture)
 
-    def test_prints_and_appends_a_validated_row(self, tmp_path: Path, capsys) -> None:
+    def test_prints_and_appends_a_validated_row(self, tmp_path: Path, capsys, monkeypatch) -> None:
+        monkeypatch.chdir(tmp_path)
         capture = tmp_path / "review.json"
         capture.write_text(json.dumps(self._result()), encoding="utf-8")
         ledger = tmp_path / "receipts.md"
@@ -802,9 +803,24 @@ class TestLedgerCli:
         assert review.ledger_cli(["--result", str(capture), "--disposition-file", str(dfile)]) == 0
         assert capsys.readouterr().out.strip().endswith("| clean — triaged by hand |")
 
+    def test_append_outside_the_cwd_is_refused(self, tmp_path: Path, capsys, monkeypatch) -> None:
+        inside = tmp_path / "repo"
+        inside.mkdir()
+        monkeypatch.chdir(inside)
+        capture = inside / "review.json"
+        capture.write_text(json.dumps(self._result()), encoding="utf-8")
+        outside = tmp_path / "elsewhere.md"
+        rc = review.ledger_cli(
+            ["--result", str(capture), "--disposition", "1 real — fixed", "--append", str(outside)]
+        )
+        assert rc == 1
+        assert "ledger:" in capsys.readouterr().err
+        assert not outside.exists()
+
     def test_gate_failing_disposition_exits_1_and_appends_nothing(
-        self, tmp_path: Path, capsys
+        self, tmp_path: Path, capsys, monkeypatch
     ) -> None:
+        monkeypatch.chdir(tmp_path)
         capture = tmp_path / "review.json"
         capture.write_text(json.dumps(self._result()), encoding="utf-8")
         ledger = tmp_path / "receipts.md"

--- a/tests/unit/roundtable/test_review.py
+++ b/tests/unit/roundtable/test_review.py
@@ -3,8 +3,10 @@ advisory invariant, board degrade, ledger rendering."""
 
 from __future__ import annotations
 
+import json
 import os
 import subprocess
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -742,3 +744,98 @@ def test_ambiguous_host_also_reports_unverified(repo, monkeypatch):
     invoke = _invoke_stub("NO FINDINGS")
     result = review.run_review(repo, base_ref="main", invoke_seat=invoke)
     assert result["host"] is None and result["self_review"] is None
+
+
+class TestLedgerCli:
+    """``python -m attune.roundtable ledger`` (retro 2026-09-12 item 1)."""
+
+    @staticmethod
+    def _result(status: str = "findings", findings: int = 1) -> dict[str, Any]:
+        return {
+            "seat": "codex",
+            "host": "claude",
+            "self_review": False,
+            "claude_auth": None,
+            "status": status,
+            "target": "branch vs merge-base abc1234 (origin/main)",
+            "manifest": {"sent": ["a.py"], "omitted": [], "chars": 10},
+            "findings": [{"file": "a.py", "line": 1, "severity": "low", "claim": "x"}] * findings,
+        }
+
+    def test_parses_the_last_line_behind_a_digest_line(self, tmp_path: Path) -> None:
+        capture = tmp_path / "review.json"
+        capture.write_text(
+            "2026-09-11 17:00:50 [info] cross_review board=posted findings=1\n"
+            + json.dumps(self._result())
+            + "\n",
+            encoding="utf-8",
+        )
+        assert review.load_review_result(capture)["seat"] == "codex"
+
+    @pytest.mark.parametrize("body", ["", "   \n", "not json\n", '{"seat": "codex"}\n'])
+    def test_rejects_captures_without_a_result(self, tmp_path: Path, body: str) -> None:
+        capture = tmp_path / "review.json"
+        capture.write_text(body, encoding="utf-8")
+        with pytest.raises(ValueError):
+            review.load_review_result(capture)
+
+    def test_prints_and_appends_a_validated_row(self, tmp_path: Path, capsys) -> None:
+        capture = tmp_path / "review.json"
+        capture.write_text(json.dumps(self._result()), encoding="utf-8")
+        ledger = tmp_path / "receipts.md"
+        ledger.write_text("| header |\n", encoding="utf-8")
+        rc = review.ledger_cli(
+            ["--result", str(capture), "--disposition", "1 real — fixed", "--append", str(ledger)]
+        )
+        assert rc == 0
+        out = capsys.readouterr().out.strip()
+        assert out.endswith("| 1 (findings) | 1 real — fixed |")
+        assert ledger.read_text(encoding="utf-8") == "| header |\n" + out + "\n"
+
+    def test_disposition_file_and_clean_default(self, tmp_path: Path, capsys) -> None:
+        capture = tmp_path / "review.json"
+        capture.write_text(json.dumps(self._result(status="clean", findings=0)), encoding="utf-8")
+        assert review.ledger_cli(["--result", str(capture)]) == 0
+        assert "clean — no findings; complete manifest" in capsys.readouterr().out
+        dfile = tmp_path / "d.txt"
+        dfile.write_text("clean — triaged by hand\n", encoding="utf-8")
+        assert review.ledger_cli(["--result", str(capture), "--disposition-file", str(dfile)]) == 0
+        assert capsys.readouterr().out.strip().endswith("| clean — triaged by hand |")
+
+    def test_gate_failing_disposition_exits_1_and_appends_nothing(
+        self, tmp_path: Path, capsys
+    ) -> None:
+        capture = tmp_path / "review.json"
+        capture.write_text(json.dumps(self._result()), encoding="utf-8")
+        ledger = tmp_path / "receipts.md"
+        rc = review.ledger_cli(
+            ["--result", str(capture), "--disposition", "5 real", "--append", str(ledger)]
+        )
+        assert rc == 1
+        assert "exceeds the findings count" in capsys.readouterr().err
+        assert not ledger.exists()
+
+    def test_module_entry_point_round_trip(self, tmp_path: Path) -> None:
+        capture = tmp_path / "review.json"
+        capture.write_text(json.dumps(self._result()), encoding="utf-8")
+        run = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "attune.roundtable",
+                "ledger",
+                "--result",
+                str(capture),
+                "--disposition",
+                "1 real — fixed",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        assert run.returncode == 0, run.stderr
+        assert run.stdout.strip().endswith("| 1 real — fixed |")
+        usage = subprocess.run(
+            [sys.executable, "-m", "attune.roundtable"], capture_output=True, text=True, timeout=60
+        )
+        assert usage.returncode == 2 and "usage:" in usage.stderr


### PR DESCRIPTION
## Summary

Retro 2026-09-12 item 1 (chair: do now). The `/cross-review` skill's step 4
said "append `review.ledger_row(result)`", and every session hand-wrote the
same dozen lines to load the capture, pass a disposition and validate it
(four times in this morning's session alone).

- **`src/attune/roundtable/review.py`** — `load_review_result(path)` parses
  the LAST non-empty line of a `> review.json` capture (tolerates the
  pre-#2524 structlog digest line; rejects empty / non-JSON / non-result
  lines with a `ValueError`). `ledger_cli(argv)` — `--result`, one of
  `--disposition` / `--disposition-file`, optional `--append RECEIPTS_MD`;
  renders via `ledger_row`, so a disposition that would fail either ledger
  gate exits 1 with the problems on stderr and appends nothing.
- **`src/attune/roundtable/__main__.py`** (new) — `python -m attune.roundtable
  ledger …`; any other invocation prints usage, exit 2.
- **`plugin/skills/cross-review/SKILL.md`** — step 4 shows the command;
  `.agents` mirror and the help reference template re-projected (the drift
  test that bit #2524 passes here).
- **CHANGELOG** — one bullet under the existing `### Added`.

## Receipts

Serial, from this worktree: `PYTHONPATH=<worktree>/src ANTHROPIC_API_KEY=""
<main venv python> -m pytest <targets> -q -p no:xdist -o addopts=`.

| Probe | Result |
|---|---|
| `tests/unit/roundtable/test_review.py` (+6 CLI tests: digest-line tolerance, 4 rejected capture shapes, print+append, disposition-file + clean default, gate-failing disposition → 1 / no append, subprocess round trip of the module entry point + usage exit 2) + `tests/unit/help/test_generated_help_drift.py` + `tests/unit/plugins/test_sync_agents_skills.py` + `test_plugin_reference_validation.py` | 154 passed, 3 skipped |
| `tests/unit/quality` + broad-except + path-validation ratchets, rerun on efc1db937 | green (105 passed with the roundtable suite) |
| pre-commit on all 7 changed files | all Passed; commit-time run also Passed |
| `git cat-file -p HEAD \| grep -c gpgsig` | 1 |

## Disclosures

- **`--append` is cwd-bound** (21e6729ae): the path goes through `attune.security.path_validation._validate_file_path(allowed_dir=cwd)` — the path-validation gate flagged the raw `.open()` on the first push, and validating beats an allowlist entry (which would have made this a gate-allowlist diff). Pinned by `test_append_outside_the_cwd_is_refused`.
- **Intermediate red push (21e6729ae):** a patch anchor missed after black reformatted a test signature, and my chain committed with two append tests red before I saw it; efc1db937 fixes them. Nothing merged in between.

- No different-model lane: not a hook, gate allowlist, security,
  persistence or rule-text surface. Merge-on-receipts.
- `__main__.py`'s `argv is None` branch is exercised only by the subprocess
  round trip, which coverage does not see in-process; codecov patch may
  report those two lines uncovered.
- Not arming; Patrick merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

